### PR TITLE
feat(posthog): Phase A Day 5 — PostHog統合 + LLM Analytics + Event ID重複排除

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -142,6 +142,11 @@ STRIPE_SECRET_KEY=sk_test_xxxx
 STRIPE_WEBHOOK_SECRET=whsec_xxxx
 BILLING_PORTAL_RETURN_URL=https://admin.r2c.biz/billing
 
+# ==== PostHog (Phase A Day 5) ====
+# R2C運営用 LLM Analytics送信プロジェクト
+POSTHOG_PROJECT_API_KEY=phc_xxxx
+POSTHOG_API_HOST=https://eu.i.posthog.com
+
 # ==== Monitoring ====
 SLACK_WEBHOOK_URL=
 SENTIMENT_SERVICE_URL=

--- a/admin-ui/src/pages/admin/tenants/[id].tsx
+++ b/admin-ui/src/pages/admin/tenants/[id].tsx
@@ -1633,6 +1633,228 @@ interface Ga4StatusData {
   recent_tests: { test_type: string; success: boolean; error_message: string | null; tested_at: string }[];
 }
 
+// ─── PostHog Integration Tab ──────────────────────────────────────────────
+
+interface PostHogStatus {
+  configured: boolean;
+  key_hint: string | null;
+}
+
+function PostHogIntegrationTab({ tenantId }: { tenantId: string }) {
+  const [status, setStatus] = useState<PostHogStatus | null>(null);
+  const [apiKey, setApiKey] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [verifying, setVerifying] = useState(false);
+  const [verifyResult, setVerifyResult] = useState<{ ok: boolean; status: string } | null>(null);
+  const [disconnecting, setDisconnecting] = useState(false);
+  const [showDisconnectModal, setShowDisconnectModal] = useState(false);
+  const [toast, setToast] = useState<{ msg: string; ok: boolean } | null>(null);
+
+  const showToast = (msg: string, ok = true) => {
+    setToast({ msg, ok });
+    setTimeout(() => setToast(null), 3500);
+  };
+
+  useEffect(() => {
+    authFetch(`${API_BASE}/v1/admin/tenants/${tenantId}/posthog/status`)
+      .then((r) => r.json() as Promise<PostHogStatus>)
+      .then((d) => setStatus(d))
+      .catch(() => setStatus({ configured: false, key_hint: null }));
+  }, [tenantId]);
+
+  const handleSave = async () => {
+    if (!apiKey.trim()) return;
+    setSaving(true);
+    try {
+      const res = await authFetch(`${API_BASE}/v1/admin/tenants/${tenantId}/posthog/connect`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ project_api_key: apiKey.trim() }),
+      });
+      if (!res.ok) throw new Error();
+      showToast("PostHog Project API Key を保存しました");
+      setApiKey("");
+      const updated = await authFetch(`${API_BASE}/v1/admin/tenants/${tenantId}/posthog/status`).then((r) => r.json() as Promise<PostHogStatus>);
+      setStatus(updated);
+    } catch {
+      showToast("保存に失敗しました", false);
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleVerify = async () => {
+    setVerifying(true);
+    setVerifyResult(null);
+    try {
+      const res = await authFetch(`${API_BASE}/v1/admin/tenants/${tenantId}/posthog/verify`, { method: "POST" });
+      const d = await res.json() as { ok: boolean; status: string };
+      setVerifyResult(d);
+    } catch {
+      setVerifyResult({ ok: false, status: "error" });
+    } finally {
+      setVerifying(false);
+    }
+  };
+
+  const handleDisconnect = async () => {
+    setDisconnecting(true);
+    try {
+      await authFetch(`${API_BASE}/v1/admin/tenants/${tenantId}/posthog/disconnect`, { method: "DELETE" });
+      setStatus({ configured: false, key_hint: null });
+      setShowDisconnectModal(false);
+      showToast("PostHog連携を解除しました");
+    } catch {
+      showToast("解除に失敗しました", false);
+    } finally {
+      setDisconnecting(false);
+    }
+  };
+
+  const cardStyle: React.CSSProperties = {
+    background: "#1e293b", borderRadius: 8, padding: "20px 24px", marginBottom: 16,
+  };
+  const labelStyle: React.CSSProperties = {
+    display: "block", color: "#9ca3af", fontSize: 12, marginBottom: 6,
+  };
+  const inputStyle: React.CSSProperties = {
+    width: "100%", background: "#0f172a", border: "1px solid #334155",
+    borderRadius: 6, color: "#e2e8f0", fontSize: 14, padding: "8px 12px",
+  };
+  const btnStyle = (color: string): React.CSSProperties => ({
+    background: color, color: "#fff", border: "none", borderRadius: 6,
+    padding: "8px 18px", fontSize: 13, cursor: "pointer", marginRight: 8,
+  });
+
+  return (
+    <div style={{ padding: "16px 0" }}>
+      {toast && (
+        <div style={{
+          position: "fixed", top: 16, right: 16, zIndex: 9999,
+          background: toast.ok ? "#166534" : "#7f1d1d",
+          color: "#fff", padding: "10px 20px", borderRadius: 8,
+        }}>
+          {toast.msg}
+        </div>
+      )}
+
+      {/* 概要 */}
+      <div style={cardStyle}>
+        <div style={{ color: "#e2e8f0", fontSize: 15, fontWeight: 600, marginBottom: 8 }}>PostHog 連携</div>
+        <div style={{ color: "#9ca3af", fontSize: 13, lineHeight: 1.6 }}>
+          PostHog のプロジェクト API キーを登録すると、このテナントのウィジェットから
+          widget_opened / message_sent / llm_response_received / cv_macro イベントが自動送信されます。
+          <br />
+          LLM Analytics ($ai_generation) も自動収集されます。
+        </div>
+        {status && (
+          <div style={{ marginTop: 12, display: "flex", alignItems: "center", gap: 8 }}>
+            <span style={{
+              background: status.configured ? "rgba(34,197,94,0.15)" : "rgba(107,114,128,0.2)",
+              color: status.configured ? "#4ade80" : "#9ca3af",
+              borderRadius: 12, padding: "2px 10px", fontSize: 12,
+            }}>
+              {status.configured ? "✓ 設定済み" : "未設定"}
+            </span>
+            {status.key_hint && (
+              <span style={{ color: "#9ca3af", fontSize: 12, fontFamily: "monospace" }}>
+                キー: {status.key_hint}
+              </span>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* API Key 設定 */}
+      <div style={cardStyle}>
+        <div style={{ color: "#e2e8f0", fontSize: 14, fontWeight: 600, marginBottom: 12 }}>
+          Project API Key 設定
+        </div>
+        <label style={labelStyle}>
+          PostHog Project API Key（phc_ で始まるキー）
+        </label>
+        <input
+          type="password"
+          style={inputStyle}
+          placeholder="phc_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+        />
+        <div style={{ marginTop: 8, fontSize: 12, color: "#6b7280" }}>
+          AES-256-GCM で暗号化してDBに保存されます。平文は保存されません。
+        </div>
+        <button
+          style={{ ...btnStyle("#2563eb"), marginTop: 12, opacity: (!apiKey.trim() || saving) ? 0.5 : 1 }}
+          onClick={handleSave}
+          disabled={!apiKey.trim() || saving}
+        >
+          {saving ? "保存中..." : "保存"}
+        </button>
+      </div>
+
+      {/* 接続確認 */}
+      {status?.configured && (
+        <div style={cardStyle}>
+          <div style={{ color: "#e2e8f0", fontSize: 14, fontWeight: 600, marginBottom: 12 }}>
+            接続確認
+          </div>
+          <button style={btnStyle("#0891b2")} onClick={handleVerify} disabled={verifying}>
+            {verifying ? "テスト中..." : "接続テスト実行"}
+          </button>
+          {verifyResult && (
+            <div style={{
+              marginTop: 12, padding: "10px 14px", borderRadius: 6,
+              background: verifyResult.ok ? "rgba(34,197,94,0.1)" : "rgba(239,68,68,0.1)",
+              color: verifyResult.ok ? "#4ade80" : "#f87171", fontSize: 13,
+            }}>
+              {verifyResult.ok
+                ? "✓ PostHog への接続を確認しました"
+                : `✗ 接続エラー: ${verifyResult.status}`}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* 連携解除 */}
+      {status?.configured && (
+        <div style={cardStyle}>
+          <div style={{ color: "#e2e8f0", fontSize: 14, fontWeight: 600, marginBottom: 8 }}>
+            連携解除
+          </div>
+          <button style={btnStyle("#dc2626")} onClick={() => setShowDisconnectModal(true)}>
+            PostHog 連携を解除する
+          </button>
+        </div>
+      )}
+
+      {/* 解除確認モーダル */}
+      {showDisconnectModal && (
+        <div style={{
+          position: "fixed", inset: 0, background: "rgba(0,0,0,0.7)",
+          display: "flex", alignItems: "center", justifyContent: "center", zIndex: 9999,
+        }}>
+          <div style={{ background: "#1e293b", borderRadius: 8, padding: 24, maxWidth: 400, width: "90%" }}>
+            <div style={{ color: "#e2e8f0", fontSize: 15, fontWeight: 600, marginBottom: 8 }}>
+              PostHog 連携を解除しますか？
+            </div>
+            <div style={{ color: "#9ca3af", fontSize: 13, marginBottom: 16 }}>
+              Project API Key が削除されます。ウィジェットからのイベント送信が停止します。
+            </div>
+            <button style={btnStyle("#dc2626")} onClick={handleDisconnect} disabled={disconnecting}>
+              {disconnecting ? "解除中..." : "解除する"}
+            </button>
+            <button style={btnStyle("#374151")} onClick={() => setShowDisconnectModal(false)}>
+              キャンセル
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── GA4 Integration Tab ──────────────────────────────────────────────────
+
 function Ga4IntegrationTab({ tenantId }: { tenantId: string }) {
   const [statusData, setStatusData] = useState<Ga4StatusData | null>(null);
   const [serviceAccountEmail, setServiceAccountEmail] = useState<string | null>(null);
@@ -2029,7 +2251,7 @@ function Ga4IntegrationTab({ tenantId }: { tenantId: string }) {
 
 // ─── メインページ ─────────────────────────────────────────────────────────────
 
-type TabId = "settings" | "apikeys" | "embed" | "avatar" | "ai-report" | "ab-test" | "objection-patterns" | "conversion" | "deep-research" | "tuning" | "test" | "ga4";
+type TabId = "settings" | "apikeys" | "embed" | "avatar" | "ai-report" | "ab-test" | "objection-patterns" | "conversion" | "deep-research" | "tuning" | "test" | "ga4" | "posthog";
 
 export default function TenantDetailPage() {
   const navigate = useNavigate();
@@ -2143,6 +2365,7 @@ export default function TenantDetailPage() {
     { id: "embed", label: t("tenant_detail.tab_embed") },
     { id: "avatar", label: "🤖 アバター" },
     { id: "ga4", label: "📊 GA4連携" },
+    { id: "posthog", label: "📈 PostHog連携" },
     { id: "ai-report", label: aiReportLabel },
     { id: "conversion", label: "🎯 成果設定" },
     { id: "deep-research", label: "🔬 ディープリサーチ" },
@@ -2326,6 +2549,9 @@ export default function TenantDetailPage() {
           )}
           {activeTab === "ga4" && (
             <Ga4IntegrationTab tenantId={tenantId} />
+          )}
+          {activeTab === "posthog" && (
+            <PostHogIntegrationTab tenantId={tenantId} />
           )}
           {activeTab === "ai-report" && (
             <AIReportTab tenantId={tenantId} />

--- a/package.json
+++ b/package.json
@@ -124,6 +124,7 @@
     "pg": "8.16.3",
     "pino": "10.1.0",
     "pino-pretty": "13.1.2",
+    "posthog-node": "^5.29.2",
     "prom-client": "^15.1.3",
     "stripe": "^20.4.1",
     "uuid": "^13.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,6 +70,9 @@ importers:
       pino-pretty:
         specifier: 13.1.2
         version: 13.1.2
+      posthog-node:
+        specifier: ^5.29.2
+        version: 5.29.2(rxjs@7.8.2)
       prom-client:
         specifier: ^15.1.3
         version: 15.1.3
@@ -618,6 +621,9 @@ packages:
     resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
     engines: {node: '>=18'}
     hasBin: true
+
+  '@posthog/core@1.25.2':
+    resolution: {integrity: sha512-h2FO7ut/BbfwpAXWpwdDHTzQgUo9ibDFEs6ZO+3cI3KPWQt5XwczK1OLAuPprcjm8T/jl0SH8jSFo5XdU4RbTg==}
 
   '@protobufjs/aspromise@1.1.2':
     resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
@@ -2606,6 +2612,15 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
+  posthog-node@5.29.2:
+    resolution: {integrity: sha512-rI7kkF0XqDc0G1qjx+Hb4iuY9NAlL+XQNoGOpnEpRNTUcXvjY6WlsRGZ9m2whgc39emrrYdszi/YT8wZkr2xsg==}
+    engines: {node: ^20.20.0 || >=22.22.0}
+    peerDependencies:
+      rxjs: ^7.0.0
+    peerDependenciesMeta:
+      rxjs:
+        optional: true
+
   prelude-ls@1.1.2:
     resolution: {integrity: sha512-ESF23V4SKG6lVSGZgYNpbsiaAkdab6ZgOxe52p7+Kid3W3u3bxR4Vfd/o21dmN7jSt0IwgZ4v5MUd26FEtXE9w==}
     engines: {node: '>= 0.8.0'}
@@ -3916,6 +3931,8 @@ snapshots:
   '@playwright/test@1.59.1':
     dependencies:
       playwright: 1.59.1
+
+  '@posthog/core@1.25.2': {}
 
   '@protobufjs/aspromise@1.1.2': {}
 
@@ -6138,6 +6155,12 @@ snapshots:
   postgres-interval@1.2.0:
     dependencies:
       xtend: 4.0.2
+
+  posthog-node@5.29.2(rxjs@7.8.2):
+    dependencies:
+      '@posthog/core': 1.25.2
+    optionalDependencies:
+      rxjs: 7.8.2
 
   prelude-ls@1.1.2: {}
 

--- a/public/widget.js
+++ b/public/widget.js
@@ -23,6 +23,7 @@
   var tenantId = currentScript ? currentScript.getAttribute('data-tenant') : '';
   var apiKey = currentScript ? currentScript.getAttribute('data-api-key') : '';
   var avatarConfigId = currentScript ? (currentScript.getAttribute('data-avatar-config-id') || '') : '';
+  var posthogKey = currentScript ? (currentScript.getAttribute('data-posthog-key') || '') : '';
 
   if (!tenantId) {
     console.warn('[FAQ Widget] data-tenant 属性が必要です。例: data-tenant="your-tenant-id"');
@@ -47,6 +48,56 @@
   var allowedOrigins = rawAllowed
     ? rawAllowed.split(',').map(function (s) { return s.trim(); })
     : [window.location.origin];
+
+  /* ------------------------------------------------------------------ */
+  /* 2a. PostHog SDK 読み込み + イベントキャプチャ                        */
+  /* ------------------------------------------------------------------ */
+
+  var _posthogReady = false;
+  var _posthogQueue = [];
+
+  function capturePostHog(eventName, props) {
+    try {
+      var p = Object.assign({ tenant_id: tenantId }, props || {});
+      if (_posthogReady && window.posthog && typeof window.posthog.capture === 'function') {
+        window.posthog.capture(eventName, p);
+      } else {
+        _posthogQueue.push({ eventName: eventName, props: p });
+      }
+    } catch (_e) { /* fire-and-forget */ }
+  }
+
+  if (posthogKey) {
+    try {
+      var phScript = document.createElement('script');
+      phScript.src = 'https://eu-assets.i.posthog.com/static/array.js';
+      phScript.async = true;
+      phScript.onload = function () {
+        try {
+          var sessionId = '';
+          try { sessionId = sessionStorage.getItem('r2c_sid') || ''; } catch (_e) {}
+
+          window.posthog.init(posthogKey, {
+            api_host: 'https://eu.i.posthog.com',
+            autocapture: false,
+            capture_pageview: false,
+            capture_heatmaps: false,
+          });
+          if (sessionId) {
+            window.posthog.identify(sessionId, { tenant_id: tenantId });
+          }
+          _posthogReady = true;
+          // drain queue
+          for (var qi = 0; qi < _posthogQueue.length; qi++) {
+            var item = _posthogQueue[qi];
+            window.posthog.capture(item.eventName, item.props);
+          }
+          _posthogQueue = [];
+        } catch (_initErr) { /* ignore */ }
+      };
+      document.head.appendChild(phScript);
+    } catch (_e) { /* ignore */ }
+  }
 
   /* ------------------------------------------------------------------ */
   /* 2. prefers-reduced-motion 検出                                       */
@@ -1781,6 +1832,7 @@
     }
     textarea.focus();
     emitToHost('widget:opened', {});
+    capturePostHog('widget_opened', { page_url: window.location.href.slice(0, 2048) });
     // 既存 Room が接続中ならエリアを再表示するだけ（再fetch・再接続しない）
     if (window.__rajiuceRoom && window.__rajiuceRoom.state === 'connected') {
       avatarArea.style.display = 'flex';
@@ -1822,6 +1874,7 @@
       fab.appendChild(svgIcon(CHAT_SVG_PATH));
     }
     emitToHost('widget:closed', {});
+    capturePostHog('widget_closed', {});
     // LiveKit Room を切断（次回開閉時に新規接続で安定化）
     if (window.__rajiuceRoom) {
       try { window.__rajiuceRoom.disconnect(); } catch (_e) {}
@@ -1878,6 +1931,8 @@
     textarea.disabled = true;
 
     emitToHost('user:message', { messageLength: text.length });
+    capturePostHog('message_sent', { message_length: text.length });
+    var _phSendStart = Date.now();
 
     // Anam アバター有効時 → Client-Side Custom LLM (Groq) で応答生成してTTSへ
     if (avatarProvider === 'anam' && (anamClient || window.__anamClient)) {
@@ -1972,6 +2027,10 @@
         }
 
         emitToHost('assistant:message', { messageLength: assistantContent.length });
+        capturePostHog('llm_response_received', {
+          latency_ms: typeof _phSendStart !== 'undefined' ? Date.now() - _phSendStart : undefined,
+          response_length: assistantContent.length,
+        });
       })
       .catch(function (err) {
         if (err && err.name === 'AbortError') return;
@@ -2531,6 +2590,12 @@
         referrer: document.referrer
       }]
     };
+
+    capturePostHog('cv_macro', {
+      conversion_type: conversionType,
+      conversion_value: (typeof conversionValue === 'number') ? conversionValue : null,
+      session_id: sessionId || 'unknown',
+    });
 
     fetch(apiBase + '/api/events', {
       method: 'POST',

--- a/src/agent/orchestrator/llmCalls.ts
+++ b/src/agent/orchestrator/llmCalls.ts
@@ -7,6 +7,7 @@ import type { PlannerPlan } from '../dialog/types';
 import type { PlannerRoute } from '../llm/modelRouter';
 import { RAG_EXCERPT_MAX_CHARS, RAG_MAX_EXCERPTS } from '../config/ragLimits';
 import { detectIntentHint, type DialogInput, type RagContext } from './flowControl';
+import { trackLlmGeneration } from '../../lib/posthog/llmAnalyticsTracker';
 
 const logger = pino();
 
@@ -303,5 +304,19 @@ export async function callAnswerLLM(
     { route, model, safeMode: !!payload.safeMode, latencyMs },
     'dialog.answer.finished',
   );
+
+  // Fire-and-forget LLM Analytics (non-blocking, failure ignored)
+  setImmediate(() => {
+    try {
+      trackLlmGeneration({
+        tenantId: payload.input.tenantId,
+        sessionId: payload.input.conversationId ?? 'unknown',
+        model,
+        provider: 'groq',
+        latencyMs,
+      });
+    } catch { /* ignore */ }
+  });
+
   return raw;
 }

--- a/src/api/admin/tenants/posthogRoutes.ts
+++ b/src/api/admin/tenants/posthogRoutes.ts
@@ -1,0 +1,190 @@
+import type { Express, NextFunction, Request, Response } from "express";
+import type { Pool } from "pg";
+import type { AuthedReq } from "../../middleware/roleAuth";
+import jwt from "jsonwebtoken";
+import { z } from "zod";
+import { encryptText, decryptText, isEncrypted } from "../../../lib/crypto/textEncrypt";
+import { logger } from "../../../lib/logger";
+
+const connectSchema = z.object({
+  project_api_key: z.string().min(1).max(200),
+});
+
+export function registerPostHogTenantRoutes(app: Express, db: Pool): void {
+  function tenantAuth(req: Request, res: Response, next: NextFunction): void {
+    const authHeader = req.headers.authorization ?? "";
+    if (process.env.NODE_ENV === "development") {
+      if (authHeader.startsWith("Bearer ")) {
+        try {
+          (req as AuthedReq).supabaseUser =
+            (jwt.decode(authHeader.slice(7).trim()) as import("../../middleware/roleAuth").SupabaseJwtUser) ?? undefined;
+        } catch { /* ignore */ }
+      }
+      next();
+      return;
+    }
+    const secret = process.env.SUPABASE_JWT_SECRET;
+    if (!secret) { next(); return; }
+    if (!authHeader.startsWith("Bearer ")) {
+      res.status(401).json({ error: "Missing Bearer token" });
+      return;
+    }
+    try {
+      (req as AuthedReq).supabaseUser = jwt.verify(
+        authHeader.slice(7).trim(),
+        secret,
+      ) as import("../../middleware/roleAuth").SupabaseJwtUser;
+      next();
+    } catch {
+      res.status(401).json({ error: "Invalid token" });
+    }
+  }
+
+  function canAccessTenant(req: Request, res: Response, tenantId: string, next: NextFunction): void {
+    const su = (req as AuthedReq).supabaseUser;
+    const role = su?.app_metadata?.role ?? su?.user_metadata?.role ?? "anonymous";
+    const jwtTenantId = su?.app_metadata?.tenant_id as string | undefined;
+    if (role === "super_admin" || jwtTenantId === tenantId) { next(); return; }
+    res.status(403).json({ error: "forbidden" });
+  }
+
+  // POST /v1/admin/tenants/:id/posthog/connect — PostHog Project API Key登録 (暗号化)
+  app.post(
+    "/v1/admin/tenants/:id/posthog/connect",
+    tenantAuth,
+    (req: Request, res: Response, next: NextFunction) =>
+      canAccessTenant(req, res, req.params.id, next),
+    async (req: Request, res: Response) => {
+      const parsed = connectSchema.safeParse(req.body ?? {});
+      if (!parsed.success) {
+        return res.status(400).json({ error: "invalid_request", details: parsed.error.issues });
+      }
+      try {
+        const encrypted = encryptText(parsed.data.project_api_key);
+        const result = await db.query(
+          `UPDATE tenants
+           SET posthog_project_api_key_encrypted = $1, updated_at = NOW()
+           WHERE id = $2
+           RETURNING id`,
+          [encrypted, req.params.id],
+        );
+        if (result.rowCount === 0) {
+          return res.status(404).json({ error: "not_found" });
+        }
+        return res.json({ ok: true });
+      } catch (err) {
+        logger.warn({ err }, "[posthogRoutes] connect failed");
+        return res.status(500).json({ error: "save failed" });
+      }
+    },
+  );
+
+  // GET /v1/admin/tenants/:id/posthog/status — PostHog設定状態
+  app.get(
+    "/v1/admin/tenants/:id/posthog/status",
+    tenantAuth,
+    (req: Request, res: Response, next: NextFunction) =>
+      canAccessTenant(req, res, req.params.id, next),
+    async (req: Request, res: Response) => {
+      try {
+        const result = await db.query<{ posthog_project_api_key_encrypted: string | null }>(
+          `SELECT posthog_project_api_key_encrypted FROM tenants WHERE id = $1`,
+          [req.params.id],
+        );
+        if (result.rowCount === 0) {
+          return res.status(404).json({ error: "not_found" });
+        }
+        const encrypted = result.rows[0].posthog_project_api_key_encrypted;
+        const configured = !!encrypted;
+        const keyHint = configured && encrypted
+          ? maskApiKey(decryptKey(encrypted))
+          : null;
+        return res.json({ configured, key_hint: keyHint });
+      } catch (err) {
+        logger.warn({ err }, "[posthogRoutes] status failed");
+        return res.status(500).json({ error: "status fetch failed" });
+      }
+    },
+  );
+
+  // POST /v1/admin/tenants/:id/posthog/verify — 接続テスト
+  app.post(
+    "/v1/admin/tenants/:id/posthog/verify",
+    tenantAuth,
+    (req: Request, res: Response, next: NextFunction) =>
+      canAccessTenant(req, res, req.params.id, next),
+    async (req: Request, res: Response) => {
+      try {
+        const result = await db.query<{ posthog_project_api_key_encrypted: string | null }>(
+          `SELECT posthog_project_api_key_encrypted FROM tenants WHERE id = $1`,
+          [req.params.id],
+        );
+        if (result.rowCount === 0) {
+          return res.status(404).json({ error: "not_found" });
+        }
+        const encrypted = result.rows[0].posthog_project_api_key_encrypted;
+        if (!encrypted) {
+          return res.status(400).json({ error: "posthog_not_configured" });
+        }
+        const apiKey = decryptKey(encrypted);
+        const apiHost = process.env.POSTHOG_API_HOST ?? "https://eu.i.posthog.com";
+
+        const verifyRes = await fetch(`${apiHost}/decide?v=3`, {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({ api_key: apiKey, distinct_id: "test-verify" }),
+          signal: AbortSignal.timeout(10_000),
+        });
+
+        if (verifyRes.ok || verifyRes.status === 400) {
+          return res.json({ ok: true, status: "connected" });
+        }
+        return res.json({ ok: false, status: "error", http_status: verifyRes.status });
+      } catch (err) {
+        logger.warn({ err }, "[posthogRoutes] verify failed");
+        return res.status(500).json({ error: "verify failed" });
+      }
+    },
+  );
+
+  // DELETE /v1/admin/tenants/:id/posthog/disconnect — PostHog連携解除
+  app.delete(
+    "/v1/admin/tenants/:id/posthog/disconnect",
+    tenantAuth,
+    (req: Request, res: Response, next: NextFunction) =>
+      canAccessTenant(req, res, req.params.id, next),
+    async (req: Request, res: Response) => {
+      try {
+        const result = await db.query(
+          `UPDATE tenants
+           SET posthog_project_api_key_encrypted = NULL, updated_at = NOW()
+           WHERE id = $1
+           RETURNING id`,
+          [req.params.id],
+        );
+        if (result.rowCount === 0) {
+          return res.status(404).json({ error: "not_found" });
+        }
+        return res.json({ ok: true });
+      } catch (err) {
+        logger.warn({ err }, "[posthogRoutes] disconnect failed");
+        return res.status(500).json({ error: "disconnect failed" });
+      }
+    },
+  );
+}
+
+function decryptKey(encrypted: string): string {
+  try {
+    return isEncrypted(encrypted) ? decryptText(encrypted) : encrypted;
+  } catch {
+    return encrypted;
+  }
+}
+
+function maskApiKey(key: string): string {
+  if (key.length <= 8) return "****";
+  return `${key.slice(0, 7)}...${key.slice(-4)}`;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,7 @@ import { registerPremiumGenerationRoutes } from "./api/admin/avatar/premiumGener
 import { registerInternalUsageRoutes } from "./api/internal/usageRoutes";
 import { registerInternalAvatarConfigRoutes } from "./api/internal/avatarConfigRoutes";
 import { registerGa4TenantRoutes } from "./api/admin/tenants/ga4Routes";
+import { registerPostHogTenantRoutes } from "./api/admin/tenants/posthogRoutes";
 import { registerInternalGa4SyncRoutes } from "./api/internal/ga4SyncRoutes";
 import { registerEvaluationRoutes } from "./api/admin/evaluations/routes";
 import { registerVariantRoutes } from "./api/admin/variants/routes";
@@ -485,6 +486,9 @@ if (db) registerTenantAdminRoutes(app, db);
 
 // Phase A: GA4連携管理API (テナント別 connect/test/status/disconnect)
 if (db) registerGa4TenantRoutes(app, db);
+
+// Phase A Day 5: PostHog連携管理API
+if (db) registerPostHogTenantRoutes(app, db);
 
 // Phase32: 課金管理API
 if (db) initUsageTracker(db, logger);

--- a/src/lib/billing/posthogUsageTracker.ts
+++ b/src/lib/billing/posthogUsageTracker.ts
@@ -1,0 +1,80 @@
+import { logger } from "../logger";
+
+export interface MonthlyLlmUsage {
+  tenantId: string;
+  month: string;
+  totalGenerations: number;
+  totalInputTokens: number;
+  totalOutputTokens: number;
+  estimatedCostUsd: number;
+  source: "posthog";
+}
+
+export async function getMonthlyLLMUsageFromPostHog(
+  tenantId: string,
+  month: string,
+): Promise<MonthlyLlmUsage | null> {
+  const apiKey = process.env.POSTHOG_PROJECT_API_KEY;
+  const apiHost = process.env.POSTHOG_API_HOST ?? "https://eu.i.posthog.com";
+
+  if (!apiKey) {
+    logger.warn("[posthogUsageTracker] POSTHOG_PROJECT_API_KEY not set");
+    return null;
+  }
+
+  const [year, monthNum] = month.split("-").map(Number);
+  const startDate = new Date(year, monthNum - 1, 1).toISOString().split("T")[0];
+  const endDate = new Date(year, monthNum, 0).toISOString().split("T")[0];
+
+  try {
+    const query = {
+      kind: "HogQLQuery",
+      query: `
+        SELECT
+          count() AS total_generations,
+          sum(properties.\$ai_input_tokens) AS total_input_tokens,
+          sum(properties.\$ai_output_tokens) AS total_output_tokens,
+          sum(properties.\$ai_cost) AS estimated_cost_usd
+        FROM events
+        WHERE event = '\$ai_generation'
+          AND properties.tenant_id = '${tenantId.replace(/'/g, "''")}'
+          AND timestamp >= '${startDate}'
+          AND timestamp <= '${endDate}'
+      `.trim(),
+    };
+
+    const res = await fetch(`${apiHost}/api/query/`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${apiKey}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(query),
+      signal: AbortSignal.timeout(30_000),
+    });
+
+    if (!res.ok) {
+      logger.warn({ status: res.status }, "[posthogUsageTracker] query failed");
+      return null;
+    }
+
+    const data = (await res.json()) as {
+      results?: Array<[number, number, number, number]>;
+    };
+    const row = data.results?.[0];
+    if (!row) return null;
+
+    return {
+      tenantId,
+      month,
+      totalGenerations: row[0] ?? 0,
+      totalInputTokens: row[1] ?? 0,
+      totalOutputTokens: row[2] ?? 0,
+      estimatedCostUsd: row[3] ?? 0,
+      source: "posthog",
+    };
+  } catch (err) {
+    logger.warn({ err, tenantId, month }, "[posthogUsageTracker] fetch error");
+    return null;
+  }
+}

--- a/src/lib/posthog/eventIdDedupe.ts
+++ b/src/lib/posthog/eventIdDedupe.ts
@@ -1,0 +1,73 @@
+import type { Pool } from "pg";
+import { logger } from "../logger";
+
+export type EventSource = "r2c_db" | "ga4" | "posthog";
+export type EventRank = "A" | "B" | "C" | "D";
+
+export interface DedupeInput {
+  eventId: string;
+  tenantId: string;
+  source: EventSource;
+  eventType?: string;
+  conversionValue?: number;
+  metadataJson?: string;
+}
+
+export interface DedupeResult {
+  isDuplicate: boolean;
+  rank: EventRank;
+  sourceCount: number;
+}
+
+export async function recordAndDedupe(
+  input: DedupeInput,
+  db: Pool,
+): Promise<DedupeResult> {
+  try {
+    await db.query(
+      `INSERT INTO conversion_attributions
+         (event_id, tenant_id, source, event_type, conversion_value, metadata, deduplicated_at)
+       VALUES ($1, $2, $3, $4, $5, $6, NOW())
+       ON CONFLICT (event_id) DO UPDATE
+         SET fired_count = conversion_attributions.fired_count + 1,
+             deduplicated_at = NOW()`,
+      [
+        input.eventId,
+        input.tenantId,
+        input.source,
+        input.eventType ?? "macro",
+        input.conversionValue ?? null,
+        input.metadataJson ?? null,
+      ],
+    );
+
+    const countRow = await db.query<{ cnt: string }>(
+      `SELECT COUNT(DISTINCT source)::text AS cnt FROM conversion_attributions WHERE event_id = $1`,
+      [input.eventId],
+    );
+    const sourceCount = parseInt(countRow.rows[0]?.cnt ?? "1", 10);
+
+    const isDuplicate = sourceCount > 1;
+    const rank = computeRank(input, sourceCount);
+
+    await db.query(
+      `UPDATE conversion_attributions SET rank = $1 WHERE event_id = $2`,
+      [rank, input.eventId],
+    );
+
+    return { isDuplicate, rank, sourceCount };
+  } catch (err) {
+    logger.warn({ err, eventId: input.eventId }, "[eventIdDedupe] failed (non-blocking)");
+    return { isDuplicate: false, rank: "C", sourceCount: 1 };
+  }
+}
+
+function computeRank(input: DedupeInput, sourceCount: number): EventRank {
+  if (sourceCount >= 3) return "A";
+  if (sourceCount === 2) return "B";
+  if (
+    input.conversionValue !== undefined &&
+    input.conversionValue < 0
+  ) return "D";
+  return "C";
+}

--- a/src/lib/posthog/llmAnalyticsTracker.ts
+++ b/src/lib/posthog/llmAnalyticsTracker.ts
@@ -1,0 +1,58 @@
+import { getPostHogClient } from "./posthogClient";
+import { logger } from "../logger";
+
+export interface LlmAnalyticsEvent {
+  tenantId: string;
+  sessionId: string;
+  model: string;
+  provider: string;
+  latencyMs: number;
+  inputTokens?: number;
+  outputTokens?: number;
+}
+
+const COST_PER_1K: Record<string, { input: number; output: number }> = {
+  "groq/compound": { input: 0.0009, output: 0.0009 },
+  "groq/compound-mini": { input: 0.0006, output: 0.0006 },
+  "llama-3.3-70b-versatile": { input: 0.00059, output: 0.00079 },
+  "llama-3.1-8b-instant": { input: 0.00005, output: 0.00008 },
+};
+
+function estimateCostUsd(
+  model: string,
+  inputTokens: number,
+  outputTokens: number,
+): number {
+  const rates = COST_PER_1K[model];
+  if (!rates) return 0;
+  return (inputTokens / 1000) * rates.input + (outputTokens / 1000) * rates.output;
+}
+
+export function trackLlmGeneration(event: LlmAnalyticsEvent): void {
+  const client = getPostHogClient();
+  if (!client) return;
+
+  try {
+    const costUsd =
+      event.inputTokens !== undefined && event.outputTokens !== undefined
+        ? estimateCostUsd(event.model, event.inputTokens, event.outputTokens)
+        : undefined;
+
+    client.capture({
+      distinctId: `tenant:${event.tenantId}`,
+      event: "$ai_generation",
+      properties: {
+        $ai_provider: event.provider,
+        $ai_model: event.model,
+        $ai_latency: event.latencyMs / 1000,
+        ...(event.inputTokens !== undefined && { $ai_input_tokens: event.inputTokens }),
+        ...(event.outputTokens !== undefined && { $ai_output_tokens: event.outputTokens }),
+        ...(costUsd !== undefined && { $ai_cost: costUsd }),
+        tenant_id: event.tenantId,
+        session_id: event.sessionId,
+      },
+    });
+  } catch (err) {
+    logger.warn({ err }, "[llmAnalyticsTracker] capture failed (non-blocking)");
+  }
+}

--- a/src/lib/posthog/posthogClient.ts
+++ b/src/lib/posthog/posthogClient.ts
@@ -1,0 +1,29 @@
+import { PostHog } from "posthog-node";
+import { logger } from "../logger";
+
+let _client: PostHog | null = null;
+
+export function getPostHogClient(): PostHog | null {
+  const key = process.env.POSTHOG_PROJECT_API_KEY;
+  if (!key) return null;
+
+  if (!_client) {
+    const host = process.env.POSTHOG_API_HOST ?? "https://eu.i.posthog.com";
+    _client = new PostHog(key, { host, flushAt: 20, flushInterval: 10_000 });
+    logger.info({ host }, "[posthog] client initialized");
+  }
+  return _client;
+}
+
+export async function flushPostHog(): Promise<void> {
+  if (_client) {
+    await _client.flush();
+  }
+}
+
+export function _resetPostHogClientForTest(): void {
+  if (_client) {
+    _client.shutdown().catch(() => undefined);
+    _client = null;
+  }
+}

--- a/tests/phase-a/eventIdDedupe.test.ts
+++ b/tests/phase-a/eventIdDedupe.test.ts
@@ -1,0 +1,80 @@
+// tests/phase-a/eventIdDedupe.test.ts
+import { recordAndDedupe } from "../../src/lib/posthog/eventIdDedupe";
+
+function makeMockDb(insertOk: boolean, countValue: number) {
+  let callCount = 0;
+  return {
+    query: jest.fn().mockImplementation(() => {
+      const i = callCount++;
+      if (i === 0) {
+        if (!insertOk) return Promise.reject(new Error("db error"));
+        return Promise.resolve({ rows: [], rowCount: 1 });
+      }
+      if (i === 1) {
+        return Promise.resolve({ rows: [{ cnt: String(countValue) }], rowCount: 1 });
+      }
+      // UPDATE rank
+      return Promise.resolve({ rows: [], rowCount: 1 });
+    }),
+  } as any;
+}
+
+describe("recordAndDedupe", () => {
+  it("returns isDuplicate=false and rank=C for first occurrence (1 source)", async () => {
+    const db = makeMockDb(true, 1);
+    const result = await recordAndDedupe({
+      eventId: "evt-001",
+      tenantId: "t1",
+      source: "r2c_db",
+    }, db);
+    expect(result.isDuplicate).toBe(false);
+    expect(result.rank).toBe("C");
+    expect(result.sourceCount).toBe(1);
+  });
+
+  it("returns isDuplicate=true and rank=B for 2 sources", async () => {
+    const db = makeMockDb(true, 2);
+    const result = await recordAndDedupe({
+      eventId: "evt-002",
+      tenantId: "t1",
+      source: "ga4",
+    }, db);
+    expect(result.isDuplicate).toBe(true);
+    expect(result.rank).toBe("B");
+    expect(result.sourceCount).toBe(2);
+  });
+
+  it("returns isDuplicate=true and rank=A for 3 sources", async () => {
+    const db = makeMockDb(true, 3);
+    const result = await recordAndDedupe({
+      eventId: "evt-003",
+      tenantId: "t1",
+      source: "posthog",
+    }, db);
+    expect(result.isDuplicate).toBe(true);
+    expect(result.rank).toBe("A");
+    expect(result.sourceCount).toBe(3);
+  });
+
+  it("returns rank=D for negative conversion value (疑義あり)", async () => {
+    const db = makeMockDb(true, 1);
+    const result = await recordAndDedupe({
+      eventId: "evt-004",
+      tenantId: "t1",
+      source: "r2c_db",
+      conversionValue: -100,
+    }, db);
+    expect(result.rank).toBe("D");
+  });
+
+  it("returns safe fallback on DB error (non-blocking)", async () => {
+    const db = makeMockDb(false, 1);
+    const result = await recordAndDedupe({
+      eventId: "evt-err",
+      tenantId: "t1",
+      source: "r2c_db",
+    }, db);
+    expect(result.isDuplicate).toBe(false);
+    expect(result.rank).toBe("C");
+  });
+});

--- a/tests/phase-a/llmAnalyticsTracker.test.ts
+++ b/tests/phase-a/llmAnalyticsTracker.test.ts
@@ -1,0 +1,70 @@
+// tests/phase-a/llmAnalyticsTracker.test.ts
+import { trackLlmGeneration } from "../../src/lib/posthog/llmAnalyticsTracker";
+import { _resetPostHogClientForTest } from "../../src/lib/posthog/posthogClient";
+
+const mockCapture = jest.fn();
+jest.mock("posthog-node", () => ({
+  PostHog: jest.fn().mockImplementation(() => ({
+    capture: mockCapture,
+    flush: jest.fn().mockResolvedValue(undefined),
+    shutdown: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+describe("trackLlmGeneration", () => {
+  beforeEach(() => {
+    _resetPostHogClientForTest();
+    mockCapture.mockClear();
+  });
+
+  afterEach(() => {
+    delete process.env.POSTHOG_PROJECT_API_KEY;
+    _resetPostHogClientForTest();
+  });
+
+  it("does nothing when POSTHOG_PROJECT_API_KEY is not set", () => {
+    delete process.env.POSTHOG_PROJECT_API_KEY;
+    trackLlmGeneration({
+      tenantId: "t1", sessionId: "s1", model: "groq/compound", provider: "groq", latencyMs: 500,
+    });
+    expect(mockCapture).not.toHaveBeenCalled();
+  });
+
+  it("captures $ai_generation event with required fields", () => {
+    process.env.POSTHOG_PROJECT_API_KEY = "phc_test";
+    trackLlmGeneration({
+      tenantId: "t1", sessionId: "s1", model: "groq/compound", provider: "groq", latencyMs: 1200,
+    });
+    expect(mockCapture).toHaveBeenCalledWith(expect.objectContaining({
+      distinctId: "tenant:t1",
+      event: "$ai_generation",
+      properties: expect.objectContaining({
+        $ai_provider: "groq",
+        $ai_model: "groq/compound",
+        $ai_latency: 1.2,
+        tenant_id: "t1",
+        session_id: "s1",
+      }),
+    }));
+  });
+
+  it("includes token counts and cost when provided", () => {
+    process.env.POSTHOG_PROJECT_API_KEY = "phc_test";
+    trackLlmGeneration({
+      tenantId: "t1", sessionId: "s1", model: "groq/compound", provider: "groq",
+      latencyMs: 500, inputTokens: 100, outputTokens: 50,
+    });
+    const call = mockCapture.mock.calls[0][0] as { properties: Record<string, unknown> };
+    expect(call.properties.$ai_input_tokens).toBe(100);
+    expect(call.properties.$ai_output_tokens).toBe(50);
+    expect(typeof call.properties.$ai_cost).toBe("number");
+  });
+
+  it("does not throw on unexpected errors", () => {
+    process.env.POSTHOG_PROJECT_API_KEY = "phc_test";
+    mockCapture.mockImplementationOnce(() => { throw new Error("network error"); });
+    expect(() => trackLlmGeneration({
+      tenantId: "t1", sessionId: "s1", model: "groq/compound", provider: "groq", latencyMs: 500,
+    })).not.toThrow();
+  });
+});

--- a/tests/phase-a/posthogClient.test.ts
+++ b/tests/phase-a/posthogClient.test.ts
@@ -1,0 +1,61 @@
+// tests/phase-a/posthogClient.test.ts
+import { getPostHogClient, _resetPostHogClientForTest } from "../../src/lib/posthog/posthogClient";
+
+jest.mock("posthog-node", () => ({
+  PostHog: jest.fn().mockImplementation(() => ({
+    capture: jest.fn(),
+    flush: jest.fn().mockResolvedValue(undefined),
+    shutdown: jest.fn().mockResolvedValue(undefined),
+  })),
+}));
+
+import { PostHog } from "posthog-node";
+const MockedPostHog = PostHog as jest.MockedClass<typeof PostHog>;
+
+describe("getPostHogClient", () => {
+  beforeEach(() => {
+    _resetPostHogClientForTest();
+    MockedPostHog.mockClear();
+  });
+
+  afterEach(() => {
+    delete process.env.POSTHOG_PROJECT_API_KEY;
+    delete process.env.POSTHOG_API_HOST;
+    _resetPostHogClientForTest();
+  });
+
+  it("returns null when POSTHOG_PROJECT_API_KEY is not set", () => {
+    delete process.env.POSTHOG_PROJECT_API_KEY;
+    const client = getPostHogClient();
+    expect(client).toBeNull();
+    expect(MockedPostHog).not.toHaveBeenCalled();
+  });
+
+  it("creates PostHog instance when key is set", () => {
+    process.env.POSTHOG_PROJECT_API_KEY = "phc_test_key";
+    const client = getPostHogClient();
+    expect(client).not.toBeNull();
+    expect(MockedPostHog).toHaveBeenCalledWith(
+      "phc_test_key",
+      expect.objectContaining({ host: "https://eu.i.posthog.com" }),
+    );
+  });
+
+  it("uses custom POSTHOG_API_HOST when set", () => {
+    process.env.POSTHOG_PROJECT_API_KEY = "phc_test_key";
+    process.env.POSTHOG_API_HOST = "https://custom.posthog.com";
+    getPostHogClient();
+    expect(MockedPostHog).toHaveBeenCalledWith(
+      "phc_test_key",
+      expect.objectContaining({ host: "https://custom.posthog.com" }),
+    );
+  });
+
+  it("returns the same instance on multiple calls (singleton)", () => {
+    process.env.POSTHOG_PROJECT_API_KEY = "phc_test_key";
+    const c1 = getPostHogClient();
+    const c2 = getPostHogClient();
+    expect(c1).toBe(c2);
+    expect(MockedPostHog).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
- **widget.js**: PostHog JS SDK動的読み込み (`data-posthog-key`属性)、6イベント自動capture
- **VPS**: `src/lib/posthog/` 新規 (posthogClient / llmAnalyticsTracker / eventIdDedupe)
- **Billing**: `posthogUsageTracker.ts` — PostHog HogQL で月次LLM使用量取得
- **API**: `posthogRoutes.ts` — connect/status/verify/disconnect 4エンドポイント (AES-256暗号化)
- **LLM Hook**: `callAnswerLLM` 後に `$ai_generation` fire-and-forget
- **Admin UI**: 📈 PostHog連携タブ追加

## Test plan
- [x] pnpm test → 1149 tests pass (Phase A 38 tests含む)
- [x] pnpm build → 0 errors
- [x] admin-ui pnpm build → success
- [ ] Gate 4b/6: PostHog連携タブのブラウザ動作確認 (人間実施)

## 手動対応事項
- VPS .env に `POSTHOG_PROJECT_API_KEY` / `POSTHOG_API_HOST` 追加
- Admin UIでテナントに PostHog Project API Key を登録
- widget.js 埋め込み側に `data-posthog-key="phc_xxx"` 追加 (テナントごと)

🤖 Generated with [Claude Code](https://claude.com/claude-code)