### PR TITLE
feat(phase68): knowledge attribution analytics

### DIFF
--- a/VPS_OPS_GUIDE.md
+++ b/VPS_OPS_GUIDE.md
@@ -93,6 +93,7 @@ ssh root@65.108.159.161 "psql 'postgresql://postgres:hezdus-4jygWy-pyqrub@127.0.
 | `src/api/admin/analytics/migration_sentiment.sql` | `chat_messages.sentiment` JSONB カラム追加 | Phase 51 |
 | `src/api/admin/avatar/migration_fix_active_constraint.sql` | `idx_avatar_configs_active` 再作成（デフォルト除外）+ デフォルトアバター is_active=true 一括更新 | Phase 64修正 |
 | `src/api/admin/tenants/migration_r2c_default.sql` | r2c_default テナント追加 + is_default=true アバター carnation→r2c_default 移行 | Phase 66 |
+| `src/api/admin/analytics/migration_rag_sources.sql` | `chat_messages.rag_sources` JSONB カラム追加 + GINインデックス（ナレッジCV影響度解析用） | Phase 68 |
 
 > 新しいマイグレーションを追加した場合は、このテーブルを更新すること。
 

--- a/admin-ui/src/components/knowledge/KnowledgeAttributionTab.tsx
+++ b/admin-ui/src/components/knowledge/KnowledgeAttributionTab.tsx
@@ -1,0 +1,446 @@
+// Phase68: ナレッジ別CV影響度タブ
+// /v1/admin/analytics/knowledge-attribution を呼び出して
+// FAQ/書籍チャンクの利用頻度・CV寄与を可視化する。
+
+import { useCallback, useEffect, useMemo, useState, type CSSProperties } from "react";
+import { Bar } from "react-chartjs-2";
+import { authFetch, API_BASE } from "../../lib/api";
+
+type Period = "7d" | "30d" | "90d";
+type SourceType = "all" | "faq" | "book";
+type SortBy = "conversion_rate" | "usage_count" | "judge_score";
+
+interface AttributionItem {
+  chunk_id: string;
+  source: "faq" | "book";
+  title: string;
+  principle?: string;
+  usage_count: number;
+  conversation_count: number;
+  conversion_count: number;
+  conversion_rate: number;
+  avg_judge_score: number | null;
+  trend: "up" | "down" | "stable";
+}
+
+interface AttributionResponse {
+  period: string;
+  tenant_id: string;
+  source_type: SourceType;
+  sort_by: SortBy;
+  items: AttributionItem[];
+  summary: {
+    total_chunks_used: number;
+    avg_conversion_rate: number;
+    top_performer: AttributionItem | null;
+    worst_performer: AttributionItem | null;
+  };
+}
+
+// ─── スタイル ─────────────────────────────────────────────────────────────────
+
+const CARD: CSSProperties = {
+  borderRadius: 14,
+  border: "1px solid #1f2937",
+  background: "linear-gradient(145deg, rgba(15,23,42,0.95), rgba(15,23,42,0.7))",
+  padding: "18px",
+};
+
+const SELECT: CSSProperties = {
+  padding: "10px 12px",
+  minHeight: 44,
+  borderRadius: 8,
+  border: "1px solid #374151",
+  background: "rgba(15,23,42,0.8)",
+  color: "#e5e7eb",
+  fontSize: 14,
+};
+
+const TH: CSSProperties = {
+  textAlign: "left",
+  padding: "10px 12px",
+  fontSize: 12,
+  color: "#9ca3af",
+  fontWeight: 600,
+  borderBottom: "1px solid #1f2937",
+  cursor: "pointer",
+  userSelect: "none",
+};
+
+const TD: CSSProperties = {
+  padding: "10px 12px",
+  fontSize: 13,
+  color: "#e5e7eb",
+  borderBottom: "1px solid rgba(31,41,55,0.5)",
+  verticalAlign: "top",
+};
+
+function formatRate(r: number): string {
+  return `${(r * 100).toFixed(1)}%`;
+}
+
+function trendLabel(trend: AttributionItem["trend"]): { label: string; color: string } {
+  switch (trend) {
+    case "up":
+      return { label: "▲ 上昇", color: "#4ade80" };
+    case "down":
+      return { label: "▼ 下降", color: "#f87171" };
+    default:
+      return { label: "→ 横這い", color: "#9ca3af" };
+  }
+}
+
+function sourceLabel(source: "faq" | "book"): { label: string; color: string } {
+  return source === "book"
+    ? { label: "書籍", color: "#fbbf24" }
+    : { label: "FAQ", color: "#60a5fa" };
+}
+
+// ─── コンポーネント本体 ───────────────────────────────────────────────────────
+
+export default function KnowledgeAttributionTab({ tenantId }: { tenantId: string }) {
+  const [period, setPeriod] = useState<Period>("30d");
+  const [sourceType, setSourceType] = useState<SourceType>("all");
+  const [sortBy, setSortBy] = useState<SortBy>("conversion_rate");
+  const [data, setData] = useState<AttributionResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    if (!tenantId) return;
+    setLoading(true);
+    setError(null);
+    try {
+      const params = new URLSearchParams({
+        tenant_id: tenantId,
+        period,
+        source_type: sourceType,
+        sort_by: sortBy,
+      });
+      const res = await authFetch(
+        `${API_BASE}/v1/admin/analytics/knowledge-attribution?${params.toString()}`,
+      );
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body?.error ?? `HTTP ${res.status}`);
+      }
+      const json: AttributionResponse = await res.json();
+      setData(json);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setData(null);
+    } finally {
+      setLoading(false);
+    }
+  }, [tenantId, period, sourceType, sortBy]);
+
+  useEffect(() => {
+    void fetchData();
+  }, [fetchData]);
+
+  // Top10 棒グラフ用データ
+  const top10BarData = useMemo(() => {
+    if (!data) return null;
+    const top10 = [...data.items]
+      .sort((a, b) => b.conversion_rate - a.conversion_rate)
+      .slice(0, 10);
+    return {
+      labels: top10.map((x) =>
+        x.title.length > 20 ? `${x.title.slice(0, 20)}…` : x.title,
+      ),
+      datasets: [
+        {
+          label: "CV率 (%)",
+          data: top10.map((x) => Number((x.conversion_rate * 100).toFixed(1))),
+          backgroundColor: top10.map((x) =>
+            x.source === "book" ? "rgba(251,191,36,0.7)" : "rgba(96,165,250,0.7)",
+          ),
+          borderColor: top10.map((x) =>
+            x.source === "book" ? "#fbbf24" : "#60a5fa",
+          ),
+          borderWidth: 1,
+        },
+      ],
+    };
+  }, [data]);
+
+  const top10BarOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { display: false },
+      title: {
+        display: true,
+        text: "Top10 ナレッジ CV率比較",
+        color: "#e5e7eb",
+      },
+    },
+    scales: {
+      x: {
+        ticks: { color: "#9ca3af", font: { size: 10 } },
+        grid: { color: "rgba(255,255,255,0.04)" },
+      },
+      y: {
+        ticks: { color: "#9ca3af", callback: (v: unknown) => `${v}%` },
+        grid: { color: "rgba(255,255,255,0.08)" },
+      },
+    },
+  };
+
+  return (
+    <div>
+      {/* フィルター */}
+      <div
+        style={{
+          display: "flex",
+          gap: 12,
+          flexWrap: "wrap",
+          alignItems: "flex-end",
+          marginBottom: 20,
+        }}
+      >
+        <div>
+          <label
+            style={{ display: "block", fontSize: 12, color: "#9ca3af", marginBottom: 4 }}
+          >
+            期間
+          </label>
+          <select
+            value={period}
+            onChange={(e) => setPeriod(e.target.value as Period)}
+            style={SELECT}
+          >
+            <option value="7d">過去7日</option>
+            <option value="30d">過去30日</option>
+            <option value="90d">過去90日</option>
+          </select>
+        </div>
+        <div>
+          <label
+            style={{ display: "block", fontSize: 12, color: "#9ca3af", marginBottom: 4 }}
+          >
+            ソース
+          </label>
+          <select
+            value={sourceType}
+            onChange={(e) => setSourceType(e.target.value as SourceType)}
+            style={SELECT}
+          >
+            <option value="all">全て</option>
+            <option value="faq">FAQ</option>
+            <option value="book">書籍</option>
+          </select>
+        </div>
+        <div>
+          <label
+            style={{ display: "block", fontSize: 12, color: "#9ca3af", marginBottom: 4 }}
+          >
+            並び順
+          </label>
+          <select
+            value={sortBy}
+            onChange={(e) => setSortBy(e.target.value as SortBy)}
+            style={SELECT}
+          >
+            <option value="conversion_rate">CV率</option>
+            <option value="usage_count">利用回数</option>
+            <option value="judge_score">Judgeスコア</option>
+          </select>
+        </div>
+      </div>
+
+      {loading && <p style={{ color: "#9ca3af" }}>読み込み中…</p>}
+      {error && (
+        <p style={{ color: "#fca5a5", fontSize: 14 }}>
+          エラー: {error}
+        </p>
+      )}
+
+      {data && !loading && (
+        <>
+          {/* サマリーカード */}
+          <div
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(auto-fit, minmax(220px, 1fr))",
+              gap: 12,
+              marginBottom: 20,
+            }}
+          >
+            <div style={CARD}>
+              <p style={{ margin: 0, fontSize: 12, color: "#9ca3af" }}>利用ナレッジ数</p>
+              <p
+                style={{
+                  margin: "6px 0 0",
+                  fontSize: 28,
+                  fontWeight: 700,
+                  color: "#f9fafb",
+                }}
+              >
+                {data.summary.total_chunks_used}
+              </p>
+            </div>
+            <div style={CARD}>
+              <p style={{ margin: 0, fontSize: 12, color: "#9ca3af" }}>平均CV率</p>
+              <p
+                style={{
+                  margin: "6px 0 0",
+                  fontSize: 28,
+                  fontWeight: 700,
+                  color: "#4ade80",
+                }}
+              >
+                {formatRate(data.summary.avg_conversion_rate)}
+              </p>
+            </div>
+            <div style={CARD}>
+              <p style={{ margin: 0, fontSize: 12, color: "#9ca3af" }}>
+                最高パフォーマー
+              </p>
+              {data.summary.top_performer ? (
+                <>
+                  <p
+                    style={{
+                      margin: "6px 0 2px",
+                      fontSize: 14,
+                      color: "#f9fafb",
+                      lineHeight: 1.35,
+                    }}
+                  >
+                    {data.summary.top_performer.title}
+                  </p>
+                  <p
+                    style={{
+                      margin: 0,
+                      fontSize: 13,
+                      fontWeight: 700,
+                      color: "#4ade80",
+                    }}
+                  >
+                    CV率 {formatRate(data.summary.top_performer.conversion_rate)}
+                  </p>
+                </>
+              ) : (
+                <p style={{ margin: "6px 0 0", fontSize: 14, color: "#6b7280" }}>
+                  データなし
+                </p>
+              )}
+            </div>
+          </div>
+
+          {/* 棒グラフ */}
+          {top10BarData && data.items.length > 0 && (
+            <div style={{ ...CARD, marginBottom: 20, height: 320 }}>
+              <Bar data={top10BarData} options={top10BarOptions} />
+            </div>
+          )}
+
+          {/* テーブル */}
+          <div
+            style={{
+              ...CARD,
+              padding: 0,
+              overflow: "auto",
+            }}
+          >
+            <table
+              style={{
+                width: "100%",
+                borderCollapse: "collapse",
+                minWidth: 720,
+              }}
+            >
+              <thead>
+                <tr>
+                  <th style={TH}>ナレッジ</th>
+                  <th style={TH}>種別</th>
+                  <th
+                    style={TH}
+                    onClick={() => setSortBy("usage_count")}
+                    title="クリックで利用回数順"
+                  >
+                    利用回数
+                  </th>
+                  <th style={TH}>CV回数</th>
+                  <th
+                    style={TH}
+                    onClick={() => setSortBy("conversion_rate")}
+                    title="クリックでCV率順"
+                  >
+                    CV率
+                  </th>
+                  <th
+                    style={TH}
+                    onClick={() => setSortBy("judge_score")}
+                    title="クリックでJudgeスコア順"
+                  >
+                    Judgeスコア
+                  </th>
+                  <th style={TH}>トレンド</th>
+                </tr>
+              </thead>
+              <tbody>
+                {data.items.length === 0 && (
+                  <tr>
+                    <td style={{ ...TD, textAlign: "center", color: "#6b7280" }} colSpan={7}>
+                      データがまだありません。RAGソース記録は Phase68 デプロイ以降の会話から蓄積されます。
+                    </td>
+                  </tr>
+                )}
+                {data.items.map((item) => {
+                  const sLabel = sourceLabel(item.source);
+                  const tLabel = trendLabel(item.trend);
+                  return (
+                    <tr key={`${item.source}:${item.chunk_id}`}>
+                      <td style={TD}>
+                        <div style={{ fontWeight: 600, color: "#f9fafb" }}>
+                          {item.title}
+                        </div>
+                        {item.principle && (
+                          <div
+                            style={{ fontSize: 11, color: "#fbbf24", marginTop: 2 }}
+                          >
+                            原則: {item.principle}
+                          </div>
+                        )}
+                      </td>
+                      <td style={TD}>
+                        <span
+                          style={{
+                            display: "inline-block",
+                            padding: "2px 8px",
+                            borderRadius: 999,
+                            fontSize: 11,
+                            fontWeight: 700,
+                            background: `${sLabel.color}22`,
+                            color: sLabel.color,
+                            border: `1px solid ${sLabel.color}`,
+                          }}
+                        >
+                          {sLabel.label}
+                        </span>
+                      </td>
+                      <td style={TD}>{item.usage_count}</td>
+                      <td style={TD}>{item.conversion_count}</td>
+                      <td style={{ ...TD, fontWeight: 700, color: "#4ade80" }}>
+                        {formatRate(item.conversion_rate)}
+                      </td>
+                      <td style={TD}>
+                        {item.avg_judge_score != null
+                          ? item.avg_judge_score.toFixed(1)
+                          : "—"}
+                      </td>
+                      <td style={{ ...TD, color: tLabel.color, fontWeight: 600 }}>
+                        {tLabel.label}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/admin-ui/src/pages/admin/analytics/index.tsx
+++ b/admin-ui/src/pages/admin/analytics/index.tsx
@@ -168,6 +168,8 @@ export default function AnalyticsDashboardPage() {
   const [evaluations, setEvaluations] = useState<AnalyticsEvaluationsResponse | null>(null);
   const [conversion, setConversion] = useState<ConversionResponse | null>(null);
   const [techSortAsc, setTechSortAsc] = useState(false);
+  // Phase68: ナレッジ貢献度 — Top3 の平均 CV 率
+  const [knowledgeTop3AvgRate, setKnowledgeTop3AvgRate] = useState<number | null>(null);
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -211,6 +213,42 @@ export default function AnalyticsDashboardPage() {
       setTrends((await trendsRes.json()) as AnalyticsTrendsResponse);
       setEvaluations((await evalsRes.json()) as AnalyticsEvaluationsResponse);
       setConversion((await convRes.json()) as ConversionResponse);
+
+      // Phase68: ナレッジ貢献度（特定テナントが選ばれている場合のみ）
+      const effectiveTenantId =
+        tenantId ?? (isSuperAdmin && tenantFilter ? tenantFilter : undefined);
+      if (effectiveTenantId) {
+        try {
+          const kaParams = new URLSearchParams({
+            tenant_id: effectiveTenantId,
+            period,
+            sort_by: "conversion_rate",
+            limit: "3",
+          });
+          const kaRes = await authFetch(
+            `${API_BASE}/v1/admin/analytics/knowledge-attribution?${kaParams}`,
+          );
+          if (kaRes.ok) {
+            const ka = (await kaRes.json()) as {
+              items: Array<{ conversion_rate: number }>;
+            };
+            if (ka.items.length > 0) {
+              const top3 = ka.items.slice(0, 3);
+              const avg =
+                top3.reduce((s, i) => s + (i.conversion_rate ?? 0), 0) / top3.length;
+              setKnowledgeTop3AvgRate(avg);
+            } else {
+              setKnowledgeTop3AvgRate(null);
+            }
+          } else {
+            setKnowledgeTop3AvgRate(null);
+          }
+        } catch {
+          setKnowledgeTop3AvgRate(null);
+        }
+      } else {
+        setKnowledgeTop3AvgRate(null);
+      }
     } catch {
       setError("データの読み込みに失敗しました");
     } finally {
@@ -622,6 +660,29 @@ export default function AnalyticsDashboardPage() {
               <span style={{ fontSize: 13, fontWeight: 600, color: "#d1d5db" }}>CV件数(30日)</span>
               <span style={{ fontSize: 12, color: "#6b7280" }}>
                 ¥{(summary?.cv_total_value_30d ?? 0).toLocaleString("ja-JP")}
+              </span>
+            </div>
+
+            {/* ナレッジ貢献度 (Phase68) */}
+            <div style={cardStyle}>
+              <span style={{ fontSize: 24 }}>📈</span>
+              <span
+                style={{
+                  fontSize: 28,
+                  fontWeight: 700,
+                  color: knowledgeTop3AvgRate != null ? "#4ade80" : "#9ca3af",
+                  lineHeight: 1,
+                }}
+              >
+                {knowledgeTop3AvgRate != null
+                  ? `${(knowledgeTop3AvgRate * 100).toFixed(1)}%`
+                  : "—"}
+              </span>
+              <span style={{ fontSize: 13, fontWeight: 600, color: "#d1d5db" }}>
+                ナレッジ貢献度
+              </span>
+              <span style={{ fontSize: 12, color: "#6b7280" }}>
+                Top3 平均CV率
               </span>
             </div>
 

--- a/admin-ui/src/pages/admin/knowledge/[tenantId].tsx
+++ b/admin-ui/src/pages/admin/knowledge/[tenantId].tsx
@@ -7,6 +7,7 @@ import { useLang } from "../../../i18n/LangContext";
 import LangSwitcher from "../../../components/LangSwitcher";
 import { useAuth } from "../../../auth/useAuth";
 import BookChunksPanel from "./BookChunksPanel";
+import KnowledgeAttributionTab from "../../../components/knowledge/KnowledgeAttributionTab";
 
 // ─── 型定義 ──────────────────────────────────────────────────────────────────
 
@@ -51,7 +52,7 @@ interface ScrapePreviewItem {
   error?: string;
 }
 
-type Tab = "list" | "text" | "scrape" | "pdf";
+type Tab = "list" | "text" | "scrape" | "pdf" | "attribution";
 type DeleteState = "idle" | "confirming" | "deleting" | "success" | "error";
 type Category = string;
 
@@ -2176,7 +2177,12 @@ export default function TenantKnowledgePage() {
   const gapQuestion = searchParams.get("question") ?? undefined;
 
   const [activeTab, setActiveTab] = useState<Tab>(
-    tabParam === "text" || tabParam === "scrape" || tabParam === "pdf" ? tabParam : "list"
+    tabParam === "text" ||
+      tabParam === "scrape" ||
+      tabParam === "pdf" ||
+      tabParam === "attribution"
+      ? tabParam
+      : "list"
   );
 
   // tenantId の解決: URL params → pathnameの末尾 → JWTのtenantId
@@ -2197,6 +2203,7 @@ export default function TenantKnowledgePage() {
     { id: "text", label: t("knowledge.tab_text"), icon: "✏️" },
     { id: "scrape", label: t("knowledge.tab_scrape"), icon: "🌐" },
     { id: "pdf", label: "PDFアップロード", icon: "📚" },
+    { id: "attribution", label: "CV影響度", icon: "📈" },
   ];
 
   const isGlobalTenant = resolvedTenantId === "global";
@@ -2275,6 +2282,9 @@ export default function TenantKnowledgePage() {
       {activeTab === "text" && <TextInputTab tenantId={resolvedTenantId} gapQuestion={gapQuestion} gapId={gapId} />}
       {activeTab === "scrape" && <ScrapeTab tenantId={resolvedTenantId} onCommitSuccess={() => setActiveTab("list")} gapQuestion={gapQuestion} gapId={gapId} />}
       {activeTab === "pdf" && <PdfUploadTab tenantId={resolvedTenantId} />}
+      {activeTab === "attribution" && (
+        <KnowledgeAttributionTab tenantId={resolvedTenantId} />
+      )}
     </div>
   );
 }

--- a/src/agent/dialog/dialogAgent.ts
+++ b/src/agent/dialog/dialogAgent.ts
@@ -201,6 +201,7 @@ export async function runDialogTurn(
         orchestrated.clarifyingQuestions ?? multiStepPlan.clarifyingQuestions,
       gapSignal: orchestrated.gapSignal,
       llmUsage: orchestrated.llmUsage,
+      ragSources: orchestrated.ragSources,
     },
   };
 

--- a/src/agent/dialog/types.ts
+++ b/src/agent/dialog/types.ts
@@ -114,6 +114,8 @@ export interface DialogTurnMeta {
   gapSignal?: { hitCount: number; topScore: number };
   /** Phase53: Groq API実トークン数 */
   llmUsage?: { prompt_tokens: number; completion_tokens: number };
+  /** Phase68: 応答生成に使用された RAG チャンク */
+  ragSources?: import("../types").RagSource[];
 }
 
 export interface DialogTurnResult {

--- a/src/agent/flow/dialogOrchestrator.ts
+++ b/src/agent/flow/dialogOrchestrator.ts
@@ -1,6 +1,7 @@
 // src/agent/flow/dialogOrchestrator.ts
 
 import type { DialogMessage, MultiStepQueryPlan, OrchestratorStep } from '../dialog/types'
+import type { RagSource } from '../types'
 import { runSearchAgent } from './searchAgent'
 
 // Re-exported for backward compatibility — definition lives in dialog/types.ts
@@ -28,6 +29,8 @@ export interface OrchestratorResult {
   gapSignal?: { hitCount: number; topScore: number }
   /** Phase53: Groq API実トークン数 */
   llmUsage?: { prompt_tokens: number; completion_tokens: number }
+  /** Phase68: 応答生成に使用された RAG チャンク */
+  ragSources?: RagSource[]
 }
 
 /**
@@ -111,5 +114,6 @@ export async function runDialogOrchestrator(
     final: true,
     gapSignal: searchResult.gapSignal,
     llmUsage: searchResult.llmUsage,
+    ragSources: searchResult.ragSources,
   }
 }

--- a/src/agent/flow/searchAgent.ts
+++ b/src/agent/flow/searchAgent.ts
@@ -10,6 +10,7 @@ import type {
   AgentSearchParams,
   AgentSearchResponse,
   AgentStep,
+  RagSource,
 } from "../types";
 import { planQueryWithLlmAsync } from "./llmPlannerRuntime";
 import { planQuery } from "./queryPlanner";
@@ -184,10 +185,29 @@ export async function runSearchAgent(
     rerankEngine: rerankResult.rerankEngine,
   };
 
+  // Phase68: rerank 後の topK チャンクを RAG ソースとして抽出。
+  // metadata の 'source' が 'book' のときのみ principle/book 扱い、
+  // 未設定 (ES ヒット or 旧データ) は FAQ として扱う。
+  const ragSources: RagSource[] = rerankResult.items.map((it) => {
+    const meta = (it as { metadata?: Record<string, unknown> }).metadata;
+    const sourceType = meta && meta["source"] === "book" ? "book" : "faq";
+    const principle = typeof meta?.["principle"] === "string"
+      ? (meta["principle"] as string)
+      : undefined;
+    const source: RagSource = {
+      chunk_id: String(it.id),
+      source: sourceType,
+      score: typeof it.score === "number" ? it.score : 0,
+    };
+    if (principle) source.principle = principle;
+    return source;
+  });
+
   return {
     answer: synth.answer,
     steps,
     ragStats,
+    ragSources,
     gapSignal: synth.gapSignal,
     llmUsage: synth.llmUsage,
     debug: {

--- a/src/agent/tools/rerankTool.ts
+++ b/src/agent/tools/rerankTool.ts
@@ -27,6 +27,8 @@ export async function rerankTool(
     text: hit.text,
     score: hit.score,
     source: hit.source,
+    // Phase68: metadata を rerank 層に引き継ぐ（rerank 内で spread 保持）
+    metadata: hit.metadata,
   }));
 
   const result = await rerank(query, ceItems, topK);

--- a/src/agent/tools/searchTool.ts
+++ b/src/agent/tools/searchTool.ts
@@ -36,6 +36,8 @@ export async function searchTool(
         score: hit.score,
         // pgvector だが、既存の 'pg' ソース種別に合わせておく
         source: 'pg',
+        // Phase68: faq_embeddings.metadata を引き継ぐ (source/principle/book_id)
+        metadata: hit.metadata,
       }));
 
       return {

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -47,6 +47,22 @@ export interface AgentSearchParams {
   visitorId?: string;
 }
 
+/**
+ * Phase68: LLM応答に使用された RAG チャンクの 1 件。
+ * chat_messages.rag_sources に JSONB 配列として永続化される。
+ * ナレッジ別 CV 影響度の集計キーとなる。
+ */
+export interface RagSource {
+  /** faq_embeddings.id の文字列表現 */
+  chunk_id: string;
+  /** FAQ チャンクか書籍チャンクか */
+  source: "faq" | "book";
+  /** rerank 後の最終スコア (0〜1 目安) */
+  score: number;
+  /** 書籍チャンクに関連づけられた心理原則（書籍チャンクのみ） */
+  principle?: string;
+}
+
 export interface AgentSearchResponse {
   answer: string;
   steps: AgentStep[];
@@ -58,6 +74,8 @@ export interface AgentSearchResponse {
     totalMs?: number;
     rerankEngine?: string;
   };
+  /** Phase68: 応答生成に使用された RAG チャンク（rerank 後の topK） */
+  ragSources?: RagSource[];
   gapSignal?: { hitCount: number; topScore: number };
   /** Phase53: Groq API実トークン数 */
   llmUsage?: { prompt_tokens: number; completion_tokens: number };

--- a/src/api/admin/analytics/knowledgeAttribution.test.ts
+++ b/src/api/admin/analytics/knowledgeAttribution.test.ts
@@ -55,7 +55,7 @@ type AttrRow = {
   conversion_count: number;
   conversion_rate: number;
   avg_judge_score: number | null;
-  title: string | null;
+  raw_text: string | null;
   book_title: string | null;
   prev_rate: number;
 };
@@ -78,7 +78,7 @@ describe('GET /v1/admin/analytics/knowledge-attribution', () => {
         conversion_count: 12,
         conversion_rate: 12 / 38,
         avg_judge_score: 72.5,
-        title: '返品はできますか？',
+        raw_text: '返品はできますか？',
         book_title: null,
         prev_rate: 0.25, // 上昇傾向
       },
@@ -91,7 +91,7 @@ describe('GET /v1/admin/analytics/knowledge-attribution', () => {
         conversion_count: 7,
         conversion_rate: 0.5,
         avg_judge_score: 80.0,
-        title: '返報性の原理は顧客心理に強く働く',
+        raw_text: '返報性の原理は顧客心理に強く働く',
         book_title: '影響力の武器',
         prev_rate: 0.5, // stable
       },

--- a/src/api/admin/analytics/knowledgeAttribution.test.ts
+++ b/src/api/admin/analytics/knowledgeAttribution.test.ts
@@ -1,0 +1,242 @@
+// src/api/admin/analytics/knowledgeAttribution.test.ts
+// Phase68: ナレッジ別 CV 影響度集計 API のユニットテスト
+
+import express from 'express';
+import request from 'supertest';
+
+// ---------------------------------------------------------------------------
+// DB モック
+// ---------------------------------------------------------------------------
+
+const mockQuery = jest.fn();
+jest.mock('../../../lib/db', () => ({
+  pool: { query: (...args: unknown[]) => mockQuery(...args) },
+  getPool: () => ({ query: (...args: unknown[]) => mockQuery(...args) }),
+}));
+
+jest.mock('../../../lib/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock('../../../lib/notifications', () => ({
+  createNotification: jest.fn(),
+  notificationExists: jest.fn().mockResolvedValue(false),
+}));
+
+// supabase auth middleware: x-role, x-tenant-id ヘッダでロール/テナントを注入
+jest.mock('../../../admin/http/supabaseAuthMiddleware', () => ({
+  supabaseAuthMiddleware: (req: any, _res: any, next: any) => {
+    req.supabaseUser = {
+      app_metadata: {
+        role: (req.headers['x-role'] as string) ?? 'client_admin',
+        tenant_id: (req.headers['x-tenant-id'] as string) ?? 'tenant-A',
+      },
+    };
+    next();
+  },
+}));
+
+import { registerAnalyticsRoutes } from './routes';
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  registerAnalyticsRoutes(app);
+  return app;
+}
+
+// テスト用の集計結果レコード (実 SQL CTE の joined 相当)
+type AttrRow = {
+  chunk_id: string;
+  src_type: 'faq' | 'book' | null;
+  principle: string | null;
+  usage_count: number;
+  conversation_count: number;
+  conversion_count: number;
+  conversion_rate: number;
+  avg_judge_score: number | null;
+  title: string | null;
+  book_title: string | null;
+  prev_rate: number;
+};
+
+describe('GET /v1/admin/analytics/knowledge-attribution', () => {
+  beforeEach(() => mockQuery.mockClear());
+
+  // -------------------------------------------------------------------------
+  // 正常系
+  // -------------------------------------------------------------------------
+
+  it('FAQ/書籍混在の集計結果を整形して返す', async () => {
+    const rows: AttrRow[] = [
+      {
+        chunk_id: '101',
+        src_type: 'faq',
+        principle: null,
+        usage_count: 40,
+        conversation_count: 38,
+        conversion_count: 12,
+        conversion_rate: 12 / 38,
+        avg_judge_score: 72.5,
+        title: '返品はできますか？',
+        book_title: null,
+        prev_rate: 0.25, // 上昇傾向
+      },
+      {
+        chunk_id: '202',
+        src_type: 'book',
+        principle: 'reciprocity',
+        usage_count: 15,
+        conversation_count: 14,
+        conversion_count: 7,
+        conversion_rate: 0.5,
+        avg_judge_score: 80.0,
+        title: '返報性の原理は顧客心理に強く働く',
+        book_title: '影響力の武器',
+        prev_rate: 0.5, // stable
+      },
+    ];
+    mockQuery.mockResolvedValueOnce({ rows });
+
+    const res = await request(makeApp())
+      .get('/v1/admin/analytics/knowledge-attribution')
+      .query({ period: '30d', source_type: 'all', sort_by: 'conversion_rate' })
+      .set('x-tenant-id', 'tenant-A');
+
+    expect(res.status).toBe(200);
+    expect(res.body.tenant_id).toBe('tenant-A');
+    expect(res.body.period).toBe('30d');
+    expect(res.body.source_type).toBe('all');
+
+    expect(res.body.items).toHaveLength(2);
+    const faqItem = res.body.items.find((x: any) => x.chunk_id === '101');
+    expect(faqItem.source).toBe('faq');
+    expect(faqItem.title).toBe('返品はできますか？');
+    expect(faqItem.conversion_rate).toBeCloseTo(12 / 38, 4);
+    expect(faqItem.trend).toBe('up'); // 12/38 ≈ 0.316 > 0.25+0.02
+
+    const bookItem = res.body.items.find((x: any) => x.chunk_id === '202');
+    expect(bookItem.source).toBe('book');
+    expect(bookItem.principle).toBe('reciprocity');
+    expect(bookItem.title).toContain('影響力の武器');
+    expect(bookItem.trend).toBe('stable'); // |0.5 - 0.5| < 0.02
+
+    // summary
+    expect(res.body.summary.total_chunks_used).toBe(2);
+    expect(res.body.summary.top_performer.chunk_id).toBe('202');
+    expect(res.body.summary.worst_performer.chunk_id).toBe('101');
+  });
+
+  it('SQL の ORDER BY が sort_by に合わせて切り替わる (usage_count)', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await request(makeApp())
+      .get('/v1/admin/analytics/knowledge-attribution')
+      .query({ sort_by: 'usage_count' })
+      .set('x-tenant-id', 'tenant-A');
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const sqlArg = String(mockQuery.mock.calls[0]?.[0] ?? '');
+    expect(sqlArg).toMatch(/ORDER BY\s+c\.usage_count\s+DESC/);
+  });
+
+  it('source_type=book のとき LATERAL に絞り込みパラメータが追加される', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await request(makeApp())
+      .get('/v1/admin/analytics/knowledge-attribution')
+      .query({ source_type: 'book' })
+      .set('x-tenant-id', 'tenant-A');
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain("(src->>'source') = $3");
+    expect(params).toEqual(['tenant-A', '30 days', 'book']);
+  });
+
+  // -------------------------------------------------------------------------
+  // RBAC
+  // -------------------------------------------------------------------------
+
+  it('super_admin: ?tenant_id で任意テナントを指定可能', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    const res = await request(makeApp())
+      .get('/v1/admin/analytics/knowledge-attribution')
+      .query({ tenant_id: 'tenant-X' })
+      .set('x-role', 'super_admin');
+
+    expect(res.status).toBe(200);
+    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(params[0]).toBe('tenant-X');
+  });
+
+  it('super_admin が tenant_id を指定しない場合は 400', async () => {
+    const res = await request(makeApp())
+      .get('/v1/admin/analytics/knowledge-attribution')
+      .set('x-role', 'super_admin')
+      .set('x-tenant-id', ''); // empty
+
+    expect(res.status).toBe(400);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it('client_admin は JWT の tenant_id が必ず使われ、?tenant_id クエリは無視される', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await request(makeApp())
+      .get('/v1/admin/analytics/knowledge-attribution')
+      .query({ tenant_id: 'other-tenant' })
+      .set('x-tenant-id', 'tenant-A'); // client_admin
+
+    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(params[0]).toBe('tenant-A');
+  });
+
+  // -------------------------------------------------------------------------
+  // バリデーション
+  // -------------------------------------------------------------------------
+
+  it('不正な sort_by は conversion_rate にフォールバック', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    const res = await request(makeApp())
+      .get('/v1/admin/analytics/knowledge-attribution')
+      .query({ sort_by: 'drop_all_tables' })
+      .set('x-tenant-id', 'tenant-A');
+
+    expect(res.status).toBe(200);
+    expect(res.body.sort_by).toBe('conversion_rate');
+    const [sql] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).not.toMatch(/drop_all_tables/);
+  });
+
+  it('period=7d の interval が渡される', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await request(makeApp())
+      .get('/v1/admin/analytics/knowledge-attribution')
+      .query({ period: '7d' })
+      .set('x-tenant-id', 'tenant-A');
+
+    const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(params[1]).toBe('7 days');
+  });
+
+  it('DB エラー時は 500', async () => {
+    mockQuery.mockRejectedValueOnce(new Error('db down'));
+    const res = await request(makeApp())
+      .get('/v1/admin/analytics/knowledge-attribution')
+      .set('x-tenant-id', 'tenant-A');
+
+    expect(res.status).toBe(500);
+  });
+
+  it('空の集計結果でもサマリーは 0 で返る', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    const res = await request(makeApp())
+      .get('/v1/admin/analytics/knowledge-attribution')
+      .set('x-tenant-id', 'tenant-A');
+
+    expect(res.status).toBe(200);
+    expect(res.body.items).toEqual([]);
+    expect(res.body.summary.total_chunks_used).toBe(0);
+    expect(res.body.summary.avg_conversion_rate).toBe(0);
+    expect(res.body.summary.top_performer).toBeNull();
+    expect(res.body.summary.worst_performer).toBeNull();
+  });
+});

--- a/src/api/admin/analytics/migration_rag_sources.sql
+++ b/src/api/admin/analytics/migration_rag_sources.sql
@@ -1,0 +1,23 @@
+-- Phase68: ナレッジ別CV影響度解析用カラム
+-- chat_messages に RAG で使用されたチャンクの記録を追加する。
+--
+-- rag_sources の構造（assistant メッセージのみ記録）:
+--   [
+--     { "chunk_id": "<faq_embeddings.id>", "source": "faq"|"book",
+--       "score": <number>, "principle": "<string>" }   // book 時のみ principle
+--   ]
+--
+-- user メッセージでは NULL のまま。
+
+ALTER TABLE chat_messages
+  ADD COLUMN IF NOT EXISTS rag_sources JSONB DEFAULT NULL;
+
+-- jsonb_array_elements での集計を高速化する GIN インデックス
+CREATE INDEX IF NOT EXISTS idx_chat_messages_rag_sources
+  ON chat_messages USING GIN (rag_sources);
+
+-- ============================================================
+-- 確認クエリ (実行後に手動実行して確認)
+-- ============================================================
+-- \d chat_messages
+-- SELECT COUNT(*) FROM chat_messages WHERE rag_sources IS NOT NULL;

--- a/src/api/admin/analytics/routes.ts
+++ b/src/api/admin/analytics/routes.ts
@@ -969,4 +969,250 @@ export function registerAnalyticsRoutes(app: Express): void {
       }
     },
   );
