### PR TITLE
feat(workers): Phase A Day 4 — Cloudflare Workers Cron + Email Service実装

### DIFF
--- a/cloudflare-workers/r2c-analytics-worker/src/globals.d.ts
+++ b/cloudflare-workers/r2c-analytics-worker/src/globals.d.ts
@@ -1,0 +1,7 @@
+// EmailMessage is a runtime global in Cloudflare Workers but workers-types defines it
+// only as an interface. Augment global scope so it can be used as a constructor.
+declare const EmailMessage: new (
+  from: string,
+  to: string,
+  raw: string | ReadableStream,
+) => { from: string; to: string; raw: ReadableStream | string };

--- a/cloudflare-workers/r2c-analytics-worker/src/handlers/errorNotifyHandler.ts
+++ b/cloudflare-workers/r2c-analytics-worker/src/handlers/errorNotifyHandler.ts
@@ -1,0 +1,76 @@
+import { buildHmacHeaders } from '../lib/hmacSigner';
+import { sendEmail } from '../lib/emailSender';
+import type { Env } from '../types';
+
+interface NotifyPayload {
+  to: string;
+  subject: string;
+  body: string;
+}
+
+// POST /send-notification — called by VPS via HMAC-authenticated request
+export async function handleSendNotification(request: Request, env: Env): Promise<Response> {
+  if (request.method !== 'POST') {
+    return new Response('Method Not Allowed', { status: 405 });
+  }
+
+  const hmacError = await verifyHmac(request.clone(), env.INTERNAL_API_HMAC_SECRET);
+  if (hmacError) {
+    return Response.json({ error: hmacError }, { status: 401 });
+  }
+
+  let payload: NotifyPayload;
+  try {
+    payload = (await request.json()) as NotifyPayload;
+  } catch {
+    return Response.json({ error: 'invalid_json' }, { status: 400 });
+  }
+
+  if (!payload.to || !payload.subject || !payload.body) {
+    return Response.json({ error: 'missing_fields' }, { status: 400 });
+  }
+
+  try {
+    await sendEmail(env, payload);
+    return Response.json({ ok: true });
+  } catch (err) {
+    console.error('[errorNotifyHandler] send failed:', err);
+    return Response.json({ error: 'send_failed', detail: String(err) }, { status: 500 });
+  }
+}
+
+async function verifyHmac(request: Request, secret: string): Promise<string | null> {
+  const timestamp = request.headers.get('x-hmac-timestamp');
+  const signature = request.headers.get('x-hmac-signature');
+
+  if (!timestamp || !signature) return 'missing_hmac_headers';
+
+  const now = Math.floor(Date.now() / 1000);
+  if (Math.abs(now - parseInt(timestamp, 10)) > 300) return 'stale_timestamp';
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return 'invalid_body';
+  }
+
+  const message = `${timestamp}:${JSON.stringify(body)}`;
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const sigBuf = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(message));
+  const expected = Array.from(new Uint8Array(sigBuf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+
+  if (signature !== expected) return 'invalid_signature';
+  return null;
+}
+
+// Build signed headers for outbound requests (re-exported for testing convenience)
+export { buildHmacHeaders };

--- a/cloudflare-workers/r2c-analytics-worker/src/handlers/ga4HealthCheckHandler.ts
+++ b/cloudflare-workers/r2c-analytics-worker/src/handlers/ga4HealthCheckHandler.ts
@@ -1,0 +1,80 @@
+import { callGa4HealthCheckAll } from '../lib/vpsApiClient';
+import { sendEmail } from '../lib/emailSender';
+import type { Env, Ga4TenantHealthResult } from '../types';
+
+const ERROR_STATUSES = new Set(['error', 'timeout', 'permission_revoked']);
+
+// In-memory dedupe: tenantId → last notification timestamp (ms)
+// Resets on Worker process restart; notifications throttled to once per hour per tenant
+const lastNotifiedAt = new Map<string, number>();
+const NOTIFY_INTERVAL_MS = 60 * 60 * 1000;
+
+export async function runGa4HealthCheckCron(env: Env): Promise<void> {
+  console.log('[ga4HealthCheckHandler] starting cron run');
+
+  let results: Ga4TenantHealthResult[];
+  try {
+    results = await callGa4HealthCheckAll(env);
+  } catch (err) {
+    console.error('[ga4HealthCheckHandler] VPS call failed:', err);
+    await notifyAdminError(env, `GA4ヘルスチェックCron実行エラー\n\n${String(err)}`);
+    return;
+  }
+
+  console.log(`[ga4HealthCheckHandler] checked ${results.length} tenants`);
+
+  const now = Date.now();
+  for (const result of results) {
+    if (!ERROR_STATUSES.has(result.status)) continue;
+
+    const lastNotified = lastNotifiedAt.get(result.tenant_id) ?? 0;
+    if (now - lastNotified < NOTIFY_INTERVAL_MS) {
+      console.log(`[ga4HealthCheckHandler] skip duplicate notification for ${result.tenant_id}`);
+      continue;
+    }
+
+    lastNotifiedAt.set(result.tenant_id, now);
+    await notifyTenantError(env, result);
+  }
+}
+
+async function notifyTenantError(env: Env, result: Ga4TenantHealthResult): Promise<void> {
+  const to = env.ALERT_EMAIL_TO;
+  const subject = `[R2C] GA4連携エラー検知 (tenant: ${result.tenant_id})`;
+  const body = [
+    'GA4連携エラーが検知されました。',
+    '',
+    `テナントID: ${result.tenant_id}`,
+    `エラーステータス: ${result.status}`,
+    `エラー内容: ${result.error_message ?? '(詳細なし)'}`,
+    '',
+    '対処方法:',
+    '1. Admin UI → テナント詳細 → 📊 GA4連携 タブを開く',
+    '2. 「接続テスト」を実行してエラー詳細を確認する',
+    '3. 必要に応じてサービスアカウントのGA4プロパティへのアクセス権を再設定する',
+    '',
+    `確認URL: https://admin.r2c.biz/admin/tenants/${result.tenant_id}`,
+    '',
+    '---',
+    'このメールはR2CシステムのCloudflare Workersから自動送信されています。',
+  ].join('\n');
+
+  try {
+    await sendEmail(env, { to, subject, body });
+    console.log(`[ga4HealthCheckHandler] error notification sent for ${result.tenant_id}`);
+  } catch (err) {
+    console.error(`[ga4HealthCheckHandler] email send failed for ${result.tenant_id}:`, err);
+  }
+}
+
+async function notifyAdminError(env: Env, message: string): Promise<void> {
+  try {
+    await sendEmail(env, {
+      to: env.ALERT_EMAIL_TO,
+      subject: '[R2C] GA4 Cronワーカーエラー',
+      body: message,
+    });
+  } catch (err) {
+    console.error('[ga4HealthCheckHandler] admin error notification failed:', err);
+  }
+}

--- a/cloudflare-workers/r2c-analytics-worker/src/index.ts
+++ b/cloudflare-workers/r2c-analytics-worker/src/index.ts
@@ -1,23 +1,12 @@
-export interface Env {
-  ENVIRONMENT: string;
-  INTERNAL_API_URL: string;
-  INTERNAL_API_HMAC_SECRET: string;
-  EMAIL: SendEmail;
-}
+import { runGa4HealthCheckCron } from './handlers/ga4HealthCheckHandler';
+import { handleSendNotification } from './handlers/errorNotifyHandler';
+import type { Env } from './types';
 
-// Cron handler — runs on schedule defined in wrangler.jsonc
 export default {
-  async scheduled(event: ScheduledEvent, env: Env, ctx: ExecutionContext): Promise<void> {
-    console.log(`[r2c-analytics-worker] cron triggered: ${event.cron} at ${new Date(event.scheduledTime).toISOString()}`);
-    console.log(`[r2c-analytics-worker] environment: ${env.ENVIRONMENT}`);
-    console.log(`[r2c-analytics-worker] internal api: ${env.INTERNAL_API_URL}`);
-
-    // Day 4: implement GA4 sync, CV deduplication, weekly report
-    // For now, just confirm the worker is alive
-    ctx.waitUntil(pingInternalApi(env));
+  async scheduled(_event: ScheduledEvent, env: Env, ctx: ExecutionContext): Promise<void> {
+    ctx.waitUntil(runGa4HealthCheckCron(env));
   },
 
-  // HTTP handler — for manual triggers and health checks
   async fetch(request: Request, env: Env, _ctx: ExecutionContext): Promise<Response> {
     const url = new URL(request.url);
 
@@ -29,49 +18,10 @@ export default {
       });
     }
 
-    return new Response('r2c-analytics-worker v0.1.0', { status: 200 });
+    if (url.pathname === '/send-notification') {
+      return handleSendNotification(request, env);
+    }
+
+    return new Response('r2c-analytics-worker v0.2.0', { status: 200 });
   },
 };
