### PR TITLE
feat(phase1-stepe-c): SCRIPTS/r2c-queue-*.sh × 4 (SQLite queue)

### DIFF
--- a/SCRIPTS/r2c-queue-add.sh
+++ b/SCRIPTS/r2c-queue-add.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# r2c-queue-add.sh — R2C SQLite キューに新規 task を INSERT
+#
+# 用途: Asana から取り込んだタスクを r2c-queue.db.tasks に追加。
+#       asana_gid UNIQUE 制約により idempotent (ON CONFLICT DO NOTHING)。
+#       Phase 1 Step E-C (Asana GID 1214888697569649)。
+#
+# 必須引数:
+#   --asana-gid <gid>
+#   --name <text>
+#   --tier <B|A|S>
+#   --task-type <skill|hook|docs|schema|api|prod_change|migration|test|other>
+#
+# オプション:
+#   --notes <text>
+#   --permalink <url>
+#   --due-on <YYYY-MM-DD>
+#   --model <claude-sonnet-4-6|claude-opus-4-7|claude-haiku-4-5>
+#   --gate-2-5-required          gate_2_5_required=1
+#   --night-mode-allowed <0|1>   default 1
+#   --max-attempts <N>           default 3
+#   --dry-run                    実行 SQL を stdout に出力、書き込みなし
+#   -h, --help
+#
+# 呼び出し例:
+#   bash SCRIPTS/r2c-queue-add.sh \
+#     --asana-gid 1234567890 \
+#     --name "Fix CORS preflight" \
+#     --tier A --task-type api --gate-2-5-required
+
+set -euo pipefail
+
+R2C_ROOT="${R2C_ROOT:-$HOME/Documents/GitHub/commerce-faq-tasks}"
+R2C_CONFIG="${R2C_CONFIG:-$HOME/.claude-r2c-config}"
+QUEUE_DB="${QUEUE_DB:-${R2C_ROOT}/.claude/queue/r2c-queue.db}"
+LOG_DIR="${LOG_DIR:-${R2C_CONFIG}/logs}"
+LOG_FILE="${LOG_DIR}/queue-add.log"
+
+ASANA_GID=""
+NAME=""
+TIER=""
+TASK_TYPE=""
+NOTES=""
+PERMALINK=""
+DUE_ON=""
+MODEL="claude-sonnet-4-6"
+GATE_2_5=0
+NIGHT_MODE_ALLOWED=1
+MAX_ATTEMPTS=3
+DRY_RUN=0
+
+usage() {
+    sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --asana-gid) ASANA_GID="${2:-}"; shift 2 ;;
+        --name) NAME="${2:-}"; shift 2 ;;
+        --tier) TIER="${2:-}"; shift 2 ;;
+        --task-type) TASK_TYPE="${2:-}"; shift 2 ;;
+        --notes) NOTES="${2:-}"; shift 2 ;;
+        --permalink) PERMALINK="${2:-}"; shift 2 ;;
+        --due-on) DUE_ON="${2:-}"; shift 2 ;;
+        --model) MODEL="${2:-}"; shift 2 ;;
+        --gate-2-5-required) GATE_2_5=1; shift ;;
+        --night-mode-allowed) NIGHT_MODE_ALLOWED="${2:-1}"; shift 2 ;;
+        --max-attempts) MAX_ATTEMPTS="${2:-3}"; shift 2 ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "ERROR: unknown arg: $1" >&2; usage >&2; exit 1 ;;
+    esac
+done
+
+# Required-args check
+for pair in "ASANA_GID:--asana-gid" "NAME:--name" "TIER:--tier" "TASK_TYPE:--task-type"; do
+    var="${pair%%:*}"
+    flag="${pair##*:}"
+    if [ -z "${!var}" ]; then
+        echo "ERROR: missing required: $flag" >&2
+        exit 1
+    fi
+done
+
+# Numeric guards (avoid injection via numeric args)
+if ! printf '%s' "$MAX_ATTEMPTS" | grep -qE '^[0-9]+$'; then
+    echo "ERROR: --max-attempts must be non-negative integer" >&2
+    exit 1
+fi
+if [ "$NIGHT_MODE_ALLOWED" != "0" ] && [ "$NIGHT_MODE_ALLOWED" != "1" ]; then
+    echo "ERROR: --night-mode-allowed must be 0 or 1" >&2
+    exit 1
+fi
+
+# SQL string escape: single-quote doubling
+sql_escape() {
+    printf "%s" "${1//\'/\'\'}"
+}
+
+# NULL or quoted literal
+sql_str_or_null() {
+    if [ -z "$1" ]; then
+        printf 'NULL'
+    else
+        printf "'%s'" "$(sql_escape "$1")"
+    fi
+}
+
+ESC_GID=$(sql_escape "$ASANA_GID")
+ESC_NAME=$(sql_escape "$NAME")
+ESC_TIER=$(sql_escape "$TIER")
+ESC_TYPE=$(sql_escape "$TASK_TYPE")
+ESC_MODEL=$(sql_escape "$MODEL")
+LIT_NOTES=$(sql_str_or_null "$NOTES")
+LIT_LINK=$(sql_str_or_null "$PERMALINK")
+LIT_DUE=$(sql_str_or_null "$DUE_ON")
+
+SQL=$(cat <<SQL_EOF
+INSERT INTO tasks (
+    asana_gid, asana_name, asana_notes, asana_permalink, asana_due_on,
+    tier, task_type, model,
+    gate_2_5_required, max_attempts, night_mode_allowed
+) VALUES (
+    '${ESC_GID}', '${ESC_NAME}', ${LIT_NOTES}, ${LIT_LINK}, ${LIT_DUE},
+    '${ESC_TIER}', '${ESC_TYPE}', '${ESC_MODEL}',
+    ${GATE_2_5}, ${MAX_ATTEMPTS}, ${NIGHT_MODE_ALLOWED}
+)
+ON CONFLICT(asana_gid) DO NOTHING
+RETURNING id;
+SQL_EOF
+)
+
+log() {
+    local msg
+    msg="[$(date '+%Y-%m-%dT%H:%M:%S%z')] $*"
+    printf '%s\n' "$msg"
+    if [ "$DRY_RUN" -eq 0 ]; then
+        mkdir -p "$LOG_DIR"
+        printf '%s\n' "$msg" >> "$LOG_FILE"
+    fi
+}
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    printf '%s\n' "-- DRY RUN against: $QUEUE_DB"
+    printf '%s\n' "$SQL"
+    exit 0
+fi
+
+if [ ! -f "$QUEUE_DB" ]; then
+    echo "ERROR: queue DB not found: $QUEUE_DB (run r2c-queue-init.sh first)" >&2
+    exit 2
+fi
+
+mkdir -p "$LOG_DIR"
+log "==== r2c-queue-add.sh asana_gid=$ASANA_GID tier=$TIER type=$TASK_TYPE ===="
+
+NEW_ID=$(sqlite3 "$QUEUE_DB" "$SQL" || true)
+
+if [ -n "$NEW_ID" ]; then
+    log "  inserted id=$NEW_ID"
+    printf '%s\n' "$NEW_ID"
+else
+    EXISTING=$(sqlite3 "$QUEUE_DB" \
+        "SELECT id FROM tasks WHERE asana_gid='${ESC_GID}';")
+    log "  duplicate asana_gid; existing id=$EXISTING (no-op)"
+    printf '%s\n' "$EXISTING"
+fi