+
+  // -------------------------------------------------------------------------
+  // GET /v1/admin/analytics/knowledge-attribution
+  // Phase68: ナレッジ別 CV 影響度集計
+  //   - tenant_id 必須（super_admin は query、client_admin は JWT 強制）
+  //   - period: 7d | 30d | 90d（デフォルト 30d）
+  //   - source_type: all | faq | book（デフォルト all）
+  //   - sort_by: conversion_rate | usage_count | judge_score（デフォルト conversion_rate）
+  // -------------------------------------------------------------------------
+  app.get(
+    "/v1/admin/analytics/knowledge-attribution",
+    async (req: Request, res: Response) => {
+      const su = (req as any).supabaseUser as Record<string, any> | undefined;
+      const jwtTenantId: string =
+        su?.app_metadata?.tenant_id ?? su?.user_metadata?.tenant_id ?? su?.tenant_id ?? "";
+      const isSuperAdmin: boolean =
+        (su?.app_metadata?.role ?? su?.user_metadata?.role ?? "") === "super_admin";
+
+      // RBAC: client_admin は JWT の tenantId を強制、super_admin は query ?tenant_id=
+      const tenantId: string | undefined = isSuperAdmin
+        ? ((req.query["tenant_id"] as string | undefined) || undefined)
+        : (jwtTenantId || undefined);
+
+      if (!tenantId) {
+        return res.status(400).json({
+          error: isSuperAdmin
+            ? "tenant_id クエリパラメータが必要です"
+            : "テナントIDが解決できません",
+        });
+      }
+
+      const period = ((req.query["period"] as string | undefined) ?? "30d");
+      const interval = periodToInterval(period);
+
+      const sourceTypeRaw = (req.query["source_type"] as string | undefined) ?? "all";
+      const sourceType: "all" | "faq" | "book" =
+        sourceTypeRaw === "faq" || sourceTypeRaw === "book" ? sourceTypeRaw : "all";
+
+      const sortByRaw = (req.query["sort_by"] as string | undefined) ?? "conversion_rate";
+      const validSortBy = ["conversion_rate", "usage_count", "judge_score"] as const;
+      const sortBy: typeof validSortBy[number] = validSortBy.includes(
+        sortByRaw as typeof validSortBy[number],
+      )
+        ? (sortByRaw as typeof validSortBy[number])
+        : "conversion_rate";
+
+      const limitRaw = parseInt((req.query["limit"] as string | undefined) ?? "50", 10);
+      const limit = Math.max(1, Math.min(Number.isFinite(limitRaw) ? limitRaw : 50, 200));
+
+      if (!pool) {
+        return res.status(503).json({ error: "データベース接続が利用できません" });
+      }
+
+      // ORDER BY 列を allow-list から選択（SQLインジェクション防止）
+      const orderColumn =
+        sortBy === "usage_count"
+          ? "c.usage_count"
+          : sortBy === "judge_score"
+          ? "c.avg_judge_score"
+          : "conversion_rate";
+
+      const sourceFilterClause =
+        sourceType === "all" ? "" : "AND (src->>'source') = $3";
+
+      try {
+        // ----- 現期間・前期間を1発のCTEクエリで集計 -----
+        // chat_messages.rag_sources は [{chunk_id, source, score, principle?}, ...] 想定
+        const queryArgs: (string | number)[] = [tenantId, interval];
+        if (sourceType !== "all") queryArgs.push(sourceType);
+
+        const sql = `
+          WITH current_period AS (
+            SELECT
+              (src->>'chunk_id') AS chunk_id,
+              (src->>'source') AS src_type,
+              (src->>'principle') AS principle,
+              cs.id AS session_uuid,
+              cs.session_id AS session_text_id,
+              ca.id IS NOT NULL AS converted,
+              ev.score AS judge_score
+            FROM chat_messages cm
+            JOIN chat_sessions cs ON cs.id = cm.session_id
+            LEFT JOIN conversion_attributions ca ON ca.session_id = cs.id
+            LEFT JOIN conversation_evaluations ev ON ev.session_id = cs.session_id AND ev.score > 0
+            CROSS JOIN LATERAL jsonb_array_elements(cm.rag_sources) AS src
+            WHERE cs.tenant_id = $1
+              AND cm.rag_sources IS NOT NULL
+              AND cm.role = 'assistant'
+              AND cm.created_at >= NOW() - $2::interval
+              ${sourceFilterClause}
+          ),
+          previous_period AS (
+            SELECT
+              (src->>'chunk_id') AS chunk_id,
+              cs.id AS session_uuid,
+              ca.id IS NOT NULL AS converted
+            FROM chat_messages cm
+            JOIN chat_sessions cs ON cs.id = cm.session_id
+            LEFT JOIN conversion_attributions ca ON ca.session_id = cs.id
+            CROSS JOIN LATERAL jsonb_array_elements(cm.rag_sources) AS src
+            WHERE cs.tenant_id = $1
+              AND cm.rag_sources IS NOT NULL
+              AND cm.role = 'assistant'
+              AND cm.created_at >= NOW() - ($2::interval * 2)
+              AND cm.created_at <  NOW() - $2::interval
+              ${sourceFilterClause}
+          ),
+          current_agg AS (
+            SELECT
+              chunk_id,
+              MAX(src_type) AS src_type,
+              MAX(principle) AS principle,
+              COUNT(*)::int AS usage_count,
+              COUNT(DISTINCT session_uuid)::int AS conversation_count,
+              COUNT(DISTINCT CASE WHEN converted THEN session_uuid END)::int AS conversion_count,
+              AVG(judge_score)::float AS avg_judge_score
+            FROM current_period
+            GROUP BY chunk_id
+          ),
+          previous_agg AS (
+            SELECT
+              chunk_id,
+              CASE
+                WHEN COUNT(DISTINCT session_uuid) > 0
+                THEN COUNT(DISTINCT CASE WHEN converted THEN session_uuid END)::float
+                     / COUNT(DISTINCT session_uuid)
+                ELSE 0
+              END AS prev_rate
+            FROM previous_period
+            GROUP BY chunk_id
+          ),
+          joined AS (
+            SELECT
+              c.chunk_id,
+              c.src_type,
+              c.principle,
+              c.usage_count,
+              c.conversation_count,
+              c.conversion_count,
+              CASE
+                WHEN c.conversation_count > 0
+                THEN (c.conversion_count::float / c.conversation_count)
+                ELSE 0
+              END AS conversion_rate,
+              c.avg_judge_score,
+              COALESCE(LEFT(fe.text, 50), '(削除済み)') AS title,
+              bu.title AS book_title,
+              COALESCE(p.prev_rate, 0) AS prev_rate
+            FROM current_agg c
+            LEFT JOIN faq_embeddings fe
+              ON fe.id::text = c.chunk_id AND (fe.tenant_id = $1 OR fe.tenant_id = 'global')
+            LEFT JOIN book_uploads bu
+              ON bu.id::text = fe.metadata->>'book_id'
+            LEFT JOIN previous_agg p ON p.chunk_id = c.chunk_id
+          )
+          SELECT * FROM joined
+          ORDER BY ${orderColumn} DESC NULLS LAST, usage_count DESC
+          LIMIT ${limit}
+        `;
+
+        const result = await pool.query(sql, queryArgs);
+
+        type AttrRow = {
+          chunk_id: string;
+          src_type: "faq" | "book" | null;
+          principle: string | null;
+          usage_count: number;
+          conversation_count: number;
+          conversion_count: number;
+          conversion_rate: number;
+          avg_judge_score: number | null;
+          title: string | null;
+          book_title: string | null;
+          prev_rate: number;
+        };
+
+        const items = (result.rows as AttrRow[]).map((row) => {
+          const currentRate = row.conversion_rate ?? 0;
+          const prevRate = row.prev_rate ?? 0;
+          const delta = currentRate - prevRate;
+          const trend: "up" | "down" | "stable" =
+            Math.abs(delta) < 0.02 ? "stable" : delta > 0 ? "up" : "down";
+          // タイトル: FAQ は text 先頭50文字、書籍は 書名 + チャンク先頭50文字
+          const displayTitle =
+            row.src_type === "book" && row.book_title
+              ? `${row.book_title} — ${row.title ?? ""}`
+              : row.title ?? "(削除済み)";
+          return {
+            chunk_id: row.chunk_id,
+            source: (row.src_type ?? "faq") as "faq" | "book",
+            title: displayTitle,
+            principle: row.principle ?? undefined,
+            usage_count: row.usage_count,
+            conversation_count: row.conversation_count,
+            conversion_count: row.conversion_count,
+            conversion_rate: Number(currentRate.toFixed(4)),
+            avg_judge_score:
+              row.avg_judge_score != null
+                ? Number(row.avg_judge_score.toFixed(2))
+                : null,
+            trend,
+          };
+        });
+
+        // サマリー
+        const totalChunksUsed = items.length;
+        const avgConversionRate =
+          totalChunksUsed > 0
+            ? Number(
+                (
+                  items.reduce((s, i) => s + i.conversion_rate, 0) / totalChunksUsed
+                ).toFixed(4),
+              )
+            : 0;
+        const topPerformer = items.reduce<typeof items[number] | null>(
+          (best, it) =>
+            best == null || it.conversion_rate > best.conversion_rate ? it : best,
+          null,
+        );
+        const worstPerformer = items.reduce<typeof items[number] | null>(
+          (worst, it) =>
+            worst == null || it.conversion_rate < worst.conversion_rate ? it : worst,
+          null,
+        );
+
+        return res.json({
+          period,
+          tenant_id: tenantId,
+          source_type: sourceType,
+          sort_by: sortBy,
+          items,
+          summary: {
+            total_chunks_used: totalChunksUsed,
+            avg_conversion_rate: avgConversionRate,
+            top_performer: topPerformer,
+            worst_performer: worstPerformer,
+          },
+        });
+      } catch (err) {
+        logger.warn("[GET /v1/admin/analytics/knowledge-attribution]", err);
+        return res
+          .status(500)
+          .json({ error: "ナレッジ貢献度の集計に失敗しました" });
+      }
+    },
+  );
 }