-
-async function pingInternalApi(env: Env): Promise<void> {
-  const body = { task: 'heartbeat', timestamp: new Date().toISOString() };
-  const hmacHeader = await buildHmacHeaders(body, env.INTERNAL_API_HMAC_SECRET);
-
-  try {
-    const res = await fetch(`${env.INTERNAL_API_URL}/health`, {
-      method: 'GET',
-      headers: {
-        'X-Internal-Request': '1',
-        ...hmacHeader,
-      },
-    });
-    console.log(`[r2c-analytics-worker] VPS health: ${res.status}`);
-  } catch (err) {
-    console.error('[r2c-analytics-worker] VPS unreachable:', err);
-  }
-}
-
-async function buildHmacHeaders(
-  body: unknown,
-  secret: string,
-): Promise<Record<string, string>> {
-  const timestamp = Math.floor(Date.now() / 1000).toString();
-  const message = `${timestamp}:${JSON.stringify(body)}`;
-
-  const key = await crypto.subtle.importKey(
-    'raw',
-    new TextEncoder().encode(secret),
-    { name: 'HMAC', hash: 'SHA-256' },
-    false,
-    ['sign'],
-  );
-  const sigBuf = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(message));
-  const signature = Array.from(new Uint8Array(sigBuf))
-    .map((b) => b.toString(16).padStart(2, '0'))
-    .join('');
-
-  return {
-    'X-HMAC-Timestamp': timestamp,
-    'X-HMAC-Signature': signature,
-  };
-}

