### PR TITLE
fix(phase69-1): close authz/race/timeout vulnerabilities found by Codex (Round 1-6)

### DIFF
--- a/src/api/admin/chat-history/deleteSession.test.ts
+++ b/src/api/admin/chat-history/deleteSession.test.ts
@@ -177,4 +177,64 @@ describe("DELETE /v1/admin/chat-history/sessions/:sessionId", () => {
       }),
     );
   });
+
+  // ── [HIGH] 認可ホワイトリスト追加テスト ─────────────────────────────────
+
+  it("認可: viewer ロールは403を返す", async () => {
+    const viewerToken = makeDevJwt({
+      email: "viewer@example.com",
+      app_metadata: { role: "viewer", tenant_id: "tenant-a" },
+    });
+
+    const res = await request(app)
+      .delete("/v1/admin/chat-history/sessions/sess-uuid-1")
+      .set("Authorization", `Bearer ${viewerToken}`)
+      .send({ reason: VALID_REASON });
+
+    expect(res.status).toBe(403);
+    expect(mockDeleteSession).not.toHaveBeenCalled();
+  });
+
+  it("認可: role が undefined (unknown) のユーザーは403を返す", async () => {
+    const noRoleToken = makeDevJwt({
+      email: "norole@example.com",
+      app_metadata: { tenant_id: "tenant-a" },
+    });
+
+    const res = await request(app)
+      .delete("/v1/admin/chat-history/sessions/sess-uuid-1")
+      .set("Authorization", `Bearer ${noRoleToken}`)
+      .send({ reason: VALID_REASON });
+
+    expect(res.status).toBe(403);
+    expect(mockDeleteSession).not.toHaveBeenCalled();
+  });
+
+  it("認可: ALLOWED_ROLES 外の任意の文字列ロールは403を返す", async () => {
+    const bogusRoleToken = makeDevJwt({
+      email: "bogus@example.com",
+      app_metadata: { role: "tenant_manager", tenant_id: "tenant-a" },
+    });
+
+    const res = await request(app)
+      .delete("/v1/admin/chat-history/sessions/sess-uuid-1")
+      .set("Authorization", `Bearer ${bogusRoleToken}`)
+      .send({ reason: VALID_REASON });
+
+    expect(res.status).toBe(403);
+    expect(mockDeleteSession).not.toHaveBeenCalled();
+  });
+
+  // ── [MEDIUM] 並行削除 / audit_logs 整合性テスト ──────────────────────────
+
+  it("並行削除: deleteSession が throw した場合は500を返し、audit_logs は挿入されない", async () => {
+    mockDeleteSession.mockRejectedValueOnce(new Error("Deletion verification failed"));
+
+    const res = await request(app)
+      .delete("/v1/admin/chat-history/sessions/sess-uuid-1")
+      .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`)
+      .send({ reason: VALID_REASON });
+
+    expect(res.status).toBe(500);
+  });
 });

--- a/src/api/admin/chat-history/deleteSession.test.ts
+++ b/src/api/admin/chat-history/deleteSession.test.ts
@@ -7,8 +7,20 @@ import { registerChatHistoryRoutes } from "./routes";
 
 jest.mock("./deleteSessionRepository");
 jest.mock("../../../lib/db");
+jest.mock("../../../lib/logger", () => ({
+  logger: {
+    warn: jest.fn(),
+    info: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+    trace: jest.fn(),
+    fatal: jest.fn(),
+    child: jest.fn(),
+  },
+}));
 import { deleteSession } from "./deleteSessionRepository";
 import * as dbModule from "../../../lib/db";
+import { logger } from "../../../lib/logger";
 const mockDeleteSession = deleteSession as jest.MockedFunction<typeof deleteSession>;
 
 function makeDevJwt(payload: object): string {
@@ -391,6 +403,141 @@ describe("DELETE /v1/admin/chat-history/sessions/:sessionId", () => {
 
     expect(res.status).toBe(403);
     expect(mockDeleteSession).not.toHaveBeenCalled();
+  });
+
+  // ── [HIGH] Round 6: jwtTenantId の su.tenant_id フォールバック削除 ──────────
+  // app_metadata.tenant_id のみを信頼し、top-level tenant_id は無視することを確認
+
+  it("Test 26: app_metadata.tenant_id='t1', su.tenant_id='t2' → t1 でスコープ (cross-tenant 防止)", async () => {
+    mockDeleteSession.mockResolvedValueOnce(MOCK_RESULT);
+
+    const crossTenantToken = makeDevJwt({
+      email: "admin@example.com",
+      tenant_id: "t2",
+      app_metadata: { role: "client_admin", tenant_id: "t1" },
+    });
+
+    const res = await request(app)
+      .delete("/v1/admin/chat-history/sessions/sess-uuid-1")
+      .set("Authorization", `Bearer ${crossTenantToken}`)
+      .send({ reason: VALID_REASON });
+
+    expect(res.status).toBe(200);
+    expect(mockDeleteSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: { kind: "tenant", tenantId: "t1" },
+      }),
+    );
+  });
+
+  it("Test 27 [攻撃シナリオ]: app_metadata.tenant_id なし, su.tenant_id='t1' → 403", async () => {
+    const noAppTenantToken = makeDevJwt({
+      email: "attacker@example.com",
+      tenant_id: "t1",
+      app_metadata: { role: "client_admin" },
+    });
+
+    const res = await request(app)
+      .delete("/v1/admin/chat-history/sessions/sess-uuid-1")
+      .set("Authorization", `Bearer ${noAppTenantToken}`)
+      .send({ reason: VALID_REASON });
+
+    expect(res.status).toBe(403);
+    expect(mockDeleteSession).not.toHaveBeenCalled();
+  });
+
+  it("Test 28 [攻撃シナリオ]: app_metadata.tenant_id='', su.tenant_id='t1' → 403 (空文字攻撃)", async () => {
+    const emptyAppTenantToken = makeDevJwt({
+      email: "attacker@example.com",
+      tenant_id: "t1",
+      app_metadata: { role: "client_admin", tenant_id: "" },
+    });
+
+    const res = await request(app)
+      .delete("/v1/admin/chat-history/sessions/sess-uuid-1")
+      .set("Authorization", `Bearer ${emptyAppTenantToken}`)
+      .send({ reason: VALID_REASON });
+
+    expect(res.status).toBe(403);
+    expect(mockDeleteSession).not.toHaveBeenCalled();
+  });
+
+  // ── [MEDIUM] Round 6: 55P03 structured warning ログ ─────────────────────────
+
+  it("Test 31: 55P03 エラー発生時、logger.warn が呼ばれる", async () => {
+    const lockErr = Object.assign(new Error("lock timeout"), { code: "55P03" });
+    mockDeleteSession.mockRejectedValueOnce(lockErr);
+
+    await request(app)
+      .delete("/v1/admin/chat-history/sessions/sess-uuid-1")
+      .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`)
+      .send({ reason: VALID_REASON });
+
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it("Test 32: 55P03 logger.warn payload に必要フィールドが含まれる", async () => {
+    const lockErr = Object.assign(new Error("lock timeout"), { code: "55P03" });
+    mockDeleteSession.mockRejectedValueOnce(lockErr);
+
+    await request(app)
+      .delete("/v1/admin/chat-history/sessions/sess-uuid-1")
+      .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`)
+      .send({ reason: VALID_REASON });
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: "chat_history_delete_lock_timeout",
+        errorCode: "55P03",
+        sessionId: "sess-uuid-1",
+      }),
+      expect.any(String),
+    );
+  });
+});
+
+// ── [HIGH] Round 6: GET 系エンドポイントの jwtTenantId フォールバック削除 ──────
+
+describe("GET /v1/admin/chat-history: tenant_id fallback 削除", () => {
+  let app: ReturnType<typeof express>;
+
+  beforeAll(() => {
+    process.env.NODE_ENV = "development";
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    app = express();
+    app.use(express.json());
+    registerChatHistoryRoutes(app);
+  });
+
+  it("Test 29: GET sessions 一覧で app_metadata.tenant_id なし, su.tenant_id あり → 403", async () => {
+    const noAppTenantToken = makeDevJwt({
+      email: "attacker@example.com",
+      tenant_id: "t1",
+      app_metadata: { role: "client_admin" },
+    });
+
+    const res = await request(app)
+      .get("/v1/admin/chat-history/sessions")
+      .set("Authorization", `Bearer ${noAppTenantToken}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("Test 30: GET sessions/:id/messages で app_metadata.tenant_id なし, su.tenant_id あり → 403", async () => {
+    const noAppTenantToken = makeDevJwt({
+      email: "attacker@example.com",
+      tenant_id: "t1",
+      app_metadata: { role: "client_admin" },
+    });
+
+    const res = await request(app)
+      .get("/v1/admin/chat-history/sessions/sess-uuid-1/messages")
+      .set("Authorization", `Bearer ${noAppTenantToken}`);
+
+    expect(res.status).toBe(403);
   });
 });
 

--- a/src/api/admin/chat-history/deleteSession.test.ts
+++ b/src/api/admin/chat-history/deleteSession.test.ts
@@ -317,6 +317,81 @@ describe("DELETE /v1/admin/chat-history/sessions/:sessionId", () => {
     expect(res.status).toBe(409);
     expect(res.body.error).toMatch(/再度お試し/);
   });
+
+  // ── [CRITICAL] Round 5: user_metadata.role フォールバック削除 ─────────────
+  // app_metadata.role のみを信頼し、user_metadata.role は無視することを確認
+
+  it("Test 21: app_metadata.role='super_admin', user_metadata なし → 200 (正常系)", async () => {
+    mockDeleteSession.mockResolvedValueOnce(MOCK_RESULT);
+
+    const res = await request(app)
+      .delete("/v1/admin/chat-history/sessions/sess-uuid-1")
+      .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`)
+      .send({ reason: VALID_REASON });
+
+    expect(res.status).toBe(200);
+    expect(res.body.deleted_session_id).toBe("sess-uuid-1");
+  });
+
+  it("Test 22 [攻撃シナリオ]: app_metadata.role なし, user_metadata.role='super_admin' → 403", async () => {
+    const attackToken = makeDevJwt({
+      email: "attacker@example.com",
+      user_metadata: { role: "super_admin" },
+    });
+
+    const res = await request(app)
+      .delete("/v1/admin/chat-history/sessions/sess-uuid-1")
+      .set("Authorization", `Bearer ${attackToken}`)
+      .send({ reason: VALID_REASON });
+
+    expect(res.status).toBe(403);
+    expect(mockDeleteSession).not.toHaveBeenCalled();
+  });
+
+  it("Test 23 [攻撃シナリオ]: app_metadata.role なし, user_metadata.role='client_admin' → 403", async () => {
+    const attackToken = makeDevJwt({
+      email: "attacker@example.com",
+      user_metadata: { role: "client_admin" },
+    });
+
+    const res = await request(app)
+      .delete("/v1/admin/chat-history/sessions/sess-uuid-1")
+      .set("Authorization", `Bearer ${attackToken}`)
+      .send({ reason: VALID_REASON });
+
+    expect(res.status).toBe(403);
+    expect(mockDeleteSession).not.toHaveBeenCalled();
+  });
+
+  it("Test 24: app_metadata.role='viewer', user_metadata.role='super_admin' → 403 (ALLOWED_ROLES外)", async () => {
+    const mixedToken = makeDevJwt({
+      email: "viewer@example.com",
+      app_metadata: { role: "viewer", tenant_id: "tenant-a" },
+      user_metadata: { role: "super_admin" },
+    });
+
+    const res = await request(app)
+      .delete("/v1/admin/chat-history/sessions/sess-uuid-1")
+      .set("Authorization", `Bearer ${mixedToken}`)
+      .send({ reason: VALID_REASON });
+
+    expect(res.status).toBe(403);
+    expect(mockDeleteSession).not.toHaveBeenCalled();
+  });
+
+  it("Test 25: app_metadata.role なし, user_metadata.role なし → 403", async () => {
+    const noRoleToken = makeDevJwt({
+      email: "nobody@example.com",
+    });
+
+    const res = await request(app)
+      .delete("/v1/admin/chat-history/sessions/sess-uuid-1")
+      .set("Authorization", `Bearer ${noRoleToken}`)
+      .send({ reason: VALID_REASON });
+
+    expect(res.status).toBe(403);
+    expect(mockDeleteSession).not.toHaveBeenCalled();
+  });
 });
 
 // ── リポジトリ内部クエリ整合性テスト（Tests 18-20） ──────────────────────────

--- a/src/api/admin/chat-history/deleteSession.test.ts
+++ b/src/api/admin/chat-history/deleteSession.test.ts
@@ -6,7 +6,9 @@ import request from "supertest";
 import { registerChatHistoryRoutes } from "./routes";
 
 jest.mock("./deleteSessionRepository");
+jest.mock("../../../lib/db");
 import { deleteSession } from "./deleteSessionRepository";
+import * as dbModule from "../../../lib/db";
 const mockDeleteSession = deleteSession as jest.MockedFunction<typeof deleteSession>;
 
 function makeDevJwt(payload: object): string {
@@ -161,7 +163,7 @@ describe("DELETE /v1/admin/chat-history/sessions/:sessionId", () => {
     );
   });
 
-  it("super_admin は tenantId 縛りなし（tenantId: undefined）で呼び出す", async () => {
+  it("super_admin は scope: global で呼び出す（テナント縛りなし）", async () => {
     mockDeleteSession.mockResolvedValueOnce(MOCK_RESULT);
 
     await request(app)
@@ -171,11 +173,74 @@ describe("DELETE /v1/admin/chat-history/sessions/:sessionId", () => {
 
     expect(mockDeleteSession).toHaveBeenCalledWith(
       expect.objectContaining({
-        tenantId: undefined,
+        scope: { kind: "global" },
         actorRole: "super_admin",
         actorEmail: "super@example.com",
       }),
     );
+  });
+
+  it("client_admin は scope: tenant で呼び出す（自テナント限定）", async () => {
+    mockDeleteSession.mockResolvedValueOnce(MOCK_RESULT);
+
+    await request(app)
+      .delete("/v1/admin/chat-history/sessions/sess-uuid-1")
+      .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`)
+      .send({ reason: VALID_REASON });
+
+    expect(mockDeleteSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        scope: { kind: "tenant", tenantId: "tenant-a" },
+        actorRole: "client_admin",
+      }),
+    );
+  });
+
+  // ── [HIGH] Round2: client_admin の tenantId 必須チェック ─────────────────
+
+  it("認可: client_admin で tenantId が空（app_metadata なし）は403を返す", async () => {
+    const noTenantToken = makeDevJwt({
+      email: "admin@example.com",
+      app_metadata: { role: "client_admin" },
+    });
+
+    const res = await request(app)
+      .delete("/v1/admin/chat-history/sessions/sess-uuid-1")
+      .set("Authorization", `Bearer ${noTenantToken}`)
+      .send({ reason: VALID_REASON });
+
+    expect(res.status).toBe(403);
+    expect(mockDeleteSession).not.toHaveBeenCalled();
+  });
+
+  it("認可: client_admin で tenant_id が空文字は403を返す", async () => {
+    const emptyTenantToken = makeDevJwt({
+      email: "admin@example.com",
+      app_metadata: { role: "client_admin", tenant_id: "" },
+    });
+
+    const res = await request(app)
+      .delete("/v1/admin/chat-history/sessions/sess-uuid-1")
+      .set("Authorization", `Bearer ${emptyTenantToken}`)
+      .send({ reason: VALID_REASON });
+
+    expect(res.status).toBe(403);
+    expect(mockDeleteSession).not.toHaveBeenCalled();
+  });
+
+  it("認可: client_admin で tenant_id がスペースのみは403を返す", async () => {
+    const spaceTenantToken = makeDevJwt({
+      email: "admin@example.com",
+      app_metadata: { role: "client_admin", tenant_id: "   " },
+    });
+
+    const res = await request(app)
+      .delete("/v1/admin/chat-history/sessions/sess-uuid-1")
+      .set("Authorization", `Bearer ${spaceTenantToken}`)
+      .send({ reason: VALID_REASON });
+
+    expect(res.status).toBe(403);
+    expect(mockDeleteSession).not.toHaveBeenCalled();
   });
 
   // ── [HIGH] 認可ホワイトリスト追加テスト ─────────────────────────────────
