### PR TITLE
fix(phase69-1.5): remove user_metadata fallback in tenants/* admin routes (PR-C1)

### DIFF
--- a/src/api/admin/tenants/analyticsSummaryRoutes.ts
+++ b/src/api/admin/tenants/analyticsSummaryRoutes.ts
@@ -43,7 +43,10 @@ export function registerAnalyticsSummaryRoutes(app: Express, db: Pool): void {
 
   function canAccessTenant(req: Request, res: Response, tenantId: string, next: NextFunction): void {
     const su = (req as AuthedReq).supabaseUser;
-    const role = su?.app_metadata?.role ?? su?.user_metadata?.role ?? "anonymous";
+    // セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
+    // user_metadata はクライアント編集可能なため、特権判定に使用してはならない
+    const rawRole = su?.app_metadata?.role;
+    const role = typeof rawRole === "string" ? rawRole : "";
     const jwtTenantId = su?.app_metadata?.tenant_id as string | undefined;
     if (role === "super_admin" || jwtTenantId === tenantId) { next(); return; }
     res.status(403).json({ error: "forbidden" });

--- a/src/api/admin/tenants/ga4Routes.ts
+++ b/src/api/admin/tenants/ga4Routes.ts
@@ -54,7 +54,10 @@ export function registerGa4TenantRoutes(app: Express, db: Pool): void {
     next: NextFunction,
   ): void {
     const su = (req as AuthedReq).supabaseUser;
-    const role = su?.app_metadata?.role ?? su?.user_metadata?.role ?? "anonymous";
+    // セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
+    // user_metadata はクライアント編集可能なため、特権判定に使用してはならない
+    const rawRole = su?.app_metadata?.role;
+    const role = typeof rawRole === "string" ? rawRole : "";
     const jwtTenantId = su?.app_metadata?.tenant_id as string | undefined;
     if (role === "super_admin" || jwtTenantId === tenantId) {
       next();

--- a/src/api/admin/tenants/notificationPreferencesRoutes.ts
+++ b/src/api/admin/tenants/notificationPreferencesRoutes.ts
@@ -44,7 +44,10 @@ export function registerNotificationPreferencesRoutes(app: Express, db: Pool): v
 
   function canAccessTenant(req: Request, res: Response, tenantId: string, next: NextFunction): void {
     const su = (req as AuthedReq).supabaseUser;
-    const role = su?.app_metadata?.role ?? su?.user_metadata?.role ?? "anonymous";
+    // セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
+    // user_metadata はクライアント編集可能なため、特権判定に使用してはならない
+    const rawRole = su?.app_metadata?.role;
+    const role = typeof rawRole === "string" ? rawRole : "";
     const jwtTenantId = su?.app_metadata?.tenant_id as string | undefined;
     if (role === "super_admin" || jwtTenantId === tenantId) { next(); return; }
     res.status(403).json({ error: "forbidden" });

--- a/src/api/admin/tenants/posthogRoutes.ts
+++ b/src/api/admin/tenants/posthogRoutes.ts
@@ -42,7 +42,10 @@ export function registerPostHogTenantRoutes(app: Express, db: Pool): void {
 
   function canAccessTenant(req: Request, res: Response, tenantId: string, next: NextFunction): void {
     const su = (req as AuthedReq).supabaseUser;
-    const role = su?.app_metadata?.role ?? su?.user_metadata?.role ?? "anonymous";
+    // セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
+    // user_metadata はクライアント編集可能なため、特権判定に使用してはならない
+    const rawRole = su?.app_metadata?.role;
+    const role = typeof rawRole === "string" ? rawRole : "";
     const jwtTenantId = su?.app_metadata?.tenant_id as string | undefined;
     if (role === "super_admin" || jwtTenantId === tenantId) { next(); return; }
     res.status(403).json({ error: "forbidden" });

--- a/src/api/admin/tenants/routes.ts
+++ b/src/api/admin/tenants/routes.ts
@@ -90,7 +90,10 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
 
   function requireSuperAdmin(req: Request, res: Response, next: NextFunction): void {
     const su = (req as AuthedReq).supabaseUser;
-    const role = su?.app_metadata?.role ?? su?.user_metadata?.role ?? "anonymous";
+    // セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
+    // user_metadata はクライアント編集可能なため、特権判定に使用してはならない
+    const rawRole = su?.app_metadata?.role;
+    const role = typeof rawRole === "string" ? rawRole : "";
     if (role !== "super_admin") {
       res.status(403).json({ error: "forbidden", message: "スーパー管理者のみアクセスできます" });
       return;


### PR DESCRIPTION
## Summary
Phase69-1.5 PR-C1: tenants/* admin routes hardening.

Addresses cross-cutting `user_metadata.role` fallback removal identified
during Phase69-1 retroactive Gate 2.5 (Round 5/6). Mechanical replacement
across 5 files in `src/api/admin/tenants/`.

## Changes

### Pattern applied (5 files)

**Before:**
\`\`\`typescript
const role = su?.app_metadata?.role ?? su?.user_metadata?.role ?? "anonymous";
\`\`\`

**After:**
\`\`\`typescript
// セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
// user_metadata はクライアント編集可能なため、特権判定に使用してはならない
const rawRole = su?.app_metadata?.role;
const role = typeof rawRole === "string" ? rawRole : "";
\`\`\`

### Files modified (5)
- `src/api/admin/tenants/routes.ts`
- `src/api/admin/tenants/notificationPreferencesRoutes.ts`
- `src/api/admin/tenants/posthogRoutes.ts`
- `src/api/admin/tenants/ga4Routes.ts`
- `src/api/admin/tenants/analyticsSummaryRoutes.ts` (discovered during grep)

## Gate 2.5 Status

✅ Codex adversarial-review: **approve** / No material findings

> "Ship: from the provided diff, this change removes a client-editable
> user_metadata.role authorization fallback and tightens role trust to
> app_metadata.role only; I cannot support a material blocking risk in
> this patch."

## Tests

No new tests added. Common middleware attack scenarios already covered by PR-A (#147).
Existing 1225 tests all pass (0 failed, 1225 passed).

## Verification (grep)

Post-fix verification:
- `user_metadata` in code (tenants/*): **0 occurrences** ✅
- `?? su?.tenant_id` (tenants/*): **0 occurrences** ✅
- Comments mentioning user_metadata: 5 (security documentation, expected)

## Affected Scope

- **In scope**: tenants/* admin routes (5 files)
- **Out of scope**: analytics/*, feedback/*, tuning/*, other admin routes →
  deferred to PR-C2, C3, C4

## Deployment

Hold until PR-C2/C3/C4 merged. Then deploy with Phase69-1 fix (PR #146).

Asana: 1214771938406621