--- a/cloudflare-workers/r2c-analytics-worker/src/lib/emailSender.ts
+++ b/cloudflare-workers/r2c-analytics-worker/src/lib/emailSender.ts
@@ -1,0 +1,31 @@
+import type { Env } from '../types';
+
+const FROM_ADDRESS = 'noreply@r2c.biz';
+const FROM_NAME = 'R2C System';
+
+export interface EmailOptions {
+  to: string;
+  subject: string;
+  body: string;
+}
+
+export async function sendEmail(env: Env, opts: EmailOptions): Promise<void> {
+  const raw = buildRawEmail(opts.to, opts.subject, opts.body);
+  const message = new EmailMessage(FROM_ADDRESS, opts.to, raw);
+  await env.EMAIL.send(message);
+}
+
+function buildRawEmail(to: string, subject: string, body: string): string {
+  const date = new Date().toUTCString();
+  return [
+    `Date: ${date}`,
+    `From: ${FROM_NAME} <${FROM_ADDRESS}>`,
+    `To: ${to}`,
+    `Subject: ${subject}`,
+    `MIME-Version: 1.0`,
+    `Content-Type: text/plain; charset="utf-8"`,
+    `Content-Transfer-Encoding: quoted-printable`,
+    '',
+    body,
+  ].join('\r\n');
+}

--- a/cloudflare-workers/r2c-analytics-worker/src/lib/hmacSigner.ts
+++ b/cloudflare-workers/r2c-analytics-worker/src/lib/hmacSigner.ts
@@ -1,0 +1,19 @@
+export async function buildHmacHeaders(
+  body: unknown,
+  secret: string,
+): Promise<Record<string, string>> {
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const message = `${timestamp}:${JSON.stringify(body)}`;
+  const key = await crypto.subtle.importKey(
+    'raw',
+    new TextEncoder().encode(secret),
+    { name: 'HMAC', hash: 'SHA-256' },
+    false,
+    ['sign'],
+  );
+  const sigBuf = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(message));
+  const signature = Array.from(new Uint8Array(sigBuf))
+    .map((b) => b.toString(16).padStart(2, '0'))
+    .join('');
+  return { 'X-HMAC-Timestamp': timestamp, 'X-HMAC-Signature': signature };
+}

--- a/cloudflare-workers/r2c-analytics-worker/src/lib/vpsApiClient.ts
+++ b/cloudflare-workers/r2c-analytics-worker/src/lib/vpsApiClient.ts
@@ -1,0 +1,59 @@
+import { buildHmacHeaders } from './hmacSigner';
+import type { Env, Ga4TenantHealthResult } from '../types';
+
+interface HealthCheckAllResponse {
+  ok: boolean;
+  results: Ga4TenantHealthResult[];
+  checked_at: string;
+}
+
+export async function callGa4HealthCheckAll(env: Env): Promise<Ga4TenantHealthResult[]> {
+  const body = {};
+  const hmacHeaders = await buildHmacHeaders(body, env.INTERNAL_API_HMAC_SECRET);
+
+  const res = await fetch(`${env.INTERNAL_API_URL}/internal/ga4/health-check-all`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Internal-Request': '1',
+      ...hmacHeaders,
+    },
+    body: JSON.stringify(body),
+    signal: AbortSignal.timeout(25_000),
+  });
+
+  if (!res.ok) {
+    throw new Error(`VPS /internal/ga4/health-check-all responded ${res.status}`);
+  }
+
+  const data = (await res.json()) as HealthCheckAllResponse;
+  return data.results ?? [];
+}
+
+export interface SendNotificationPayload {
+  to: string;
+  subject: string;
+  body: string;
+}
+
+export async function callSendNotification(
+  env: Env,
+  payload: SendNotificationPayload,
+): Promise<void> {
+  const hmacHeaders = await buildHmacHeaders(payload, env.INTERNAL_API_HMAC_SECRET);
+
+  const res = await fetch(`${env.INTERNAL_API_URL}/internal/notification/send`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Internal-Request': '1',
+      ...hmacHeaders,
+    },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!res.ok) {
+    throw new Error(`VPS /internal/notification/send responded ${res.status}`);
+  }
+}

--- a/cloudflare-workers/r2c-analytics-worker/src/types.ts
+++ b/cloudflare-workers/r2c-analytics-worker/src/types.ts
@@ -1,0 +1,13 @@
+export interface Env {
+  ENVIRONMENT: string;
+  INTERNAL_API_URL: string;
+  INTERNAL_API_HMAC_SECRET: string;
+  EMAIL: SendEmail;
+  ALERT_EMAIL_TO: string;
+}
+
+export interface Ga4TenantHealthResult {
+  tenant_id: string;
+  status: string;
+  error_message: string | null;
+}

--- a/cloudflare-workers/r2c-analytics-worker/wrangler.jsonc
+++ b/cloudflare-workers/r2c-analytics-worker/wrangler.jsonc
@@ -13,24 +13,33 @@
   },
 
   // Email Service binding (Cloudflare Email Routing)
