### PR TITLE
test(phase69-1.5): add allow-path tests for analytics admin routes (PR-C2 Round 5)

### DIFF
--- a/src/api/admin/analytics/analyticsAuthGuard.test.ts
+++ b/src/api/admin/analytics/analyticsAuthGuard.test.ts
@@ -1,0 +1,93 @@
+// src/api/admin/analytics/analyticsAuthGuard.test.ts
+// Phase69-1.5: analytics/* ALLOWED_ROLES whitelist + tenant_id fail-closed regression tests
+// Codex adversarial-review Round 2 findings: analytics endpoints did not reject
+// non-admin roles or client_admin with missing app_metadata.tenant_id.
+
+jest.mock('../../../lib/db', () => ({
+  pool: null,
+  getPool: () => null,
+}));
+jest.mock('../../../lib/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock('../../../lib/notifications', () => ({
+  createNotification: jest.fn(),
+  notificationExists: jest.fn(),
+}));
+jest.mock('../../../admin/http/supabaseAuthMiddleware', () => ({
+  supabaseAuthMiddleware: (req: any, _res: any, next: any) => {
+    req.supabaseUser = req._mockUser ?? null;
+    next();
+  },
+}));
+
+import express from 'express';
+import request from 'supertest';
+import { registerAnalyticsRoutes } from './routes';
+import { registerEventAnalyticsRoutes } from './eventAnalyticsRoutes';
+
+function makeApp(appMetadata: Record<string, unknown> | null) {
+  const app = express();
+  app.use(express.json());
+  app.use((req: any, _res: any, next: any) => {
+    req._mockUser = appMetadata ? { app_metadata: appMetadata } : null;
+    next();
+  });
+  registerAnalyticsRoutes(app);
+  registerEventAnalyticsRoutes(app);
+  return app;
+}
+
+// Routes that enforce both ALLOWED_ROLES and non-super-admin tenant_id presence
+const TENANT_SCOPED_ROUTES = [
+  '/v1/admin/analytics/summary',
+  '/v1/admin/analytics/trends',
+  '/v1/admin/analytics/evaluations',
+  '/v1/admin/analytics/conversions',
+  '/v1/admin/analytics/knowledge-attribution',
+  '/v1/admin/analytics/events',
+];
+
+// All routes including super_admin-only cv-status
+const ALL_ROUTES = [...TENANT_SCOPED_ROUTES, '/v1/admin/analytics/cv-status'];
+
+// ---------------------------------------------------------------------------
+// Whitelist: viewer role → 403
+// ---------------------------------------------------------------------------
+describe('analytics routes — ALLOWED_ROLES whitelist (viewer → 403)', () => {
+  ALL_ROUTES.forEach((route) => {
+    it(`${route} — viewer → 403`, async () => {
+      const app = makeApp({ role: 'viewer', tenant_id: 'tenant-a' });
+      const res = await request(app).get(route);
+      expect(res.status).toBe(403);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Whitelist: undefined role → 403
+// ---------------------------------------------------------------------------
+describe('analytics routes — ALLOWED_ROLES whitelist (no role → 403)', () => {
+  ALL_ROUTES.forEach((route) => {
+    it(`${route} — no role → 403`, async () => {
+      const app = makeApp({ tenant_id: 'tenant-a' }); // role absent
+      const res = await request(app).get(route);
+      expect(res.status).toBe(403);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fail-closed: client_admin without app_metadata.tenant_id → 403
+// cv-status is super_admin-only and rejects client_admin at the isSuperAdmin check,
+// so it is excluded from this specific tenant guard scenario.
+// ---------------------------------------------------------------------------
+describe('analytics routes — tenant_id fail-closed (client_admin + no tenant → 403)', () => {
+  TENANT_SCOPED_ROUTES.forEach((route) => {
+    it(`${route} — client_admin + no tenant → 403`, async () => {
+      const app = makeApp({ role: 'client_admin' }); // tenant_id absent
+      const res = await request(app).get(route);
+      expect(res.status).toBe(403);
+    });
+  });
+});

--- a/src/api/admin/analytics/analyticsAuthGuard.test.ts
+++ b/src/api/admin/analytics/analyticsAuthGuard.test.ts
@@ -23,6 +23,7 @@ jest.mock('../../../admin/http/supabaseAuthMiddleware', () => ({
 
 import express from 'express';
 import request from 'supertest';
+import { logger } from '../../../lib/logger';
 import { registerAnalyticsRoutes } from './routes';
 import { registerEventAnalyticsRoutes } from './eventAnalyticsRoutes';
 
@@ -50,6 +51,10 @@ const TENANT_SCOPED_ROUTES = [
 
 // All routes including super_admin-only cv-status
 const ALL_ROUTES = [...TENANT_SCOPED_ROUTES, '/v1/admin/analytics/cv-status'];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
 
 // ---------------------------------------------------------------------------
 // Whitelist: viewer role → 403
@@ -89,5 +94,99 @@ describe('analytics routes — tenant_id fail-closed (client_admin + no tenant �
       const res = await request(app).get(route);
       expect(res.status).toBe(403);
     });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Observability: logger.warn called with structured payload on 403 denials
+// ---------------------------------------------------------------------------
+describe('analytics routes — logger.warn structured payload on 403 (observability)', () => {
+  it('/v1/admin/analytics/summary — viewer → logger.warn with AUTH_ROLE_INVALID', async () => {
+    const app = makeApp({ role: 'viewer', tenant_id: 'tenant-a' });
+    await request(app).get('/v1/admin/analytics/summary');
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'analytics_access_denied',
+        reason: 'invalid_role',
+        errorCode: 'AUTH_ROLE_INVALID',
+        hasAppMetadataRole: true,
+        hasUserMetadataRole: false,
+      }),
+      expect.any(String),
+    );
+  });
+
+  it('/v1/admin/analytics/summary — no role → logger.warn with AUTH_ROLE_INVALID', async () => {
+    const app = makeApp({ tenant_id: 'tenant-a' }); // role absent
+    await request(app).get('/v1/admin/analytics/summary');
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'analytics_access_denied',
+        reason: 'invalid_role',
+        errorCode: 'AUTH_ROLE_INVALID',
+        hasAppMetadataRole: false,
+      }),
+      expect.any(String),
+    );
+  });
+
+  it('/v1/admin/analytics/summary — client_admin + no tenant → logger.warn with AUTH_TENANT_INVALID', async () => {
+    const app = makeApp({ role: 'client_admin' }); // tenant_id absent
+    await request(app).get('/v1/admin/analytics/summary');
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'analytics_access_denied',
+        reason: 'tenant_id_missing',
+        errorCode: 'AUTH_TENANT_INVALID',
+        hasAppMetadataTenantId: false,
+      }),
+      expect.any(String),
+    );
+  });
+
+  it('/v1/admin/analytics/events — viewer → logger.warn with AUTH_ROLE_INVALID', async () => {
+    const app = makeApp({ role: 'viewer', tenant_id: 'tenant-a' });
+    await request(app).get('/v1/admin/analytics/events');
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'analytics_access_denied',
+        reason: 'invalid_role',
+        errorCode: 'AUTH_ROLE_INVALID',
+      }),
+      expect.any(String),
+    );
+  });
+
+  it('/v1/admin/analytics/events — client_admin + no tenant → logger.warn with AUTH_TENANT_INVALID', async () => {
+    const app = makeApp({ role: 'client_admin' }); // tenant_id absent
+    await request(app).get('/v1/admin/analytics/events');
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'analytics_access_denied',
+        reason: 'tenant_id_missing',
+        errorCode: 'AUTH_TENANT_INVALID',
+      }),
+      expect.any(String),
+    );
+  });
+
+  it('/v1/admin/analytics/cv-status — client_admin (insufficient role) → logger.warn with AUTH_ROLE_INSUFFICIENT', async () => {
+    const app = makeApp({ role: 'client_admin', tenant_id: 'tenant-a' });
+    await request(app).get('/v1/admin/analytics/cv-status');
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        event: 'analytics_access_denied',
+        reason: 'insufficient_role',
+        errorCode: 'AUTH_ROLE_INSUFFICIENT',
+      }),
+      expect.any(String),
+    );
+  });
+
+  it('403 response includes errorCode field', async () => {
+    const app = makeApp({ role: 'viewer', tenant_id: 'tenant-a' });
+    const res = await request(app).get('/v1/admin/analytics/summary');
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({ code: 'AUTH_ROLE_INVALID' });
   });
 });

