### PR TITLE
feat(phase1-stepe-d): SCRIPTS/r2c-*.sh × 4 (運用系)

### DIFF
--- a/SCRIPTS/r2c-cleanup.sh
+++ b/SCRIPTS/r2c-cleanup.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# r2c-cleanup.sh — 全 worktree + ローカルブランチの後始末 (R2C 24h loop)
+#
+# 用途:
+#   - .claude/worktrees/ 配下の worktree のうち、対応ブランチが既に merged のものを削除
+#   - 古い (--age 時間以上前作成) worktree のみに限定
+#   - queue で state IN ('merged','done','rollbacked','cancelled') かつ worktree_path が残っているものをチェック
+#
+# 環境変数:
+#   R2C_ROOT, R2C_CONFIG, QUEUE_DB, WORKTREE_BASE, LOG_DIR
+#
+# 呼び出し例:
+#   bash SCRIPTS/r2c-cleanup.sh --dry-run
+#   bash SCRIPTS/r2c-cleanup.sh --age 24      # 24時間以上前の merged worktree を削除
+#   bash SCRIPTS/r2c-cleanup.sh --force --yes # merge 未確認でも削除 (危険、自動承認)
+
+set -euo pipefail
+
+R2C_ROOT="${R2C_ROOT:-$HOME/Documents/GitHub/commerce-faq-tasks}"
+R2C_CONFIG="${R2C_CONFIG:-$HOME/.claude-r2c-config}"
+QUEUE_DB="${QUEUE_DB:-${R2C_ROOT}/.claude/queue/r2c-queue.db}"
+WORKTREE_BASE="${WORKTREE_BASE:-${R2C_ROOT}/.claude/worktrees}"
+LOG_DIR="${LOG_DIR:-${R2C_CONFIG}/logs}"
+
+AGE_HOURS=24
+DRY_RUN=0
+FORCE=0
+YES=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --age)     AGE_HOURS="$2"; shift 2 ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        --force)   FORCE=1; shift ;;
+        --yes)     YES=1; shift ;;
+        *)         echo "Unknown arg: $1" >&2; exit 1 ;;
+    esac
+done
+
+mkdir -p "${LOG_DIR}"
+LOG_FILE="${LOG_DIR}/cleanup.log"
+if [ "${DRY_RUN}" -eq 0 ]; then
+    exec >> "${LOG_FILE}" 2>&1
+fi
+
+# shellcheck disable=SC1091
+source "${R2C_CONFIG}/secrets/r2c-loop.env" 2>/dev/null || true
+
+echo "[$(date +%Y-%m-%d_%H:%M:%S)] === r2c-cleanup start (age=${AGE_HOURS}h, force=${FORCE}, dry-run=${DRY_RUN}) ==="
+
+cd "${R2C_ROOT}"
+
+# 全 worktree を列挙 (path branch hash の 3 行 1 セット)
+DELETED_COUNT=0
+SKIPPED_COUNT=0
+
+while IFS= read -r WT_PATH; do
+    # WORKTREE_BASE 配下のみ対象 (safety: rm -rf prefix check)
+    case "${WT_PATH}" in
+        "${WORKTREE_BASE}"/*) ;;
+        *) continue ;;
+    esac
+
+    # ベースリポ本体は対象外
+    if [ "${WT_PATH}" = "${R2C_ROOT}" ]; then
+        continue
+    fi
+
+    # 該当 branch
+    WT_BRANCH=$(git worktree list --porcelain | awk -v p="${WT_PATH}" '$1=="worktree" && $2==p {found=1; next} found && $1=="branch" {sub(/^refs\/heads\//,"",$2); print $2; exit}')
+
+    # 作成からの経過時間 (秒)
+    if [ ! -d "${WT_PATH}" ]; then
+        continue
+    fi
+    if [ "$(uname)" = "Darwin" ]; then
+        CREATED_TS=$(stat -f %B "${WT_PATH}" 2>/dev/null || echo 0)
+    else
+        CREATED_TS=$(stat -c %Y "${WT_PATH}" 2>/dev/null || echo 0)
+    fi
+    NOW_TS=$(date +%s)
+    AGE_SECS=$((NOW_TS - CREATED_TS))
+    AGE_LIMIT=$((AGE_HOURS * 3600))
+
+    if [ "${AGE_SECS}" -lt "${AGE_LIMIT}" ]; then
+        echo "  SKIP (young): ${WT_PATH} (age=${AGE_SECS}s)"
+        SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+        continue
+    fi
+
+    # merge 確認 (gh pr list で該当 branch を search)
+    IS_MERGED=0
+    if [ -n "${WT_BRANCH:-}" ]; then
+        MERGED_COUNT=$(gh pr list --state merged --search "head:${WT_BRANCH}" --json number --jq 'length' 2>/dev/null || echo 0)
+        if [ "${MERGED_COUNT}" -gt 0 ]; then
+            IS_MERGED=1
+        fi
+    fi
+
+    if [ "${IS_MERGED}" -eq 0 ] && [ "${FORCE}" -eq 0 ]; then
+        echo "  SKIP (not-merged): ${WT_PATH} (branch=${WT_BRANCH:-unknown})"
+        SKIPPED_COUNT=$((SKIPPED_COUNT + 1))
+        continue
+    fi
+
+    if [ "${FORCE}" -eq 1 ] && [ "${YES}" -eq 0 ]; then
+        printf "  CONFIRM delete %s? [y/N] " "${WT_PATH}"
+        read -r ANS
+        [ "${ANS}" = "y" ] || { SKIPPED_COUNT=$((SKIPPED_COUNT + 1)); continue; }
+    fi
+
+    if [ "${DRY_RUN}" -eq 1 ]; then
+        echo "  [dry-run] would remove worktree=${WT_PATH} branch=${WT_BRANCH:-unknown}"
+    else
+        git worktree remove --force "${WT_PATH}" 2>&1 || echo "  WARN: worktree remove failed for ${WT_PATH}"
+        if [ -n "${WT_BRANCH:-}" ]; then
+            git branch -D "${WT_BRANCH}" 2>&1 || echo "  WARN: branch -D failed for ${WT_BRANCH}"
+        fi
+        echo "  REMOVED: ${WT_PATH}"
+    fi
+    DELETED_COUNT=$((DELETED_COUNT + 1))
+done < <(git worktree list --porcelain | awk '$1=="worktree" {print $2}')
+
+echo "[$(date +%Y-%m-%d_%H:%M:%S)] === done (deleted=${DELETED_COUNT}, skipped=${SKIPPED_COUNT}) ==="

--- a/SCRIPTS/r2c-cron-wrapper.sh
+++ b/SCRIPTS/r2c-cron-wrapper.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+# r2c-cron-wrapper.sh — launchd / cron 共通 wrapper (R2C 24h loop)
+#
+# 用途:
+#   - launchd / cron の最小 PATH 環境で R2C scripts を確実に起動
+#   - PATH 設定 + env load + log rotation + 失敗時 Pushover を共通化
+#
+# 環境変数:
+#   R2C_ROOT, R2C_CONFIG, LOG_DIR
+#
+# 呼び出し例:
+#   bash SCRIPTS/r2c-cron-wrapper.sh --script r2c-asana-poll.sh
+#   bash SCRIPTS/r2c-cron-wrapper.sh --script r2c-dispatch.sh -- --auto
+#   bash SCRIPTS/r2c-cron-wrapper.sh --script r2c-health-check.sh -- --with-pushover
+#   bash SCRIPTS/r2c-cron-wrapper.sh --script r2c-asana-poll.sh --dry-run
+
+set -euo pipefail
+
+R2C_ROOT="${R2C_ROOT:-$HOME/Documents/GitHub/commerce-faq-tasks}"
+R2C_CONFIG="${R2C_CONFIG:-$HOME/.claude-r2c-config}"
+LOG_DIR="${LOG_DIR:-${R2C_CONFIG}/logs}"
+
+# launchd は最小 PATH なので明示設定 (Homebrew / Python / Node)
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${HOME}/.local/bin:${HOME}/.bun/bin:/opt/homebrew/opt/postgresql@17/bin:${PATH:-}"
+
+SCRIPT=""
+DRY_RUN=0
+PASS_THROUGH=()
+
+# 引数パース: --script <name> [--dry-run] [-- <pass-through args>]
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --script)  SCRIPT="$2"; shift 2 ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        --)        shift; PASS_THROUGH=("$@"); break ;;
+        *)         PASS_THROUGH+=("$1"); shift ;;
+    esac
+done
+
+if [ -z "${SCRIPT}" ]; then
+    echo "ERROR: --script <name> required" >&2
+    echo "Usage: $0 --script r2c-foo.sh [-- pass-through-args...]" >&2
+    exit 1
+fi
+
+# script 名 validation (path traversal 防御): スラッシュ含む / .. 始まりを拒否
+case "${SCRIPT}" in
+    */*|..*)
+        echo "ERROR: --script must be plain filename (no path / no '..')" >&2
+        exit 1
+        ;;
+esac
+
+mkdir -p "${LOG_DIR}"
+WRAPPER_LOG="${LOG_DIR}/cron-wrapper.log"
+TARGET_LOG="${LOG_DIR}/${SCRIPT%.sh}.log"
+
+# log rotation: 10MB 超で .1 にローテート
+rotate_log() {
+    local f="$1"
+    [ -f "${f}" ] || return 0
+    local size
+    if [ "$(uname)" = "Darwin" ]; then
+        size=$(stat -f %z "${f}" 2>/dev/null || echo 0)
+    else
+        size=$(stat -c %s "${f}" 2>/dev/null || echo 0)
+    fi
+    if [ "${size}" -gt 10485760 ]; then
+        mv "${f}" "${f}.1"
+        : > "${f}"
+    fi
+}
+
+rotate_log "${WRAPPER_LOG}"
+rotate_log "${TARGET_LOG}"
+
+# env load (失敗しても続行)
+# shellcheck disable=SC1091
+source "${R2C_CONFIG}/secrets/r2c-loop.env" 2>/dev/null || true
+
+if [ "${DRY_RUN}" -eq 1 ]; then
+    echo "=== r2c-cron-wrapper dry-run ==="
+    echo "PATH=${PATH}"
+    echo "R2C_ROOT=${R2C_ROOT}"
+    echo "R2C_CONFIG=${R2C_CONFIG}"
+    echo "SCRIPT=${SCRIPT}"
+    echo "PASS_THROUGH=${PASS_THROUGH[*]:-}"
+    echo "TARGET_LOG=${TARGET_LOG}"
+    if [ -x "${R2C_ROOT}/SCRIPTS/${SCRIPT}" ]; then
+        echo "TARGET_EXISTS=yes"
+    else
+        echo "TARGET_EXISTS=NO (or not executable)"
+    fi
+    exit 0
+fi
+
+# wrapper log にエントリを残す
+{
+    echo "[$(date +%Y-%m-%d_%H:%M:%S)] start ${SCRIPT} args=${PASS_THROUGH[*]:-}"
+} >> "${WRAPPER_LOG}"
+
+cd "${R2C_ROOT}"
+
+START_TS=$(date +%s)
+set +e
+bash "SCRIPTS/${SCRIPT}" "${PASS_THROUGH[@]:-}" >> "${TARGET_LOG}" 2>&1
+EXIT_CODE=$?
+set -e
+END_TS=$(date +%s)
+DURATION=$((END_TS - START_TS))
+
+{
+    echo "[$(date +%Y-%m-%d_%H:%M:%S)] end ${SCRIPT} exit=${EXIT_CODE} duration=${DURATION}s"
+} >> "${WRAPPER_LOG}"
+
+# 失敗時 Pushover
+if [ "${EXIT_CODE}" -ne 0 ]; then
+    PUSHOVER="${R2C_ROOT}/SCRIPTS/r2c-pushover.sh"
+    if [ -x "${PUSHOVER}" ]; then
+        "${PUSHOVER}" \
+            --priority 0 \
+            --summary "${SCRIPT} failed exit=${EXIT_CODE}" \
+            --details-url "file://${TARGET_LOG}" 2>>"${WRAPPER_LOG}" || true
+    fi
+fi
+
+exit "${EXIT_CODE}"

