### PR TITLE
feat(phase-a-day6): Admin UIタブ充実 + アナリティクス/通知設定API

### DIFF
--- a/admin-ui/src/pages/admin/tenants/[id].tsx
+++ b/admin-ui/src/pages/admin/tenants/[id].tsx
@@ -101,7 +101,7 @@ async function fetchTenantDetail(tenantId: string): Promise<TenantDetail> {
 
 async function updateTenant(
   tenantId: string,
-  data: { name: string; status: "active" | "inactive"; allowed_origins: string[]; system_prompt?: string }
+  data: { name: string; status: "active" | "inactive"; allowed_origins: string[]; system_prompt?: string; tenant_contact_email?: string | null }
 ): Promise<TenantDetail> {
   // Backend expects is_active: boolean (not status string)
   const res = await authFetch(`${API_BASE}/v1/admin/tenants/${tenantId}`, {
@@ -111,6 +111,7 @@ async function updateTenant(
       is_active: data.status === "active",
       allowed_origins: data.allowed_origins,
       system_prompt: data.system_prompt ?? "",
+      tenant_contact_email: data.tenant_contact_email,
     }),
   });
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
@@ -689,7 +690,7 @@ function SettingsTab({
 }: {
   tenant: TenantDetail;
   isSuperAdmin: boolean;
-  onSave: (data: { name: string; status: "active" | "inactive"; allowed_origins: string[]; system_prompt?: string }) => Promise<void>;
+  onSave: (data: { name: string; status: "active" | "inactive"; allowed_origins: string[]; system_prompt?: string; tenant_contact_email?: string | null }) => Promise<void>;
   onBillingUpdate: (updated: TenantDetail) => void;
 }) {
   const { t } = useLang();
@@ -697,6 +698,7 @@ function SettingsTab({
   const [status, setStatus] = useState<"active" | "inactive">(tenant.status);
   const [originsText, setOriginsText] = useState((tenant.allowed_origins ?? []).join("\n"));
   const [systemPrompt, setSystemPrompt] = useState(tenant.system_prompt ?? "");
+  const [contactEmail, setContactEmail] = useState(tenant.tenant_contact_email ?? "");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -714,7 +716,7 @@ function SettingsTab({
     setSaving(true);
     setError(null);
     try {
-      await onSave({ name: name.trim(), status, allowed_origins, system_prompt: systemPrompt });
+      await onSave({ name: name.trim(), status, allowed_origins, system_prompt: systemPrompt, tenant_contact_email: contactEmail.trim() || null });
     } catch {
       setError(t("tenant_detail.save_error"));
     } finally {
@@ -820,6 +822,20 @@ function SettingsTab({
           <p style={{ fontSize: 12, color: "#6b7280", margin: "4px 0 0", textAlign: "right" }}>
             {systemPrompt.length} / 5000
           </p>
+        </div>
+
+        <div>
+          <label style={LABEL_STYLE}>担当者メールアドレス</label>
+          <p style={{ fontSize: 12, color: "#6b7280", margin: "0 0 8px", lineHeight: 1.5 }}>
+            GA4エラー通知・請求通知の送信先
+          </p>
+          <input
+            type="email"
+            value={contactEmail}
+            onChange={(e) => setContactEmail(e.target.value)}
+            placeholder="contact@example.com"
+            style={INPUT_STYLE}
+          />
         </div>
 
         <button
@@ -2249,9 +2265,289 @@ function Ga4IntegrationTab({ tenantId }: { tenantId: string }) {
   );
 }
 
+// ─── タブ: アナリティクスサマリー ──────────────────────────────────────────────
+
+interface AnalyticsSummary {
+  period: string;
+  conversations: { total: number; avg_per_day: number };
+  cv: {
+    macro: { r2c_db: number; ga4: number; posthog: number; ranked_a: number; ranked_d: number };
+    micro: { r2c_db: number; ga4: number; posthog: number };
+  };
+  llm_usage: { tokens: number; cost_jpy: number; generations: number } | null;
+  alerts: { source_mismatch_count: number; ranked_d_count: number };
+}
+
+function AnalyticsSummaryTab({ tenantId }: { tenantId: string }) {
+  const [period, setPeriod] = useState<"last_7d" | "last_30d" | "last_90d">("last_30d");
+  const [data, setData] = useState<AnalyticsSummary | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const load = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const res = await authFetch(`${API_BASE}/v1/admin/tenants/${tenantId}/analytics-summary?period=${period}`);
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        setData(await res.json() as AnalyticsSummary);
+      } catch {
+        setError("データ取得に失敗しました");
+      } finally {
+        setLoading(false);
+      }
+    };
+    void load();
+  }, [tenantId, period]);
+
+  const periodLabel: Record<string, string> = { last_7d: "7日間", last_30d: "30日間", last_90d: "90日間" };
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+      {/* Period selector */}
+      <div style={{ ...CARD_STYLE, display: "flex", gap: 10, alignItems: "center" }}>
+        <span style={{ fontSize: 14, color: "#9ca3af", fontWeight: 600 }}>期間:</span>
+        {(["last_7d", "last_30d", "last_90d"] as const).map((p) => (
+          <button
+            key={p}
+            type="button"
+            onClick={() => setPeriod(p)}
+            style={{
+              padding: "8px 16px",
+              minHeight: 36,
+              borderRadius: 8,
+              border: period === p ? "1px solid #4ade80" : "1px solid #374151",
+              background: period === p ? "rgba(34,197,94,0.15)" : "rgba(0,0,0,0.3)",
+              color: period === p ? "#4ade80" : "#9ca3af",
+              fontSize: 13,
+              fontWeight: 600,
+              cursor: "pointer",
+            }}
+          >
+            {periodLabel[p]}
+          </button>
+        ))}
+      </div>
+
+      {loading && <div style={{ color: "#6b7280", textAlign: "center", padding: 32 }}>読み込み中...</div>}
+      {error && <div style={{ color: "#f87171", padding: 16 }}>{error}</div>}
+
+      {data && !loading && (
+        <>
+          {/* Conversations */}
+          <div style={{ ...CARD_STYLE }}>
+            <h3 style={{ fontSize: 15, fontWeight: 700, color: "#d1d5db", margin: "0 0 16px" }}>💬 会話数</h3>
+            <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
+              {[
+                { label: "総会話数", value: data.conversations.total.toLocaleString() },
+                { label: "1日平均", value: `${data.conversations.avg_per_day}件` },
+              ].map(({ label, value }) => (
+                <div key={label} style={{ padding: "16px", borderRadius: 10, background: "rgba(255,255,255,0.03)", border: "1px solid #1f2937" }}>
+                  <div style={{ fontSize: 12, color: "#9ca3af", marginBottom: 6 }}>{label}</div>
+                  <div style={{ fontSize: 22, fontWeight: 700, color: "#e5e7eb" }}>{value}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* CV */}
+          <div style={{ ...CARD_STYLE }}>
+            <h3 style={{ fontSize: 15, fontWeight: 700, color: "#d1d5db", margin: "0 0 16px" }}>🎯 コンバージョン</h3>
+            <div style={{ display: "grid", gap: 10 }}>
+              {[
+                { label: "マクロCV (r2c_db)", value: data.cv.macro.r2c_db },
+                { label: "マクロCV (GA4)", value: data.cv.macro.ga4 },
+                { label: "マクロCV (PostHog)", value: data.cv.macro.posthog },
+                { label: "マイクロCV (r2c_db)", value: data.cv.micro.r2c_db },
+                { label: "マイクロCV (GA4)", value: data.cv.micro.ga4 },
+                { label: "ランクA (3ソース確認済)", value: data.cv.macro.ranked_a },
+              ].map(({ label, value }) => (
+                <div key={label} style={{ display: "flex", justifyContent: "space-between", padding: "10px 14px", borderRadius: 8, background: "rgba(255,255,255,0.02)", border: "1px solid #1f2937", fontSize: 14 }}>
+                  <span style={{ color: "#9ca3af" }}>{label}</span>
+                  <span style={{ color: "#e5e7eb", fontWeight: 600 }}>{value}</span>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* LLM Usage */}
+          {data.llm_usage && (
+            <div style={{ ...CARD_STYLE }}>
+              <h3 style={{ fontSize: 15, fontWeight: 700, color: "#d1d5db", margin: "0 0 16px" }}>🤖 LLM使用量（今月）</h3>
+              <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 10 }}>
+                {[
+                  { label: "総トークン", value: data.llm_usage.tokens.toLocaleString() },
+                  { label: "推定コスト", value: `¥${data.llm_usage.cost_jpy.toLocaleString()}` },
+                  { label: "生成回数", value: data.llm_usage.generations.toLocaleString() },
+                ].map(({ label, value }) => (
+                  <div key={label} style={{ padding: "14px", borderRadius: 10, background: "rgba(255,255,255,0.03)", border: "1px solid #1f2937" }}>
+                    <div style={{ fontSize: 11, color: "#9ca3af", marginBottom: 4 }}>{label}</div>
+                    <div style={{ fontSize: 18, fontWeight: 700, color: "#4ade80" }}>{value}</div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Alerts */}
+          {(data.alerts.source_mismatch_count > 0 || data.alerts.ranked_d_count > 0) && (
+            <div style={{ ...CARD_STYLE, border: "1px solid rgba(239,68,68,0.4)", background: "rgba(127,29,29,0.15)" }}>
+              <h3 style={{ fontSize: 15, fontWeight: 700, color: "#f87171", margin: "0 0 12px" }}>⚠️ アラート</h3>
+              <div style={{ display: "grid", gap: 8 }}>
+                {data.alerts.source_mismatch_count > 0 && (
+                  <div style={{ fontSize: 14, color: "#fca5a5" }}>ソース不一致: {data.alerts.source_mismatch_count}件（同一イベントが複数ソースで記録）</div>
+                )}
+                {data.alerts.ranked_d_count > 0 && (
+                  <div style={{ fontSize: 14, color: "#fca5a5" }}>ランクD（疑義あり）: {data.alerts.ranked_d_count}件</div>
+                )}
+              </div>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+// ─── タブ: 請求情報 ───────────────────────────────────────────────────────────
+
+function BillingInfoTab({ tenant }: { tenant: TenantDetail }) {
+  return (
+    <div style={{ ...CARD_STYLE, display: "flex", flexDirection: "column", gap: 16 }}>
+      <h3 style={{ fontSize: 15, fontWeight: 700, color: "#d1d5db", margin: 0 }}>💳 請求情報</h3>
+      <div style={{ display: "grid", gap: 10 }}>
+        {[
+          { label: "プラン", value: tenant.plan.toUpperCase() },
+          { label: "課金有効", value: tenant.billing_enabled ? "有効" : "無効" },
+          { label: "無料期間（開始）", value: tenant.billing_free_from ? new Date(tenant.billing_free_from).toLocaleDateString("ja-JP") : "—" },
+          { label: "無料期間（終了）", value: tenant.billing_free_until ? new Date(tenant.billing_free_until).toLocaleDateString("ja-JP") : "—" },
+        ].map(({ label, value }) => (
+          <div key={label} style={{ display: "flex", justifyContent: "space-between", padding: "12px 16px", borderRadius: 8, background: "rgba(255,255,255,0.02)", border: "1px solid #1f2937", fontSize: 14 }}>
+            <span style={{ color: "#9ca3af" }}>{label}</span>
+            <span style={{ color: "#e5e7eb", fontWeight: 600 }}>{value}</span>
+          </div>
+        ))}
+      </div>
+      <p style={{ fontSize: 12, color: "#6b7280", margin: 0 }}>
+        詳細な請求設定はSuper Admin専用の設定タブから変更できます。
+      </p>
+    </div>
+  );
+}
+
+// ─── タブ: 通知設定 ───────────────────────────────────────────────────────────
+
+interface NotificationPref {
+  notification_type: string;
+  email_enabled: boolean;
+  in_app_enabled: boolean;
+  threshold: Record<string, unknown> | null;
+}
+
+const DEFAULT_NOTIFICATION_TYPES = [
+  { type: "ga4_error", label: "GA4接続エラー" },
+  { type: "cv_drop", label: "CV数急減" },
+  { type: "llm_cost_spike", label: "LLMコスト急増" },
+  { type: "weekly_report", label: "週次レポート" },
+];
+
+function NotificationPreferencesTab({ tenantId }: { tenantId: string }) {
+  const [prefs, setPrefs] = useState<Record<string, NotificationPref>>({});
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState<string | null>(null);
+  const [toast, setToast] = useState<string | null>(null);
+
+  const showToast = (msg: string) => { setToast(msg); setTimeout(() => setToast(null), 3000); };
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const res = await authFetch(`${API_BASE}/v1/admin/tenants/${tenantId}/notification-preferences`);
+        if (!res.ok) return;
+        const json = await res.json() as { preferences: NotificationPref[] };
+        const map: Record<string, NotificationPref> = {};
+        for (const p of json.preferences) map[p.notification_type] = p;
+        setPrefs(map);
+      } finally {
+        setLoading(false);
+      }
+    };
+    void load();
+  }, [tenantId]);
+
+  const handleToggle = async (type: string, field: "email_enabled" | "in_app_enabled") => {
+    const current = prefs[type] ?? { notification_type: type, email_enabled: true, in_app_enabled: true, threshold: null };
+    const updated = { ...current, [field]: !current[field] };
+    setSaving(type);
+    try {
+      const res = await authFetch(`${API_BASE}/v1/admin/tenants/${tenantId}/notification-preferences`, {
+        method: "PUT",
+        body: JSON.stringify({ notification_type: type, email_enabled: updated.email_enabled, in_app_enabled: updated.in_app_enabled }),
+      });
+      if (res.ok) {
+        setPrefs((prev) => ({ ...prev, [type]: updated }));
+        showToast("✅ 保存しました");
+      }
+    } finally {
+      setSaving(null);
+    }
+  };
+
+  if (loading) return <div style={{ color: "#6b7280", textAlign: "center", padding: 32 }}>読み込み中...</div>;
+
+  return (
+    <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
+      {toast && (
+        <div style={{ padding: "12px 16px", borderRadius: 10, background: "rgba(15,23,42,0.98)", border: "1px solid #22c55e", color: "#4ade80", fontSize: 14, fontWeight: 600 }}>
+          {toast}
+        </div>
+      )}
+      <div style={{ ...CARD_STYLE }}>
+        <h3 style={{ fontSize: 15, fontWeight: 700, color: "#d1d5db", margin: "0 0 16px" }}>🔔 通知設定</h3>
+        <div style={{ display: "grid", gap: 8 }}>
+          {DEFAULT_NOTIFICATION_TYPES.map(({ type, label }) => {
+            const pref = prefs[type] ?? { notification_type: type, email_enabled: true, in_app_enabled: true, threshold: null };
+            const isSavingThis = saving === type;
+            return (
+              <div key={type} style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "12px 16px", borderRadius: 10, background: "rgba(255,255,255,0.02)", border: "1px solid #1f2937" }}>
+                <span style={{ fontSize: 14, color: "#d1d5db", fontWeight: 500 }}>{label}</span>
+                <div style={{ display: "flex", gap: 12 }}>
+                  {(["email_enabled", "in_app_enabled"] as const).map((field) => (
+                    <button
+                      key={field}
+                      type="button"
+                      disabled={isSavingThis}
+                      onClick={() => void handleToggle(type, field)}
+                      style={{
+                        padding: "6px 14px",
+                        minHeight: 32,
+                        borderRadius: 6,
+                        border: pref[field] ? "1px solid #4ade80" : "1px solid #374151",
+                        background: pref[field] ? "rgba(34,197,94,0.15)" : "rgba(0,0,0,0.3)",
+                        color: pref[field] ? "#4ade80" : "#6b7280",
+                        fontSize: 12,
+                        fontWeight: 600,
+                        cursor: isSavingThis ? "not-allowed" : "pointer",
+                        opacity: isSavingThis ? 0.5 : 1,
+                      }}
+                    >
+                      {field === "email_enabled" ? "📧 メール" : "🔔 アプリ内"}
+                    </button>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 // ─── メインページ ─────────────────────────────────────────────────────────────
 
-type TabId = "settings" | "apikeys" | "embed" | "avatar" | "ai-report" | "ab-test" | "objection-patterns" | "conversion" | "deep-research" | "tuning" | "test" | "ga4" | "posthog";
+type TabId = "settings" | "apikeys" | "embed" | "avatar" | "ai-report" | "ab-test" | "objection-patterns" | "conversion" | "deep-research" | "tuning" | "test" | "ga4" | "posthog" | "analytics" | "billing-info" | "notification-prefs";
 
 export default function TenantDetailPage() {
   const navigate = useNavigate();
@@ -2300,6 +2596,7 @@ export default function TenantDetailPage() {
     status: "active" | "inactive";
     allowed_origins: string[];
     system_prompt?: string;
+    tenant_contact_email?: string | null;
   }) => {
     const updated = await updateTenant(tenantId, data);
     setTenant(updated);
@@ -2366,6 +2663,9 @@ export default function TenantDetailPage() {
     { id: "avatar", label: "🤖 アバター" },
     { id: "ga4", label: "📊 GA4連携" },
     { id: "posthog", label: "📈 PostHog連携" },
+    { id: "analytics", label: "📉 アナリティクス" },
+    { id: "billing-info", label: "💳 請求情報" },
+    { id: "notification-prefs", label: "🔔 通知設定" },
     { id: "ai-report", label: aiReportLabel },
     { id: "conversion", label: "🎯 成果設定" },
     { id: "deep-research", label: "🔬 ディープリサーチ" },
@@ -2552,6 +2852,15 @@ export default function TenantDetailPage() {
           )}
           {activeTab === "posthog" && (
             <PostHogIntegrationTab tenantId={tenantId} />
+          )}
+          {activeTab === "analytics" && (
+            <AnalyticsSummaryTab tenantId={tenantId} />
+          )}
+          {activeTab === "billing-info" && tenant && (
+            <BillingInfoTab tenant={tenant} />
+          )}
+          {activeTab === "notification-prefs" && (
+            <NotificationPreferencesTab tenantId={tenantId} />
           )}
           {activeTab === "ai-report" && (
             <AIReportTab tenantId={tenantId} />

--- a/docs/PHASE_A_INTEGRATION.md
+++ b/docs/PHASE_A_INTEGRATION.md
@@ -1,0 +1,103 @@
+# Phase A: GA4 + PostHog 統合ドキュメント
+
+## 概要
+
+Phase A では GA4 および PostHog との計測統合、LLM Analytics トラッキング、コンバージョンイベント重複排除、Admin UI のタブ充実を実装しました。
+
+---
+
+## 実装サマリー
+
+### Day 1-2: 基盤構築
+- `conversion_attributions` テーブル設計・マイグレーション
+- Widget.js への計測埋め込み（GA4 `gtag` + イベント送信）
+- `POST /api/conversion` エンドポイント実装
+
+### Day 3: Admin UI GA4 Wizard タブ
+- テナント詳細ページに GA4 連携ウィザードタブを追加
+- GA4 プロパティ ID 入力 → 接続テスト → ステータス表示
+
+### Day 4: Cloudflare Workers Cron + Email 通知
+- `r2c-analytics-worker` に Cron Trigger（`*/10 * * * *`）
+- GA4 ヘルスチェック定期実行（`/internal/ga4/health-check-all`）
+- HMAC-SHA256 認証付き Email 通知ハンドラ
+- 1時間インメモリ重複通知抑制
+
+### Day 5: PostHog 統合
+- `posthog-node` シングルトンクライアント（`src/lib/posthog/posthogClient.ts`）
+- `$ai_generation` LLM Analytics イベント（`llmAnalyticsTracker.ts`）
+- コンバージョンイベント重複排除・ランク付け（`eventIdDedupe.ts`）
+  - ランク A: 3ソース確認済 / B: 2ソース / C: 1ソース / D: 疑義あり（負値）
+- Admin UI PostHog 連携タブ（接続・検証・切断）
+- Widget.js PostHog JS SDK 動的ロード
+
+### Day 6: Admin UI タブ充実
+- **SettingsTab 拡張**: `tenant_contact_email` フィールド追加
+- **アナリティクスサマリータブ** (`/v1/admin/tenants/:id/analytics-summary`)
+  - 期間選択（7日/30日/90日）
+  - 会話数・CV（マクロ/マイクロ・ソース別）・LLM使用量・アラート
+- **請求情報タブ**: プラン・課金状態・無料期間の確認
+- **通知設定タブ** (`/v1/admin/tenants/:id/notification-preferences`)
+  - GA4エラー・CV急減・LLMコスト急増・週次レポートの ON/OFF
+
+---
+
+## DB テーブル（`migration_phase_a.sql`）
+
+| テーブル | 用途 |
+|---|---|
+| `conversion_attributions` | CV イベント記録・重複排除・ランク管理 |
+| `notification_preferences` | テナント別通知設定 |
+| `ga4_connection_logs` | GA4 接続テスト履歴 |
+
+**テナント追加カラム:**
+- `tenants.ga4_property_id` — GA4 プロパティ ID
+- `tenants.ga4_status` — 接続ステータス
+- `tenants.posthog_api_key_encrypted` — AES-256-GCM 暗号化
+- `tenants.tenant_contact_email` — 担当者メールアドレス（通知送信先）
+
+---
+
+## 新規エンドポイント一覧
+
+| メソッド | パス | 認証 | 説明 |
+|---|---|---|---|
+| GET | `/v1/admin/tenants/:id/analytics-summary` | JWT | アナリティクスサマリー取得 |
+| GET | `/v1/admin/tenants/:id/notification-preferences` | JWT | 通知設定一覧 |
+| PUT | `/v1/admin/tenants/:id/notification-preferences` | JWT | 通知設定 UPSERT |
+| POST | `/v1/admin/tenants/:id/posthog/connect` | JWT | PostHog API キー登録 |
+| GET | `/v1/admin/tenants/:id/posthog/status` | JWT | PostHog 接続状態 |
+| POST | `/v1/admin/tenants/:id/posthog/verify` | JWT | PostHog 接続確認 |
+| DELETE | `/v1/admin/tenants/:id/posthog/disconnect` | JWT | PostHog 切断 |
+| POST | `/internal/ga4/health-check-all` | HMAC | 全テナント GA4 ヘルスチェック |
+| POST | `/internal/send-notification` | HMAC | Cloudflare Worker → メール通知 |
+
+---
+
+## 環境変数（追加分）
+
+```bash
+POSTHOG_PROJECT_API_KEY=phc_...          # PostHog サーバーサイドキー
+POSTHOG_API_HOST=https://eu.i.posthog.com  # デフォルト: EU エンドポイント
+INTERNAL_API_HMAC_SECRET=...             # Cloudflare Worker 認証シークレット
+GOOGLE_APPLICATION_CREDENTIALS_JSON=... # GA4 サービスアカウント JSON
+```
+
+---
+
+## VPS デプロイ手順
+
+1. `migration_phase_a.sql` を VPS の PostgreSQL で実行
+2. `.env` に上記環境変数を追加し PM2 再起動
+3. Cloudflare Workers: `wrangler secret put INTERNAL_API_HMAC_SECRET` → `npm run deploy`
+4. `bash SCRIPTS/deploy-vps.sh` でアプリをデプロイ
+5. `curl https://api.r2c.biz/health` で疎通確認
+
+---
+
+## セキュリティ考慮事項
+
+- PostHog API キーは AES-256-GCM で DB 保存（`src/lib/crypto/textEncrypt.ts`）
+- 内部 API (`/internal/*`) は HMAC-SHA256 + ±5分タイムスタンプ検証
+- `tenant_contact_email` は JWT テナント ID 照合後のみ更新可能
+- コンバージョン値が負の場合は自動でランク D（疑義フラグ）に設定

--- a/src/api/admin/tenants/analyticsSummaryRoutes.ts
+++ b/src/api/admin/tenants/analyticsSummaryRoutes.ts
@@ -1,0 +1,175 @@
+import type { Express, NextFunction, Request, Response } from "express";
+import type { Pool } from "pg";
+import type { AuthedReq } from "../../middleware/roleAuth";
+import jwt from "jsonwebtoken";
+import { getMonthlyLLMUsageFromPostHog } from "../../../lib/billing/posthogUsageTracker";
+import { logger } from "../../../lib/logger";
+
+const PERIOD_DAYS: Record<string, number> = {
+  last_7d: 7,
+  last_30d: 30,
+  last_90d: 90,
+};
+
+export function registerAnalyticsSummaryRoutes(app: Express, db: Pool): void {
+  function tenantAuth(req: Request, res: Response, next: NextFunction): void {
+    const authHeader = req.headers.authorization ?? "";
+    if (process.env.NODE_ENV === "development") {
+      if (authHeader.startsWith("Bearer ")) {
+        try {
+          (req as AuthedReq).supabaseUser =
+            (jwt.decode(authHeader.slice(7).trim()) as import("../../middleware/roleAuth").SupabaseJwtUser) ?? undefined;
+        } catch { /* ignore */ }
+      }
+      next();
+      return;
+    }
+    const secret = process.env.SUPABASE_JWT_SECRET;
+    if (!secret) { next(); return; }
+    if (!authHeader.startsWith("Bearer ")) {
+      res.status(401).json({ error: "Missing Bearer token" });
+      return;
+    }
+    try {
+      (req as AuthedReq).supabaseUser = jwt.verify(
+        authHeader.slice(7).trim(),
+        secret,
+      ) as import("../../middleware/roleAuth").SupabaseJwtUser;
+      next();
+    } catch {
+      res.status(401).json({ error: "Invalid token" });
+    }
+  }
+
+  function canAccessTenant(req: Request, res: Response, tenantId: string, next: NextFunction): void {
+    const su = (req as AuthedReq).supabaseUser;
+    const role = su?.app_metadata?.role ?? su?.user_metadata?.role ?? "anonymous";
+    const jwtTenantId = su?.app_metadata?.tenant_id as string | undefined;
+    if (role === "super_admin" || jwtTenantId === tenantId) { next(); return; }
+    res.status(403).json({ error: "forbidden" });
+  }
+
+  // GET /v1/admin/tenants/:id/analytics-summary
+  app.get(
+    "/v1/admin/tenants/:id/analytics-summary",
+    tenantAuth,
+    (req: Request, res: Response, next: NextFunction) =>
+      canAccessTenant(req, res, req.params.id, next),
+    async (req: Request, res: Response) => {
+      const tenantId = req.params.id;
+      const periodKey = (req.query.period as string) ?? "last_30d";
+      const days = PERIOD_DAYS[periodKey] ?? 30;
+      const interval = `${days} days`;
+
+      try {
+        const [
+          conversationsRow,
+          cvMacroRow,
+          cvMicroRow,
+          cvRankRow,
+          alertRow,
+        ] = await Promise.all([
+          db.query<{ total: string; avg_per_day: string }>(
+            `SELECT
+               COUNT(*)::text AS total,
+               ROUND(COUNT(*) / GREATEST($2::float, 1), 2)::text AS avg_per_day
+             FROM chat_sessions
+             WHERE tenant_id = $1
+               AND created_at >= NOW() - ($3::text)::interval`,
+            [tenantId, days, interval],
+          ),
+          db.query<{ source: string; cnt: string }>(
+            `SELECT source, COUNT(*)::text AS cnt
+             FROM conversion_attributions
+             WHERE tenant_id = $1
+               AND event_type = 'macro'
+               AND created_at >= NOW() - ($2::text)::interval
+             GROUP BY source`,
+            [tenantId, interval],
+          ),
+          db.query<{ source: string; cnt: string }>(
+            `SELECT source, COUNT(*)::text AS cnt
+             FROM conversion_attributions
+             WHERE tenant_id = $1
+               AND event_type = 'micro'
+               AND created_at >= NOW() - ($2::text)::interval
+             GROUP BY source`,
+            [tenantId, interval],
+          ),
+          db.query<{ rank: string; cnt: string }>(
+            `SELECT rank, COUNT(*)::text AS cnt
+             FROM conversion_attributions
+             WHERE tenant_id = $1
+               AND created_at >= NOW() - ($2::text)::interval
+             GROUP BY rank`,
+            [tenantId, interval],
+          ),
+          db.query<{ mismatch: string; ranked_d: string }>(
+            `SELECT
+               COUNT(CASE WHEN fired_count > 1 THEN 1 END)::text AS mismatch,
+               COUNT(CASE WHEN rank = 'D' THEN 1 END)::text AS ranked_d
+             FROM conversion_attributions
+             WHERE tenant_id = $1
+               AND created_at >= NOW() - ($2::text)::interval`,
+            [tenantId, interval],
+          ),
+        ]);
+
+        const toNum = (s: string | undefined) => parseInt(s ?? "0", 10);
+
+        const macroBySource = Object.fromEntries(
+          cvMacroRow.rows.map((r) => [r.source, toNum(r.cnt)]),
+        );
+        const microBySource = Object.fromEntries(
+          cvMicroRow.rows.map((r) => [r.source, toNum(r.cnt)]),
+        );
+        const rankDist = Object.fromEntries(
+          cvRankRow.rows.map((r) => [r.rank, toNum(r.cnt)]),
+        );
+
+        // PostHog LLM usage (optional, non-blocking)
+        const now = new Date();
+        const month = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, "0")}`;
+        const llmUsage = await getMonthlyLLMUsageFromPostHog(tenantId, month).catch(() => null);
+
+        const alertData = alertRow.rows[0];
+
+        return res.json({
+          period: periodKey,
+          conversations: {
+            total: toNum(conversationsRow.rows[0]?.total),
+            avg_per_day: parseFloat(conversationsRow.rows[0]?.avg_per_day ?? "0"),
+          },
+          cv: {
+            macro: {
+              r2c_db: macroBySource.r2c_db ?? 0,
+              ga4: macroBySource.ga4 ?? 0,
+              posthog: macroBySource.posthog ?? 0,
+              ranked_a: rankDist.A ?? 0,
+              ranked_d: rankDist.D ?? 0,
+            },
+            micro: {
+              r2c_db: microBySource.r2c_db ?? 0,
+              ga4: microBySource.ga4 ?? 0,
+              posthog: microBySource.posthog ?? 0,
+            },
+          },
+          llm_usage: llmUsage
+            ? {
+                tokens: llmUsage.totalInputTokens + llmUsage.totalOutputTokens,
+                cost_jpy: Math.round(llmUsage.estimatedCostUsd * 150),
+                generations: llmUsage.totalGenerations,
+              }
+            : null,
+          alerts: {
+            source_mismatch_count: toNum(alertData?.mismatch),
+            ranked_d_count: toNum(alertData?.ranked_d),
+          },
+        });
+      } catch (err) {
+        logger.warn({ err, tenantId }, "[analyticsSummary] failed");
+        return res.status(500).json({ error: "analytics fetch failed" });
+      }
+    },
+  );
+}

--- a/src/api/admin/tenants/notificationPreferencesRoutes.ts
+++ b/src/api/admin/tenants/notificationPreferencesRoutes.ts
@@ -1,0 +1,115 @@
+import type { Express, NextFunction, Request, Response } from "express";
+import type { Pool } from "pg";
+import type { AuthedReq } from "../../middleware/roleAuth";
+import jwt from "jsonwebtoken";
+import { z } from "zod";
+import { logger } from "../../../lib/logger";
+
+const upsertPreferencesSchema = z.object({
+  notification_type: z.string().min(1).max(100),
+  email_enabled: z.boolean(),
+  in_app_enabled: z.boolean(),
+  threshold: z.record(z.string(), z.unknown()).nullable().optional(),
+});
+
+export function registerNotificationPreferencesRoutes(app: Express, db: Pool): void {
+  function tenantAuth(req: Request, res: Response, next: NextFunction): void {
+    const authHeader = req.headers.authorization ?? "";
+    if (process.env.NODE_ENV === "development") {
+      if (authHeader.startsWith("Bearer ")) {
+        try {
+          (req as AuthedReq).supabaseUser =
+            (jwt.decode(authHeader.slice(7).trim()) as import("../../middleware/roleAuth").SupabaseJwtUser) ?? undefined;
+        } catch { /* ignore */ }
+      }
+      next();
+      return;
+    }
+    const secret = process.env.SUPABASE_JWT_SECRET;
+    if (!secret) { next(); return; }
+    if (!authHeader.startsWith("Bearer ")) {
+      res.status(401).json({ error: "Missing Bearer token" });
+      return;
+    }
+    try {
+      (req as AuthedReq).supabaseUser = jwt.verify(
+        authHeader.slice(7).trim(),
+        secret,
+      ) as import("../../middleware/roleAuth").SupabaseJwtUser;
+      next();
+    } catch {
+      res.status(401).json({ error: "Invalid token" });
+    }
+  }
+
+  function canAccessTenant(req: Request, res: Response, tenantId: string, next: NextFunction): void {
+    const su = (req as AuthedReq).supabaseUser;
+    const role = su?.app_metadata?.role ?? su?.user_metadata?.role ?? "anonymous";
+    const jwtTenantId = su?.app_metadata?.tenant_id as string | undefined;
+    if (role === "super_admin" || jwtTenantId === tenantId) { next(); return; }
+    res.status(403).json({ error: "forbidden" });
+  }
+
+  // GET /v1/admin/tenants/:id/notification-preferences
+  app.get(
+    "/v1/admin/tenants/:id/notification-preferences",
+    tenantAuth,
+    (req: Request, res: Response, next: NextFunction) =>
+      canAccessTenant(req, res, req.params.id, next),
+    async (req: Request, res: Response) => {
+      const tenantId = req.params.id;
+      try {
+        const result = await db.query<{
+          notification_type: string;
+          email_enabled: boolean;
+          in_app_enabled: boolean;
+          threshold: Record<string, unknown> | null;
+        }>(
+          `SELECT notification_type, email_enabled, in_app_enabled, threshold
+           FROM notification_preferences
+           WHERE tenant_id = $1
+           ORDER BY notification_type`,
+          [tenantId],
+        );
+        return res.json({ preferences: result.rows });
+      } catch (err) {
+        logger.warn({ err, tenantId }, "[notificationPreferences] GET failed");
+        return res.status(500).json({ error: "fetch failed" });
+      }
+    },
+  );
+
+  // PUT /v1/admin/tenants/:id/notification-preferences
+  app.put(
+    "/v1/admin/tenants/:id/notification-preferences",
+    tenantAuth,
+    (req: Request, res: Response, next: NextFunction) =>
+      canAccessTenant(req, res, req.params.id, next),
+    async (req: Request, res: Response) => {
+      const tenantId = req.params.id;
+      const parsed = upsertPreferencesSchema.safeParse(req.body ?? {});
+      if (!parsed.success) {
+        return res.status(400).json({ error: "invalid body", details: parsed.error.flatten() });
+      }
+      const { notification_type, email_enabled, in_app_enabled, threshold } = parsed.data;
+      try {
+        await db.query(
+          `INSERT INTO notification_preferences
+             (tenant_id, notification_type, email_enabled, in_app_enabled, threshold)
+           VALUES ($1, $2, $3, $4, $5)
+           ON CONFLICT (tenant_id, notification_type)
+           DO UPDATE SET
+             email_enabled = EXCLUDED.email_enabled,
+             in_app_enabled = EXCLUDED.in_app_enabled,
+             threshold = EXCLUDED.threshold,
+             updated_at = NOW()`,
+          [tenantId, notification_type, email_enabled, in_app_enabled, threshold ?? null],
+        );
+        return res.json({ ok: true });
+      } catch (err) {
+        logger.warn({ err, tenantId }, "[notificationPreferences] PUT failed");
+        return res.status(500).json({ error: "update failed" });
+      }
+    },
+  );
+}

--- a/src/api/admin/tenants/routes.ts
+++ b/src/api/admin/tenants/routes.ts
@@ -47,6 +47,8 @@ const updateTenantSchema = z.object({
   lemonslice_agent_id: z.string().max(200).nullable().optional(),
   // Phase52f: コンバージョンタイプ（文字列配列、最大10件、各50文字以内）
   conversion_types: z.array(z.string().max(50)).max(10).optional(),
+  // Phase A Day 6: テナント担当者メールアドレス
+  tenant_contact_email: z.string().email().nullable().optional(),
 });
 
 export function registerTenantAdminRoutes(app: Express, db: Pool): void {
@@ -294,10 +296,11 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
       if (fields.features !== undefined) { params.push(JSON.stringify(fields.features)); setClauses.push(`features = COALESCE(features, '{}'::jsonb) || $${params.length}::jsonb`); }
       if ('lemonslice_agent_id' in fields) { params.push(fields.lemonslice_agent_id ?? null); setClauses.push(`lemonslice_agent_id = $${params.length}`); }
       if (fields.conversion_types !== undefined) { params.push(JSON.stringify(fields.conversion_types)); setClauses.push(`conversion_types = $${params.length}::jsonb`); }
+      if ('tenant_contact_email' in fields) { params.push(fields.tenant_contact_email ?? null); setClauses.push(`tenant_contact_email = $${params.length}`); }
       setClauses.push(`updated_at = NOW()`);
       params.push(id);
       const result = await db.query(
-        `UPDATE tenants SET ${setClauses.join(", ")} WHERE id = $${params.length} RETURNING id, name, plan, is_active, allowed_origins, system_prompt, billing_enabled, billing_free_from, billing_free_until, features, lemonslice_agent_id, conversion_types, created_at, updated_at`,
+        `UPDATE tenants SET ${setClauses.join(", ")} WHERE id = $${params.length} RETURNING id, name, plan, is_active, allowed_origins, system_prompt, billing_enabled, billing_free_from, billing_free_until, features, lemonslice_agent_id, conversion_types, tenant_contact_email, created_at, updated_at`,
         params
       );
       return res.json(result.rows[0]);

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,6 +62,8 @@ import { registerInternalUsageRoutes } from "./api/internal/usageRoutes";
 import { registerInternalAvatarConfigRoutes } from "./api/internal/avatarConfigRoutes";
 import { registerGa4TenantRoutes } from "./api/admin/tenants/ga4Routes";
 import { registerPostHogTenantRoutes } from "./api/admin/tenants/posthogRoutes";
+import { registerAnalyticsSummaryRoutes } from "./api/admin/tenants/analyticsSummaryRoutes";
+import { registerNotificationPreferencesRoutes } from "./api/admin/tenants/notificationPreferencesRoutes";
 import { registerInternalGa4SyncRoutes } from "./api/internal/ga4SyncRoutes";
 import { registerEvaluationRoutes } from "./api/admin/evaluations/routes";
 import { registerVariantRoutes } from "./api/admin/variants/routes";
@@ -489,6 +491,10 @@ if (db) registerGa4TenantRoutes(app, db);
 
 // Phase A Day 5: PostHog連携管理API
 if (db) registerPostHogTenantRoutes(app, db);
+
+// Phase A Day 6: Analytics Summary + Notification Preferences
+if (db) registerAnalyticsSummaryRoutes(app, db);
+if (db) registerNotificationPreferencesRoutes(app, db);
 
 // Phase32: 課金管理API
 if (db) initUsageTracker(db, logger);

--- a/tests/phase-a/analyticsSummaryRoutes.test.ts
+++ b/tests/phase-a/analyticsSummaryRoutes.test.ts
@@ -1,0 +1,110 @@
+// tests/phase-a/analyticsSummaryRoutes.test.ts
+import express from "express";
+import request from "supertest";
+import { registerAnalyticsSummaryRoutes } from "../../src/api/admin/tenants/analyticsSummaryRoutes";
+import jwt from "jsonwebtoken";
+
+jest.mock("../../src/lib/billing/posthogUsageTracker", () => ({
+  getMonthlyLLMUsageFromPostHog: jest.fn().mockResolvedValue(null),
+}));
+
+function makeMockDb(rows: {
+  conversations?: { total: string; avg_per_day: string }[];
+  cvMacro?: { source: string; cnt: string }[];
+  cvMicro?: { source: string; cnt: string }[];
+  cvRank?: { rank: string; cnt: string }[];
+  alert?: { mismatch: string; ranked_d: string }[];
+}) {
+  let call = 0;
+  return {
+    query: jest.fn().mockImplementation(() => {
+      const i = call++;
+      switch (i) {
+        case 0: return Promise.resolve({ rows: rows.conversations ?? [{ total: "10", avg_per_day: "0.33" }] });
+        case 1: return Promise.resolve({ rows: rows.cvMacro ?? [] });
+        case 2: return Promise.resolve({ rows: rows.cvMicro ?? [] });
+        case 3: return Promise.resolve({ rows: rows.cvRank ?? [] });
+        case 4: return Promise.resolve({ rows: rows.alert ?? [{ mismatch: "0", ranked_d: "0" }] });
+        default: return Promise.resolve({ rows: [] });
+      }
+    }),
+  } as any;
+}
+
+function makeApp(db: any) {
+  const app = express();
+  app.use(express.json());
+  process.env.NODE_ENV = "development";
+  registerAnalyticsSummaryRoutes(app, db);
+  return app;
+}
+
+function makeToken(tenantId: string) {
+  return jwt.sign({ app_metadata: { tenant_id: tenantId, role: "client_admin" } }, "test");
+}
+
+describe("GET /v1/admin/tenants/:id/analytics-summary", () => {
+  afterEach(() => { delete process.env.NODE_ENV; });
+
+  it("returns summary with conversations and CV data", async () => {
+    const db = makeMockDb({
+      conversations: [{ total: "42", avg_per_day: "1.40" }],
+      cvMacro: [{ source: "r2c_db", cnt: "15" }, { source: "ga4", cnt: "10" }],
+      cvMicro: [{ source: "posthog", cnt: "5" }],
+      cvRank: [{ rank: "A", cnt: "3" }, { rank: "D", cnt: "1" }],
+      alert: [{ mismatch: "2", ranked_d: "1" }],
+    });
+    const app = makeApp(db);
+    const res = await request(app)
+      .get("/v1/admin/tenants/t1/analytics-summary?period=last_30d")
+      .set("Authorization", `Bearer ${makeToken("t1")}`);
+    expect(res.status).toBe(200);
+    expect(res.body.period).toBe("last_30d");
+    expect(res.body.conversations.total).toBe(42);
+    expect(res.body.cv.macro.r2c_db).toBe(15);
+    expect(res.body.cv.macro.ga4).toBe(10);
+    expect(res.body.cv.micro.posthog).toBe(5);
+    expect(res.body.cv.macro.ranked_a).toBe(3);
+    expect(res.body.alerts.source_mismatch_count).toBe(2);
+    expect(res.body.alerts.ranked_d_count).toBe(1);
+  });
+
+  it("returns 403 when tenant_id does not match", async () => {
+    const db = makeMockDb({});
+    const app = makeApp(db);
+    const res = await request(app)
+      .get("/v1/admin/tenants/other-tenant/analytics-summary")
+      .set("Authorization", `Bearer ${makeToken("t1")}`);
+    expect(res.status).toBe(403);
+  });
+
+  it("super_admin can access any tenant", async () => {
+    const db = makeMockDb({});
+    const app = makeApp(db);
+    const token = jwt.sign({ app_metadata: { role: "super_admin" } }, "test");
+    const res = await request(app)
+      .get("/v1/admin/tenants/any-tenant/analytics-summary")
+      .set("Authorization", `Bearer ${token}`);
+    expect(res.status).toBe(200);
+  });
+
+  it("uses default period last_30d when invalid period provided", async () => {
+    const db = makeMockDb({});
+    const app = makeApp(db);
+    const res = await request(app)
+      .get("/v1/admin/tenants/t1/analytics-summary?period=invalid")
+      .set("Authorization", `Bearer ${makeToken("t1")}`);
+    expect(res.status).toBe(200);
+    expect(res.body.period).toBe("invalid");
+    // days defaults to 30 for unknown period key
+  });
+
+  it("returns 500 on DB error", async () => {
+    const db = { query: jest.fn().mockRejectedValue(new Error("db error")) } as any;
+    const app = makeApp(db);
+    const res = await request(app)
+      .get("/v1/admin/tenants/t1/analytics-summary")
+      .set("Authorization", `Bearer ${makeToken("t1")}`);
+    expect(res.status).toBe(500);
+  });
+});

--- a/tests/phase-a/notificationPreferencesRoutes.test.ts
+++ b/tests/phase-a/notificationPreferencesRoutes.test.ts
@@ -1,0 +1,97 @@
+// tests/phase-a/notificationPreferencesRoutes.test.ts
+import express from "express";
+import request from "supertest";
+import { registerNotificationPreferencesRoutes } from "../../src/api/admin/tenants/notificationPreferencesRoutes";
+import jwt from "jsonwebtoken";
+
+function makeMockDb(getRows: any[] = [], putOk = true) {
+  let call = 0;
+  return {
+    query: jest.fn().mockImplementation(() => {
+      const i = call++;
+      if (i === 0 && putOk !== false) {
+        return Promise.resolve({ rows: getRows });
+      }
+      if (!putOk) return Promise.reject(new Error("db error"));
+      return Promise.resolve({ rows: [] });
+    }),
+  } as any;
+}
+
+function makeApp(db: any) {
+  const app = express();
+  app.use(express.json());
+  process.env.NODE_ENV = "development";
+  registerNotificationPreferencesRoutes(app, db);
+  return app;
+}
+
+function makeToken(tenantId: string) {
+  return jwt.sign({ app_metadata: { tenant_id: tenantId, role: "client_admin" } }, "test");
+}
+
+describe("Notification Preferences Routes", () => {
+  afterEach(() => { delete process.env.NODE_ENV; });
+
+  describe("GET /v1/admin/tenants/:id/notification-preferences", () => {
+    it("returns preferences list", async () => {
+      const rows = [
+        { notification_type: "ga4_error", email_enabled: true, in_app_enabled: false, threshold: null },
+      ];
+      const db = makeMockDb(rows);
+      const app = makeApp(db);
+      const res = await request(app)
+        .get("/v1/admin/tenants/t1/notification-preferences")
+        .set("Authorization", `Bearer ${makeToken("t1")}`);
+      expect(res.status).toBe(200);
+      expect(res.body.preferences).toHaveLength(1);
+      expect(res.body.preferences[0].notification_type).toBe("ga4_error");
+    });
+
+    it("returns 403 for wrong tenant", async () => {
+      const app = makeApp(makeMockDb([]));
+      const res = await request(app)
+        .get("/v1/admin/tenants/other/notification-preferences")
+        .set("Authorization", `Bearer ${makeToken("t1")}`);
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("PUT /v1/admin/tenants/:id/notification-preferences", () => {
+    it("upserts preference and returns ok", async () => {
+      let callCount = 0;
+      const db = {
+        query: jest.fn().mockImplementation(() => {
+          callCount++;
+          return Promise.resolve({ rows: [] });
+        }),
+      } as any;
+      const app = makeApp(db);
+      const res = await request(app)
+        .put("/v1/admin/tenants/t1/notification-preferences")
+        .set("Authorization", `Bearer ${makeToken("t1")}`)
+        .send({ notification_type: "ga4_error", email_enabled: true, in_app_enabled: false });
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(callCount).toBe(1);
+    });
+
+    it("returns 400 for invalid body", async () => {
+      const app = makeApp(makeMockDb([]));
+      const res = await request(app)
+        .put("/v1/admin/tenants/t1/notification-preferences")
+        .set("Authorization", `Bearer ${makeToken("t1")}`)
+        .send({ email_enabled: "not-a-bool" });
+      expect(res.status).toBe(400);
+    });
+
+    it("returns 403 for wrong tenant", async () => {
+      const app = makeApp(makeMockDb([]));
+      const res = await request(app)
+        .put("/v1/admin/tenants/other/notification-preferences")
+        .set("Authorization", `Bearer ${makeToken("t1")}`)
+        .send({ notification_type: "ga4_error", email_enabled: true, in_app_enabled: true });
+      expect(res.status).toBe(403);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `analyticsSummaryRoutes`: `GET /v1/admin/tenants/:id/analytics-summary` — 期間別（7d/30d/90d）会話数・CV（ソース別・ランク別）・PostHog LLM使用量・アラート
- `notificationPreferencesRoutes`: `GET/PUT /v1/admin/tenants/:id/notification-preferences` — テナント別通知設定 UPSERT
- `updateTenantSchema` に `tenant_contact_email` 追加（PATCH テナント）
- Admin UI: AnalyticsSummaryTab / BillingInfoTab / NotificationPreferencesTab 追加（計3タブ）
- SettingsTab に担当者メールアドレス入力欄
- テスト 10件追加（analyticsSummary x5, notificationPreferences x5）
- `docs/PHASE_A_INTEGRATION.md` 作成

## Test plan
- [ ] pnpm typecheck → 0 errors ✅
- [ ] pnpm lint → 0 warnings ✅
- [ ] pnpm test → 1159 passed ✅
- [ ] pnpm build → success ✅
- [ ] admin-ui pnpm build → success ✅

## VPS手動作業（hkobayashi）
- `migration_phase_a.sql` 実行（`tenant_contact_email` カラム追加含む）
- `bash SCRIPTS/deploy-vps.sh` でデプロイ

🤖 Generated with [Claude Code](https://claude.com/claude-code)