### PR TITLE
docs(phase1-step-c): Phase 1 成果物 cross-reference 集約

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -406,3 +406,19 @@ Playwright MCPで現象確認してから修正。推測で修正しない。
 - 根本原因特定+再発防止（症状修正で終わらない）
 - バグ報告→テキスト推測禁止→Playwright MCP/pm2 logs/DB SELECTの3点確認
 - CLI報告に「変更しました/no diff/リスク最小」→スコープ再評価要求
+
+## Phase 1 24h 自律ループ実装状況 (2026-05-18 時点)
+
+| 項目 | 状態 | 関連 PR | 関連ドキュメント |
+|---|---|---|---|
+| Claude.ai 指示文 v1 | ✅ | #155 | docs/R2C_CLAUDE_AI_INSTRUCTIONS_V1.md |
+| Phase 0 評価 | ✅ | #156 | docs/24H_AUTOMATION_R2C_GAP_ANALYSIS.md |
+| 移行手順書 + verify | ✅ | #157 | docs/PHASE1_ACCOUNT_MIGRATION_RUNBOOK.md |
+| 並列ベース整備 | ✅ | #158 | docs/PHASE1_PARALLEL_WORK_RULES.md |
+| SECURITY_SCAN_ALLOWLIST | ✅ | #159 | docs/SECURITY_SCAN_ALLOWLIST.md |
+| .wolf/hooks worktree 検知 | ✅ | #160 | .wolf/hooks/HOOK_BEHAVIOR.md |
+| lane-templates × 5 | ✅ | #162 | .claude/lane-templates/ |
+| retry + Pushover spec | ✅ | #161 | docs/24H_LOOP_RETRY_AND_NOTIFICATION_SPEC.md |
+| アカウント分離 (Tier S 実行) | ⏳ 2026-05-19 06:05 | - | docs/PHASE1_ACCOUNT_MIGRATION_RUNBOOK.md |
+| RUNBOOK_R2C 作成 | ⏳ UATa runbook 本文待ち | - | - |
+| SCRIPTS/r2c-*.sh 16本 | ⏳ Tier S + RUNBOOK 後 | - | - |

--- a/docs/24H_AUTOMATION_R2C_GAP_ANALYSIS.md
+++ b/docs/24H_AUTOMATION_R2C_GAP_ANALYSIS.md
@@ -433,6 +433,24 @@ DoD:
 
 ---
 
+## Phase 1 進捗 (2026-05-18 完了)
+
+| Phase 1 タスク | PR | 状態 |
+|---|---|---|
+| Claude.ai 指示文 v1 | #155 | ✅ |
+| Phase 0 評価 (本ドキュメント) | #156 | ✅ |
+| 移行手順書 | #157 | ✅ |
+| 並列ベース整備 | #158 | ✅ |
+| SECURITY_SCAN_ALLOWLIST | #159 | ✅ |
+| .wolf/hooks worktree 検知 | #160 | ✅ |
+| retry + Pushover spec | #161 | ✅ |
+| lane-templates × 5 | #162 | ✅ |
+| アカウント分離実行 | (Tier S) | ⏳ 2026-05-19 06:05 |
+| RUNBOOK_R2C.md | - | ⏳ UATa runbook 取得後 |
+| SCRIPTS/r2c-*.sh 16本 | - | ⏳ Tier S + RUNBOOK 後 |
+
+---
+
 ## 改訂履歴
 
 | バージョン | 日付 | 変更点 | Asana |

--- a/docs/R2C_DEVELOPMENT_PLAYBOOK.md
+++ b/docs/R2C_DEVELOPMENT_PLAYBOOK.md
@@ -606,3 +606,16 @@ claude      # default ~/.claude/ を使う
 bash scripts/verify-account-isolation.sh
 ```
 ```
+
+---
+
+## 16. Lane retry / Pushover 通知仕様
+
+24h ループの Lane 失敗時 retry 戦略と Pushover priority マッピングの詳細は以下を参照:
+
+- **仕様書**: `docs/24H_LOOP_RETRY_AND_NOTIFICATION_SPEC.md`
+  - Section 1: Lane 失敗 retry 戦略（1 回目=5 分後 / 2 回目=30 分後 priority 0 / 3 回目=停止 priority 1）
+  - Section 2: Pushover priority 完全列挙（2 Critical / 1 High / 0 Normal / -1 Low / -2 Lowest）
+  - Section 3: 構造化 JSON 通知本文ルール
+  - Section 4: morning-report Slack Block Kit JSON schema
+- **正本**: `docs/R2C_CLAUDE_AI_INSTRUCTIONS_V1.md` §16

--- a/docs/SECURITY_SCAN_POLICY.md
+++ b/docs/SECURITY_SCAN_POLICY.md
@@ -73,3 +73,4 @@ bash SCRIPTS/security-scan.sh
 - CI ワークフロー: `.github/workflows/security-scan.yml`
 - デプロイチェックリスト: `docs/DEPLOY_CHECKLIST.md`
 - CLAUDE.md セキュリティゲートセクション: `## Security Scan`
+- ALLOWLIST 運用: `docs/SECURITY_SCAN_ALLOWLIST.md`


### PR DESCRIPTION
## DoD
CLAUDE.md / R2C_DEVELOPMENT_PLAYBOOK.md §16 / SECURITY_SCAN_POLICY.md / 24H_AUTOMATION_R2C_GAP_ANALYSIS.md §9 への Phase 1 成果物参照リンク追記

## 概要
Phase 1 Step C 集約 PR (PHASE1_PARALLEL_WORK_RULES.md「Step C 集約 PR の役割」に基づく)。T1-T4 (PR #159-#162) merge 完了後の共有 docs への cross-reference を 1 PR にまとめる。

## 変更内容 (4 ファイル、追記のみ)

| ファイル | 追加 | 行数 |
|---|---|---|
| CLAUDE.md | 「Phase 1 24h 自律ループ実装状況 (2026-05-18 時点)」テーブル (PR #155-#162 + Tier S/RUNBOOK/scripts 待ち項目 11 行) | +16 |
| docs/R2C_DEVELOPMENT_PLAYBOOK.md | §16「Lane retry / Pushover 通知仕様」(T4 成果物への参照リンク) | +13 |
| docs/SECURITY_SCAN_POLICY.md | 関連ファイルに ALLOWLIST 運用エントリ (T1 成果物) | +1 |
| docs/24H_AUTOMATION_R2C_GAP_ANALYSIS.md | Phase 1 進捗テーブル (改訂履歴の直前に挿入) | +18 |

合計 +48 行 / -0 行 (削除・置換なし)。

## 制約遵守
- 4 ファイル only、それ以外の編集なし
- 既存内容の削除・改変なし (追記のみ)
- PR 番号は事実確認済 (`git log --oneline -8`)

## Gate
docs only → Gate 1 markdownlint のみ (該当なし許容)、Gate 1.5/2/2.5/3 該当なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)