--- a/src/api/admin/analytics/routes.ts
+++ b/src/api/admin/analytics/routes.ts
@@ -7,6 +7,7 @@ import { supabaseAuthMiddleware } from "../../../admin/http/supabaseAuthMiddlewa
 import { pool } from "../../../lib/db";
 import { createNotification, notificationExists } from "../../../lib/notifications";
 import { logger } from '../../../lib/logger';
+import { decryptText } from '../../../lib/crypto/textEncrypt';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -1114,7 +1115,7 @@ export function registerAnalyticsRoutes(app: Express): void {
                 ELSE 0
               END AS conversion_rate,
               c.avg_judge_score,
-              COALESCE(LEFT(fe.text, 50), '(削除済み)') AS title,
+              fe.text AS raw_text,
               bu.title AS book_title,
               COALESCE(p.prev_rate, 0) AS prev_rate
             FROM current_agg c
@@ -1140,7 +1141,7 @@ export function registerAnalyticsRoutes(app: Express): void {
           conversion_count: number;
           conversion_rate: number;
           avg_judge_score: number | null;
-          title: string | null;
+          raw_text: string | null;
           book_title: string | null;
           prev_rate: number;
         };
@@ -1151,11 +1152,14 @@ export function registerAnalyticsRoutes(app: Express): void {
           const delta = currentRate - prevRate;
           const trend: "up" | "down" | "stable" =
             Math.abs(delta) < 0.02 ? "stable" : delta > 0 ? "up" : "down";
-          // タイトル: FAQ は text 先頭50文字、書籍は 書名 + チャンク先頭50文字
+          // タイトル: 暗号化テキストを復号し先頭50文字を表示
+          const chunkTitle = row.raw_text
+            ? (() => { try { return decryptText(row.raw_text).slice(0, 50); } catch { return row.raw_text.slice(0, 50); } })()
+            : null;
           const displayTitle =
             row.src_type === "book" && row.book_title
-              ? `${row.book_title} — ${row.title ?? ""}`
-              : row.title ?? "(削除済み)";
+              ? `${row.book_title} — ${chunkTitle ?? ""}`
+              : chunkTitle ?? "(削除済み)";
           return {
             chunk_id: row.chunk_id,
             source: (row.src_type ?? "faq") as "faq" | "book",

--- a/src/api/admin/chat-history/chatHistoryRepository.ts
+++ b/src/api/admin/chat-history/chatHistoryRepository.ts
@@ -2,6 +2,7 @@
 // Phase38: 会話履歴DB永続化リポジトリ（Step1: 保存 / Step2: 取得）
 
 import { getPool } from "../../../lib/db";
+import type { RagSource } from "../../../agent/types";
 
 export interface SaveMessageParams {
   tenantId: string;
@@ -12,6 +13,12 @@ export interface SaveMessageParams {
   /** Phase46: A/Bテスト variant記録 */
   promptVariantId?: string | null;
   promptVariantName?: string | null;
+  /**
+   * Phase68: 応答生成に使用された RAG チャンク（assistant メッセージのみ）。
+   * chat_messages.rag_sources JSONB カラムに配列として保存される。
+   * 既存テスト互換のため optional。
+   */
+  ragSources?: RagSource[];
 }
 
 /**
@@ -42,16 +49,21 @@ export async function saveMessage(params: SaveMessageParams): Promise<void> {
   const dbSessionId = sessionResult.rows[0]?.id;
   if (!dbSessionId) return;
 
-  // 3. メッセージを保存
+  // 3. メッセージを保存 (Phase68: rag_sources を assistant メッセージのみ記録)
+  const ragSourcesJson =
+    params.ragSources && params.ragSources.length > 0
+      ? JSON.stringify(params.ragSources)
+      : null;
   await pool.query(
-    `INSERT INTO chat_messages (session_id, tenant_id, role, content, metadata)
-     VALUES ($1, $2, $3, $4, $5)`,
+    `INSERT INTO chat_messages (session_id, tenant_id, role, content, metadata, rag_sources)
+     VALUES ($1, $2, $3, $4, $5, $6)`,
     [
       dbSessionId,
       params.tenantId,
       params.role,
       params.content,
       JSON.stringify(params.metadata ?? {}),
+      ragSourcesJson,
     ],
   );
 }

--- a/src/api/chat/route.ts
+++ b/src/api/chat/route.ts
@@ -294,6 +294,7 @@ export function createChatHandler(logger: Logger) {
       }
 
       // Phase38: アシスタント応答をDBに保存（fire-and-forget、レスポンス後）
+      // Phase68: ragSources を専用カラムに記録してナレッジCV影響度集計に利用する
       saveMessage({
         tenantId,
         sessionId,
@@ -306,6 +307,7 @@ export function createChatHandler(logger: Logger) {
           rag_top_score: gapSignal?.topScore ?? 0,
           knowledge_gap: isKnowledgeGap(gapSignal) || isResponseGap(content),
         },
+        ragSources: result.meta?.ragSources,
       }).catch((err) =>
         logger.warn({ err }, "[chat-history] save assistant message failed")
       );

--- a/src/search/hybrid.ts
+++ b/src/search/hybrid.ts
@@ -139,6 +139,9 @@ export async function hybridSearch(
       text: decryptText(h._source?.text ?? ""),
       score: h._score ?? 0,
       source: "es" as const,
+      metadata: h._source?.["source"] != null
+        ? { source: h._source["source"], book_id: h._source["book_id"] }
+        : undefined,
     }));
   } catch (e: unknown) {
     const esErrCode = (e as any)?.meta?.statusCode ?? (e as any)?.statusCode;
@@ -166,6 +169,9 @@ export async function hybridSearch(
           text: decryptText(h._source?.text ?? ""),
           score: h._score ?? 0,
           source: "es" as const,
+          metadata: h._source?.["source"] != null
+            ? { source: h._source["source"], book_id: h._source["book_id"] }
+            : undefined,
         }));
         if (esHits.length > 0) {
           notes.push(`es_lang_fallback:${fallbackIndex} hits=${esHits.length}`);
@@ -218,6 +224,9 @@ export async function hybridSearch(
         text: decryptText(h._source?.text ?? ""),
         score: h._score ?? 0,
         source: "es" as const,
+        metadata: h._source?.["source"] != null
+          ? { source: h._source["source"], book_id: h._source["book_id"] }
+          : undefined,
       }));
       if (probeHits.length > 0) {
         esHits = probeHits;

--- a/src/search/hybrid.ts
+++ b/src/search/hybrid.ts
@@ -10,6 +10,8 @@ export interface Hit {
   text: string;
   score: number;
   source: "es" | "pg";
+  /** Phase68: faq_embeddings.metadata（pgvector 経由のヒット時に格納） */
+  metadata?: Record<string, unknown>;
 }
 type EsHit = { _id: string; _source?: { text?: string; [key: string]: unknown }; _score?: number };
 type EsSearchResult = { hits?: { hits?: EsHit[] } };

--- a/src/search/pgvectorSearch.ts
+++ b/src/search/pgvectorSearch.ts
@@ -16,6 +16,8 @@ export type PgvectorSearchItem = {
   text: string;
   score: number;
   source: "pgvector";
+  /** Phase68: faq_embeddings.metadata（source='faq'|'book', principle, book_id 等） */
+  metadata?: Record<string, unknown>;
 };
 
 export type PgvectorSearchResult = {
@@ -42,6 +44,7 @@ export async function searchPgVector(
       SELECT
         id::text,
         text,
+        metadata,
         1 - (embedding <-> $1::vector) / 2 AS score
       FROM faq_embeddings
       WHERE tenant_id = $2 OR tenant_id = 'global'
@@ -58,7 +61,7 @@ export async function searchPgVector(
     const result = await pool.query(query, [embeddingLiteral, tenantId, topK]);
     const t1 = performance.now();
 
-    const items: PgvectorSearchItem[] = (result.rows as Array<{ id: string; text: string | null; score: number }>).map((row) => ({
+    const items: PgvectorSearchItem[] = (result.rows as Array<{ id: string; text: string | null; score: number; metadata: Record<string, unknown> | null }>).map((row) => ({
       id: String(row.id),
       text: decryptText(row.text ?? ""),
       score: (() => {
@@ -67,6 +70,7 @@ export async function searchPgVector(
         return Math.max(0, Math.min(1, s));
       })(),
       source: "pgvector",
+      metadata: row.metadata ?? undefined,
     }));
 
     return {

--- a/src/search/rerank.ts
+++ b/src/search/rerank.ts
@@ -101,6 +101,8 @@ export type Item = {
   text: string;
   score: number;
   source: "es" | "pg" | "pgvector";
+  /** Phase68: faq_embeddings.metadata（source='faq'|'book', principle 等） */
+  metadata?: Record<string, unknown>;
 };
 
 export type RerankResult = {


### PR DESCRIPTION
## Summary
- rag_sources JSONB カラムを chat_messages に追加（マイグレーション同梱）
- 各 RAG 応答時にチャンク ID / スコアを記録
- 新 API: GET /v1/admin/analytics/knowledge-attribution
- 新 UI: KnowledgeAttributionTab（知識管理ページ）
- Analytics ダッシュボード: 知識貢献 KPI カード追加
- RBAC: super_admin クロステナント / client_admin 自テナント
- Codex P1: 書籍チャンクタイトルの復号処理追加（暗号文→平文）
- Codex P2: ES フォールバック時の書籍ソース分類修正

## Test plan
- [x] pnpm typecheck → 0 errors
- [x] pnpm test → 119 suites / 1169 tests all pass
- [x] pnpm build + admin-ui build → success
- [x] security-scan → 0 critical / 0 high
- [x] Codex review → P1/P2 fixed and re-verified

Asana: https://app.asana.com/0/1213607637045514/1214245295529036

🤖 Generated with [Claude Code](https://claude.com/claude-code)