### PR TITLE
fix(phase69-1.5): PR-C4 v2 remove user_metadata fallback + ALLOWED_ROLES guard in misc admin routes (12 files)

### DIFF
--- a/src/api/admin/avatar/avatarAuthGuard.test.ts
+++ b/src/api/admin/avatar/avatarAuthGuard.test.ts
@@ -1,0 +1,102 @@
+// src/api/admin/avatar/avatarAuthGuard.test.ts
+// Phase69-1.5 PR-C4 v2 — avatar/* (★ PR-C4 v1 で漏れたファイル)
+
+jest.mock('../../../lib/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock('../../../admin/http/supabaseAuthMiddleware', () => ({
+  supabaseAuthMiddleware: (req: any, _res: any, next: any) => {
+    req.supabaseUser = req._mockUser ?? null;
+    next();
+  },
+}));
+jest.mock('../../../auth/supabaseClient', () => ({
+  supabaseAdmin: null,
+}));
+
+import express from 'express';
+import request from 'supertest';
+import { logger } from '../../../lib/logger';
+import { registerAvatarConfigRoutes } from './routes';
+
+function makeApp(user: Record<string, unknown> | null) {
+  const fakeDb = {
+    query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+    connect: jest.fn().mockResolvedValue({
+      query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+      release: jest.fn(),
+    }),
+  };
+  const app = express();
+  app.use(express.json());
+  app.use((req: any, _res: any, next: any) => {
+    req._mockUser = user;
+    next();
+  });
+  registerAvatarConfigRoutes(app, fakeDb);
+  return app;
+}
+
+const TENANT_SCOPED = [
+  { method: 'get' as const, path: '/v1/admin/avatar/configs' },
+  { method: 'post' as const, path: '/v1/admin/avatar/configs' },
+  { method: 'patch' as const, path: '/v1/admin/avatar/configs/123' },
+  { method: 'delete' as const, path: '/v1/admin/avatar/configs/123' },
+  { method: 'post' as const, path: '/v1/admin/avatar/configs/123/activate' },
+  { method: 'post' as const, path: '/v1/admin/avatar/configs/123/reset-to-default' },
+];
+const SUPER_ADMIN_ONLY = [
+  { method: 'post' as const, path: '/v1/admin/avatar/defaults/upload' },
+  { method: 'get' as const, path: '/v1/admin/avatar/configs/all' },
+];
+const ALL = [...TENANT_SCOPED, ...SUPER_ADMIN_ONLY];
+
+beforeEach(() => { jest.clearAllMocks(); });
+
+describe('avatar — ALLOWED_ROLES whitelist', () => {
+  ALL.forEach(({ method, path }) => {
+    it(`${method.toUpperCase()} ${path} — viewer → 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'viewer', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path).send({ name: 'a' });
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('AUTHZ_ROLE_DENIED');
+      expect(logger.warn).toHaveBeenCalled();
+    });
+    it(`${method.toUpperCase()} ${path} — stale JWT → 403`, async () => {
+      const app = makeApp({ user_metadata: { role: 'super_admin', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path).send({ name: 'a' });
+      expect(res.status).toBe(403);
+    });
+    it(`${method.toUpperCase()} ${path} — null user → 403`, async () => {
+      const app = makeApp(null);
+      const res = await (request(app) as any)[method](path).send({ name: 'a' });
+      expect(res.status).toBe(403);
+    });
+  });
+});
+
+describe('avatar SUPER_ADMIN_ONLY denies client_admin', () => {
+  SUPER_ADMIN_ONLY.forEach(({ method, path }) => {
+    it(`${method.toUpperCase()} ${path} — client_admin → 403 AUTHZ_ROLE_DENIED`, async () => {
+      const app = makeApp({ app_metadata: { role: 'client_admin', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path);
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('AUTHZ_ROLE_DENIED');
+    });
+  });
+});
+
+describe('avatar TENANT_SCOPED allow', () => {
+  TENANT_SCOPED.forEach(({ method, path }) => {
+    it(`${method.toUpperCase()} ${path} — super_admin → not 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'super_admin', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path).send({ name: 'a' });
+      expect(res.status).not.toBe(403);
+    });
+    it(`${method.toUpperCase()} ${path} — client_admin → not 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'client_admin', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path).send({ name: 'a' });
+      expect(res.status).not.toBe(403);
+    });
+  });
+});

--- a/src/api/admin/avatar/routes.ts
+++ b/src/api/admin/avatar/routes.ts
@@ -143,15 +143,54 @@ const updateSchema = z.object({
 });
 
 // ---------------------------------------------------------------------------
+// ALLOWED_ROLES whitelist (Phase69-1.5 PR-C4 v2)
+// ---------------------------------------------------------------------------
+
+const ALLOWED_AVATAR_ROLES = ['super_admin', 'client_admin'] as const;
+type AllowedAvatarRole = typeof ALLOWED_AVATAR_ROLES[number];
+function isAllowedAvatarRole(role: unknown): role is AllowedAvatarRole {
+  return typeof role === 'string' &&
+         (ALLOWED_AVATAR_ROLES as readonly string[]).includes(role);
+}
+
+// ---------------------------------------------------------------------------
 // ヘルパー: JWT から tenantId / super_admin 判定
 // ---------------------------------------------------------------------------
 
 function extractAuth(req: Request) {
   const su = (req as any).supabaseUser as Record<string, any> | undefined;
+  const role = su?.app_metadata?.role;
   const tenantId: string = su?.app_metadata?.tenant_id ?? su?.tenant_id ?? "";
-  const isSuperAdmin: boolean =
-    (su?.app_metadata?.role ?? su?.user_metadata?.role ?? "") === "super_admin";
-  return { tenantId, isSuperAdmin };
+  const isSuperAdmin: boolean = role === "super_admin";
+  return { su, role, tenantId, isSuperAdmin };
+}
+
+function denyAvatarRole(req: Request, res: Response, su: Record<string, any> | undefined, role: unknown) {
+  logger.warn({
+    event: 'avatar_access_denied',
+    reason: 'invalid_role',
+    errorCode: 'AUTHZ_ROLE_DENIED',
+    requested_path: req.path,
+    actor_email: su?.['email'] ? String(su['email']).slice(0, 3) + '***' : 'unknown',
+    actor_role: role,
+    required_roles: ALLOWED_AVATAR_ROLES,
+    hasAppMetadataRole: !!su?.['app_metadata']?.role,
+    hasUserMetadataRole: !!su?.['user_metadata']?.role,
+  }, 'avatar access denied: invalid actor role');
+  return res.status(403).json({ error: 'この操作を実行する権限がありません', code: 'AUTHZ_ROLE_DENIED' });
+}
+
+function denyAvatarInsufficient(req: Request, res: Response, su: Record<string, any> | undefined, role: unknown) {
+  logger.warn({
+    event: 'avatar_access_denied',
+    reason: 'insufficient_role',
+    errorCode: 'AUTHZ_ROLE_DENIED',
+    requested_path: req.path,
+    actor_email: su?.['email'] ? String(su['email']).slice(0, 3) + '***' : 'unknown',
+    actor_role: role,
+    required_roles: ['super_admin'],
+  }, 'avatar access denied: super_admin required');
+  return res.status(403).json({ error: 'Super Admin権限が必要です', code: 'AUTHZ_ROLE_DENIED' });
 }
 
 // ---------------------------------------------------------------------------
@@ -170,9 +209,12 @@ export function registerAvatarConfigRoutes(app: Express, db: any): void {
     "/v1/admin/avatar/defaults/upload",
     upload.single("file"),
     async (req: Request, res: Response) => {
-      const { isSuperAdmin } = extractAuth(req);
+      const { su, role, isSuperAdmin } = extractAuth(req);
+      if (!isAllowedAvatarRole(role)) {
+        return denyAvatarRole(req, res, su, role);
+      }
       if (!isSuperAdmin) {
-        return res.status(403).json({ error: 'Super Admin権限が必要です' });
+        return denyAvatarInsufficient(req, res, su, role);
       }
       if (!supabaseAdmin) {
         return res.status(503).json({ error: 'Supabase Storage が利用できません' });
@@ -219,9 +261,12 @@ export function registerAvatarConfigRoutes(app: Express, db: any): void {
   // GET /v1/admin/avatar/configs/all — Super Admin: 全テナント横断一覧 (tenant_name付き)
   // -----------------------------------------------------------------------
   app.get("/v1/admin/avatar/configs/all", async (req: Request, res: Response) => {
-    const { isSuperAdmin } = extractAuth(req);
+    const { su, role, isSuperAdmin } = extractAuth(req);
+    if (!isAllowedAvatarRole(role)) {
+      return denyAvatarRole(req, res, su, role);
+    }
     if (!isSuperAdmin) {
-      return res.status(403).json({ error: "Super Admin権限が必要です" });
+      return denyAvatarInsufficient(req, res, su, role);
     }
     try {
       const result = await db.query(
@@ -241,7 +286,10 @@ export function registerAvatarConfigRoutes(app: Express, db: any): void {
   // GET /v1/admin/avatar/configs — テナント一覧
   // -----------------------------------------------------------------------
   app.get("/v1/admin/avatar/configs", async (req: Request, res: Response) => {
-    const { tenantId, isSuperAdmin } = extractAuth(req);
+    const { su, role, tenantId, isSuperAdmin } = extractAuth(req);
+    if (!isAllowedAvatarRole(role)) {
+      return denyAvatarRole(req, res, su, role);
+    }
 
     // Bug-3 fix: client_admin は tenantId が空でも JWT から取得済みの tenantId を必ず使う。
     // isSuperAdmin の場合のみ query パラメータによるテナント絞り込みを許可する。
@@ -279,7 +327,10 @@ export function registerAvatarConfigRoutes(app: Express, db: any): void {
   // POST /v1/admin/avatar/configs — 新規作成
   // -----------------------------------------------------------------------
   app.post("/v1/admin/avatar/configs", async (req: Request, res: Response) => {
-    const { tenantId } = extractAuth(req);
+    const { su, role, tenantId } = extractAuth(req);
+    if (!isAllowedAvatarRole(role)) {
+      return denyAvatarRole(req, res, su, role);
+    }
 
     if (!tenantId) {
       return res.status(403).json({ error: "テナント情報が取得できません" });
@@ -359,7 +410,10 @@ export function registerAvatarConfigRoutes(app: Express, db: any): void {
   app.patch(
     "/v1/admin/avatar/configs/:id",
     async (req: Request, res: Response) => {
-      const { tenantId, isSuperAdmin } = extractAuth(req);
+      const { su, role, tenantId, isSuperAdmin } = extractAuth(req);
+      if (!isAllowedAvatarRole(role)) {
+        return denyAvatarRole(req, res, su, role);
+      }
       const id = req.params["id"];
 
       const parsed = updateSchema.safeParse(req.body ?? {});
@@ -442,7 +496,10 @@ export function registerAvatarConfigRoutes(app: Express, db: any): void {
   app.delete(
     "/v1/admin/avatar/configs/:id",
     async (req: Request, res: Response) => {
-      const { tenantId, isSuperAdmin } = extractAuth(req);
+      const { su, role, tenantId, isSuperAdmin } = extractAuth(req);
+      if (!isAllowedAvatarRole(role)) {
+        return denyAvatarRole(req, res, su, role);
+      }
       const id = req.params["id"];
 
       try {
@@ -496,7 +553,10 @@ export function registerAvatarConfigRoutes(app: Express, db: any): void {
   app.post(
     "/v1/admin/avatar/configs/:id/activate",
     async (req: Request, res: Response) => {
-      const { tenantId, isSuperAdmin } = extractAuth(req);
+      const { su, role, tenantId, isSuperAdmin } = extractAuth(req);
+      if (!isAllowedAvatarRole(role)) {
+        return denyAvatarRole(req, res, su, role);
+      }
       const id = req.params["id"];
 
       const client = await db.connect();
@@ -550,7 +610,10 @@ export function registerAvatarConfigRoutes(app: Express, db: any): void {
   app.post(
     "/v1/admin/avatar/configs/:id/reset-to-default",
     async (req: Request, res: Response) => {
-      const { tenantId, isSuperAdmin } = extractAuth(req);
+      const { su, role, tenantId, isSuperAdmin } = extractAuth(req);
+      if (!isAllowedAvatarRole(role)) {
+        return denyAvatarRole(req, res, su, role);
+      }
       const id = req.params["id"];
 
       try {

--- a/src/api/admin/chatTest/chatTestAuthGuard.test.ts
+++ b/src/api/admin/chatTest/chatTestAuthGuard.test.ts
@@ -1,0 +1,64 @@
+// src/api/admin/chatTest/chatTestAuthGuard.test.ts
+// Phase69-1.5 PR-C4 v2
+
+jest.mock('../../../lib/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import express from 'express';
+import request from 'supertest';
+import { logger } from '../../../lib/logger';
+import { registerChatTestRoutes } from './routes';
+
+function makeApp(user: Record<string, unknown> | null) {
+  const app = express();
+  app.use(express.json());
+  app.use((req: any, _res: any, next: any) => {
+    if (user) {
+      (req as any).supabaseUser = user;
+    }
+    next();
+  });
+  registerChatTestRoutes(app);
+  return app;
+}
+
+const PATH = '/v1/admin/chat-test/token?tenantId=t1';
+
+beforeEach(() => { jest.clearAllMocks(); });
+
+describe('chat-test — ALLOWED_ROLES whitelist', () => {
+  it('viewer → 403', async () => {
+    const app = makeApp({ app_metadata: { role: 'viewer', tenant_id: 't1' }, email: 't@t.com' });
+    const res = await request(app).get(PATH);
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('AUTHZ_ROLE_DENIED');
+    expect(logger.warn).toHaveBeenCalled();
+  });
+  it('stale JWT (user_metadata.role only) → 403', async () => {
+    const app = makeApp({ user_metadata: { role: 'super_admin', tenant_id: 't1' }, email: 't@t.com' });
+    const res = await request(app).get(PATH);
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('AUTHZ_ROLE_DENIED');
+  });
+  it('top-level role only → 403 (no app_metadata)', async () => {
+    const app = makeApp({ role: 'super_admin', email: 't@t.com' });
+    const res = await request(app).get(PATH);
+    expect(res.status).toBe(403);
+  });
+  it('no user → 403', async () => {
+    const app = makeApp(null);
+    const res = await request(app).get(PATH);
+    expect(res.status).toBe(403);
+  });
+  it('super_admin → not 403', async () => {
+    const app = makeApp({ app_metadata: { role: 'super_admin', tenant_id: 't1' }, email: 't@t.com' });
+    const res = await request(app).get(PATH);
+    expect(res.status).not.toBe(403);
+  });
+  it('client_admin → not 403', async () => {
+    const app = makeApp({ app_metadata: { role: 'client_admin', tenant_id: 't1' }, email: 't@t.com' });
+    const res = await request(app).get(PATH);
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/src/api/admin/chatTest/routes.ts
+++ b/src/api/admin/chatTest/routes.ts
@@ -3,6 +3,17 @@ import type { Express, NextFunction, Request, Response } from "express";
 import jwt from "jsonwebtoken";
 import { logger } from '../../../lib/logger';
 
+// ---------------------------------------------------------------------------
+// ALLOWED_ROLES whitelist (Phase69-1.5 PR-C4 v2)
+// ---------------------------------------------------------------------------
+
+const ALLOWED_CHAT_TEST_ROLES = ['super_admin', 'client_admin'] as const;
+type AllowedChatTestRole = typeof ALLOWED_CHAT_TEST_ROLES[number];
+function isAllowedChatTestRole(role: unknown): role is AllowedChatTestRole {
+  return typeof role === 'string' &&
+         (ALLOWED_CHAT_TEST_ROLES as readonly string[]).includes(role);
+}
+
 
 export function registerChatTestRoutes(app: Express): void {
   // ── インライン認証スタック (knowledge/routes.ts と同パターン) ──────────────
@@ -40,11 +51,21 @@ export function registerChatTestRoutes(app: Express): void {
   // GET /v1/admin/chat-test/token?tenantId=xxx
   app.get("/v1/admin/chat-test/token", chatTestAuth, async (req: Request, res: Response) => {
     const su = (req as any).supabaseUser as Record<string, any> | undefined;
-    const role =
-      su?.app_metadata?.role ?? su?.user_metadata?.role ?? su?.role ?? "anonymous";
+    const role: unknown = su?.app_metadata?.role;
 
-    if (!["super_admin", "client_admin"].includes(role)) {
-      return res.status(403).json({ error: "forbidden", message: "管理者ログインが必要です" });
+    if (!isAllowedChatTestRole(role)) {
+      logger.warn({
+        event: 'chat_test_access_denied',
+        reason: 'invalid_role',
+        errorCode: 'AUTHZ_ROLE_DENIED',
+        requested_path: req.path,
+        actor_email: su?.['email'] ? String(su['email']).slice(0, 3) + '***' : 'unknown',
+        actor_role: role,
+        required_roles: ALLOWED_CHAT_TEST_ROLES,
+        hasAppMetadataRole: !!su?.['app_metadata']?.role,
+        hasUserMetadataRole: !!su?.['user_metadata']?.role,
+      }, 'chat-test access denied: invalid actor role');
+      return res.status(403).json({ error: "forbidden", message: "管理者ログインが必要です", code: 'AUTHZ_ROLE_DENIED' });
     }
 
     // JWT から自テナントID を取得

--- a/src/api/admin/evaluations/evaluationsAuthGuard.test.ts
+++ b/src/api/admin/evaluations/evaluationsAuthGuard.test.ts
@@ -1,0 +1,89 @@
+// src/api/admin/evaluations/evaluationsAuthGuard.test.ts
+// Phase69-1.5 PR-C4 v2
+
+jest.mock('../../../lib/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock('../../../admin/http/supabaseAuthMiddleware', () => ({
+  supabaseAuthMiddleware: (req: any, _res: any, next: any) => {
+    req.supabaseUser = req._mockUser ?? null;
+    next();
+  },
+}));
+jest.mock('./evaluationsRepository', () => ({
+  listEvaluations: jest.fn().mockResolvedValue({ items: [], total: 0 }),
+  getDetailedStats: jest.fn().mockResolvedValue({}),
+  getEvaluationsBySession: jest.fn().mockResolvedValue([]),
+  updateOutcome: jest.fn().mockResolvedValue({ id: 1 }),
+  getKpiStats: jest.fn().mockResolvedValue({}),
+  approveTuningRule: jest.fn().mockResolvedValue({ id: 1 }),
+  rejectTuningRule: jest.fn().mockResolvedValue({ id: 1 }),
+  getEvaluationById: jest.fn().mockResolvedValue(null),
+  checkAlreadyEvaluated: jest.fn().mockResolvedValue(false),
+  updateSuggestedRuleStatus: jest.fn().mockResolvedValue({ id: 1 }),
+  insertTuningRuleFromSuggestion: jest.fn().mockResolvedValue(undefined),
+}));
+
+import express from 'express';
+import request from 'supertest';
+import { logger } from '../../../lib/logger';
+import { registerEvaluationRoutes } from './routes';
+
+function makeApp(user: Record<string, unknown> | null) {
+  const app = express();
+  app.use(express.json());
+  app.use((req: any, _res: any, next: any) => {
+    req._mockUser = user;
+    next();
+  });
+  registerEvaluationRoutes(app);
+  return app;
+}
+
+const ROUTES = [
+  { method: 'get' as const, path: '/v1/admin/evaluations' },
+  { method: 'get' as const, path: '/v1/admin/evaluations/stats' },
+  { method: 'get' as const, path: '/v1/admin/evaluations/kpi-stats' },
+  { method: 'post' as const, path: '/v1/admin/evaluations/trigger' },
+  { method: 'get' as const, path: '/v1/admin/evaluations/by-id/123' },
+  { method: 'patch' as const, path: '/v1/admin/evaluations/123/rules/0' },
+  { method: 'get' as const, path: '/v1/admin/evaluations/sess123' },
+  { method: 'put' as const, path: '/v1/admin/evaluations/123/outcome' },
+  { method: 'put' as const, path: '/v1/admin/tuning/123/approve' },
+  { method: 'put' as const, path: '/v1/admin/tuning/123/reject' },
+];
+
+beforeEach(() => { jest.clearAllMocks(); });
+
+describe('evaluations — ALLOWED_ROLES whitelist', () => {
+  ROUTES.forEach(({ method, path }) => {
+    it(`${method.toUpperCase()} ${path} — viewer → 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'viewer', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path).send({ session_id: 's', action: 'approve', outcome: 'replied' });
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('AUTHZ_ROLE_DENIED');
+      expect(logger.warn).toHaveBeenCalled();
+    });
+    it(`${method.toUpperCase()} ${path} — stale JWT → 403`, async () => {
+      const app = makeApp({ user_metadata: { role: 'super_admin', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path).send({ session_id: 's', action: 'approve', outcome: 'replied' });
+      expect(res.status).toBe(403);
+    });
+    it(`${method.toUpperCase()} ${path} — null user → 401 or 403`, async () => {
+      const app = makeApp(null);
+      const res = await (request(app) as any)[method](path).send({ session_id: 's', action: 'approve', outcome: 'replied' });
+      // PATCH rules/:id uses supabaseAuthMiddleware twice — null user → 401; others → 403
+      expect([401, 403]).toContain(res.status);
+    });
+    it(`${method.toUpperCase()} ${path} — super_admin → not 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'super_admin' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path).send({ session_id: 's', action: 'approve', outcome: 'replied' });
+      expect(res.status).not.toBe(403);
+    });
+    it(`${method.toUpperCase()} ${path} — client_admin → not 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'client_admin', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path).send({ session_id: 's', action: 'approve', outcome: 'replied' });
+      expect(res.status).not.toBe(403);
+    });
+  });
+});

