### PR TITLE
feat(phase69-2): excluded_ids ゼロ知識検索 + dialog バリデーション (Round 5 Final)

### DIFF
--- a/SCRIPTS/sync-es.ts
+++ b/SCRIPTS/sync-es.ts
@@ -41,6 +41,9 @@ if (!allMode && !tenantArg) {
 }
 
 // ESインデックスのmappings（kuromojiアナライザー付き）
+// Phase69-2 PR-C2 Round 2: is_published / is_excluded_from_search を明示マッピング
+//   - dynamic mapping のブレを防ぐ
+//   - hybrid.ts の filter.must_not で参照される
 const MAPPINGS_KUROMOJI = {
   mappings: {
     properties: {
@@ -51,6 +54,8 @@ const MAPPINGS_KUROMOJI = {
       tags: { type: "keyword" },
       faq_id: { type: "integer" },
       created_at: { type: "date" },
+      is_published: { type: "boolean" },
+      is_excluded_from_search: { type: "boolean" },
     },
   },
 };
@@ -66,6 +71,8 @@ const MAPPINGS_STANDARD = {
       tags: { type: "keyword" },
       faq_id: { type: "integer" },
       created_at: { type: "date" },
+      is_published: { type: "boolean" },
+      is_excluded_from_search: { type: "boolean" },
     },
   },
 };
@@ -161,6 +168,9 @@ async function bulkIndex(index: string, rows: any[]): Promise<number> {
       created_at: row.created_at
         ? new Date(row.created_at).toISOString()
         : null,
+      // Phase69-2 PR-C2 Round 2: 永続フィルター用フィールドを ES に同期
+      is_published: row.is_published === false ? false : true,
+      is_excluded_from_search: row.is_excluded_from_search === true,
     });
     lines.push(action);
     lines.push(doc);

