### PR TITLE
fix(phase68): add judge_score ORDER BY test + deploy CWD guard

### DIFF
--- a/SCRIPTS/deploy-vps.sh
+++ b/SCRIPTS/deploy-vps.sh
@@ -18,6 +18,14 @@ set -euo pipefail
 VPS="${1:-root@65.108.159.161}"
 REMOTE_DIR="/opt/rajiuce"
 
+# CWD guard: must be run from project root
+if [[ ! -f package.json ]] || [[ ! -f ecosystem.config.cjs ]]; then
+  echo "❌ ERROR: deploy-vps.sh must be run from the project root directory"
+  echo "  Current directory: $(pwd)"
+  echo "  Expected: package.json and ecosystem.config.cjs in CWD"
+  exit 1
+fi
+
 # Pre-deploy: Environment Check (warning-only, does not block deploy)
 echo "=== Pre-deploy: Environment Check ==="
 bash SCRIPTS/env-check.sh 2>&1 || true

--- a/src/api/admin/analytics/knowledgeAttribution.test.ts
+++ b/src/api/admin/analytics/knowledgeAttribution.test.ts
@@ -137,6 +137,21 @@ describe('GET /v1/admin/analytics/knowledge-attribution', () => {
     expect(mockQuery).toHaveBeenCalledTimes(1);
     const sqlArg = String(mockQuery.mock.calls[0]?.[0] ?? '');
     expect(sqlArg).toMatch(/ORDER BY\s+usage_count\s+DESC/);
+    // ORDER BY 節に c. プレフィックスが付いていないこと（CTE スコープ外）
+    expect(sqlArg).not.toMatch(/ORDER BY\s+c\.usage_count/);
+  });
+
+  it('SQL の ORDER BY が sort_by に合わせて切り替わる (judge_score)', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await request(makeApp())
+      .get('/v1/admin/analytics/knowledge-attribution')
+      .query({ sort_by: 'judge_score' })
+      .set('x-tenant-id', 'tenant-A');
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const sqlArg = String(mockQuery.mock.calls[0]?.[0] ?? '');
+    expect(sqlArg).toMatch(/ORDER BY\s+avg_judge_score\s+DESC/);
+    expect(sqlArg).not.toMatch(/ORDER BY\s+c\.avg_judge_score/);
   });
 
   it('source_type=book のとき LATERAL に絞り込みパラメータが追加される', async () => {


### PR DESCRIPTION
## Summary
- **テスト追加**: sort_by=judge_score のとき ORDER BY avg_judge_score になることを検証（c. プレフィックス排除も確認）
- **テスト強化**: sort_by=usage_count の assertion を ORDER BY 節に限定した正規表現に変更（CTE 内の c.usage_count は正当）
- **deploy-vps.sh CWD ガード**: package.json と ecosystem.config.cjs が CWD に存在しない場合は即 exit 1（サブディレクトリから誤実行して rsync がプロジェクトルート以外を転送するのを防ぐ）

## Root cause of previous deploy accident
`cd admin-ui && pnpm build` 後に deploy-vps.sh を実行したため CWD が admin-ui/ になり、rsync source がサブディレクトリになった。本 PR のガードで再発防止。

## Test plan
- [x] pnpm typecheck → 0 errors
- [x] pnpm test → 119 suites / 1170 tests pass
- [x] pnpm build → success

Asana: https://app.asana.com/0/1213607637045514/1214245295529036

🤖 Generated with [Claude Code](https://claude.com/claude-code)