--- a/SCRIPTS/r2c-queue-init.sh
+++ b/SCRIPTS/r2c-queue-init.sh
@@ -1,0 +1,152 @@
+#!/usr/bin/env bash
+# r2c-queue-init.sh — R2C 24h Autonomous Loop: SQLite キュー DB 初期化
+#
+# 用途: .claude/queue/r2c-queue.db の schema を作成/更新 (idempotent)。
+#       Phase 1 Step E-C (Asana GID 1214888697569649)。
+#
+# 必須引数: なし
+# オプション:
+#   --reset      既存 DB を timestamp 付き .bak に退避してから再作成
+#   --dry-run    実行 SQL を stdout に出力するだけ (書き込みなし)
+#   -h, --help   ヘルプ表示
+#
+# 呼び出し例:
+#   bash SCRIPTS/r2c-queue-init.sh
+#   bash SCRIPTS/r2c-queue-init.sh --reset
+#   bash SCRIPTS/r2c-queue-init.sh --dry-run
+
+set -euo pipefail
+
+R2C_ROOT="${R2C_ROOT:-$HOME/Documents/GitHub/commerce-faq-tasks}"
+R2C_CONFIG="${R2C_CONFIG:-$HOME/.claude-r2c-config}"
+QUEUE_DB="${QUEUE_DB:-${R2C_ROOT}/.claude/queue/r2c-queue.db}"
+LOG_DIR="${LOG_DIR:-${R2C_CONFIG}/logs}"
+LOG_FILE="${LOG_DIR}/queue-init.log"
+
+DRY_RUN=0
+RESET=0
+
+usage() {
+    sed -n '2,18p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --reset) RESET=1; shift ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "ERROR: unknown arg: $1" >&2; usage >&2; exit 1 ;;
+    esac
+done
+
+SCHEMA_SQL=$(cat <<'SQL'
+PRAGMA journal_mode = WAL;
+PRAGMA synchronous = NORMAL;
+PRAGMA foreign_keys = ON;
+
+CREATE TABLE IF NOT EXISTS tasks (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    asana_gid TEXT UNIQUE NOT NULL,
+    asana_name TEXT NOT NULL,
+    asana_notes TEXT,
+    asana_permalink TEXT,
+    asana_due_on TEXT,
+    tier TEXT NOT NULL CHECK (tier IN ('B','A','S')),
+    task_type TEXT NOT NULL CHECK (task_type IN ('skill','hook','docs','schema','api','prod_change','migration','test','other')),
+    model TEXT NOT NULL DEFAULT 'claude-sonnet-4-6'
+        CHECK (model IN ('claude-sonnet-4-6','claude-opus-4-7','claude-haiku-4-5')),
+    state TEXT NOT NULL DEFAULT 'pending' CHECK (state IN (
+        'pending','prompt_generated','running','pr_created','verify_passed',
+        'ready_to_merge','needs_approval','needs_approval_critical',
+        'merged','deployed','done','failed','rollbacked','cancelled'
+    )),
+    branch TEXT,
+    worktree_path TEXT,
+    prompt_path TEXT,
+    pr_number INTEGER,
+    pr_url TEXT,
+    session_id TEXT,
+    gate_2_5_required INTEGER NOT NULL DEFAULT 0,
+    attempt_count INTEGER NOT NULL DEFAULT 0,
+    max_attempts INTEGER NOT NULL DEFAULT 3,
+    night_mode_allowed INTEGER NOT NULL DEFAULT 1 CHECK (night_mode_allowed IN (0,1)),
+    created_at TEXT NOT NULL DEFAULT (datetime('now')),
+    updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+    started_at TEXT,
+    completed_at TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_tasks_state ON tasks(state);
+CREATE INDEX IF NOT EXISTS idx_tasks_tier ON tasks(tier);
+CREATE INDEX IF NOT EXISTS idx_tasks_asana_gid ON tasks(asana_gid);
+
+CREATE TABLE IF NOT EXISTS automation_state (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+INSERT OR IGNORE INTO automation_state(key, value) VALUES
+    ('mode', 'daytime'),
+    ('pause_dispatching', '0'),
+    ('max_slots', '5');
+
+CREATE TABLE IF NOT EXISTS lane_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    task_id INTEGER NOT NULL REFERENCES tasks(id),
+    event_type TEXT NOT NULL,
+    payload TEXT,
+    created_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+SQL
+)
+
+log() {
+    local msg
+    msg="[$(date '+%Y-%m-%dT%H:%M:%S%z')] $*"
+    printf '%s\n' "$msg"
+    if [ "$DRY_RUN" -eq 0 ]; then
+        mkdir -p "$LOG_DIR"
+        printf '%s\n' "$msg" >> "$LOG_FILE"
+    fi
+}
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    printf '%s\n' "-- DRY RUN: would init DB at: $QUEUE_DB"
+    if [ "$RESET" -eq 1 ] && [ -f "$QUEUE_DB" ]; then
+        printf '%s\n' "-- DRY RUN: would mv $QUEUE_DB -> $QUEUE_DB.bak.YYYYMMDD_HHMMSS"
+    fi
+    printf '%s\n' "$SCHEMA_SQL"
+    printf '%s\n' "-- DRY RUN: would run PRAGMA integrity_check"
+    exit 0
+fi
+
+mkdir -p "$(dirname "$QUEUE_DB")"
+mkdir -p "$LOG_DIR"
+
+log "==== r2c-queue-init.sh start ===="
+log "QUEUE_DB=$QUEUE_DB"
+log "RESET=$RESET"
+
+if [ "$RESET" -eq 1 ] && [ -f "$QUEUE_DB" ]; then
+    BAK="${QUEUE_DB}.bak.$(date +%Y%m%d_%H%M%S)"
+    mv "$QUEUE_DB" "$BAK"
+    log "  reset: moved existing DB to $BAK"
+fi
+
+printf '%s\n' "$SCHEMA_SQL" | sqlite3 "$QUEUE_DB"
+log "  schema applied (idempotent)"
+
+INTEGRITY=$(sqlite3 "$QUEUE_DB" "PRAGMA integrity_check;")
+log "  PRAGMA integrity_check: $INTEGRITY"
+if [ "$INTEGRITY" != "ok" ]; then
+    log "ERROR: integrity_check failed"
+    exit 3
+fi
+
+TASK_CNT=$(sqlite3 "$QUEUE_DB" "SELECT COUNT(*) FROM tasks;")
+STATE_CNT=$(sqlite3 "$QUEUE_DB" "SELECT COUNT(*) FROM automation_state;")
+log "  tasks=$TASK_CNT automation_state=$STATE_CNT"
+log "==== r2c-queue-init.sh done ===="
+
+printf '%s\n' "OK: $QUEUE_DB initialized."

--- a/SCRIPTS/r2c-queue-list.sh
+++ b/SCRIPTS/r2c-queue-list.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# r2c-queue-list.sh — R2C SQLite キューの task を一覧表示 (読み取り専用)
+#
+# 用途: state / tier / asana_gid でフィルタして tasks 一覧を出力。
+#       human (table) / json / tsv の 3 フォーマット対応。
+#       Phase 1 Step E-C (Asana GID 1214888697569649)。
+#
+# オプション:
+#   --state <csv>          例: pending,running  (省略時=全state)
+#   --tier <B|A|S>
+#   --asana-gid <gid>
+#   --limit <N>            default 20
+#   --format <human|json|tsv>   default human
+#   --with-events          json mode のみ。lane_events を埋め込む
+#   -h, --help
+#
+# 呼び出し例:
+#   bash SCRIPTS/r2c-queue-list.sh
+#   bash SCRIPTS/r2c-queue-list.sh --state pending,running --tier A
+#   bash SCRIPTS/r2c-queue-list.sh --format json | jq '.[] | .id'
+
+set -euo pipefail
+
+R2C_ROOT="${R2C_ROOT:-$HOME/Documents/GitHub/commerce-faq-tasks}"
+QUEUE_DB="${QUEUE_DB:-${R2C_ROOT}/.claude/queue/r2c-queue.db}"
+
+STATE_CSV=""
+TIER=""
+ASANA_GID=""
+LIMIT=20
+FORMAT="human"
+WITH_EVENTS=0
+
+usage() {
+    sed -n '2,21p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --state) STATE_CSV="${2:-}"; shift 2 ;;
+        --tier) TIER="${2:-}"; shift 2 ;;
+        --asana-gid) ASANA_GID="${2:-}"; shift 2 ;;
+        --limit) LIMIT="${2:-20}"; shift 2 ;;
+        --format) FORMAT="${2:-human}"; shift 2 ;;
+        --with-events) WITH_EVENTS=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "ERROR: unknown arg: $1" >&2; usage >&2; exit 1 ;;
+    esac
+done
+
+if ! printf '%s' "$LIMIT" | grep -qE '^[0-9]+$'; then
+    echo "ERROR: --limit must be non-negative integer" >&2
+    exit 1
+fi
+case "$FORMAT" in
+    human|json|tsv) ;;
+    *) echo "ERROR: --format must be human|json|tsv" >&2; exit 1 ;;
+esac
+
+if [ ! -f "$QUEUE_DB" ]; then
+    echo "ERROR: queue DB not found: $QUEUE_DB (run r2c-queue-init.sh first)" >&2
+    exit 2
+fi
+
+sql_escape() {
+    printf "%s" "${1//\'/\'\'}"
+}
+
+# Build WHERE
+WHERE_PARTS=()
+if [ -n "$STATE_CSV" ]; then
+    IN_LIST=""
+    IFS=',' read -ra ARR <<< "$STATE_CSV"
+    for s in "${ARR[@]}"; do
+        s_trim="${s// /}"
+        [ -z "$s_trim" ] && continue
+        esc=$(sql_escape "$s_trim")
+        if [ -z "$IN_LIST" ]; then
+            IN_LIST="'${esc}'"
+        else
+            IN_LIST="${IN_LIST},'${esc}'"
+        fi
+    done
+    if [ -n "$IN_LIST" ]; then
+        WHERE_PARTS+=("state IN (${IN_LIST})")
+    fi
+fi
+if [ -n "$TIER" ]; then
+    WHERE_PARTS+=("tier='$(sql_escape "$TIER")'")
+fi
+if [ -n "$ASANA_GID" ]; then
+    WHERE_PARTS+=("asana_gid='$(sql_escape "$ASANA_GID")'")
+fi
+
+WHERE_CLAUSE=""
+for w in "${WHERE_PARTS[@]:-}"; do
+    [ -z "$w" ] && continue
+    if [ -z "$WHERE_CLAUSE" ]; then
+        WHERE_CLAUSE="WHERE $w"
+    else
+        WHERE_CLAUSE="${WHERE_CLAUSE} AND $w"
+    fi
+done
+
+COLS="id, asana_gid, asana_name, tier, task_type, state, attempt_count, created_at, pr_number, pr_url"
+BASE_SQL="SELECT ${COLS} FROM tasks ${WHERE_CLAUSE} ORDER BY id DESC LIMIT ${LIMIT};"
+
+case "$FORMAT" in
+    human)
+        # Pipe-separated for safe parsing, then awk format
+        printf 'id\tgid\tname\ttier\ttype\tstate\tattempt\tcreated\n'
+        printf '%s\n' "----"
+        sqlite3 -separator $'\t' "$QUEUE_DB" \
+            "SELECT id, asana_gid, substr(asana_name,1,40), tier, task_type, state, attempt_count, created_at FROM tasks ${WHERE_CLAUSE} ORDER BY id DESC LIMIT ${LIMIT};" \
+            | awk -F'\t' 'BEGIN{OFS="\t"} {print $1,$2,$3,$4,$5,$6,$7,$8}'
+        ;;
+    tsv)
+        sqlite3 -separator $'\t' "$QUEUE_DB" "$BASE_SQL"
+        ;;
+    json)
+        # Use sqlite3's -json (available in modern sqlite3 >=3.33)
+        TASKS_JSON=$(sqlite3 -json "$QUEUE_DB" "$BASE_SQL" 2>/dev/null || true)
+        if [ -z "$TASKS_JSON" ]; then
+            TASKS_JSON="[]"
+        fi
+        if [ "$WITH_EVENTS" -eq 1 ]; then
+            if ! command -v jq > /dev/null 2>&1; then
+                echo "ERROR: --with-events requires jq" >&2
+                exit 1
+            fi
+            EVENTS_JSON=$(sqlite3 -json "$QUEUE_DB" \
+                "SELECT task_id, event_type, payload, created_at FROM lane_events WHERE task_id IN (SELECT id FROM tasks ${WHERE_CLAUSE} ORDER BY id DESC LIMIT ${LIMIT}) ORDER BY id ASC;" \
+                2>/dev/null || true)
+            [ -z "$EVENTS_JSON" ] && EVENTS_JSON="[]"
+            printf '%s' "$TASKS_JSON" | jq --argjson ev "$EVENTS_JSON" \
+                'map(. as $t | . + {events: ($ev | map(select(.task_id == $t.id)))})'
+        else
+            printf '%s\n' "$TASKS_JSON"
+        fi
+        ;;
+esac

