### PR TITLE
feat(phase-a-day-2): GA4連携コアロジック + HMAC認証 + SQL migration

### DIFF
--- a/docs/DEPLOY_CHECKLIST.md
+++ b/docs/DEPLOY_CHECKLIST.md
@@ -111,6 +111,37 @@ VITE_SUPABASE_ANON_KEY=YOUR_ANON_KEY
 |---|---|---|
 | `src/api/admin/feedback/migration_feedback.sql` | feedback_messages テーブル初期作成 | ✅ |
 | `src/api/admin/feedback/migration_feedback_flagged.sql` | flagged_for_improvement カラム追加 + インデックス | 要適用 |
+| `src/api/admin/tenants/migration_phase_a.sql` | Phase A Day 2: tenants GA4/PostHog拡張 + notification_preferences + ga4_connection_logs + ga4_test_history + conversion_attributions拡張 | 要適用 |
+
+### Phase A Day 2 migration 実行手順
+
+```bash
+# 1. VPS SSH接続
+ssh root@65.108.159.161
+
+# 2. バックアップ (必須)
+pg_dump $DATABASE_URL > /opt/backups/pre_phase_a_$(date +%Y%m%d_%H%M).sql
+
+# 3. Migration 実行
+psql $DATABASE_URL < /opt/rajiuce/src/api/admin/tenants/migration_phase_a.sql
+
+# 4. 確認
+psql $DATABASE_URL -c "\d tenants" | grep ga4
+psql $DATABASE_URL -c "\d notification_preferences"
+psql $DATABASE_URL -c "\d ga4_connection_logs"
+psql $DATABASE_URL -c "\d ga4_test_history"
+psql $DATABASE_URL -c "\d conversion_attributions" | grep event_id
+```
+
+### Phase A Day 2 環境変数追加 (.env)
+
+```bash
+# GA4 Data API (サービスアカウントJSON をbase64エンコード)
+GOOGLE_APPLICATION_CREDENTIALS_JSON=<base64-encoded-service-account-json>
+
+# Cloudflare Workers → VPS HMAC認証 (Workers側と同じ値を設定)
+INTERNAL_API_HMAC_SECRET=<random-256bit-secret>
+```
 
 ```bash
 # VPS で実行:

--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
   },
   "dependencies": {
     "@elastic/elasticsearch": "8.19.1",
+    "@google-analytics/data": "^5.2.1",
     "@langchain/core": "^0.3.80",
     "@langchain/langgraph": "^0.2.74",
     "@notionhq/client": "^5.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
       '@elastic/elasticsearch':
         specifier: 8.19.1
         version: 8.19.1
+      '@google-analytics/data':
+        specifier: ^5.2.1
+        version: 5.2.1
       '@langchain/core':
         specifier: ^0.3.80
         version: 0.3.80(@opentelemetry/api@1.9.0)
@@ -357,6 +360,19 @@ packages:
   '@emnapi/wasi-threads@1.1.0':
     resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
+  '@google-analytics/data@5.2.1':
+    resolution: {integrity: sha512-JZdRY4OGPx0RnAdsFu0k/mD5x7mVXATKccSi5bB5ncbgaBbfLOz2cCjNna6dHxwDchYYZv1Zm/sISZHKtCclgw==}
+    engines: {node: '>=18'}
+
+  '@grpc/grpc-js@1.14.3':
+    resolution: {integrity: sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA==}
+    engines: {node: '>=12.10.0'}
+
+  '@grpc/proto-loader@0.8.0':
+    resolution: {integrity: sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==}
+    engines: {node: '>=6'}
+    hasBin: true
+
   '@hapi/address@5.1.1':
     resolution: {integrity: sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==}
     engines: {node: '>=14.0.0'}
@@ -516,6 +532,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
+  '@js-sdsl/ordered-map@4.4.2':
+    resolution: {integrity: sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==}
+
   '@langchain/core@0.3.80':
     resolution: {integrity: sha512-vcJDV2vk1AlCwSh3aBm/urQ1ZrlXFFBocv11bz/NBUfLWD5/UDNMzwPdaAd2dKvNmTWa9FM2lirLU3+JCf4cRA==}
     engines: {node: '>=18'}
@@ -599,6 +618,36 @@ packages:
     resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
   '@sinclair/typebox@0.34.41':
     resolution: {integrity: sha512-6gS8pZzSXdyRHTIqoqSVknxolr1kzfy4/CeDnrzsVz8TTIWUbOBr6gnzOmTYJ3eXQNh4IYHIGi5aIL7sOZ2G/g==}
@@ -920,6 +969,10 @@ packages:
     resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
     engines: {node: '>=12.0'}
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ansi-escapes@4.3.2:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
@@ -1050,6 +1103,9 @@ packages:
   baseline-browser-mapping@2.9.4:
     resolution: {integrity: sha512-ZCQ9GEWl73BVm8bu5Fts8nt7MHdbt5vY9bP6WGnUh+r3l8M7CgfyTlwsgCbMC66BNxPr6Xoce3j66Ms5YUQTNA==}
     hasBin: true
+
+  bignumber.js@9.3.1:
+    resolution: {integrity: sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==}
 
   binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -1292,6 +1348,10 @@ packages:
   crypt@0.0.2:
     resolution: {integrity: sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==}
 
+  data-uri-to-buffer@4.0.1:
+    resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
+    engines: {node: '>= 12'}
+
   dateformat@4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
 
@@ -1368,6 +1428,9 @@ packages:
 
   duplexer@0.1.2:
     resolution: {integrity: sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==}
+
+  duplexify@4.1.3:
+    resolution: {integrity: sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==}
 
   dynamic-dedupe@0.3.0:
     resolution: {integrity: sha512-ssuANeD+z97meYOqd50e04Ze5qp4bPqo8cCkI4TRjZkzAUgIDTrXV1R8QCdINpiI+hw14+rYazvTRdQrz0/rFQ==}
@@ -1486,6 +1549,9 @@ packages:
     resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
     engines: {node: '>= 18'}
 
+  extend@3.0.2:
+    resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
+
   fast-copy@3.0.2:
     resolution: {integrity: sha512-dl0O9Vhju8IrcLndv2eU4ldt1ftXMqqfgN4H1cpmGV7P6jeB9FwpN9a2c8DPGE1Ys88rNUJVYDHq73CGAGOPfQ==}
 
@@ -1503,6 +1569,10 @@ packages:
 
   fb-watchman@2.0.2:
     resolution: {integrity: sha512-p5161BqbuCaSnB8jIbzQHOlpgsPmK5rJVDfDKO91Axs5NC1uu3HRQm6wt9cd9/+GtQQIO53JdGXXoyDpTAsgYA==}
+
+  fetch-blob@3.2.0:
+    resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
+    engines: {node: ^12.20 || >= 14.13}
 
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
@@ -1553,6 +1623,10 @@ packages:
     resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
     engines: {node: '>= 6'}
 
+  formdata-polyfill@4.0.10:
+    resolution: {integrity: sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==}
+    engines: {node: '>=12.20.0'}
+
   formidable@3.5.4:
     resolution: {integrity: sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==}
     engines: {node: '>=14.0.0'}
@@ -1583,6 +1657,14 @@ packages:
 
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  gaxios@7.1.4:
+    resolution: {integrity: sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==}
+    engines: {node: '>=18'}
+
+  gcp-metadata@8.1.2:
+    resolution: {integrity: sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==}
+    engines: {node: '>=18'}
 
   generator-function@2.0.1:
     resolution: {integrity: sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g==}
@@ -1628,6 +1710,18 @@ packages:
     resolution: {integrity: sha512-jgcs2vKir9hFogGhXIfs0ODhJTfIrbECCehg38tqFgHm8zqXx7kAJyCYAFK4jTjx71AxrkFtkJBawbAxYUPX9A==}
     engines: {node: '>=14'}
     deprecated: The gm module has been sunset. Please migrate to an alternative. https://github.com/aheckmann/gm?tab=readme-ov-file#2025-02-24-this-project-is-not-maintained
+
+  google-auth-library@10.6.2:
+    resolution: {integrity: sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==}
+    engines: {node: '>=18'}
+
+  google-gax@5.0.6:
+    resolution: {integrity: sha512-1kGbqVQBZPAAu4+/R1XxPQKP0ydbNYoLAr4l0ZO2bMV0kLyLW4I1gAk++qBLWt7DPORTzmWRMsCZe86gDjShJA==}
+    engines: {node: '>=18'}
+
+  google-logging-utils@1.1.3:
+    resolution: {integrity: sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==}
+    engines: {node: '>=14'}
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -1686,6 +1780,14 @@ packages:
 
   http-parser-js@0.5.10:
     resolution: {integrity: sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
 
   human-signals@2.1.0:
     resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
@@ -2001,6 +2103,9 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-bigint@1.0.0:
+    resolution: {integrity: sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==}
+
   json-bignum@0.0.3:
     resolution: {integrity: sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==}
     engines: {node: '>=0.8'}
@@ -2107,6 +2212,9 @@ packages:
 
   lodash@4.18.1:
     resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
@@ -2242,8 +2350,17 @@ packages:
   neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
 
+  node-domexception@1.0.0:
+    resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
+    engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
+
   node-ensure@0.0.0:
     resolution: {integrity: sha512-DRI60hzo2oKN1ma0ckc6nQWlHU69RH6xN0sjQTjMpChPfTYvKZdcQFfdYK2RWbJcKyUizSIy/l8OTGxMAM1QDw==}
+
+  node-fetch@3.3.2:
+    resolution: {integrity: sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -2262,6 +2379,10 @@ packages:
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
+
+  object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -2512,6 +2633,14 @@ packages:
     resolution: {integrity: sha512-6ZiOBfCywsD4k1BN9IX0uZhF+tJkV8q8llP64G5Hajs4JOeVLPCwpPVcpXy3BwYiUGgyJzsJJQeOIv7+hDSq8g==}
     engines: {node: ^16 || ^18 || >=20}
 
+  proto3-json-serializer@3.0.4:
+    resolution: {integrity: sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==}
+    engines: {node: '>=18'}
+
+  protobufjs@7.5.5:
+    resolution: {integrity: sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==}
+    engines: {node: '>=12.0.0'}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
@@ -2595,6 +2724,10 @@ packages:
   retimer@3.0.0:
     resolution: {integrity: sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA==}
 
+  retry-request@8.0.2:
+    resolution: {integrity: sha512-JzFPAfklk1kjR1w76f0QOIhoDkNkSqW8wYKT08n9yysTmZfB+RQ2QoXoTAeOi1HD9ZipTyTAZg3c4pM/jeqgSw==}
+    engines: {node: '>=18'}
+
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
@@ -2602,6 +2735,10 @@ packages:
   rimraf@2.7.1:
     resolution: {integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==}
     deprecated: Rimraf versions prior to v4 are no longer supported
+    hasBin: true
+
+  rimraf@5.0.10:
+    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
     hasBin: true
 
   router@2.2.0:
@@ -2740,6 +2877,12 @@ packages:
   stream-combiner@0.0.4:
     resolution: {integrity: sha512-rT00SPnTVyRsaSz5zgSPma/aHSOic5U1prhYdRy5HS2kTZviFpmDgzilbtsJsxiroqACmayynDN/9VzIbX5DOw==}
 
+  stream-events@1.0.5:
+    resolution: {integrity: sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==}
+
+  stream-shift@1.0.3:
+    resolution: {integrity: sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==}
+
   streamsearch@1.1.0:
     resolution: {integrity: sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==}
     engines: {node: '>=10.0.0'}
@@ -2806,6 +2949,9 @@ packages:
       '@types/node':
         optional: true
 
+  stubs@3.0.0:
+    resolution: {integrity: sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==}
+
   superagent@10.3.0:
     resolution: {integrity: sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==}
     engines: {node: '>=14.18.0'}
@@ -2840,6 +2986,10 @@ packages:
 
   tdigest@0.1.2:
     resolution: {integrity: sha512-+G0LLgjjo9BZX2MfdvPfH+MKLCrxlXSYec5DaPYP1fe6Iyhf0/fSmJ0bFiZ1F8BT6cGXl2LpltQptzjXKWEkKA==}
+
+  teeny-request@10.1.2:
+    resolution: {integrity: sha512-Xj0ZAQ0CeuQn6UxCDPLbFRlgcSTUEyO3+wiepr2grjIjyL/lMMs1Z4OwXn8kLvn/V1OuaEP0UY7Na6UDNNsYrQ==}
+    engines: {node: '>=18'}
 
   terser@5.46.1:
     resolution: {integrity: sha512-vzCjQO/rgUuK9sf8VJZvjqiqiHFaZLnOiimmUuOKODxWL8mm/xua7viT7aqX7dgPY60otQjUotzFMmCB4VdmqQ==}
@@ -3050,6 +3200,10 @@ packages:
 
   walker@1.0.8:
     resolution: {integrity: sha512-ts/8E8l5b7kY0vlWLewOkDXMmPdLcVV4GmOQLyxuSswIJsweeFZtAsMF7k1Nszz+TYBQrlYRmzOnr398y1JemQ==}
+
+  web-streams-polyfill@3.3.3:
+    resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
+    engines: {node: '>= 8'}
 
   which-typed-array@1.1.20:
     resolution: {integrity: sha512-LYfpUkmqwl0h9A2HL09Mms427Q1RZWuOHsukfVcKRq9q95iQxdw0ix1JQrqbcDR9PH1QDwf5Qo8OZb5lksZ8Xg==}
@@ -3382,6 +3536,24 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@google-analytics/data@5.2.1':
+    dependencies:
+      google-gax: 5.0.6
+    transitivePeerDependencies:
+      - supports-color
+
+  '@grpc/grpc-js@1.14.3':
+    dependencies:
+      '@grpc/proto-loader': 0.8.0
+      '@js-sdsl/ordered-map': 4.4.2
+
+  '@grpc/proto-loader@0.8.0':
+    dependencies:
+      lodash.camelcase: 4.3.0
+      long: 5.3.2
+      protobufjs: 7.5.5
+      yargs: 17.7.2
+
   '@hapi/address@5.1.1':
     dependencies:
       '@hapi/hoek': 11.0.7
@@ -3653,6 +3825,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@js-sdsl/ordered-map@4.4.2': {}
+
   '@langchain/core@0.3.80(@opentelemetry/api@1.9.0)':
     dependencies:
       '@cfworker/json-schema': 4.1.1
@@ -3742,6 +3916,29 @@ snapshots:
   '@playwright/test@1.59.1':
     dependencies:
       playwright: 1.59.1
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.4': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.0': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.0': {}
 
   '@sinclair/typebox@0.34.41': {}
 
@@ -4061,6 +4258,8 @@ snapshots:
 
   adm-zip@0.5.17: {}
 
+  agent-base@7.1.4: {}
+
   ansi-escapes@4.3.2:
     dependencies:
       type-fest: 0.21.3
@@ -4233,6 +4432,8 @@ snapshots:
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.9.4: {}
+
+  bignumber.js@9.3.1: {}
 
   binary-extensions@2.3.0: {}
 
@@ -4478,6 +4679,8 @@ snapshots:
 
   crypt@0.0.2: {}
 
+  data-uri-to-buffer@4.0.1: {}
+
   dateformat@4.6.3: {}
 
   debug@3.2.7:
@@ -4530,6 +4733,13 @@ snapshots:
       gopd: 1.2.0
 
   duplexer@0.1.2: {}
+
+  duplexify@4.1.3:
+    dependencies:
+      end-of-stream: 1.4.5
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+      stream-shift: 1.0.3
 
   dynamic-dedupe@0.3.0:
     dependencies:
@@ -4672,6 +4882,8 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  extend@3.0.2: {}
+
   fast-copy@3.0.2: {}
 
   fast-deep-equal@3.1.3: {}
@@ -4685,6 +4897,11 @@ snapshots:
   fb-watchman@2.0.2:
     dependencies:
       bser: 2.1.1
+
+  fetch-blob@3.2.0:
+    dependencies:
+      node-domexception: 1.0.0
+      web-streams-polyfill: 3.3.3
 
   fill-range@7.1.1:
     dependencies:
@@ -4739,6 +4956,10 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
+  formdata-polyfill@4.0.10:
+    dependencies:
+      fetch-blob: 3.2.0
+
   formidable@3.5.4:
     dependencies:
       '@paralleldrive/cuid2': 2.3.1
@@ -4760,6 +4981,22 @@ snapshots:
     optional: true
 
   function-bind@1.1.2: {}
+
+  gaxios@7.1.4:
+    dependencies:
+      extend: 3.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+    transitivePeerDependencies:
+      - supports-color
+
+  gcp-metadata@8.1.2:
+    dependencies:
+      gaxios: 7.1.4
+      google-logging-utils: 1.1.3
+      json-bigint: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   generator-function@2.0.1: {}
 
@@ -4820,6 +5057,35 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  google-auth-library@10.6.2:
+    dependencies:
+      base64-js: 1.5.1
+      ecdsa-sig-formatter: 1.0.11
+      gaxios: 7.1.4
+      gcp-metadata: 8.1.2
+      google-logging-utils: 1.1.3
+      jws: 4.0.1
+    transitivePeerDependencies:
+      - supports-color
+
+  google-gax@5.0.6:
+    dependencies:
+      '@grpc/grpc-js': 1.14.3
+      '@grpc/proto-loader': 0.8.0
+      duplexify: 4.1.3
+      google-auth-library: 10.6.2
+      google-logging-utils: 1.1.3
+      node-fetch: 3.3.2
+      object-hash: 3.0.0
+      proto3-json-serializer: 3.0.4
+      protobufjs: 7.5.5
+      retry-request: 8.0.2
+      rimraf: 5.0.10
+    transitivePeerDependencies:
+      - supports-color
+
+  google-logging-utils@1.1.3: {}
+
   gopd@1.2.0: {}
 
   graceful-fs@4.2.11: {}
@@ -4874,6 +5140,20 @@ snapshots:
       toidentifier: 1.0.1
 
   http-parser-js@0.5.10: {}
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   human-signals@2.1.0: {}
 
@@ -5401,6 +5681,10 @@ snapshots:
 
   jsesc@3.1.0: {}
 
+  json-bigint@1.0.0:
+    dependencies:
+      bignumber.js: 9.3.1
+
   json-bignum@0.0.3: {}
 
   json-parse-even-better-errors@2.3.1: {}
@@ -5494,6 +5778,8 @@ snapshots:
   lodash@4.17.21: {}
 
   lodash@4.18.1: {}
+
+  long@5.3.2: {}
 
   lru-cache@10.4.3: {}
 
@@ -5601,7 +5887,15 @@ snapshots:
 
   neo-async@2.6.2: {}
 
+  node-domexception@1.0.0: {}
+
   node-ensure@0.0.0: {}
+
+  node-fetch@3.3.2:
+    dependencies:
+      data-uri-to-buffer: 4.0.1
+      fetch-blob: 3.2.0
+      formdata-polyfill: 4.0.10
 
   node-int64@0.4.0: {}
 
@@ -5614,6 +5908,8 @@ snapshots:
       path-key: 3.1.1
 
   object-assign@4.1.1: {}
+
+  object-hash@3.0.0: {}
 
   object-inspect@1.13.4: {}
 
@@ -5864,6 +6160,25 @@ snapshots:
       '@opentelemetry/api': 1.9.0
       tdigest: 0.1.2
 
+  proto3-json-serializer@3.0.4:
+    dependencies:
+      protobufjs: 7.5.5
+
+  protobufjs@7.5.5:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 24.10.0
+      long: 5.3.2
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -5937,11 +6252,22 @@ snapshots:
 
   retimer@3.0.0: {}
 
+  retry-request@8.0.2:
+    dependencies:
+      extend: 3.0.2
+      teeny-request: 10.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   retry@0.13.1: {}
 
   rimraf@2.7.1:
     dependencies:
       glob: 7.2.3
+
+  rimraf@5.0.10:
+    dependencies:
+      glob: 10.5.0
 
   router@2.2.0:
     dependencies:
@@ -6106,6 +6432,12 @@ snapshots:
     dependencies:
       duplexer: 0.1.2
 
+  stream-events@1.0.5:
+    dependencies:
+      stubs: 3.0.0
+
+  stream-shift@1.0.3: {}
+
   streamsearch@1.1.0: {}
 
   string-length@4.0.2:
@@ -6159,6 +6491,8 @@ snapshots:
     optionalDependencies:
       '@types/node': 24.10.0
 
+  stubs@3.0.0: {}
+
   superagent@10.3.0:
     dependencies:
       component-emitter: 1.3.1
@@ -6211,6 +6545,15 @@ snapshots:
   tdigest@0.1.2:
     dependencies:
       bintrees: 1.0.2
+
+  teeny-request@10.1.2:
+    dependencies:
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 3.3.2
+      stream-events: 1.0.5
+    transitivePeerDependencies:
+      - supports-color
 
   terser@5.46.1:
     dependencies:
@@ -6431,6 +6774,8 @@ snapshots:
   walker@1.0.8:
     dependencies:
       makeerror: 1.0.12
+
+  web-streams-polyfill@3.3.3: {}
 
   which-typed-array@1.1.20:
     dependencies:

--- a/src/api/admin/tenants/ga4Routes.ts
+++ b/src/api/admin/tenants/ga4Routes.ts
@@ -1,0 +1,217 @@
+import type { Express, NextFunction, Request, Response } from "express";
+import type { Pool } from "pg";
+import type { AuthedReq } from "../../middleware/roleAuth";
+import jwt from "jsonwebtoken";
+import { z } from "zod";
+import { runGa4HealthCheck } from "../../../lib/ga4/ga4HealthCheck";
+import { logger } from "../../../lib/logger";
+
+const connectSchema = z.object({
+  property_id: z
+    .string()
+    .min(1)
+    .max(50)
+    .regex(/^\d+$/, "GA4 Property IDは数字のみ"),
+  contact_email: z.string().email().optional(),
+});
+
+export function registerGa4TenantRoutes(app: Express, db: Pool): void {
+  function tenantAuth(req: Request, res: Response, next: NextFunction): void {
+    const authHeader = req.headers.authorization ?? "";
+    if (process.env.NODE_ENV === "development") {
+      if (authHeader.startsWith("Bearer ")) {
+        try {
+          (req as AuthedReq).supabaseUser =
+            (jwt.decode(authHeader.slice(7).trim()) as import("../../middleware/roleAuth").SupabaseJwtUser) ?? undefined;
+        } catch {
+          // ignore
+        }
+      }
+      next();
+      return;
+    }
+    const secret = process.env.SUPABASE_JWT_SECRET;
+    if (!secret) { next(); return; }
+    if (!authHeader.startsWith("Bearer ")) {
+      res.status(401).json({ error: "Missing Bearer token" });
+      return;
+    }
+    try {
+      (req as AuthedReq).supabaseUser = jwt.verify(
+        authHeader.slice(7).trim(),
+        secret,
+      ) as import("../../middleware/roleAuth").SupabaseJwtUser;
+      next();
+    } catch {
+      res.status(401).json({ error: "Invalid token" });
+    }
+  }
+
+  function canAccessTenant(
+    req: Request,
+    res: Response,
+    tenantId: string,
+    next: NextFunction,
+  ): void {
+    const su = (req as AuthedReq).supabaseUser;
+    const role = su?.app_metadata?.role ?? su?.user_metadata?.role ?? "anonymous";
+    const jwtTenantId = su?.app_metadata?.tenant_id as string | undefined;
+    if (role === "super_admin" || jwtTenantId === tenantId) {
+      next();
+      return;
+    }
+    res.status(403).json({ error: "forbidden" });
+  }
+
+  // POST /v1/admin/tenants/:id/ga4/connect — GA4 Property ID登録
+  app.post(
+    "/v1/admin/tenants/:id/ga4/connect",
+    tenantAuth,
+    (req: Request, res: Response, next: NextFunction) =>
+      canAccessTenant(req, res, req.params.id, next),
+    async (req: Request, res: Response) => {
+      const parsed = connectSchema.safeParse(req.body ?? {});
+      if (!parsed.success) {
+        return res.status(400).json({ error: "invalid_request", details: parsed.error.issues });
+      }
+      const { property_id, contact_email } = parsed.data;
+      try {
+        const updates = [
+          "ga4_property_id = $1",
+          "ga4_status = 'pending'",
+          "ga4_invited_at = NOW()",
+          "ga4_error_message = NULL",
+          "updated_at = NOW()",
+        ];
+        const params: unknown[] = [property_id, req.params.id];
+        if (contact_email) {
+          updates.push(`tenant_contact_email = $${params.length + 1}`);
+          params.splice(params.length - 1, 0, contact_email);
+        }
+        const result = await db.query(
+          `UPDATE tenants SET ${updates.join(", ")}
+           WHERE id = $${params.length}
+           RETURNING id, ga4_property_id, ga4_status, ga4_invited_at`,
+          params,
+        );
+        if (result.rowCount === 0) {
+          return res.status(404).json({ error: "not_found" });
+        }
+
+        await db.query(
+          `INSERT INTO ga4_connection_logs
+             (tenant_id, action, status, message, metadata, triggered_by)
+           VALUES ($1, 'invite_sent', 'success', $2, $3, $4)`,
+          [
+            req.params.id,
+            `GA4 property ${property_id} registered`,
+            JSON.stringify({ property_id }),
+            `user:${(req as AuthedReq).supabaseUser?.sub ?? "unknown"}`,
+          ],
+        );
+
+        return res.json({ ok: true, tenant: result.rows[0] });
+      } catch (err) {
+        logger.warn({ err }, "[ga4Routes] connect failed");
+        return res.status(500).json({ error: "connection failed" });
+      }
+    },
+  );
+
+  // POST /v1/admin/tenants/:id/ga4/test — 接続テスト実行
+  app.post(
+    "/v1/admin/tenants/:id/ga4/test",
+    tenantAuth,
+    (req: Request, res: Response, next: NextFunction) =>
+      canAccessTenant(req, res, req.params.id, next),
+    async (req: Request, res: Response) => {
+      const tenantId = req.params.id;
+      try {
+        const row = await db.query(
+          `SELECT ga4_property_id FROM tenants WHERE id = $1`,
+          [tenantId],
+        );
+        if (row.rowCount === 0) {
+          return res.status(404).json({ error: "not_found" });
+        }
+        const propertyId = row.rows[0].ga4_property_id as string | null;
+        if (!propertyId) {
+          return res.status(400).json({ error: "GA4 Property IDが未登録です" });
+        }
+
+        const result = await runGa4HealthCheck(tenantId, propertyId, db);
+        return res.json({ ok: result.status === "connected", result });
+      } catch (err) {
+        logger.warn({ err }, "[ga4Routes] test failed");
+        return res.status(500).json({ error: "test failed" });
+      }
+    },
+  );
+
+  // GET /v1/admin/tenants/:id/ga4/status — 現在のGA4状態
+  app.get(
+    "/v1/admin/tenants/:id/ga4/status",
+    tenantAuth,
+    (req: Request, res: Response, next: NextFunction) =>
+      canAccessTenant(req, res, req.params.id, next),
+    async (req: Request, res: Response) => {
+      try {
+        const result = await db.query(
+          `SELECT ga4_property_id, ga4_status, ga4_invited_at, ga4_connected_at,
+                  ga4_last_sync_at, ga4_error_message, tenant_contact_email
+           FROM tenants WHERE id = $1`,
+          [req.params.id],
+        );
+        if (result.rowCount === 0) {
+          return res.status(404).json({ error: "not_found" });
+        }
+        const history = await db.query(
+          `SELECT test_type, success, error_message, tested_at
+           FROM ga4_test_history WHERE tenant_id = $1
+           ORDER BY tested_at DESC LIMIT 5`,
+          [req.params.id],
+        );
+        return res.json({ ...result.rows[0], recent_tests: history.rows });
+      } catch (err) {
+        logger.warn({ err }, "[ga4Routes] status failed");
+        return res.status(500).json({ error: "status fetch failed" });
+      }
+    },
+  );
+
+  // DELETE /v1/admin/tenants/:id/ga4/disconnect — GA4連携解除
+  app.delete(
+    "/v1/admin/tenants/:id/ga4/disconnect",
+    tenantAuth,
+    (req: Request, res: Response, next: NextFunction) =>
+      canAccessTenant(req, res, req.params.id, next),
+    async (req: Request, res: Response) => {
+      try {
+        const result = await db.query(
+          `UPDATE tenants
+           SET ga4_property_id = NULL, ga4_status = 'not_configured',
+               ga4_connected_at = NULL, ga4_error_message = NULL, updated_at = NOW()
+           WHERE id = $1
+           RETURNING id`,
+          [req.params.id],
+        );
+        if (result.rowCount === 0) {
+          return res.status(404).json({ error: "not_found" });
+        }
+        await db.query(
+          `INSERT INTO ga4_connection_logs
+             (tenant_id, action, status, triggered_by)
+           VALUES ($1, 'disconnected', 'success', $2)`,
+          [
+            req.params.id,
+            `user:${(req as AuthedReq).supabaseUser?.sub ?? "unknown"}`,
+          ],
+        );
+        return res.json({ ok: true });
+      } catch (err) {
+        logger.warn({ err }, "[ga4Routes] disconnect failed");
+        return res.status(500).json({ error: "disconnect failed" });
+      }
+    },
+  );
+}

--- a/src/api/admin/tenants/migration_phase_a.sql
+++ b/src/api/admin/tenants/migration_phase_a.sql
@@ -1,0 +1,154 @@
+-- Phase A Day 2: GA4/PostHog統合 DB Migration
+-- 実行日: 2026-04-22 (Day 2)
+-- 対象: VPS PostgreSQL (65.108.159.161)
+-- 参照: docs/PHASE_A_DB_SCHEMA.md
+
+-- ============================================================
+-- A-1: tenants テーブル GA4/PostHog カラム追加
+-- ============================================================
+
+ALTER TABLE tenants
+  ADD COLUMN IF NOT EXISTS ga4_property_id              TEXT,
+  ADD COLUMN IF NOT EXISTS ga4_status                   TEXT
+    CHECK (ga4_status IN (
+      'not_configured', 'pending', 'connected',
+      'error', 'timeout', 'permission_revoked'
+    )),
+  ADD COLUMN IF NOT EXISTS ga4_invited_at               TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS ga4_connected_at             TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS ga4_last_sync_at             TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS ga4_error_message            TEXT,
+  ADD COLUMN IF NOT EXISTS tenant_contact_email         TEXT,
+  ADD COLUMN IF NOT EXISTS posthog_project_api_key_encrypted TEXT;
+
+-- デフォルト値設定
+UPDATE tenants
+  SET ga4_status = 'not_configured'
+  WHERE ga4_status IS NULL;
+
+ALTER TABLE tenants
+  ALTER COLUMN ga4_status SET DEFAULT 'not_configured';
+
+CREATE INDEX IF NOT EXISTS idx_tenants_ga4_status
+  ON tenants (ga4_status)
+  WHERE ga4_status != 'not_configured';
+
+-- ============================================================
+-- A-2: notification_preferences テーブル新規作成
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS notification_preferences (
+  id                UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id         TEXT NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  notification_type TEXT NOT NULL,
+  email_enabled     BOOLEAN DEFAULT true,
+  in_app_enabled    BOOLEAN DEFAULT true,
+  threshold         JSONB,
+  created_at        TIMESTAMPTZ DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ DEFAULT NOW(),
+
+  UNIQUE (tenant_id, notification_type)
+);
+
+CREATE INDEX IF NOT EXISTS idx_notification_preferences_tenant
+  ON notification_preferences (tenant_id);
+
+-- ============================================================
+-- A-2: ga4_connection_logs テーブル新規作成
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS ga4_connection_logs (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id    TEXT NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  action       TEXT NOT NULL CHECK (action IN (
+    'invite_sent', 'connection_test', 'sync_started',
+    'sync_completed', 'sync_failed', 'disconnected', 'permission_check'
+  )),
+  status       TEXT NOT NULL CHECK (status IN ('success', 'failure', 'pending')),
+  message      TEXT,
+  metadata     JSONB,
+  triggered_by TEXT,
+  created_at   TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ga4_connection_logs_tenant
+  ON ga4_connection_logs (tenant_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_ga4_connection_logs_action
+  ON ga4_connection_logs (action, created_at DESC);
+
+-- ============================================================
+-- A-2: ga4_test_history テーブル新規作成
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS ga4_test_history (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id     TEXT NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  test_type     TEXT NOT NULL CHECK (test_type IN (
+    'measurement_protocol', 'data_stream', 'realtime', 'admin_api'
+  )),
+  success       BOOLEAN NOT NULL,
+  response_code INTEGER,
+  response_body JSONB,
+  latency_ms    INTEGER,
+  error_message TEXT,
+  tested_at     TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_ga4_test_history_tenant_recent
+  ON ga4_test_history (tenant_id, tested_at DESC);
+
+-- ============================================================
+-- A-3: conversion_attributions 拡張 (Phase65既存テーブル)
+-- ============================================================
+
+ALTER TABLE conversion_attributions
+  ADD COLUMN IF NOT EXISTS event_id         UUID,
+  ADD COLUMN IF NOT EXISTS event_type       TEXT
+    CHECK (event_type IN ('macro', 'micro'))
+    DEFAULT 'macro',
+  ADD COLUMN IF NOT EXISTS source           TEXT
+    CHECK (source IN ('r2c_db', 'ga4', 'posthog'))
+    DEFAULT 'r2c_db',
+  ADD COLUMN IF NOT EXISTS rank             TEXT
+    CHECK (rank IN ('A', 'B', 'C', 'D')),
+  ADD COLUMN IF NOT EXISTS deduplicated_at  TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS fired_count      INTEGER DEFAULT 1
+    CHECK (fired_count >= 1);
+
+-- 既存レコードにUUIDを付与
+UPDATE conversion_attributions
+  SET event_id = gen_random_uuid()
+  WHERE event_id IS NULL;
+
+-- event_id を NOT NULL + UNIQUE に変更
+ALTER TABLE conversion_attributions
+  ALTER COLUMN event_id SET NOT NULL;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'conversion_attributions_event_id_key'
+  ) THEN
+    ALTER TABLE conversion_attributions ADD CONSTRAINT conversion_attributions_event_id_key UNIQUE (event_id);
+  END IF;
+END$$;
+
+CREATE INDEX IF NOT EXISTS idx_conversion_attributions_event_id
+  ON conversion_attributions (event_id);
+
+CREATE INDEX IF NOT EXISTS idx_conversion_attributions_source
+  ON conversion_attributions (source, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_conversion_attributions_event_type
+  ON conversion_attributions (event_type, tenant_id, created_at DESC);
+
+-- ============================================================
+-- 確認クエリ (実行後に手動実行して確認)
+-- ============================================================
+-- \d tenants
+-- \d notification_preferences
+-- \d ga4_connection_logs
+-- \d ga4_test_history
+-- \d conversion_attributions

--- a/src/api/internal/ga4SyncRoutes.ts
+++ b/src/api/internal/ga4SyncRoutes.ts
@@ -1,0 +1,84 @@
+import type { Express, Request, Response } from "express";
+import type { Pool } from "pg";
+import { z } from "zod";
+import { internalHmacMiddleware } from "../../lib/crypto/hmacVerifier";
+import { runGa4HealthCheck } from "../../lib/ga4/ga4HealthCheck";
+import { fetchGa4Conversions } from "../../lib/ga4/ga4ConversionFetcher";
+import { logger } from "../../lib/logger";
+
+const healthCheckSchema = z.object({
+  tenant_id: z.string().min(1),
+});
+
+const syncSchema = z.object({
+  tenant_id: z.string().min(1),
+  start_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).default("7daysAgo"),
+  end_date: z.string().default("today"),
+});
+
+export function registerInternalGa4SyncRoutes(app: Express, db: Pool): void {
+  // POST /internal/ga4/health-check — Cloudflare Workers Cron用
+  app.post(
+    "/internal/ga4/health-check",
+    internalHmacMiddleware,
+    async (req: Request, res: Response) => {
+      const parsed = healthCheckSchema.safeParse(req.body ?? {});
+      if (!parsed.success) {
+        return res.status(400).json({ error: "invalid_request", details: parsed.error.issues });
+      }
+      const { tenant_id } = parsed.data;
+      try {
+        const row = await db.query(
+          `SELECT ga4_property_id FROM tenants WHERE id = $1 AND is_active = true`,
+          [tenant_id],
+        );
+        if (row.rowCount === 0) {
+          return res.status(404).json({ error: "tenant_not_found" });
+        }
+        const propertyId = row.rows[0].ga4_property_id as string | null;
+        if (!propertyId) {
+          return res.json({ ok: false, reason: "ga4_not_configured" });
+        }
+        const result = await runGa4HealthCheck(tenant_id, propertyId, db);
+        return res.json({ ok: result.status === "connected", result });
+      } catch (err) {
+        logger.warn({ err, tenant_id }, "[internalGa4] health-check error");
+        return res.status(500).json({ error: "internal error" });
+      }
+    },
+  );
+
+  // POST /internal/ga4/sync — CV取得バッチ (Cloudflare Workers Cron用)
+  app.post(
+    "/internal/ga4/sync",
+    internalHmacMiddleware,
+    async (req: Request, res: Response) => {
+      const parsed = syncSchema.safeParse(req.body ?? {});
+      if (!parsed.success) {
+        return res.status(400).json({ error: "invalid_request", details: parsed.error.issues });
+      }
+      const { tenant_id, start_date, end_date } = parsed.data;
+      try {
+        const row = await db.query(
+          `SELECT ga4_property_id, ga4_status FROM tenants WHERE id = $1 AND is_active = true`,
+          [tenant_id],
+        );
+        if (row.rowCount === 0) {
+          return res.status(404).json({ error: "tenant_not_found" });
+        }
+        const { ga4_property_id: propertyId, ga4_status: status } = row.rows[0] as {
+          ga4_property_id: string | null;
+          ga4_status: string;
+        };
+        if (!propertyId || status !== "connected") {
+          return res.json({ ok: false, reason: `ga4_status_${status}` });
+        }
+        const summary = await fetchGa4Conversions(tenant_id, propertyId, start_date, end_date, db);
+        return res.json({ ok: !!summary, summary });
+      } catch (err) {
+        logger.warn({ err, tenant_id }, "[internalGa4] sync error");
+        return res.status(500).json({ error: "internal error" });
+      }
+    },
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,8 @@ import { registerFalGenerationRoutes } from "./api/admin/avatar/falGenerationRou
 import { registerPremiumGenerationRoutes } from "./api/admin/avatar/premiumGenerationRoutes";
 import { registerInternalUsageRoutes } from "./api/internal/usageRoutes";
 import { registerInternalAvatarConfigRoutes } from "./api/internal/avatarConfigRoutes";
+import { registerGa4TenantRoutes } from "./api/admin/tenants/ga4Routes";
+import { registerInternalGa4SyncRoutes } from "./api/internal/ga4SyncRoutes";
 import { registerEvaluationRoutes } from "./api/admin/evaluations/routes";
 import { registerVariantRoutes } from "./api/admin/variants/routes";
 import { registerObjectionPatternRoutes } from "./api/admin/objection-patterns/routes";
@@ -481,6 +483,9 @@ registerKnowledgeAdminRoutes(app);
 // Phase31: テナント管理API
 if (db) registerTenantAdminRoutes(app, db);
 
+// Phase A: GA4連携管理API (テナント別 connect/test/status/disconnect)
+if (db) registerGa4TenantRoutes(app, db);
+
 // Phase32: 課金管理API
 if (db) initUsageTracker(db, logger);
 
@@ -545,6 +550,9 @@ registerInternalUsageRoutes(app);
 
 // Internal: avatar-agent → テナント別アバター設定取得（X-Internal-Request: 1 認証）
 registerInternalAvatarConfigRoutes(app);
+
+// Phase A: GA4連携 内部API (Cloudflare Workers Cron用, HMAC認証)
+if (db) registerInternalGa4SyncRoutes(app, db);
 
 // Phase41: Avatar Customization Studio — Admin CRUD API
 if (db) registerAvatarConfigRoutes(app, db);

--- a/src/lib/crypto/hmacVerifier.ts
+++ b/src/lib/crypto/hmacVerifier.ts
@@ -1,0 +1,64 @@
+import { createHmac, timingSafeEqual } from "node:crypto";
+import type { Request, Response, NextFunction } from "express";
+import { logger } from "../logger";
+
+const TIMESTAMP_TOLERANCE_SEC = 300; // 5 minutes
+
+export function verifyHmacSignature(
+  secret: string,
+  timestamp: string,
+  body: unknown,
+  signature: string,
+): boolean {
+  const now = Math.floor(Date.now() / 1000);
+  const ts = parseInt(timestamp, 10);
+  if (isNaN(ts) || Math.abs(now - ts) > TIMESTAMP_TOLERANCE_SEC) {
+    return false;
+  }
+  const message = `${timestamp}:${JSON.stringify(body)}`;
+  const expected = createHmac("sha256", secret).update(message).digest("hex");
+  try {
+    return timingSafeEqual(Buffer.from(signature, "hex"), Buffer.from(expected, "hex"));
+  } catch {
+    return false;
+  }
+}
+
+export function internalHmacMiddleware(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  if (req.headers["x-internal-request"] !== "1") {
+    res.status(403).json({ error: "forbidden" });
+    return;
+  }
+
+  const secret = process.env.INTERNAL_API_HMAC_SECRET;
+  if (!secret) {
+    // HMAC secret 未設定は開発環境のみ許容
+    if (process.env.NODE_ENV !== "production") {
+      next();
+      return;
+    }
+    res.status(500).json({ error: "HMAC secret not configured" });
+    return;
+  }
+
+  const timestamp = req.headers["x-hmac-timestamp"] as string | undefined;
+  const signature = req.headers["x-hmac-signature"] as string | undefined;
+
+  if (!timestamp || !signature) {
+    logger.warn("[hmacVerifier] missing HMAC headers");
+    res.status(401).json({ error: "Missing HMAC headers" });
+    return;
+  }
+
+  if (!verifyHmacSignature(secret, timestamp, req.body, signature)) {
+    logger.warn("[hmacVerifier] invalid HMAC signature");
+    res.status(401).json({ error: "Invalid HMAC signature" });
+    return;
+  }
+
+  next();
+}

--- a/src/lib/ga4/ga4Client.ts
+++ b/src/lib/ga4/ga4Client.ts
@@ -1,0 +1,91 @@
+import { BetaAnalyticsDataClient } from "@google-analytics/data";
+import { logger } from "../logger";
+
+export type Ga4ClientStatus = "ok" | "not_configured" | "error";
+
+export interface Ga4CheckResult {
+  status: Ga4ClientStatus;
+  error?: string;
+}
+
+let _client: BetaAnalyticsDataClient | null = null;
+
+function getClient(): BetaAnalyticsDataClient | null {
+  if (_client) return _client;
+
+  const credentialsB64 = process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON;
+  if (!credentialsB64) return null;
+
+  try {
+    const json = Buffer.from(credentialsB64, "base64").toString("utf-8");
+    const credentials = JSON.parse(json) as Record<string, unknown>;
+    _client = new BetaAnalyticsDataClient({ credentials });
+    return _client;
+  } catch (err) {
+    logger.warn({ err }, "[ga4Client] failed to initialize client");
+    return null;
+  }
+}
+
+export async function checkGa4Connection(
+  propertyId: string,
+): Promise<Ga4CheckResult> {
+  const client = getClient();
+  if (!client) {
+    return { status: "not_configured" };
+  }
+
+  try {
+    // Minimal request to verify access — last 1 day, 1 dimension, 1 metric
+    await client.runReport({
+      property: `properties/${propertyId}`,
+      dateRanges: [{ startDate: "1daysAgo", endDate: "today" }],
+      dimensions: [{ name: "date" }],
+      metrics: [{ name: "sessions" }],
+      limit: 1,
+    });
+    return { status: "ok" };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.warn({ err, propertyId }, "[ga4Client] connection check failed");
+
+    if (message.includes("PERMISSION_DENIED") || message.includes("403")) {
+      return { status: "error", error: "permission_denied" };
+    }
+    if (message.includes("NOT_FOUND") || message.includes("404")) {
+      return { status: "error", error: "property_not_found" };
+    }
+    return { status: "error", error: message.slice(0, 200) };
+  }
+}
+
+export async function runGa4ConversionReport(
+  propertyId: string,
+  startDate: string,
+  endDate: string,
+): Promise<{ date: string; conversions: number }[]> {
+  const client = getClient();
+  if (!client) return [];
+
+  try {
+    const [response] = await client.runReport({
+      property: `properties/${propertyId}`,
+      dateRanges: [{ startDate, endDate }],
+      dimensions: [{ name: "date" }],
+      metrics: [{ name: "conversions" }],
+    });
+
+    return (response.rows ?? []).map((row) => ({
+      date: row.dimensionValues?.[0]?.value ?? "",
+      conversions: Number(row.metricValues?.[0]?.value ?? 0),
+    }));
+  } catch (err) {
+    logger.warn({ err, propertyId }, "[ga4Client] runReport failed");
+    return [];
+  }
+}
+
+// Allow resetting client in tests
+export function _resetClientForTest(): void {
+  _client = null;
+}

--- a/src/lib/ga4/ga4ConversionFetcher.ts
+++ b/src/lib/ga4/ga4ConversionFetcher.ts
@@ -1,0 +1,54 @@
+import type { Pool } from "pg";
+import { runGa4ConversionReport } from "./ga4Client";
+import { logger } from "../logger";
+
+export interface Ga4ConversionSummary {
+  propertyId: string;
+  startDate: string;
+  endDate: string;
+  totalConversions: number;
+  byDate: { date: string; conversions: number }[];
+}
+
+export async function fetchGa4Conversions(
+  tenantId: string,
+  propertyId: string,
+  startDate: string,
+  endDate: string,
+  db: Pool,
+): Promise<Ga4ConversionSummary | null> {
+  try {
+    const rows = await runGa4ConversionReport(propertyId, startDate, endDate);
+    const totalConversions = rows.reduce((sum, r) => sum + r.conversions, 0);
+
+    // Update last sync timestamp
+    await db.query(
+      `UPDATE tenants SET ga4_last_sync_at = NOW() WHERE id = $1`,
+      [tenantId],
+    );
+
+    await db.query(
+      `INSERT INTO ga4_connection_logs
+         (tenant_id, action, status, message, metadata, triggered_by)
+       VALUES ($1, 'sync_completed', 'success', $2, $3, 'cron')`,
+      [
+        tenantId,
+        `Fetched ${totalConversions} conversions`,
+        JSON.stringify({ startDate, endDate, rows: rows.length }),
+      ],
+    );
+
+    return { propertyId, startDate, endDate, totalConversions, byDate: rows };
+  } catch (err) {
+    logger.warn({ err, tenantId, propertyId }, "[ga4ConversionFetcher] fetch failed");
+
+    await db.query(
+      `INSERT INTO ga4_connection_logs
+         (tenant_id, action, status, message, triggered_by)
+       VALUES ($1, 'sync_failed', 'failure', $2, 'cron')`,
+      [tenantId, err instanceof Error ? err.message.slice(0, 200) : "unknown"],
+    ).catch(() => undefined);
+
+    return null;
+  }
+}

--- a/src/lib/ga4/ga4HealthCheck.ts
+++ b/src/lib/ga4/ga4HealthCheck.ts
@@ -1,0 +1,113 @@
+import type { Pool } from "pg";
+import { checkGa4Connection } from "./ga4Client";
+import { logger } from "../logger";
+
+export type Ga4StatusValue =
+  | "not_configured"
+  | "pending"
+  | "connected"
+  | "error"
+  | "timeout"
+  | "permission_revoked";
+
+export interface Ga4HealthResult {
+  status: Ga4StatusValue;
+  errorMessage?: string;
+  connectedAt?: Date;
+}
+
+const TEST_TIMEOUT_MS = 10_000;
+
+export async function runGa4HealthCheck(
+  tenantId: string,
+  propertyId: string,
+  db: Pool,
+): Promise<Ga4HealthResult> {
+  logger.info({ tenantId, propertyId }, "[ga4HealthCheck] starting");
+
+  let result: Ga4HealthResult;
+
+  try {
+    const checkPromise = checkGa4Connection(propertyId);
+    const timeoutPromise = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error("timeout")), TEST_TIMEOUT_MS),
+    );
+
+    const check = await Promise.race([checkPromise, timeoutPromise]);
+
+    if (check.status === "not_configured") {
+      result = { status: "not_configured" };
+    } else if (check.status === "ok") {
+      result = { status: "connected", connectedAt: new Date() };
+    } else {
+      const errMsg = check.error ?? "unknown";
+      const status: Ga4StatusValue = errMsg === "permission_denied"
+        ? "permission_revoked"
+        : "error";
+      result = { status, errorMessage: errMsg };
+    }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (message === "timeout") {
+      result = { status: "timeout", errorMessage: "Connection timed out after 10s" };
+    } else {
+      result = { status: "error", errorMessage: message.slice(0, 200) };
+    }
+  }
+
+  await persistHealthResult(tenantId, propertyId, result, db);
+  return result;
+}
+
+async function persistHealthResult(
+  tenantId: string,
+  propertyId: string,
+  result: Ga4HealthResult,
+  db: Pool,
+): Promise<void> {
+  try {
+    // Update tenant GA4 status
+    const updates: string[] = ["ga4_status = $1", "updated_at = NOW()"];
+    const params: unknown[] = [result.status, tenantId];
+
+    if (result.errorMessage !== undefined) {
+      updates.push(`ga4_error_message = $${params.length + 1}`);
+      params.splice(params.length - 1, 0, result.errorMessage);
+    }
+    if (result.status === "connected" && result.connectedAt) {
+      updates.push(`ga4_connected_at = $${params.length}`);
+      params.splice(params.length - 1, 0, result.connectedAt);
+    }
+    if (result.status === "connected") {
+      updates.push(`ga4_last_sync_at = NOW()`);
+    }
+
+    await db.query(
+      `UPDATE tenants SET ${updates.join(", ")} WHERE id = $${params.length}`,
+      params,
+    );
+
+    // Insert test history
+    await db.query(
+      `INSERT INTO ga4_test_history
+         (tenant_id, test_type, success, error_message, tested_at)
+       VALUES ($1, 'measurement_protocol', $2, $3, NOW())`,
+      [tenantId, result.status === "connected", result.errorMessage ?? null],
+    );
+
+    // Log action
+    await db.query(
+      `INSERT INTO ga4_connection_logs
+         (tenant_id, action, status, message, metadata, triggered_by)
+       VALUES ($1, 'connection_test', $2, $3, $4, 'user')`,
+      [
+        tenantId,
+        result.status === "connected" ? "success" : "failure",
+        result.errorMessage ?? result.status,
+        JSON.stringify({ propertyId }),
+      ],
+    );
+  } catch (err) {
+    logger.warn({ err, tenantId }, "[ga4HealthCheck] failed to persist result");
+  }
+}

--- a/tests/phase-a/ga4Client.test.ts
+++ b/tests/phase-a/ga4Client.test.ts
@@ -1,0 +1,67 @@
+// tests/phase-a/ga4Client.test.ts
+import { checkGa4Connection, _resetClientForTest } from "../../src/lib/ga4/ga4Client";
+
+jest.mock("@google-analytics/data", () => ({
+  BetaAnalyticsDataClient: jest.fn().mockImplementation(() => ({
+    runReport: jest.fn(),
+  })),
+}));
+
+import { BetaAnalyticsDataClient } from "@google-analytics/data";
+
+const MockedClient = BetaAnalyticsDataClient as jest.MockedClass<typeof BetaAnalyticsDataClient>;
+
+describe("checkGa4Connection", () => {
+  beforeEach(() => {
+    _resetClientForTest();
+    MockedClient.mockClear();
+  });
+
+  afterEach(() => {
+    delete process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON;
+  });
+
+  it("returns not_configured when credentials env is missing", async () => {
+    delete process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON;
+    const result = await checkGa4Connection("123456789");
+    expect(result.status).toBe("not_configured");
+  });
+
+  it("returns ok when runReport succeeds", async () => {
+    const creds = { type: "service_account", project_id: "test", private_key: "k", client_email: "e@test.iam.gserviceaccount.com" };
+    process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON = Buffer.from(JSON.stringify(creds)).toString("base64");
+
+    const mockRunReport = jest.fn().mockResolvedValue([{ rows: [] }]);
+    MockedClient.mockImplementation(() => ({ runReport: mockRunReport } as unknown as BetaAnalyticsDataClient));
+
+    const result = await checkGa4Connection("123456789");
+    expect(result.status).toBe("ok");
+    expect(mockRunReport).toHaveBeenCalledWith(expect.objectContaining({
+      property: "properties/123456789",
+    }));
+  });
+
+  it("returns error with permission_denied for 403 error", async () => {
+    const creds = { type: "service_account" };
+    process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON = Buffer.from(JSON.stringify(creds)).toString("base64");
+
+    const mockRunReport = jest.fn().mockRejectedValue(new Error("PERMISSION_DENIED: Access denied"));
+    MockedClient.mockImplementation(() => ({ runReport: mockRunReport } as unknown as BetaAnalyticsDataClient));
+
+    const result = await checkGa4Connection("123456789");
+    expect(result.status).toBe("error");
+    expect(result.error).toBe("permission_denied");
+  });
+
+  it("returns error with property_not_found for 404 error", async () => {
+    const creds = { type: "service_account" };
+    process.env.GOOGLE_APPLICATION_CREDENTIALS_JSON = Buffer.from(JSON.stringify(creds)).toString("base64");
+
+    const mockRunReport = jest.fn().mockRejectedValue(new Error("NOT_FOUND: Property not found"));
+    MockedClient.mockImplementation(() => ({ runReport: mockRunReport } as unknown as BetaAnalyticsDataClient));
+
+    const result = await checkGa4Connection("999999999");
+    expect(result.status).toBe("error");
+    expect(result.error).toBe("property_not_found");
+  });
+});

--- a/tests/phase-a/ga4Routes.test.ts
+++ b/tests/phase-a/ga4Routes.test.ts
@@ -1,0 +1,165 @@
+// tests/phase-a/ga4Routes.test.ts
+import express from "express";
+import request from "supertest";
+import jwt from "jsonwebtoken";
+import { registerGa4TenantRoutes } from "../../src/api/admin/tenants/ga4Routes";
+
+jest.mock("../../src/lib/ga4/ga4HealthCheck", () => ({
+  runGa4HealthCheck: jest.fn(),
+}));
+
+import { runGa4HealthCheck } from "../../src/lib/ga4/ga4HealthCheck";
+const mockHealthCheck = runGa4HealthCheck as jest.MockedFunction<typeof runGa4HealthCheck>;
+
+const JWT_SECRET = "test-jwt-secret";
+
+function makeToken(role: "super_admin" | "client_admin", tenantId: string) {
+  return jwt.sign({ app_metadata: { role, tenant_id: tenantId } }, JWT_SECRET);
+}
+
+function makeApp(queryResponses: Array<{ rows: unknown[]; rowCount?: number } | Error>) {
+  const app = express();
+  app.use(express.json());
+  process.env.SUPABASE_JWT_SECRET = JWT_SECRET;
+  process.env.NODE_ENV = "production";
+
+  let callCount = 0;
+  const mockDb: any = {
+    query: jest.fn().mockImplementation(() => {
+      const resp = queryResponses[callCount++] ?? { rows: [], rowCount: 0 };
+      if (resp instanceof Error) return Promise.reject(resp);
+      return Promise.resolve(resp);
+    }),
+  };
+  registerGa4TenantRoutes(app, mockDb);
+  return { app, mockDb };
+}
+
+describe("POST /v1/admin/tenants/:id/ga4/connect", () => {
+  afterEach(() => {
+    delete process.env.SUPABASE_JWT_SECRET;
+    delete process.env.NODE_ENV;
+  });
+
+  it("saves property ID and returns pending status", async () => {
+    const { app } = makeApp([
+      { rows: [{ id: "tenant-a", ga4_property_id: "111", ga4_status: "pending", ga4_invited_at: new Date() }], rowCount: 1 },
+      { rows: [], rowCount: 1 }, // log insert
+    ]);
+    const res = await request(app)
+      .post("/v1/admin/tenants/tenant-a/ga4/connect")
+      .set("Authorization", `Bearer ${makeToken("super_admin", "tenant-a")}`)
+      .send({ property_id: "111" });
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.tenant.ga4_status).toBe("pending");
+  });
+
+  it("rejects invalid property_id (non-numeric)", async () => {
+    const { app } = makeApp([]);
+    const res = await request(app)
+      .post("/v1/admin/tenants/tenant-a/ga4/connect")
+      .set("Authorization", `Bearer ${makeToken("super_admin", "tenant-a")}`)
+      .send({ property_id: "not-a-number" });
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 403 for wrong tenant client_admin", async () => {
+    const { app } = makeApp([]);
+    const res = await request(app)
+      .post("/v1/admin/tenants/tenant-b/ga4/connect")
+      .set("Authorization", `Bearer ${makeToken("client_admin", "tenant-a")}`)
+      .send({ property_id: "111" });
+    expect(res.status).toBe(403);
+  });
+});
+
+describe("POST /v1/admin/tenants/:id/ga4/test", () => {
+  afterEach(() => {
+    delete process.env.SUPABASE_JWT_SECRET;
+    delete process.env.NODE_ENV;
+    mockHealthCheck.mockClear();
+  });
+
+  it("returns ok:true when health check passes", async () => {
+    mockHealthCheck.mockResolvedValue({ status: "connected", connectedAt: new Date() });
+    const { app } = makeApp([
+      { rows: [{ ga4_property_id: "111" }], rowCount: 1 },
+    ]);
+    const res = await request(app)
+      .post("/v1/admin/tenants/tenant-a/ga4/test")
+      .set("Authorization", `Bearer ${makeToken("super_admin", "tenant-a")}`);
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.result.status).toBe("connected");
+  });
+
+  it("returns ok:false when health check fails", async () => {
+    mockHealthCheck.mockResolvedValue({ status: "error", errorMessage: "permission_denied" });
+    const { app } = makeApp([
+      { rows: [{ ga4_property_id: "111" }], rowCount: 1 },
+    ]);
+    const res = await request(app)
+      .post("/v1/admin/tenants/tenant-a/ga4/test")
+      .set("Authorization", `Bearer ${makeToken("super_admin", "tenant-a")}`);
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(false);
+  });
+
+  it("returns 400 when no property_id is set", async () => {
+    const { app } = makeApp([
+      { rows: [{ ga4_property_id: null }], rowCount: 1 },
+    ]);
+    const res = await request(app)
+      .post("/v1/admin/tenants/tenant-a/ga4/test")
+      .set("Authorization", `Bearer ${makeToken("super_admin", "tenant-a")}`);
+    expect(res.status).toBe(400);
+  });
+});
+
+describe("GET /v1/admin/tenants/:id/ga4/status", () => {
+  afterEach(() => {
+    delete process.env.SUPABASE_JWT_SECRET;
+    delete process.env.NODE_ENV;
+  });
+
+  it("returns GA4 status with recent tests", async () => {
+    const { app } = makeApp([
+      {
+        rows: [{
+          ga4_property_id: "111", ga4_status: "connected",
+          ga4_invited_at: null, ga4_connected_at: new Date(),
+          ga4_last_sync_at: new Date(), ga4_error_message: null,
+          tenant_contact_email: "test@example.com",
+        }],
+        rowCount: 1,
+      },
+      { rows: [{ test_type: "measurement_protocol", success: true, error_message: null, tested_at: new Date() }], rowCount: 1 },
+    ]);
+    const res = await request(app)
+      .get("/v1/admin/tenants/tenant-a/ga4/status")
+      .set("Authorization", `Bearer ${makeToken("super_admin", "tenant-a")}`);
+    expect(res.status).toBe(200);
+    expect(res.body.ga4_status).toBe("connected");
+    expect(res.body.recent_tests).toHaveLength(1);
+  });
+});
+
+describe("DELETE /v1/admin/tenants/:id/ga4/disconnect", () => {
+  afterEach(() => {
+    delete process.env.SUPABASE_JWT_SECRET;
+    delete process.env.NODE_ENV;
+  });
+
+  it("disconnects GA4 and returns ok", async () => {
+    const { app } = makeApp([
+      { rows: [{ id: "tenant-a" }], rowCount: 1 },
+      { rows: [], rowCount: 1 },
+    ]);
+    const res = await request(app)
+      .delete("/v1/admin/tenants/tenant-a/ga4/disconnect")
+      .set("Authorization", `Bearer ${makeToken("super_admin", "tenant-a")}`);
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+});

--- a/tests/phase-a/hmacVerifier.test.ts
+++ b/tests/phase-a/hmacVerifier.test.ts
@@ -1,0 +1,101 @@
+// tests/phase-a/hmacVerifier.test.ts
+import { createHmac } from "node:crypto";
+import express from "express";
+import request from "supertest";
+import { internalHmacMiddleware, verifyHmacSignature } from "../../src/lib/crypto/hmacVerifier";
+
+const SECRET = "test-secret-for-jest";
+
+function makeSignedHeaders(body: unknown, secret: string = SECRET) {
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const message = `${timestamp}:${JSON.stringify(body)}`;
+  const signature = createHmac("sha256", secret).update(message).digest("hex");
+  return { "x-hmac-timestamp": timestamp, "x-hmac-signature": signature };
+}
+
+describe("verifyHmacSignature", () => {
+  const body = { task: "test" };
+
+  it("returns true for valid signature", () => {
+    const { "x-hmac-timestamp": ts, "x-hmac-signature": sig } = makeSignedHeaders(body);
+    expect(verifyHmacSignature(SECRET, ts, body, sig)).toBe(true);
+  });
+
+  it("returns false for wrong secret", () => {
+    const { "x-hmac-timestamp": ts, "x-hmac-signature": sig } = makeSignedHeaders(body, "wrong-secret");
+    expect(verifyHmacSignature(SECRET, ts, body, sig)).toBe(false);
+  });
+
+  it("returns false for stale timestamp (>5min)", () => {
+    const oldTimestamp = (Math.floor(Date.now() / 1000) - 400).toString();
+    const message = `${oldTimestamp}:${JSON.stringify(body)}`;
+    const sig = createHmac("sha256", SECRET).update(message).digest("hex");
+    expect(verifyHmacSignature(SECRET, oldTimestamp, body, sig)).toBe(false);
+  });
+
+  it("returns false for tampered body", () => {
+    const { "x-hmac-timestamp": ts, "x-hmac-signature": sig } = makeSignedHeaders(body);
+    expect(verifyHmacSignature(SECRET, ts, { task: "tampered" }, sig)).toBe(false);
+  });
+});
+
+describe("internalHmacMiddleware", () => {
+  function makeApp() {
+    const app = express();
+    app.use(express.json());
+    process.env.INTERNAL_API_HMAC_SECRET = SECRET;
+    app.post("/internal/test", internalHmacMiddleware, (_req, res) => {
+      res.json({ ok: true });
+    });
+    return app;
+  }
+
+  afterEach(() => {
+    delete process.env.INTERNAL_API_HMAC_SECRET;
+  });
+
+  it("allows request with valid HMAC and x-internal-request header", async () => {
+    const app = makeApp();
+    const body = { task: "sync" };
+    const headers = makeSignedHeaders(body);
+    const res = await request(app)
+      .post("/internal/test")
+      .set("x-internal-request", "1")
+      .set(headers)
+      .send(body);
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it("rejects without x-internal-request header", async () => {
+    const app = makeApp();
+    const body = { task: "sync" };
+    const headers = makeSignedHeaders(body);
+    const res = await request(app)
+      .post("/internal/test")
+      .set(headers)
+      .send(body);
+    expect(res.status).toBe(403);
+  });
+
+  it("rejects with invalid HMAC signature", async () => {
+    const app = makeApp();
+    const body = { task: "sync" };
+    const res = await request(app)
+      .post("/internal/test")
+      .set("x-internal-request", "1")
+      .set("x-hmac-timestamp", Math.floor(Date.now() / 1000).toString())
+      .set("x-hmac-signature", "deadbeef".repeat(8))
+      .send(body);
+    expect(res.status).toBe(401);
+  });
+
+  it("rejects when HMAC headers are missing", async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .post("/internal/test")
+      .set("x-internal-request", "1")
+      .send({ task: "sync" });
+    expect(res.status).toBe(401);
+  });
+});


### PR DESCRIPTION
## Summary
- `src/lib/ga4/`: GA4 Data API クライアント・ヘルスチェック・CV取得 (3ファイル)
- `src/lib/crypto/hmacVerifier.ts`: HMAC-SHA256ミドルウェア (Cloudflare Workers ↔ VPS認証)
- `src/api/admin/tenants/ga4Routes.ts`: GA4 connect/test/status/disconnect 4エンドポイント
- `src/api/internal/ga4SyncRoutes.ts`: Workers Cron用内部API (HMAC認証)
- `src/api/admin/tenants/migration_phase_a.sql`: DB migration SQL (Day 2でVPSに手動適用)
- `docs/DEPLOY_CHECKLIST.md`: migration手順 + 環境変数追加手順を追記

## API一覧
| Method | Path | 認証 | 概要 |
|---|---|---|---|
| POST | /v1/admin/tenants/:id/ga4/connect | JWT | Property ID登録 |
| POST | /v1/admin/tenants/:id/ga4/test | JWT | 接続テスト |
| GET | /v1/admin/tenants/:id/ga4/status | JWT | 現在の状態 |
| DELETE | /v1/admin/tenants/:id/ga4/disconnect | JWT | 連携解除 |
| POST | /internal/ga4/health-check | HMAC | Workers Cron用 |
| POST | /internal/ga4/sync | HMAC | Workers CV取得用 |

## Gate結果
- ✅ Gate 1 (typecheck): 0 errors
- ✅ Gate 2 (test): 1131 passed (新規20テスト: hmacVerifier x8, ga4Client x4, ga4Routes x8)
- ✅ Gate 3 (build): 0 errors

## ⚠️ Day 2 でhkobayashiが手動実行
```bash
# VPS: バックアップ後に migration_phase_a.sql 適用
psql $DATABASE_URL < /opt/rajiuce/src/api/admin/tenants/migration_phase_a.sql
# .env に GOOGLE_APPLICATION_CREDENTIALS_JSON, INTERNAL_API_HMAC_SECRET を追加
```

## Asana
- 親タスク: https://app.asana.com/1/817733952351708/project/1213607637045514/task/1214145722184082
- サブタスク: https://app.asana.com/1/817733952351708/project/1213607637045514/task/1214145936746584

🤖 Generated with [Claude Code](https://claude.com/claude-code)