### PR TITLE
fix(phase68): remove c. alias from ORDER BY in knowledge-attribution

### DIFF
--- a/src/api/admin/analytics/knowledgeAttribution.test.ts
+++ b/src/api/admin/analytics/knowledgeAttribution.test.ts
@@ -136,7 +136,7 @@ describe('GET /v1/admin/analytics/knowledge-attribution', () => {
 
     expect(mockQuery).toHaveBeenCalledTimes(1);
     const sqlArg = String(mockQuery.mock.calls[0]?.[0] ?? '');
-    expect(sqlArg).toMatch(/ORDER BY\s+c\.usage_count\s+DESC/);
+    expect(sqlArg).toMatch(/ORDER BY\s+usage_count\s+DESC/);
   });
 
   it('source_type=book のとき LATERAL に絞り込みパラメータが追加される', async () => {

--- a/src/api/admin/analytics/routes.ts
+++ b/src/api/admin/analytics/routes.ts
@@ -1026,9 +1026,9 @@ export function registerAnalyticsRoutes(app: Express): void {
       // ORDER BY 列を allow-list から選択（SQLインジェクション防止）
       const orderColumn =
         sortBy === "usage_count"
-          ? "c.usage_count"
+          ? "usage_count"
           : sortBy === "judge_score"
-          ? "c.avg_judge_score"
+          ? "avg_judge_score"
           : "conversion_rate";
 
       const sourceFilterClause =


### PR DESCRIPTION
## Summary
- sort_by=usage_count / sort_by=judge_score で 500 エラーが発生していた
- ORDER BY 句が c.usage_count / c.avg_judge_score を参照していたが c は joined CTE 内にしか存在しない
- プレフィックスを削除し usage_count / avg_judge_score に修正

## Root cause
Before (NG): ORDER BY c.usage_count DESC — c は joined CTE の外側では未定義
After (OK):  ORDER BY usage_count DESC

## Test plan
- [x] pnpm typecheck → 0 errors
- [x] pnpm test → knowledgeAttribution 10/10 pass
- [x] pnpm build → success

Asana: https://app.asana.com/0/1213607637045514/1214245295529036

🤖 Generated with [Claude Code](https://claude.com/claude-code)