@@ -236,5 +301,99 @@ describe("DELETE /v1/admin/chat-history/sessions/:sessionId", () => {
       .send({ reason: VALID_REASON });
 
     expect(res.status).toBe(500);
+  });
+
+  // ── [HIGH] lock_timeout (55P03) → 409 ────────────────────────────────────
+
+  it("Test 17: lock_timeout エラー (55P03) 発生時は409を返す", async () => {
+    const lockErr = Object.assign(new Error("lock timeout"), { code: "55P03" });
+    mockDeleteSession.mockRejectedValueOnce(lockErr);
+
+    const res = await request(app)
+      .delete("/v1/admin/chat-history/sessions/sess-uuid-1")
+      .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`)
+      .send({ reason: VALID_REASON });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toMatch(/再度お試し/);
+  });
+});
+
+// ── リポジトリ内部クエリ整合性テスト（Tests 18-20） ──────────────────────────
+// deleteSession の実装を直接テスト: lib/db をモックしてクエリシーケンスを検証
+
+describe("deleteSessionRepository: lock_timeout / ROLLBACK 整合性", () => {
+  let mockQuery: jest.Mock;
+  let mockRelease: jest.Mock;
+  let realDeleteSession: (p: Parameters<typeof import("./deleteSessionRepository").deleteSession>[0]) => Promise<unknown>;
+
+  const BASE_PARAMS = {
+    sessionDbId: "sess-uuid-1",
+    scope: { kind: "global" as const },
+    actorRole: "super_admin",
+    actorEmail: "super@example.com",
+    reason: "test reason here",
+  };
+
+  beforeEach(() => {
+    mockQuery = jest.fn();
+    mockRelease = jest.fn();
+
+    jest.mocked(dbModule.getPool).mockReturnValue({
+      connect: jest.fn().mockResolvedValue({ query: mockQuery, release: mockRelease }),
+    } as unknown as ReturnType<typeof dbModule.getPool>);
+
+    realDeleteSession = (jest.requireActual<typeof import("./deleteSessionRepository")>(
+      "./deleteSessionRepository",
+    ) as { deleteSession: typeof realDeleteSession }).deleteSession;
+  });
+
+  it("Test 18: BEGIN 直後に SET LOCAL lock_timeout = '3s' が実行される", async () => {
+    mockQuery.mockResolvedValue({ rows: [], rowCount: 0 }); // session not found → return null
+
+    await realDeleteSession(BASE_PARAMS);
+
+    const calls = mockQuery.mock.calls.map((c) => c[0] as string);
+    const beginIdx = calls.findIndex((q) => q === "BEGIN");
+    const lockIdx = calls.findIndex((q) => q === "SET LOCAL lock_timeout = '3s'");
+
+    expect(beginIdx).toBeGreaterThanOrEqual(0);
+    expect(lockIdx).toBe(beginIdx + 1);
+  });
+
+  it("Test 19: rowCount !== 1 検証失敗時、手動 ROLLBACK は呼ばれず catch の ROLLBACK のみ（合計1回）", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // BEGIN
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // SET LOCAL lock_timeout
+      .mockResolvedValueOnce({                           // SELECT FOR UPDATE → found
+        rows: [{ id: "sess-uuid-1", tenant_id: "tenant-a" }],
+        rowCount: 1,
+      })
+      .mockResolvedValueOnce({ rows: [{ cnt: "2" }], rowCount: 1 }) // COUNT messages
+      .mockResolvedValueOnce({ rows: [{ cnt: "0" }], rowCount: 1 }) // COUNT orders (0)
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // DELETE RETURNING → rowCount=0
+      .mockResolvedValue({ rows: [], rowCount: 0 }); // ROLLBACK
+
+    await expect(realDeleteSession(BASE_PARAMS)).rejects.toThrow("Deletion verification failed");
+
+    const rollbackCalls = mockQuery.mock.calls.filter(
+      (c) => typeof c[0] === "string" && (c[0] as string).toUpperCase() === "ROLLBACK",
+    );
+    expect(rollbackCalls).toHaveLength(1); // catch のみ、手動 ROLLBACK なし
+  });
+
+  it("Test 20: DB エラー発生時に catch block が ROLLBACK を実行し connection を release する", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // BEGIN
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // SET LOCAL lock_timeout
+      .mockRejectedValueOnce(new Error("DB connection error")); // SELECT fails
+
+    await expect(realDeleteSession(BASE_PARAMS)).rejects.toThrow("DB connection error");
+
+    const rollbackCalls = mockQuery.mock.calls.filter(
+      (c) => typeof c[0] === "string" && (c[0] as string).toUpperCase() === "ROLLBACK",
+    );
+    expect(rollbackCalls).toHaveLength(1);
+    expect(mockRelease).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/api/admin/chat-history/deleteSessionRepository.ts
+++ b/src/api/admin/chat-history/deleteSessionRepository.ts
@@ -36,11 +36,12 @@ export async function deleteSession(
   try {
     await client.query("BEGIN");
 
-    // 1. セッション取得（テナント所有権チェック）
+    // 1. セッション取得（テナント所有権チェック + 行ロック）
+    // FOR UPDATE で並行削除との競合を防ぐ
     const sessionResult = await client.query<{ id: string; tenant_id: string }>(
       params.tenantId
-        ? `SELECT id, tenant_id FROM chat_sessions WHERE id = $1 AND tenant_id = $2`
-        : `SELECT id, tenant_id FROM chat_sessions WHERE id = $1`,
+        ? `SELECT id, tenant_id FROM chat_sessions WHERE id = $1 AND tenant_id = $2 FOR UPDATE`
+        : `SELECT id, tenant_id FROM chat_sessions WHERE id = $1 FOR UPDATE`,
       params.tenantId ? [params.sessionDbId, params.tenantId] : [params.sessionDbId],
     );
 
@@ -74,12 +75,20 @@ export async function deleteSession(
     }
 
     // 4. chat_sessions 削除（chat_messages は CASCADE DELETE）
-    await client.query(
-      `DELETE FROM chat_sessions WHERE id = $1`,
+    // Phase69-1 fix [MEDIUM]: RETURNING で実際に削除されたことを証明し、
+    // audit_logs への記録を削除成功後にのみ行う
+    const deleteResult = await client.query<{ id: string }>(
+      `DELETE FROM chat_sessions WHERE id = $1 RETURNING id`,
       [session.id],
     );
 
-    // 5. audit_logs 記録（同一 TX）
+    if ((deleteResult.rowCount ?? 0) !== 1) {
+      // FOR UPDATE 取得後に消えることは通常起き得ないが、防御として
+      await client.query("ROLLBACK");
+      throw new Error(`Deletion verification failed for session ${session.id}`);
+    }
+
+    // 5. audit_logs 記録（削除成功が証明された後のみ）
     const metadata = {
       reason: params.reason,
       affected_counts: {

--- a/src/api/admin/chat-history/deleteSessionRepository.ts
+++ b/src/api/admin/chat-history/deleteSessionRepository.ts
@@ -3,9 +3,16 @@
 
 import { getPool } from "../../../lib/db";
 
+// Phase69-1 fix [MEDIUM]: discriminated union でスコープを型レベルで強制
+// - 'tenant': client_admin 用。tenantId 必須、所有権チェックあり
+// - 'global': super_admin 用。tenantId なし、全テナントスコープ
+export type DeleteSessionScope =
+  | { kind: "tenant"; tenantId: string }
+  | { kind: "global" };
+
 export interface DeleteSessionParams {
   sessionDbId: string;    // chat_sessions.id (UUID)
-  tenantId: string | undefined; // undefined = super_admin（テナント縛りなし）
+  scope: DeleteSessionScope;
   actorRole: string;
   actorEmail: string;     // NOT NULL: 空文字許容
   reason: string;         // 5–500 文字必須
@@ -35,14 +42,19 @@ export async function deleteSession(
 
   try {
     await client.query("BEGIN");
+    await client.query("SET LOCAL lock_timeout = '3s'");
 
     // 1. セッション取得（テナント所有権チェック + 行ロック）
     // FOR UPDATE で並行削除との競合を防ぐ
+    const scope = params.scope;
+    const isTenantScoped = scope.kind === "tenant";
     const sessionResult = await client.query<{ id: string; tenant_id: string }>(
-      params.tenantId
+      isTenantScoped
         ? `SELECT id, tenant_id FROM chat_sessions WHERE id = $1 AND tenant_id = $2 FOR UPDATE`
         : `SELECT id, tenant_id FROM chat_sessions WHERE id = $1 FOR UPDATE`,
-      params.tenantId ? [params.sessionDbId, params.tenantId] : [params.sessionDbId],
+      isTenantScoped && scope.kind === "tenant"
+        ? [params.sessionDbId, scope.tenantId]
+        : [params.sessionDbId],
     );
 
     if (sessionResult.rows.length === 0) {
@@ -75,8 +87,7 @@ export async function deleteSession(
     }
 
     // 4. chat_sessions 削除（chat_messages は CASCADE DELETE）
-    // Phase69-1 fix [MEDIUM]: RETURNING で実際に削除されたことを証明し、
-    // audit_logs への記録を削除成功後にのみ行う
+    // RETURNING で実際に削除されたことを証明し、audit_logs への記録を削除成功後にのみ行う
     const deleteResult = await client.query<{ id: string }>(
       `DELETE FROM chat_sessions WHERE id = $1 RETURNING id`,
       [session.id],
@@ -84,7 +95,7 @@ export async function deleteSession(
 
     if ((deleteResult.rowCount ?? 0) !== 1) {
       // FOR UPDATE 取得後に消えることは通常起き得ないが、防御として
-      await client.query("ROLLBACK");
+      // ROLLBACK は catch block に委譲（二重ロールバック防止）
       throw new Error(`Deletion verification failed for session ${session.id}`);
     }
 

--- a/src/api/admin/chat-history/routes.ts
+++ b/src/api/admin/chat-history/routes.ts
@@ -150,8 +150,6 @@ export function registerChatHistoryRoutes(app: Express): void {
       const sessionDbId: string = req.params["sessionId"] ?? "";
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
       const jwtTenantId: string = su?.app_metadata?.tenant_id ?? su?.tenant_id ?? "";
-      const isSuperAdmin: boolean =
-        (su?.app_metadata?.role ?? su?.user_metadata?.role ?? "") === "super_admin";
       const actorRole: string =
         su?.app_metadata?.role ?? su?.user_metadata?.role ?? "unknown";
       const actorEmail: string = su?.email ?? su?.app_metadata?.email ?? "";
@@ -167,6 +165,19 @@ export function registerChatHistoryRoutes(app: Express): void {
         return res.status(403).json({ error: "この操作を実行する権限がありません" });
       }
 
+      // Phase69-1 fix [HIGH] Round2: client_admin は必ず有効な tenant_id を持つこと
+      // JWT app_metadata が欠損/不正な場合でもクロステナント削除を防ぐ
+      let scope: import("./deleteSessionRepository").DeleteSessionScope;
+      if (actorRole === "client_admin") {
+        if (!jwtTenantId || typeof jwtTenantId !== "string" || jwtTenantId.trim() === "") {
+          return res.status(403).json({ error: "この操作を実行する権限がありません" });
+        }
+        scope = { kind: "tenant", tenantId: jwtTenantId };
+      } else {
+        // super_admin: スコープなし（全テナント対象）
+        scope = { kind: "global" };
+      }
+
       const { reason } = (req.body ?? {}) as Record<string, unknown>;
       if (typeof reason !== "string" || reason.trim().length < 5) {
         return res.status(400).json({ error: "reason は5文字以上500文字以下の文字列が必要です" });
@@ -176,12 +187,10 @@ export function registerChatHistoryRoutes(app: Express): void {
       }
       const reasonValue = reason.trim();
 
-      const tenantFilter: string | undefined = isSuperAdmin ? undefined : jwtTenantId;
-
       try {
         const result = await deleteSession({
           sessionDbId,
-          tenantId: tenantFilter,
+          scope,
           actorRole,
           actorEmail,
           reason: reasonValue,
@@ -196,6 +205,10 @@ export function registerChatHistoryRoutes(app: Express): void {
           affected_counts: result.affected_counts,
         });
       } catch (err) {
+        // Phase69-1 fix [HIGH]: lock_timeout (55P03) → 409
+        if ((err as { code?: string }).code === "55P03") {
+          return res.status(409).json({ error: "他の処理中のため、少し時間をおいて再度お試しください" });
+        }
         logger.warn("[DELETE /v1/admin/chat-history/sessions/:id]", err);
         return res.status(500).json({ error: "セッションの削除に失敗しました" });
       }

--- a/src/api/admin/chat-history/routes.ts
+++ b/src/api/admin/chat-history/routes.ts
@@ -160,6 +160,13 @@ export function registerChatHistoryRoutes(app: Express): void {
         return res.status(400).json({ error: "sessionId が必要です" });
       }
 
+      // Phase69-1 fix [HIGH]: ロールホワイトリスト強制
+      const ALLOWED_ROLES = ["super_admin", "client_admin"] as const;
+      type AllowedRole = typeof ALLOWED_ROLES[number];
+      if (!ALLOWED_ROLES.includes(actorRole as AllowedRole)) {
+        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+      }
+
       const { reason } = (req.body ?? {}) as Record<string, unknown>;
       if (typeof reason !== "string" || reason.trim().length < 5) {
         return res.status(400).json({ error: "reason は5文字以上500文字以下の文字列が必要です" });

--- a/src/api/admin/chat-history/routes.ts
+++ b/src/api/admin/chat-history/routes.ts
@@ -38,11 +38,17 @@ export function registerChatHistoryRoutes(app: Express): void {
     "/v1/admin/chat-history/sessions",
     async (req: Request, res: Response) => {
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
-      const jwtTenantId: string = su?.app_metadata?.tenant_id ?? su?.tenant_id ?? "";
+      // セキュリティ要件: テナントスコープも app_metadata.tenant_id のみを信頼する
+      // su.tenant_id (top-level claim) はクライアント制御可能なため使用しない
+      const jwtTenantId: string = su?.app_metadata?.tenant_id ?? "";
       // セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
       // user_metadata はクライアント編集可能なため、特権判定に使用してはならない
       const isSuperAdmin: boolean =
         su?.app_metadata?.role === "super_admin";
+
+      if (!isSuperAdmin && !jwtTenantId) {
+        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+      }
 
       const tenantFilter = resolveTenantFilter(req, jwtTenantId, isSuperAdmin);
 
@@ -106,7 +112,9 @@ export function registerChatHistoryRoutes(app: Express): void {
     async (req: Request, res: Response) => {
       const sessionDbId: string = req.params["sessionId"] ?? "";
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
-      const jwtTenantId: string = su?.app_metadata?.tenant_id ?? su?.tenant_id ?? "";
+      // セキュリティ要件: テナントスコープも app_metadata.tenant_id のみを信頼する
+      // su.tenant_id (top-level claim) はクライアント制御可能なため使用しない
+      const jwtTenantId: string = su?.app_metadata?.tenant_id ?? "";
       // セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
       // user_metadata はクライアント編集可能なため、特権判定に使用してはならない
       const isSuperAdmin: boolean =
@@ -123,7 +131,7 @@ export function registerChatHistoryRoutes(app: Express): void {
         return res.status(400).json({ error: "sessionId が必要です" });
       }
       if (!isSuperAdmin && !tenantId) {
-        return res.status(400).json({ error: "tenant が解決できません" });
+        return res.status(403).json({ error: "この操作を実行する権限がありません" });
       }
 
       try {
@@ -153,7 +161,9 @@ export function registerChatHistoryRoutes(app: Express): void {
     async (req: Request, res: Response) => {
       const sessionDbId: string = req.params["sessionId"] ?? "";
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
-      const jwtTenantId: string = su?.app_metadata?.tenant_id ?? su?.tenant_id ?? "";
+      // セキュリティ要件: テナントスコープも app_metadata.tenant_id のみを信頼する
+      // su.tenant_id (top-level claim) はクライアント制御可能なため使用しない
+      const jwtTenantId: string = su?.app_metadata?.tenant_id ?? "";
       // セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
       // user_metadata はクライアント編集可能なため、特権判定に使用してはならない
       const actorRole: string | undefined = su?.app_metadata?.role as string | undefined;
@@ -215,6 +225,13 @@ export function registerChatHistoryRoutes(app: Express): void {
       } catch (err) {
         // Phase69-1 fix [HIGH]: lock_timeout (55P03) → 409
         if ((err as { code?: string }).code === "55P03") {
+          logger.warn({
+            event: "chat_history_delete_lock_timeout",
+            tenantId: jwtTenantId || "unknown",
+            sessionId: sessionDbId,
+            actorEmail: actorEmail || "unknown",
+            errorCode: "55P03",
+          }, "DELETE session lock timeout (3s exceeded)");
           return res.status(409).json({ error: "他の処理中のため、少し時間をおいて再度お試しください" });
         }
         logger.warn("[DELETE /v1/admin/chat-history/sessions/:id]", err);
@@ -235,7 +252,9 @@ export function registerChatHistoryRoutes(app: Express): void {
       const pool = getPool();
       const sessionDbId: string = req.params["sessionId"] ?? "";
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
-      const jwtTenantId: string = su?.app_metadata?.tenant_id ?? su?.tenant_id ?? "";
+      // セキュリティ要件: テナントスコープも app_metadata.tenant_id のみを信頼する
+      // su.tenant_id (top-level claim) はクライアント制御可能なため使用しない
+      const jwtTenantId: string = su?.app_metadata?.tenant_id ?? "";
       // セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
       // user_metadata はクライアント編集可能なため、特権判定に使用してはならない
       const isSuperAdmin: boolean =

--- a/src/api/admin/chat-history/routes.ts
+++ b/src/api/admin/chat-history/routes.ts
@@ -39,8 +39,10 @@ export function registerChatHistoryRoutes(app: Express): void {
     async (req: Request, res: Response) => {
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
       const jwtTenantId: string = su?.app_metadata?.tenant_id ?? su?.tenant_id ?? "";
+      // セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
+      // user_metadata はクライアント編集可能なため、特権判定に使用してはならない
       const isSuperAdmin: boolean =
-        (su?.app_metadata?.role ?? su?.user_metadata?.role ?? "") === "super_admin";
+        su?.app_metadata?.role === "super_admin";
 
       const tenantFilter = resolveTenantFilter(req, jwtTenantId, isSuperAdmin);
 
@@ -105,8 +107,10 @@ export function registerChatHistoryRoutes(app: Express): void {
       const sessionDbId: string = req.params["sessionId"] ?? "";
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
       const jwtTenantId: string = su?.app_metadata?.tenant_id ?? su?.tenant_id ?? "";
+      // セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
+      // user_metadata はクライアント編集可能なため、特権判定に使用してはならない
       const isSuperAdmin: boolean =
-        (su?.app_metadata?.role ?? su?.user_metadata?.role ?? "") === "super_admin";
+        su?.app_metadata?.role === "super_admin";
 
       // テナント検証:
       //   super_admin: ?tenant=xxx があればそれを使う。なければ undefined (全セッション閲覧可)
@@ -150,8 +154,12 @@ export function registerChatHistoryRoutes(app: Express): void {
       const sessionDbId: string = req.params["sessionId"] ?? "";
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
       const jwtTenantId: string = su?.app_metadata?.tenant_id ?? su?.tenant_id ?? "";
-      const actorRole: string =
-        su?.app_metadata?.role ?? su?.user_metadata?.role ?? "unknown";
+      // セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
+      // user_metadata はクライアント編集可能なため、特権判定に使用してはならない
+      const actorRole: string | undefined = su?.app_metadata?.role as string | undefined;
+      if (!actorRole || typeof actorRole !== "string") {
+        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+      }
       const actorEmail: string = su?.email ?? su?.app_metadata?.email ?? "";
 
       if (!sessionDbId) {
@@ -228,8 +236,10 @@ export function registerChatHistoryRoutes(app: Express): void {
       const sessionDbId: string = req.params["sessionId"] ?? "";
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
       const jwtTenantId: string = su?.app_metadata?.tenant_id ?? su?.tenant_id ?? "";
+      // セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
+      // user_metadata はクライアント編集可能なため、特権判定に使用してはならない
       const isSuperAdmin: boolean =
-        (su?.app_metadata?.role ?? su?.user_metadata?.role ?? "") === "super_admin";
+        su?.app_metadata?.role === "super_admin";
       const email: string = su?.email ?? su?.app_metadata?.email ?? "";
 
       if (!sessionDbId) {


### PR DESCRIPTION
## Summary

Retroactive Gate 2.5 (adversarial-review) for PR #145 (Phase69-1: Right to Erasure).
PR #145 was merged without Gate 2.5 due to process violation. This fix PR resolves
all CRITICAL/HIGH/MEDIUM issues found through 6 rounds of adversarial-review.

## Findings and Fixes

### Round 1: HIGH + MEDIUM
- **HIGH**: Authorization gap — any authenticated tenant user could delete
  → Added explicit role whitelist (super_admin, client_admin)
- **MEDIUM**: SELECT/DELETE race could produce false audit evidence
  → Use FOR UPDATE row lock + DELETE...RETURNING for audit log integrity

### Round 2: HIGH + MEDIUM
- **HIGH**: client_admin could perform unscoped delete if tenant context absent
  → Added mandatory tenant_id check for client_admin role
- **MEDIUM**: Repository scope was optional, creating future "landmine"
  → Refactored to discriminated union (DeleteSessionScope) for type safety

### Round 3: HIGH + MEDIUM
- **HIGH**: FOR UPDATE without timeout could block indefinitely
  → Added SET LOCAL lock_timeout = '3s', return 409 on lock_not_available
- **MEDIUM**: Manual ROLLBACK in try-block caused double-rollback risk
  → Removed manual rollback, delegate to transaction wrapper

### Round 5: CRITICAL
- **CRITICAL**: Privilege escalation via user_metadata.role fallback
  → user_metadata is client-controllable. Only trust app_metadata.role.
    Reject with 403 if missing.

### Round 6: HIGH + MEDIUM
- **HIGH**: tenant_id fallback to su.tenant_id allowed cross-tenant escalation
  → Same pattern as Round 5. Only trust app_metadata.tenant_id, reject if missing.
    Fixed in all 4 chat-history routes (DELETE + GET list + GET detail + PATCH outcome).
- **MEDIUM**: 55P03 lock contention had no observability logs
  → Added structured logger.warn before 409 response.

## Round 7 Findings (Deferred to Phase69-1.5)

Round 7 found existing HIGH issues in chat-history GET handlers (not introduced
by PR #145):
- GET /sessions: ALLOWED_ROLES whitelist missing (viewers could read chat history)
- GET /sessions/:id/messages: same issue

These are pre-existing authorization gaps that exist in production today.
They will be addressed in Phase69-1.5 (Asana GID: 1214771938406621) with
cross-cutting fix in roleAuth.ts + common authz middleware for all admin/* routes.

**Deployment is held until Phase69-1.5 completes**, ensuring no new vulnerability
exposure in production.

## Gate 2.5 Status

| Round | Verdict | Status |
|---|---|---|
| 1 | HIGH + MEDIUM (authz + race) | Fixed |
| 2 | HIGH + MEDIUM (tenantId + type safety) | Fixed |
| 3 | HIGH + MEDIUM (lock timeout + ROLLBACK) | Fixed |
| 4 | False positive (Codex referenced pre-fix code) | N/A |
| 5 | **CRITICAL** (user_metadata.role privilege escalation) | Fixed |
| 6 | HIGH + MEDIUM (tenant_id fallback + observability) | Fixed |
| 7 | HIGH × 2 (pre-existing GET handler issues, not introduced by #145) | Deferred → Phase69-1.5 |

## Commits

- `03086f3` fix(phase69-1): close authz whitelist gap and audit log race
- `7dce23e` fix(phase69-1): add lock_timeout and remove manual ROLLBACK
- `d07d2ad` fix(phase69-1): remove user_metadata.role fallback in chat-history routes
- `3473d36` fix(phase69-1): remove tenant_id fallback in all chat-history routes

## Tests

Total: 1180 → 1204 (24 new tests added across rounds)
Including attack scenario tests (Tests 22-23: forged user_metadata.role; Tests 27-28: injected tenant_id) for regression prevention.

## Deployment Plan

- Phase69-1 fix merge (this PR) — no deploy yet
- Phase69-1.5 fix merge (next PR, Asana GID: 1214771938406621)
- Deploy both simultaneously after Phase69-1.5 completes

Asana: Phase69-1 (1214250322439971) / Phase69-1.5 (1214771938406621)

🤖 Generated with [Claude Code](https://claude.com/claude-code)