--- a/admin-ui/src/components/KnowledgeFaqEditModal.tsx
+++ b/admin-ui/src/components/KnowledgeFaqEditModal.tsx
@@ -11,6 +11,8 @@ export interface KnowledgeFaqItem {
   category: string | null;
   tags: string[] | null;
   is_published?: boolean;
+  /** Phase69-2: 検索除外フラグ */
+  is_excluded_from_search?: boolean;
 }
 
 interface Props {
@@ -61,6 +63,7 @@ export default function KnowledgeFaqEditModal({ mode, tenantId, item, onClose, o
   const [category, setCategory] = useState(item?.category ?? "inventory");
   const [tagsInput, setTagsInput] = useState((item?.tags ?? []).join(", "));
   const [isPublished, setIsPublished] = useState(item?.is_published ?? true);
+  const [isExcluded, setIsExcluded] = useState(item?.is_excluded_from_search ?? false);
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -103,6 +106,7 @@ export default function KnowledgeFaqEditModal({ mode, tenantId, item, onClose, o
       category: category || null,
       tags,
       is_published: isPublished,
+      is_excluded_from_search: isExcluded,
     };
 
     try {
@@ -346,6 +350,56 @@ export default function KnowledgeFaqEditModal({ mode, tenantId, item, onClose, o
                   position: "absolute",
                   top: 3,
                   left: isPublished ? 25 : 3,
+                  width: 24,
+                  height: 24,
+                  borderRadius: "50%",
+                  background: "#fff",
+                  transition: "left 0.2s",
+                  boxShadow: "0 2px 6px rgba(0,0,0,0.3)",
+                }}
+              />
+            </div>
+          </div>
+
+          {/* 検索除外トグル（Phase69-2） */}
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              justifyContent: "space-between",
+              padding: "18px 20px",
+              borderRadius: 12,
+              border: `1px solid ${isExcluded ? "rgba(239,68,68,0.4)" : "#374151"}`,
+              background: isExcluded ? "rgba(69,10,10,0.5)" : "rgba(15,23,42,0.6)",
+              transition: "all 0.2s",
+              cursor: "pointer",
+            }}
+            onClick={() => setIsExcluded((v) => !v)}
+          >
+            <div>
+              <div style={{ fontSize: 16, fontWeight: 600, color: isExcluded ? "#f87171" : "#9ca3af" }}>
+                {isExcluded ? "検索から除外中" : "検索に含める"}
+              </div>
+              <div style={{ fontSize: 13, color: "#6b7280", marginTop: 2 }}>
+                {isExcluded ? "このナレッジは検索結果に表示されません" : "検索クエリにヒットすれば表示されます"}
+              </div>
+            </div>
+            <div
+              style={{
+                width: 52,
+                height: 30,
+                borderRadius: 999,
+                background: isExcluded ? "#ef4444" : "#374151",
+                position: "relative",
+                flexShrink: 0,
+                transition: "background 0.2s",
+              }}
+            >
+              <div
+                style={{
+                  position: "absolute",
+                  top: 3,
+                  left: isExcluded ? 25 : 3,
                   width: 24,
                   height: 24,
                   borderRadius: "50%",

--- a/admin-ui/src/components/knowledge/KnowledgeListTab.tsx
+++ b/admin-ui/src/components/knowledge/KnowledgeListTab.tsx
@@ -534,6 +534,21 @@ export default function KnowledgeListTab({ tenantId }: { tenantId: string }) {
                   >
                     {categoryLabel(item.category)}
                   </span>
+                  {item.is_excluded_from_search && (
+                    <span
+                      style={{
+                        padding: "2px 8px",
+                        borderRadius: 999,
+                        background: "rgba(239,68,68,0.1)",
+                        border: "1px solid rgba(239,68,68,0.3)",
+                        color: "#f87171",
+                        fontSize: 11,
+                        fontWeight: 600,
+                      }}
+                    >
+                      検索除外
+                    </span>
+                  )}
                   <span style={{ fontSize: 11, color: "#6b7280" }}>
                     {formatDate(item.created_at, locale)}
                   </span>
@@ -580,6 +595,7 @@ export default function KnowledgeListTab({ tenantId }: { tenantId: string }) {
                       category: item.category,
                       tags: item.tags,
                       is_published: item.is_published,
+                      is_excluded_from_search: item.is_excluded_from_search,
                     })
                   }
                   style={{

--- a/admin-ui/src/components/knowledge/shared.ts
+++ b/admin-ui/src/components/knowledge/shared.ts
@@ -20,6 +20,8 @@ export interface KnowledgeItem {
   category: string | null;
   tags: string[] | null;
   is_published?: boolean;
+  /** Phase69-2: 検索除外フラグ */
+  is_excluded_from_search?: boolean;
   created_at: string;
 }
 

--- a/docs/VPS_OPS_GUIDE.md
+++ b/docs/VPS_OPS_GUIDE.md
@@ -154,3 +154,109 @@ ssh root@65.108.159.161 "nginx -t"
 # リロード
 ssh root@65.108.159.161 "systemctl reload nginx"
 ```
+
+---
+
+## 7. Phase 別デプロイ後の手動運用手順
+
+### Phase69-2: excluded_ids ゼロ知識検索
+
+`deploy-vps.sh` 完了後、以下を **hkobayashi が手動で順次実行**。
+
+#### (a) DB マイグレーション
+
+```bash
+ssh root@65.108.159.161 "cd /opt/rajiuce && psql \$DATABASE_URL -f src/migrations/phase69_2_excluded_ids.sql"
+```
+
+追加されるもの:
+- `faq_embeddings.is_excluded_from_search BOOLEAN DEFAULT FALSE`
+- `faq_docs.is_excluded_from_search BOOLEAN DEFAULT FALSE`
+- `tenants.default_excluded_ids TEXT[] DEFAULT '{}'`
+- 上記カラムへのインデックス
+
+#### (b) Elasticsearch re-index
+
+Phase69-2 で ES mapping に `is_published` / `is_excluded_from_search` を明示追加した。
+既存インデックスは dynamic mapping のため、明示マッピングを反映するには re-index が必要。
+
+```bash
+ssh root@65.108.159.161 "cd /opt/rajiuce && pnpm ts-node SCRIPTS/sync-es.ts --all"
+```
+
+これにより全テナントの `faq_<tenantId>` インデックスが削除→再作成され、
+新しい mapping (`is_excluded_from_search: { type: 'boolean' }`) で再構築される。
+
+#### (c) 反映検証
+
+```bash
+# 1. テストテナントで FAQ を1件除外フラグ ON にする
+curl -X PATCH https://api.r2c.biz/v1/admin/knowledge/faq/<faqId>/exclude \
+  -H "Authorization: Bearer <JWT>" \
+  -H "Content-Type: application/json" \
+  -d '{"is_excluded_from_search": true}'
+
+# 2. 該当 FAQ を含むクエリで hybrid 検索を実行し、結果に出ないことを確認
+curl -X POST https://api.r2c.biz/agent.search \
+  -H "x-api-key: <API_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{"q": "<該当FAQに含まれる質問>", "topK": 10}'
+
+# 3. ES 側でも除外されていることを直接確認（オプション）
+ssh root@65.108.159.161 'curl -s "$ES_URL/faq_<tenantId>/_search" \
+  -H "Content-Type: application/json" \
+  -d "{\"query\":{\"term\":{\"is_excluded_from_search\":true}},\"_source\":[\"faq_id\",\"is_excluded_from_search\"]}"'
+```
+
+#### ロールバック手順
+
+ES 同期失敗時:
+- DB は source-of-truth なので、ES 不整合があれば `sync-es.ts --all` で再同期可能
+- API は fire-and-forget で 5xx を返さないため、Admin UI 操作は成功扱い
+
+DB マイグレーション失敗時:
+- `phase69_2_excluded_ids.sql` は `IF NOT EXISTS` 付きなので冪等
+- カラム追加失敗時は `ALTER TABLE ... DROP COLUMN is_excluded_from_search` で巻き戻し
+
+#### (d) 除外対象スコープ (Round 3, Codex Adversarial #1 対応)
+
+Phase69-2 の `PATCH /v1/admin/knowledge/faq/:id/exclude` および
+`pgvector.ts` の source 分岐は **FAQ 系 embedding のみが対象**:
+
+| source | スコープ | exclusion 経路 |
+|---|---|---|
+| `scrape` / `text` / `faq` | **FAQ 系** (Phase69-2 対象) | `faq_docs.is_excluded_from_search` + `faq_embeddings.is_excluded_from_search` (両更新) |
+| `book` / `book:pdf:qwen-ocr` | 非 FAQ 系 (書籍 PDF) | 将来 Phase で UI 化予定 |
+| `carnation:web` | 非 FAQ 系 (web scrape) | 将来 Phase で UI 化予定 |
+| `groq/compound-mini` | 非 FAQ 系 (LLM 自動生成) | 将来 Phase で UI 化予定 |
+| `NULL` | 非 FAQ 系扱い (defensive default) | 将来 Phase で対応 |
+
+参考: 2026-05-15 時点の VPS DB 実態 (`faq_embeddings` 全 147 件):
+- FAQ 系: scrape 41 + text 10 + faq 2 = **53 件** (全件 `metadata.faq_id` 保持)
+- 非 FAQ 系: book 40 + book:pdf:qwen-ocr 29 + carnation:web 22 + groq/compound-mini 3 = **94 件** (`faq_id` NULL)
+- orphan (faq_id 持つが faq_docs に対応なし): **1 件** → 別タスク (Phase69-2-D) で対処予定
+
+`pgvector.ts` の WHERE 句は以下の構造で source を判定:
+
+```sql
+-- FAQ 系: faq_docs 厳格チェック (legacy 未連携 embedding は FAQ 検索結果から除外)
+fe.metadata->>'source' IN ('scrape', 'text', 'faq')
+AND fd.id IS NOT NULL
+AND fd.is_published = true
+AND (fd.is_excluded_from_search IS NULL OR fd.is_excluded_from_search = false)
+-- OR
+-- 非 FAQ 系: faq_docs チェックをスキップ (faq_embeddings レイヤーのみで判定)
+(fe.metadata->>'source' IS NULL OR fe.metadata->>'source' NOT IN ('scrape', 'text', 'faq'))
+```
+
+加えて `fe.is_excluded_from_search` フィルターは全 source 共通で適用される (二重防御)。
+
+orphan 検出 SQL (運用確認用):
+
+```sql
+-- orphan: faq_id を持つが faq_docs に対応行なし
+SELECT fe.id, fe.tenant_id, fe.metadata->>'faq_id' AS faq_id
+FROM faq_embeddings fe
+LEFT JOIN faq_docs fd ON fd.id = (fe.metadata->>'faq_id')::bigint
+WHERE fe.metadata->>'faq_id' ~ '^[0-9]+$' AND fd.id IS NULL;
+```

--- a/docs/VPS_OPS_GUIDE.md
+++ b/docs/VPS_OPS_GUIDE.md
@@ -180,6 +180,13 @@ ssh root@65.108.159.161 "cd /opt/rajiuce && psql \$DATABASE_URL -f src/migration
 Phase69-2 で ES mapping に `is_published` / `is_excluded_from_search` を明示追加した。
 既存インデックスは dynamic mapping のため、明示マッピングを反映するには re-index が必要。
 
+> **ES write path の注意 (Phase69-2 Round 5 / Phase69-2-E 参照)**
+> `upsertToEsAsync`（CRUD POST/PUT）・`syncIsExcludedToEsAsync`（/exclude PATCH）はいずれも
+> `is_excluded_from_search` を ES に伝搬する。ただし書き込み index は `ES_FAQ_INDEX || "faqs"` であり、
+> 検索 read path (`faq_<tenantId>`) とは index 名が異なる可能性がある（Phase33-c 起因の既存不整合）。
+> **この不整合により、Phase69-2-E 完了まで ES への除外同期は事実上機能しない可能性がある。**
+> pgvector 経由の除外フィルター（`WHERE fd.is_excluded_from_search = false`）は index 名に依存せず機能する。
+
 ```bash
 ssh root@65.108.159.161 "cd /opt/rajiuce && pnpm ts-node SCRIPTS/sync-es.ts --all"
 ```

--- a/docs/VPS_OPS_GUIDE.md
+++ b/docs/VPS_OPS_GUIDE.md
@@ -218,40 +218,74 @@ DB マイグレーション失敗時:
 - `phase69_2_excluded_ids.sql` は `IF NOT EXISTS` 付きなので冪等
 - カラム追加失敗時は `ALTER TABLE ... DROP COLUMN is_excluded_from_search` で巻き戻し
 
-#### (d) 除外対象スコープ (Round 3, Codex Adversarial #1 対応)
+#### (d) 除外対象スコープ — identity-based 判定 (Round 4, Codex Adversarial Round 3 #1 対応)
 
-Phase69-2 の `PATCH /v1/admin/knowledge/faq/:id/exclude` および
-`pgvector.ts` の source 分岐は **FAQ 系 embedding のみが対象**:
+`pgvector.ts` の WHERE 句は **faq_id identity** で FAQ かどうかを判定する:
+- **FAQ identity** = `metadata.faq_id` が数値文字列で、対応する `faq_docs` 行が存在する
+- **非 FAQ** = `metadata.faq_id` が存在しない、または数値以外
 
-| source | スコープ | exclusion 経路 |
+##### 設計の変遷
+
+| Round | 判定方式 | 問題 |
 |---|---|---|
-| `scrape` / `text` / `faq` | **FAQ 系** (Phase69-2 対象) | `faq_docs.is_excluded_from_search` + `faq_embeddings.is_excluded_from_search` (両更新) |
-| `book` / `book:pdf:qwen-ocr` | 非 FAQ 系 (書籍 PDF) | 将来 Phase で UI 化予定 |
-| `carnation:web` | 非 FAQ 系 (web scrape) | 将来 Phase で UI 化予定 |
-| `groq/compound-mini` | 非 FAQ 系 (LLM 自動生成) | 将来 Phase で UI 化予定 |
-| `NULL` | 非 FAQ 系扱い (defensive default) | 将来 Phase で対応 |
+| Round 2 (旧) | `fd.id IS NULL` でパススルー | legacy embedding が exclusion をすり抜ける (Codex Round 2 #1) |
+| Round 3 (旧) | `source IN ('scrape','text','faq')` で FAQ 系を限定 | CRUD 経由 (`source='faq_crud'`) が非 FAQ branch に落ちて未公開 FAQ が漏れる (Codex Round 3 #1) |
+| **Round 4 (現行)** | `faq_id` の有無 + `faq_docs` JOIN 成功で判定 | source 名のミスタイプ・列挙漏れに無敵 |
+
+##### embedding source 別の挙動
+
+| source | `faq_id` | identity 判定 | exclusion 経路 |
+|---|---|---|---|
+| `faq_crud` (CRUD POST/PUT) | 数値 | **FAQ 系** | `faq_docs.is_excluded_from_search` + `faq_embeddings.is_excluded_from_search` (両更新) |
+| `scrape` / `text` / `faq` (旧 import) | 数値 | **FAQ 系** | 同上 |
+| `book` / `book:pdf:qwen-ocr` (PDF) | NULL | 非 FAQ | `faq_embeddings.is_excluded_from_search` のみ (将来 UI 化) |
+| `carnation:web` (web scrape) | NULL | 非 FAQ | 同上 |
+| `groq/compound-mini` (LLM 生成) | NULL | 非 FAQ | 同上 |
+| `NULL` | (任意) | `faq_id` で判定 | 同上 |
+| orphan (`faq_id` 数値だが `faq_docs` 行なし) | 数値 | **どちらにもマッチせず除外** | 自動的に検索結果から除外 |
 
 参考: 2026-05-15 時点の VPS DB 実態 (`faq_embeddings` 全 147 件):
-- FAQ 系: scrape 41 + text 10 + faq 2 = **53 件** (全件 `metadata.faq_id` 保持)
-- 非 FAQ 系: book 40 + book:pdf:qwen-ocr 29 + carnation:web 22 + groq/compound-mini 3 = **94 件** (`faq_id` NULL)
-- orphan (faq_id 持つが faq_docs に対応なし): **1 件** → 別タスク (Phase69-2-D) で対処予定
+- FAQ 系 (faq_id 数値持ち + faq_docs JOIN 成功): 53 件
+- 非 FAQ (faq_id NULL): 94 件 (book 40 + book:pdf:qwen-ocr 29 + carnation:web 22 + groq/compound-mini 3)
+- orphan: 1 件 → 別タスク (Phase69-2-D) で対処予定
 
-`pgvector.ts` の WHERE 句は以下の構造で source を判定:
+##### pgvector.ts WHERE 句 (identity-based)
 
 ```sql
--- FAQ 系: faq_docs 厳格チェック (legacy 未連携 embedding は FAQ 検索結果から除外)
-fe.metadata->>'source' IN ('scrape', 'text', 'faq')
-AND fd.id IS NOT NULL
-AND fd.is_published = true
-AND (fd.is_excluded_from_search IS NULL OR fd.is_excluded_from_search = false)
--- OR
--- 非 FAQ 系: faq_docs チェックをスキップ (faq_embeddings レイヤーのみで判定)
-(fe.metadata->>'source' IS NULL OR fe.metadata->>'source' NOT IN ('scrape', 'text', 'faq'))
+WHERE (fe.tenant_id = $1 OR fe.tenant_id = 'global')
+  AND (
+    -- FAQ identity branch: faq_docs を厳格チェック
+    (
+      fe.metadata->>'faq_id' ~ '^[0-9]+$'
+      AND fd.id IS NOT NULL
+      AND fd.is_published = true
+      AND (fd.is_excluded_from_search IS NULL OR fd.is_excluded_from_search = false)
+    )
+    OR
+    -- 非 FAQ branch: faq_docs を見ない
+    (fe.metadata->>'faq_id' IS NULL OR fe.metadata->>'faq_id' !~ '^[0-9]+$')
+  )
+  AND (fe.is_excluded_from_search IS NULL OR fe.is_excluded_from_search = false)
 ```
 
-加えて `fe.is_excluded_from_search` フィルターは全 source 共通で適用される (二重防御)。
+`fe.is_excluded_from_search` フィルターは全 identity 共通で適用 (二重防御)。
 
-orphan 検出 SQL (運用確認用):
+##### /exclude エンドポイント — in-tx lock + rowCount assertion (Round 4)
+
+`PATCH /v1/admin/knowledge/faq/:id/exclude` は以下のシーケンスで動作する:
+
+1. `BEGIN`
+2. `SET LOCAL lock_timeout = '3s'`
+3. `SELECT id, tenant_id FROM faq_docs WHERE id = $1 FOR UPDATE` ← tx 内 precheck + 行ロック
+4. rowCount=0 → 404 (`ROLLBACK`)、tenant 不一致 → 403 (`ROLLBACK`)
+5. `UPDATE faq_docs SET is_excluded_from_search = $1 ...` ← rowCount=1 を assert (異常時 500 + `ROLLBACK`)
+6. `UPDATE faq_embeddings SET is_excluded_from_search = $1 WHERE ... AND (metadata->>'faq_id') ~ '^[0-9]+$' AND (metadata->>'faq_id')::bigint = $3`
+7. `COMMIT`
+8. COMMIT 後に ES へ partial update を fire-and-forget 同期
+
+これにより precheck → UPDATE 間のレース (削除/移動) でも 200 success を返さない。
+
+##### orphan 検出 SQL (運用確認用)
 
 ```sql
 -- orphan: faq_id を持つが faq_docs に対応行なし
@@ -260,3 +294,6 @@ FROM faq_embeddings fe
 LEFT JOIN faq_docs fd ON fd.id = (fe.metadata->>'faq_id')::bigint
 WHERE fe.metadata->>'faq_id' ~ '^[0-9]+$' AND fd.id IS NULL;
 ```
+
+orphan は Round 4 の identity-based 判定で自動的に検索結果から除外される
+(FAQ identity branch には `fd.id IS NOT NULL` が必須、非 FAQ branch には `faq_id IS NULL` が必須)。

--- a/src/agent/crew/CrewAgent.ts
+++ b/src/agent/crew/CrewAgent.ts
@@ -5,7 +5,7 @@ import type { DialogAgentMeta } from "../dialog/types";
 export type CrewAgentInput = {
   message: string;
   history?: Array<{ role: "user" | "assistant"; content: string }>;
-  context?: { sessionId?: string; locale?: string; tenantId?: string; mode?: string; useMultiStepPlanner?: boolean };
+  context?: { sessionId?: string; locale?: string; tenantId?: string; mode?: string; useMultiStepPlanner?: boolean; excludedIds?: string[] };
 };
 
 export type CrewAgentOutput = {

--- a/src/agent/crew/CrewGraph.ts
+++ b/src/agent/crew/CrewGraph.ts
@@ -31,6 +31,8 @@ export interface CrewGraphState {
     locale: string;
     tenantId?: string;
     sessionId?: string;
+    /** Phase69-2: 検索結果から除外するエントリID一覧 */
+    excludedIds?: string[];
   };
 
   // プランナーが生成したプラン（LangGraph / CrewGraph いずれでも可）

--- a/src/agent/crew/CrewOrchestrator.ts
+++ b/src/agent/crew/CrewOrchestrator.ts
@@ -37,6 +37,7 @@ export class CrewOrchestrator {
         locale: input.context?.locale ?? "ja",
         tenantId: input.context?.tenantId,
         sessionId: input.context?.sessionId,
+        excludedIds: input.context?.excludedIds,
       },
       plannerPlan: undefined,
       answerText: undefined,

--- a/src/agent/crew/nodes/PlannerNode.ts
+++ b/src/agent/crew/nodes/PlannerNode.ts
@@ -29,6 +29,7 @@ export class PlannerNode implements CrewNode {
       locale: locale as "ja" | "en",
       conversationId,
       history: input.history,
+      excludedIds: input.excludedIds,
     });
 
     return {

--- a/src/agent/dialog/types.ts
+++ b/src/agent/dialog/types.ts
@@ -100,6 +100,8 @@ export interface DialogTurnInput {
     piiMode?: boolean;
     /** Phase57: Widget の EventTracker が生成した visitor_id */
     visitorId?: string;
+    /** Phase69-2: 検索結果から除外するエントリID一覧 */
+    excluded_ids?: string[];
   };
 }
 

--- a/src/agent/flow/searchAgent.ts
+++ b/src/agent/flow/searchAgent.ts
@@ -25,7 +25,7 @@ import { logger } from '../../lib/logger';
 export async function runSearchAgent(
   params: AgentSearchParams
 ): Promise<AgentSearchResponse> {
-  const { q, topK, debug = true, useLlmPlanner, tenantId, visitorId } = params;
+  const { q, topK, debug = true, useLlmPlanner, tenantId, visitorId, excludedIds } = params;
   const effectiveTenantId = tenantId ?? "demo";
   const steps: AgentStep[] = [];
 
@@ -65,6 +65,7 @@ export async function runSearchAgent(
       tenantId: effectiveTenantId,
       embedding,
       topK: plan.topK ?? topK,
+      excludedIds,
     });
     const tPg1 = performance.now();
     pgVectorItems = pgRes.items ?? [];
@@ -80,6 +81,7 @@ export async function runSearchAgent(
   const baseSearchResult = await searchTool({
     query: plan.searchQuery,
     tenantId: effectiveTenantId,
+    excludedIds,
   });
   const tSearch1 = performance.now();
 
@@ -124,6 +126,7 @@ export async function runSearchAgent(
     query: plan.searchQuery,
     items: searchResult.items,
     topK: plan.topK,
+    excludedIds,
   });
   const tRerank1 = performance.now();
   steps.push({

--- a/src/agent/http/AgentDialogOrchestrator.ts
+++ b/src/agent/http/AgentDialogOrchestrator.ts
@@ -71,6 +71,8 @@ export class AgentDialogOrchestrator {
     const locale: "ja" | "en" =
       body.options?.language === "en" ? "en" : "ja";
 
+    const excludedIds = body.options?.excluded_ids;
+
     // CrewOrchestrator 経由で LangGraph / CrewGraph を実行
     const crewResult = await this.crew.run({
       message: body.message,
@@ -81,6 +83,7 @@ export class AgentDialogOrchestrator {
         sessionId,
         mode,
         useMultiStepPlanner: useMultiStep,
+        excludedIds,
       },
     });
 

--- a/src/agent/http/agentDialogRoute.test.ts
+++ b/src/agent/http/agentDialogRoute.test.ts
@@ -158,6 +158,42 @@ async function test_dialog_returns_clarify_when_multi_step_enabled() {
   assertAdapterMetaShape(body.meta);
 }
 
+async function test_dialog_excluded_ids_over_500_returns_400() {
+  const overLimitIds = Array.from({ length: 501 }, (_, i) => `id-${i}`);
+  const { statusCode, body } = await callHandler({
+    message: "返品の送料を知りたい",
+    options: { excluded_ids: overLimitIds },
+  });
+  assert.equal(statusCode, 400, "should return 400 for excluded_ids > 500");
+  assert.equal(body.error, "invalid_excluded_ids", "error field should be invalid_excluded_ids");
+}
+
+async function test_dialog_excluded_ids_500_or_less_succeeds() {
+  const ids = Array.from({ length: 5 }, (_, i) => `id-${i}`);
+  const { statusCode } = await callHandler({
+    message: "返品の送料を知りたい",
+    options: { excluded_ids: ids },
+  });
+  assert.equal(statusCode, 200, "should return 200 for excluded_ids <= 500");
+}
+
+async function test_dialog_excluded_ids_omitted_variants_succeed() {
+  const cases: Array<{ label: string; options: unknown }> = [
+    { label: "options=undefined", options: undefined },
+    { label: "options={}", options: {} },
+    { label: "excluded_ids=[]", options: { excluded_ids: [] } },
+    { label: "excluded_ids=null", options: { excluded_ids: null } },
+  ];
+
+  for (const { label, options } of cases) {
+    const { statusCode } = await callHandler({
+      message: "返品の送料を知りたい",
+      options,
+    });
+    assert.equal(statusCode, 200, `should return 200 when ${label}`);
+  }
+}
+
 async function main() {
   console.log("Running /agent.dialog http tests...");
 
@@ -170,6 +206,18 @@ async function main() {
     [
       "dialog returns clarify when multi-step enabled",
       test_dialog_returns_clarify_when_multi_step_enabled,
+    ],
+    [
+      "dialog excluded_ids over 500 returns 400",
+      test_dialog_excluded_ids_over_500_returns_400,
+    ],
+    [
+      "dialog excluded_ids 500 or less succeeds",
+      test_dialog_excluded_ids_500_or_less_succeeds,
+    ],
+    [
+      "dialog excluded_ids omitted/null/empty succeeds",
+      test_dialog_excluded_ids_omitted_variants_succeed,
     ],
   ];
 

--- a/src/agent/http/agentDialogRoute.ts
+++ b/src/agent/http/agentDialogRoute.ts
@@ -1,5 +1,6 @@
 import type { Request, Response } from "express";
 import type { Logger } from "pino";
+import { z } from "zod";
 import type { DialogTurnInput } from "../dialog/types";
 import { AgentDialogOrchestrator } from "./AgentDialogOrchestrator";
 import { maybeProbeLemonSliceReadiness } from "./presentation/lemonSliceAdapter";
@@ -20,6 +21,16 @@ export function createAgentDialogHandler(
     if (!body || typeof body.message !== "string") {
       res.status(400).json({ error: "invalid_body" });
       return;
+    }
+
+    // Phase69-2: excluded_ids の入力検証（/agent.search と同等の上限）
+    const rawExcludedIds = (body.options as Record<string, unknown> | undefined)?.excluded_ids;
+    if (rawExcludedIds !== undefined) {
+      const result = z.array(z.string()).max(500).safeParse(rawExcludedIds);
+      if (!result.success) {
+        res.status(400).json({ error: "invalid_excluded_ids", details: result.error.flatten() });
+        return;
+      }
     }
 
     const tenantId = (req as Request & { tenantId?: string }).tenantId ?? "demo-tenant";

--- a/src/agent/http/agentDialogRoute.ts
+++ b/src/agent/http/agentDialogRoute.ts
@@ -24,8 +24,9 @@ export function createAgentDialogHandler(
     }
 
     // Phase69-2: excluded_ids の入力検証（/agent.search と同等の上限）
+    // null は undefined と同等（除外なし）として扱う
     const rawExcludedIds = (body.options as Record<string, unknown> | undefined)?.excluded_ids;
-    if (rawExcludedIds !== undefined) {
+    if (rawExcludedIds != null) {
       const result = z.array(z.string()).max(500).safeParse(rawExcludedIds);
       if (!result.success) {
         res.status(400).json({ error: "invalid_excluded_ids", details: result.error.flatten() });

--- a/src/agent/http/agentSearchRoute.ts
+++ b/src/agent/http/agentSearchRoute.ts
@@ -10,6 +10,8 @@ const AgentSearchSchema = z.object({
   topK: z.number().int().min(1).max(20).optional(),
   debug: z.boolean().optional(),
   useLlmPlanner: z.boolean().optional(),
+  /** Phase69-2: 検索結果から除外するエントリID一覧（最大500件） */
+  excluded_ids: z.array(z.string()).max(500).optional(),
 });
 
 type AgentSearchDeps = {
@@ -69,7 +71,7 @@ export function createAgentSearchHandler(
       return;
     }
 
-    const { q, topK, debug, useLlmPlanner } = parsed.data;
+    const { q, topK, debug, useLlmPlanner, excluded_ids } = parsed.data;
     const startedAt = Date.now();
 
     const headerTenantId = req.header("x-tenant-id");
@@ -85,6 +87,7 @@ export function createAgentSearchHandler(
         debug,
         useLlmPlanner,
         tenantId,
+        excludedIds: excluded_ids,
       });
 
       const durationMs = Date.now() - startedAt;

--- a/src/agent/orchestrator/flowControl.ts
+++ b/src/agent/orchestrator/flowControl.ts
@@ -30,6 +30,8 @@ export interface DialogInput {
   history: Array<{ role: 'user' | 'assistant'; content: string }>;
   /** 圧縮された過去履歴のサマリ。 */
   historySummary?: string;
+  /** Phase69-2: 検索結果から除外するエントリID一覧 */
+  excludedIds?: string[];
 }
 
 /**

--- a/src/agent/orchestrator/ragRetrieval.ts
+++ b/src/agent/orchestrator/ragRetrieval.ts
@@ -27,6 +27,8 @@ export async function runInitialRagRetrieval(
     topK: 8,
     useLlmPlanner: false,
     debug: true,
+    tenantId: initialInput.tenantId,
+    excludedIds: initialInput.excludedIds,
   });
 
   const rerankDebug = searchResponse.debug?.rerank as

--- a/src/agent/tools/rerankTool.ts
+++ b/src/agent/tools/rerankTool.ts
@@ -7,6 +7,8 @@ export interface RerankToolInput {
   query: string;
   items: Hit[];
   topK: number;
+  /** Phase69-2: rerank後の二重防御フィルター用除外ID一覧 */
+  excludedIds?: string[];
 }
 
 export interface RerankToolOutput extends RerankResult {
@@ -20,7 +22,7 @@ export interface RerankToolOutput extends RerankResult {
 export async function rerankTool(
   input: RerankToolInput,
 ): Promise<RerankToolOutput> {
-  const { query, items, topK } = input;
+  const { query, items, topK, excludedIds } = input;
 
   const ceItems: RerankItem[] = items.map((hit) => ({
     id: hit.id,
@@ -31,7 +33,7 @@ export async function rerankTool(
     metadata: hit.metadata,
   }));
 
-  const result = await rerank(query, ceItems, topK);
+  const result = await rerank(query, ceItems, topK, excludedIds);
   return {
     ...result,
     rerankEngine: result.engine,

--- a/src/agent/tools/searchTool.ts
+++ b/src/agent/tools/searchTool.ts
@@ -7,6 +7,8 @@ import { embedText } from '../llm/openaiEmbeddingClient';
 export interface SearchToolInput {
   query: string;
   tenantId?: string;
+  /** Phase69-2: 検索結果から除外するエントリID一覧 */
+  excludedIds?: string[];
 }
 
 export interface SearchToolOutput {
@@ -18,7 +20,7 @@ export interface SearchToolOutput {
 export async function searchTool(
   input: SearchToolInput,
 ): Promise<SearchToolOutput> {
-  const { query, tenantId } = input;
+  const { query, tenantId, excludedIds } = input;
   const effectiveTenantId = tenantId ?? 'default';
 
   // 1) Try pgvector (Groq embeddings + pgvector)
@@ -27,6 +29,7 @@ export async function searchTool(
     const vecResult = await searchPgVector({
       tenantId: effectiveTenantId,
       embedding,
+      excludedIds,
     });
 
     if (vecResult.items.length > 0) {
@@ -52,6 +55,6 @@ export async function searchTool(
   }
 
   // 2) Fallback: 既存の hybridSearch（ES + PG FTS 等）
-  const result = await hybridSearch(query, tenantId);
+  const result = await hybridSearch(query, tenantId, undefined, excludedIds);
   return result;
 }

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -45,6 +45,8 @@ export interface AgentSearchParams {
   tenantId?: string;
   /** Phase57: visitor_id (行動コンテキスト注入用) */
   visitorId?: string;
+  /** Phase69-2: 検索結果から除外するエントリID一覧 */
+  excludedIds?: string[];
 }
 
 /**

--- a/src/api/admin/knowledge/faqCrudRoutes.ts
+++ b/src/api/admin/knowledge/faqCrudRoutes.ts
@@ -50,12 +50,13 @@ function upsertToEsAsync(
   faqId: number,
   question: string,
   answer: string,
-  isPublished = true
+  isPublished = true,
+  isExcludedFromSearch = false
 ): void {
   const esUrl = process.env.ES_URL;
   const index = process.env.ES_FAQ_INDEX || "faqs";
   if (!esUrl) return;
-  const doc = { tenant_id: tenantId, question, answer, faq_id: faqId, is_published: isPublished };
+  const doc = { tenant_id: tenantId, question, answer, faq_id: faqId, is_published: isPublished, is_excluded_from_search: isExcludedFromSearch };
   const url = `${esUrl.replace(/\/$/, "")}/${index}/_doc/${faqId}_${tenantId}`;
   fetch(url, {
     method: "PUT",
@@ -271,7 +272,7 @@ export function registerFaqCrudRoutes(
       const embText = `${row.question}\n${row.answer}`;
 
       insertEmbeddingAsync(db, tenantId, embText, faqId, { source: "faq_crud", faq_id: faqId });
-      upsertToEsAsync(tenantId, faqId, row.question, row.answer, row.is_published);
+      upsertToEsAsync(tenantId, faqId, row.question, row.answer, row.is_published, false);
 
       return res.status(201).json(row);
     } catch (err) {
@@ -361,7 +362,7 @@ export function registerFaqCrudRoutes(
         faq_id: updated.id,
         is_excluded_from_search: updated.is_excluded_from_search ?? false,
       });
-      upsertToEsAsync(tenantId, updated.id, updated.question, updated.answer, updated.is_published);
+      upsertToEsAsync(tenantId, updated.id, updated.question, updated.answer, updated.is_published, updated.is_excluded_from_search ?? false);
 
       return res.json(updated);
     } catch (err) {

--- a/src/api/admin/knowledge/faqCrudRoutes.ts
+++ b/src/api/admin/knowledge/faqCrudRoutes.ts
@@ -33,11 +33,12 @@ function insertEmbeddingAsync(
   faqId: number,
   meta: Record<string, unknown>
 ): void {
+  const isExcluded = Boolean(meta.is_excluded_from_search);
   embedText(text)
     .then((vec) =>
       db.query(
-        "INSERT INTO faq_embeddings (tenant_id, text, embedding, metadata) VALUES ($1, $2, $3::vector, $4::jsonb)",
-        [tenantId, text, `[${vec.join(",")}]`, JSON.stringify(meta)]
+        "INSERT INTO faq_embeddings (tenant_id, text, embedding, metadata, is_excluded_from_search) VALUES ($1, $2, $3::vector, $4::jsonb, $5)",
+        [tenantId, text, `[${vec.join(",")}]`, JSON.stringify(meta), isExcluded]
       )
     )
     .catch((e) => logger.warn("[faqCrud] embedding insert failed", e));
@@ -91,6 +92,13 @@ const updateSchema = z.object({
   category: z.enum(CATEGORIES).optional(),
   tags: z.array(z.string()).optional(),
   is_published: z.boolean().optional(),
+  /** Phase69-2: 検索除外フラグ */
+  is_excluded_from_search: z.boolean().optional(),
+});
+
+/** Phase69-2: 検索除外フラグのみを更新するスキーマ */
+const excludeSchema = z.object({
+  is_excluded_from_search: z.boolean(),
 });
 
 type KnowledgeMiddleware = (req: Request, res: Response, next: NextFunction) => void;
@@ -270,7 +278,7 @@ export function registerFaqCrudRoutes(
       return res.status(400).json({ error: "invalid_request", details: parsed.error.issues });
     }
 
-    const { question, answer, category, tags, is_published } = parsed.data;
+    const { question, answer, category, tags, is_published, is_excluded_from_search } = parsed.data;
 
     try {
       // 存在チェック + テナント確認
@@ -295,6 +303,7 @@ export function registerFaqCrudRoutes(
              category = $3,
              tags = COALESCE($4, tags),
              is_published = COALESCE($5, is_published),
+             is_excluded_from_search = COALESCE($8, is_excluded_from_search),
              updated_at = NOW()
          WHERE id = $6 AND tenant_id = $7
          RETURNING *`,
@@ -306,10 +315,11 @@ export function registerFaqCrudRoutes(
           is_published !== undefined ? is_published : null,
           id,
           tenantId,
+          is_excluded_from_search !== undefined ? is_excluded_from_search : null,
         ]
       );
 
-      const updated = updateResult.rows[0] as { id: number; question: string; answer: string; is_published: boolean };
+      const updated = updateResult.rows[0] as { id: number; question: string; answer: string; is_published: boolean; is_excluded_from_search: boolean };
 
       // 古い embedding を削除し再挿入
       try {
@@ -327,12 +337,68 @@ export function registerFaqCrudRoutes(
       insertEmbeddingAsync(db, tenantId, embText, updated.id, {
         source: "faq_crud",
         faq_id: updated.id,
+        is_excluded_from_search: updated.is_excluded_from_search ?? false,
       });
       upsertToEsAsync(tenantId, updated.id, updated.question, updated.answer, updated.is_published);
 
       return res.json(updated);
     } catch (err) {
       logger.warn("[PUT /v1/admin/knowledge/faq/:id]", err);
+      return res.status(500).json({ error: "更新に失敗しました" });
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // PATCH /v1/admin/knowledge/faq/:id/exclude
+  // Phase69-2: 検索除外フラグのみ更新（embedding 再生成不要）
+  // -------------------------------------------------------------------------
+  app.patch("/v1/admin/knowledge/faq/:id/exclude", knowledgeAuth, requireKnowledgeRole, requireKnowledgeTenant, async (req: Request, res: Response) => {
+    const tenantId = resolveTenantId(req);
+    if (!tenantId) {
+      return res.status(400).json({ error: "tenant クエリパラメータが必要です" });
+    }
+
+    const id = Number(req.params.id);
+    if (!Number.isFinite(id)) {
+      return res.status(400).json({ error: "idが不正です" });
+    }
+
+    const parsed = excludeSchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      return res.status(400).json({ error: "invalid_request", details: parsed.error.issues });
+    }
+
+    const { is_excluded_from_search } = parsed.data;
+
+    try {
+      const check = await db.query(
+        `SELECT id, tenant_id FROM faq_docs WHERE id = $1`,
+        [id]
+      );
+
+      if (check.rowCount === 0) {
+        return res.status(404).json({ error: "FAQが見つかりません" });
+      }
+
+      const existing = check.rows[0] as { tenant_id: string };
+      if (existing.tenant_id !== tenantId) {
+        return res.status(403).json({ error: "アクセス権限がありません" });
+      }
+
+      // faq_docs + faq_embeddings の両方を同時更新
+      await db.query(
+        `UPDATE faq_docs SET is_excluded_from_search = $1, updated_at = NOW() WHERE id = $2 AND tenant_id = $3`,
+        [is_excluded_from_search, id, tenantId]
+      );
+      await db.query(
+        `UPDATE faq_embeddings SET is_excluded_from_search = $1
+         WHERE tenant_id = $2 AND (metadata->>'faq_id')::bigint = $3`,
+        [is_excluded_from_search, tenantId, id]
+      );
+
+      return res.json({ id, is_excluded_from_search });
+    } catch (err) {
+      logger.warn("[PATCH /v1/admin/knowledge/faq/:id/exclude]", err);
       return res.status(500).json({ error: "更新に失敗しました" });
     }
   });

--- a/src/api/admin/knowledge/faqCrudRoutes.ts
+++ b/src/api/admin/knowledge/faqCrudRoutes.ts
@@ -64,6 +64,28 @@ function upsertToEsAsync(
   }).catch((e) => logger.warn("[faqCrud] ES upsert failed", e));
 }
 
+// Phase69-2 PR-C2 Round 2: ES に is_excluded_from_search を partial update で伝搬する
+// 設計判断 (Codex adversarial Round 1):
+//   - fire-and-forget: DB が source-of-truth、ES は eventual consistency
+//   - POST _update: question/answer 等を消さない partial doc 更新
+//   - pgvector layer (永続フィルター) + ES layer (今回追加) + リクエスト excluded_ids の三層防御
+/** ESインデックスの is_excluded_from_search のみ partial update（fire-and-forget） */
+function syncIsExcludedToEsAsync(
+  tenantId: string,
+  faqId: number,
+  isExcludedFromSearch: boolean
+): void {
+  const esUrl = process.env.ES_URL;
+  const index = process.env.ES_FAQ_INDEX || "faqs";
+  if (!esUrl) return;
+  const url = `${esUrl.replace(/\/$/, "")}/${index}/_update/${faqId}_${tenantId}`;
+  fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ doc: { is_excluded_from_search: isExcludedFromSearch } }),
+  }).catch((e) => logger.warn("[faqCrud] ES is_excluded_from_search sync failed", e));
+}
+
 const listQuerySchema = z.object({
   tenant: z.string().optional(),
   limit: z.coerce.number().int().min(1).max(200).default(50),
@@ -385,16 +407,50 @@ export function registerFaqCrudRoutes(
         return res.status(403).json({ error: "アクセス権限がありません" });
       }
 
-      // faq_docs + faq_embeddings の両方を同時更新
-      await db.query(
-        `UPDATE faq_docs SET is_excluded_from_search = $1, updated_at = NOW() WHERE id = $2 AND tenant_id = $3`,
-        [is_excluded_from_search, id, tenantId]
-      );
-      await db.query(
-        `UPDATE faq_embeddings SET is_excluded_from_search = $1
-         WHERE tenant_id = $2 AND (metadata->>'faq_id')::bigint = $3`,
-        [is_excluded_from_search, tenantId, id]
-      );
+      // Phase69-2 PR-C2 Round 2 (Codex adversarial Round 1 HIGH/MEDIUM 対応):
+      //   - HIGH-2: faq_docs と faq_embeddings の UPDATE を単一 DB tx で atomic 化
+      //   - MEDIUM-1: (metadata->>'faq_id')::bigint キャスト前に '^[0-9]+$' で数値ガード
+      //   - HIGH-1: COMMIT 後に ES へ is_excluded_from_search を fire-and-forget 同期
+      // pattern: deleteSessionRepository (Phase69-1) / bulk-delete (このファイル下部) 準拠
+      const client = await db.connect();
+      try {
+        await client.query("BEGIN");
+        await client.query("SET LOCAL lock_timeout = '3s'");
+
+        await client.query(
+          `UPDATE faq_docs SET is_excluded_from_search = $1, updated_at = NOW() WHERE id = $2 AND tenant_id = $3`,
+          [is_excluded_from_search, id, tenantId]
+        );
+        await client.query(
+          `UPDATE faq_embeddings SET is_excluded_from_search = $1
+           WHERE tenant_id = $2
+             AND (metadata->>'faq_id') ~ '^[0-9]+$'
+             AND (metadata->>'faq_id')::bigint = $3`,
+          [is_excluded_from_search, tenantId, id]
+        );
+
+        await client.query("COMMIT");
+      } catch (txErr) {
+        await client.query("ROLLBACK").catch(() => {});
+        const pgErr = txErr as { code?: string };
+        logger.warn({
+          event: 'faq_exclude_tx_failed',
+          tenantId,
+          faqId: id,
+          targetState: is_excluded_from_search,
+          errorCode: pgErr.code === '55P03' ? 'DB_LOCK_TIMEOUT' : 'DB_TX_FAILED',
+          pgCode: pgErr.code,
+        }, "PATCH /faq/:id/exclude transaction failed; rolled back");
+        if (pgErr.code === '55P03') {
+          return res.status(409).json({ error: "他の処理中のため、少し時間をおいて再度お試しください" });
+        }
+        return res.status(500).json({ error: "更新に失敗しました" });
+      } finally {
+        client.release();
+      }
+
+      // COMMIT 後に ES 同期（fire-and-forget — DB が source-of-truth）
+      syncIsExcludedToEsAsync(tenantId, id, is_excluded_from_search);
 
       return res.json({ id, is_excluded_from_search });
     } catch (err) {

--- a/src/api/admin/knowledge/faqCrudRoutes.ts
+++ b/src/api/admin/knowledge/faqCrudRoutes.ts
@@ -393,34 +393,54 @@ export function registerFaqCrudRoutes(
     const { is_excluded_from_search } = parsed.data;
 
     try {
-      const check = await db.query(
-        `SELECT id, tenant_id FROM faq_docs WHERE id = $1`,
-        [id]
-      );
-
-      if (check.rowCount === 0) {
-        return res.status(404).json({ error: "FAQが見つかりません" });
-      }
-
-      const existing = check.rows[0] as { tenant_id: string };
-      if (existing.tenant_id !== tenantId) {
-        return res.status(403).json({ error: "アクセス権限がありません" });
-      }
-
-      // Phase69-2 PR-C2 Round 2 (Codex adversarial Round 1 HIGH/MEDIUM 対応):
-      //   - HIGH-2: faq_docs と faq_embeddings の UPDATE を単一 DB tx で atomic 化
-      //   - MEDIUM-1: (metadata->>'faq_id')::bigint キャスト前に '^[0-9]+$' で数値ガード
-      //   - HIGH-1: COMMIT 後に ES へ is_excluded_from_search を fire-and-forget 同期
-      // pattern: deleteSessionRepository (Phase69-1) / bulk-delete (このファイル下部) 準拠
+      // Phase69-2 PR-C2 Round 4 (Codex adversarial Round 3 MEDIUM-2 対応):
+      //   precheck を tx 外で行うと、SELECT 通過後・UPDATE 開始前に行が削除/移動された場合
+      //   UPDATE rowCount=0 でも COMMIT 成功扱いとなり、200 を返す check-then-act レースが残る。
+      //   対策として:
+      //     - SELECT ... FOR UPDATE で precheck を tx 内に取り込み、ターゲット行をロック
+      //     - faq_docs UPDATE rowCount=1 を assert (FOR UPDATE で 1 件取れた後の不一致は内部矛盾)
+      //   その他 Round 2 維持事項:
+      //     - HIGH-2: faq_docs と faq_embeddings UPDATE を単一 DB tx で atomic 化
+      //     - MEDIUM-1: (metadata->>'faq_id')::bigint キャスト前に '^[0-9]+$' で数値ガード
+      //     - HIGH-1: COMMIT 後に ES へ is_excluded_from_search を fire-and-forget 同期
       const client = await db.connect();
+      let txSucceeded = false;
       try {
         await client.query("BEGIN");
         await client.query("SET LOCAL lock_timeout = '3s'");
 
-        await client.query(
+        // in-tx lock + tenant 確認 (Round 4: precheck を tx 内に移動)
+        const lockResult = await client.query(
+          `SELECT id, tenant_id FROM faq_docs WHERE id = $1 FOR UPDATE`,
+          [id]
+        );
+        if (lockResult.rowCount === 0) {
+          await client.query("ROLLBACK");
+          return res.status(404).json({ error: "FAQが見つかりません" });
+        }
+        const lockedRow = lockResult.rows[0] as { tenant_id: string };
+        if (lockedRow.tenant_id !== tenantId) {
+          await client.query("ROLLBACK");
+          return res.status(403).json({ error: "アクセス権限がありません" });
+        }
+
+        const docsResult = await client.query(
           `UPDATE faq_docs SET is_excluded_from_search = $1, updated_at = NOW() WHERE id = $2 AND tenant_id = $3`,
           [is_excluded_from_search, id, tenantId]
         );
+        // FOR UPDATE で 1 件取れた直後の rowCount 不一致は内部矛盾。ROLLBACK して 500。
+        if (docsResult.rowCount !== 1) {
+          await client.query("ROLLBACK");
+          logger.error({
+            event: 'faq_exclude_docs_update_unexpected',
+            errorCode: 'FAQ_DOCS_UPDATE_ROWCOUNT_MISMATCH',
+            tenantId,
+            faqId: id,
+            rowCount: docsResult.rowCount,
+          }, "Unexpected rowCount on faq_docs UPDATE after SELECT FOR UPDATE");
+          return res.status(500).json({ error: "更新に失敗しました" });
+        }
+
         await client.query(
           `UPDATE faq_embeddings SET is_excluded_from_search = $1
            WHERE tenant_id = $2
@@ -430,6 +450,7 @@ export function registerFaqCrudRoutes(
         );
 
         await client.query("COMMIT");
+        txSucceeded = true;
       } catch (txErr) {
         await client.query("ROLLBACK").catch(() => {});
         const pgErr = txErr as { code?: string };
@@ -449,10 +470,13 @@ export function registerFaqCrudRoutes(
         client.release();
       }
 
-      // COMMIT 後に ES 同期（fire-and-forget — DB が source-of-truth）
-      syncIsExcludedToEsAsync(tenantId, id, is_excluded_from_search);
-
-      return res.json({ id, is_excluded_from_search });
+      if (txSucceeded) {
+        // COMMIT 後に ES 同期（fire-and-forget — DB が source-of-truth）
+        syncIsExcludedToEsAsync(tenantId, id, is_excluded_from_search);
+        return res.json({ id, is_excluded_from_search });
+      }
+      // 防御的: txSucceeded=false かつ catch も response 返さず通過した場合
+      return res.status(500).json({ error: "更新に失敗しました" });
     } catch (err) {
       logger.warn("[PATCH /v1/admin/knowledge/faq/:id/exclude]", err);
       return res.status(500).json({ error: "更新に失敗しました" });

--- a/src/migrations/phase69_2_excluded_ids.sql
+++ b/src/migrations/phase69_2_excluded_ids.sql
@@ -1,0 +1,46 @@
+-- Phase69-2: excluded_ids ゼロ知識検索
+-- 実行日: VPS で手動実行
+-- 対象: VPS PostgreSQL (65.108.159.161)
+
+-- ============================================================
+-- 1. faq_embeddings に is_excluded_from_search カラム追加
+--    検索クエリのフィルター対象（INDEX付き）
+-- ============================================================
+
+ALTER TABLE faq_embeddings
+  ADD COLUMN IF NOT EXISTS is_excluded_from_search BOOLEAN DEFAULT FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_faq_embeddings_excluded
+  ON faq_embeddings (tenant_id, is_excluded_from_search)
+  WHERE is_excluded_from_search = true;
+
+-- ============================================================
+-- 2. faq_docs に is_excluded_from_search カラム追加
+--    Admin UI から操作する際のソース・オブ・トゥルース
+-- ============================================================
+
+ALTER TABLE faq_docs
+  ADD COLUMN IF NOT EXISTS is_excluded_from_search BOOLEAN DEFAULT FALSE;
+
+CREATE INDEX IF NOT EXISTS idx_faq_docs_excluded
+  ON faq_docs (tenant_id, is_excluded_from_search)
+  WHERE is_excluded_from_search = true;
+
+-- ============================================================
+-- 3. tenants に default_excluded_ids カラム追加
+--    テナント管理者がグローバル除外IDを設定可能に
+-- ============================================================
+
+ALTER TABLE tenants
+  ADD COLUMN IF NOT EXISTS default_excluded_ids TEXT[] DEFAULT '{}';
+
+COMMENT ON COLUMN tenants.default_excluded_ids IS 'Phase69-2: テナントレベルのデフォルト除外ID一覧（faq_embeddings.id）';
+
+-- ============================================================
+-- 確認クエリ (実行後に手動確認)
+-- ============================================================
+-- SELECT column_name, data_type, column_default
+-- FROM information_schema.columns
+-- WHERE table_name IN ('faq_embeddings', 'faq_docs', 'tenants')
+--   AND column_name IN ('is_excluded_from_search', 'default_excluded_ids')
+-- ORDER BY table_name, column_name;

--- a/src/search/excludedIds.test.ts
+++ b/src/search/excludedIds.test.ts
@@ -1,0 +1,89 @@
+// src/search/excludedIds.test.ts
+// Phase69-2: excluded_ids ゼロ知識検索テスト
+import { rerank, type Item } from "./rerank";
+import { hybridSearch } from "./hybrid";
+
+// --- rerank の excludedIds テスト ---
+
+const makeItems = (...ids: string[]): Item[] =>
+  ids.map((id, i) => ({
+    id,
+    text: `item ${id}`,
+    score: 1 - i * 0.1,
+    source: "es" as const,
+  }));
+
+describe("rerank: excludedIds", () => {
+  it("除外IDがヒットしないこと", async () => {
+    const items = makeItems("1", "2", "3", "4", "5");
+    const result = await rerank("query", items, 5, ["2", "4"]);
+    const ids = result.items.map((it) => it.id);
+    expect(ids).not.toContain("2");
+    expect(ids).not.toContain("4");
+  });
+
+  it("除外ID空配列はフィルターしないこと", async () => {
+    const items = makeItems("1", "2", "3");
+    const result = await rerank("query", items, 3, []);
+    expect(result.items).toHaveLength(3);
+  });
+
+  it("除外IDがundefinedでもエラーにならないこと", async () => {
+    const items = makeItems("1", "2", "3");
+    const result = await rerank("query", items, 3, undefined);
+    expect(result.items).toHaveLength(3);
+  });
+
+  it("全アイテムが除外された場合は空配列になること", async () => {
+    const items = makeItems("1", "2");
+    const result = await rerank("query", items, 5, ["1", "2"]);
+    expect(result.items).toHaveLength(0);
+  });
+
+  it("テナント分離: excludedIds はリクエスト単位であり、別テナントの除外設定が混入しないこと", async () => {
+    // テナントAの除外設定（["id-A"]）とテナントBの除外設定（["id-B"]）
+    const tenantAItems = makeItems("id-A", "id-B", "id-C");
+    const tenantBItems = makeItems("id-A", "id-B", "id-C");
+
+    const resultA = await rerank("query", tenantAItems, 5, ["id-A"]);
+    const resultB = await rerank("query", tenantBItems, 5, ["id-B"]);
+
+    // テナントAでは id-A が除外され id-B は残る
+    expect(resultA.items.map((it) => it.id)).not.toContain("id-A");
+    expect(resultA.items.map((it) => it.id)).toContain("id-B");
+
+    // テナントBでは id-B が除外され id-A は残る
+    expect(resultB.items.map((it) => it.id)).not.toContain("id-B");
+    expect(resultB.items.map((it) => it.id)).toContain("id-A");
+  });
+});
+
+// --- hybridSearch の excludedIds テスト (ES_URL なし = モック不要) ---
+
+describe("hybridSearch: excludedIds (ES_URL なし)", () => {
+  const origEnv = process.env.ES_URL;
+
+  beforeEach(() => {
+    delete process.env.ES_URL;
+  });
+
+  afterEach(() => {
+    if (origEnv !== undefined) process.env.ES_URL = origEnv;
+    else delete process.env.ES_URL;
+  });
+
+  it("ES_URLなしでもexcludedIdsを渡してもエラーにならないこと", async () => {
+    const result = await hybridSearch("test query", "tenant1", undefined, ["id1", "id2"]);
+    expect(result.items).toBeInstanceOf(Array);
+  });
+
+  it("excludedIdsがnullish（undefined）でもエラーにならないこと", async () => {
+    const result = await hybridSearch("test query", "tenant1", undefined, undefined);
+    expect(result.items).toBeInstanceOf(Array);
+  });
+
+  it("excludedIdsが空配列でもエラーにならないこと", async () => {
+    const result = await hybridSearch("test query", "tenant1", undefined, []);
+    expect(result.items).toBeInstanceOf(Array);
+  });
+});

--- a/src/search/excludedIds.test.ts
+++ b/src/search/excludedIds.test.ts
@@ -90,19 +90,22 @@ describe("hybridSearch: excludedIds (ES_URL なし)", () => {
   });
 });
 
-// --- pgvector.ts: source-aware exclusion (Phase69-2 Round 3, Codex #1 対応) ---
+// --- pgvector.ts: identity-based exclusion (Phase69-2 Round 4, Codex Round 3 #1 対応) ---
 //
 // pgvector.ts は widget chat / dialog (searchTool 経由) で使われる主検索パス。
-// Codex Adversarial Round 2 #1: legacy embedding without faq_id metadata が
-// fd.id IS NULL pass-through で FAQ exclusion をすり抜ける問題への対応。
+// Codex Adversarial Round 3 #1: Round 3 の source-based 分岐 (scrape/text/faq) に対し、
+// CRUD 経由で書き込まれる embedding (source='faq_crud') が非 FAQ branch にすり抜けて
+// faq_docs の visibility check (is_published / is_excluded_from_search) をバイパスする
+// 問題への対応。
 //
-// 対応方針 (Option C): source 判定で FAQ 系 / 非 FAQ 系を分離
-//   - FAQ 系 (scrape/text/faq) → faq_docs 厳格チェック (fd.id IS NOT NULL 必須)
-//   - 非 FAQ 系 (book/web/groq, source NULL) → faq_embeddings.is_excluded_from_search のみ
+// Round 4 設計: source 文字列に依存せず、faq_id identity で FAQ かどうかを判定する。
+//   - FAQ 系 (numeric faq_id + faq_docs JOIN 成功) → faq_docs 厳格チェック
+//   - 非 FAQ (faq_id を持たない or 数値以外) → faq_embeddings.is_excluded_from_search のみ
+//   - orphan (numeric faq_id 持ちだが faq_docs 行なし) → 両 branch にマッチせず除外
 //
 // 静的 SQL 検証 (本番 SQL は Postgres 側評価のため、SQL 文字列に必要句が含まれることで確認)
 
-describe("pgvector.ts SQL: source-aware exclusion (Phase69-2 Round 3)", () => {
+describe("pgvector.ts SQL: identity-based exclusion (Phase69-2 Round 4)", () => {
   const filePath = path.resolve(__dirname, "pgvector.ts");
   let source: string;
 
@@ -110,32 +113,32 @@ describe("pgvector.ts SQL: source-aware exclusion (Phase69-2 Round 3)", () => {
     source = fs.readFileSync(filePath, "utf8");
   });
 
-  it("FAQ 系 source (scrape/text/faq) を IN 句で限定する", () => {
-    expect(source).toMatch(/fe\.metadata->>'source'\s+IN\s+\(\s*'scrape'\s*,\s*'text'\s*,\s*'faq'\s*\)/);
+  it("source-based の判定句 (IN ('scrape','text','faq')) は削除されている", () => {
+    // Round 3 で書いた source-based 判定が残っていないこと
+    expect(source).not.toMatch(/fe\.metadata->>'source'\s+IN\s+\(\s*'scrape'\s*,\s*'text'\s*,\s*'faq'\s*\)/);
+    expect(source).not.toMatch(/fe\.metadata->>'source'\s+NOT\s+IN\s+\(\s*'scrape'\s*,\s*'text'\s*,\s*'faq'\s*\)/);
   });
 
-  it("FAQ 系では fd.id IS NOT NULL を要求する (legacy 未連携 embedding を除外)", () => {
-    // FAQ 系ブロック内で fd.id IS NOT NULL が現れることを確認
+  it("FAQ identity branch: numeric faq_id + fd.id IS NOT NULL + is_published + 非 excluded を要求", () => {
+    // FAQ identity ブロックを最初の OR の前方 400 文字以内で確認
     const faqBlockMatch = source.match(
-      /fe\.metadata->>'source'\s+IN\s+\(\s*'scrape'\s*,\s*'text'\s*,\s*'faq'\s*\)[\s\S]{0,400}/
+      /fe\.metadata->>'faq_id'\s*~\s*'\^\[0-9\]\+\$'[\s\S]{0,400}fd\.id IS NOT NULL[\s\S]{0,300}/
     );
     expect(faqBlockMatch).not.toBeNull();
-    expect(faqBlockMatch![0]).toMatch(/fd\.id IS NOT NULL/);
     expect(faqBlockMatch![0]).toMatch(/fd\.is_published\s*=\s*true/);
     expect(faqBlockMatch![0]).toMatch(/fd\.is_excluded_from_search/);
   });
 
-  it("非 FAQ 系 (source NULL or NOT IN リスト) は OR ブランチで faq_docs チェックをスキップ", () => {
-    expect(source).toMatch(/fe\.metadata->>'source'\s+IS\s+NULL/);
-    expect(source).toMatch(/fe\.metadata->>'source'\s+NOT\s+IN\s+\(\s*'scrape'\s*,\s*'text'\s*,\s*'faq'\s*\)/);
+  it("非 FAQ branch: faq_id IS NULL OR !~ '^[0-9]+$' で網羅", () => {
+    expect(source).toMatch(/fe\.metadata->>'faq_id'\s+IS\s+NULL/);
+    expect(source).toMatch(/fe\.metadata->>'faq_id'\s+!~\s+'\^\[0-9\]\+\$'/);
   });
 
-  it("faq_embeddings 直接の is_excluded_from_search フィルターは維持される (全 source 共通)", () => {
+  it("faq_embeddings 直接の is_excluded_from_search フィルターは維持される (全 identity 共通)", () => {
     expect(source).toMatch(/fe\.is_excluded_from_search IS NULL OR fe\.is_excluded_from_search\s*=\s*false/);
   });
 
   it("JOIN ON 句に numeric guard (~ '^[0-9]+$') が入る (非数値 faq_id での bigint キャスト失敗を防ぐ)", () => {
-    // LEFT JOIN ブロック内に numeric guard が含まれることを確認
     const joinBlockMatch = source.match(/left join faq_docs fd[\s\S]{0,300}/);
     expect(joinBlockMatch).not.toBeNull();
     expect(joinBlockMatch![0]).toMatch(/fe\.metadata->>'faq_id'\s*~\s*'\^\[0-9\]\+\$'/);
@@ -146,9 +149,9 @@ describe("pgvector.ts SQL: source-aware exclusion (Phase69-2 Round 3)", () => {
   });
 });
 
-// --- pgvector.ts: 実 SQL 実行系テスト (pool.query をモックして bind/結果マッピングを検証) ---
+// --- pgvector.ts: 実 SQL 実行系テスト (pool.query をモックして bind/SQL を検証) ---
 
-describe("pgvector.ts: searchPgVector runtime behavior (Phase69-2 Round 3)", () => {
+describe("pgvector.ts: searchPgVector runtime behavior (Phase69-2 Round 4)", () => {
   const origDbUrl = process.env.DATABASE_URL;
   let capturedSql: string | null = null;
   let capturedParams: unknown[] | null = null;
@@ -216,14 +219,30 @@ describe("pgvector.ts: searchPgVector runtime behavior (Phase69-2 Round 3)", () 
     expect(capturedParams).toHaveLength(3);
   });
 
-  it("実行 SQL に source 判定の OR ブランチ両方が含まれる", async () => {
+  it("実行 SQL に identity-based の OR ブランチ両方が含まれる (FAQ identity + 非 FAQ)", async () => {
     const { searchPgVector } = await import("./pgvector");
     await searchPgVector({
       tenantId: "tenantA",
       embedding: [0.1],
     });
-    expect(capturedSql).toMatch(/fe\.metadata->>'source'\s+IN\s+\(\s*'scrape'\s*,\s*'text'\s*,\s*'faq'\s*\)/);
-    expect(capturedSql).toMatch(/fe\.metadata->>'source'\s+NOT\s+IN\s+\(\s*'scrape'\s*,\s*'text'\s*,\s*'faq'\s*\)/);
+    // FAQ identity branch
+    expect(capturedSql).toMatch(/fe\.metadata->>'faq_id'\s*~\s*'\^\[0-9\]\+\$'/);
     expect(capturedSql).toMatch(/fd\.id IS NOT NULL/);
+    expect(capturedSql).toMatch(/fd\.is_published\s*=\s*true/);
+    // 非 FAQ branch
+    expect(capturedSql).toMatch(/fe\.metadata->>'faq_id'\s+IS\s+NULL/);
+    expect(capturedSql).toMatch(/fe\.metadata->>'faq_id'\s+!~\s+'\^\[0-9\]\+\$'/);
+  });
+
+  it("Round 3 で残した source 文字列リテラル ('scrape'/'text'/'faq') は SQL に含まれない", async () => {
+    // Codex Round 3 #1: source-based 分岐は faq_crud をすり抜けたため identity-based に統一
+    const { searchPgVector } = await import("./pgvector");
+    await searchPgVector({
+      tenantId: "tenantA",
+      embedding: [0.1],
+    });
+    expect(capturedSql).not.toMatch(/'scrape'/);
+    expect(capturedSql).not.toMatch(/'text'/);
+    expect(capturedSql).not.toMatch(/'faq_crud'/);
   });
 });

--- a/src/search/excludedIds.test.ts
+++ b/src/search/excludedIds.test.ts
@@ -1,5 +1,7 @@
 // src/search/excludedIds.test.ts
 // Phase69-2: excluded_ids ゼロ知識検索テスト
+import fs from "fs";
+import path from "path";
 import { rerank, type Item } from "./rerank";
 import { hybridSearch } from "./hybrid";
 
@@ -85,5 +87,143 @@ describe("hybridSearch: excludedIds (ES_URL なし)", () => {
   it("excludedIdsが空配列でもエラーにならないこと", async () => {
     const result = await hybridSearch("test query", "tenant1", undefined, []);
     expect(result.items).toBeInstanceOf(Array);
+  });
+});
+
+// --- pgvector.ts: source-aware exclusion (Phase69-2 Round 3, Codex #1 対応) ---
+//
+// pgvector.ts は widget chat / dialog (searchTool 経由) で使われる主検索パス。
+// Codex Adversarial Round 2 #1: legacy embedding without faq_id metadata が
+// fd.id IS NULL pass-through で FAQ exclusion をすり抜ける問題への対応。
+//
+// 対応方針 (Option C): source 判定で FAQ 系 / 非 FAQ 系を分離
+//   - FAQ 系 (scrape/text/faq) → faq_docs 厳格チェック (fd.id IS NOT NULL 必須)
+//   - 非 FAQ 系 (book/web/groq, source NULL) → faq_embeddings.is_excluded_from_search のみ
+//
+// 静的 SQL 検証 (本番 SQL は Postgres 側評価のため、SQL 文字列に必要句が含まれることで確認)
+
+describe("pgvector.ts SQL: source-aware exclusion (Phase69-2 Round 3)", () => {
+  const filePath = path.resolve(__dirname, "pgvector.ts");
+  let source: string;
+
+  beforeAll(() => {
+    source = fs.readFileSync(filePath, "utf8");
+  });
+
+  it("FAQ 系 source (scrape/text/faq) を IN 句で限定する", () => {
+    expect(source).toMatch(/fe\.metadata->>'source'\s+IN\s+\(\s*'scrape'\s*,\s*'text'\s*,\s*'faq'\s*\)/);
+  });
+
+  it("FAQ 系では fd.id IS NOT NULL を要求する (legacy 未連携 embedding を除外)", () => {
+    // FAQ 系ブロック内で fd.id IS NOT NULL が現れることを確認
+    const faqBlockMatch = source.match(
+      /fe\.metadata->>'source'\s+IN\s+\(\s*'scrape'\s*,\s*'text'\s*,\s*'faq'\s*\)[\s\S]{0,400}/
+    );
+    expect(faqBlockMatch).not.toBeNull();
+    expect(faqBlockMatch![0]).toMatch(/fd\.id IS NOT NULL/);
+    expect(faqBlockMatch![0]).toMatch(/fd\.is_published\s*=\s*true/);
+    expect(faqBlockMatch![0]).toMatch(/fd\.is_excluded_from_search/);
+  });
+
+  it("非 FAQ 系 (source NULL or NOT IN リスト) は OR ブランチで faq_docs チェックをスキップ", () => {
+    expect(source).toMatch(/fe\.metadata->>'source'\s+IS\s+NULL/);
+    expect(source).toMatch(/fe\.metadata->>'source'\s+NOT\s+IN\s+\(\s*'scrape'\s*,\s*'text'\s*,\s*'faq'\s*\)/);
+  });
+
+  it("faq_embeddings 直接の is_excluded_from_search フィルターは維持される (全 source 共通)", () => {
+    expect(source).toMatch(/fe\.is_excluded_from_search IS NULL OR fe\.is_excluded_from_search\s*=\s*false/);
+  });
+
+  it("JOIN ON 句に numeric guard (~ '^[0-9]+$') が入る (非数値 faq_id での bigint キャスト失敗を防ぐ)", () => {
+    // LEFT JOIN ブロック内に numeric guard が含まれることを確認
+    const joinBlockMatch = source.match(/left join faq_docs fd[\s\S]{0,300}/);
+    expect(joinBlockMatch).not.toBeNull();
+    expect(joinBlockMatch![0]).toMatch(/fe\.metadata->>'faq_id'\s*~\s*'\^\[0-9\]\+\$'/);
+  });
+
+  it("tenant 分離フィルター (fe.tenant_id = $1 OR fe.tenant_id = 'global') は維持される", () => {
+    expect(source).toMatch(/fe\.tenant_id\s*=\s*\$1\s+OR\s+fe\.tenant_id\s*=\s*'global'/);
+  });
+});
+
+// --- pgvector.ts: 実 SQL 実行系テスト (pool.query をモックして bind/結果マッピングを検証) ---
+
+describe("pgvector.ts: searchPgVector runtime behavior (Phase69-2 Round 3)", () => {
+  const origDbUrl = process.env.DATABASE_URL;
+  let capturedSql: string | null = null;
+  let capturedParams: unknown[] | null = null;
+
+  beforeAll(() => {
+    process.env.DATABASE_URL = "postgres://test:test@localhost:5432/test";
+  });
+
+  afterAll(() => {
+    if (origDbUrl !== undefined) process.env.DATABASE_URL = origDbUrl;
+    else delete process.env.DATABASE_URL;
+  });
+
+  beforeEach(() => {
+    capturedSql = null;
+    capturedParams = null;
+    jest.resetModules();
+    jest.doMock("../lib/db", () => ({
+      pool: {
+        query: jest.fn((sql: string, params: unknown[]) => {
+          capturedSql = sql;
+          capturedParams = params;
+          return Promise.resolve({ rows: [] });
+        }),
+      },
+    }));
+  });
+
+  afterEach(() => {
+    jest.dontMock("../lib/db");
+  });
+
+  it("SQL の bind params に tenantId, embedding literal, topK が含まれる (順序維持)", async () => {
+    const { searchPgVector } = await import("./pgvector");
+    await searchPgVector({
+      tenantId: "tenantA",
+      embedding: [0.1, 0.2, 0.3],
+      topK: 5,
+    });
+    expect(capturedParams).not.toBeNull();
+    expect(capturedParams![0]).toBe("tenantA");
+    expect(capturedParams![1]).toBe("[0.1,0.2,0.3]");
+    expect(capturedParams![2]).toBe(5);
+  });
+
+  it("excludedIds 指定時は SQL に != ALL($4::text[]) 句が追加され、bind 4番目に配列が渡る", async () => {
+    const { searchPgVector } = await import("./pgvector");
+    await searchPgVector({
+      tenantId: "tenantA",
+      embedding: [0.5, 0.6],
+      excludedIds: ["e1", "e2"],
+    });
+    expect(capturedSql).toMatch(/fe\.id::text\s*!=\s*ALL\(\$4::text\[\]\)/);
+    expect(capturedParams![3]).toEqual(["e1", "e2"]);
+  });
+
+  it("excludedIds 空の場合は SQL に != ALL 句が現れない (動的句なし)", async () => {
+    const { searchPgVector } = await import("./pgvector");
+    await searchPgVector({
+      tenantId: "tenantA",
+      embedding: [0.5, 0.6],
+      excludedIds: [],
+    });
+    expect(capturedSql).not.toMatch(/!=\s*ALL\(\$4/);
+    expect(capturedParams).toHaveLength(3);
+  });
+
+  it("実行 SQL に source 判定の OR ブランチ両方が含まれる", async () => {
+    const { searchPgVector } = await import("./pgvector");
+    await searchPgVector({
+      tenantId: "tenantA",
+      embedding: [0.1],
+    });
+    expect(capturedSql).toMatch(/fe\.metadata->>'source'\s+IN\s+\(\s*'scrape'\s*,\s*'text'\s*,\s*'faq'\s*\)/);
+    expect(capturedSql).toMatch(/fe\.metadata->>'source'\s+NOT\s+IN\s+\(\s*'scrape'\s*,\s*'text'\s*,\s*'faq'\s*\)/);
+    expect(capturedSql).toMatch(/fd\.id IS NOT NULL/);
   });
 });

--- a/src/search/hybrid.ts
+++ b/src/search/hybrid.ts
@@ -30,7 +30,8 @@ const normZ = (xs: number[]) => {
 export async function hybridSearch(
   q: string,
   tenantId?: string,
-  lang?: unknown // Phase33 C: SupportedLang に変換（不正値は DEFAULT_LANG）
+  lang?: unknown, // Phase33 C: SupportedLang に変換（不正値は DEFAULT_LANG）
+  excludedIds?: string[]
 ) {
   const t0 = Date.now();
   const notes: string[] = [];
@@ -260,6 +261,10 @@ export async function hybridSearch(
     };
   }
 
+  // Phase69-2: excluded_ids フィルター（テナント分離のため呼び出し元から渡された id のみ除外）
+  const safeExcludedIds = new Set((excludedIds ?? []).filter(Boolean));
+  const filterExcluded = (h: Hit) => safeExcludedIds.size === 0 || !safeExcludedIds.has(h.id);
+
   // z-scoreで正規化（将来PG経路とマージする前提のままにしておく）
   const zES = normZ(esHits.map((h) => h.score));
   const zPG = normZ(pgHits.map((h) => h.score));
@@ -269,6 +274,7 @@ export async function hybridSearch(
   ]
     .sort((a, b) => b.z - a.z)
     .filter((h, i, self) => self.findIndex((x) => x.id === h.id) === i)
+    .filter(filterExcluded)
     .slice(0, 80)
     .map(({ z, ...rest }) => rest);
 

--- a/src/search/hybrid.ts
+++ b/src/search/hybrid.ts
@@ -124,6 +124,13 @@ export async function hybridSearch(
                           minimum_should_match: 1,
                         },
                       },
+                      // Phase69-2 PR-C2 Round 2: ES 永続フィルター（is_excluded_from_search=true は除外）
+                      // pgvector の WHERE 句と対応。リクエストスコープ excluded_ids との二重防御
+                      {
+                        bool: {
+                          must_not: { term: { is_excluded_from_search: true } },
+                        },
+                      },
                     ],
                   },
                 },

--- a/src/search/pgvector.ts
+++ b/src/search/pgvector.ts
@@ -77,12 +77,22 @@ export async function searchPgVector(
     ? `and fe.id::text != ALL($4::text[])`
     : "";
 
-  // Phase69-2 Round 3: source 判定で FAQ 系 / 非 FAQ 系を分離 (Codex Adversarial #1 対応)
-  //   - FAQ 系 (source IN ('scrape','text','faq')) は faq_docs 厳格チェック
-  //     → fd.id IS NOT NULL 必須。faq_id を持たない legacy embedding は FAQ 検索から除外。
-  //   - 非 FAQ 系 (book/web/groq 等、または source NULL) は faq_docs を見ない
-  //     → faq_embeddings.is_excluded_from_search のみで判定。
-  // JOIN ON 句に numeric guard を入れて非数値 faq_id での bigint キャスト失敗を防ぐ。
+  // Phase69-2 Round 4: identity-based FAQ visibility (Codex Adversarial Round 3 #1 対応)
+  //
+  // Round 3 では source 文字列リテラル ('scrape'/'text'/'faq') で FAQ 系を判定していたが、
+  // CRUD 経由で書き込まれる embedding は source='faq_crud' のため非 FAQ branch に落ちて
+  // faq_docs.is_published / is_excluded_from_search のチェックをすり抜けていた。
+  //
+  // Round 4 では source 名に依存せず、faq_id identity (= 数値 faq_id + faq_docs JOIN 成功)
+  // で FAQ かどうかを判定する。これにより:
+  //   - FAQ 系 (faq_crud / scrape / text / faq, など faq_id を持つ全 source) は
+  //     faq_docs を厳格にチェック (is_published=true かつ is_excluded_from_search != true)。
+  //   - 非 FAQ (faq_id を持たない book/web/groq 等) は faq_docs を見ず
+  //     faq_embeddings.is_excluded_from_search のみで判定。
+  //   - orphan (数値 faq_id 持ちだが faq_docs 行なし) はどちらの branch にもマッチせず
+  //     検索結果から除外される (Codex Round 2 で問題視された fd.id IS NULL pass-through が消える)。
+  //
+  // JOIN ON 句にも numeric guard を入れて非数値 faq_id での bigint キャスト失敗を防ぐ。
   const sql = `
     select
       fe.id::text as id,
@@ -96,15 +106,15 @@ export async function searchPgVector(
     where (fe.tenant_id = $1 OR fe.tenant_id = 'global')
       and (
         (
-          fe.metadata->>'source' IN ('scrape', 'text', 'faq')
+          fe.metadata->>'faq_id' ~ '^[0-9]+$'
           and fd.id IS NOT NULL
           and fd.is_published = true
           and (fd.is_excluded_from_search IS NULL OR fd.is_excluded_from_search = false)
         )
         OR
         (
-          fe.metadata->>'source' IS NULL
-          OR fe.metadata->>'source' NOT IN ('scrape', 'text', 'faq')
+          fe.metadata->>'faq_id' IS NULL
+          OR fe.metadata->>'faq_id' !~ '^[0-9]+$'
         )
       )
       and (fe.is_excluded_from_search IS NULL OR fe.is_excluded_from_search = false)

--- a/src/search/pgvector.ts
+++ b/src/search/pgvector.ts
@@ -20,6 +20,8 @@ export interface PgVectorSearchParams {
   tenantId: string;
   embedding: number[]; // クエリ埋め込み
   topK?: number;
+  /** Phase69-2: 検索結果から除外するエントリID一覧（テナント分離保証） */
+  excludedIds?: string[];
 }
 
 /**
@@ -46,7 +48,7 @@ export interface PgVectorSearchParams {
 export async function searchPgVector(
   params: PgVectorSearchParams
 ): Promise<PgVectorSearchResult> {
-  const { tenantId, embedding, topK = 20 } = params;
+  const { tenantId, embedding, topK = 20, excludedIds } = params;
 
   if (!pg) {
     return {
@@ -70,8 +72,11 @@ export async function searchPgVector(
   // pgvector 用に '[0.1,0.2,...]' 形式のリテラルを作る
   const embedLiteral = `[${embedding.join(",")}]`;
 
-  // faq_docs と LEFT JOIN して is_published = false のエントリを除外
-  // (metadata に faq_id がない古いエントリはそのまま返す)
+  const safeExcludedIds = (excludedIds ?? []).filter(Boolean);
+  const excludeClause = safeExcludedIds.length > 0
+    ? `and fe.id::text != ALL($4::text[])`
+    : "";
+
   const sql = `
     select
       fe.id::text as id,
@@ -83,12 +88,18 @@ export async function searchPgVector(
       on fd.id = (fe.metadata->>'faq_id')::bigint
     where (fe.tenant_id = $1 OR fe.tenant_id = 'global')
       and (fd.is_published = true OR fd.id IS NULL)
+      and (fd.is_excluded_from_search IS NULL OR fd.is_excluded_from_search = false)
+      and (fe.is_excluded_from_search IS NULL OR fe.is_excluded_from_search = false)
+      ${excludeClause}
     order by fe.embedding <-> $2::vector
     limit $3;
   `;
 
+  const queryParams: unknown[] = [tenantId, embedLiteral, topK];
+  if (safeExcludedIds.length > 0) queryParams.push(safeExcludedIds);
+
   try {
-    const res = await pg.query(sql, [tenantId, embedLiteral, topK]);
+    const res = await pg.query(sql, queryParams);
     const ms = Date.now() - t0;
 
     type PgRow = { id: string; text: string | null; metadata: Record<string, unknown> | null; score: number };

--- a/src/search/pgvector.ts
+++ b/src/search/pgvector.ts
@@ -77,6 +77,12 @@ export async function searchPgVector(
     ? `and fe.id::text != ALL($4::text[])`
     : "";
 
+  // Phase69-2 Round 3: source 判定で FAQ 系 / 非 FAQ 系を分離 (Codex Adversarial #1 対応)
+  //   - FAQ 系 (source IN ('scrape','text','faq')) は faq_docs 厳格チェック
+  //     → fd.id IS NOT NULL 必須。faq_id を持たない legacy embedding は FAQ 検索から除外。
+  //   - 非 FAQ 系 (book/web/groq 等、または source NULL) は faq_docs を見ない
+  //     → faq_embeddings.is_excluded_from_search のみで判定。
+  // JOIN ON 句に numeric guard を入れて非数値 faq_id での bigint キャスト失敗を防ぐ。
   const sql = `
     select
       fe.id::text as id,
@@ -85,10 +91,22 @@ export async function searchPgVector(
       1 - (fe.embedding <-> $2::vector) as score
     from faq_embeddings fe
     left join faq_docs fd
-      on fd.id = (fe.metadata->>'faq_id')::bigint
+      on fe.metadata->>'faq_id' ~ '^[0-9]+$'
+     and fd.id = (fe.metadata->>'faq_id')::bigint
     where (fe.tenant_id = $1 OR fe.tenant_id = 'global')
-      and (fd.is_published = true OR fd.id IS NULL)
-      and (fd.is_excluded_from_search IS NULL OR fd.is_excluded_from_search = false)
+      and (
+        (
+          fe.metadata->>'source' IN ('scrape', 'text', 'faq')
+          and fd.id IS NOT NULL
+          and fd.is_published = true
+          and (fd.is_excluded_from_search IS NULL OR fd.is_excluded_from_search = false)
+        )
+        OR
+        (
+          fe.metadata->>'source' IS NULL
+          OR fe.metadata->>'source' NOT IN ('scrape', 'text', 'faq')
+        )
+      )
       and (fe.is_excluded_from_search IS NULL OR fe.is_excluded_from_search = false)
       ${excludeClause}
     order by fe.embedding <-> $2::vector

--- a/src/search/pgvectorSearch.ts
+++ b/src/search/pgvectorSearch.ts
@@ -9,6 +9,8 @@ export type PgvectorSearchParams = {
   tenantId: string;
   embedding: number[];
   topK?: number;
+  /** Phase69-2: 検索結果から除外するエントリID一覧（テナント分離保証） */
+  excludedIds?: string[];
 };
 
 export type PgvectorSearchItem = {
@@ -29,7 +31,7 @@ export type PgvectorSearchResult = {
 export async function searchPgVector(
   params: PgvectorSearchParams
 ): Promise<PgvectorSearchResult> {
-  const { tenantId, embedding, topK = 5 } = params;
+  const { tenantId, embedding, topK = 5, excludedIds } = params;
   const t0 = performance.now();
 
   if (!pool) {
@@ -40,6 +42,11 @@ export async function searchPgVector(
     return { items: [], ms: 0 };
   }
 
+  const safeExcludedIds = (excludedIds ?? []).filter(Boolean);
+  const excludeClause = safeExcludedIds.length > 0
+    ? `AND id::text != ALL($4::text[])`
+    : "";
+
   const query = `
       SELECT
         id::text,
@@ -47,7 +54,9 @@ export async function searchPgVector(
         metadata,
         1 - (embedding <-> $1::vector) / 2 AS score
       FROM faq_embeddings
-      WHERE tenant_id = $2 OR tenant_id = 'global'
+      WHERE (tenant_id = $2 OR tenant_id = 'global')
+        AND (is_excluded_from_search IS NULL OR is_excluded_from_search = false)
+        ${excludeClause}
       ORDER BY embedding <-> $1::vector
       LIMIT $3
     `;
@@ -56,9 +65,11 @@ export async function searchPgVector(
   // node-postgres would otherwise send this as a Postgres array ("{0.1,0.2,...}"),
   // which causes a "malformed vector literal" error.
   const embeddingLiteral = `[${embedding.join(",")}]`;
+  const queryParams: unknown[] = [embeddingLiteral, tenantId, topK];
+  if (safeExcludedIds.length > 0) queryParams.push(safeExcludedIds);
 
   try {
-    const result = await pool.query(query, [embeddingLiteral, tenantId, topK]);
+    const result = await pool.query(query, queryParams);
     const t1 = performance.now();
 
     const items: PgvectorSearchItem[] = (result.rows as Array<{ id: string; text: string | null; score: number; metadata: Record<string, unknown> | null }>).map((row) => ({

--- a/src/search/rerank.ts
+++ b/src/search/rerank.ts
@@ -218,7 +218,8 @@ export function ceStatus() {
 export async function rerank(
   q: string,
   items: Item[],
-  topK = 5
+  topK = 5,
+  excludedIds?: string[]
 ): Promise<RerankResult> {
   if (!items.length) {
     return { items: [], ce_ms: 0, engine: "heuristic" };
@@ -280,6 +281,12 @@ export async function rerank(
       .slice(0, safeTopK)
       .map(({ __ce: _ce, ...rest }) => rest as Item);
     engineLabel = "heuristic";
+  }
+
+  // Phase69-2: rerank後の二重防御フィルター（upstream フィルター漏れ対応）
+  if (excludedIds && excludedIds.length > 0) {
+    const excludedSet = new Set(excludedIds.filter(Boolean));
+    finalItems = finalItems.filter((it) => !excludedSet.has(it.id));
   }
 
   return {

--- a/tests/agent/agentDialogExcludedIds.test.ts
+++ b/tests/agent/agentDialogExcludedIds.test.ts
@@ -1,0 +1,133 @@
+// tests/agent/agentDialogExcludedIds.test.ts
+// Phase69-2 Round 5 (Codex Round 5 MEDIUM): dialog excluded_ids 入力検証テスト
+
+import express from "express";
+import * as http from "http";
+import { createAgentDialogHandler } from "../../src/agent/http/agentDialogRoute";
+import pino from "pino";
+
+// AgentDialogOrchestrator の run をモック — バリデーション以降の LLM 呼び出しを抑制
+jest.mock("../../src/agent/http/AgentDialogOrchestrator", () => ({
+  AgentDialogOrchestrator: jest.fn().mockImplementation(() => ({
+    run: jest.fn().mockResolvedValue({
+      answer: "mock answer",
+      steps: [],
+      sessionId: "mock-session",
+      needsClarification: false,
+      clarifyingQuestions: [],
+      meta: {
+        route: "20b",
+        plannerReasons: [],
+        orchestratorMode: "langgraph",
+        safetyTag: "none",
+        requiresSafeMode: false,
+        ragStats: {},
+        salesMeta: undefined,
+        plannerPlan: undefined,
+        graphVersion: "langgraph-v1",
+        kpiFunnel: undefined,
+        multiStepPlan: {},
+        sessionId: "mock-session",
+        adapter: { status: "disabled", provider: "none" },
+      },
+    }),
+  })),
+}));
+
+// maybeProbeLemonSliceReadiness もモック
+jest.mock("../../src/agent/http/presentation/lemonSliceAdapter", () => ({
+  maybeProbeLemonSliceReadiness: jest.fn().mockResolvedValue({
+    status: "disabled",
+    provider: "none",
+  }),
+}));
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  const logger = pino({ level: "silent" });
+  const handler = createAgentDialogHandler(logger, {});
+  app.post("/dialog/turn", handler);
+  return app;
+}
+
+function request(
+  app: ReturnType<typeof buildApp>,
+  body: unknown
+): Promise<{ status: number; body: unknown }> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(app).listen(0, () => {
+      const addr = server.address() as { port: number };
+      const bodyStr = JSON.stringify(body);
+      const req = http.request(
+        {
+          hostname: "127.0.0.1",
+          port: addr.port,
+          method: "POST",
+          path: "/dialog/turn",
+          headers: {
+            "Content-Type": "application/json",
+            "Content-Length": Buffer.byteLength(bodyStr),
+          },
+        },
+        (res) => {
+          let data = "";
+          res.on("data", (chunk) => (data += chunk));
+          res.on("end", () => {
+            server.close();
+            try {
+              resolve({ status: res.statusCode ?? 0, body: JSON.parse(data) });
+            } catch {
+              resolve({ status: res.statusCode ?? 0, body: data });
+            }
+          });
+        }
+      );
+      req.on("error", (err) => {
+        server.close();
+        reject(err);
+      });
+      req.write(bodyStr);
+      req.end();
+    });
+  });
+}
+
+describe("dialog /dialog/turn — excluded_ids バリデーション (Phase69-2 Round 5)", () => {
+  it("excluded_ids が 501 件超過の場合 400 を返す", async () => {
+    const app = buildApp();
+    const oversized = Array.from({ length: 501 }, (_, i) => String(i));
+    const res = await request(app, {
+      message: "test query",
+      options: { excluded_ids: oversized },
+    });
+    expect(res.status).toBe(400);
+    expect((res.body as { error: string }).error).toBe("invalid_excluded_ids");
+  });
+
+  it("excluded_ids が 500 件以下の場合は通常処理 (200) される", async () => {
+    const app = buildApp();
+    const withinLimit = Array.from({ length: 500 }, (_, i) => String(i));
+    const res = await request(app, {
+      message: "test query",
+      options: { excluded_ids: withinLimit },
+    });
+    expect(res.status).toBe(200);
+  });
+
+  it("excluded_ids が undefined / null / 空配列でも 400 にならない", async () => {
+    const app = buildApp();
+
+    const resUndef = await request(app, {
+      message: "test query",
+      options: {},
+    });
+    expect(resUndef.status).toBe(200);
+
+    const resEmpty = await request(app, {
+      message: "test query",
+      options: { excluded_ids: [] },
+    });
+    expect(resEmpty.status).toBe(200);
+  });
+});

--- a/tests/faqCrud.test.ts
+++ b/tests/faqCrud.test.ts
@@ -344,3 +344,270 @@ describe("DELETE /v1/admin/knowledge/faq/:id", () => {
     expect(res.status).toBe(400);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Phase69-2 PR-C2 Round 2: PATCH /v1/admin/knowledge/faq/:id/exclude
+// Codex adversarial Round 1 指摘 (HIGH×2, MEDIUM×1) の回帰テスト
+// ---------------------------------------------------------------------------
+
+// Transaction-aware mock helper: db.query (pool-level) + db.connect (client-level)
+function makeTxMockDb(
+  poolQueryImpl: jest.Mock,
+  clientQueryImpl: jest.Mock,
+  releaseImpl?: jest.Mock,
+) {
+  const client = {
+    query: clientQueryImpl,
+    release: releaseImpl ?? jest.fn(),
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return {
+    query: poolQueryImpl,
+    connect: jest.fn().mockResolvedValue(client),
+    __client: client,
+  } as any; // eslint-disable-line @typescript-eslint/no-explicit-any
+}
+
+function buildAppTx(
+  poolQueryImpl: jest.Mock,
+  clientQueryImpl: jest.Mock,
+  releaseImpl?: jest.Mock,
+): { app: Express; db: ReturnType<typeof makeTxMockDb> } {
+  const app = express();
+  app.use(express.json());
+  const db = makeTxMockDb(poolQueryImpl, clientQueryImpl, releaseImpl);
+  const noop = (_req: any, _res: any, next: any) => next(); // eslint-disable-line @typescript-eslint/no-explicit-any
+  registerFaqCrudRoutes(app, db, noop, noop, noop);
+  return { app, db };
+}
+
+describe("PATCH /v1/admin/knowledge/faq/:id/exclude (Phase69-2 PR-C2 Round 2)", () => {
+  const ORIGINAL_ES_URL = process.env.ES_URL;
+
+  beforeEach(() => {
+    mockFetch.mockClear();
+    mockFetch.mockResolvedValue({ ok: true });
+    process.env.ES_URL = "http://es.test:9200";
+    process.env.ES_FAQ_INDEX = "faqs";
+  });
+
+  afterAll(() => {
+    if (ORIGINAL_ES_URL === undefined) delete process.env.ES_URL;
+    else process.env.ES_URL = ORIGINAL_ES_URL;
+  });
+
+  it("[HIGH-1] propagates is_excluded_from_search to ES via POST _update (partial doc)", async () => {
+    const poolQuery = jest.fn().mockResolvedValueOnce({
+      rowCount: 1,
+      rows: [{ id: 42, tenant_id: "tenant-test" }],
+    });
+    const clientQuery = jest.fn().mockResolvedValue({ rowCount: 1 });
+    const { app } = buildAppTx(poolQuery, clientQuery);
+
+    const res = await request(app, "PATCH", "/v1/admin/knowledge/faq/42/exclude", {
+      body: { is_excluded_from_search: true },
+    });
+
+    expect(res.status).toBe(200);
+    // ES fire-and-forget は非同期。次のイベントループまで待つ
+    await new Promise((r) => setImmediate(r));
+    const esCalls = mockFetch.mock.calls.filter((c) =>
+      String(c[0]).includes("/_update/42_tenant-test"),
+    );
+    expect(esCalls).toHaveLength(1);
+    const call = esCalls[0];
+    expect(call[1]?.method).toBe("POST");
+    expect(JSON.parse(call[1]?.body as string)).toEqual({
+      doc: { is_excluded_from_search: true },
+    });
+  });
+
+  it("[HIGH-1] also propagates is_excluded_from_search=false (un-exclude)", async () => {
+    const poolQuery = jest.fn().mockResolvedValueOnce({
+      rowCount: 1,
+      rows: [{ id: 7, tenant_id: "tenant-test" }],
+    });
+    const clientQuery = jest.fn().mockResolvedValue({ rowCount: 1 });
+    const { app } = buildAppTx(poolQuery, clientQuery);
+
+    const res = await request(app, "PATCH", "/v1/admin/knowledge/faq/7/exclude", {
+      body: { is_excluded_from_search: false },
+    });
+
+    expect(res.status).toBe(200);
+    await new Promise((r) => setImmediate(r));
+    const esCalls = mockFetch.mock.calls.filter((c) =>
+      String(c[0]).includes("/_update/7_tenant-test"),
+    );
+    expect(esCalls).toHaveLength(1);
+    expect(JSON.parse(esCalls[0][1]?.body as string)).toEqual({
+      doc: { is_excluded_from_search: false },
+    });
+  });
+
+  it("[HIGH-2] wraps both UPDATEs in a single transaction (BEGIN/COMMIT)", async () => {
+    const poolQuery = jest.fn().mockResolvedValueOnce({
+      rowCount: 1,
+      rows: [{ id: 1, tenant_id: "tenant-test" }],
+    });
+    const clientQuery = jest.fn().mockResolvedValue({ rowCount: 1 });
+    const release = jest.fn();
+    const { app, db } = buildAppTx(poolQuery, clientQuery, release);
+
+    const res = await request(app, "PATCH", "/v1/admin/knowledge/faq/1/exclude", {
+      body: { is_excluded_from_search: true },
+    });
+
+    expect(res.status).toBe(200);
+    expect(db.connect).toHaveBeenCalled();
+    const sqls = clientQuery.mock.calls.map((c) => String(c[0]));
+    expect(sqls[0]).toBe("BEGIN");
+    expect(sqls[1]).toContain("lock_timeout");
+    expect(sqls[2]).toContain("UPDATE faq_docs");
+    expect(sqls[3]).toContain("UPDATE faq_embeddings");
+    expect(sqls[4]).toBe("COMMIT");
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("[HIGH-2] ROLLBACK and returns 500 when faq_embeddings UPDATE fails; ES sync is not called", async () => {
+    const poolQuery = jest.fn().mockResolvedValueOnce({
+      rowCount: 1,
+      rows: [{ id: 2, tenant_id: "tenant-test" }],
+    });
+    // BEGIN, SET, UPDATE faq_docs OK; UPDATE faq_embeddings rejects; ROLLBACK
+    const clientQuery = jest
+      .fn()
+      .mockResolvedValueOnce({ rowCount: 0 }) // BEGIN
+      .mockResolvedValueOnce({ rowCount: 0 }) // SET lock_timeout
+      .mockResolvedValueOnce({ rowCount: 1 }) // UPDATE faq_docs
+      .mockRejectedValueOnce(new Error("cast error")) // UPDATE faq_embeddings
+      .mockResolvedValueOnce({ rowCount: 0 }); // ROLLBACK
+    const release = jest.fn();
+    const { app } = buildAppTx(poolQuery, clientQuery, release);
+
+    const initialEsCalls = mockFetch.mock.calls.length;
+    const res = await request(app, "PATCH", "/v1/admin/knowledge/faq/2/exclude", {
+      body: { is_excluded_from_search: true },
+    });
+
+    expect(res.status).toBe(500);
+    const sqls = clientQuery.mock.calls.map((c) => String(c[0]));
+    expect(sqls).toContain("ROLLBACK");
+    expect(release).toHaveBeenCalledTimes(1);
+    await new Promise((r) => setImmediate(r));
+    // ES 同期は COMMIT 後にしか呼ばれない → エラー時は呼ばれない
+    const esUpdateCalls = mockFetch.mock.calls
+      .slice(initialEsCalls)
+      .filter((c) => String(c[0]).includes("/_update/"));
+    expect(esUpdateCalls).toHaveLength(0);
+  });
+
+  it("[HIGH-2] returns 409 with errorCode DB_LOCK_TIMEOUT when PostgreSQL lock_timeout (55P03) fires", async () => {
+    const poolQuery = jest.fn().mockResolvedValueOnce({
+      rowCount: 1,
+      rows: [{ id: 3, tenant_id: "tenant-test" }],
+    });
+    const lockErr = Object.assign(new Error("canceling statement due to lock timeout"), { code: "55P03" });
+    const clientQuery = jest
+      .fn()
+      .mockResolvedValueOnce({ rowCount: 0 }) // BEGIN
+      .mockResolvedValueOnce({ rowCount: 0 }) // SET lock_timeout
+      .mockRejectedValueOnce(lockErr) // UPDATE faq_docs → lock timeout
+      .mockResolvedValueOnce({ rowCount: 0 }); // ROLLBACK
+    const release = jest.fn();
+    const { app } = buildAppTx(poolQuery, clientQuery, release);
+
+    const res = await request(app, "PATCH", "/v1/admin/knowledge/faq/3/exclude", {
+      body: { is_excluded_from_search: true },
+    });
+
+    expect(res.status).toBe(409);
+    expect((res.body as { error: string }).error).toMatch(/少し時間/);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("[MEDIUM-1] embeddings UPDATE SQL includes numeric guard for metadata->>'faq_id'", async () => {
+    const poolQuery = jest.fn().mockResolvedValueOnce({
+      rowCount: 1,
+      rows: [{ id: 9, tenant_id: "tenant-test" }],
+    });
+    const clientQuery = jest.fn().mockResolvedValue({ rowCount: 0 });
+    const { app } = buildAppTx(poolQuery, clientQuery);
+
+    await request(app, "PATCH", "/v1/admin/knowledge/faq/9/exclude", {
+      body: { is_excluded_from_search: true },
+    });
+
+    const embeddingsCall = clientQuery.mock.calls.find((c) =>
+      String(c[0]).includes("UPDATE faq_embeddings"),
+    );
+    expect(embeddingsCall).toBeDefined();
+    expect(String(embeddingsCall![0])).toMatch(/~ '\^\[0-9\]\+\$'/);
+  });
+
+  it("returns 404 when FAQ does not exist (no transaction opened)", async () => {
+    const poolQuery = jest.fn().mockResolvedValueOnce({ rowCount: 0, rows: [] });
+    const clientQuery = jest.fn();
+    const { app, db } = buildAppTx(poolQuery, clientQuery);
+
+    const res = await request(app, "PATCH", "/v1/admin/knowledge/faq/999/exclude", {
+      body: { is_excluded_from_search: true },
+    });
+
+    expect(res.status).toBe(404);
+    expect(db.connect).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 on tenant mismatch (no transaction opened)", async () => {
+    const poolQuery = jest.fn().mockResolvedValueOnce({
+      rowCount: 1,
+      rows: [{ id: 5, tenant_id: "other-tenant" }],
+    });
+    const clientQuery = jest.fn();
+    const { app, db } = buildAppTx(poolQuery, clientQuery);
+
+    const res = await request(app, "PATCH", "/v1/admin/knowledge/faq/5/exclude", {
+      body: { is_excluded_from_search: true },
+    });
+
+    expect(res.status).toBe(403);
+    expect(db.connect).not.toHaveBeenCalled();
+  });
+
+  it("returns 200 even if ES sync fails (fire-and-forget — DB is source-of-truth)", async () => {
+    const poolQuery = jest.fn().mockResolvedValueOnce({
+      rowCount: 1,
+      rows: [{ id: 11, tenant_id: "tenant-test" }],
+    });
+    const clientQuery = jest.fn().mockResolvedValue({ rowCount: 1 });
+    const { app } = buildAppTx(poolQuery, clientQuery);
+
+    // ES sync が失敗してもAPIは成功
+    mockFetch.mockRejectedValueOnce(new Error("ES connection refused"));
+
+    const res = await request(app, "PATCH", "/v1/admin/knowledge/faq/11/exclude", {
+      body: { is_excluded_from_search: true },
+    });
+
+    expect(res.status).toBe(200);
+    expect((res.body as { is_excluded_from_search: boolean }).is_excluded_from_search).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Phase69-2 PR-C2 Round 2: hybrid.ts ES クエリ永続フィルター回帰
+// ---------------------------------------------------------------------------
+describe("hybridSearch ES query — is_excluded_from_search must_not filter (Phase69-2 PR-C2 Round 2)", () => {
+  it("ES filter.bool.must includes a must_not for is_excluded_from_search: true", () => {
+    // hybrid.ts のクエリ構造を文字列レベルで検証（実 ES 呼び出し不要）
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const fs = require("fs") as typeof import("fs");
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const path = require("path") as typeof import("path");
+    const hybridSrc = fs.readFileSync(
+      path.join(__dirname, "../src/search/hybrid.ts"),
+      "utf-8",
+    );
+    expect(hybridSrc).toMatch(/must_not:\s*{\s*term:\s*{\s*is_excluded_from_search:\s*true\s*}\s*}/);
+  });
+});

--- a/tests/faqCrud.test.ts
+++ b/tests/faqCrud.test.ts
@@ -381,7 +381,7 @@ function buildAppTx(
   return { app, db };
 }
 
-describe("PATCH /v1/admin/knowledge/faq/:id/exclude (Phase69-2 PR-C2 Round 2)", () => {
+describe("PATCH /v1/admin/knowledge/faq/:id/exclude (Phase69-2 Round 2 + Round 4)", () => {
   const ORIGINAL_ES_URL = process.env.ES_URL;
 
   beforeEach(() => {
@@ -396,12 +396,31 @@ describe("PATCH /v1/admin/knowledge/faq/:id/exclude (Phase69-2 PR-C2 Round 2)", 
     else process.env.ES_URL = ORIGINAL_ES_URL;
   });
 
+  // ---- Round 4 (Codex Round 3 MEDIUM-2): in-tx SELECT FOR UPDATE precheck ----
+  //
+  // Round 4 では precheck (existence + tenant) を tx 内に取り込み、
+  // SELECT ... FOR UPDATE で対象行をロックする。これにより precheck → UPDATE 間で
+  // 削除/移動された場合に COMMIT 成功 + 200 を返す check-then-act race が消える。
+  //
+  // 期待される client.query 呼び出し順:
+  //   1. BEGIN
+  //   2. SET LOCAL lock_timeout = '3s'
+  //   3. SELECT id, tenant_id FROM faq_docs WHERE id = $1 FOR UPDATE  ← Round 4 新規
+  //   4. UPDATE faq_docs ...
+  //   5. UPDATE faq_embeddings ...
+  //   6. COMMIT
+
   it("[HIGH-1] propagates is_excluded_from_search to ES via POST _update (partial doc)", async () => {
-    const poolQuery = jest.fn().mockResolvedValueOnce({
-      rowCount: 1,
-      rows: [{ id: 42, tenant_id: "tenant-test" }],
-    });
-    const clientQuery = jest.fn().mockResolvedValue({ rowCount: 1 });
+    const poolQuery = jest.fn();
+    // precheck → SELECT FOR UPDATE → UPDATE faq_docs (rowCount=1) → UPDATE faq_embeddings → COMMIT
+    const clientQuery = jest
+      .fn()
+      .mockResolvedValueOnce({ rowCount: 0 }) // BEGIN
+      .mockResolvedValueOnce({ rowCount: 0 }) // SET lock_timeout
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 42, tenant_id: "tenant-test" }] }) // SELECT FOR UPDATE
+      .mockResolvedValueOnce({ rowCount: 1 }) // UPDATE faq_docs
+      .mockResolvedValueOnce({ rowCount: 0 }) // UPDATE faq_embeddings
+      .mockResolvedValueOnce({ rowCount: 0 }); // COMMIT
     const { app } = buildAppTx(poolQuery, clientQuery);
 
     const res = await request(app, "PATCH", "/v1/admin/knowledge/faq/42/exclude", {
@@ -409,7 +428,6 @@ describe("PATCH /v1/admin/knowledge/faq/:id/exclude (Phase69-2 PR-C2 Round 2)", 
     });
 
     expect(res.status).toBe(200);
-    // ES fire-and-forget は非同期。次のイベントループまで待つ
     await new Promise((r) => setImmediate(r));
     const esCalls = mockFetch.mock.calls.filter((c) =>
       String(c[0]).includes("/_update/42_tenant-test"),
@@ -423,11 +441,15 @@ describe("PATCH /v1/admin/knowledge/faq/:id/exclude (Phase69-2 PR-C2 Round 2)", 
   });
 
   it("[HIGH-1] also propagates is_excluded_from_search=false (un-exclude)", async () => {
-    const poolQuery = jest.fn().mockResolvedValueOnce({
-      rowCount: 1,
-      rows: [{ id: 7, tenant_id: "tenant-test" }],
-    });
-    const clientQuery = jest.fn().mockResolvedValue({ rowCount: 1 });
+    const poolQuery = jest.fn();
+    const clientQuery = jest
+      .fn()
+      .mockResolvedValueOnce({ rowCount: 0 }) // BEGIN
+      .mockResolvedValueOnce({ rowCount: 0 }) // SET
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 7, tenant_id: "tenant-test" }] }) // SELECT FOR UPDATE
+      .mockResolvedValueOnce({ rowCount: 1 }) // UPDATE faq_docs
+      .mockResolvedValueOnce({ rowCount: 0 }) // UPDATE faq_embeddings
+      .mockResolvedValueOnce({ rowCount: 0 }); // COMMIT
     const { app } = buildAppTx(poolQuery, clientQuery);
 
     const res = await request(app, "PATCH", "/v1/admin/knowledge/faq/7/exclude", {
@@ -445,12 +467,16 @@ describe("PATCH /v1/admin/knowledge/faq/:id/exclude (Phase69-2 PR-C2 Round 2)", 
     });
   });
 
-  it("[HIGH-2] wraps both UPDATEs in a single transaction (BEGIN/COMMIT)", async () => {
-    const poolQuery = jest.fn().mockResolvedValueOnce({
-      rowCount: 1,
-      rows: [{ id: 1, tenant_id: "tenant-test" }],
-    });
-    const clientQuery = jest.fn().mockResolvedValue({ rowCount: 1 });
+  it("[HIGH-2 + Round 4] wraps SELECT FOR UPDATE + both UPDATEs in a single transaction (BEGIN/COMMIT)", async () => {
+    const poolQuery = jest.fn();
+    const clientQuery = jest
+      .fn()
+      .mockResolvedValueOnce({ rowCount: 0 }) // BEGIN
+      .mockResolvedValueOnce({ rowCount: 0 }) // SET
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 1, tenant_id: "tenant-test" }] }) // SELECT FOR UPDATE
+      .mockResolvedValueOnce({ rowCount: 1 }) // UPDATE faq_docs
+      .mockResolvedValueOnce({ rowCount: 0 }) // UPDATE faq_embeddings
+      .mockResolvedValueOnce({ rowCount: 0 }); // COMMIT
     const release = jest.fn();
     const { app, db } = buildAppTx(poolQuery, clientQuery, release);
 
@@ -463,22 +489,23 @@ describe("PATCH /v1/admin/knowledge/faq/:id/exclude (Phase69-2 PR-C2 Round 2)", 
     const sqls = clientQuery.mock.calls.map((c) => String(c[0]));
     expect(sqls[0]).toBe("BEGIN");
     expect(sqls[1]).toContain("lock_timeout");
-    expect(sqls[2]).toContain("UPDATE faq_docs");
-    expect(sqls[3]).toContain("UPDATE faq_embeddings");
-    expect(sqls[4]).toBe("COMMIT");
+    expect(sqls[2]).toContain("SELECT id, tenant_id FROM faq_docs");
+    expect(sqls[2]).toContain("FOR UPDATE");
+    expect(sqls[3]).toContain("UPDATE faq_docs");
+    expect(sqls[4]).toContain("UPDATE faq_embeddings");
+    expect(sqls[5]).toBe("COMMIT");
     expect(release).toHaveBeenCalledTimes(1);
+    // pool-level (db.query) precheck は廃止
+    expect(poolQuery).not.toHaveBeenCalled();
   });
 
   it("[HIGH-2] ROLLBACK and returns 500 when faq_embeddings UPDATE fails; ES sync is not called", async () => {
-    const poolQuery = jest.fn().mockResolvedValueOnce({
-      rowCount: 1,
-      rows: [{ id: 2, tenant_id: "tenant-test" }],
-    });
-    // BEGIN, SET, UPDATE faq_docs OK; UPDATE faq_embeddings rejects; ROLLBACK
+    const poolQuery = jest.fn();
     const clientQuery = jest
       .fn()
       .mockResolvedValueOnce({ rowCount: 0 }) // BEGIN
       .mockResolvedValueOnce({ rowCount: 0 }) // SET lock_timeout
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 2, tenant_id: "tenant-test" }] }) // SELECT FOR UPDATE
       .mockResolvedValueOnce({ rowCount: 1 }) // UPDATE faq_docs
       .mockRejectedValueOnce(new Error("cast error")) // UPDATE faq_embeddings
       .mockResolvedValueOnce({ rowCount: 0 }); // ROLLBACK
@@ -495,7 +522,6 @@ describe("PATCH /v1/admin/knowledge/faq/:id/exclude (Phase69-2 PR-C2 Round 2)", 
     expect(sqls).toContain("ROLLBACK");
     expect(release).toHaveBeenCalledTimes(1);
     await new Promise((r) => setImmediate(r));
-    // ES 同期は COMMIT 後にしか呼ばれない → エラー時は呼ばれない
     const esUpdateCalls = mockFetch.mock.calls
       .slice(initialEsCalls)
       .filter((c) => String(c[0]).includes("/_update/"));
@@ -503,16 +529,13 @@ describe("PATCH /v1/admin/knowledge/faq/:id/exclude (Phase69-2 PR-C2 Round 2)", 
   });
 
   it("[HIGH-2] returns 409 with errorCode DB_LOCK_TIMEOUT when PostgreSQL lock_timeout (55P03) fires", async () => {
-    const poolQuery = jest.fn().mockResolvedValueOnce({
-      rowCount: 1,
-      rows: [{ id: 3, tenant_id: "tenant-test" }],
-    });
+    const poolQuery = jest.fn();
     const lockErr = Object.assign(new Error("canceling statement due to lock timeout"), { code: "55P03" });
     const clientQuery = jest
       .fn()
       .mockResolvedValueOnce({ rowCount: 0 }) // BEGIN
       .mockResolvedValueOnce({ rowCount: 0 }) // SET lock_timeout
-      .mockRejectedValueOnce(lockErr) // UPDATE faq_docs → lock timeout
+      .mockRejectedValueOnce(lockErr) // SELECT FOR UPDATE → lock timeout
       .mockResolvedValueOnce({ rowCount: 0 }); // ROLLBACK
     const release = jest.fn();
     const { app } = buildAppTx(poolQuery, clientQuery, release);
@@ -527,11 +550,15 @@ describe("PATCH /v1/admin/knowledge/faq/:id/exclude (Phase69-2 PR-C2 Round 2)", 
   });
 
   it("[MEDIUM-1] embeddings UPDATE SQL includes numeric guard for metadata->>'faq_id'", async () => {
-    const poolQuery = jest.fn().mockResolvedValueOnce({
-      rowCount: 1,
-      rows: [{ id: 9, tenant_id: "tenant-test" }],
-    });
-    const clientQuery = jest.fn().mockResolvedValue({ rowCount: 0 });
+    const poolQuery = jest.fn();
+    const clientQuery = jest
+      .fn()
+      .mockResolvedValueOnce({ rowCount: 0 }) // BEGIN
+      .mockResolvedValueOnce({ rowCount: 0 }) // SET
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 9, tenant_id: "tenant-test" }] }) // SELECT FOR UPDATE
+      .mockResolvedValueOnce({ rowCount: 1 }) // UPDATE faq_docs
+      .mockResolvedValueOnce({ rowCount: 0 }) // UPDATE faq_embeddings
+      .mockResolvedValueOnce({ rowCount: 0 }); // COMMIT
     const { app } = buildAppTx(poolQuery, clientQuery);
 
     await request(app, "PATCH", "/v1/admin/knowledge/faq/9/exclude", {
@@ -545,44 +572,123 @@ describe("PATCH /v1/admin/knowledge/faq/:id/exclude (Phase69-2 PR-C2 Round 2)", 
     expect(String(embeddingsCall![0])).toMatch(/~ '\^\[0-9\]\+\$'/);
   });
 
-  it("returns 404 when FAQ does not exist (no transaction opened)", async () => {
-    const poolQuery = jest.fn().mockResolvedValueOnce({ rowCount: 0, rows: [] });
-    const clientQuery = jest.fn();
-    const { app, db } = buildAppTx(poolQuery, clientQuery);
+  // ---- Round 4 新規 (Codex Round 3 MEDIUM-2 回帰防御) ----
+
+  it("[Round 4] returns 404 when SELECT FOR UPDATE finds 0 rows (in-tx existence check), ROLLBACK called", async () => {
+    const poolQuery = jest.fn();
+    const clientQuery = jest
+      .fn()
+      .mockResolvedValueOnce({ rowCount: 0 }) // BEGIN
+      .mockResolvedValueOnce({ rowCount: 0 }) // SET
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] }) // SELECT FOR UPDATE → 0 rows
+      .mockResolvedValueOnce({ rowCount: 0 }); // ROLLBACK
+    const release = jest.fn();
+    const { app, db } = buildAppTx(poolQuery, clientQuery, release);
 
     const res = await request(app, "PATCH", "/v1/admin/knowledge/faq/999/exclude", {
       body: { is_excluded_from_search: true },
     });
 
     expect(res.status).toBe(404);
-    expect(db.connect).not.toHaveBeenCalled();
+    // pool-level (db.query) precheck は呼ばれない: tx 内 SELECT FOR UPDATE が唯一の存在確認
+    expect(poolQuery).not.toHaveBeenCalled();
+    expect(db.connect).toHaveBeenCalled();
+    const sqls = clientQuery.mock.calls.map((c) => String(c[0]));
+    expect(sqls).toContain("ROLLBACK");
+    expect(sqls.some((s) => /UPDATE faq_/.test(s))).toBe(false); // UPDATE は走らない
+    expect(release).toHaveBeenCalledTimes(1);
+    // ES 同期も呼ばれない
+    await new Promise((r) => setImmediate(r));
+    const esCalls = mockFetch.mock.calls.filter((c) => String(c[0]).includes("/_update/"));
+    expect(esCalls).toHaveLength(0);
   });
 
-  it("returns 403 on tenant mismatch (no transaction opened)", async () => {
-    const poolQuery = jest.fn().mockResolvedValueOnce({
-      rowCount: 1,
-      rows: [{ id: 5, tenant_id: "other-tenant" }],
-    });
-    const clientQuery = jest.fn();
-    const { app, db } = buildAppTx(poolQuery, clientQuery);
+  it("[Round 4] returns 403 on tenant mismatch within tx, ROLLBACK called, no UPDATE", async () => {
+    const poolQuery = jest.fn();
+    const clientQuery = jest
+      .fn()
+      .mockResolvedValueOnce({ rowCount: 0 }) // BEGIN
+      .mockResolvedValueOnce({ rowCount: 0 }) // SET
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 5, tenant_id: "other-tenant" }] }) // SELECT FOR UPDATE
+      .mockResolvedValueOnce({ rowCount: 0 }); // ROLLBACK
+    const release = jest.fn();
+    const { app, db } = buildAppTx(poolQuery, clientQuery, release);
 
     const res = await request(app, "PATCH", "/v1/admin/knowledge/faq/5/exclude", {
       body: { is_excluded_from_search: true },
     });
 
     expect(res.status).toBe(403);
-    expect(db.connect).not.toHaveBeenCalled();
+    expect(poolQuery).not.toHaveBeenCalled();
+    expect(db.connect).toHaveBeenCalled();
+    const sqls = clientQuery.mock.calls.map((c) => String(c[0]));
+    expect(sqls).toContain("ROLLBACK");
+    expect(sqls.some((s) => /UPDATE faq_/.test(s))).toBe(false);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("[Round 4] returns 500 + ROLLBACK if UPDATE faq_docs rowCount !== 1 after SELECT FOR UPDATE (assertion)", async () => {
+    // 想定: FOR UPDATE で行ロック取得直後の UPDATE rowCount=0 は内部矛盾
+    const poolQuery = jest.fn();
+    const clientQuery = jest
+      .fn()
+      .mockResolvedValueOnce({ rowCount: 0 }) // BEGIN
+      .mockResolvedValueOnce({ rowCount: 0 }) // SET
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 1, tenant_id: "tenant-test" }] }) // SELECT FOR UPDATE
+      .mockResolvedValueOnce({ rowCount: 0 }) // UPDATE faq_docs → rowCount=0 (想定外)
+      .mockResolvedValueOnce({ rowCount: 0 }); // ROLLBACK
+    const release = jest.fn();
+    const { app } = buildAppTx(poolQuery, clientQuery, release);
+
+    const res = await request(app, "PATCH", "/v1/admin/knowledge/faq/1/exclude", {
+      body: { is_excluded_from_search: true },
+    });
+
+    expect(res.status).toBe(500);
+    const sqls = clientQuery.mock.calls.map((c) => String(c[0]));
+    expect(sqls).toContain("ROLLBACK");
+    // UPDATE faq_embeddings は走らない (rowCount assertion で早期 ROLLBACK)
+    expect(sqls.some((s) => /UPDATE faq_embeddings/.test(s))).toBe(false);
+    expect(release).toHaveBeenCalledTimes(1);
+    // ES 同期も走らない
+    await new Promise((r) => setImmediate(r));
+    const esCalls = mockFetch.mock.calls.filter((c) => String(c[0]).includes("/_update/"));
+    expect(esCalls).toHaveLength(0);
+  });
+
+  it("[Round 4] SELECT FOR UPDATE SQL contains 'FOR UPDATE' clause", async () => {
+    const poolQuery = jest.fn();
+    const clientQuery = jest
+      .fn()
+      .mockResolvedValueOnce({ rowCount: 0 }) // BEGIN
+      .mockResolvedValueOnce({ rowCount: 0 }) // SET
+      .mockResolvedValueOnce({ rowCount: 0, rows: [] }) // SELECT FOR UPDATE (404 path)
+      .mockResolvedValueOnce({ rowCount: 0 }); // ROLLBACK
+    const { app } = buildAppTx(poolQuery, clientQuery);
+
+    await request(app, "PATCH", "/v1/admin/knowledge/faq/42/exclude", {
+      body: { is_excluded_from_search: true },
+    });
+
+    const selectCall = clientQuery.mock.calls.find((c) =>
+      String(c[0]).includes("SELECT") && String(c[0]).includes("faq_docs"),
+    );
+    expect(selectCall).toBeDefined();
+    expect(String(selectCall![0])).toMatch(/FOR UPDATE/);
   });
 
   it("returns 200 even if ES sync fails (fire-and-forget — DB is source-of-truth)", async () => {
-    const poolQuery = jest.fn().mockResolvedValueOnce({
-      rowCount: 1,
-      rows: [{ id: 11, tenant_id: "tenant-test" }],
-    });
-    const clientQuery = jest.fn().mockResolvedValue({ rowCount: 1 });
+    const poolQuery = jest.fn();
+    const clientQuery = jest
+      .fn()
+      .mockResolvedValueOnce({ rowCount: 0 }) // BEGIN
+      .mockResolvedValueOnce({ rowCount: 0 }) // SET
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 11, tenant_id: "tenant-test" }] }) // SELECT FOR UPDATE
+      .mockResolvedValueOnce({ rowCount: 1 }) // UPDATE faq_docs
+      .mockResolvedValueOnce({ rowCount: 0 }) // UPDATE faq_embeddings
+      .mockResolvedValueOnce({ rowCount: 0 }); // COMMIT
     const { app } = buildAppTx(poolQuery, clientQuery);
 
-    // ES sync が失敗してもAPIは成功
     mockFetch.mockRejectedValueOnce(new Error("ES connection refused"));
 
     const res = await request(app, "PATCH", "/v1/admin/knowledge/faq/11/exclude", {

--- a/tests/faqCrud.test.ts
+++ b/tests/faqCrud.test.ts
@@ -701,6 +701,73 @@ describe("PATCH /v1/admin/knowledge/faq/:id/exclude (Phase69-2 Round 2 + Round 4
 });
 
 // ---------------------------------------------------------------------------
+// Phase69-2 Round 5 (Codex Round 4 Finding #1): upsertToEsAsync に is_excluded_from_search 伝搬
+// ---------------------------------------------------------------------------
+describe("upsertToEsAsync — is_excluded_from_search propagation (Phase69-2 Round 5)", () => {
+  beforeEach(() => {
+    mockFetch.mockClear();
+    process.env.ES_URL = "http://es-test:9200";
+  });
+
+  afterEach(() => {
+    delete process.env.ES_URL;
+  });
+
+  it("POST /faq: ES upsert payload contains is_excluded_from_search: false on create", async () => {
+    const createdRow = {
+      id: 99,
+      tenant_id: "tenant-test",
+      question: "新規Q",
+      answer: "新規A",
+      is_published: true,
+    };
+    const queryMock = jest.fn().mockResolvedValueOnce({ rows: [createdRow] });
+    const app = buildApp(queryMock);
+
+    await request(app, "POST", "/v1/admin/knowledge/faq", {
+      body: { question: "新規Q", answer: "新規A" },
+    });
+
+    await new Promise((r) => setImmediate(r));
+    const esCalls = mockFetch.mock.calls.filter((c) =>
+      String(c[0]).includes("/_doc/99_tenant-test"),
+    );
+    expect(esCalls.length).toBeGreaterThanOrEqual(1);
+    const payload = JSON.parse(esCalls[0][1]?.body as string);
+    expect(payload).toHaveProperty("is_excluded_from_search", false);
+  });
+
+  it("PUT /faq/:id: ES upsert payload contains is_excluded_from_search from updated row", async () => {
+    const updatedRow = {
+      id: 5,
+      tenant_id: "tenant-test",
+      question: "変更Q",
+      answer: "変更A",
+      is_published: true,
+      is_excluded_from_search: true,
+    };
+    const queryMock = jest
+      .fn()
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 5, tenant_id: "tenant-test" }] }) // SELECT check
+      .mockResolvedValueOnce({ rows: [updatedRow] }) // UPDATE RETURNING
+      .mockResolvedValueOnce({ rowCount: 0 }); // DELETE embeddings
+    const app = buildApp(queryMock);
+
+    await request(app, "PUT", "/v1/admin/knowledge/faq/5", {
+      body: { question: "変更Q", answer: "変更A", is_excluded_from_search: true },
+    });
+
+    await new Promise((r) => setImmediate(r));
+    const esCalls = mockFetch.mock.calls.filter((c) =>
+      String(c[0]).includes("/_doc/5_tenant-test"),
+    );
+    expect(esCalls.length).toBeGreaterThanOrEqual(1);
+    const payload = JSON.parse(esCalls[0][1]?.body as string);
+    expect(payload).toHaveProperty("is_excluded_from_search", true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Phase69-2 PR-C2 Round 2: hybrid.ts ES クエリ永続フィルター回帰
 // ---------------------------------------------------------------------------
 describe("hybridSearch ES query — is_excluded_from_search must_not filter (Phase69-2 PR-C2 Round 2)", () => {

--- a/tests/integration/wiring-check.test.ts
+++ b/tests/integration/wiring-check.test.ts
@@ -262,7 +262,7 @@ describe("Flow 2: searchTool wires to hybridSearch (ES/pgvector fallback)", () =
 
     const result = await searchTool({ query: "返品", tenantId: "test-tenant" });
 
-    expect(hybridSearch).toHaveBeenCalledWith("返品", "test-tenant");
+    expect(hybridSearch).toHaveBeenCalledWith("返品", "test-tenant", undefined, undefined);
     expect(result.items.length).toBeGreaterThanOrEqual(1);
     expect(result.items[0]).toHaveProperty("text");
     expect(result.items[0]).toHaveProperty("score");


### PR DESCRIPTION
## Summary

- Phase69-2: `excluded_ids` ゼロ知識検索の実装（pgvector + ES 両パス）
- `/agent.search` と `/agent/dialog` に `excluded_ids` フィールド追加（最大500件）
- `/agent/dialog` で `excluded_ids` の Zod バリデーション追加（Round 5 Final 対応）
- `excluded_ids=null` を `undefined` と同等（除外なし）として扱う
- テスト追加: 超過→400、正常→200、omit/null/[]→200

## Codex Adversarial Round 5 Final Findings

### [MEDIUM] dialog excluded_ids 未検証 → **修正完了**
- `agentDialogRoute.ts` に `z.array(z.string()).max(500)` バリデーション追加
- `null` は `undefined` と同等（`!= null` チェック）
- テスト3件追加

### [HIGH] ES index mismatch → **acknowledged & out-of-scope**
- Phase33-c (2026-03-12, commit 97a764c) からの既存バグ
- Phase69-2-A の責任範囲外（既存パターン踏襲）
- **Phase69-2-E (Asana GID: 1214821660260379, due 2026-05-22) で独立修正**
- 多層防御済み: pgvector path には永続フラグフィルター実装済み
- hybrid 検索の merge 時に request-scope `excluded_ids` で二重防御可能

## Codex Review Round 6 (Final)

> I did not find any introduced defects that are clearly actionable and likely to be fixed by the author. The excluded_ids propagation, validation, and DB/ES filtering changes appear internally consistent across the updated paths.

## Test plan

- [x] Gate 1: `pnpm verify` — 1304 tests all pass, 0 typecheck errors
- [x] Gate 2: security-scan — Critical: 0 / High: 0
- [x] Gate 3: `pnpm build` + `cd admin-ui && pnpm build` — success
- [x] Gate 2.5: Codex adversarial review Round 6 — No material findings
- [ ] Gate 5: `curl https://api.r2c.biz/health` + Admin UI login（人間確認）
- [ ] DB migration: `src/migrations/phase69_2_excluded_ids.sql`（人間手動実行）

## DB Migration

```sql
-- 実行前に VPS で確認クエリを使って既適用済みか確認すること
-- src/migrations/phase69_2_excluded_ids.sql
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)