+  // destination_address restricts outbound email to this address during testing
   "send_email": [
     {
-      "name": "EMAIL"
+      "name": "EMAIL",
+      "destination_address": "hkobayashi@mooores.com"
     }
   ],
 
   // Environment variables (non-secret)
   "vars": {
     "ENVIRONMENT": "development",
-    "INTERNAL_API_URL": "https://api.r2c.biz"
+    "INTERNAL_API_URL": "https://api.r2c.biz",
+    "ALERT_EMAIL_TO": "hkobayashi@mooores.com"
   },
 
   // Production environment overrides
   "env": {
     "production": {
+      "send_email": [
+        {
+          "name": "EMAIL"
+        }
+      ],
       "vars": {
         "ENVIRONMENT": "production",
-        "INTERNAL_API_URL": "https://api.r2c.biz"
+        "INTERNAL_API_URL": "https://api.r2c.biz",
+        "ALERT_EMAIL_TO": "hkobayashi@mooores.com"
       }
     }
   }

--- a/docs/PHASE_A_CLOUDFLARE_WORKERS.md
+++ b/docs/PHASE_A_CLOUDFLARE_WORKERS.md
@@ -1,7 +1,7 @@
-# Phase A Cloudflare Workers 設計書
+# Phase A Cloudflare Workers 設計・実装書
 
 **作成日**: 2026-04-21  
-**対象フェーズ**: Phase A Day 1 (初期セットアップ) → Day 4 (実機能実装)  
+**更新日**: 2026-04-21 (Day 4 実装完了)  
 **担当**: Claude Code (Sonnet 4.6)
 
 ---
@@ -21,213 +21,27 @@
                           │  │  r2c-analytics-worker       │ │
                           │  │  (Cloudflare Workers)       │ │
                           │  │                             │ │
-                          │  │  [Cron Trigger]             │ │
-                          │  │  */10 * * * *               │ │
-                          │  │  → GA4 データ同期           │ │
-                          │  │  → CV重複排除               │ │
-                          │  │  → Email送信                │ │
+                          │  │  [Cron: */10 * * * *]       │ │
+                          │  │  → GA4ヘルスチェック        │ │
+                          │  │  → エラー時メール通知       │ │
+                          │  │                             │ │
+                          │  │  [HTTP: POST /send-notif.]  │ │
+                          │  │  → VPS起点のメール送信      │ │
                           │  └───────────┬─────────────────┘ │
                           │              │ HMAC認証           │
                           └──────────────┼───────────────────┘
                                          │
                                          ▼ HTTPS
                           ┌──────────────────────────────────┐
-                          │  Hetzner VPS (65.108.159.161)    │
+                          │  Hetzner VPS (api.r2c.biz)       │
                           │                                   │
-                          │  Nginx (api.r2c.biz)              │
-                          │    ↓                              │
-                          │  PM2 rajiuce-api (port 3100)     │
-                          │    /internal/analytics/sync       │
-                          │    /internal/cv/deduplicate       │
-                          │    /internal/report/weekly        │
+                          │  POST /internal/ga4/health-check-all  │
+                          │  POST /internal/ga4/health-check  │
+                          │  POST /internal/ga4/sync          │
                           │                                   │
                           │  PostgreSQL (pgvector)            │
