### PR TITLE
feat(phase1-stepe-a): SCRIPTS/r2c-*.sh × 4 (Asana 統合)

### DIFF
--- a/SCRIPTS/r2c-asana-poll.sh
+++ b/SCRIPTS/r2c-asana-poll.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+# r2c-asana-poll.sh
+# 用途: Asana を 5 分間隔で polling し、新規タスクを SQLite queue に取り込む
+# Cron 間隔: */5 * * * *
+# 必要環境変数:
+#   ASANA_ACCESS_TOKEN  (必須、${R2C_CONFIG}/secrets/r2c-loop.env から読込)
+# 呼び出し例:
+#   bash SCRIPTS/r2c-asana-poll.sh
+#   bash SCRIPTS/r2c-asana-poll.sh --dry-run
+#
+# Phase 1 Step E-A (Asana 統合 4 本のうち 1) — 詳細は
+# docs/24H_AUTOMATION_RUNBOOK_R2C.md を参照。
+
+set -euo pipefail
+
+# ─── R2C 定数 (bake-in) ────────────────────────────────────────────────────
+ASANA_PROJECT_GID="1213607637045514"
+R2C_ROOT="${R2C_ROOT:-$HOME/Documents/GitHub/commerce-faq-tasks}"
+R2C_CONFIG="${R2C_CONFIG:-$HOME/.claude-r2c-config}"
+QUEUE_DB="${R2C_ROOT}/.claude/queue/r2c-queue.db"
+LOG_DIR="${R2C_CONFIG}/logs"
+SCRIPT_NAME="$(basename "$0" .sh)"
+
+# ─── 引数 ──────────────────────────────────────────────────────────────────
+DRY_RUN=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run) DRY_RUN=1; shift ;;
+        -h|--help) sed -n '2,15p' "$0"; exit 0 ;;
+        *) echo "ERROR: unknown arg: $1" >&2; exit 1 ;;
+    esac
+done
+
+mkdir -p "$LOG_DIR"
+if [ "$DRY_RUN" -eq 0 ]; then
+    exec >> "${LOG_DIR}/${SCRIPT_NAME}.log" 2>&1
+fi
+
+# ─── 環境変数読込 ─────────────────────────────────────────────────────────
+# shellcheck disable=SC1091
+source "${R2C_CONFIG}/secrets/r2c-loop.env" 2>/dev/null || true
+
+echo "[$(date +%Y-%m-%d_%H:%M:%S)] === r2c-asana-poll start (dry-run=${DRY_RUN}) ==="
+
+if [ -z "${ASANA_ACCESS_TOKEN:-}" ]; then
+    echo "ERROR: ASANA_ACCESS_TOKEN not set. Place 'export ASANA_ACCESS_TOKEN=...' in ${R2C_CONFIG}/secrets/r2c-loop.env" >&2
+    exit 1
+fi
+
+if [ "$DRY_RUN" -eq 0 ] && [ ! -f "$QUEUE_DB" ]; then
+    echo "ERROR: Queue DB not found: $QUEUE_DB" >&2
+    exit 1
+fi
+
+# ─── ヘルパー ─────────────────────────────────────────────────────────────
+SQ() { sqlite3 "$QUEUE_DB" "$1"; }
+sqlq() { local s=${1//\'/\'\'}; printf "'%s'" "$s"; }
+
+# ─── Asana API ─────────────────────────────────────────────────────────────
+RAW=$(mktemp)
+TASKS_JSON=$(mktemp)
+trap 'rm -f "$RAW" "$TASKS_JSON"' EXIT
+
+ASANA_URL="https://app.asana.com/api/1.0/tasks?project=${ASANA_PROJECT_GID}&completed_since=now&opt_fields=name,notes,due_on,permalink_url,completed&limit=100"
+
+if ! curl -sf --max-time 20 \
+    -H "Authorization: Bearer ${ASANA_ACCESS_TOKEN}" \
+    -H "Accept: application/json" \
+    "$ASANA_URL" > "$RAW"; then
+    echo "WARNING: Asana API call failed, skipping this cycle"
+    exit 0
+fi
+
+if ! jq -e '.data' < "$RAW" >/dev/null 2>&1; then
+    echo "WARNING: Unexpected Asana response (first 500 bytes):"
+    head -c 500 "$RAW"; echo ""
+    exit 0
+fi
+
+jq '[.data[] | select(.completed == false) | {
+      gid,
+      name,
+      notes: (.notes // ""),
+      due_on: (.due_on // ""),
+      permalink_url: (.permalink_url // "")
+    }]' < "$RAW" > "$TASKS_JSON"
+
+TASK_COUNT=$(jq 'length' < "$TASKS_JSON")
+echo "Found ${TASK_COUNT} open Asana tasks"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    echo "DRY-RUN: would process ${TASK_COUNT} tasks. Sample:"
+    jq -r '.[0:3] | .[] | "  - " + .gid + " | " + .name' < "$TASKS_JSON" || true
+    echo "DRY-RUN: queue writes skipped"
+    exit 0
+fi
+
+# ─── Queue 取り込み ───────────────────────────────────────────────────────
+NEW_COUNT=0
+UPDATED_COUNT=0
+
+while IFS= read -r task_json; do
+    GID=$(jq -r '.gid' <<< "$task_json")
+    NAME=$(jq -r '.name' <<< "$task_json")
+    NOTES=$(jq -r '.notes' <<< "$task_json")
+    DUE_ON=$(jq -r '.due_on' <<< "$task_json")
+    PERMALINK=$(jq -r '.permalink_url' <<< "$task_json")
+
+    # Tier prefix 抽出: タスク名先頭の [Tier B|A|S] を正規表現で
+    TIER="B"
+    if [[ "$NAME" =~ \[Tier\ ?S\] ]]; then
+        TIER="S"
+    elif [[ "$NAME" =~ \[Tier\ ?A\] ]]; then
+        TIER="A"
+    elif [[ "$NAME" =~ \[Tier\ ?B\] ]]; then
+        TIER="B"
+    fi
+
+    # task_type: <種類>: 部分を抽出
+    TASK_TYPE="other"
+    if [[ "$NAME" =~ (skill|hook|docs|schema|api|migration|test|prod_change): ]]; then
+        TASK_TYPE="${BASH_REMATCH[1]}"
+    fi
+
+    # Tier S は夜間禁止、Tier A も夜間禁止 (UATa 慣習踏襲)
+    NIGHT_OK=1
+    if [ "$TIER" = "S" ] || [ "$TIER" = "A" ]; then
+        NIGHT_OK=0
+    fi
+
+    EXISTS=$(SQ "SELECT COUNT(*) FROM tasks WHERE asana_gid = '${GID}';")
+
+    if [ "$EXISTS" = "0" ]; then
+        if ! bash "${R2C_ROOT}/SCRIPTS/r2c-queue-add.sh" \
+                --asana-gid "$GID" \
+                --name "$NAME" \
+                --tier "$TIER" \
+                --task-type "$TASK_TYPE" \
+                --notes "$NOTES" \
+                --permalink "$PERMALINK" \
+                --due-on "$DUE_ON" \
+                --night-mode-allowed "$NIGHT_OK" 2>&1; then
+            echo "WARNING: r2c-queue-add.sh failed for GID ${GID}"
+            continue
+        fi
+        NEW_COUNT=$((NEW_COUNT + 1))
+        echo "  + NEW: [Tier ${TIER}/${TASK_TYPE}] ${NAME} (GID ${GID})"
+    else
+        OLD_NAME=$(SQ "SELECT asana_name FROM tasks WHERE asana_gid = '${GID}';")
+        if [ "$OLD_NAME" != "$NAME" ]; then
+            SQ "UPDATE tasks SET asana_name = $(sqlq "$NAME") WHERE asana_gid = '${GID}';"
+            UPDATED_COUNT=$((UPDATED_COUNT + 1))
+        fi
+    fi
+done < <(jq -c '.[]' < "$TASKS_JSON")
+
+SQ "INSERT OR REPLACE INTO automation_state (key, value) VALUES ('last_asana_poll', '$(date -u +%Y-%m-%dT%H:%M:%SZ)');" || true
+
+echo "Summary: ${NEW_COUNT} new, ${UPDATED_COUNT} updated"
+echo "[$(date +%Y-%m-%d_%H:%M:%S)] === r2c-asana-poll done ==="
+echo ""

--- a/SCRIPTS/r2c-dispatch.sh
+++ b/SCRIPTS/r2c-dispatch.sh
@@ -1,0 +1,197 @@
+#!/usr/bin/env bash
+# r2c-dispatch.sh
+# 用途: prompt_generated 状態のタスクを Lane (claude --bg) に dispatch する。
+#       --auto モード (cron) は空き slot に Tier 優先で投入。
+#       night mode 中は Tier S/A を投入しない。
+# Cron 間隔: */1 * * * *  (--auto)
+# 必要環境変数:
+#   ${R2C_CONFIG}/secrets/r2c-loop.env から読込 (Asana token 等は使わないが PATH 系を継承)
+# 呼び出し例:
+#   bash SCRIPTS/r2c-dispatch.sh --auto
+#   bash SCRIPTS/r2c-dispatch.sh --task-id 42
+#   bash SCRIPTS/r2c-dispatch.sh --auto --dry-run
+#
+# Phase 1 Step E-A — docs/24H_AUTOMATION_RUNBOOK_R2C.md 参照。
+
+set -euo pipefail
+
+# ─── R2C 定数 ─────────────────────────────────────────────────────────────
+R2C_ROOT="${R2C_ROOT:-$HOME/Documents/GitHub/commerce-faq-tasks}"
+R2C_CONFIG="${R2C_CONFIG:-$HOME/.claude-r2c-config}"
+QUEUE_DB="${R2C_ROOT}/.claude/queue/r2c-queue.db"
+WORKTREE_BASE="${R2C_ROOT}/.claude/worktrees"
+LOG_DIR="${R2C_CONFIG}/logs"
+SCRIPT_NAME="$(basename "$0" .sh)"
+MAX_SLOTS=5
+
+# ─── 引数 ──────────────────────────────────────────────────────────────────
+TASK_ID=""
+AUTO_MODE=0
+DRY_RUN=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --task-id) TASK_ID="$2"; shift 2 ;;
+        --auto)    AUTO_MODE=1; shift ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        -h|--help) sed -n '2,18p' "$0"; exit 0 ;;
+        *) echo "ERROR: unknown arg: $1" >&2; exit 1 ;;
+    esac
+done
+
+if [ -z "$TASK_ID" ] && [ "$AUTO_MODE" -eq 0 ]; then
+    echo "Usage: $0 --task-id <id> | --auto [--dry-run]" >&2
+    exit 1
+fi
+
+mkdir -p "$LOG_DIR"
+if [ "$DRY_RUN" -eq 0 ]; then
+    exec >> "${LOG_DIR}/${SCRIPT_NAME}.log" 2>&1
+fi
+
+# shellcheck disable=SC1091
+source "${R2C_CONFIG}/secrets/r2c-loop.env" 2>/dev/null || true
+
+echo "[$(date +%Y-%m-%d_%H:%M:%S)] === r2c-dispatch start (auto=${AUTO_MODE} task=${TASK_ID:-NA} dry=${DRY_RUN}) ==="
+
+if [ ! -f "$QUEUE_DB" ]; then
+    echo "ERROR: Queue DB not found: $QUEUE_DB" >&2
+    exit 1
+fi
+
+# ─── ヘルパー ─────────────────────────────────────────────────────────────
+SQ() { sqlite3 "$QUEUE_DB" "$1"; }
+
+# ─── 自動 mode の前段チェック ────────────────────────────────────────────
+CURRENT_MODE=$(SQ "SELECT value FROM automation_state WHERE key = 'mode';" || true)
+PAUSE=$(SQ "SELECT value FROM automation_state WHERE key = 'pause_dispatching';" || true)
+
+if [ "${PAUSE:-0}" = "1" ]; then
+    if [ "$AUTO_MODE" -eq 1 ]; then
+        exit 0
+    fi
+    echo "Dispatching is paused. Resume: sqlite3 ${QUEUE_DB} \"UPDATE automation_state SET value='0' WHERE key='pause_dispatching';\""
+    exit 0
+fi
+
+ACTIVE_COUNT=$(SQ "SELECT COUNT(*) FROM tasks WHERE state = 'running';")
+ACTIVE_COUNT=${ACTIVE_COUNT:-0}
+AVAILABLE_SLOTS=$((MAX_SLOTS - ACTIVE_COUNT))
+
+if [ "$AUTO_MODE" -eq 1 ] && [ "$AVAILABLE_SLOTS" -le 0 ]; then
+    echo "No free slots (active=${ACTIVE_COUNT}/${MAX_SLOTS}), skipping cycle"
+    exit 0
+fi
+
+# ─── auto mode: dispatch 候補抽出 ────────────────────────────────────────
+NIGHT_FILTER=""
+if [ "${CURRENT_MODE:-day}" = "night" ]; then
+    NIGHT_FILTER="AND night_mode_allowed = 1 AND tier = 'B'"
+fi
+
+dispatch_one() {
+    local task_id="$1"
+
+    local task_data
+    task_data=$(SQ "SELECT asana_gid, asana_name, tier, task_type, prompt_path, state, model FROM tasks WHERE id = ${task_id};") || true
+    if [ -z "$task_data" ]; then
+        echo "ERROR: Task ${task_id} not found"
+        return 1
+    fi
+
+    local asana_gid name tier task_type prompt_path state model
+    IFS='|' read -r asana_gid name tier task_type prompt_path state model <<< "$task_data"
+    echo "  asana_gid=${asana_gid} tier=${tier} type=${task_type}"
+
+    if [ "$state" != "prompt_generated" ]; then
+        echo "ERROR: Task ${task_id} state='${state}', expected 'prompt_generated'"
+        return 1
+    fi
+
+    if [ -z "$prompt_path" ] || [ ! -f "$prompt_path" ]; then
+        echo "ERROR: prompt_path missing for task ${task_id}: ${prompt_path}"
+        return 1
+    fi
+
+    local slug
+    slug=$(echo "$name" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' | cut -c1-40)
+    [ -z "$slug" ] && slug="task"
+    local worktree_path="${WORKTREE_BASE}/lane-${task_id}-${slug}"
+    local branch_name="auto/${tier,,}-${task_id}-${slug}"
+    local log_file="${LOG_DIR}/lane-${task_id}.log"
+    local lane_name="auto-${tier,,}-${task_id}"
+    local perm_mode="acceptEdits"
+    case "$tier" in
+        A) perm_mode="plan" ;;
+        S) perm_mode="plan" ;;
+    esac
+    local resolved_model="${model:-claude-sonnet-4-6}"
+
+    if [ "$DRY_RUN" -eq 1 ]; then
+        echo "DRY-RUN: would dispatch task=${task_id} tier=${tier} type=${task_type}"
+        echo "  worktree=${worktree_path}"
+        echo "  branch=${branch_name}"
+        echo "  model=${resolved_model} perm=${perm_mode}"
+        echo "  prompt=${prompt_path}"
+        return 0
+    fi
+
+    if [ ! -d "$worktree_path" ]; then
+        (
+            cd "$R2C_ROOT"
+            git fetch origin main 2>&1 | tail -3 || true
+            if git show-ref --verify --quiet "refs/heads/${branch_name}"; then
+                git worktree add "$worktree_path" "$branch_name"
+            else
+                git worktree add -b "$branch_name" "$worktree_path" origin/main
+            fi
+        ) || {
+            echo "ERROR: git worktree add failed for task ${task_id}"
+            SQ "UPDATE tasks SET state='failed', error_message='worktree add failed', last_action='dispatch_abort' WHERE id = ${task_id};"
+            return 1
+        }
+    fi
+
+    SQ "UPDATE tasks SET state='running', worktree_path='${worktree_path}', branch='${branch_name}', started_at=datetime('now'), attempt_count=COALESCE(attempt_count,0)+1, last_action='dispatched' WHERE id = ${task_id};"
+
+    mkdir -p "$(dirname "$log_file")"
+
+    nohup bash -c "
+        cd '${worktree_path}'
+        export PATH='/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:\$PATH'
+        claude --bg --name '${lane_name}' \\
+            --model '${resolved_model}' \\
+            --permission-mode '${perm_mode}' \\
+            --prompt-file '${prompt_path}' > '${log_file}' 2>&1
+    " > /dev/null 2>&1 &
+    disown
+
+    echo "Dispatched task ${task_id} (lane=${lane_name}) → ${log_file}"
+    return 0
+}
+
+if [ "$AUTO_MODE" -eq 1 ]; then
+    SLOTS_USED=0
+    while [ "$SLOTS_USED" -lt "$AVAILABLE_SLOTS" ]; do
+        NEXT_ID=$(SQ "SELECT id FROM tasks
+                      WHERE state = 'prompt_generated' ${NIGHT_FILTER}
+                      ORDER BY CASE tier WHEN 'S' THEN 0 WHEN 'A' THEN 1 ELSE 2 END,
+                               COALESCE(asana_due_on, '9999-12-31') ASC,
+                               id ASC
+                      LIMIT 1;")
+        if [ -z "$NEXT_ID" ]; then
+            echo "No more prompt_generated tasks (slots used=${SLOTS_USED}/${AVAILABLE_SLOTS})"
+            break
+        fi
+        if dispatch_one "$NEXT_ID"; then
+            SLOTS_USED=$((SLOTS_USED + 1))
+        else
+            echo "WARNING: dispatch_one failed for ${NEXT_ID}, continuing"
+        fi
+    done
+else
+    dispatch_one "$TASK_ID"
+fi
+
+echo "[$(date +%Y-%m-%d_%H:%M:%S)] === r2c-dispatch done ==="
+echo ""

--- a/SCRIPTS/r2c-generate-lane.sh
+++ b/SCRIPTS/r2c-generate-lane.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# r2c-generate-lane.sh
+# 用途: queue の task ID を受け取り、lane-templates から適切なテンプレを
+#       選択 → プレースホルダ置換 → .claude/lanes/lane-<id>.md に出力。
+#       changedFiles 判別ロジックは未実装 (本スクリプトは prompt 生成のみ)。
+# 呼び出し例:
+#   bash SCRIPTS/r2c-generate-lane.sh --task-id 42
+#   bash SCRIPTS/r2c-generate-lane.sh --task-id 42 --dry-run
+#
+# Phase 1 Step E-A — docs/24H_AUTOMATION_RUNBOOK_R2C.md 参照。
+
+set -euo pipefail
+
+# ─── R2C 定数 ─────────────────────────────────────────────────────────────
+R2C_ROOT="${R2C_ROOT:-$HOME/Documents/GitHub/commerce-faq-tasks}"
+R2C_CONFIG="${R2C_CONFIG:-$HOME/.claude-r2c-config}"
+QUEUE_DB="${R2C_ROOT}/.claude/queue/r2c-queue.db"
+TEMPLATE_DIR="${R2C_ROOT}/.claude/lane-templates"
+LANES_DIR="${R2C_ROOT}/.claude/lanes"
+WORKTREE_BASE="${R2C_ROOT}/.claude/worktrees"
+LOG_DIR="${R2C_CONFIG}/logs"
+SCRIPT_NAME="$(basename "$0" .sh)"
+
+# ─── 引数 ──────────────────────────────────────────────────────────────────
+TASK_ID=""
+DRY_RUN=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --task-id) TASK_ID="$2"; shift 2 ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        -h|--help) sed -n '2,15p' "$0"; exit 0 ;;
+        *) echo "ERROR: unknown arg: $1" >&2; exit 1 ;;
+    esac
+done
+
+if [ -z "$TASK_ID" ]; then
+    echo "Usage: $0 --task-id <id> [--dry-run]" >&2
+    exit 1
+fi
+
+mkdir -p "$LOG_DIR"
+if [ "$DRY_RUN" -eq 0 ]; then
+    exec >> "${LOG_DIR}/${SCRIPT_NAME}.log" 2>&1
+fi
+
+# shellcheck disable=SC1091
+source "${R2C_CONFIG}/secrets/r2c-loop.env" 2>/dev/null || true
+
+echo "[$(date +%Y-%m-%d_%H:%M:%S)] === r2c-generate-lane start (task=${TASK_ID} dry=${DRY_RUN}) ==="
+
+if [ ! -f "$QUEUE_DB" ]; then
+    echo "ERROR: Queue DB not found: $QUEUE_DB" >&2
+    exit 1
+fi
+if [ ! -d "$TEMPLATE_DIR" ]; then
+    echo "ERROR: Template dir not found: $TEMPLATE_DIR" >&2
+    exit 1
+fi
+
+# ─── ヘルパー ─────────────────────────────────────────────────────────────
+SQ() { sqlite3 "$QUEUE_DB" "$1"; }
+sqlq() { local s=${1//\'/\'\'}; printf "'%s'" "$s"; }
+
+TASK_DATA=$(SQ "SELECT asana_gid, asana_name, asana_notes, asana_permalink, asana_due_on, tier, task_type, model FROM tasks WHERE id = ${TASK_ID};")
+if [ -z "$TASK_DATA" ]; then
+    echo "ERROR: Task ${TASK_ID} not found" >&2
+    exit 1
+fi
+
+IFS='|' read -r ASANA_GID ASANA_NAME ASANA_NOTES ASANA_PERMALINK ASANA_DUE_ON TIER TASK_TYPE MODEL <<< "$TASK_DATA"
+
+# ─── テンプレ選択 ────────────────────────────────────────────────────────
+TEMPLATE_FILE=""
+case "${TIER}:${TASK_TYPE}" in
+    "B:docs"|"B:test"|"B:other") TEMPLATE_FILE="${TEMPLATE_DIR}/tier-b-docs.md" ;;
+    "B:skill"|"B:hook")          TEMPLATE_FILE="${TEMPLATE_DIR}/tier-b-skill.md" ;;
+    "A:api"|"A:migration")       TEMPLATE_FILE="${TEMPLATE_DIR}/tier-a-api.md" ;;
+    "A:schema")                  TEMPLATE_FILE="${TEMPLATE_DIR}/tier-a-schema.md" ;;
+    "S:"*)                       TEMPLATE_FILE="${TEMPLATE_DIR}/tier-s-prod.md" ;;
+    *)
+        echo "WARNING: no template match for tier=${TIER} type=${TASK_TYPE}, fallback to tier-b-docs.md"
+        TEMPLATE_FILE="${TEMPLATE_DIR}/tier-b-docs.md"
+        ;;
+esac
+
+if [ ! -f "$TEMPLATE_FILE" ]; then
+    echo "ERROR: Template missing: ${TEMPLATE_FILE}" >&2
+    exit 1
+fi
+
+# ─── branch / worktree path 算出 ─────────────────────────────────────────
+SAFE_NAME=$(echo "$ASANA_NAME" | tr '[:upper:]' '[:lower:]' | sed -E 's/[^a-z0-9]+/-/g; s/^-+|-+$//g' | cut -c1-40)
+[ -z "$SAFE_NAME" ] && SAFE_NAME="task"
+BRANCH_NAME="auto/${TIER,,}-${TASK_ID}-${SAFE_NAME}"
+WORKTREE_PATH="${WORKTREE_BASE}/lane-${TASK_ID}-${SAFE_NAME}"
+OUTPUT="${LANES_DIR}/lane-${TASK_ID}.md"
+
+echo "Template: ${TEMPLATE_FILE}"
+echo "Branch:   ${BRANCH_NAME}"
+echo "Worktree: ${WORKTREE_PATH}"
+echo "Output:   ${OUTPUT}"
+
+# ─── プレースホルダ置換 ──────────────────────────────────────────────────
+# 単純な値 (GID / branch / worktree / id / tier / type / model / due / permalink)
+# は sed で置換。Asana name/notes は改行・特殊文字を含むので、テンプレ展開後の
+# 末尾に専用ブロックでそのまま追記する (sed の delimiter 衝突回避)。
+RENDERED=$(mktemp)
+trap 'rm -f "$RENDERED"' EXIT
+
+{
+    sed -e "s|{{ASANA_GID}}|${ASANA_GID}|g" \
+        -e "s|{{BRANCH_NAME}}|${BRANCH_NAME}|g" \
+        -e "s|{{WORKTREE_PATH}}|${WORKTREE_PATH}|g" \
+        -e "s|{{TASK_ID}}|${TASK_ID}|g" \
+        -e "s|{{TIER}}|${TIER}|g" \
+        -e "s|{{TASK_TYPE}}|${TASK_TYPE}|g" \
+        -e "s|{{MODEL}}|${MODEL:-claude-sonnet-4-6}|g" \
+        -e "s|{{DUE_ON}}|${ASANA_DUE_ON}|g" \
+        -e "s|{{PERMALINK}}|${ASANA_PERMALINK}|g" \
+        "$TEMPLATE_FILE"
+    echo ""
+    echo "---"
+    echo "## このタスクの内容 (Asana より自動取得)"
+    echo ""
+    echo "### Asana GID"
+    echo "${ASANA_GID}"
+    echo ""
+    echo "### タスク名"
+    echo "${ASANA_NAME}"
+    echo ""
+    echo "### Asana notes (DoD など)"
+    echo "${ASANA_NOTES}"
+    echo ""
+    echo "### Permalink"
+    echo "${ASANA_PERMALINK}"
+    echo ""
+    echo "### Due"
+    echo "${ASANA_DUE_ON}"
+} > "$RENDERED"
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    echo "DRY-RUN: rendered prompt follows (no file write, no DB update)"
+    echo "---8<---"
+    cat "$RENDERED"
+    echo "--->8---"
+    exit 0
+fi
+
+mkdir -p "$LANES_DIR"
+mv "$RENDERED" "$OUTPUT"
+trap - EXIT
+
+SQ "UPDATE tasks SET state='prompt_generated', branch=$(sqlq "$BRANCH_NAME"), prompt_path=$(sqlq "$OUTPUT"), last_action='prompt_generated' WHERE id = ${TASK_ID};"
+
+echo "Lane prompt generated: ${OUTPUT}"
+echo "[$(date +%Y-%m-%d_%H:%M:%S)] === r2c-generate-lane done ==="
+echo ""

