### PR TITLE
docs(claude): PRマージ自動化 auto-merge 運用ルール追記 Phase1 (Asana 1214121039752589)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -237,6 +237,50 @@ git commit                        # 同内容で再コミット
 - mainへの直接pushはCodex review（Gate 2.5）が機能しない（base=mainでdiff=0になる）
 - PRマージ記録がなくなりレビュー・承認フローが消える
 
+## PRマージ自動化 (auto-merge) ルール
+
+### 背景
+2026-04-19 に PR #110-#117 の 8 本を一括マージする際、手動操作の長さと conflict 解消で一日が大きく削られた。
+同様の手動作業を避けるため、以下の運用ルールを遵守する。
+
+### 運用ルール
+
+**PR 作成時は必ず auto-merge を有効化する:**
+
+```bash
+gh pr create --title "..." --body "..." && \
+gh pr merge $(gh pr view --json number -q .number) --auto --squash --delete-branch
+```
+
+または既存 PR 番号を使って:
+```bash
+gh pr merge <PR番号> --auto --squash --delete-branch
+```
+
+### auto-merge の動作条件
+
+以下が全て揃った時点で自動マージされる:
+- CI (pnpm verify / build) が green
+- 必要なレビュー承認済み（プロジェクト設定による）
+- conflict なし
+
+### conflict が発生した場合
+
+- auto-merge は停止、PR 画面で「Merge conflict」警告が表示される
+- hkobayashi または CLI が手動で conflict を解消
+- 解消後に再度 auto-merge が有効化される
+
+### マージ方式の統一
+
+- **squash and merge** を標準とする（linear history 維持）
+- rebase merge / merge commit は使わない（履歴複雑化回避）
+
+### 関連タスク
+
+- Phase1（本ルール策定）: Asana 1214121039752589
+- Phase2（SCRIPTS/merge-ready-prs.sh 作成）: Asana 1214121039752589（別タスク化済み）
+- Phase3（Claude Code CLI /merge エージェント）: 将来タスク、未起票
+
 ## Settings Hygiene
 - `.claude/settings.local.json` は `.gitignore` に登録済み（プロジェクトローカルルール）
 - allowedTools にAPIトークン・パスワード等の認証情報を含めない


### PR DESCRIPTION
## Summary

`CLAUDE.md` に PR マージ自動化 (auto-merge) 運用ルールを追記。Phase1 のみ（CLAUDE.md 追記）。

**Before: 289行 / After: 333行（+44行）**

追記箇所: `Git Branch Rule` セクションと `Settings Hygiene` セクションの間

## 追記内容

- `gh pr merge --auto --squash --delete-branch` を PR 作成時の必須手順として明記
- auto-merge の動作条件（CI green / レビュー承認 / conflict なし）
- conflict 発生時の対処フロー
- squash and merge をマージ方式の標準として明記（linear history 維持）
- Phase 関連タスクへのリンク

## 背景

2026-04-19 に PR #110-#117 の 8 本を一括マージした際、手動操作と conflict 解消に大量の時間を消費。
同様の問題を防ぐため auto-merge の標準運用を CLAUDE.md に明文化。

## スコープ（Phase1のみ）

- ✅ Phase1: CLAUDE.md への運用ルール追記（本PR）
- ⏳ Phase2: `SCRIPTS/merge-ready-prs.sh` 作成（別タスク化済み）
- 📋 Phase3: Claude Code CLI `/merge` エージェント（将来タスク、未起票）

## Gate 結果

| Gate | 結果 |
|---|---|
| Gate 1: `pnpm verify` (フルスクリプト) | ✅ typecheck 0 errors / 1122 tests passed / security-scan CRITICAL/HIGH 0件 |
| Gate 1.5: dead-code-check | N/A（docs-only変更） |
| Gate 2: security-scan | ✅ CRITICAL/HIGH 0件（pnpm verify 内に含む） |
| Gate 2.5: Codex review | ✅ 指摘 0件「does not modify runtime code, tests, or configuration behavior」 |
| Gate 3: `pnpm build` + `cd admin-ui && pnpm build` | ✅ 両方成功 |
| Gate 4b/6: UI変更 | N/A |

🤖 Generated with [Claude Code](https://claude.com/claude-code)