-                          │  Elasticsearch                    │
                           └──────────────────────────────────┘
 ```
-
----
-
-## Workers → VPS 内部API通信フロー
-
-### Cron 実行フロー
-
-```
-1. Cloudflare Cron Trigger (*/10 * * * *)
-   └─▶ scheduled() ハンドラ起動
-
-2. Worker がタスクを判定
-   ├─ GA4 sync (毎時 :00)
-   ├─ CV dedup (10分ごと)
-   └─ Weekly report (月曜 09:00 JST)
-
-3. VPS 内部API エンドポイントへ HTTPS POST
-   URL: ${INTERNAL_API_URL}/internal/analytics/sync
-   Headers:
-     X-Internal-Request: 1
-     X-HMAC-Timestamp: <unix_timestamp>
-     X-HMAC-Signature: <HMAC-SHA256>
-   Body: { "task": "ga4_sync", "tenant_id": "..." }
-
-4. VPS API がリクエストを受理
-   └─ HMAC検証 → タスク実行 → 202 Accepted
-
-5. Worker がレスポンスをログに記録
-```
-
-### HMAC 認証設計
-
-Workers と VPS 間の内部通信を HMAC-SHA256 で保護する。
-
-```typescript
-// Worker 側: 署名生成
-const timestamp = Math.floor(Date.now() / 1000).toString();
-const message = `${timestamp}:${JSON.stringify(body)}`;
-const key = await crypto.subtle.importKey(
-  'raw',
-  new TextEncoder().encode(env.INTERNAL_API_HMAC_SECRET),
-  { name: 'HMAC', hash: 'SHA-256' },
-  false,
-  ['sign']
-);
-const signature = await crypto.subtle.sign('HMAC', key, new TextEncoder().encode(message));
-const signatureHex = Array.from(new Uint8Array(signature))
-  .map(b => b.toString(16).padStart(2, '0'))
-  .join('');
-
-// リクエストヘッダーに付与
-headers['X-Internal-Request'] = '1';
-headers['X-HMAC-Timestamp'] = timestamp;
-headers['X-HMAC-Signature'] = signatureHex;
-```
-
-```typescript
-// VPS 側: 署名検証 (既存 X-Internal-Request ミドルウェアに追加)
-function verifyHmac(req: Request): boolean {
-  const timestamp = req.headers['x-hmac-timestamp'];
-  const signature = req.headers['x-hmac-signature'];
-
-  // タイムスタンプの鮮度確認 (5分以内)
-  const now = Math.floor(Date.now() / 1000);
-  if (Math.abs(now - parseInt(timestamp)) > 300) return false;
-
-  const message = `${timestamp}:${JSON.stringify(req.body)}`;
-  const expected = createHmac('sha256', process.env.INTERNAL_API_HMAC_SECRET!)
-    .update(message)
-    .digest('hex');
-  return timingSafeEqual(Buffer.from(signature), Buffer.from(expected));
-}
-```
-
-### リプレイ攻撃対策
-
-- タイムスタンプが現在時刻 ± 5分以内でなければ拒否
-- `X-Internal-Request: 1` は既存ミドルウェアで確認済み (二重チェック)
-
----
-
-## 環境変数一覧
-
-### Worker 側 (wrangler.jsonc で定義)
-
-| 変数名 | 種別 | 説明 |
-|---|---|---|
-| `INTERNAL_API_URL` | var | VPS API のベース URL (例: `https://api.r2c.biz`) |
-| `INTERNAL_API_HMAC_SECRET` | secret | HMAC署名用シークレット (wrangler secret コマンドで設定) |
-| `ENVIRONMENT` | var | `development` / `production` |
-
-### VPS 側 (.env に追加)
-
-| 変数名 | 説明 |
-|---|---|
-| `INTERNAL_API_HMAC_SECRET` | Worker と同じシークレット (共有鍵) |
-| `CLOUDFLARE_WORKER_ALLOWED_IPS` | Workers からの固定IPリスト (オプション) |
-
-### Wrangler Secret 設定手順
-
-```bash
-# ローカル開発時
-echo "your-secret-here" | npx wrangler secret put INTERNAL_API_HMAC_SECRET
-
-# または .dev.vars ファイル (gitignore 必須)
-echo "INTERNAL_API_HMAC_SECRET=your-secret-here" > .dev.vars
-```
-
----
-
-## デプロイ手順
-
-### 手動デプロイ
-
-```bash
-cd cloudflare-workers/r2c-analytics-worker
-
-# 依存関係インストール
-npm install
-
-# TypeScript ビルド確認
-npm run build
-
-# ローカル開発サーバー起動
-npx wrangler dev
-
-# 本番デプロイ
-npx wrangler deploy --env production
-```
-
-### GitHub Actions 自動デプロイ (将来実装)
-
-```yaml
-# .github/workflows/deploy-workers.yml (Day 4 以降に追加)
-name: Deploy Cloudflare Workers
-on:
-  push:
-    branches: [main]
-    paths:
-      - 'cloudflare-workers/**'
-
-jobs:
-  deploy:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: cloudflare/wrangler-action@v3
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          workingDirectory: cloudflare-workers/r2c-analytics-worker
-          command: deploy --env production
-```
-
-### 必要な Cloudflare アカウント設定
-
-1. **Paid Plan** — Workers Cron Triggers は有料プランのみ
-2. **API Token** — `Edit Cloudflare Workers` 権限
-3. **Email Routing** — `send_email` binding のために Email Routing を有効化
-4. **Custom Domain** (オプション) — Worker に独自ドメインを割り当てる場合
-
----
-
-## Day 1 → Day 4 実装ロードマップ
-
-### Day 1 (現在): 初期セットアップ
-- `wrangler.jsonc`, `package.json`, `src/index.ts`, `tsconfig.json` を作成
-- Hello World + Cron ハンドラの骨組みのみ
-
-### Day 4: 実機能実装
-- **Cron 1** (`*/10 * * * *`): CV 重複排除バッチ → VPS `/internal/cv/deduplicate` を叩く
-- **Cron 2** (`0 * * * *`): GA4 データ同期 → VPS `/internal/analytics/ga4-sync` を叩く
-- **Cron 3** (`0 0 * * 1`): 週次レポート生成 → VPS `/internal/report/weekly` → Email 送信
-- **Email Service binding**: 成功/失敗通知メールを Cloudflare Email Routing 経由で送信
-
-### VPS 側で必要な内部 API エンドポイント (Day 2 以降)
-
-```
-POST /internal/analytics/sync
-POST /internal/cv/deduplicate
-POST /internal/report/weekly
-```
-
-これらは既存の `X-Internal-Request: 1` ミドルウェアで保護し、HMAC 検証を追加する。
 
 ---
 