--- a/SCRIPTS/r2c-health-check.sh
+++ b/SCRIPTS/r2c-health-check.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# r2c-health-check.sh — Production /health endpoint check (R2C 24h loop)
+#
+# 用途:
+#   - https://api.r2c.biz/health に curl して status code を取得
+#   - 直近 5 分連続 503 を検出 → Pushover priority 2 で通知 (--with-pushover 時)
+#   - SQLite に履歴を残し morning-report の L1 集計に使う
+#
+# 環境変数:
+#   R2C_ROOT, R2C_CONFIG, QUEUE_DB, LOG_DIR (デフォルト bake-in)
+#
+# 呼び出し例:
+#   bash SCRIPTS/r2c-health-check.sh                # 通常実行
+#   bash SCRIPTS/r2c-health-check.sh --with-pushover  # 5 分連続 503 で Pushover
+#   bash SCRIPTS/r2c-health-check.sh --json         # JSON stdout
+#   bash SCRIPTS/r2c-health-check.sh --dry-run      # 履歴書き込みなし
+
+set -euo pipefail
+
+R2C_ROOT="${R2C_ROOT:-$HOME/Documents/GitHub/commerce-faq-tasks}"
+R2C_CONFIG="${R2C_CONFIG:-$HOME/.claude-r2c-config}"
+QUEUE_DB="${QUEUE_DB:-${R2C_ROOT}/.claude/queue/r2c-queue.db}"
+LOG_DIR="${LOG_DIR:-${R2C_CONFIG}/logs}"
+API_HEALTH_URL="${API_HEALTH_URL:-https://api.r2c.biz/health}"
+
+WITH_PUSHOVER=0
+DRY_RUN=0
+JSON_OUTPUT=0
+
+# Args
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --with-pushover) WITH_PUSHOVER=1; shift ;;
+        --dry-run)       DRY_RUN=1; shift ;;
+        --json)          JSON_OUTPUT=1; shift ;;
+        *)               echo "Unknown arg: $1" >&2; exit 1 ;;
+    esac
+done
+
+mkdir -p "${LOG_DIR}"
+LOG_FILE="${LOG_DIR}/health-check.log"
+
+# log mode (json / dry-run は stdout を保持)
+if [ "${JSON_OUTPUT}" -eq 0 ] && [ "${DRY_RUN}" -eq 0 ]; then
+    exec >> "${LOG_FILE}" 2>&1
+fi
+
+# shellcheck disable=SC1091
+source "${R2C_CONFIG}/secrets/r2c-loop.env" 2>/dev/null || true
+
+# Schema: health_check_history (idempotent CREATE)
+if [ "${DRY_RUN}" -eq 0 ] && [ -f "${QUEUE_DB}" ]; then
+    sqlite3 "${QUEUE_DB}" <<'SQL'
+CREATE TABLE IF NOT EXISTS health_check_history (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    status_code INTEGER NOT NULL,
+    checked_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+CREATE INDEX IF NOT EXISTS idx_health_checked_at ON health_check_history(checked_at);
+DELETE FROM health_check_history WHERE checked_at < datetime('now', '-1 day');
+SQL
+fi
+
+CHECKED_AT=$(date +%Y-%m-%dT%H:%M:%S%z)
+
+# curl with 10s timeout
+HTTP_CODE=$(curl -sf -o /dev/null -w '%{http_code}' --max-time 10 "${API_HEALTH_URL}" 2>/dev/null || echo "000")
+
+if [ "${DRY_RUN}" -eq 1 ]; then
+    echo "[dry-run] would log: status_code=${HTTP_CODE} at ${CHECKED_AT}"
+elif [ -f "${QUEUE_DB}" ]; then
+    sqlite3 "${QUEUE_DB}" "INSERT INTO health_check_history(status_code) VALUES(${HTTP_CODE});"
+fi
+
+# JSON output
+if [ "${JSON_OUTPUT}" -eq 1 ]; then
+    STATUS_TEXT="ok"
+    [ "${HTTP_CODE}" != "200" ] && STATUS_TEXT="down"
+    printf '{"status":"%s","http_code":%s,"checked_at":"%s","url":"%s"}\n' \
+        "${STATUS_TEXT}" "${HTTP_CODE}" "${CHECKED_AT}" "${API_HEALTH_URL}"
+fi
+
+# Pushover priority 2: 5 分連続 503 (or 5xx) 判定
+if [ "${WITH_PUSHOVER}" -eq 1 ] && [ "${DRY_RUN}" -eq 0 ] && [ -f "${QUEUE_DB}" ]; then
+    FAIL_COUNT=$(sqlite3 "${QUEUE_DB}" "SELECT COUNT(*) FROM health_check_history WHERE checked_at >= datetime('now', '-5 minutes') AND status_code != 200;")
+    if [ "${FAIL_COUNT}" -ge 5 ]; then
+        bash "${R2C_ROOT}/SCRIPTS/r2c-pushover.sh" \
+            --priority 2 \
+            --summary "/health DOWN 5min連続" \
+            --details-url "${API_HEALTH_URL}" || true
+    fi
+fi
+
+if [ "${HTTP_CODE}" = "200" ]; then
+    exit 0
+else
+    exit 1
+fi

--- a/SCRIPTS/r2c-lane-cleanup.sh
+++ b/SCRIPTS/r2c-lane-cleanup.sh
@@ -1,0 +1,117 @@
+#!/usr/bin/env bash
+# r2c-lane-cleanup.sh — Lane 単位の worktree + ローカルブランチ削除 (R2C 24h loop)
+#
+# 用途:
+#   - r2c-supervisor.sh から stuck Lane の rollback 時に呼ばれる
+#   - queue から worktree_path / branch / session_id を取得 → プロセス kill + worktree 削除
+#   - best-effort (各ステップ独立で || true、失敗しても続行)
+#
+# 環境変数:
+#   R2C_ROOT, R2C_CONFIG, QUEUE_DB, WORKTREE_BASE, LOG_DIR
+#
+# 呼び出し例:
+#   bash SCRIPTS/r2c-lane-cleanup.sh --task-id 42
+#   bash SCRIPTS/r2c-lane-cleanup.sh --task-id 42 --dry-run
+
+set -euo pipefail
+
+R2C_ROOT="${R2C_ROOT:-$HOME/Documents/GitHub/commerce-faq-tasks}"
+R2C_CONFIG="${R2C_CONFIG:-$HOME/.claude-r2c-config}"
+QUEUE_DB="${QUEUE_DB:-${R2C_ROOT}/.claude/queue/r2c-queue.db}"
+WORKTREE_BASE="${WORKTREE_BASE:-${R2C_ROOT}/.claude/worktrees}"
+LOG_DIR="${LOG_DIR:-${R2C_CONFIG}/logs}"
+
+TASK_ID=""
+DRY_RUN=0
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --task-id) TASK_ID="$2"; shift 2 ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        *)         echo "Unknown arg: $1" >&2; exit 1 ;;
+    esac
+done
+
+if [ -z "${TASK_ID}" ]; then
+    echo "ERROR: --task-id required" >&2
+    exit 1
+fi
+
+# 数値 validation (SQL injection 防御)
+if ! [[ "${TASK_ID}" =~ ^[0-9]+$ ]]; then
+    echo "ERROR: --task-id must be numeric" >&2
+    exit 1
+fi
+
+mkdir -p "${LOG_DIR}"
+LOG_FILE="${LOG_DIR}/lane-cleanup.log"
+if [ "${DRY_RUN}" -eq 0 ]; then
+    exec >> "${LOG_FILE}" 2>&1
+fi
+
+# shellcheck disable=SC1091
+source "${R2C_CONFIG}/secrets/r2c-loop.env" 2>/dev/null || true
+
+echo "[$(date +%Y-%m-%d_%H:%M:%S)] === lane-cleanup task_id=${TASK_ID} dry-run=${DRY_RUN} ==="
+
+if [ ! -f "${QUEUE_DB}" ]; then
+    echo "ERROR: queue db not found: ${QUEUE_DB}" >&2
+    exit 1
+fi
+
+# queue から情報取得
+ROW=$(sqlite3 -separator $'\t' "${QUEUE_DB}" "SELECT IFNULL(worktree_path,''), IFNULL(branch,''), IFNULL(session_id,'') FROM tasks WHERE id=${TASK_ID};")
+if [ -z "${ROW}" ]; then
+    echo "ERROR: task id ${TASK_ID} not found in queue" >&2
+    exit 1
+fi
+
+WORKTREE_PATH=$(echo "${ROW}" | cut -f1)
+BRANCH=$(echo "${ROW}" | cut -f2)
+SESSION_ID=$(echo "${ROW}" | cut -f3)
+
+echo "  worktree_path: ${WORKTREE_PATH:-<none>}"
+echo "  branch:        ${BRANCH:-<none>}"
+echo "  session_id:    ${SESSION_ID:-<none>}"
+
+# 1. プロセス kill (session_id があれば)
+if [ -n "${SESSION_ID}" ]; then
+    if [ "${DRY_RUN}" -eq 1 ]; then
+        echo "  [dry-run] would pkill -f 'claude.*${SESSION_ID}'"
+    else
+        pkill -f "claude.*${SESSION_ID}" 2>/dev/null || true
+        echo "  pkill claude session done"
+    fi
+fi
+
+# 2. worktree 削除 (WORKTREE_BASE prefix check で safety)
+if [ -n "${WORKTREE_PATH}" ]; then
+    case "${WORKTREE_PATH}" in
+        "${WORKTREE_BASE}"/*)
+            if [ "${DRY_RUN}" -eq 1 ]; then
+                echo "  [dry-run] would git worktree remove --force ${WORKTREE_PATH}"
+            else
+                (cd "${R2C_ROOT}" && git worktree remove --force "${WORKTREE_PATH}" 2>&1) || echo "  WARN: worktree remove failed"
+            fi
+            ;;
+        *)
+            echo "  REJECT worktree (not under WORKTREE_BASE): ${WORKTREE_PATH}"
+            ;;
+    esac
+fi
+
+# 3. branch 削除
+if [ -n "${BRANCH}" ]; then
+    if [ "${DRY_RUN}" -eq 1 ]; then
+        echo "  [dry-run] would git branch -D ${BRANCH}"
+    else
+        (cd "${R2C_ROOT}" && git branch -D "${BRANCH}" 2>&1) || echo "  WARN: branch -D failed (may not exist or be current)"
+    fi
+fi
+
+# 4. lane_events 記録
+if [ "${DRY_RUN}" -eq 0 ]; then
+    sqlite3 "${QUEUE_DB}" "INSERT INTO lane_events(task_id, event_type, payload) VALUES(${TASK_ID}, 'lane_cleanup', '{\"by\":\"r2c-lane-cleanup.sh\"}');" || true
+fi
+
+echo "[$(date +%Y-%m-%d_%H:%M:%S)] === lane-cleanup done ==="


### PR DESCRIPTION
## DoD
r2c-health-check / r2c-cleanup / r2c-lane-cleanup / r2c-cron-wrapper (shellcheck PASS, `rm -rf` 経路に WORKTREE_BASE prefix check)

## 概要
Phase 1 Step E-D。Asana GID `1214888697569649` (Step E 全体)。運用系 4 scripts (合計 466 行)。

| ファイル | 行 | 役割 |
|---|---|---|
| SCRIPTS/r2c-health-check.sh | 98 | /health curl + health_check_history テーブル + 5min 連続失敗で Pushover priority 2 |
| SCRIPTS/r2c-cleanup.sh | 124 | 全 worktree 列挙 + merge 確認 (gh pr list) + age フィルタ + WORKTREE_BASE prefix check |
| SCRIPTS/r2c-lane-cleanup.sh | 117 | task_id 必須 + pkill (session_id) + git worktree remove + branch -D + lane_events 記録 |
| SCRIPTS/r2c-cron-wrapper.sh | 127 | launchd 用 PATH 設定 + env load + log rotation (10MB) + 失敗時 Pushover + path traversal 防御 |

## Gate 1 (shellcheck)
- 0 warning (SC1091 source disable 適用, SC2221/SC2222 解消)
- 全 4 本に --dry-run mode
- token hardcode なし (env file source、shellcheck disable=SC1091)

## Gate 2 (安全性)
- `rm -rf` 経路に `WORKTREE_BASE` prefix check 適用 (r2c-cleanup.sh, r2c-lane-cleanup.sh)
- `--script` 引数に path traversal 防御 (`*/*|..*` 拒否, r2c-cron-wrapper.sh)
- queue task_id を数値 regex で validation (r2c-lane-cleanup.sh)

## 注記
E-D teammate (general-purpose agent) が Bash 拒否されたため Team Lead 自身が直接実装。

## auto-merge
未有効 (Team Lead が E-A→B→C→D の順で手動 merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)