### PR TITLE
fix(phase69-1.5): remove user_metadata fallback in common authz middleware (PR-A)

### DIFF
--- a/src/api/admin/tenants/superAdminMiddleware.test.ts
+++ b/src/api/admin/tenants/superAdminMiddleware.test.ts
@@ -1,0 +1,85 @@
+// src/api/admin/tenants/superAdminMiddleware.test.ts
+// Phase69-1.5: superAdminMiddleware の信頼境界テスト
+
+import type { NextFunction, Request, Response } from "express";
+import { superAdminMiddleware } from "./superAdminMiddleware";
+
+function mockReq(supabaseUser?: unknown): Request {
+  return { supabaseUser } as unknown as Request;
+}
+
+function mockRes(): Response {
+  const res: Partial<Response> = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res as Response;
+}
+
+const next: NextFunction = jest.fn();
+
+beforeEach(() => jest.clearAllMocks());
+
+describe("superAdminMiddleware", () => {
+  beforeAll(() => {
+    process.env.NODE_ENV = "test";
+  });
+
+  // ── 正常系 ──────────────────────────────────────────────────────────────────
+
+  it("app_metadata.role='super_admin' → next() を呼ぶ", () => {
+    const req = mockReq({ app_metadata: { role: "super_admin" } });
+    superAdminMiddleware(req, mockRes(), next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("認証なし (supabaseUser なし) → 401", () => {
+    const req = mockReq(undefined);
+    const res = mockRes();
+    superAdminMiddleware(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("app_metadata.role='client_admin' → 403", () => {
+    const req = mockReq({ app_metadata: { role: "client_admin" } });
+    const res = mockRes();
+    superAdminMiddleware(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  // ── [攻撃シナリオ] 信頼境界テスト ─────────────────────────────────────────
+
+  it("[攻撃防止] user_metadata.role='super_admin', app_metadata なし → 403", () => {
+    const req = mockReq({
+      user_metadata: { role: "super_admin" },
+      // app_metadata.role は未設定
+    });
+    const res = mockRes();
+    superAdminMiddleware(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("[攻撃防止] top-level role='super_admin', app_metadata なし → 403", () => {
+    const req = mockReq({
+      role: "super_admin",
+      // app_metadata.role は未設定
+    });
+    const res = mockRes();
+    superAdminMiddleware(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("[攻撃防止] app_metadata.role='viewer', user_metadata.role='super_admin' → 403", () => {
+    const req = mockReq({
+      app_metadata: { role: "viewer" },
+      user_metadata: { role: "super_admin" },
+    });
+    const res = mockRes();
+    superAdminMiddleware(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/src/api/admin/tenants/superAdminMiddleware.ts
+++ b/src/api/admin/tenants/superAdminMiddleware.ts
@@ -20,11 +20,10 @@ export function superAdminMiddleware(
     return;
   }
 
-  // Supabase JWT: app_metadata.role または user_metadata.role をチェック
-  const role =
-    user.app_metadata?.role ||
-    user.user_metadata?.role ||
-    user.role;
+  // セキュリティ要件: ロールは app_metadata.role のみを信頼する
+  // user_metadata / top-level role はクライアント制御可能なため使用してはならない
+  const rawRole = user.app_metadata?.role;
+  const role: string = typeof rawRole === "string" ? rawRole : "";
 
   if (role !== "super_admin") {
     res.status(403).json({ error: "forbidden", message: "Super Admin権限が必要です。" });

--- a/src/api/middleware/roleAuth.test.ts
+++ b/src/api/middleware/roleAuth.test.ts
@@ -83,13 +83,32 @@ describe("roleAuthMiddleware", () => {
     expect(user.tenantId).toBe("tenant-abc");
   });
 
-  it("falls back to user_metadata.tenant_id when app_metadata.tenant_id is absent", () => {
+  it("[攻撃防止] user_metadata.role='super_admin' は anonymous になる (クライアント制御可能)", () => {
     const req = mockReq({
       supabaseUser: {
-        sub: "user-003",
-        email: "client2@example.com",
+        sub: "attacker-001",
+        email: "attacker@example.com",
+        user_metadata: { role: "super_admin" },
+        // app_metadata.role は未設定
+      },
+    });
+    const res = mockRes();
+    roleAuthMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    const user: AuthenticatedUser = (req as any).user;
+    expect(user.role).toBe("anonymous");
+    expect(user.tenantId).toBeNull();
+  });
+
+  it("[攻撃防止] user_metadata.tenant_id は無視され tenantId が null になる", () => {
+    const req = mockReq({
+      supabaseUser: {
+        sub: "attacker-002",
+        email: "attacker@example.com",
         app_metadata: { role: "client_admin" },
-        user_metadata: { tenant_id: "tenant-from-user-meta" },
+        user_metadata: { tenant_id: "injected-tenant" },
+        // app_metadata.tenant_id は未設定
       },
     });
     const res = mockRes();
@@ -98,7 +117,25 @@ describe("roleAuthMiddleware", () => {
     expect(next).toHaveBeenCalled();
     const user: AuthenticatedUser = (req as any).user;
     expect(user.role).toBe("client_admin");
-    expect(user.tenantId).toBe("tenant-from-user-meta");
+    expect(user.tenantId).toBeNull(); // user_metadata.tenant_id は無視
+  });
+
+  it("[攻撃防止] app_metadata なし + user_metadata のみ → anonymous / null", () => {
+    const req = mockReq({
+      supabaseUser: {
+        sub: "attacker-003",
+        email: "attacker@example.com",
+        user_metadata: { role: "client_admin", tenant_id: "attacker-tenant" },
+        // app_metadata 自体なし
+      },
+    });
+    const res = mockRes();
+    roleAuthMiddleware(req, res, next);
+
+    expect(next).toHaveBeenCalled();
+    const user: AuthenticatedUser = (req as any).user;
+    expect(user.role).toBe("anonymous");
+    expect(user.tenantId).toBeNull();
   });
 });
 

--- a/src/api/middleware/roleAuth.test.ts
+++ b/src/api/middleware/roleAuth.test.ts
@@ -137,6 +137,72 @@ describe("roleAuthMiddleware", () => {
     expect(user.role).toBe("anonymous");
     expect(user.tenantId).toBeNull();
   });
+
+  // ── fail-closed: client_admin without tenant_id ─────────────────────────
+
+  it("[X] client_admin + app_metadata.tenant_id=undefined → 403 (fail-closed)", () => {
+    const req = mockReq({
+      supabaseUser: {
+        sub: "user-010",
+        email: "cadmin@example.com",
+        app_metadata: { role: "client_admin" },
+        // tenant_id 未設定
+      },
+    });
+    const res = mockRes();
+    roleAuthMiddleware(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("[Y] client_admin + app_metadata.tenant_id='' → 403 (fail-closed)", () => {
+    const req = mockReq({
+      supabaseUser: {
+        sub: "user-011",
+        email: "cadmin2@example.com",
+        app_metadata: { role: "client_admin", tenant_id: "" },
+      },
+    });
+    const res = mockRes();
+    roleAuthMiddleware(req, res, next);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("[Z] client_admin + app_metadata.tenant_id='t1' → next() 呼ばれる", () => {
+    const req = mockReq({
+      supabaseUser: {
+        sub: "user-012",
+        email: "cadmin3@example.com",
+        app_metadata: { role: "client_admin", tenant_id: "t1" },
+      },
+    });
+    const res = mockRes();
+    roleAuthMiddleware(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+    const user: AuthenticatedUser = (req as any).user;
+    expect(user.role).toBe("client_admin");
+    expect(user.tenantId).toBe("t1");
+  });
+
+  it("[W] super_admin + tenant_id なし → next() 呼ばれる (グローバル操作は影響なし)", () => {
+    const req = mockReq({
+      supabaseUser: {
+        sub: "user-013",
+        email: "superadmin@example.com",
+        app_metadata: { role: "super_admin" },
+        // tenant_id なし — super_admin は全テナント対象
+      },
+    });
+    const res = mockRes();
+    roleAuthMiddleware(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+    const user: AuthenticatedUser = (req as any).user;
+    expect(user.role).toBe("super_admin");
+    expect(user.tenantId).toBeNull();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/api/middleware/roleAuth.ts
+++ b/src/api/middleware/roleAuth.ts
@@ -17,8 +17,16 @@ export type SupabaseJwtUser = {
   email?: string;
   tenant_id?: string;
   app_metadata?: { role?: string; tenant_id?: string };
+  // user_metadata は Supabase JWT に存在するがクライアント制御可能なため、
+  // 認可ロジックでは使用してはならない（型定義のみ保持）
   user_metadata?: { role?: string; tenant_id?: string };
 };
+
+// セキュリティ要件: JWT claim を安全に string として取得する
+// typeof ガードにより any/undefined を "" にフォールバック（実行時保証）
+function safeStringClaim(v: unknown): string {
+  return typeof v === "string" ? v : "";
+}
 
 export type AuthedReq = Request & {
   supabaseUser?: SupabaseJwtUser;
@@ -46,15 +54,14 @@ export function roleAuthMiddleware(
     return next();
   }
 
+  // セキュリティ要件: ロール / テナントスコープは app_metadata のみを信頼する
+  // user_metadata はクライアント制御可能なため、特権判定に使用してはならない
+  const rawRole = safeStringClaim(supabaseUser.app_metadata?.role);
   const role: UserRole =
-    (supabaseUser.app_metadata?.role as UserRole | undefined) ||
-    (supabaseUser.user_metadata?.role as UserRole | undefined) ||
-    "anonymous";
+    rawRole === "super_admin" || rawRole === "client_admin" ? rawRole : "anonymous";
 
-  const tenantId: string | null =
-    supabaseUser.app_metadata?.tenant_id ||
-    supabaseUser.user_metadata?.tenant_id ||
-    null;
+  const rawTenantId = safeStringClaim(supabaseUser.app_metadata?.tenant_id);
+  const tenantId: string | null = rawTenantId || null;
 
   (req as AuthedReq).user = {
     id: supabaseUser.sub || supabaseUser.id || "",

--- a/src/api/middleware/roleAuth.ts
+++ b/src/api/middleware/roleAuth.ts
@@ -63,6 +63,13 @@ export function roleAuthMiddleware(
   const rawTenantId = safeStringClaim(supabaseUser.app_metadata?.tenant_id);
   const tenantId: string | null = rawTenantId || null;
 
+  // セキュリティ要件: client_admin は必ず tenant_id を持つこと
+  // 防御深度: ミドルウェア層と route 層の両方で fail-closed
+  if (role === "client_admin" && (!tenantId || typeof tenantId !== "string" || tenantId.trim() === "")) {
+    res.status(403).json({ error: "この操作を実行する権限がありません" });
+    return;
+  }
+
   (req as AuthedReq).user = {
     id: supabaseUser.sub || supabaseUser.id || "",
     email: supabaseUser.email || "",


### PR DESCRIPTION
## Summary
Phase69-1.5 cross-cutting fix PR-A: common authz middleware hardening.

Related to Phase69-1 retroactive Gate 2.5 (Round 5) findings about
user_metadata privilege escalation. This PR addresses the **common middleware**
layer. Individual admin/*/routes.ts (which bypass roleAuthMiddleware) will be
fixed in PR-C.

## Changes
- **roleAuth.ts**: 
  - role/tenant_id resolution only trusts app_metadata (typeof string guard)
  - Added safeStringClaim helper for null/type safety
  - **Fail-closed for client_admin without tenant_id** (Gate 2.5 hardening)
- **superAdminMiddleware.ts**: 
  - 3-tier fallback (app_metadata.role || user_metadata.role || user.role) 
  - → app_metadata.role only

## Gate 2.5 (adversarial-review)
- Initial review: HIGH (1) — middleware-layer fail-closed missing
- After fix (commit 1322766): ✅ Ship-ready, Critical/High 0
- Codex evaluation: "Ship-ready... consistently hardens trust boundaries
  by restricting authz claims to app_metadata and adds fail-closed
  behavior for client_admin without tenant_id."

## Tests
- Updated roleAuth.test.ts: attack scenarios for user_metadata (3 cases)
- New superAdminMiddleware.test.ts: attack scenarios (6 cases)
- Added client_admin tenant_id attack scenarios (4 cases)
- Total: 1204 → 1216 (12 new tests)

## Affected scope
- roleAuthMiddleware-using routes: knowledge/pdf, billing, conversion, engagement, auth
- admin/*/routes.ts (bypass roleAuthMiddleware): **out of scope, deferred to PR-C**

## Deployment
Hold until PR-B and PR-C merged. Then deploy with Phase69-1 fix (PR #146).

Asana: 1214771938406621

🤖 Generated with [Claude Code](https://claude.com/claude-code)