@@ -236,23 +50,179 @@ POST /internal/report/weekly
 ```
 cloudflare-workers/
 └── r2c-analytics-worker/
-    ├── wrangler.jsonc        ← Cloudflare Workers 設定
-    ├── package.json          ← 依存関係
-    ├── tsconfig.json         ← TypeScript 設定
-    ├── .dev.vars             ← ローカル開発用シークレット (gitignore済み)
+    ├── wrangler.jsonc                   ← Workers 設定 (Cron / Email binding)
+    ├── package.json                     ← 依存関係 (wrangler, workers-types)
+    ├── tsconfig.json                    ← TypeScript 設定
+    ├── .dev.vars                        ← ローカル開発用シークレット (gitignore済み)
     └── src/
-        └── index.ts          ← Worker エントリポイント
+        ├── index.ts                     ← エントリポイント (scheduled + fetch handlers)
+        ├── types.ts                     ← Env interface + 共有型定義
+        ├── globals.d.ts                 ← EmailMessage コンストラクタ型拡張
+        ├── lib/
+        │   ├── hmacSigner.ts           ← HMAC-SHA256 署名生成 (VPS hmacVerifier対応)
+        │   ├── vpsApiClient.ts         ← VPS 内部 API 呼び出し
+        │   └── emailSender.ts          ← Cloudflare Email Service binding wrapper
+        └── handlers/
+            ├── ga4HealthCheckHandler.ts ← Cronハンドラ: 全テナント一括チェック + メール通知
+            └── errorNotifyHandler.ts   ← POST /send-notification ハンドラ
 ```
 
 ---
 
-## 注意事項
+## Cron 動作フロー
 
-- `.dev.vars` は `.gitignore` に追加済みであること（シークレットの漏洩防止）
-- Workers の無料プランには Cron Triggers がないため、Paid Plan ($5/月) が必要
-- HMAC シークレットは VPS の `.env` と Worker の Secrets に同じ値を設定すること
-- `wrangler deploy` 前に必ず `npx wrangler dev` でローカル動作確認を行うこと
+```
+1. Cloudflare Cron Trigger (*/10 * * * *)
+   └─▶ scheduled() → runGa4HealthCheckCron(env)
+
+2. VPS POST /internal/ga4/health-check-all (HMAC署名付き)
+   └─▶ 全連携テナントのGA4接続チェック結果を一括取得
+
+3. エラーステータス (error / timeout / permission_revoked) のテナントを検出
+   └─▶ 同一テナントへの通知を1時間以内に重複送信しない (in-memoryデデュプ)
+
+4. エラー検知時: Cloudflare Email Service でアラートメール送信
+   件名: [R2C] GA4連携エラー検知 (tenant: xxx)
+   宛先: ALERT_EMAIL_TO 環境変数
+```
 
 ---
 
-*設計書作成: Claude Code (Sonnet 4.6) — 2026-04-21*
+## HTTP エンドポイント
+
+| Path | Method | 説明 |
+|---|---|---|
+| `/health` | GET | Workers ヘルスチェック (公開) |
+| `/send-notification` | POST | VPS 起点のメール送信 (HMAC認証必須) |
+
+---
+
+## HMAC 認証設計
+
+Workers と VPS は共通シークレット `INTERNAL_API_HMAC_SECRET` で通信を保護する。
+
+```
+メッセージ形式: "{timestamp}:{JSON.stringify(body)}"
+アルゴリズム: HMAC-SHA256 (hex)
+タイムスタンプ許容誤差: ±5分
+```
+
+Workers 側 (`src/lib/hmacSigner.ts`) と VPS 側 (`src/lib/crypto/hmacVerifier.ts`) で
+同じメッセージ形式を使用。
+
+---
+
+## 環境変数一覧
+
+### Worker 側
+
+| 変数名 | 種別 | 説明 |
+|---|---|---|
+| `INTERNAL_API_URL` | var | VPS API ベース URL (`https://api.r2c.biz`) |
+| `ALERT_EMAIL_TO` | var | エラー通知メール送信先 |
+| `ENVIRONMENT` | var | `development` / `production` |
+| `INTERNAL_API_HMAC_SECRET` | **secret** | HMAC 署名用シークレット |
+
+### VPS 側 (.env に追加)
+
+| 変数名 | 説明 |
+|---|---|
+| `INTERNAL_API_HMAC_SECRET` | Workers と同じシークレット (共有鍵) |
+| `GOOGLE_APPLICATION_CREDENTIALS_JSON` | GA4 サービスアカウント JSON (base64) |
+
+---
+
+## デプロイ手順
+
+### 1. シークレット設定
+
+```bash
+cd cloudflare-workers/r2c-analytics-worker
+
+# Wrangler でシークレット登録 (VPS .env の INTERNAL_API_HMAC_SECRET と同じ値)
+echo "your-secret-here" | npx wrangler secret put INTERNAL_API_HMAC_SECRET
+```
+
+### 2. ローカル動作確認
+
+```bash
+# .dev.vars ファイルを作成 (gitignore済み)
+echo "INTERNAL_API_HMAC_SECRET=your-secret-here" > .dev.vars
+
+# ローカル開発サーバー起動
+npm run dev
+
+# 別ターミナルで Cron Trigger を手動発火
+curl "http://localhost:8787/__scheduled?cron=*+*+*+*+*"
+
+# ヘルスチェック確認
+curl http://localhost:8787/health
+```
+
+### 3. ステージングデプロイ
+
+```bash
+npm run build   # dry-run でビルド確認
+npm run deploy  # wrangler deploy (development環境)
+```
+
+### 4. 本番デプロイ
+
+```bash
+npm run deploy:prod  # wrangler deploy --env production
+```
+
+### 5. デプロイ後確認
+
+- Cloudflare Workers 管理画面でCron Trigger 実行履歴を確認
+- Email Routing 管理画面で Email binding が有効であることを確認
+- `https://r2c-analytics-worker.{your-subdomain}.workers.dev/health` でヘルスチェック
+
+---
+
+## トラブルシューティング
+
+### Email 送信失敗
+
+**原因**: Email Routing が有効になっていない / `destination_address` 制限
+```
+解決: Cloudflare Dashboard → Email Routing → Enable
+     wrangler.jsonc の destination_address を確認
+     本番では send_email binding の destination_address を削除 (全宛先に送信可能にする)
+```
+
+### HMAC mismatch (401 エラー)
+
+**原因**: Worker のシークレットと VPS の INTERNAL_API_HMAC_SECRET が一致しない
+```
+解決: wrangler secret put INTERNAL_API_HMAC_SECRET で再設定
+     VPS .env を確認: INTERNAL_API_HMAC_SECRET=同じ値
+```
+
+### VPS タイムアウト (25秒)
+
+**原因**: テナント数が多い場合、全テナント一括チェックが25秒を超える
+```
+解決 (将来): health-check-all を並列度制限付き実装 (pLimit等)
+```
+
+### Cron が実行されない
+
+**原因**: Workers Paid Plan ($5/月) が未契約
+```
+解決: Cloudflare Dashboard → Workers & Pages → Upgrade to Paid Plan
+```
+
+---
+
+## 次ステップ (Day 5)
+
+- PostHog 統合 (widget.js + backend イベント送信)
+- LLM Analytics 接続
+- Event ID 重複排除実装 (conversion_attributions テーブル)
+- Cloudflare Workers KV による永続的デデュプリケーション (現在はin-memory)
+
+---
+
+*設計書作成: Claude Code (Sonnet 4.6) — 2026-04-21*  
+*Day 4 実装更新: Claude Code (Sonnet 4.6) — 2026-04-21*

