### PR TITLE
fix(widget): prevent FAB avatar image degrading to chat icon after chat close

### DIFF
--- a/public/widget.js
+++ b/public/widget.js
@@ -1592,11 +1592,23 @@
         window.__rajiuceRoom = null;
         // Room が切断されたら次のパネル開閉で再fetch可能にする
         avatarConfigFetched = false;
+        // avatar thumbnail URL を disconnected 後のFAB復元用に保持してから avatarConfig を解放
+        var _disconnectThumbUrl = avatarConfig ? (avatarConfig.imageUrl || null) : null;
         avatarConfig = null;
         // FABをリセット
         fabVideoEl = null;
         fabMediaContainer = null;
-        resetFabIcon();
+        // パネルが閉じている場合: アバター顔画像を復元（disconnect でアイコン劣化を防ぐ）
+        // パネルが開いている場合: FABは非表示なのでリセットで問題なし
+        if (!isOpen && _disconnectThumbUrl) {
+          var _thumbImg = document.createElement('img');
+          _thumbImg.src = _disconnectThumbUrl;
+          _thumbImg.alt = 'アバター';
+          _thumbImg.onerror = function () { resetFabIcon(); };
+          showFabMedia(_thumbImg);
+        } else {
+          resetFabIcon();
+        }
       });
 
       room.on(LK.RoomEvent.Reconnecting, function () {
@@ -1868,6 +1880,10 @@
         fabVideoEl.parentNode.removeChild(fabVideoEl);
       }
       showFabMedia(fabVideoEl);
+    } else if (fabMediaContainer && fabMediaContainer.firstChild) {
+      // 静止画アバター: openPanel で fab から切り離された fabMediaContainer を復元
+      while (fab.firstChild) { fab.removeChild(fab.firstChild); }
+      fab.appendChild(fabMediaContainer);
     } else {
       // アバターなし: チャットアイコン
       while (fab.firstChild) { fab.removeChild(fab.firstChild); }

--- a/tests/e2e/widget-fab-avatar.spec.ts
+++ b/tests/e2e/widget-fab-avatar.spec.ts
@@ -1,0 +1,170 @@
+import { test, expect } from '@playwright/test';
+
+const E2E_ENABLED = process.env.E2E_ENABLED === '1' || !!process.env.CI;
+
+/**
+ * FAB avatar persistence test
+ * Verifies that the FAB retains the avatar thumbnail image after chat close/open cycles.
+ * Regression guard for the bug where closePanel() replaced avatar img with chat SVG icon.
+ *
+ * Test target: carnation chat-test page (avatar-configured tenant)
+ * Uses Shadow DOM piercing to inspect FAB internals.
+ */
+test.describe('Widget FAB — Avatar persistence on chat open/close', () => {
+  test.skip(!E2E_ENABLED, 'E2E tests require E2E_ENABLED=1 or CI=true');
+
+  const CHAT_TEST_URL = process.env.E2E_CHAT_TEST_URL || 'https://admin.r2c.biz';
+
+  /** Wait for FAB to appear inside the widget Shadow DOM */
+  async function getFabState(page: any) {
+    return page.evaluate(() => {
+      const host = document.getElementById('faq-chat-widget-host') as HTMLElement | null;
+      if (!host || !host.shadowRoot) return null;
+      const fab = host.shadowRoot.querySelector('.fab') as HTMLElement | null;
+      if (!fab) return null;
+
+      const hasImg = !!fab.querySelector('img');
+      const hasVideo = !!fab.querySelector('video');
+      const hasSvg = !!fab.querySelector('svg');
+      const hasFabMedia = !!fab.querySelector('.fab-media-container');
+      const imgSrc = fab.querySelector('img')?.getAttribute('src') ?? null;
+      return { hasImg, hasVideo, hasSvg, hasFabMedia, imgSrc };
+    });
+  }
+
+  test('FAB retains avatar image after chat close (single cycle)', async ({ page }) => {
+    // Navigate to carnation demo — widget initializes with avatar config
+    const resp = await page.goto('https://api.r2c.biz/carnation-demo/index.html');
+    expect(resp?.status()).toBe(200);
+
+    // Wait for widget init + avatar config prefetch (max 8s)
+    await page.waitForFunction(
+      () => {
+        const host = document.getElementById('faq-chat-widget-host') as HTMLElement | null;
+        return !!host?.shadowRoot?.querySelector('.fab');
+      },
+      { timeout: 8000 }
+    );
+    // Additional wait for avatar config fetch
+    await page.waitForTimeout(3000);
+
+    const fabBefore = await getFabState(page);
+    if (!fabBefore) {
+      test.skip(); // Widget not initialized (possibly no avatar configured for this page)
+      return;
+    }
+
+    // Record whether FAB had avatar image before open
+    const hadAvatarBefore = fabBefore.hasImg || fabBefore.hasVideo;
+
+    // Open chat
+    await page.evaluate(() => {
+      const host = document.getElementById('faq-chat-widget-host') as HTMLElement | null;
+      const fab = host?.shadowRoot?.querySelector<HTMLButtonElement>('.fab');
+      fab?.click();
+    });
+    await page.waitForTimeout(500);
+
+    // Close chat via close button inside panel
+    await page.evaluate(() => {
+      const host = document.getElementById('faq-chat-widget-host') as HTMLElement | null;
+      const closeBtn = host?.shadowRoot?.querySelector<HTMLButtonElement>('.close-btn');
+      closeBtn?.click();
+    });
+    await page.waitForTimeout(500);
+
+    const fabAfter = await getFabState(page);
+    expect(fabAfter).not.toBeNull();
+
+    if (hadAvatarBefore) {
+      // Avatar was shown before: must persist after close (not degraded to SVG-only)
+      expect(fabAfter!.hasImg || fabAfter!.hasVideo).toBe(true);
+      expect(fabAfter!.hasSvg && !fabAfter!.hasImg && !fabAfter!.hasVideo).toBe(false);
+    } else {
+      // No avatar configured: chat SVG icon is correct
+      expect(fabAfter!.hasSvg).toBe(true);
+    }
+  });
+
+  test('FAB retains avatar image across multiple open/close cycles', async ({ page }) => {
+    const resp = await page.goto('https://api.r2c.biz/carnation-demo/index.html');
+    expect(resp?.status()).toBe(200);
+
+    await page.waitForFunction(
+      () => {
+        const host = document.getElementById('faq-chat-widget-host') as HTMLElement | null;
+        return !!host?.shadowRoot?.querySelector('.fab');
+      },
+      { timeout: 8000 }
+    );
+    await page.waitForTimeout(3000);
+
+    const fabInitial = await getFabState(page);
+    if (!fabInitial || !(fabInitial.hasImg || fabInitial.hasVideo)) {
+      test.skip(); // No avatar configured
+      return;
+    }
+    const initialImgSrc = fabInitial.imgSrc;
+
+    // 3 open/close cycles
+    for (let i = 0; i < 3; i++) {
+      await page.evaluate(() => {
+        const host = document.getElementById('faq-chat-widget-host') as HTMLElement | null;
+        host?.shadowRoot?.querySelector<HTMLButtonElement>('.fab')?.click();
+      });
+      await page.waitForTimeout(400);
+
+      await page.evaluate(() => {
+        const host = document.getElementById('faq-chat-widget-host') as HTMLElement | null;
+        host?.shadowRoot?.querySelector<HTMLButtonElement>('.close-btn')?.click();
+      });
+      await page.waitForTimeout(400);
+
+      const fabState = await getFabState(page);
+      expect(fabState!.hasImg || fabState!.hasVideo).toBe(true);
+      // Image src must remain the same across cycles
+      if (initialImgSrc && fabState!.imgSrc) {
+        expect(fabState!.imgSrc).toBe(initialImgSrc);
+      }
+    }
+  });
+
+  test('FAB shows chat SVG icon for non-avatar tenant (demo page without avatar)', async ({ page }) => {
+    // Demo page uses a different tenant without avatar configuration
+    // If FAB has no avatar image initially, it should have chat SVG — open/close should keep it
+    const resp = await page.goto('https://api.r2c.biz/carnation-demo/index.html');
+    expect(resp?.status()).toBe(200);
+
+    await page.waitForFunction(
+      () => {
+        const host = document.getElementById('faq-chat-widget-host') as HTMLElement | null;
+        return !!host?.shadowRoot?.querySelector('.fab');
+      },
+      { timeout: 8000 }
+    );
+    await page.waitForTimeout(3000);
+
+    const fabInitial = await getFabState(page);
+    if (!fabInitial) { test.skip(); return; }
+    if (fabInitial.hasImg || fabInitial.hasVideo) { test.skip(); return; } // has avatar — wrong test
+
+    // No avatar: should have SVG
+    expect(fabInitial.hasSvg).toBe(true);
+
+    // Open/close: should remain SVG
+    await page.evaluate(() => {
+      const host = document.getElementById('faq-chat-widget-host') as HTMLElement | null;
+      host?.shadowRoot?.querySelector<HTMLButtonElement>('.fab')?.click();
+    });
+    await page.waitForTimeout(400);
+    await page.evaluate(() => {
+      const host = document.getElementById('faq-chat-widget-host') as HTMLElement | null;
+      host?.shadowRoot?.querySelector<HTMLButtonElement>('.close-btn')?.click();
+    });
+    await page.waitForTimeout(400);
+
+    const fabAfter = await getFabState(page);
+    expect(fabAfter!.hasSvg).toBe(true);
+    expect(fabAfter!.hasImg).toBe(false);
+  });
+});


### PR DESCRIPTION
## 症状

Widget FABがチャット閉じ後にアバター顔画像→青い吹き出しアイコンに劣化する。

## 根本原因（2段階）

### 主因: LiveKit Disconnected ハンドラーの無条件 resetFabIcon()
1. `closePanel()` が `showFabMedia(fabVideoEl)` でFABにアバター顔を復元 ✅
2. `closePanel()` が `room.disconnect()` を呼ぶ
3. 非同期で `RoomEvent.Disconnected` が発火
4. ハンドラーが `fabVideoEl = null; fabMediaContainer = null; resetFabIcon()` → FAB が青いアイコンに ❌

### 副因: 静止画アバターの closePanel else ブランチ漏れ
`closePanel` の `else` ブランチが `fabVideoEl===null` のとき `fabMediaContainer`（img入り）を確認せずチャットアイコンに置き換えていた。

## 修正内容

**Fix 1** (`RoomEvent.Disconnected` ハンドラー):
- `avatarConfig.imageUrl` をクリア前に保存
- `!isOpen`（パネル閉鎖中）の場合は `resetFabIcon()` の代わりに thumbnail img を `showFabMedia()` で復元

**Fix 2** (`closePanel` else ブランチ):
- `fabMediaContainer && fabMediaContainer.firstChild` の確認を追加
- 静止画アバター（LiveKitなし）のクローズ時も顔画像を維持

## Before / After

**Before（バグあり VPS）:**

チャット開閉前:
> FAB = アバター顔画像（女性アバター）

チャット閉じ後:
> FAB = 青い吹き出しアイコン ❌

**After（修正版）:**
> FAB = アバター顔画像のまま ✅

*(スクリーンショット: `fab-before-open.jpeg` / `fab-after-close-buggy.jpeg` を調査で取得済み)*

## テスト計画

- [x] `pnpm typecheck` → 0 errors
- [x] `pnpm test` → 1159 pass
- [x] `pnpm build` → 0 errors
- [x] Playwright MCP で現行VPSのバグを再現確認済み（青いアイコン劣化を目視確認）
- [x] E2Eテスト追加: `tests/e2e/widget-fab-avatar.spec.ts`（3シナリオ）
- [ ] `bash SCRIPTS/deploy-vps.sh` でデプロイ後、After スクリーンショット取得

## 影響範囲
- `public/widget.js` のみ（API/DB変更なし）
- アバター未設定テナント: `fabMediaContainer` が null のため `resetFabIcon()` 既存パスを通る（変更なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)