### PR TITLE
fix(phase69-1.5): add ALLOWED_ROLES whitelist to chat-history routes (PR-B)

### DIFF
--- a/src/api/admin/chat-history/deleteSession.test.ts
+++ b/src/api/admin/chat-history/deleteSession.test.ts
@@ -539,6 +539,145 @@ describe("GET /v1/admin/chat-history: tenant_id fallback 削除", () => {
 
     expect(res.status).toBe(403);
   });
+
+  // ── [HIGH] Phase69-1.5: GET エンドポイントのロールホワイトリスト ──────────
+
+  it("Test 33: GET sessions — viewer ロールは403を返す", async () => {
+    const viewerToken = makeDevJwt({
+      email: "viewer@example.com",
+      app_metadata: { role: "viewer", tenant_id: "tenant-a" },
+    });
+
+    const res = await request(app)
+      .get("/v1/admin/chat-history/sessions")
+      .set("Authorization", `Bearer ${viewerToken}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("Test 34: GET sessions — role が undefined のユーザーは403を返す", async () => {
+    const noRoleToken = makeDevJwt({
+      email: "norole@example.com",
+      app_metadata: { tenant_id: "tenant-a" },
+    });
+
+    const res = await request(app)
+      .get("/v1/admin/chat-history/sessions")
+      .set("Authorization", `Bearer ${noRoleToken}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("Test 35: GET sessions — role が空文字のユーザーは403を返す", async () => {
+    const emptyRoleToken = makeDevJwt({
+      email: "empty@example.com",
+      app_metadata: { role: "", tenant_id: "tenant-a" },
+    });
+
+    const res = await request(app)
+      .get("/v1/admin/chat-history/sessions")
+      .set("Authorization", `Bearer ${emptyRoleToken}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("Test 36: GET sessions/:id/messages — viewer ロールは403を返す", async () => {
+    const viewerToken = makeDevJwt({
+      email: "viewer@example.com",
+      app_metadata: { role: "viewer", tenant_id: "tenant-a" },
+    });
+
+    const res = await request(app)
+      .get("/v1/admin/chat-history/sessions/sess-uuid-1/messages")
+      .set("Authorization", `Bearer ${viewerToken}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("Test 37: GET sessions/:id/messages — role が undefined のユーザーは403を返す", async () => {
+    const noRoleToken = makeDevJwt({
+      email: "norole@example.com",
+      app_metadata: { tenant_id: "tenant-a" },
+    });
+
+    const res = await request(app)
+      .get("/v1/admin/chat-history/sessions/sess-uuid-1/messages")
+      .set("Authorization", `Bearer ${noRoleToken}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  it("Test 38: GET sessions/:id/messages — role が空文字のユーザーは403を返す", async () => {
+    const emptyRoleToken = makeDevJwt({
+      email: "empty@example.com",
+      app_metadata: { role: "", tenant_id: "tenant-a" },
+    });
+
+    const res = await request(app)
+      .get("/v1/admin/chat-history/sessions/sess-uuid-1/messages")
+      .set("Authorization", `Bearer ${emptyRoleToken}`);
+
+    expect(res.status).toBe(403);
+  });
+});
+
+// ── [HIGH] Phase69-1.5: PATCH エンドポイントのロールホワイトリスト ─────────────
+
+describe("PATCH /v1/admin/chat-history: role whitelist", () => {
+  let app: ReturnType<typeof express>;
+
+  beforeAll(() => {
+    process.env.NODE_ENV = "development";
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    app = express();
+    app.use(express.json());
+    registerChatHistoryRoutes(app);
+  });
+
+  it("Test 39: PATCH outcome — viewer ロールは403を返す", async () => {
+    const viewerToken = makeDevJwt({
+      email: "viewer@example.com",
+      app_metadata: { role: "viewer", tenant_id: "tenant-a" },
+    });
+
+    const res = await request(app)
+      .patch("/v1/admin/chat-history/sessions/sess-uuid-1/outcome")
+      .set("Authorization", `Bearer ${viewerToken}`)
+      .send({ outcome: "購入完了" });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("Test 40: PATCH outcome — role が undefined のユーザーは403を返す", async () => {
+    const noRoleToken = makeDevJwt({
+      email: "norole@example.com",
+      app_metadata: { tenant_id: "tenant-a" },
+    });
+
+    const res = await request(app)
+      .patch("/v1/admin/chat-history/sessions/sess-uuid-1/outcome")
+      .set("Authorization", `Bearer ${noRoleToken}`)
+      .send({ outcome: "購入完了" });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("Test 41: PATCH outcome — role が空文字のユーザーは403を返す", async () => {
+    const emptyRoleToken = makeDevJwt({
+      email: "empty@example.com",
+      app_metadata: { role: "", tenant_id: "tenant-a" },
+    });
+
+    const res = await request(app)
+      .patch("/v1/admin/chat-history/sessions/sess-uuid-1/outcome")
+      .set("Authorization", `Bearer ${emptyRoleToken}`)
+      .send({ outcome: "購入完了" });
+
+    expect(res.status).toBe(403);
+  });
 });
 
 // ── リポジトリ内部クエリ整合性テスト（Tests 18-20） ──────────────────────────

--- a/src/api/admin/chat-history/routes.ts
+++ b/src/api/admin/chat-history/routes.ts
@@ -27,6 +27,13 @@ function resolveTenantFilter(
   return jwtTenantId; // client_admin は自テナント強制
 }
 
+const ALLOWED_ADMIN_ROLES = ["super_admin", "client_admin"] as const;
+type AllowedAdminRole = typeof ALLOWED_ADMIN_ROLES[number];
+function isAllowedAdminRole(role: unknown): role is AllowedAdminRole {
+  return typeof role === "string" &&
+         (ALLOWED_ADMIN_ROLES as readonly string[]).includes(role);
+}
+
 export function registerChatHistoryRoutes(app: Express): void {
   // 認証ミドルウェアを適用
   app.use("/v1/admin/chat-history", supabaseAuthMiddleware);
@@ -38,13 +45,14 @@ export function registerChatHistoryRoutes(app: Express): void {
     "/v1/admin/chat-history/sessions",
     async (req: Request, res: Response) => {
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
+      const actorRole = su?.app_metadata?.role;
+      if (!isAllowedAdminRole(actorRole)) {
+        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+      }
       // セキュリティ要件: テナントスコープも app_metadata.tenant_id のみを信頼する
       // su.tenant_id (top-level claim) はクライアント制御可能なため使用しない
       const jwtTenantId: string = su?.app_metadata?.tenant_id ?? "";
-      // セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
-      // user_metadata はクライアント編集可能なため、特権判定に使用してはならない
-      const isSuperAdmin: boolean =
-        su?.app_metadata?.role === "super_admin";
+      const isSuperAdmin: boolean = actorRole === "super_admin";
 
       if (!isSuperAdmin && !jwtTenantId) {
         return res.status(403).json({ error: "この操作を実行する権限がありません" });
@@ -112,13 +120,14 @@ export function registerChatHistoryRoutes(app: Express): void {
     async (req: Request, res: Response) => {
       const sessionDbId: string = req.params["sessionId"] ?? "";
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
+      const actorRole = su?.app_metadata?.role;
+      if (!isAllowedAdminRole(actorRole)) {
+        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+      }
       // セキュリティ要件: テナントスコープも app_metadata.tenant_id のみを信頼する
       // su.tenant_id (top-level claim) はクライアント制御可能なため使用しない
       const jwtTenantId: string = su?.app_metadata?.tenant_id ?? "";
-      // セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
-      // user_metadata はクライアント編集可能なため、特権判定に使用してはならない
-      const isSuperAdmin: boolean =
-        su?.app_metadata?.role === "super_admin";
+      const isSuperAdmin: boolean = actorRole === "super_admin";
 
       // テナント検証:
       //   super_admin: ?tenant=xxx があればそれを使う。なければ undefined (全セッション閲覧可)
@@ -166,21 +175,14 @@ export function registerChatHistoryRoutes(app: Express): void {
       const jwtTenantId: string = su?.app_metadata?.tenant_id ?? "";
       // セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
       // user_metadata はクライアント編集可能なため、特権判定に使用してはならない
-      const actorRole: string | undefined = su?.app_metadata?.role as string | undefined;
-      if (!actorRole || typeof actorRole !== "string") {
+      const actorRole = su?.app_metadata?.role;
+      if (!isAllowedAdminRole(actorRole)) {
         return res.status(403).json({ error: "この操作を実行する権限がありません" });
       }
       const actorEmail: string = su?.email ?? su?.app_metadata?.email ?? "";
 
       if (!sessionDbId) {
         return res.status(400).json({ error: "sessionId が必要です" });
-      }
-
-      // Phase69-1 fix [HIGH]: ロールホワイトリスト強制
-      const ALLOWED_ROLES = ["super_admin", "client_admin"] as const;
-      type AllowedRole = typeof ALLOWED_ROLES[number];
-      if (!ALLOWED_ROLES.includes(actorRole as AllowedRole)) {
-        return res.status(403).json({ error: "この操作を実行する権限がありません" });
       }
 
       // Phase69-1 fix [HIGH] Round2: client_admin は必ず有効な tenant_id を持つこと
@@ -252,13 +254,14 @@ export function registerChatHistoryRoutes(app: Express): void {
       const pool = getPool();
       const sessionDbId: string = req.params["sessionId"] ?? "";
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
+      const actorRole = su?.app_metadata?.role;
+      if (!isAllowedAdminRole(actorRole)) {
+        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+      }
       // セキュリティ要件: テナントスコープも app_metadata.tenant_id のみを信頼する
       // su.tenant_id (top-level claim) はクライアント制御可能なため使用しない
       const jwtTenantId: string = su?.app_metadata?.tenant_id ?? "";
-      // セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
-      // user_metadata はクライアント編集可能なため、特権判定に使用してはならない
-      const isSuperAdmin: boolean =
-        su?.app_metadata?.role === "super_admin";
+      const isSuperAdmin: boolean = actorRole === "super_admin";
       const email: string = su?.email ?? su?.app_metadata?.email ?? "";
 
       if (!sessionDbId) {

--- a/src/api/middleware/roleAuth.test.ts
+++ b/src/api/middleware/roleAuth.test.ts
@@ -101,7 +101,7 @@ describe("roleAuthMiddleware", () => {
     expect(user.tenantId).toBeNull();
   });
 
-  it("[攻撃防止] user_metadata.tenant_id は無視され tenantId が null になる", () => {
+  it("[攻撃防止] client_admin + user_metadata.tenant_id のみ → fail-closed で 403", () => {
     const req = mockReq({
       supabaseUser: {
         sub: "attacker-002",
@@ -114,10 +114,13 @@ describe("roleAuthMiddleware", () => {
     const res = mockRes();
     roleAuthMiddleware(req, res, next);
 
-    expect(next).toHaveBeenCalled();
-    const user: AuthenticatedUser = (req as any).user;
-    expect(user.role).toBe("client_admin");
-    expect(user.tenantId).toBeNull(); // user_metadata.tenant_id は無視
+    // user_metadata.tenant_id は信頼源として扱われないため app_metadata.tenant_id が欠損
+    // → client_admin + tenantId=null → fail-closed で 403
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({
+      error: expect.any(String),
+    }));
   });
 
   it("[攻撃防止] app_metadata なし + user_metadata のみ → anonymous / null", () => {


### PR DESCRIPTION
## Summary
Phase69-1.5 PR-B: chat-history GET/PATCH endpoints authorization hardening.

Addresses Phase69-1 retroactive Gate 2.5 (Round 7) findings about
pre-existing authorization gaps in chat-history GET handlers, plus
fixes a broken test from PR-A (#147).

## Changes

### chat-history/routes.ts
- Added file-level `ALLOWED_ADMIN_ROLES = ['super_admin', 'client_admin']`
  constant + `isAllowedAdminRole` type guard helper
- Applied whitelist check to all admin endpoints:
  - **GET /sessions** (list): previously only checked isSuperAdmin/tenant_id
  - **GET /sessions/:id/messages** (detail): same
  - **PATCH** (outcome update): same
  - **DELETE**: already had whitelist (Phase69-1 fix), now uses file-level constant
- Non-admin roles (viewer, undefined, empty string) are rejected with 403

### roleAuth.test.ts (cross-cutting fix)
- Updated test at L117 to align with fail-closed behavior introduced in PR-A
- PR-A added fail-closed for client_admin without app_metadata.tenant_id,
  but the corresponding attack-prevention test was not updated
- The test now correctly expects 403 (fail-closed) instead of next() called
- This was a pre-existing broken test on main (1216 tests: 1 failed, 1215 passed),
  now main returns to fully green (1225 tests: 0 failed, 1225 passed)

## Gate 2.5 Status

✅ Codex adversarial-review: **approve** / No material findings

Codex evaluation:
> "Ship-ready from an adversarial standpoint: within the provided diff,
> I could not substantiate a material security or reliability regression
> against main. The new role whitelist checks are consistently fail-closed
> on modified chat-history endpoints, and the updated middleware test
> aligns with that posture."

## Tests

- Added 9 new tests (Tests 33-41) in deleteSession.test.ts:
  - GET /sessions: viewer/undefined/empty string → 403 (3 tests)
  - GET /sessions/:id/messages: same (3 tests)
  - PATCH: same (3 tests)
- Fixed 1 existing test in roleAuth.test.ts (PR-A 由来 broken test)
- Total: 1216 (1 failed) → 1225 (0 failed)

## Affected Scope

- **chat-history endpoints**: GET /sessions, GET /sessions/:id/messages, PATCH, DELETE
- **common middleware**: roleAuth.test.ts (1 test fix only, implementation unchanged)
- **Out of scope**: other admin/*/routes.ts → deferred to PR-C

## Deployment

Hold until PR-C merged. Then deploy with Phase69-1 fix (PR #146).

Asana: 1214771938406621