--- a/SCRIPTS/r2c-queue-update.sh
+++ b/SCRIPTS/r2c-queue-update.sh
@@ -1,0 +1,244 @@
+#!/usr/bin/env bash
+# r2c-queue-update.sh — R2C SQLite キューの task を UPDATE
+#
+# 用途: state 遷移 (CHECK 表に基づく) や branch / pr_number / 各種ステータス
+#       フィールドを更新。state 遷移時は lane_events に履歴を追記。
+#       Phase 1 Step E-C (Asana GID 1214888697569649)。
+#
+# 必須引数:
+#   --task-id <id>
+#
+# 更新フィールド (1 個以上指定):
+#   --state <new-state>          遷移許容表を bake-in、不正なら exit 2
+#   --branch <name>
+#   --worktree-path <path>
+#   --prompt-path <path>
+#   --pr-number <num>
+#   --pr-url <url>
+#   --session-id <sid>
+#   --attempt-inc                attempt_count = attempt_count + 1
+#   --started                    started_at = datetime('now')
+#   --completed                  completed_at = datetime('now')
+#
+# その他:
+#   --force                      state 遷移 check を bypass
+#   --dry-run                    実行 SQL を stdout に出力、書き込みなし
+#   -h, --help
+#
+# 呼び出し例:
+#   bash SCRIPTS/r2c-queue-update.sh --task-id 42 --state running --started
+#   bash SCRIPTS/r2c-queue-update.sh --task-id 42 --pr-number 999 --pr-url https://...
+
+set -euo pipefail
+
+R2C_ROOT="${R2C_ROOT:-$HOME/Documents/GitHub/commerce-faq-tasks}"
+R2C_CONFIG="${R2C_CONFIG:-$HOME/.claude-r2c-config}"
+QUEUE_DB="${QUEUE_DB:-${R2C_ROOT}/.claude/queue/r2c-queue.db}"
+LOG_DIR="${LOG_DIR:-${R2C_CONFIG}/logs}"
+LOG_FILE="${LOG_DIR}/queue-update.log"
+
+TASK_ID=""
+NEW_STATE=""
+BRANCH=""
+WORKTREE_PATH=""
+PROMPT_PATH=""
+PR_NUMBER=""
+PR_URL=""
+SESSION_ID=""
+ATTEMPT_INC=0
+SET_STARTED=0
+SET_COMPLETED=0
+FORCE=0
+DRY_RUN=0
+
+# Sentinels (so we can distinguish "not provided" from "empty value")
+HAS_BRANCH=0
+HAS_WORKTREE=0
+HAS_PROMPT=0
+HAS_PR_NUMBER=0
+HAS_PR_URL=0
+HAS_SESSION=0
+
+usage() {
+    sed -n '2,33p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --task-id) TASK_ID="${2:-}"; shift 2 ;;
+        --state) NEW_STATE="${2:-}"; shift 2 ;;
+        --branch) BRANCH="${2:-}"; HAS_BRANCH=1; shift 2 ;;
+        --worktree-path) WORKTREE_PATH="${2:-}"; HAS_WORKTREE=1; shift 2 ;;
+        --prompt-path) PROMPT_PATH="${2:-}"; HAS_PROMPT=1; shift 2 ;;
+        --pr-number) PR_NUMBER="${2:-}"; HAS_PR_NUMBER=1; shift 2 ;;
+        --pr-url) PR_URL="${2:-}"; HAS_PR_URL=1; shift 2 ;;
+        --session-id) SESSION_ID="${2:-}"; HAS_SESSION=1; shift 2 ;;
+        --attempt-inc) ATTEMPT_INC=1; shift ;;
+        --started) SET_STARTED=1; shift ;;
+        --completed) SET_COMPLETED=1; shift ;;
+        --force) FORCE=1; shift ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        *) echo "ERROR: unknown arg: $1" >&2; usage >&2; exit 1 ;;
+    esac
+done
+
+if [ -z "$TASK_ID" ]; then
+    echo "ERROR: --task-id is required" >&2
+    exit 1
+fi
+if ! printf '%s' "$TASK_ID" | grep -qE '^[0-9]+$'; then
+    echo "ERROR: --task-id must be positive integer" >&2
+    exit 1
+fi
+if [ -n "$PR_NUMBER" ] && ! printf '%s' "$PR_NUMBER" | grep -qE '^[0-9]+$'; then
+    echo "ERROR: --pr-number must be integer" >&2
+    exit 1
+fi
+
+# Allowed transitions (terminal states: done / rollbacked / cancelled)
+allowed_transition() {
+    local from="$1" to="$2"
+    case "$from->$to" in
+        "pending->prompt_generated"|"pending->cancelled") return 0 ;;
+        "prompt_generated->running"|"prompt_generated->cancelled") return 0 ;;
+        "running->pr_created"|"running->failed") return 0 ;;
+        "pr_created->verify_passed"|"pr_created->failed") return 0 ;;
+        "verify_passed->ready_to_merge"|"verify_passed->needs_approval"|"verify_passed->needs_approval_critical"|"verify_passed->failed") return 0 ;;
+        "ready_to_merge->merged"|"ready_to_merge->failed") return 0 ;;
+        "needs_approval->merged"|"needs_approval->cancelled") return 0 ;;
+        "needs_approval_critical->merged"|"needs_approval_critical->cancelled") return 0 ;;
+        "merged->deployed"|"merged->failed") return 0 ;;
+        "deployed->done"|"deployed->failed") return 0 ;;
+        "failed->pending"|"failed->rollbacked") return 0 ;;
+        *) return 1 ;;
+    esac
+}
+
+sql_escape() {
+    printf "%s" "${1//\'/\'\'}"
+}
+
+log() {
+    local msg
+    msg="[$(date '+%Y-%m-%dT%H:%M:%S%z')] $*"
+    printf '%s\n' "$msg"
+    if [ "$DRY_RUN" -eq 0 ]; then
+        mkdir -p "$LOG_DIR"
+        printf '%s\n' "$msg" >> "$LOG_FILE"
+    fi
+}
+
+# Build SET clause incrementally
+SET_PARTS=()
+
+if [ -n "$NEW_STATE" ]; then
+    ESC_STATE=$(sql_escape "$NEW_STATE")
+    SET_PARTS+=("state='${ESC_STATE}'")
+fi
+if [ "$HAS_BRANCH" -eq 1 ]; then
+    SET_PARTS+=("branch='$(sql_escape "$BRANCH")'")
+fi
+if [ "$HAS_WORKTREE" -eq 1 ]; then
+    SET_PARTS+=("worktree_path='$(sql_escape "$WORKTREE_PATH")'")
+fi
+if [ "$HAS_PROMPT" -eq 1 ]; then
+    SET_PARTS+=("prompt_path='$(sql_escape "$PROMPT_PATH")'")
+fi
+if [ "$HAS_PR_NUMBER" -eq 1 ]; then
+    if [ -z "$PR_NUMBER" ]; then
+        SET_PARTS+=("pr_number=NULL")
+    else
+        SET_PARTS+=("pr_number=${PR_NUMBER}")
+    fi
+fi
+if [ "$HAS_PR_URL" -eq 1 ]; then
+    SET_PARTS+=("pr_url='$(sql_escape "$PR_URL")'")
+fi
+if [ "$HAS_SESSION" -eq 1 ]; then
+    SET_PARTS+=("session_id='$(sql_escape "$SESSION_ID")'")
+fi
+if [ "$ATTEMPT_INC" -eq 1 ]; then
+    SET_PARTS+=("attempt_count=attempt_count+1")
+fi
+if [ "$SET_STARTED" -eq 1 ]; then
+    SET_PARTS+=("started_at=datetime('now')")
+fi
+if [ "$SET_COMPLETED" -eq 1 ]; then
+    SET_PARTS+=("completed_at=datetime('now')")
+fi
+# Always bump updated_at
+SET_PARTS+=("updated_at=datetime('now')")
+
+if [ "${#SET_PARTS[@]}" -le 1 ]; then
+    echo "ERROR: no update fields provided" >&2
+    usage >&2
+    exit 1
+fi
+
+# Build SET clause (comma-joined)
+SET_CLAUSE=""
+for p in "${SET_PARTS[@]}"; do
+    if [ -z "$SET_CLAUSE" ]; then
+        SET_CLAUSE="$p"
+    else
+        SET_CLAUSE="${SET_CLAUSE}, $p"
+    fi
+done
+
+# Look up current state if we are transitioning
+CUR_STATE=""
+if [ -n "$NEW_STATE" ] || [ "$DRY_RUN" -eq 0 ]; then
+    if [ -f "$QUEUE_DB" ]; then
+        CUR_STATE=$(sqlite3 "$QUEUE_DB" \
+            "SELECT state FROM tasks WHERE id=${TASK_ID};" 2>/dev/null || true)
+    fi
+fi
+
+if [ -n "$NEW_STATE" ] && [ -n "$CUR_STATE" ] && [ "$FORCE" -eq 0 ]; then
+    if [ "$CUR_STATE" = "$NEW_STATE" ]; then
+        log "  no-op: state already '$NEW_STATE'"
+    elif ! allowed_transition "$CUR_STATE" "$NEW_STATE"; then
+        echo "ERROR: disallowed state transition: $CUR_STATE -> $NEW_STATE (use --force to bypass)" >&2
+        exit 2
+    fi
+fi
+
+UPDATE_SQL="UPDATE tasks SET ${SET_CLAUSE} WHERE id=${TASK_ID};"
+
+EVENT_SQL=""
+if [ -n "$NEW_STATE" ] && [ -n "$CUR_STATE" ] && [ "$CUR_STATE" != "$NEW_STATE" ]; then
+    ESC_FROM=$(sql_escape "$CUR_STATE")
+    ESC_TO=$(sql_escape "$NEW_STATE")
+    PAYLOAD="{\"from\":\"${ESC_FROM}\",\"to\":\"${ESC_TO}\"}"
+    ESC_PAYLOAD=$(sql_escape "$PAYLOAD")
+    EVENT_SQL="INSERT INTO lane_events(task_id, event_type, payload) VALUES (${TASK_ID}, 'state_change', '${ESC_PAYLOAD}');"
+fi
+
+if [ "$DRY_RUN" -eq 1 ]; then
+    printf '%s\n' "-- DRY RUN against: $QUEUE_DB"
+    printf '%s\n' "$UPDATE_SQL"
+    [ -n "$EVENT_SQL" ] && printf '%s\n' "$EVENT_SQL"
+    exit 0
+fi
+
+if [ ! -f "$QUEUE_DB" ]; then
+    echo "ERROR: queue DB not found: $QUEUE_DB" >&2
+    exit 2
+fi
+
+mkdir -p "$LOG_DIR"
+log "==== r2c-queue-update.sh task_id=$TASK_ID state=$CUR_STATE->${NEW_STATE:-(no-change)} ===="
+
+# Wrap in transaction (state-change event + tasks update atomic)
+{
+    printf '%s\n' "BEGIN;"
+    printf '%s\n' "$UPDATE_SQL"
+    [ -n "$EVENT_SQL" ] && printf '%s\n' "$EVENT_SQL"
+    printf '%s\n' "COMMIT;"
+} | sqlite3 "$QUEUE_DB"
+
+CHANGED=$(sqlite3 "$QUEUE_DB" \
+    "SELECT changes();" 2>/dev/null || echo "?")
+log "  updated rows≈$CHANGED"
+printf '%s\n' "OK: task $TASK_ID updated."