--- a/src/api/internal/ga4SyncRoutes.ts
+++ b/src/api/internal/ga4SyncRoutes.ts
@@ -17,6 +17,46 @@ const syncSchema = z.object({
 });
 
 export function registerInternalGa4SyncRoutes(app: Express, db: Pool): void {
+  // POST /internal/ga4/health-check-all — Workers Cron: 全連携テナント一括チェック
+  app.post(
+    "/internal/ga4/health-check-all",
+    internalHmacMiddleware,
+    async (_req: Request, res: Response) => {
+      try {
+        const rows = await db.query<{ id: string; ga4_property_id: string }>(
+          `SELECT id, ga4_property_id FROM tenants
+           WHERE is_active = true
+             AND ga4_property_id IS NOT NULL
+             AND ga4_status IN ('connected', 'error', 'timeout', 'permission_revoked', 'pending')`,
+        );
+
+        const results = await Promise.all(
+          rows.rows.map(async (row) => {
+            try {
+              const result = await runGa4HealthCheck(row.id, row.ga4_property_id, db);
+              return {
+                tenant_id: row.id,
+                status: result.status,
+                error_message: result.errorMessage ?? null,
+              };
+            } catch (err) {
+              return {
+                tenant_id: row.id,
+                status: "error" as const,
+                error_message: err instanceof Error ? err.message.slice(0, 200) : String(err),
+              };
+            }
+          }),
+        );
+
+        return res.json({ ok: true, results, checked_at: new Date().toISOString() });
+      } catch (err) {
+        logger.warn({ err }, "[internalGa4] health-check-all error");
+        return res.status(500).json({ error: "internal error" });
+      }
+    },
+  );
+
   // POST /internal/ga4/health-check — Cloudflare Workers Cron用
   app.post(
     "/internal/ga4/health-check",

--- a/tests/phase-a/ga4SyncRoutesAll.test.ts
+++ b/tests/phase-a/ga4SyncRoutesAll.test.ts
@@ -1,0 +1,130 @@
+// tests/phase-a/ga4SyncRoutesAll.test.ts
+import express from "express";
+import request from "supertest";
+import jwt from "jsonwebtoken";
+import { createHmac } from "node:crypto";
+import { registerInternalGa4SyncRoutes } from "../../src/api/internal/ga4SyncRoutes";
+
+jest.mock("../../src/lib/ga4/ga4HealthCheck", () => ({
+  runGa4HealthCheck: jest.fn(),
+}));
+
+import { runGa4HealthCheck } from "../../src/lib/ga4/ga4HealthCheck";
+const mockHealthCheck = runGa4HealthCheck as jest.MockedFunction<typeof runGa4HealthCheck>;
+
+const HMAC_SECRET = "test-internal-hmac-secret";
+
+function makeHmacHeaders(body: unknown = {}) {
+  const timestamp = Math.floor(Date.now() / 1000).toString();
+  const message = `${timestamp}:${JSON.stringify(body)}`;
+  const signature = createHmac("sha256", HMAC_SECRET).update(message).digest("hex");
+  return {
+    "x-internal-request": "1",
+    "x-hmac-timestamp": timestamp,
+    "x-hmac-signature": signature,
+  };
+}
+
+function makeApp(queryRows: unknown[]) {
+  const app = express();
+  app.use(express.json());
+  process.env.INTERNAL_API_HMAC_SECRET = HMAC_SECRET;
+  process.env.NODE_ENV = "production";
+
+  const mockDb: any = {
+    query: jest.fn().mockResolvedValue({ rows: queryRows, rowCount: queryRows.length }),
+  };
+  registerInternalGa4SyncRoutes(app, mockDb);
+  return { app, mockDb };
+}
+
+describe("POST /internal/ga4/health-check-all", () => {
+  afterEach(() => {
+    delete process.env.INTERNAL_API_HMAC_SECRET;
+    delete process.env.NODE_ENV;
+    mockHealthCheck.mockClear();
+  });
+
+  it("returns results array for all connected tenants", async () => {
+    mockHealthCheck
+      .mockResolvedValueOnce({ status: "connected", connectedAt: new Date() })
+      .mockResolvedValueOnce({ status: "connected", connectedAt: new Date() });
+
+    const { app } = makeApp([
+      { id: "tenant-a", ga4_property_id: "111" },
+      { id: "tenant-b", ga4_property_id: "222" },
+    ]);
+
+    const body = {};
+    const res = await request(app)
+      .post("/internal/ga4/health-check-all")
+      .set(makeHmacHeaders(body))
+      .send(body);
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.results).toHaveLength(2);
+    expect(res.body.results[0].status).toBe("connected");
+    expect(res.body.results[1].status).toBe("connected");
+    expect(res.body.checked_at).toBeTruthy();
+  });
+
+  it("includes error tenants in results", async () => {
+    mockHealthCheck
+      .mockResolvedValueOnce({ status: "connected", connectedAt: new Date() })
+      .mockResolvedValueOnce({ status: "error", errorMessage: "permission_denied" });
+
+    const { app } = makeApp([
+      { id: "tenant-a", ga4_property_id: "111" },
+      { id: "tenant-c", ga4_property_id: "333" },
+    ]);
+
+    const body = {};
+    const res = await request(app)
+      .post("/internal/ga4/health-check-all")
+      .set(makeHmacHeaders(body))
+      .send(body);
+
+    expect(res.status).toBe(200);
+    expect(res.body.results).toHaveLength(2);
+    const errorResult = res.body.results.find((r: any) => r.tenant_id === "tenant-c");
+    expect(errorResult.status).toBe("error");
+    expect(errorResult.error_message).toBe("permission_denied");
+  });
+
+  it("returns empty results when no tenants are configured", async () => {
+    const { app } = makeApp([]);
+    const body = {};
+    const res = await request(app)
+      .post("/internal/ga4/health-check-all")
+      .set(makeHmacHeaders(body))
+      .send(body);
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.results).toHaveLength(0);
+  });
+
+  it("returns 401 without HMAC headers", async () => {
+    const { app } = makeApp([]);
+    const res = await request(app)
+      .post("/internal/ga4/health-check-all")
+      .set("x-internal-request", "1")
+      .send({});
+
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 without x-internal-request header", async () => {
+    const { app } = makeApp([]);
+    const body = {};
+    const headers = makeHmacHeaders(body);
+    const { "x-internal-request": _removed, ...headersWithoutInternal } = headers;
+    const res = await request(app)
+      .post("/internal/ga4/health-check-all")
+      .set(headersWithoutInternal)
+      .send(body);
+
+    expect(res.status).toBe(403);
+  });
+});