--- a/src/api/admin/evaluations/routes.ts
+++ b/src/api/admin/evaluations/routes.ts
@@ -21,17 +21,45 @@ import {
 import { logger } from '../../../lib/logger';
 
 // ---------------------------------------------------------------------------
+// ALLOWED_ROLES whitelist (Phase69-1.5 PR-C4 v2)
+// ---------------------------------------------------------------------------
+
+const ALLOWED_EVALUATION_ROLES = ['super_admin', 'client_admin'] as const;
+type AllowedEvaluationRole = typeof ALLOWED_EVALUATION_ROLES[number];
+function isAllowedEvaluationRole(role: unknown): role is AllowedEvaluationRole {
+  return typeof role === 'string' &&
+         (ALLOWED_EVALUATION_ROLES as readonly string[]).includes(role);
+}
+
+// ---------------------------------------------------------------------------
 // ユーティリティ
 // ---------------------------------------------------------------------------
 
-function resolveAuth(req: Request): { jwtTenantId: string; isSuperAdmin: boolean; email: string } {
+function resolveAuth(req: Request): { su: Record<string, any> | undefined; role: unknown; jwtTenantId: string; isSuperAdmin: boolean; email: string } {
   const su = (req as any).supabaseUser as Record<string, any> | undefined;
+  const role: unknown = su?.app_metadata?.role;
   return {
-    jwtTenantId:
-      su?.app_metadata?.tenant_id ?? su?.user_metadata?.tenant_id ?? su?.tenant_id ?? "",
-    isSuperAdmin: (su?.app_metadata?.role ?? su?.user_metadata?.role ?? "") === "super_admin",
+    su,
+    role,
+    jwtTenantId: su?.app_metadata?.tenant_id ?? su?.tenant_id ?? "",
+    isSuperAdmin: role === "super_admin",
     email: su?.email ?? "",
   };
+}
+
+function denyEvaluationRole(req: Request, res: Response, su: Record<string, any> | undefined, role: unknown) {
+  logger.warn({
+    event: 'evaluations_access_denied',
+    reason: 'invalid_role',
+    errorCode: 'AUTHZ_ROLE_DENIED',
+    requested_path: req.path,
+    actor_email: su?.['email'] ? String(su['email']).slice(0, 3) + '***' : 'unknown',
+    actor_role: role,
+    required_roles: ALLOWED_EVALUATION_ROLES,
+    hasAppMetadataRole: !!su?.['app_metadata']?.role,
+    hasUserMetadataRole: !!su?.['user_metadata']?.role,
+  }, 'evaluations access denied: invalid actor role');
+  return res.status(403).json({ error: 'この操作を実行する権限がありません', code: 'AUTHZ_ROLE_DENIED' });
 }
 
 function parseDays(raw: unknown, defaultVal: number): number {
@@ -70,7 +98,10 @@ export function registerEvaluationRoutes(app: Express): void {
   // クエリ: tenantId, days(デフォルト7), limit, offset
   // -------------------------------------------------------------------------
   app.get("/v1/admin/evaluations", async (req: Request, res: Response) => {
-    const { jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    const { su, role, jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    if (!isAllowedEvaluationRole(role)) {
+      return denyEvaluationRole(req, res, su, role);
+    }
 
     // super_admin: ?tenantId= で絞り込み可 / client_admin: 自テナント強制
     const tenantId = isSuperAdmin
@@ -100,7 +131,10 @@ export function registerEvaluationRoutes(app: Express): void {
   // クエリ: tenantId, days(デフォルト30)
   // -------------------------------------------------------------------------
   app.get("/v1/admin/evaluations/stats", async (req: Request, res: Response) => {
-    const { jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    const { su, role, jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    if (!isAllowedEvaluationRole(role)) {
+      return denyEvaluationRole(req, res, su, role);
+    }
 
     const tenantId = isSuperAdmin
       ? ((req.query["tenantId"] as string | undefined) || undefined)
@@ -122,7 +156,10 @@ export function registerEvaluationRoutes(app: Express): void {
   // クエリ: tenantId, days(デフォルト30)
   // -------------------------------------------------------------------------
   app.get("/v1/admin/evaluations/kpi-stats", async (req: Request, res: Response) => {
-    const { jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    const { su, role, jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    if (!isAllowedEvaluationRole(role)) {
+      return denyEvaluationRole(req, res, su, role);
+    }
 
     const tenantId = isSuperAdmin
       ? ((req.query["tenantId"] as string | undefined) || undefined)
@@ -144,6 +181,10 @@ export function registerEvaluationRoutes(app: Express): void {
   // 指定セッションの評価を手動トリガー（未評価の場合のみ）
   // -------------------------------------------------------------------------
   app.post("/v1/admin/evaluations/trigger", async (req: Request, res: Response) => {
+    const { su, role } = resolveAuth(req);
+    if (!isAllowedEvaluationRole(role)) {
+      return denyEvaluationRole(req, res, su, role);
+    }
     const { session_id } = (req.body ?? {}) as Record<string, unknown>;
     if (!session_id || typeof session_id !== "string") {
       return res.status(400).json({ error: "session_id is required" });
@@ -174,7 +215,10 @@ export function registerEvaluationRoutes(app: Express): void {
   // NOTE: /:sessionId の catch-all より前に登録する必要あり
   // -------------------------------------------------------------------------
   app.get("/v1/admin/evaluations/by-id/:id", async (req: Request, res: Response) => {
-    const { jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    const { su, role, jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    if (!isAllowedEvaluationRole(role)) {
+      return denyEvaluationRole(req, res, su, role);
+    }
     const id = Number(req.params["id"]);
     if (!Number.isFinite(id) || id <= 0) {
       return res.status(400).json({ error: "id must be a positive integer" });
@@ -202,14 +246,12 @@ export function registerEvaluationRoutes(app: Express): void {
     "/v1/admin/evaluations/:id/rules/:ruleIndex",
     supabaseAuthMiddleware,
     async (req: Request, res: Response) => {
-      const { jwtTenantId, isSuperAdmin, email } = resolveAuth(req);
-      const su = (req as any).supabaseUser as Record<string, any> | undefined;
+      const { su, role, jwtTenantId, isSuperAdmin, email } = resolveAuth(req);
       if (!su) {
         return res.status(401).json({ error: "unauthorized", message: "認証が必要です。" });
       }
-      const role = su.app_metadata?.role ?? su.user_metadata?.role ?? "";
-      if (role !== "super_admin" && role !== "client_admin") {
-        return res.status(403).json({ error: "forbidden", message: "権限がありません。" });
+      if (!isAllowedEvaluationRole(role)) {
+        return denyEvaluationRole(req, res, su, role);
       }
       const id = Number(req.params["id"]);
       const ruleIndex = Number(req.params["ruleIndex"]);
@@ -277,7 +319,10 @@ export function registerEvaluationRoutes(app: Express): void {
   // NOTE: 静的パス (/stats, /kpi-stats) より後に登録する必要あり
   // -------------------------------------------------------------------------
   app.get("/v1/admin/evaluations/:sessionId", async (req: Request, res: Response) => {
-    const { jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    const { su, role, jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    if (!isAllowedEvaluationRole(role)) {
+      return denyEvaluationRole(req, res, su, role);
+    }
     const sessionId = req.params["sessionId"] ?? "";
 
     if (!sessionId) {
@@ -303,7 +348,10 @@ export function registerEvaluationRoutes(app: Express): void {
   // Body: { outcome: 'replied' | 'appointment' | 'lost' | 'unknown' }
   // -------------------------------------------------------------------------
   app.put("/v1/admin/evaluations/:id/outcome", async (req: Request, res: Response) => {
-    const { jwtTenantId, isSuperAdmin, email } = resolveAuth(req);
+    const { su, role, jwtTenantId, isSuperAdmin, email } = resolveAuth(req);
+    if (!isAllowedEvaluationRole(role)) {
+      return denyEvaluationRole(req, res, su, role);
+    }
 
     const id = Number(req.params["id"]);
     if (!Number.isFinite(id) || id <= 0) {
@@ -335,7 +383,10 @@ export function registerEvaluationRoutes(app: Express): void {
   // status → 'active', approved_at = NOW()
   // -------------------------------------------------------------------------
   app.put("/v1/admin/tuning/:id/approve", async (req: Request, res: Response) => {
-    const { jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    const { su, role, jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    if (!isAllowedEvaluationRole(role)) {
+      return denyEvaluationRole(req, res, su, role);
+    }
 
     const id = Number(req.params["id"]);
     if (!Number.isFinite(id) || id <= 0) {
@@ -361,7 +412,10 @@ export function registerEvaluationRoutes(app: Express): void {
   // status → 'rejected', rejected_at = NOW()
   // -------------------------------------------------------------------------
   app.put("/v1/admin/tuning/:id/reject", async (req: Request, res: Response) => {
-    const { jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    const { su, role, jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    if (!isAllowedEvaluationRole(role)) {
+      return denyEvaluationRole(req, res, su, role);
+    }
 
     const id = Number(req.params["id"]);
     if (!Number.isFinite(id) || id <= 0) {

--- a/src/api/admin/knowledge-gaps/knowledgeGapsAuthGuard.test.ts
+++ b/src/api/admin/knowledge-gaps/knowledgeGapsAuthGuard.test.ts
@@ -1,0 +1,105 @@
+// src/api/admin/knowledge-gaps/knowledgeGapsAuthGuard.test.ts
+// Phase69-1.5 PR-C4 v2
+
+jest.mock('../../../lib/db', () => ({
+  pool: null,
+  getPool: () => null,
+}));
+jest.mock('pino', () => () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() }));
+jest.mock('../../../admin/http/supabaseAuthMiddleware', () => ({
+  supabaseAuthMiddleware: (req: any, _res: any, next: any) => {
+    req.supabaseUser = req._mockUser ?? null;
+    next();
+  },
+}));
+jest.mock('../tenants/superAdminMiddleware', () => ({
+  superAdminMiddleware: (req: any, res: any, next: any) => {
+    const role = req.supabaseUser?.app_metadata?.role;
+    if (role !== 'super_admin') {
+      return res.status(403).json({ error: 'forbidden' });
+    }
+    next();
+  },
+}));
+jest.mock('../../../agent/llm/openaiEmbeddingClient', () => ({
+  embedText: jest.fn().mockResolvedValue([0]),
+}));
+jest.mock('../../../agent/gap/gapRecommender', () => ({
+  generateRecommendations: jest.fn().mockResolvedValue([]),
+}));
+jest.mock('../../../lib/gemini/client', () => ({
+  callGeminiJudge: jest.fn().mockResolvedValue('test'),
+}));
+
+import express from 'express';
+import request from 'supertest';
+import { registerKnowledgeGapPhase46Routes } from './routes';
+
+function makeApp(user: Record<string, unknown> | null) {
+  const app = express();
+  app.use(express.json());
+  app.use((req: any, _res: any, next: any) => {
+    req._mockUser = user;
+    next();
+  });
+  registerKnowledgeGapPhase46Routes(app);
+  return app;
+}
+
+const ROUTES = [
+  { method: 'get' as const, path: '/v1/admin/knowledge-gaps' },
+  { method: 'patch' as const, path: '/v1/admin/knowledge-gaps/123' },
+  { method: 'post' as const, path: '/v1/admin/knowledge-gaps/123/add-knowledge' },
+  { method: 'post' as const, path: '/v1/admin/knowledge-gaps/123/suggest-answer' },
+];
+
+beforeEach(() => { jest.clearAllMocks(); });
+
+describe('knowledge-gaps Phase46 — ALLOWED_ROLES whitelist', () => {
+  ROUTES.forEach(({ method, path }) => {
+    it(`${method.toUpperCase()} ${path} — viewer → 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'viewer', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path).send({ action: 'approve', answer_text: 'x' });
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('AUTHZ_ROLE_DENIED');
+    });
+    it(`${method.toUpperCase()} ${path} — stale JWT → 403`, async () => {
+      const app = makeApp({ user_metadata: { role: 'super_admin', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path).send({ action: 'approve', answer_text: 'x' });
+      expect(res.status).toBe(403);
+    });
+    it(`${method.toUpperCase()} ${path} — null user → 403`, async () => {
+      const app = makeApp(null);
+      const res = await (request(app) as any)[method](path).send({ action: 'approve', answer_text: 'x' });
+      expect(res.status).toBe(403);
+    });
+    it(`${method.toUpperCase()} ${path} — super_admin → not 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'super_admin', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path).send({ action: 'approve', answer_text: 'x' });
+      expect(res.status).not.toBe(403);
+    });
+    it(`${method.toUpperCase()} ${path} — client_admin → not 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'client_admin', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path).send({ action: 'approve', answer_text: 'x' });
+      expect(res.status).not.toBe(403);
+    });
+  });
+});
+
+describe('knowledge-gaps generate-recommendations (super_admin only via middleware)', () => {
+  it('viewer → 403', async () => {
+    const app = makeApp({ app_metadata: { role: 'viewer', tenant_id: 't1' }, email: 't@t.com' });
+    const res = await request(app).post('/v1/admin/knowledge-gaps/generate-recommendations').send({ tenant_id: 't1' });
+    expect(res.status).toBe(403);
+  });
+  it('client_admin → 403', async () => {
+    const app = makeApp({ app_metadata: { role: 'client_admin', tenant_id: 't1' }, email: 't@t.com' });
+    const res = await request(app).post('/v1/admin/knowledge-gaps/generate-recommendations').send({ tenant_id: 't1' });
+    expect(res.status).toBe(403);
+  });
+  it('super_admin → not 403', async () => {
+    const app = makeApp({ app_metadata: { role: 'super_admin' }, email: 't@t.com' });
+    const res = await request(app).post('/v1/admin/knowledge-gaps/generate-recommendations').send({ tenant_id: 't1' });
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/src/api/admin/knowledge-gaps/routes.ts
+++ b/src/api/admin/knowledge-gaps/routes.ts
@@ -14,16 +14,42 @@ import { callGeminiJudge } from '../../../lib/gemini/client';
 const logger = pino();
 
 // ---------------------------------------------------------------------------
+// ALLOWED_ROLES whitelist (Phase69-1.5 PR-C4 v2)
+// ---------------------------------------------------------------------------
+
+const ALLOWED_KG_PHASE46_ROLES = ['super_admin', 'client_admin'] as const;
+type AllowedKgPhase46Role = typeof ALLOWED_KG_PHASE46_ROLES[number];
+function isAllowedKgPhase46Role(role: unknown): role is AllowedKgPhase46Role {
+  return typeof role === 'string' &&
+         (ALLOWED_KG_PHASE46_ROLES as readonly string[]).includes(role);
+}
+
+// ---------------------------------------------------------------------------
 // Auth helpers
 // ---------------------------------------------------------------------------
 
-function resolveJwt(req: Request): { jwtTenantId: string; isSuperAdmin: boolean; isClientAdmin: boolean } {
+function resolveJwt(req: Request): { su: Record<string, any> | undefined; role: unknown; jwtTenantId: string; isSuperAdmin: boolean; isClientAdmin: boolean } {
   const su = (req as any).supabaseUser as Record<string, any> | undefined;
+  const role: unknown = su?.app_metadata?.role;
   const jwtTenantId: string = su?.app_metadata?.tenant_id ?? su?.tenant_id ?? '';
-  const role: string = su?.app_metadata?.role ?? su?.user_metadata?.role ?? '';
   const isSuperAdmin = role === 'super_admin';
   const isClientAdmin = role === 'client_admin';
-  return { jwtTenantId, isSuperAdmin, isClientAdmin };
+  return { su, role, jwtTenantId, isSuperAdmin, isClientAdmin };
+}
+
+function denyKgPhase46Role(req: Request, res: Response, su: Record<string, any> | undefined, role: unknown) {
+  logger.warn({
+    event: 'knowledge_gaps_access_denied',
+    reason: 'invalid_role',
+    errorCode: 'AUTHZ_ROLE_DENIED',
+    requested_path: req.path,
+    actor_email: su?.['email'] ? String(su['email']).slice(0, 3) + '***' : 'unknown',
+    actor_role: role,
+    required_roles: ALLOWED_KG_PHASE46_ROLES,
+    hasAppMetadataRole: !!su?.['app_metadata']?.role,
+    hasUserMetadataRole: !!su?.['user_metadata']?.role,
+  }, 'knowledge-gaps access denied: invalid actor role');
+  return res.status(403).json({ error: 'この操作を実行する権限がありません', code: 'AUTHZ_ROLE_DENIED' });
 }
 
 // ---------------------------------------------------------------------------
@@ -117,9 +143,9 @@ export function registerKnowledgeGapPhase46Routes(app: Express): void {
     '/v1/admin/knowledge-gaps',
     supabaseAuthMiddleware,
     async (req: Request, res: Response) => {
-      const { jwtTenantId, isSuperAdmin, isClientAdmin } = resolveJwt(req);
-      if (!isSuperAdmin && !isClientAdmin) {
-        return res.status(403).json({ error: 'forbidden' });
+      const { su, role, jwtTenantId, isSuperAdmin } = resolveJwt(req);
+      if (!isAllowedKgPhase46Role(role)) {
+        return denyKgPhase46Role(req, res, su, role);
       }
 
       const tenantFilter = isSuperAdmin
@@ -238,9 +264,9 @@ export function registerKnowledgeGapPhase46Routes(app: Express): void {
       const id = parseInt(req.params['id'] ?? '', 10);
       if (isNaN(id)) return res.status(400).json({ error: 'id が不正です' });
 
-      const { jwtTenantId, isSuperAdmin, isClientAdmin } = resolveJwt(req);
-      if (!isSuperAdmin && !isClientAdmin) {
-        return res.status(403).json({ error: 'forbidden' });
+      const { su, role, jwtTenantId, isSuperAdmin } = resolveJwt(req);
+      if (!isAllowedKgPhase46Role(role)) {
+        return denyKgPhase46Role(req, res, su, role);
       }
 
       const parsed = recommendationActionSchema.safeParse(req.body);
@@ -309,9 +335,9 @@ export function registerKnowledgeGapPhase46Routes(app: Express): void {
       const id = parseInt(req.params['id'] ?? '', 10);
       if (isNaN(id)) return res.status(400).json({ error: 'id が不正です' });
 
-      const { jwtTenantId, isSuperAdmin, isClientAdmin } = resolveJwt(req);
-      if (!isSuperAdmin && !isClientAdmin) {
-        return res.status(403).json({ error: 'forbidden' });
+      const { su, role, jwtTenantId, isSuperAdmin } = resolveJwt(req);
+      if (!isAllowedKgPhase46Role(role)) {
+        return denyKgPhase46Role(req, res, su, role);
       }
 
       const parsed = addKnowledgeSchema.safeParse(req.body);
@@ -397,9 +423,9 @@ export function registerKnowledgeGapPhase46Routes(app: Express): void {
       const id = parseInt(req.params['id'] ?? '', 10);
       if (isNaN(id)) return res.status(400).json({ error: 'id が不正です' });
 
-      const { jwtTenantId, isSuperAdmin, isClientAdmin } = resolveJwt(req);
-      if (!isSuperAdmin && !isClientAdmin) {
-        return res.status(403).json({ error: 'forbidden' });
+      const { su, role, jwtTenantId, isSuperAdmin } = resolveJwt(req);
+      if (!isAllowedKgPhase46Role(role)) {
+        return denyKgPhase46Role(req, res, su, role);
       }
 
       try {

--- a/src/api/admin/knowledge/knowledgeGapAuthGuard.test.ts
+++ b/src/api/admin/knowledge/knowledgeGapAuthGuard.test.ts
@@ -1,0 +1,73 @@
+// src/api/admin/knowledge/knowledgeGapAuthGuard.test.ts
+// Phase69-1.5 PR-C4 v2 — knowledge/gaps legacy routes
+
+jest.mock('../../../lib/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock('../../../admin/http/supabaseAuthMiddleware', () => ({
+  supabaseAuthMiddleware: (req: any, _res: any, next: any) => {
+    req.supabaseUser = req._mockUser ?? null;
+    next();
+  },
+}));
+jest.mock('./knowledgeGapRepository', () => ({
+  getGaps: jest.fn().mockResolvedValue({ gaps: [], total: 0 }),
+  getGapCount: jest.fn().mockResolvedValue(0),
+  updateGapStatus: jest.fn().mockResolvedValue(true),
+}));
+
+import express from 'express';
+import request from 'supertest';
+import { logger } from '../../../lib/logger';
+import { registerKnowledgeGapRoutes } from './knowledgeGapRoutes';
+
+function makeApp(user: Record<string, unknown> | null) {
+  const app = express();
+  app.use(express.json());
+  app.use((req: any, _res: any, next: any) => {
+    req._mockUser = user;
+    next();
+  });
+  registerKnowledgeGapRoutes(app);
+  return app;
+}
+
+const ROUTES = [
+  { method: 'get' as const, path: '/v1/admin/knowledge/gaps/count' },
+  { method: 'get' as const, path: '/v1/admin/knowledge/gaps' },
+  { method: 'patch' as const, path: '/v1/admin/knowledge/gaps/123' },
+];
+
+beforeEach(() => { jest.clearAllMocks(); });
+
+describe('knowledge/gaps (legacy) — ALLOWED_ROLES whitelist', () => {
+  ROUTES.forEach(({ method, path }) => {
+    it(`${method.toUpperCase()} ${path} — viewer → 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'viewer', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path).send({ status: 'resolved' });
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('AUTHZ_ROLE_DENIED');
+      expect(logger.warn).toHaveBeenCalled();
+    });
+    it(`${method.toUpperCase()} ${path} — stale JWT → 403`, async () => {
+      const app = makeApp({ user_metadata: { role: 'super_admin', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path).send({ status: 'resolved' });
+      expect(res.status).toBe(403);
+    });
+    it(`${method.toUpperCase()} ${path} — null user → 403`, async () => {
+      const app = makeApp(null);
+      const res = await (request(app) as any)[method](path).send({ status: 'resolved' });
+      expect(res.status).toBe(403);
+    });
+    it(`${method.toUpperCase()} ${path} — super_admin → not 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'super_admin', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path).send({ status: 'resolved' });
+      expect(res.status).not.toBe(403);
+    });
+    it(`${method.toUpperCase()} ${path} — client_admin → not 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'client_admin', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path).send({ status: 'resolved' });
+      expect(res.status).not.toBe(403);
+    });
+  });
+});

--- a/src/api/admin/knowledge/knowledgeGapRoutes.ts
+++ b/src/api/admin/knowledge/knowledgeGapRoutes.ts
@@ -12,12 +12,38 @@ import {
 } from "./knowledgeGapRepository";
 import { logger } from '../../../lib/logger';
 
-function resolveJwtTenantId(req: Request): { jwtTenantId: string; isSuperAdmin: boolean } {
+// ---------------------------------------------------------------------------
+// ALLOWED_ROLES whitelist (Phase69-1.5 PR-C4 v2)
+// ---------------------------------------------------------------------------
+
+const ALLOWED_KG_LEGACY_ROLES = ['super_admin', 'client_admin'] as const;
+type AllowedKgLegacyRole = typeof ALLOWED_KG_LEGACY_ROLES[number];
+function isAllowedKgLegacyRole(role: unknown): role is AllowedKgLegacyRole {
+  return typeof role === 'string' &&
+         (ALLOWED_KG_LEGACY_ROLES as readonly string[]).includes(role);
+}
+
+function resolveJwtTenantId(req: Request): { su: Record<string, any> | undefined; role: unknown; jwtTenantId: string; isSuperAdmin: boolean } {
   const su = (req as any).supabaseUser as Record<string, any> | undefined;
+  const role: unknown = su?.app_metadata?.role;
   const jwtTenantId: string = su?.app_metadata?.tenant_id ?? su?.tenant_id ?? "";
-  const isSuperAdmin: boolean =
-    (su?.app_metadata?.role ?? su?.user_metadata?.role ?? "") === "super_admin";
-  return { jwtTenantId, isSuperAdmin };
+  const isSuperAdmin: boolean = role === "super_admin";
+  return { su, role, jwtTenantId, isSuperAdmin };
+}
+
+function denyKgLegacyRole(req: Request, res: Response, su: Record<string, any> | undefined, role: unknown) {
+  logger.warn({
+    event: 'knowledge_gaps_legacy_access_denied',
+    reason: 'invalid_role',
+    errorCode: 'AUTHZ_ROLE_DENIED',
+    requested_path: req.path,
+    actor_email: su?.['email'] ? String(su['email']).slice(0, 3) + '***' : 'unknown',
+    actor_role: role,
+    required_roles: ALLOWED_KG_LEGACY_ROLES,
+    hasAppMetadataRole: !!su?.['app_metadata']?.role,
+    hasUserMetadataRole: !!su?.['user_metadata']?.role,
+  }, 'knowledge/gaps access denied: invalid actor role');
+  return res.status(403).json({ error: 'この操作を実行する権限がありません', code: 'AUTHZ_ROLE_DENIED' });
 }
 
 const updateStatusSchema = z.object({
@@ -33,7 +59,10 @@ export function registerKnowledgeGapRoutes(app: Express): void {
   // NOTE: この route は /:id より先に登録する必要がある
   // -----------------------------------------------------------------------
   app.get("/v1/admin/knowledge/gaps/count", async (req: Request, res: Response) => {
-    const { jwtTenantId, isSuperAdmin } = resolveJwtTenantId(req);
+    const { su, role, jwtTenantId, isSuperAdmin } = resolveJwtTenantId(req);
+    if (!isAllowedKgLegacyRole(role)) {
+      return denyKgLegacyRole(req, res, su, role);
+    }
     const tenantFilter = isSuperAdmin
       ? ((req.query["tenant"] as string | undefined) || undefined)
       : jwtTenantId;
@@ -55,7 +84,10 @@ export function registerKnowledgeGapRoutes(app: Express): void {
   // GET /v1/admin/knowledge/gaps  (一覧)
   // -----------------------------------------------------------------------
   app.get("/v1/admin/knowledge/gaps", async (req: Request, res: Response) => {
-    const { jwtTenantId, isSuperAdmin } = resolveJwtTenantId(req);
+    const { su, role, jwtTenantId, isSuperAdmin } = resolveJwtTenantId(req);
+    if (!isAllowedKgLegacyRole(role)) {
+      return denyKgLegacyRole(req, res, su, role);
+    }
     const tenantFilter = isSuperAdmin
       ? ((req.query["tenant"] as string | undefined) || undefined)
       : jwtTenantId;
@@ -91,7 +123,10 @@ export function registerKnowledgeGapRoutes(app: Express): void {
       return res.status(400).json({ error: "id が不正です" });
     }
 
-    const { jwtTenantId, isSuperAdmin } = resolveJwtTenantId(req);
+    const { su, role, jwtTenantId, isSuperAdmin } = resolveJwtTenantId(req);
+    if (!isAllowedKgLegacyRole(role)) {
+      return denyKgLegacyRole(req, res, su, role);
+    }
     const tenantId = isSuperAdmin ? undefined : jwtTenantId;
 
     if (!isSuperAdmin && !tenantId) {

--- a/src/api/admin/knowledge/knowledgeRoutesAuthGuard.test.ts
+++ b/src/api/admin/knowledge/knowledgeRoutesAuthGuard.test.ts
@@ -1,0 +1,105 @@
+// src/api/admin/knowledge/knowledgeRoutesAuthGuard.test.ts
+// Phase69-1.5 PR-C4 v2 — knowledge/routes.ts requireKnowledgeRole guard tests
+
+jest.mock('../../../lib/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const mockDecode = jest.fn();
+jest.mock('jsonwebtoken', () => ({
+  __esModule: true,
+  default: {
+    decode: (...args: unknown[]) => mockDecode(...args),
+    verify: jest.fn(),
+    sign: jest.fn(),
+  },
+  decode: (...args: unknown[]) => mockDecode(...args),
+  verify: jest.fn(),
+  sign: jest.fn(),
+}));
+
+const mockQuery = jest.fn().mockResolvedValue({ rows: [], rowCount: 0 });
+jest.mock('../../../lib/db', () => ({
+  pool: { query: mockQuery },
+  getPool: () => ({ query: mockQuery }),
+}));
+
+jest.mock('../../../agent/llm/groqClient', () => ({
+  groqClient: { call: jest.fn().mockResolvedValue('[]') },
+}));
+jest.mock('../../../agent/llm/openaiEmbeddingClient', () => ({
+  embedText: jest.fn().mockResolvedValue([0]),
+}));
+jest.mock('./faqCrudRoutes', () => ({
+  registerFaqCrudRoutes: jest.fn(),
+}));
+jest.mock('./bookPdfRoutes', () => ({
+  registerBookPdfRoutes: jest.fn(),
+}));
+jest.mock('../../../lib/crypto/textEncrypt', () => ({
+  encryptText: (s: string) => s,
+}));
+
+import express from 'express';
+import request from 'supertest';
+import { logger } from '../../../lib/logger';
+import { registerKnowledgeAdminRoutes } from './routes';
+
+const ORIGINAL_NODE_ENV = process.env['NODE_ENV'];
+
+beforeAll(() => {
+  process.env['NODE_ENV'] = 'development';
+});
+afterAll(() => {
+  process.env['NODE_ENV'] = ORIGINAL_NODE_ENV;
+});
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+});
+
+function makeApp(decoded: Record<string, unknown> | null) {
+  mockDecode.mockReturnValue(decoded);
+  const app = express();
+  app.use(express.json());
+  registerKnowledgeAdminRoutes(app);
+  return app;
+}
+
+const PATH = '/v1/admin/knowledge?tenant=t1';
+
+describe('knowledge — requireKnowledgeRole guard', () => {
+  it('viewer → 403 AUTHZ_ROLE_DENIED', async () => {
+    const app = makeApp({ app_metadata: { role: 'viewer', tenant_id: 't1' }, email: 't@t.com' });
+    const res = await request(app).get(PATH).set('Authorization', 'Bearer fake');
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('AUTHZ_ROLE_DENIED');
+    expect(logger.warn).toHaveBeenCalled();
+  });
+  it('stale JWT (user_metadata.role only) → 403 (app_metadata.role missing)', async () => {
+    const app = makeApp({ user_metadata: { role: 'super_admin' }, email: 't@t.com' });
+    const res = await request(app).get(PATH).set('Authorization', 'Bearer fake');
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('AUTHZ_ROLE_DENIED');
+  });
+  it('no app_metadata, top-level role → 403', async () => {
+    const app = makeApp({ role: 'super_admin', email: 't@t.com' });
+    const res = await request(app).get(PATH).set('Authorization', 'Bearer fake');
+    expect(res.status).toBe(403);
+  });
+  it('null decode → 403 anonymous', async () => {
+    const app = makeApp(null);
+    const res = await request(app).get(PATH).set('Authorization', 'Bearer fake');
+    expect(res.status).toBe(403);
+  });
+  it('super_admin → not 403', async () => {
+    const app = makeApp({ app_metadata: { role: 'super_admin', tenant_id: 't1' }, email: 't@t.com' });
+    const res = await request(app).get(PATH).set('Authorization', 'Bearer fake');
+    expect(res.status).not.toBe(403);
+  });
+  it('client_admin → not 403', async () => {
+    const app = makeApp({ app_metadata: { role: 'client_admin', tenant_id: 't1' }, email: 't@t.com' });
+    const res = await request(app).get(PATH).set('Authorization', 'Bearer fake');
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/src/api/admin/knowledge/routes.ts
+++ b/src/api/admin/knowledge/routes.ts
@@ -245,7 +245,7 @@ export function registerKnowledgeAdminRoutes(app: Express): void {
       (req as KnowledgeReq).user = {
         id: su.sub ?? su.id ?? "",
         email: su.email ?? "",
-        role: su.app_metadata?.role ?? su.user_metadata?.role ?? "anonymous",
+        role: su.app_metadata?.role ?? "anonymous",
         tenantId: su.app_metadata?.tenant_id ?? null,
       };
     } else {
@@ -254,11 +254,25 @@ export function registerKnowledgeAdminRoutes(app: Express): void {
     next();
   }
 
-  // role チェック（super_admin / client_admin のみ通過）
+  // role チェック（super_admin / client_admin のみ通過 — Phase69-1.5 PR-C4 v2: ALLOWED_KNOWLEDGE_ROLES 統合）
+  const ALLOWED_KNOWLEDGE_ROLES = ["super_admin", "client_admin"] as const;
   function requireKnowledgeRole(req: Request, res: Response, next: NextFunction): void {
     const user = (req as KnowledgeReq).user;
-    if (!user || !["super_admin", "client_admin"].includes(user.role ?? "")) {
-      res.status(403).json({ error: "forbidden", message: "この操作を行う権限がありません" });
+    const role = user?.role ?? "";
+    if (!user || !(ALLOWED_KNOWLEDGE_ROLES as readonly string[]).includes(role)) {
+      const su = (req as KnowledgeReq).supabaseUser;
+      logger.warn({
+        event: 'knowledge_access_denied',
+        reason: 'invalid_role',
+        errorCode: 'AUTHZ_ROLE_DENIED',
+        requested_path: req.path,
+        actor_email: su?.email ? String(su.email).slice(0, 3) + '***' : 'unknown',
+        actor_role: role,
+        required_roles: ALLOWED_KNOWLEDGE_ROLES,
+        hasAppMetadataRole: !!su?.app_metadata?.role,
+        hasUserMetadataRole: !!(su as any)?.user_metadata?.role,
+      }, 'knowledge access denied: invalid actor role');
+      res.status(403).json({ error: "forbidden", message: "この操作を行う権限がありません", code: 'AUTHZ_ROLE_DENIED' });
       return;
     }
     next();

--- a/src/api/admin/monitoring/monitoringAuthGuard.test.ts
+++ b/src/api/admin/monitoring/monitoringAuthGuard.test.ts
@@ -1,0 +1,72 @@
+// src/api/admin/monitoring/monitoringAuthGuard.test.ts
+// Phase69-1.5 PR-C4 v2
+
+jest.mock('../../../lib/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock('../../../admin/http/supabaseAuthMiddleware', () => ({
+  supabaseAuthMiddleware: (req: any, _res: any, next: any) => {
+    req.supabaseUser = req._mockUser ?? null;
+    next();
+  },
+}));
+jest.mock('../../../lib/db', () => ({
+  getPool: () => null,
+  pool: null,
+}));
+
+import express from 'express';
+import request from 'supertest';
+import { logger } from '../../../lib/logger';
+import { registerMonitoringRoutes } from './routes';
+
+function makeApp(user: Record<string, unknown> | null) {
+  const app = express();
+  app.use(express.json());
+  app.use((req: any, _res: any, next: any) => {
+    req._mockUser = user;
+    next();
+  });
+  registerMonitoringRoutes(app);
+  return app;
+}
+
+const PATH = '/v1/admin/monitoring/kpis';
+
+beforeEach(() => { jest.clearAllMocks(); });
+
+describe('monitoring — ALLOWED_ROLES whitelist', () => {
+  it('viewer → 403 AUTHZ_ROLE_DENIED', async () => {
+    const app = makeApp({ app_metadata: { role: 'viewer', tenant_id: 't1' }, email: 't@t.com' });
+    const res = await request(app).get(PATH);
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('AUTHZ_ROLE_DENIED');
+    expect(logger.warn).toHaveBeenCalled();
+  });
+  it('stale JWT (user_metadata.role only) → 403', async () => {
+    const app = makeApp({ user_metadata: { role: 'super_admin' }, email: 't@t.com' });
+    const res = await request(app).get(PATH);
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('AUTHZ_ROLE_DENIED');
+  });
+  it('top-level role only → 403 (no app_metadata)', async () => {
+    const app = makeApp({ role: 'super_admin', email: 't@t.com' });
+    const res = await request(app).get(PATH);
+    expect(res.status).toBe(403);
+  });
+  it('null user → 403', async () => {
+    const app = makeApp(null);
+    const res = await request(app).get(PATH);
+    expect(res.status).toBe(403);
+  });
+  it('super_admin → not 403', async () => {
+    const app = makeApp({ app_metadata: { role: 'super_admin' }, email: 't@t.com' });
+    const res = await request(app).get(PATH);
+    expect(res.status).not.toBe(403);
+  });
+  it('client_admin → not 403', async () => {
+    const app = makeApp({ app_metadata: { role: 'client_admin', tenant_id: 't1' }, email: 't@t.com' });
+    const res = await request(app).get(PATH);
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/src/api/admin/monitoring/routes.ts
+++ b/src/api/admin/monitoring/routes.ts
@@ -5,6 +5,17 @@ import type { Express, Request, Response } from "express";
 import { supabaseAuthMiddleware } from "../../../admin/http/supabaseAuthMiddleware";
 import { logger } from "../../../lib/logger";
 
+// ---------------------------------------------------------------------------
+// ALLOWED_ROLES whitelist (Phase69-1.5 PR-C4 v2)
+// ---------------------------------------------------------------------------
+
+const ALLOWED_MONITORING_ROLES = ['super_admin', 'client_admin'] as const;
+type AllowedMonitoringRole = typeof ALLOWED_MONITORING_ROLES[number];
+function isAllowedMonitoringRole(role: unknown): role is AllowedMonitoringRole {
+  return typeof role === 'string' &&
+         (ALLOWED_MONITORING_ROLES as readonly string[]).includes(role);
+}
+
 const DEFAULT_SLA = {
   completionRateMin: 70,
   loopRateMax: 10,
@@ -87,11 +98,21 @@ export function registerMonitoringRoutes(app: Express): void {
 
   app.get("/v1/admin/monitoring/kpis", async (req: Request, res: Response) => {
     const su = (req as any).supabaseUser as Record<string, any> | undefined;
-    const role =
-      su?.app_metadata?.role ?? su?.user_metadata?.role ?? su?.role ?? "anonymous";
+    const role: unknown = su?.app_metadata?.role;
 
-    if (!["super_admin", "client_admin"].includes(role)) {
-      res.status(403).json({ error: "forbidden", message: "管理者ログインが必要です" });
+    if (!isAllowedMonitoringRole(role)) {
+      logger.warn({
+        event: 'monitoring_access_denied',
+        reason: 'invalid_role',
+        errorCode: 'AUTHZ_ROLE_DENIED',
+        requested_path: req.path,
+        actor_email: su?.['email'] ? String(su['email']).slice(0, 3) + '***' : 'unknown',
+        actor_role: role,
+        required_roles: ALLOWED_MONITORING_ROLES,
+        hasAppMetadataRole: !!su?.['app_metadata']?.role,
+        hasUserMetadataRole: !!su?.['user_metadata']?.role,
+      }, 'monitoring access denied: invalid actor role');
+      res.status(403).json({ error: "forbidden", message: "管理者ログインが必要です", code: 'AUTHZ_ROLE_DENIED' });
       return;
     }
 

--- a/src/api/admin/notifications/notificationsAuthGuard.test.ts
+++ b/src/api/admin/notifications/notificationsAuthGuard.test.ts
@@ -1,0 +1,96 @@
+// src/api/admin/notifications/notificationsAuthGuard.test.ts
+// Phase69-1.5 PR-C4 v2
+
+jest.mock('../../../lib/db', () => ({
+  pool: null,
+  getPool: () => null,
+}));
+jest.mock('../../../lib/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock('../../../admin/http/supabaseAuthMiddleware', () => ({
+  supabaseAuthMiddleware: (req: any, _res: any, next: any) => {
+    req.supabaseUser = req._mockUser ?? null;
+    next();
+  },
+}));
+
+import express from 'express';
+import request from 'supertest';
+import { logger } from '../../../lib/logger';
+import { registerNotificationRoutes } from './routes';
+
+function makeApp(user: Record<string, unknown> | null) {
+  const app = express();
+  app.use(express.json());
+  app.use((req: any, _res: any, next: any) => {
+    req._mockUser = user;
+    next();
+  });
+  registerNotificationRoutes(app);
+  return app;
+}
+
+const TENANT_SCOPED = [
+  { method: 'get' as const, path: '/v1/admin/notifications' },
+  { method: 'patch' as const, path: '/v1/admin/notifications/read-all' },
+  { method: 'patch' as const, path: '/v1/admin/notifications/123/read' },
+];
+const SUPER_ADMIN_ONLY = [
+  { method: 'post' as const, path: '/v1/admin/notifications' },
+];
+const ALL_ROUTES = [...TENANT_SCOPED, ...SUPER_ADMIN_ONLY];
+
+beforeEach(() => { jest.clearAllMocks(); });
+
+describe('notifications — ALLOWED_ROLES whitelist', () => {
+  ALL_ROUTES.forEach(({ method, path }) => {
+    it(`${method.toUpperCase()} ${path} — viewer → 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'viewer', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path).send({
+        recipient_tenant_id: 't1', title: 'x', message: 'y',
+      });
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('AUTHZ_ROLE_DENIED');
+      expect(logger.warn).toHaveBeenCalled();
+    });
+    it(`${method.toUpperCase()} ${path} — stale JWT → 403`, async () => {
+      const app = makeApp({ user_metadata: { role: 'super_admin', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path).send({});
+      expect(res.status).toBe(403);
+    });
+    it(`${method.toUpperCase()} ${path} — null user → 403`, async () => {
+      const app = makeApp(null);
+      const res = await (request(app) as any)[method](path).send({});
+      expect(res.status).toBe(403);
+    });
+  });
+});
+
+describe('notifications — TENANT_SCOPED allow', () => {
+  TENANT_SCOPED.forEach(({ method, path }) => {
+    it(`${method.toUpperCase()} ${path} — super_admin → not 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'super_admin', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path).send({});
+      expect(res.status).not.toBe(403);
+    });
+    it(`${method.toUpperCase()} ${path} — client_admin → not 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'client_admin', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path).send({});
+      expect(res.status).not.toBe(403);
+    });
+  });
+});
+
+describe('notifications — SUPER_ADMIN_ONLY denies client_admin', () => {
+  SUPER_ADMIN_ONLY.forEach(({ method, path }) => {
+    it(`${method.toUpperCase()} ${path} — client_admin → 403 AUTHZ_ROLE_DENIED`, async () => {
+      const app = makeApp({ app_metadata: { role: 'client_admin', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path).send({
+        recipient_tenant_id: 't1', title: 'x', message: 'y',
+      });
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('AUTHZ_ROLE_DENIED');
+    });
+  });
+});

--- a/src/api/admin/notifications/routes.ts
+++ b/src/api/admin/notifications/routes.ts
@@ -7,12 +7,51 @@ import { supabaseAuthMiddleware } from '../../../admin/http/supabaseAuthMiddlewa
 import { getPool } from '../../../lib/db';
 import { logger } from '../../../lib/logger';
 
+// ---------------------------------------------------------------------------
+// ALLOWED_ROLES whitelist (Phase69-1.5 PR-C4 v2)
+// ---------------------------------------------------------------------------
+
+const ALLOWED_NOTIFICATION_ROLES = ['super_admin', 'client_admin'] as const;
+type AllowedNotificationRole = typeof ALLOWED_NOTIFICATION_ROLES[number];
+function isAllowedNotificationRole(role: unknown): role is AllowedNotificationRole {
+  return typeof role === 'string' &&
+         (ALLOWED_NOTIFICATION_ROLES as readonly string[]).includes(role);
+}
+
 function extractAuth(req: Request) {
   const su = (req as any).supabaseUser as Record<string, any> | undefined;
+  const role = su?.app_metadata?.role;
   const tenantId: string = su?.app_metadata?.tenant_id ?? su?.tenant_id ?? '';
-  const isSuperAdmin: boolean =
-    (su?.app_metadata?.role ?? su?.user_metadata?.role ?? '') === 'super_admin';
-  return { tenantId, isSuperAdmin };
+  const isSuperAdmin: boolean = role === 'super_admin';
+  return { su, role, tenantId, isSuperAdmin };
+}
+
+function denyNotificationRole(req: Request, res: Response, su: Record<string, any> | undefined, role: unknown) {
+  logger.warn({
+    event: 'notifications_access_denied',
+    reason: 'invalid_role',
+    errorCode: 'AUTHZ_ROLE_DENIED',
+    requested_path: req.path,
+    actor_email: su?.['email'] ? String(su['email']).slice(0, 3) + '***' : 'unknown',
+    actor_role: role,
+    required_roles: ALLOWED_NOTIFICATION_ROLES,
+    hasAppMetadataRole: !!su?.['app_metadata']?.role,
+    hasUserMetadataRole: !!su?.['user_metadata']?.role,
+  }, 'notifications access denied: invalid actor role');
+  return res.status(403).json({ error: 'この操作を実行する権限がありません', code: 'AUTHZ_ROLE_DENIED' });
+}
+
+function denyNotificationInsufficient(req: Request, res: Response, su: Record<string, any> | undefined, role: unknown) {
+  logger.warn({
+    event: 'notifications_access_denied',
+    reason: 'insufficient_role',
+    errorCode: 'AUTHZ_ROLE_DENIED',
+    requested_path: req.path,
+    actor_email: su?.['email'] ? String(su['email']).slice(0, 3) + '***' : 'unknown',
+    actor_role: role,
+    required_roles: ['super_admin'],
+  }, 'notifications access denied: super_admin required');
+  return res.status(403).json({ error: '権限がありません', code: 'AUTHZ_ROLE_DENIED' });
 }
 
 export function registerNotificationRoutes(app: Express): void {
@@ -24,7 +63,10 @@ export function registerNotificationRoutes(app: Express): void {
   // Client Admin: client_admin AND (自テナント OR recipient_tenant_id IS NULL)
   // -----------------------------------------------------------------------
   app.get('/v1/admin/notifications', async (req: Request, res: Response) => {
-    const { tenantId, isSuperAdmin } = extractAuth(req);
+    const { su, role, tenantId, isSuperAdmin } = extractAuth(req);
+    if (!isAllowedNotificationRole(role)) {
+      return denyNotificationRole(req, res, su, role);
+    }
     const isReadParam = req.query['is_read'] as string | undefined;
     const limit = Math.min(parseInt((req.query['limit'] as string) ?? '20', 10), 100);
     const offset = Math.max(0, parseInt((req.query['offset'] as string) ?? '0', 10));
@@ -88,7 +130,10 @@ export function registerNotificationRoutes(app: Express): void {
   // ※ /:id/read より前に登録する必要はないが安全のため先に登録
   // -----------------------------------------------------------------------
   app.patch('/v1/admin/notifications/read-all', async (req: Request, res: Response) => {
-    const { tenantId, isSuperAdmin } = extractAuth(req);
+    const { su, role, tenantId, isSuperAdmin } = extractAuth(req);
+    if (!isAllowedNotificationRole(role)) {
+      return denyNotificationRole(req, res, su, role);
+    }
 
     try {
       const pool = getPool();
@@ -126,7 +171,10 @@ export function registerNotificationRoutes(app: Express): void {
       return res.status(400).json({ error: 'id が不正です' });
     }
 
-    const { tenantId, isSuperAdmin } = extractAuth(req);
+    const { su, role, tenantId, isSuperAdmin } = extractAuth(req);
+    if (!isAllowedNotificationRole(role)) {
+      return denyNotificationRole(req, res, su, role);
+    }
 
     try {
       const pool = getPool();
@@ -158,8 +206,13 @@ export function registerNotificationRoutes(app: Express): void {
   // POST /v1/admin/notifications — Super Admin → テナント宛通知送信 (Phase63)
   // -----------------------------------------------------------------------
   app.post('/v1/admin/notifications', async (req: Request, res: Response) => {
-    const { isSuperAdmin } = extractAuth(req);
-    if (!isSuperAdmin) return res.status(403).json({ error: '権限がありません' });
+    const { su, role, isSuperAdmin } = extractAuth(req);
+    if (!isAllowedNotificationRole(role)) {
+      return denyNotificationRole(req, res, su, role);
+    }
+    if (!isSuperAdmin) {
+      return denyNotificationInsufficient(req, res, su, role);
+    }
 
     const { recipient_tenant_id, type, title, message, link, metadata } = req.body as Record<string, unknown>;
     if (!recipient_tenant_id || !title || !message) {

--- a/src/api/admin/objection-patterns/objectionPatternsAuthGuard.test.ts
+++ b/src/api/admin/objection-patterns/objectionPatternsAuthGuard.test.ts
@@ -1,0 +1,73 @@
+// src/api/admin/objection-patterns/objectionPatternsAuthGuard.test.ts
+// Phase69-1.5 PR-C4 v2
+
+jest.mock('../../../lib/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock('../../../admin/http/supabaseAuthMiddleware', () => ({
+  supabaseAuthMiddleware: (req: any, _res: any, next: any) => {
+    req.supabaseUser = req._mockUser ?? null;
+    next();
+  },
+}));
+jest.mock('./objectionPatternsRepository', () => ({
+  listObjectionPatterns: jest.fn().mockResolvedValue([]),
+  getObjectionPattern: jest.fn().mockResolvedValue(null),
+  deleteObjectionPattern: jest.fn().mockResolvedValue(true),
+}));
+
+import express from 'express';
+import request from 'supertest';
+import { logger } from '../../../lib/logger';
+import { registerObjectionPatternRoutes } from './routes';
+
+function makeApp(user: Record<string, unknown> | null) {
+  const app = express();
+  app.use(express.json());
+  app.use((req: any, _res: any, next: any) => {
+    req._mockUser = user;
+    next();
+  });
+  registerObjectionPatternRoutes(app);
+  return app;
+}
+
+const ROUTES = [
+  { method: 'get' as const, path: '/v1/admin/objection-patterns?tenantId=t1' },
+  { method: 'get' as const, path: '/v1/admin/objection-patterns/123' },
+  { method: 'delete' as const, path: '/v1/admin/objection-patterns/123' },
+];
+
+beforeEach(() => { jest.clearAllMocks(); });
+
+describe('objection-patterns — ALLOWED_ROLES whitelist', () => {
+  ROUTES.forEach(({ method, path }) => {
+    it(`${method.toUpperCase()} ${path} — viewer → 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'viewer', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path);
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('AUTHZ_ROLE_DENIED');
+      expect(logger.warn).toHaveBeenCalled();
+    });
+    it(`${method.toUpperCase()} ${path} — stale JWT (user_metadata.role only) → 403`, async () => {
+      const app = makeApp({ user_metadata: { role: 'super_admin', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path);
+      expect(res.status).toBe(403);
+    });
+    it(`${method.toUpperCase()} ${path} — null user → 403`, async () => {
+      const app = makeApp(null);
+      const res = await (request(app) as any)[method](path);
+      expect(res.status).toBe(403);
+    });
+    it(`${method.toUpperCase()} ${path} — super_admin → not 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'super_admin', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path);
+      expect(res.status).not.toBe(403);
+    });
+    it(`${method.toUpperCase()} ${path} — client_admin → not 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'client_admin', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path);
+      expect(res.status).not.toBe(403);
+    });
+  });
+});

--- a/src/api/admin/objection-patterns/routes.ts
+++ b/src/api/admin/objection-patterns/routes.ts
@@ -12,15 +12,44 @@ import {
 import { logger } from '../../../lib/logger';
 
 // ---------------------------------------------------------------------------
+// ALLOWED_ROLES whitelist (Phase69-1.5 PR-C4 v2)
+// ---------------------------------------------------------------------------
+
+const ALLOWED_OBJECTION_PATTERN_ROLES = ['super_admin', 'client_admin'] as const;
+type AllowedObjectionPatternRole = typeof ALLOWED_OBJECTION_PATTERN_ROLES[number];
+function isAllowedObjectionPatternRole(role: unknown): role is AllowedObjectionPatternRole {
+  return typeof role === 'string' &&
+         (ALLOWED_OBJECTION_PATTERN_ROLES as readonly string[]).includes(role);
+}
+
+// ---------------------------------------------------------------------------
 // ユーティリティ
 // ---------------------------------------------------------------------------
 
-function resolveAuth(req: Request): { jwtTenantId: string; isSuperAdmin: boolean } {
+function resolveAuth(req: Request): { su: Record<string, any> | undefined; role: unknown; jwtTenantId: string; isSuperAdmin: boolean } {
   const su = (req as any).supabaseUser as Record<string, any> | undefined;
+  const role: unknown = su?.app_metadata?.role;
   return {
+    su,
+    role,
     jwtTenantId: su?.app_metadata?.tenant_id ?? su?.tenant_id ?? "",
-    isSuperAdmin: (su?.app_metadata?.role ?? su?.user_metadata?.role ?? "") === "super_admin",
+    isSuperAdmin: role === "super_admin",
   };
+}
+
+function denyObjectionPatternRole(req: Request, res: Response, su: Record<string, any> | undefined, role: unknown) {
+  logger.warn({
+    event: 'objection_patterns_access_denied',
+    reason: 'invalid_role',
+    errorCode: 'AUTHZ_ROLE_DENIED',
+    requested_path: req.path,
+    actor_email: su?.['email'] ? String(su['email']).slice(0, 3) + '***' : 'unknown',
+    actor_role: role,
+    required_roles: ALLOWED_OBJECTION_PATTERN_ROLES,
+    hasAppMetadataRole: !!su?.['app_metadata']?.role,
+    hasUserMetadataRole: !!su?.['user_metadata']?.role,
+  }, 'objection-patterns access denied: invalid actor role');
+  return res.status(403).json({ error: 'この操作を実行する権限がありません', code: 'AUTHZ_ROLE_DENIED' });
 }
 
 // ---------------------------------------------------------------------------
@@ -35,7 +64,10 @@ export function registerObjectionPatternRoutes(app: Express): void {
   // success_rate 降順
   // -------------------------------------------------------------------------
   app.get("/v1/admin/objection-patterns", async (req: Request, res: Response) => {
-    const { jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    const { su, role, jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    if (!isAllowedObjectionPatternRole(role)) {
+      return denyObjectionPatternRole(req, res, su, role);
+    }
     const queryTenantId = req.query["tenantId"] as string | undefined;
 
     if (!isSuperAdmin && queryTenantId && queryTenantId !== jwtTenantId) {
@@ -61,7 +93,10 @@ export function registerObjectionPatternRoutes(app: Express): void {
   // GET /v1/admin/objection-patterns/:id
   // -------------------------------------------------------------------------
   app.get("/v1/admin/objection-patterns/:id", async (req: Request, res: Response) => {
-    const { jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    const { su, role, jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    if (!isAllowedObjectionPatternRole(role)) {
+      return denyObjectionPatternRole(req, res, su, role);
+    }
 
     const id = Number(req.params["id"]);
     if (!Number.isFinite(id) || id <= 0) {
@@ -86,7 +121,10 @@ export function registerObjectionPatternRoutes(app: Express): void {
   // DELETE /v1/admin/objection-patterns/:id
   // -------------------------------------------------------------------------
   app.delete("/v1/admin/objection-patterns/:id", async (req: Request, res: Response) => {
-    const { jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    const { su, role, jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    if (!isAllowedObjectionPatternRole(role)) {
+      return denyObjectionPatternRole(req, res, su, role);
+    }
 
     const id = Number(req.params["id"]);
     if (!Number.isFinite(id) || id <= 0) {

--- a/src/api/admin/options/optionsAuthGuard.test.ts
+++ b/src/api/admin/options/optionsAuthGuard.test.ts
@@ -1,0 +1,116 @@
+// src/api/admin/options/optionsAuthGuard.test.ts
+// Phase69-1.5 PR-C4 v2: options/* ALLOWED_ROLES whitelist + user_metadata removal tests
+
+jest.mock('../../../lib/db', () => ({
+  pool: null,
+  getPool: () => null,
+}));
+jest.mock('../../../lib/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock('../../../lib/billing/usageTracker', () => ({
+  trackUsage: jest.fn(),
+}));
+jest.mock('../../../lib/notifications', () => ({
+  createNotification: jest.fn(),
+}));
+jest.mock('../../../admin/http/supabaseAuthMiddleware', () => ({
+  supabaseAuthMiddleware: (req: any, _res: any, next: any) => {
+    req.supabaseUser = req._mockUser ?? null;
+    next();
+  },
+}));
+
+import express from 'express';
+import request from 'supertest';
+import { logger } from '../../../lib/logger';
+import { registerOptionRoutes } from './routes';
+
+function makeApp(user: Record<string, unknown> | null) {
+  const app = express();
+  app.use(express.json());
+  app.use((req: any, _res: any, next: any) => {
+    req._mockUser = user;
+    next();
+  });
+  registerOptionRoutes(app);
+  return app;
+}
+
+const TENANT_SCOPED = [
+  { method: 'get' as const, path: '/v1/admin/options' },
+  { method: 'post' as const, path: '/v1/admin/options' },
+];
+const SUPER_ADMIN_ONLY = [
+  { method: 'put' as const, path: '/v1/admin/options/123' },
+  { method: 'put' as const, path: '/v1/admin/options/123/complete' },
+];
+const ALL_ROUTES = [...TENANT_SCOPED, ...SUPER_ADMIN_ONLY];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('options — ALLOWED_ROLES whitelist (viewer denied)', () => {
+  ALL_ROUTES.forEach(({ method, path }) => {
+    it(`${method.toUpperCase()} ${path} — viewer → 403 AUTHZ_ROLE_DENIED`, async () => {
+      const app = makeApp({ app_metadata: { role: 'viewer', tenant_id: 't1' }, email: 'test@test.com' });
+      const res = await (request(app) as any)[method](path).send({ description: 'x' });
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('AUTHZ_ROLE_DENIED');
+      expect(logger.warn).toHaveBeenCalled();
+    });
+  });
+});
+
+describe('options — stale JWT (user_metadata.role only)', () => {
+  ALL_ROUTES.forEach(({ method, path }) => {
+    it(`${method.toUpperCase()} ${path} — user_metadata.role=super_admin (no app_metadata) → 403`, async () => {
+      const app = makeApp({ user_metadata: { role: 'super_admin' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path).send({ description: 'x' });
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('AUTHZ_ROLE_DENIED');
+    });
+  });
+});
+
+describe('options — null user', () => {
+  ALL_ROUTES.forEach(({ method, path }) => {
+    it(`${method.toUpperCase()} ${path} — no supabaseUser → 403`, async () => {
+      const app = makeApp(null);
+      const res = await (request(app) as any)[method](path).send({ description: 'x' });
+      expect(res.status).toBe(403);
+    });
+  });
+});
+
+describe('options — TENANT_SCOPED allow (super_admin / client_admin)', () => {
+  TENANT_SCOPED.forEach(({ method, path }) => {
+    it(`${method.toUpperCase()} ${path} — super_admin → not 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'super_admin', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path).send({ description: 'x' });
+      expect(res.status).not.toBe(403);
+    });
+    it(`${method.toUpperCase()} ${path} — client_admin → not 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'client_admin', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path).send({ description: 'x' });
+      expect(res.status).not.toBe(403);
+    });
+  });
+});
+
+describe('options — SUPER_ADMIN_ONLY (client_admin denied with insufficient_role)', () => {
+  SUPER_ADMIN_ONLY.forEach(({ method, path }) => {
+    it(`${method.toUpperCase()} ${path} — client_admin → 403 AUTHZ_ROLE_DENIED`, async () => {
+      const app = makeApp({ app_metadata: { role: 'client_admin', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path).send({});
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('AUTHZ_ROLE_DENIED');
+    });
+    it(`${method.toUpperCase()} ${path} — super_admin → not 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'super_admin' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path).send({});
+      expect(res.status).not.toBe(403);
+    });
+  });
+});

--- a/src/api/admin/options/routes.ts
+++ b/src/api/admin/options/routes.ts
@@ -8,12 +8,51 @@ import { logger } from '../../../lib/logger';
 import { trackUsage } from '../../../lib/billing/usageTracker';
 import { createNotification } from '../../../lib/notifications';
 
+// ---------------------------------------------------------------------------
+// ALLOWED_ROLES whitelist (Phase69-1.5 PR-C4 v2)
+// ---------------------------------------------------------------------------
+
+const ALLOWED_OPTION_ROLES = ['super_admin', 'client_admin'] as const;
+type AllowedOptionRole = typeof ALLOWED_OPTION_ROLES[number];
+function isAllowedOptionRole(role: unknown): role is AllowedOptionRole {
+  return typeof role === 'string' &&
+         (ALLOWED_OPTION_ROLES as readonly string[]).includes(role);
+}
+
 function extractAuth(req: Request) {
   const su = (req as any).supabaseUser as Record<string, any> | undefined;
+  const role = su?.app_metadata?.role;
   const tenantId: string = su?.app_metadata?.tenant_id ?? su?.tenant_id ?? '';
-  const isSuperAdmin: boolean =
-    (su?.app_metadata?.role ?? su?.user_metadata?.role ?? '') === 'super_admin';
-  return { tenantId, isSuperAdmin };
+  const isSuperAdmin: boolean = role === 'super_admin';
+  return { su, role, tenantId, isSuperAdmin };
+}
+
+function denyRole(req: Request, res: Response, su: Record<string, any> | undefined, role: unknown, requiredRoles: readonly string[]) {
+  logger.warn({
+    event: 'options_access_denied',
+    reason: 'invalid_role',
+    errorCode: 'AUTHZ_ROLE_DENIED',
+    requested_path: req.path,
+    actor_email: su?.['email'] ? String(su['email']).slice(0, 3) + '***' : 'unknown',
+    actor_role: role,
+    required_roles: requiredRoles,
+    hasAppMetadataRole: !!su?.['app_metadata']?.role,
+    hasUserMetadataRole: !!su?.['user_metadata']?.role,
+  }, 'options access denied: invalid actor role');
+  return res.status(403).json({ error: 'この操作を実行する権限がありません', code: 'AUTHZ_ROLE_DENIED' });
+}
+
+function denyInsufficient(req: Request, res: Response, su: Record<string, any> | undefined, role: unknown) {
+  logger.warn({
+    event: 'options_access_denied',
+    reason: 'insufficient_role',
+    errorCode: 'AUTHZ_ROLE_DENIED',
+    requested_path: req.path,
+    actor_email: su?.['email'] ? String(su['email']).slice(0, 3) + '***' : 'unknown',
+    actor_role: role,
+    required_roles: ['super_admin'],
+  }, 'options access denied: super_admin required');
+  return res.status(403).json({ error: '権限がありません', code: 'AUTHZ_ROLE_DENIED' });
 }
 
 export function registerOptionRoutes(app: Express): void {
@@ -25,7 +64,10 @@ export function registerOptionRoutes(app: Express): void {
   // クエリパラメータ: status, limit, offset
   // -------------------------------------------------------------------------
   app.get('/v1/admin/options', async (req: Request, res: Response) => {
-    const { tenantId, isSuperAdmin } = extractAuth(req);
+    const { su, role, tenantId, isSuperAdmin } = extractAuth(req);
+    if (!isAllowedOptionRole(role)) {
+      return denyRole(req, res, su, role, ALLOWED_OPTION_ROLES);
+    }
     const statusFilter = req.query['status'] as string | undefined;
     const limit = Math.min(parseInt((req.query['limit'] as string) ?? '20', 10), 100);
     const offset = Math.max(0, parseInt((req.query['offset'] as string) ?? '0', 10));
@@ -76,7 +118,10 @@ export function registerOptionRoutes(app: Express): void {
   // POST /v1/admin/options — 新規発注作成（feedbackAIから呼ばれる）
   // -------------------------------------------------------------------------
   app.post('/v1/admin/options', async (req: Request, res: Response) => {
-    const { tenantId } = extractAuth(req);
+    const { su, role, tenantId } = extractAuth(req);
+    if (!isAllowedOptionRole(role)) {
+      return denyRole(req, res, su, role, ALLOWED_OPTION_ROLES);
+    }
 
     const { description, llm_estimate_amount, chat_session_id, type } = req.body as {
       description?: string;
@@ -129,9 +174,12 @@ export function registerOptionRoutes(app: Express): void {
   // PUT /v1/admin/options/:id — 更新（super_adminのみ）
   // -------------------------------------------------------------------------
   app.put('/v1/admin/options/:id', async (req: Request, res: Response) => {
-    const { isSuperAdmin } = extractAuth(req);
+    const { su, role, isSuperAdmin } = extractAuth(req);
+    if (!isAllowedOptionRole(role)) {
+      return denyRole(req, res, su, role, ALLOWED_OPTION_ROLES);
+    }
     if (!isSuperAdmin) {
-      return res.status(403).json({ error: '権限がありません' });
+      return denyInsufficient(req, res, su, role);
     }
 
     const { id } = req.params;
@@ -182,9 +230,12 @@ export function registerOptionRoutes(app: Express): void {
   // 3. trackUsage() で option_service 課金記録
   // -------------------------------------------------------------------------
   app.put('/v1/admin/options/:id/complete', async (req: Request, res: Response) => {
-    const { isSuperAdmin } = extractAuth(req);
+    const { su, role, isSuperAdmin } = extractAuth(req);
+    if (!isAllowedOptionRole(role)) {
+      return denyRole(req, res, su, role, ALLOWED_OPTION_ROLES);
+    }
     if (!isSuperAdmin) {
-      return res.status(403).json({ error: '権限がありません' });
+      return denyInsufficient(req, res, su, role);
     }
 
     const { id } = req.params;

--- a/src/api/admin/reports/reportsAuthGuard.test.ts
+++ b/src/api/admin/reports/reportsAuthGuard.test.ts
@@ -1,0 +1,73 @@
+// src/api/admin/reports/reportsAuthGuard.test.ts
+// Phase69-1.5 PR-C4 v2: reports/* ALLOWED_ROLES whitelist + user_metadata removal tests
+
+jest.mock('../../../lib/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock('../../../admin/http/supabaseAuthMiddleware', () => ({
+  supabaseAuthMiddleware: (req: any, _res: any, next: any) => {
+    req.supabaseUser = req._mockUser ?? null;
+    next();
+  },
+}));
+jest.mock('./reportsRepository', () => ({
+  listReports: jest.fn().mockResolvedValue([]),
+  getReport: jest.fn().mockResolvedValue(null),
+  getUnreadCount: jest.fn().mockResolvedValue(0),
+}));
+
+import express from 'express';
+import request from 'supertest';
+import { logger } from '../../../lib/logger';
+import { registerReportRoutes } from './routes';
+
+function makeApp(user: Record<string, unknown> | null) {
+  const app = express();
+  app.use(express.json());
+  app.use((req: any, _res: any, next: any) => {
+    req._mockUser = user;
+    next();
+  });
+  registerReportRoutes(app);
+  return app;
+}
+
+const ROUTES = [
+  '/v1/admin/reports?tenantId=t1',
+  '/v1/admin/reports/unread-count?tenantId=t1',
+  '/v1/admin/reports/123',
+];
+
+beforeEach(() => { jest.clearAllMocks(); });
+
+describe('reports — ALLOWED_ROLES whitelist', () => {
+  ROUTES.forEach((path) => {
+    it(`GET ${path} — viewer → 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'viewer', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await request(app).get(path);
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('AUTHZ_ROLE_DENIED');
+      expect(logger.warn).toHaveBeenCalled();
+    });
+    it(`GET ${path} — stale JWT (user_metadata.role only) → 403`, async () => {
+      const app = makeApp({ user_metadata: { role: 'super_admin', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await request(app).get(path);
+      expect(res.status).toBe(403);
+    });
+    it(`GET ${path} — null user → 403`, async () => {
+      const app = makeApp(null);
+      const res = await request(app).get(path);
+      expect(res.status).toBe(403);
+    });
+    it(`GET ${path} — super_admin → not 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'super_admin', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await request(app).get(path);
+      expect(res.status).not.toBe(403);
+    });
+    it(`GET ${path} — client_admin → not 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'client_admin', tenant_id: 't1' }, email: 't@t.com' });
+      const res = await request(app).get(path);
+      expect(res.status).not.toBe(403);
+    });
+  });
+});

--- a/src/api/admin/reports/routes.ts
+++ b/src/api/admin/reports/routes.ts
@@ -8,15 +8,44 @@ import { listReports, getReport, getUnreadCount } from "./reportsRepository";
 import { logger } from '../../../lib/logger';
 
 // ---------------------------------------------------------------------------
+// ALLOWED_ROLES whitelist (Phase69-1.5 PR-C4 v2)
+// ---------------------------------------------------------------------------
+
+const ALLOWED_REPORT_ROLES = ['super_admin', 'client_admin'] as const;
+type AllowedReportRole = typeof ALLOWED_REPORT_ROLES[number];
+function isAllowedReportRole(role: unknown): role is AllowedReportRole {
+  return typeof role === 'string' &&
+         (ALLOWED_REPORT_ROLES as readonly string[]).includes(role);
+}
+
+// ---------------------------------------------------------------------------
 // ユーティリティ
 // ---------------------------------------------------------------------------
 
-function resolveAuth(req: Request): { jwtTenantId: string; isSuperAdmin: boolean } {
+function resolveAuth(req: Request): { su: Record<string, any> | undefined; role: unknown; jwtTenantId: string; isSuperAdmin: boolean } {
   const su = (req as any).supabaseUser as Record<string, any> | undefined;
+  const role: unknown = su?.app_metadata?.role;
   return {
+    su,
+    role,
     jwtTenantId: su?.app_metadata?.tenant_id ?? su?.tenant_id ?? "",
-    isSuperAdmin: (su?.app_metadata?.role ?? su?.user_metadata?.role ?? "") === "super_admin",
+    isSuperAdmin: role === "super_admin",
   };
+}
+
+function denyReportRole(req: Request, res: Response, su: Record<string, any> | undefined, role: unknown) {
+  logger.warn({
+    event: 'reports_access_denied',
+    reason: 'invalid_role',
+    errorCode: 'AUTHZ_ROLE_DENIED',
+    requested_path: req.path,
+    actor_email: su?.['email'] ? String(su['email']).slice(0, 3) + '***' : 'unknown',
+    actor_role: role,
+    required_roles: ALLOWED_REPORT_ROLES,
+    hasAppMetadataRole: !!su?.['app_metadata']?.role,
+    hasUserMetadataRole: !!su?.['user_metadata']?.role,
+  }, 'reports access denied: invalid actor role');
+  return res.status(403).json({ error: 'この操作を実行する権限がありません', code: 'AUTHZ_ROLE_DENIED' });
 }
 
 // ---------------------------------------------------------------------------
@@ -31,7 +60,10 @@ export function registerReportRoutes(app: Express): void {
   // 週次レポート一覧（最新順）
   // -------------------------------------------------------------------------
   app.get("/v1/admin/reports", async (req: Request, res: Response) => {
-    const { jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    const { su, role, jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    if (!isAllowedReportRole(role)) {
+      return denyReportRole(req, res, su, role);
+    }
     const queryTenantId = req.query["tenantId"] as string | undefined;
 
     if (!isSuperAdmin && queryTenantId && queryTenantId !== jwtTenantId) {
@@ -59,7 +91,10 @@ export function registerReportRoutes(app: Express): void {
   // NOTE: 静的パスなので /:id より先に登録
   // -------------------------------------------------------------------------
   app.get("/v1/admin/reports/unread-count", async (req: Request, res: Response) => {
-    const { jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    const { su, role, jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    if (!isAllowedReportRole(role)) {
+      return denyReportRole(req, res, su, role);
+    }
     const queryTenantId = req.query["tenantId"] as string | undefined;
 
     if (!isSuperAdmin && queryTenantId && queryTenantId !== jwtTenantId) {
@@ -85,7 +120,10 @@ export function registerReportRoutes(app: Express): void {
   // GET /v1/admin/reports/:id
   // -------------------------------------------------------------------------
   app.get("/v1/admin/reports/:id", async (req: Request, res: Response) => {
-    const { jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    const { su, role, jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    if (!isAllowedReportRole(role)) {
+      return denyReportRole(req, res, su, role);
+    }
 
     const id = Number(req.params["id"]);
     if (!Number.isFinite(id) || id <= 0) {

--- a/src/api/admin/variants/routes.ts
+++ b/src/api/admin/variants/routes.ts
@@ -9,15 +9,44 @@ import { listVariants, upsertVariants, getVariantStats } from "./variantsReposit
 import { logger } from '../../../lib/logger';
 
 // ---------------------------------------------------------------------------
+// ALLOWED_ROLES whitelist (Phase69-1.5 PR-C4 v2)
+// ---------------------------------------------------------------------------
+
+const ALLOWED_VARIANT_ROLES = ['super_admin', 'client_admin'] as const;
+type AllowedVariantRole = typeof ALLOWED_VARIANT_ROLES[number];
+function isAllowedVariantRole(role: unknown): role is AllowedVariantRole {
+  return typeof role === 'string' &&
+         (ALLOWED_VARIANT_ROLES as readonly string[]).includes(role);
+}
+
+// ---------------------------------------------------------------------------
 // ユーティリティ
 // ---------------------------------------------------------------------------
 
-function resolveAuth(req: Request): { jwtTenantId: string; isSuperAdmin: boolean } {
+function resolveAuth(req: Request): { su: Record<string, any> | undefined; role: unknown; jwtTenantId: string; isSuperAdmin: boolean } {
   const su = (req as any).supabaseUser as Record<string, any> | undefined;
+  const role: unknown = su?.app_metadata?.role;
   return {
+    su,
+    role,
     jwtTenantId: su?.app_metadata?.tenant_id ?? su?.tenant_id ?? "",
-    isSuperAdmin: (su?.app_metadata?.role ?? su?.user_metadata?.role ?? "") === "super_admin",
+    isSuperAdmin: role === "super_admin",
   };
+}
+
+function denyVariantRole(req: Request, res: Response, su: Record<string, any> | undefined, role: unknown) {
+  logger.warn({
+    event: 'variants_access_denied',
+    reason: 'invalid_role',
+    errorCode: 'AUTHZ_ROLE_DENIED',
+    requested_path: req.path,
+    actor_email: su?.['email'] ? String(su['email']).slice(0, 3) + '***' : 'unknown',
+    actor_role: role,
+    required_roles: ALLOWED_VARIANT_ROLES,
+    hasAppMetadataRole: !!su?.['app_metadata']?.role,
+    hasUserMetadataRole: !!su?.['user_metadata']?.role,
+  }, 'variants access denied: invalid actor role');
+  return res.status(403).json({ error: 'この操作を実行する権限がありません', code: 'AUTHZ_ROLE_DENIED' });
 }
 
 function parseDays(raw: unknown, defaultVal: number): number {
@@ -52,7 +81,10 @@ export function registerVariantRoutes(app: Express): void {
   // GET /v1/admin/variants?tenantId=xxx
   // -------------------------------------------------------------------------
   app.get("/v1/admin/variants", async (req: Request, res: Response) => {
-    const { jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    const { su, role, jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    if (!isAllowedVariantRole(role)) {
+      return denyVariantRole(req, res, su, role);
+    }
     const queryTenantId = req.query["tenantId"] as string | undefined;
 
     if (!isSuperAdmin && queryTenantId && queryTenantId !== jwtTenantId) {
@@ -79,7 +111,10 @@ export function registerVariantRoutes(app: Express): void {
   // NOTE: 静的パスなので PUT より先に登録
   // -------------------------------------------------------------------------
   app.get("/v1/admin/variants/stats", async (req: Request, res: Response) => {
-    const { jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    const { su, role, jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    if (!isAllowedVariantRole(role)) {
+      return denyVariantRole(req, res, su, role);
+    }
     const queryTenantId = req.query["tenantId"] as string | undefined;
 
     if (!isSuperAdmin && queryTenantId && queryTenantId !== jwtTenantId) {
@@ -109,7 +144,10 @@ export function registerVariantRoutes(app: Express): void {
   // バリデーション: weightの合計が100であること
   // -------------------------------------------------------------------------
   app.put("/v1/admin/variants", async (req: Request, res: Response) => {
-    const { jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    const { su, role, jwtTenantId, isSuperAdmin } = resolveAuth(req);
+    if (!isAllowedVariantRole(role)) {
+      return denyVariantRole(req, res, su, role);
+    }
 
     const parsed = putVariantsSchema.safeParse(req.body ?? {});
     if (!parsed.success) {

--- a/src/api/admin/variants/variantsAuthGuard.test.ts
+++ b/src/api/admin/variants/variantsAuthGuard.test.ts
@@ -1,0 +1,81 @@
+// src/api/admin/variants/variantsAuthGuard.test.ts
+// Phase69-1.5 PR-C4 v2: variants/* ALLOWED_ROLES whitelist + user_metadata removal tests
+
+jest.mock('../../../lib/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock('../../../admin/http/supabaseAuthMiddleware', () => ({
+  supabaseAuthMiddleware: (req: any, _res: any, next: any) => {
+    req.supabaseUser = req._mockUser ?? null;
+    next();
+  },
+}));
+jest.mock('./variantsRepository', () => ({
+  listVariants: jest.fn().mockResolvedValue([]),
+  upsertVariants: jest.fn().mockResolvedValue([]),
+  getVariantStats: jest.fn().mockResolvedValue([]),
+}));
+
+import express from 'express';
+import request from 'supertest';
+import { logger } from '../../../lib/logger';
+import { registerVariantRoutes } from './routes';
+
+function makeApp(user: Record<string, unknown> | null) {
+  const app = express();
+  app.use(express.json());
+  app.use((req: any, _res: any, next: any) => {
+    req._mockUser = user;
+    next();
+  });
+  registerVariantRoutes(app);
+  return app;
+}
+
+const ALL_ROUTES = [
+  { method: 'get' as const, path: '/v1/admin/variants?tenantId=t1' },
+  { method: 'get' as const, path: '/v1/admin/variants/stats?tenantId=t1' },
+  { method: 'put' as const, path: '/v1/admin/variants' },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe('variants — ALLOWED_ROLES whitelist', () => {
+  ALL_ROUTES.forEach(({ method, path }) => {
+    it(`${method.toUpperCase()} ${path} — viewer → 403 AUTHZ_ROLE_DENIED`, async () => {
+      const app = makeApp({ app_metadata: { role: 'viewer', tenant_id: 't1' }, email: 't@t.com' });
+      const body = method === 'put' ? { tenantId: 't1', variants: [{ id: 'a', name: 'A', prompt: 'p', weight: 100 }] } : {};
+      const res = await (request(app) as any)[method](path).send(body);
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('AUTHZ_ROLE_DENIED');
+      expect(logger.warn).toHaveBeenCalled();
+    });
+    it(`${method.toUpperCase()} ${path} — stale JWT (user_metadata.role only) → 403`, async () => {
+      const app = makeApp({ user_metadata: { role: 'super_admin', tenant_id: 't1' }, email: 't@t.com' });
+      const body = method === 'put' ? { tenantId: 't1', variants: [{ id: 'a', name: 'A', prompt: 'p', weight: 100 }] } : {};
+      const res = await (request(app) as any)[method](path).send(body);
+      expect(res.status).toBe(403);
+      expect(res.body.code).toBe('AUTHZ_ROLE_DENIED');
+    });
+    it(`${method.toUpperCase()} ${path} — null user → 403`, async () => {
+      const app = makeApp(null);
+      const body = method === 'put' ? { tenantId: 't1', variants: [{ id: 'a', name: 'A', prompt: 'p', weight: 100 }] } : {};
+      const res = await (request(app) as any)[method](path).send(body);
+      expect(res.status).toBe(403);
+    });
+    it(`${method.toUpperCase()} ${path} — super_admin → not 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'super_admin', tenant_id: 't1' }, email: 't@t.com' });
+      const body = method === 'put' ? { tenantId: 't1', variants: [{ id: 'a', name: 'A', prompt: 'p', weight: 100 }] } : {};
+      const res = await (request(app) as any)[method](path).send(body);
+      expect(res.status).not.toBe(403);
+    });
+    it(`${method.toUpperCase()} ${path} — client_admin → not 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'client_admin', tenant_id: 't1' }, email: 't@t.com' });
+      const body = method === 'put' ? { tenantId: 't1', variants: [{ id: 'a', name: 'A', prompt: 'p', weight: 100 }] } : {};
+      const res = await (request(app) as any)[method](path).send(body);
+      expect(res.status).not.toBe(403);
+    });
+  });
+});


### PR DESCRIPTION
## 概要

Phase69-1.5 (Privilege Escalation 修正) の最終 PR (PR-C4 v2)。
PR-A (#147), PR-B (#148), PR-C1 (#149), PR-C2 (#150), PR-C3 (#153) のパターンをその他 admin routes 12 ファイルに展開し、**Phase69-1.5 を完了**。

## Round 1-4 パターン適用

### Round 1: Mechanical Replacement
- user_metadata.role フォールバックを 12 ファイルから完全削除
- 認可判定は app_metadata.role のみを使用

### Round 2: Fail-closed + ALLOWED_ROLES Whitelist (12 種類)

| ファイル | 定数 | TENANT/SUPER_ADMIN_ONLY |
|---|---|---|
| options/routes.ts | ALLOWED_OPTION_ROLES | 2 / 2 |
| knowledge-gaps/routes.ts | ALLOWED_KG_PHASE46_ROLES | 4 / 1 |
| variants/routes.ts | ALLOWED_VARIANT_ROLES | 3 / 0 |
| evaluations/routes.ts | ALLOWED_EVALUATION_ROLES | 10 / 0 |
| avatar/routes.ts ★ | ALLOWED_AVATAR_ROLES | 6 / 2 |
| notifications/routes.ts | ALLOWED_NOTIFICATION_ROLES | 3 / 1 |
| monitoring/routes.ts | ALLOWED_MONITORING_ROLES | 1 / 0 |
| reports/routes.ts | ALLOWED_REPORT_ROLES | 3 / 0 |
| knowledge/knowledgeGapRoutes.ts | ALLOWED_KG_LEGACY_ROLES | 3 / 0 |
| knowledge/routes.ts | ALLOWED_KNOWLEDGE_ROLES | (既存 requireKnowledgeRole 維持) |
| chatTest/routes.ts | ALLOWED_CHAT_TEST_ROLES | 1 / 0 |
| objection-patterns/routes.ts | ALLOWED_OBJECTION_PATTERN_ROLES | 3 / 0 |

★ avatar/routes.ts は PR-C4 v1 で漏れたファイル、v2 で確実にカバー

### Round 3: Observability
- logger.warn 21 declaration、47+ endpoint をカバー
- errorCode: AUTHZ_ROLE_DENIED / insufficient_role
- requested_path, actor_role, required_roles 等の構造化フィールド

### Round 4: Allow-path Tests
- 228 tests 追加 (目標 60 件の 3.8 倍)
- 各エンドポイントで allow super_admin + allow client_admin + deny role + deny stale JWT パターン網羅
- 全 228 件 pass、typecheck 0 errors

## Gate 結果

| Gate | 結果 |
|---|---|
| Gate 1 (pnpm verify) | ✅ pass (228 new tests + 1389 existing) |
| Gate 1.5 (dead-code-check) | ✅ pass (no new dead exports) |
| Gate 2 (security-scan) | ✅ pass (CRITICAL/HIGH FAIL: 0) |
| Gate 3 (build) | ✅ pass (backend + admin-ui) |
| Gate 2.5 (Codex review) | ✅ pass (No issues found) |

## Codex Review 結果

> The changes consistently tighten admin authorization to app_metadata.role with explicit allowlists and add corresponding guard tests across the touched routes. I did not find a concrete regression or logic error introduced by this patch that would break expected behavior.

## 関連

- 親タスク: Phase69-1.5 (Asana 1214771938406621)
- 前 PR: PR-C3 #153 (feedback + tuning routes)
- **完了**: Phase69-1.5 全 6 PR merged → VPS デプロイ準備完了

## 実装メモ

実装は Opus 4.7 (high effort) で行われた。PR-C4 v1 (Sonnet 4.6) で avatar/routes.ts 漏れ + テスト 0 件の品質不足が発生したため、v2 では Opus 4.7 を強制指定。結果として 228 tests / 12 files / 21 logger.warn declarations / Codex No issues found を獲得。

🤖 Generated with [Claude Code](https://claude.com/claude-code)