### PR DESCRIPTION
DoD: r2c-queue-init / r2c-queue-add / r2c-queue-update / r2c-queue-list (shellcheck PASS, SQL injection 防御 sql_escape). Phase 1 Step E-C. Asana GID 1214888697569649.

## Scripts
- `SCRIPTS/r2c-queue-init.sh` — schema 適用 (idempotent, `--reset` / `--dry-run` / `PRAGMA integrity_check`)
- `SCRIPTS/r2c-queue-add.sh` — tasks INSERT (`sql_escape` + `ON CONFLICT(asana_gid) DO NOTHING` で idempotent)
- `SCRIPTS/r2c-queue-update.sh` — state 遷移 check (RUNBOOK §3 表 bake-in) + `lane_events` 履歴。`--force` で bypass、tasks update と event INSERT を BEGIN/COMMIT 内で atomic 実行
- `SCRIPTS/r2c-queue-list.sh` — `--state` (CSV) / `--tier` / `--asana-gid` / `--limit` フィルタ。`--format human|json|tsv`、`--with-events` (json モードのみ jq 必須)

## Schema
RUNBOOK_R2C.md §3 と完全一致。`tasks` / `automation_state` (mode / pause_dispatching / max_slots seed) / `lane_events` の 3 テーブル。

## Gate 1 / Gate 2
- `shellcheck SCRIPTS/r2c-queue-*.sh` PASS (0 warning)
- 未エスケープ変数の SQL 埋め込みなし (`grep '\$\{?[A-Z_]+\}?''` の hit は全て `ESC_*` または log メッセージ)
- 全 dry-run スモークテスト済 (init / add (single quote 含む name) / update (state 遷移 + bad transition reject))

## Notes
- auto-merge は **enable しない** (Phase 1 Step E 統合レビュー後にまとめてマージ)
- env var: `R2C_ROOT` / `R2C_CONFIG` / `QUEUE_DB` / `LOG_DIR` で上書き可