--- a/src/api/admin/analytics/analyticsAuthGuard.test.ts
+++ b/src/api/admin/analytics/analyticsAuthGuard.test.ts
@@ -190,3 +190,50 @@ describe('analytics routes — logger.warn structured payload on 403 (observabil
     expect(res.body).toMatchObject({ code: 'AUTH_ROLE_INVALID' });
   });
 });
+
+// ---------------------------------------------------------------------------
+// Allow-path: super_admin passes ALLOWED_ROLES + tenant guards → 503 (pool=null)
+// knowledge-attribution without ?tenant_id returns 400 (not 403) for super_admin;
+// expect(not.toBe(403)) covers both 503 and 400 outcomes.
+// ---------------------------------------------------------------------------
+describe('analytics routes — allow-path: super_admin passes ALLOWED_ROLES + tenant guards', () => {
+  ALL_ROUTES.forEach((route) => {
+    it(`${route} — super_admin → not 403 (auth passes; pool unavailable → 503)`, async () => {
+      const app = makeApp({ role: 'super_admin' });
+      const res = await request(app).get(route);
+      expect(res.status).not.toBe(403);
+    });
+  });
+
+  it('/v1/admin/analytics/summary — super_admin with ?tenant=tenant-a query scoping → 503', async () => {
+    const app = makeApp({ role: 'super_admin' });
+    const res = await request(app).get('/v1/admin/analytics/summary?tenant=tenant-a');
+    expect(res.status).toBe(503);
+  });
+
+  it('/v1/admin/analytics/knowledge-attribution — super_admin with ?tenant_id=tenant-a → 503 (auth + tenant resolved, pool unavailable)', async () => {
+    const app = makeApp({ role: 'super_admin' });
+    const res = await request(app).get('/v1/admin/analytics/knowledge-attribution?tenant_id=tenant-a');
+    expect(res.status).toBe(503);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Allow-path: client_admin with valid tenant_id passes ALLOWED_ROLES + tenant guards → 503
+// cv-status is intentionally excluded: client_admin → 403 AUTH_ROLE_INSUFFICIENT (super_admin only)
+// ---------------------------------------------------------------------------
+describe('analytics routes — allow-path: client_admin with tenant_id passes ALLOWED_ROLES + tenant guards', () => {
+  TENANT_SCOPED_ROUTES.forEach((route) => {
+    it(`${route} — client_admin + tenant_id → 503 (auth passes, pool unavailable)`, async () => {
+      const app = makeApp({ role: 'client_admin', tenant_id: 'tenant-a' });
+      const res = await request(app).get(route);
+      expect(res.status).toBe(503);
+    });
+  });
+
+  it('/v1/admin/analytics/events — client_admin + own tenant_id in query → 503 (cross-tenant guard permits own tenant)', async () => {
+    const app = makeApp({ role: 'client_admin', tenant_id: 'tenant-a' });
+    const res = await request(app).get('/v1/admin/analytics/events?tenant_id=tenant-a');
+    expect(res.status).toBe(503);
+  });
+});

--- a/src/api/admin/analytics/eventAnalyticsRoutes.ts
+++ b/src/api/admin/analytics/eventAnalyticsRoutes.ts
@@ -8,6 +8,7 @@
 import type { Express, Request, Response } from 'express';
 import { supabaseAuthMiddleware } from '../../../admin/http/supabaseAuthMiddleware';
 import { pool } from '../../../lib/db';
+import { logger } from '../../../lib/logger';
 
 // whitelist: SQL injection防止のため group_by は固定列名のみ許可
 const ALLOWED_GROUP_BY = new Set(['event_type', 'page_url', 'visitor_id']);
@@ -72,14 +73,32 @@ export function registerEventAnalyticsRoutes(app: Express): void {
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
       const actorRole = su?.app_metadata?.role;
       if (!isAllowedAdminRole(actorRole)) {
-        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+        logger.warn({
+          event: 'analytics_access_denied',
+          reason: 'invalid_role',
+          actorEmail: su?.email ? String(su.email).slice(0, 3) + '***' : 'unknown',
+          hasAppMetadataRole: !!su?.app_metadata?.role,
+          hasUserMetadataRole: !!su?.user_metadata?.role,
+          tokenIssuedAt: su?.iat,
+          errorCode: 'AUTH_ROLE_INVALID',
+        }, "Admin analytics access denied: invalid actor role");
+        return res.status(403).json({ error: "この操作を実行する権限がありません", code: 'AUTH_ROLE_INVALID' });
       }
       // セキュリティ要件: テナントスコープも app_metadata.tenant_id のみを信頼する
       const rawTenantId = su?.app_metadata?.tenant_id;
       const jwtTenantId: string = typeof rawTenantId === "string" ? rawTenantId : "";
       const isSuperAdmin: boolean = actorRole === "super_admin";
       if (!isSuperAdmin && (!jwtTenantId || jwtTenantId.trim() === "")) {
-        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+        logger.warn({
+          event: 'analytics_access_denied',
+          reason: 'tenant_id_missing',
+          actorEmail: su?.email ? String(su.email).slice(0, 3) + '***' : 'unknown',
+          hasAppMetadataTenantId: !!su?.app_metadata?.tenant_id,
+          hasUserMetadataTenantId: !!su?.user_metadata?.tenant_id,
+          tokenIssuedAt: su?.iat,
+          errorCode: 'AUTH_TENANT_INVALID',
+        }, "Admin analytics access denied: tenant_id missing for non-super-admin");
+        return res.status(403).json({ error: "この操作を実行する権限がありません", code: 'AUTH_TENANT_INVALID' });
       }
 
       const queryTenantId = (req.query['tenant_id'] as string | undefined) ?? '';

--- a/src/api/admin/analytics/eventAnalyticsRoutes.ts
+++ b/src/api/admin/analytics/eventAnalyticsRoutes.ts
@@ -56,6 +56,13 @@ function formatEventAnalytics(
   }));
 }
 
+const ALLOWED_ADMIN_ROLES = ["super_admin", "client_admin"] as const;
+type AllowedAdminRole = typeof ALLOWED_ADMIN_ROLES[number];
+function isAllowedAdminRole(role: unknown): role is AllowedAdminRole {
+  return typeof role === "string" &&
+         (ALLOWED_ADMIN_ROLES as readonly string[]).includes(role);
+}
+
 export function registerEventAnalyticsRoutes(app: Express): void {
   app.use('/v1/admin/analytics/events', supabaseAuthMiddleware);
 
@@ -63,13 +70,17 @@ export function registerEventAnalyticsRoutes(app: Express): void {
     '/v1/admin/analytics/events',
     async (req: Request, res: Response) => {
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
+      const actorRole = su?.app_metadata?.role;
+      if (!isAllowedAdminRole(actorRole)) {
+        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+      }
       // セキュリティ要件: テナントスコープも app_metadata.tenant_id のみを信頼する
       const rawTenantId = su?.app_metadata?.tenant_id;
       const jwtTenantId: string = typeof rawTenantId === "string" ? rawTenantId : "";
-      // セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
-      // user_metadata はクライアント編集可能なため、特権判定に使用してはならない
-      const rawRole = su?.app_metadata?.role;
-      const isSuperAdmin: boolean = rawRole === "super_admin";
+      const isSuperAdmin: boolean = actorRole === "super_admin";
+      if (!isSuperAdmin && (!jwtTenantId || jwtTenantId.trim() === "")) {
+        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+      }
 
       const queryTenantId = (req.query['tenant_id'] as string | undefined) ?? '';
       const tenantId = isSuperAdmin ? (queryTenantId || null) : jwtTenantId;

--- a/src/api/admin/analytics/eventAnalyticsRoutes.ts
+++ b/src/api/admin/analytics/eventAnalyticsRoutes.ts
@@ -63,10 +63,13 @@ export function registerEventAnalyticsRoutes(app: Express): void {
     '/v1/admin/analytics/events',
     async (req: Request, res: Response) => {
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
-      const jwtTenantId: string =
-        su?.app_metadata?.tenant_id ?? su?.user_metadata?.tenant_id ?? su?.tenant_id ?? '';
-      const isSuperAdmin: boolean =
-        (su?.app_metadata?.role ?? su?.user_metadata?.role ?? '') === 'super_admin';
+      // セキュリティ要件: テナントスコープも app_metadata.tenant_id のみを信頼する
+      const rawTenantId = su?.app_metadata?.tenant_id;
+      const jwtTenantId: string = typeof rawTenantId === "string" ? rawTenantId : "";
+      // セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
+      // user_metadata はクライアント編集可能なため、特権判定に使用してはならない
+      const rawRole = su?.app_metadata?.role;
+      const isSuperAdmin: boolean = rawRole === "super_admin";
 
       const queryTenantId = (req.query['tenant_id'] as string | undefined) ?? '';
       const tenantId = isSuperAdmin ? (queryTenantId || null) : jwtTenantId;

--- a/src/api/admin/analytics/routes.ts
+++ b/src/api/admin/analytics/routes.ts
@@ -130,11 +130,13 @@ export function registerAnalyticsRoutes(app: Express): void {
     "/v1/admin/analytics/summary",
     async (req: Request, res: Response) => {
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
-      const jwtTenantId: string =
-        su?.app_metadata?.tenant_id ?? su?.user_metadata?.tenant_id ?? su?.tenant_id ?? "";
-      const isSuperAdmin: boolean =
-        (su?.app_metadata?.role ?? su?.user_metadata?.role ?? "") ===
-        "super_admin";
+      // セキュリティ要件: テナントスコープも app_metadata.tenant_id のみを信頼する
+      const rawTenantId = su?.app_metadata?.tenant_id;
+      const jwtTenantId: string = typeof rawTenantId === "string" ? rawTenantId : "";
+      // セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
+      // user_metadata はクライアント編集可能なため、特権判定に使用してはならない
+      const rawRole = su?.app_metadata?.role;
+      const isSuperAdmin: boolean = rawRole === "super_admin";
 
       const period = (req.query["period"] as string | undefined) ?? "30d";
       const interval = periodToInterval(period);
@@ -364,11 +366,13 @@ export function registerAnalyticsRoutes(app: Express): void {
     "/v1/admin/analytics/trends",
     async (req: Request, res: Response) => {
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
-      const jwtTenantId: string =
-        su?.app_metadata?.tenant_id ?? su?.user_metadata?.tenant_id ?? su?.tenant_id ?? "";
-      const isSuperAdmin: boolean =
-        (su?.app_metadata?.role ?? su?.user_metadata?.role ?? "") ===
-        "super_admin";
+      // セキュリティ要件: テナントスコープも app_metadata.tenant_id のみを信頼する
+      const rawTenantId = su?.app_metadata?.tenant_id;
+      const jwtTenantId: string = typeof rawTenantId === "string" ? rawTenantId : "";
+      // セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
+      // user_metadata はクライアント編集可能なため、特権判定に使用してはならない
+      const rawRole = su?.app_metadata?.role;
+      const isSuperAdmin: boolean = rawRole === "super_admin";
 
       const period = (req.query["period"] as string | undefined) ?? "30d";
       const interval = periodToInterval(period);
@@ -490,11 +494,13 @@ export function registerAnalyticsRoutes(app: Express): void {
     "/v1/admin/analytics/evaluations",
     async (req: Request, res: Response) => {
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
-      const jwtTenantId: string =
-        su?.app_metadata?.tenant_id ?? su?.user_metadata?.tenant_id ?? su?.tenant_id ?? "";
-      const isSuperAdmin: boolean =
-        (su?.app_metadata?.role ?? su?.user_metadata?.role ?? "") ===
-        "super_admin";
+      // セキュリティ要件: テナントスコープも app_metadata.tenant_id のみを信頼する
+      const rawTenantId = su?.app_metadata?.tenant_id;
+      const jwtTenantId: string = typeof rawTenantId === "string" ? rawTenantId : "";
+      // セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
+      // user_metadata はクライアント編集可能なため、特権判定に使用してはならない
+      const rawRole = su?.app_metadata?.role;
+      const isSuperAdmin: boolean = rawRole === "super_admin";
 
       const period = (req.query["period"] as string | undefined) ?? "30d";
       const interval = periodToInterval(period);
@@ -624,9 +630,13 @@ export function registerAnalyticsRoutes(app: Express): void {
     "/v1/admin/analytics/conversions",
     async (req: Request, res: Response) => {
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
-      const jwtTenantId: string = su?.app_metadata?.tenant_id ?? su?.user_metadata?.tenant_id ?? su?.tenant_id ?? "";
-      const isSuperAdmin: boolean =
-        (su?.app_metadata?.role ?? su?.user_metadata?.role ?? "") === "super_admin";
+      // セキュリティ要件: テナントスコープも app_metadata.tenant_id のみを信頼する
+      const rawTenantId = su?.app_metadata?.tenant_id;
+      const jwtTenantId: string = typeof rawTenantId === "string" ? rawTenantId : "";
+      // セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
+      // user_metadata はクライアント編集可能なため、特権判定に使用してはならない
+      const rawRole = su?.app_metadata?.role;
+      const isSuperAdmin: boolean = rawRole === "super_admin";
 
       const period = (req.query["period"] as string | undefined) ?? "30d";
       const interval = periodToInterval(period);
@@ -896,8 +906,10 @@ export function registerAnalyticsRoutes(app: Express): void {
     "/v1/admin/analytics/cv-status",
     async (req: Request, res: Response) => {
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
-      const isSuperAdmin: boolean =
-        (su?.app_metadata?.role ?? su?.user_metadata?.role ?? "") === "super_admin";
+      // セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
+      // user_metadata はクライアント編集可能なため、特権判定に使用してはならない
+      const rawRole = su?.app_metadata?.role;
+      const isSuperAdmin: boolean = rawRole === "super_admin";
 
       if (!isSuperAdmin) {
         return res.status(403).json({ error: "アクセス権限がありません" });
@@ -983,10 +995,13 @@ export function registerAnalyticsRoutes(app: Express): void {
     "/v1/admin/analytics/knowledge-attribution",
     async (req: Request, res: Response) => {
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
-      const jwtTenantId: string =
-        su?.app_metadata?.tenant_id ?? su?.user_metadata?.tenant_id ?? su?.tenant_id ?? "";
-      const isSuperAdmin: boolean =
-        (su?.app_metadata?.role ?? su?.user_metadata?.role ?? "") === "super_admin";
+      // セキュリティ要件: テナントスコープも app_metadata.tenant_id のみを信頼する
+      const rawTenantId = su?.app_metadata?.tenant_id;
+      const jwtTenantId: string = typeof rawTenantId === "string" ? rawTenantId : "";
+      // セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
+      // user_metadata はクライアント編集可能なため、特権判定に使用してはならない
+      const rawRole = su?.app_metadata?.role;
+      const isSuperAdmin: boolean = rawRole === "super_admin";
 
       // RBAC: client_admin は JWT の tenantId を強制、super_admin は query ?tenant_id=
       const tenantId: string | undefined = isSuperAdmin

--- a/src/api/admin/analytics/routes.ts
+++ b/src/api/admin/analytics/routes.ts
@@ -116,6 +116,13 @@ function resolveTenantFilter(
   return jwtTenantId || null;
 }
 
+const ALLOWED_ADMIN_ROLES = ["super_admin", "client_admin"] as const;
+type AllowedAdminRole = typeof ALLOWED_ADMIN_ROLES[number];
+function isAllowedAdminRole(role: unknown): role is AllowedAdminRole {
+  return typeof role === "string" &&
+         (ALLOWED_ADMIN_ROLES as readonly string[]).includes(role);
+}
+
 // ---------------------------------------------------------------------------
 // Route registration
 // ---------------------------------------------------------------------------
@@ -130,13 +137,17 @@ export function registerAnalyticsRoutes(app: Express): void {
     "/v1/admin/analytics/summary",
     async (req: Request, res: Response) => {
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
+      const actorRole = su?.app_metadata?.role;
+      if (!isAllowedAdminRole(actorRole)) {
+        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+      }
       // セキュリティ要件: テナントスコープも app_metadata.tenant_id のみを信頼する
       const rawTenantId = su?.app_metadata?.tenant_id;
       const jwtTenantId: string = typeof rawTenantId === "string" ? rawTenantId : "";
-      // セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
-      // user_metadata はクライアント編集可能なため、特権判定に使用してはならない
-      const rawRole = su?.app_metadata?.role;
-      const isSuperAdmin: boolean = rawRole === "super_admin";
+      const isSuperAdmin: boolean = actorRole === "super_admin";
+      if (!isSuperAdmin && (!jwtTenantId || jwtTenantId.trim() === "")) {
+        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+      }
 
       const period = (req.query["period"] as string | undefined) ?? "30d";
       const interval = periodToInterval(period);
@@ -366,13 +377,17 @@ export function registerAnalyticsRoutes(app: Express): void {
     "/v1/admin/analytics/trends",
     async (req: Request, res: Response) => {
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
+      const actorRole = su?.app_metadata?.role;
+      if (!isAllowedAdminRole(actorRole)) {
+        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+      }
       // セキュリティ要件: テナントスコープも app_metadata.tenant_id のみを信頼する
       const rawTenantId = su?.app_metadata?.tenant_id;
       const jwtTenantId: string = typeof rawTenantId === "string" ? rawTenantId : "";
-      // セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
-      // user_metadata はクライアント編集可能なため、特権判定に使用してはならない
-      const rawRole = su?.app_metadata?.role;
-      const isSuperAdmin: boolean = rawRole === "super_admin";
+      const isSuperAdmin: boolean = actorRole === "super_admin";
+      if (!isSuperAdmin && (!jwtTenantId || jwtTenantId.trim() === "")) {
+        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+      }
 
       const period = (req.query["period"] as string | undefined) ?? "30d";
       const interval = periodToInterval(period);
@@ -494,13 +509,17 @@ export function registerAnalyticsRoutes(app: Express): void {
     "/v1/admin/analytics/evaluations",
     async (req: Request, res: Response) => {
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
+      const actorRole = su?.app_metadata?.role;
+      if (!isAllowedAdminRole(actorRole)) {
+        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+      }
       // セキュリティ要件: テナントスコープも app_metadata.tenant_id のみを信頼する
       const rawTenantId = su?.app_metadata?.tenant_id;
       const jwtTenantId: string = typeof rawTenantId === "string" ? rawTenantId : "";
-      // セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
-      // user_metadata はクライアント編集可能なため、特権判定に使用してはならない
-      const rawRole = su?.app_metadata?.role;
-      const isSuperAdmin: boolean = rawRole === "super_admin";
+      const isSuperAdmin: boolean = actorRole === "super_admin";
+      if (!isSuperAdmin && (!jwtTenantId || jwtTenantId.trim() === "")) {
+        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+      }
 
       const period = (req.query["period"] as string | undefined) ?? "30d";
       const interval = periodToInterval(period);
@@ -630,13 +649,17 @@ export function registerAnalyticsRoutes(app: Express): void {
     "/v1/admin/analytics/conversions",
     async (req: Request, res: Response) => {
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
+      const actorRole = su?.app_metadata?.role;
+      if (!isAllowedAdminRole(actorRole)) {
+        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+      }
       // セキュリティ要件: テナントスコープも app_metadata.tenant_id のみを信頼する
       const rawTenantId = su?.app_metadata?.tenant_id;
       const jwtTenantId: string = typeof rawTenantId === "string" ? rawTenantId : "";
-      // セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
-      // user_metadata はクライアント編集可能なため、特権判定に使用してはならない
-      const rawRole = su?.app_metadata?.role;
-      const isSuperAdmin: boolean = rawRole === "super_admin";
+      const isSuperAdmin: boolean = actorRole === "super_admin";
+      if (!isSuperAdmin && (!jwtTenantId || jwtTenantId.trim() === "")) {
+        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+      }
 
       const period = (req.query["period"] as string | undefined) ?? "30d";
       const interval = periodToInterval(period);
@@ -906,10 +929,11 @@ export function registerAnalyticsRoutes(app: Express): void {
     "/v1/admin/analytics/cv-status",
     async (req: Request, res: Response) => {
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
-      // セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
-      // user_metadata はクライアント編集可能なため、特権判定に使用してはならない
-      const rawRole = su?.app_metadata?.role;
-      const isSuperAdmin: boolean = rawRole === "super_admin";
+      const actorRole = su?.app_metadata?.role;
+      if (!isAllowedAdminRole(actorRole)) {
+        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+      }
+      const isSuperAdmin: boolean = actorRole === "super_admin";
 
       if (!isSuperAdmin) {
         return res.status(403).json({ error: "アクセス権限がありません" });
@@ -995,13 +1019,17 @@ export function registerAnalyticsRoutes(app: Express): void {
     "/v1/admin/analytics/knowledge-attribution",
     async (req: Request, res: Response) => {
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
+      const actorRole = su?.app_metadata?.role;
+      if (!isAllowedAdminRole(actorRole)) {
+        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+      }
       // セキュリティ要件: テナントスコープも app_metadata.tenant_id のみを信頼する
       const rawTenantId = su?.app_metadata?.tenant_id;
       const jwtTenantId: string = typeof rawTenantId === "string" ? rawTenantId : "";
-      // セキュリティ要件: 認可ロールは app_metadata.role のみを信頼する
-      // user_metadata はクライアント編集可能なため、特権判定に使用してはならない
-      const rawRole = su?.app_metadata?.role;
-      const isSuperAdmin: boolean = rawRole === "super_admin";
+      const isSuperAdmin: boolean = actorRole === "super_admin";
+      if (!isSuperAdmin && (!jwtTenantId || jwtTenantId.trim() === "")) {
+        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+      }
 
       // RBAC: client_admin は JWT の tenantId を強制、super_admin は query ?tenant_id=
       const tenantId: string | undefined = isSuperAdmin

--- a/src/api/admin/analytics/routes.ts
+++ b/src/api/admin/analytics/routes.ts
@@ -139,14 +139,32 @@ export function registerAnalyticsRoutes(app: Express): void {
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
       const actorRole = su?.app_metadata?.role;
       if (!isAllowedAdminRole(actorRole)) {
-        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+        logger.warn({
+          event: 'analytics_access_denied',
+          reason: 'invalid_role',
+          actorEmail: su?.email ? String(su.email).slice(0, 3) + '***' : 'unknown',
+          hasAppMetadataRole: !!su?.app_metadata?.role,
+          hasUserMetadataRole: !!su?.user_metadata?.role,
+          tokenIssuedAt: su?.iat,
+          errorCode: 'AUTH_ROLE_INVALID',
+        }, "Admin analytics access denied: invalid actor role");
+        return res.status(403).json({ error: "この操作を実行する権限がありません", code: 'AUTH_ROLE_INVALID' });
       }
       // セキュリティ要件: テナントスコープも app_metadata.tenant_id のみを信頼する
       const rawTenantId = su?.app_metadata?.tenant_id;
       const jwtTenantId: string = typeof rawTenantId === "string" ? rawTenantId : "";
       const isSuperAdmin: boolean = actorRole === "super_admin";
       if (!isSuperAdmin && (!jwtTenantId || jwtTenantId.trim() === "")) {
-        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+        logger.warn({
+          event: 'analytics_access_denied',
+          reason: 'tenant_id_missing',
+          actorEmail: su?.email ? String(su.email).slice(0, 3) + '***' : 'unknown',
+          hasAppMetadataTenantId: !!su?.app_metadata?.tenant_id,
+          hasUserMetadataTenantId: !!su?.user_metadata?.tenant_id,
+          tokenIssuedAt: su?.iat,
+          errorCode: 'AUTH_TENANT_INVALID',
+        }, "Admin analytics access denied: tenant_id missing for non-super-admin");
+        return res.status(403).json({ error: "この操作を実行する権限がありません", code: 'AUTH_TENANT_INVALID' });
       }
 
       const period = (req.query["period"] as string | undefined) ?? "30d";
@@ -379,14 +397,32 @@ export function registerAnalyticsRoutes(app: Express): void {
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
       const actorRole = su?.app_metadata?.role;
       if (!isAllowedAdminRole(actorRole)) {
-        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+        logger.warn({
+          event: 'analytics_access_denied',
+          reason: 'invalid_role',
+          actorEmail: su?.email ? String(su.email).slice(0, 3) + '***' : 'unknown',
+          hasAppMetadataRole: !!su?.app_metadata?.role,
+          hasUserMetadataRole: !!su?.user_metadata?.role,
+          tokenIssuedAt: su?.iat,
+          errorCode: 'AUTH_ROLE_INVALID',
+        }, "Admin analytics access denied: invalid actor role");
+        return res.status(403).json({ error: "この操作を実行する権限がありません", code: 'AUTH_ROLE_INVALID' });
       }
       // セキュリティ要件: テナントスコープも app_metadata.tenant_id のみを信頼する
       const rawTenantId = su?.app_metadata?.tenant_id;
       const jwtTenantId: string = typeof rawTenantId === "string" ? rawTenantId : "";
       const isSuperAdmin: boolean = actorRole === "super_admin";
       if (!isSuperAdmin && (!jwtTenantId || jwtTenantId.trim() === "")) {
-        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+        logger.warn({
+          event: 'analytics_access_denied',
+          reason: 'tenant_id_missing',
+          actorEmail: su?.email ? String(su.email).slice(0, 3) + '***' : 'unknown',
+          hasAppMetadataTenantId: !!su?.app_metadata?.tenant_id,
+          hasUserMetadataTenantId: !!su?.user_metadata?.tenant_id,
+          tokenIssuedAt: su?.iat,
+          errorCode: 'AUTH_TENANT_INVALID',
+        }, "Admin analytics access denied: tenant_id missing for non-super-admin");
+        return res.status(403).json({ error: "この操作を実行する権限がありません", code: 'AUTH_TENANT_INVALID' });
       }
 
       const period = (req.query["period"] as string | undefined) ?? "30d";
@@ -511,14 +547,32 @@ export function registerAnalyticsRoutes(app: Express): void {
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
       const actorRole = su?.app_metadata?.role;
       if (!isAllowedAdminRole(actorRole)) {
-        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+        logger.warn({
+          event: 'analytics_access_denied',
+          reason: 'invalid_role',
+          actorEmail: su?.email ? String(su.email).slice(0, 3) + '***' : 'unknown',
+          hasAppMetadataRole: !!su?.app_metadata?.role,
+          hasUserMetadataRole: !!su?.user_metadata?.role,
+          tokenIssuedAt: su?.iat,
+          errorCode: 'AUTH_ROLE_INVALID',
+        }, "Admin analytics access denied: invalid actor role");
+        return res.status(403).json({ error: "この操作を実行する権限がありません", code: 'AUTH_ROLE_INVALID' });
       }
       // セキュリティ要件: テナントスコープも app_metadata.tenant_id のみを信頼する
       const rawTenantId = su?.app_metadata?.tenant_id;
       const jwtTenantId: string = typeof rawTenantId === "string" ? rawTenantId : "";
       const isSuperAdmin: boolean = actorRole === "super_admin";
       if (!isSuperAdmin && (!jwtTenantId || jwtTenantId.trim() === "")) {
-        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+        logger.warn({
+          event: 'analytics_access_denied',
+          reason: 'tenant_id_missing',
+          actorEmail: su?.email ? String(su.email).slice(0, 3) + '***' : 'unknown',
+          hasAppMetadataTenantId: !!su?.app_metadata?.tenant_id,
+          hasUserMetadataTenantId: !!su?.user_metadata?.tenant_id,
+          tokenIssuedAt: su?.iat,
+          errorCode: 'AUTH_TENANT_INVALID',
+        }, "Admin analytics access denied: tenant_id missing for non-super-admin");
+        return res.status(403).json({ error: "この操作を実行する権限がありません", code: 'AUTH_TENANT_INVALID' });
       }
 
       const period = (req.query["period"] as string | undefined) ?? "30d";
@@ -651,14 +705,32 @@ export function registerAnalyticsRoutes(app: Express): void {
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
       const actorRole = su?.app_metadata?.role;
       if (!isAllowedAdminRole(actorRole)) {
-        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+        logger.warn({
+          event: 'analytics_access_denied',
+          reason: 'invalid_role',
+          actorEmail: su?.email ? String(su.email).slice(0, 3) + '***' : 'unknown',
+          hasAppMetadataRole: !!su?.app_metadata?.role,
+          hasUserMetadataRole: !!su?.user_metadata?.role,
+          tokenIssuedAt: su?.iat,
+          errorCode: 'AUTH_ROLE_INVALID',
+        }, "Admin analytics access denied: invalid actor role");
+        return res.status(403).json({ error: "この操作を実行する権限がありません", code: 'AUTH_ROLE_INVALID' });
       }
       // セキュリティ要件: テナントスコープも app_metadata.tenant_id のみを信頼する
       const rawTenantId = su?.app_metadata?.tenant_id;
       const jwtTenantId: string = typeof rawTenantId === "string" ? rawTenantId : "";
       const isSuperAdmin: boolean = actorRole === "super_admin";
       if (!isSuperAdmin && (!jwtTenantId || jwtTenantId.trim() === "")) {
-        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+        logger.warn({
+          event: 'analytics_access_denied',
+          reason: 'tenant_id_missing',
+          actorEmail: su?.email ? String(su.email).slice(0, 3) + '***' : 'unknown',
+          hasAppMetadataTenantId: !!su?.app_metadata?.tenant_id,
+          hasUserMetadataTenantId: !!su?.user_metadata?.tenant_id,
+          tokenIssuedAt: su?.iat,
+          errorCode: 'AUTH_TENANT_INVALID',
+        }, "Admin analytics access denied: tenant_id missing for non-super-admin");
+        return res.status(403).json({ error: "この操作を実行する権限がありません", code: 'AUTH_TENANT_INVALID' });
       }
 
       const period = (req.query["period"] as string | undefined) ?? "30d";
@@ -931,12 +1003,29 @@ export function registerAnalyticsRoutes(app: Express): void {
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
       const actorRole = su?.app_metadata?.role;
       if (!isAllowedAdminRole(actorRole)) {
-        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+        logger.warn({
+          event: 'analytics_access_denied',
+          reason: 'invalid_role',
+          actorEmail: su?.email ? String(su.email).slice(0, 3) + '***' : 'unknown',
+          hasAppMetadataRole: !!su?.app_metadata?.role,
+          hasUserMetadataRole: !!su?.user_metadata?.role,
+          tokenIssuedAt: su?.iat,
+          errorCode: 'AUTH_ROLE_INVALID',
+        }, "Admin analytics access denied: invalid actor role");
+        return res.status(403).json({ error: "この操作を実行する権限がありません", code: 'AUTH_ROLE_INVALID' });
       }
       const isSuperAdmin: boolean = actorRole === "super_admin";
 
       if (!isSuperAdmin) {
-        return res.status(403).json({ error: "アクセス権限がありません" });
+        logger.warn({
+          event: 'analytics_access_denied',
+          reason: 'insufficient_role',
+          actorRole,
+          actorEmail: su?.email ? String(su.email).slice(0, 3) + '***' : 'unknown',
+          tokenIssuedAt: su?.iat,
+          errorCode: 'AUTH_ROLE_INSUFFICIENT',
+        }, "Admin analytics access denied: super_admin required");
+        return res.status(403).json({ error: "アクセス権限がありません", code: 'AUTH_ROLE_INSUFFICIENT' });
       }
 
       if (!pool) {
@@ -1021,14 +1110,32 @@ export function registerAnalyticsRoutes(app: Express): void {
       const su = (req as any).supabaseUser as Record<string, any> | undefined;
       const actorRole = su?.app_metadata?.role;
       if (!isAllowedAdminRole(actorRole)) {
-        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+        logger.warn({
+          event: 'analytics_access_denied',
+          reason: 'invalid_role',
+          actorEmail: su?.email ? String(su.email).slice(0, 3) + '***' : 'unknown',
+          hasAppMetadataRole: !!su?.app_metadata?.role,
+          hasUserMetadataRole: !!su?.user_metadata?.role,
+          tokenIssuedAt: su?.iat,
+          errorCode: 'AUTH_ROLE_INVALID',
+        }, "Admin analytics access denied: invalid actor role");
+        return res.status(403).json({ error: "この操作を実行する権限がありません", code: 'AUTH_ROLE_INVALID' });
       }
       // セキュリティ要件: テナントスコープも app_metadata.tenant_id のみを信頼する
       const rawTenantId = su?.app_metadata?.tenant_id;
       const jwtTenantId: string = typeof rawTenantId === "string" ? rawTenantId : "";
       const isSuperAdmin: boolean = actorRole === "super_admin";
       if (!isSuperAdmin && (!jwtTenantId || jwtTenantId.trim() === "")) {
-        return res.status(403).json({ error: "この操作を実行する権限がありません" });
+        logger.warn({
+          event: 'analytics_access_denied',
+          reason: 'tenant_id_missing',
+          actorEmail: su?.email ? String(su.email).slice(0, 3) + '***' : 'unknown',
+          hasAppMetadataTenantId: !!su?.app_metadata?.tenant_id,
+          hasUserMetadataTenantId: !!su?.user_metadata?.tenant_id,
+          tokenIssuedAt: su?.iat,
+          errorCode: 'AUTH_TENANT_INVALID',
+        }, "Admin analytics access denied: tenant_id missing for non-super-admin");
+        return res.status(403).json({ error: "この操作を実行する権限がありません", code: 'AUTH_TENANT_INVALID' });
       }
 
       // RBAC: client_admin は JWT の tenantId を強制、super_admin は query ?tenant_id=


### PR DESCRIPTION
## Summary
Phase69-1.5 PR-C2 Round 5: analytics admin routes に allow-path テストを追加。
Codex Round 4 指摘「allow-path tests 不足」への対応。

## Changes
- analyticsAuthGuard.test.ts: allow-path テスト 16件追加
  - super_admin × ALL_ROUTES (7) + standalone 2件
  - client_admin × TENANT_SCOPED_ROUTES (6) + standalone 1件
- パターン: PR-B (deleteSession.test.ts) の toBe(503) / not.toBe(403) 踏襲

## Gates
- Gate 1 (pnpm verify): ✅ 122 suites, 1268 tests
- Gate 2 (security-scan): ✅ Critical/High = 0
- Gate 3 (pnpm build): ✅ API + Admin UI 成功
- Gate 2.5 (Codex review): ✅ Ship-ready / 0 findings (Thread: 019e2859-0c26-7fd1-9ab9-5745406d5b16)

## Asana
- Parent: Phase69-1.5 (GID: 1214771938406621)
- Related: PR-A #147, PR-B #148, PR-C1 #149

🤖 Generated with [Claude Code](https://claude.ai/claude-code)