### PR DESCRIPTION
## Summary
- Cloudflare Workers `r2c-analytics-worker` を hello world → 本番仕様に刷新
- GA4ヘルスチェックCron (*/10 * * * *): VPS `/internal/ga4/health-check-all` を呼び、エラーテナントをメール通知
- Email Service binding 経由のメール送信 (1時間デデュプ付き)
- VPS: `POST /internal/ga4/health-check-all` 追加 (全連携テナント一括チェック)

## Changes
| ファイル | 変更内容 |
|---|---|
| `src/lib/hmacSigner.ts` | HMAC-SHA256 署名生成 (Web Crypto API) |
| `src/lib/vpsApiClient.ts` | VPS API 呼び出し (health-check-all / send-notification) |
| `src/lib/emailSender.ts` | Cloudflare Email Service binding wrapper |
| `src/handlers/ga4HealthCheckHandler.ts` | Cron ハンドラ本体 |
| `src/handlers/errorNotifyHandler.ts` | POST /send-notification ハンドラ |
| `src/api/internal/ga4SyncRoutes.ts` | /internal/ga4/health-check-all 追加 |
| `tests/phase-a/ga4SyncRoutesAll.test.ts` | 5テスト追加 |

## Test plan
- [x] Workers typecheck: 0 errors
- [x] pnpm test → 1136 tests pass
- [x] pnpm build + admin-ui build: success

## デプロイ手順 (手動)
1. `cd cloudflare-workers/r2c-analytics-worker`
2. `echo "secret" | npx wrangler secret put INTERNAL_API_HMAC_SECRET`
3. `npm run deploy` (ステージング) または `npm run deploy:prod` (本番)
4. Cron Trigger 実行確認 (Cloudflare Workers 管理画面)

🤖 Generated with [Claude Code](https://claude.com/claude-code)