--- a/SCRIPTS/r2c-supervisor.sh
+++ b/SCRIPTS/r2c-supervisor.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# r2c-supervisor.sh
+# 用途: 1 分間隔で稼働中 Lane を監視。90 分以上 running の stuck Lane を
+#       検出して kill → attempt_count に応じて retry / rollback。
+#       連続失敗の閾値超過で dispatching を pause、Pushover で通知。
+# Cron 間隔: */1 * * * *
+# 必要環境変数:
+#   ${R2C_CONFIG}/secrets/r2c-loop.env から (Pushover token 等)
+# 呼び出し例:
+#   bash SCRIPTS/r2c-supervisor.sh
+#   bash SCRIPTS/r2c-supervisor.sh --dry-run
+#
+# Phase 1 Step E-A — docs/24H_LOOP_RETRY_AND_NOTIFICATION_SPEC.md §1 準拠。
+
+set -uo pipefail
+
+# ─── R2C 定数 ─────────────────────────────────────────────────────────────
+R2C_ROOT="${R2C_ROOT:-$HOME/Documents/GitHub/commerce-faq-tasks}"
+R2C_CONFIG="${R2C_CONFIG:-$HOME/.claude-r2c-config}"
+QUEUE_DB="${R2C_ROOT}/.claude/queue/r2c-queue.db"
+LOG_DIR="${R2C_CONFIG}/logs"
+SCRIPT_NAME="$(basename "$0" .sh)"
+MAX_RUN_MINUTES=90
+MAX_ATTEMPTS=3
+RECENT_FAILED_THRESHOLD=5
+RECENT_FAILED_WINDOW="-2 hours"
+
+# ─── 引数 ──────────────────────────────────────────────────────────────────
+DRY_RUN=0
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run) DRY_RUN=1; shift ;;
+        -h|--help) sed -n '2,16p' "$0"; exit 0 ;;
+        *) echo "ERROR: unknown arg: $1" >&2; exit 1 ;;
+    esac
+done
+
+mkdir -p "$LOG_DIR"
+if [ "$DRY_RUN" -eq 0 ]; then
+    exec >> "${LOG_DIR}/${SCRIPT_NAME}.log" 2>&1
+fi
+
+# shellcheck disable=SC1091
+source "${R2C_CONFIG}/secrets/r2c-loop.env" 2>/dev/null || true
+
+echo "[$(date +%Y-%m-%d_%H:%M:%S)] === r2c-supervisor start (dry=${DRY_RUN}) ==="
+
+if [ ! -f "$QUEUE_DB" ]; then
+    echo "ERROR: Queue DB not found: $QUEUE_DB" >&2
+    exit 1
+fi
+
+# ─── ヘルパー ─────────────────────────────────────────────────────────────
+SQ() { sqlite3 "$QUEUE_DB" "$1"; }
+
+notify() {
+    # priority: 0=normal, 1=high
+    local priority="$1"
+    local title="$2"
+    local body="$3"
+    if [ -x "${R2C_ROOT}/SCRIPTS/r2c-pushover.sh" ]; then
+        bash "${R2C_ROOT}/SCRIPTS/r2c-pushover.sh" --priority "$priority" --title "$title" --message "$body" 2>&1 || true
+    else
+        echo "NOTIFY(priority=${priority}): ${title} — ${body}"
+    fi
+}
+
+# ─── 1. Stuck Lane 検出 ──────────────────────────────────────────────────
+STUCK=$(SQ "SELECT id, asana_gid, asana_name, session_id, COALESCE(attempt_count,0), worktree_path
+            FROM tasks
+            WHERE state = 'running'
+              AND started_at IS NOT NULL
+              AND started_at < datetime('now', '-${MAX_RUN_MINUTES} minutes');")
+
+STUCK_COUNT=0
+if [ -n "$STUCK" ]; then
+    STUCK_COUNT=$(echo "$STUCK" | wc -l | tr -d ' ')
+    echo "Detected ${STUCK_COUNT} stuck lane(s) (running > ${MAX_RUN_MINUTES}min)"
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    if [ -n "$STUCK" ]; then
+        echo "DRY-RUN: stuck lanes:"
+        echo "$STUCK" | awk -F'|' '{printf "  - task=%s gid=%s attempt=%s name=%s\n", $1, $2, $5, $3}'
+    else
+        echo "DRY-RUN: no stuck lanes"
+    fi
+    echo "[$(date +%Y-%m-%d_%H:%M:%S)] === r2c-supervisor done (dry) ==="
+    exit 0
+fi
+
+if [ -n "$STUCK" ]; then
+    while IFS='|' read -r TID GID NAME SID ATTEMPT WORKTREE; do
+        [ -z "$TID" ] && continue
+        echo "Stuck task ${TID} (gid=${GID:-NA}, attempt=${ATTEMPT}, session=${SID:-NA}): ${NAME}"
+
+        # claude session kill (best-effort)
+        if [ -n "$SID" ]; then
+            pkill -f "claude.*${SID}" 2>/dev/null || true
+        fi
+
+        # worktree cleanup (r2c-lane-cleanup.sh は他 worktree 担当の前提)
+        if [ -x "${R2C_ROOT}/SCRIPTS/r2c-lane-cleanup.sh" ]; then
+            bash "${R2C_ROOT}/SCRIPTS/r2c-lane-cleanup.sh" --task-id "$TID" 2>&1 || true
+        elif [ -n "$WORKTREE" ] && [ -d "$WORKTREE" ]; then
+            (cd "$R2C_ROOT" && git worktree remove --force "$WORKTREE" 2>&1) || true
+        fi
+
+        ATTEMPT_NUM=${ATTEMPT:-0}
+        if [ "$ATTEMPT_NUM" -lt "$MAX_ATTEMPTS" ]; then
+            SQ "UPDATE tasks SET state='pending', session_id=NULL, worktree_path=NULL, error_message='stuck > ${MAX_RUN_MINUTES}min, auto-retry', last_action='auto_retry' WHERE id = ${TID};"
+            echo "  → re-queued for retry (${ATTEMPT_NUM}/${MAX_ATTEMPTS})"
+            notify 0 "R2C Lane stuck, retrying" "Task ${TID} stuck >${MAX_RUN_MINUTES}min, retry ${ATTEMPT_NUM}/${MAX_ATTEMPTS}: ${NAME}"
+        else
+            SQ "UPDATE tasks SET state='rollbacked', error_message='stuck > ${MAX_RUN_MINUTES}min for ${MAX_ATTEMPTS} attempts', last_action='auto_rollback' WHERE id = ${TID};"
+            echo "  → rollbacked (${MAX_ATTEMPTS} attempts exhausted)"
+            notify 1 "R2C Lane FAILED (rollback)" "Task ${TID} failed ${MAX_ATTEMPTS}x and was rolled back: ${NAME}"
+        fi
+    done <<< "$STUCK"
+fi
+
+# ─── 2. 連続失敗の検出 → dispatching pause ──────────────────────────────
+RECENT_FAILED=$(SQ "SELECT COUNT(*) FROM tasks
+                    WHERE state IN ('failed','rollbacked')
+                      AND COALESCE(updated_at, started_at) > datetime('now', '${RECENT_FAILED_WINDOW}');")
+RECENT_FAILED=${RECENT_FAILED:-0}
+
+if [ "$RECENT_FAILED" -ge "$RECENT_FAILED_THRESHOLD" ]; then
+    PAUSED_ALREADY=$(SQ "SELECT value FROM automation_state WHERE key = 'pause_dispatching';")
+    if [ "${PAUSED_ALREADY:-0}" != "1" ]; then
+        echo "CRITICAL: ${RECENT_FAILED} failures in last 2h → pausing dispatching"
+        SQ "INSERT OR REPLACE INTO automation_state (key, value) VALUES ('pause_dispatching', '1');"
+        notify 1 "R2C Many Failures" "${RECENT_FAILED} tasks failed/rollbacked in last 2h. Dispatching paused."
+    fi
+fi
+
+# ─── 3. Queue 統計スナップショット ───────────────────────────────────────
+echo "Queue stats:"
+SQ "SELECT state, COUNT(*) FROM tasks GROUP BY state ORDER BY state;" | sed 's/^/  /'
+
+SQ "INSERT OR REPLACE INTO automation_state (key, value) VALUES ('last_supervisor_run', '$(date -u +%Y-%m-%dT%H:%M:%SZ)');" || true
+
+echo "[$(date +%Y-%m-%d_%H:%M:%S)] === r2c-supervisor done ==="
+echo ""


### PR DESCRIPTION
## Summary

Phase 1 Step E-A: Asana 統合 4 scripts を新規追加。

- `SCRIPTS/r2c-asana-poll.sh` (161行) — 5分 cron / Asana → SQLite queue 取り込み (Tier prefix `[Tier B|A|S]` / `task_type:` 抽出)
- `SCRIPTS/r2c-dispatch.sh` (198行) — 1分 cron / prompt_generated → claude --bg Lane 起動 (MAX_SLOTS=5、night mode で Tier S/A 投入抑止、pause_dispatching 尊重)
- `SCRIPTS/r2c-generate-lane.sh` (157行) — lane-template 選択 + プレースホルダ置換 → `.claude/lanes/lane-<id>.md`
- `SCRIPTS/r2c-supervisor.sh` (144行) — 1分 cron / 90min stuck Lane 検出 → attempt_count < 3 で retry、3 で rollbacked + Pushover 通知

## DoD

- [x] shellcheck PASS (0 warning) — 4 ファイルとも
- [x] R2C 固有定数 (ASANA_PROJECT_GID / QUEUE_DB / WORKTREE_BASE / MAX_SLOTS=5) を bake-in
- [x] secret は `${R2C_CONFIG}/secrets/r2c-loop.env` から source、hardcode なし
- [x] `--dry-run` mode 全 4 本に実装
- [x] SQL リテラル安全化 `sqlq()` helper (UATa パターン踏襲)
- [x] 他 teammate 担当の `r2c-queue-add.sh` / `r2c-lane-cleanup.sh` / `r2c-pushover.sh` は呼び出しのみで未実装
- [x] auto-merge 無効 (Team Lead が E-A→B→C→D の順に merge)

## Test plan

- [ ] Tier S 実行 (アカウント分離) 完了後、cron 起動して end-to-end 動作確認
- [ ] `--dry-run` で各スクリプト単体動作確認
- [ ] Asana queue add の連携: r2c-queue-add.sh 完成後の統合テスト

Asana GID: 1214888697569649 (Step E 全体).