### PR TITLE
docs(1214888719608975): 24H_LOOP_SECRETS_TEMPLATE + PUSHOVER_SETUP_GUIDE + Playbook 追記

### DIFF
--- a/docs/24H_LOOP_SECRETS_TEMPLATE.md
+++ b/docs/24H_LOOP_SECRETS_TEMPLATE.md
@@ -1,0 +1,154 @@
+# 24H Loop — Secrets テンプレート
+
+> **対応 Asana**: GID `1214888719608975`（[Tier B] docs: 24hループ secrets 配備手順）
+> **作成**: 2026-05-18
+> **対象**: `SCRIPTS/r2c-*.sh` 全 16 本が参照する `~/.claude-r2c-config/secrets/r2c-loop.env`
+
+---
+
+## 概要
+
+`SCRIPTS/r2c-*.sh` は起動時に `~/.claude-r2c-config/secrets/r2c-loop.env` を
+`source` して secrets を環境変数として読み込む。
+このファイルは **git に含めない**（`.gitignore` 登録済み）。
+実際のファイルは **2026-05-19 06:05 の Tier S アカウント分離完了後に hkobayashi が手動作成**する。
+
+---
+
+## テンプレート
+
+以下の内容を `~/.claude-r2c-config/secrets/r2c-loop.env` として保存する。
+**実値は各変数の説明を参照して記入すること。`xxx` のままでは動作しない。**
+
+```bash
+# ============================================================
+# R2C 24h Loop — Secrets File
+# Location: ~/.claude-r2c-config/secrets/r2c-loop.env
+# Mode: 600 (chmod 600 により owner read-only)
+# DO NOT COMMIT THIS FILE TO GIT
+# ============================================================
+
+# --- Asana ---
+# 取得元: https://app.asana.com/0/my-apps → "Personal access token"
+# 既存の .env.local の ASANA_ACCESS_TOKEN をコピー
+export ASANA_ACCESS_TOKEN=xxx-your-asana-pat-here
+
+# --- Pushover ---
+# 取得元: docs/PUSHOVER_SETUP_GUIDE.md を参照
+export PUSHOVER_TOKEN=xxx-your-app-token-here   # Application Token (30 chars)
+export PUSHOVER_USER=xxx-your-user-key-here     # User Key (30 chars)
+# export PUSHOVER_DEVICE=iphone                  # (オプション) デバイス名限定
+
+# --- Slack ---
+# 取得元: Slack App 管理 → "Incoming Webhooks" または "Bot Tokens"
+# SLACK_WEBHOOK_URL を優先。なければ SLACK_BOT_TOKEN にフォールバック
+export SLACK_WEBHOOK_URL=https://hooks.slack.com/services/xxx/xxx/xxx
+# export SLACK_BOT_TOKEN=xoxb-xxx-your-bot-token  # (代替、Webhook 不可時のみ)
+
+# --- Slack チャンネル ---
+# r2c-slack-notify.sh が --channel 未指定時のデフォルト
+export SLACK_CHANNEL_ID=C0AG07HFJTB
+
+# --- R2C プロジェクト設定 ---
+export R2C_REPO_PATH=/Users/hkobayashi/Documents/GitHub/commerce-faq-tasks
+export R2C_ASANA_PROJECT_GID=1213607637045514
+```
+
+---
+
+## 作成手順（hkobayashi 手動、Tier S 完了後）
+
+```bash
+# 1. ディレクトリ作成（既に存在する場合はスキップ）
+mkdir -p ~/.claude-r2c-config/secrets
+
+# 2. テンプレートをコピーして編集
+cp docs/24H_LOOP_SECRETS_TEMPLATE.md /tmp/secrets-template.md
+# エディタで実値を記入
+nano ~/.claude-r2c-config/secrets/r2c-loop.env
+
+# 3. パーミッション設定（必須）
+chmod 600 ~/.claude-r2c-config/secrets/r2c-loop.env
+
+# 4. 確認
+ls -la ~/.claude-r2c-config/secrets/r2c-loop.env
+# 期待出力: -rw------- 1 hkobayashi staff ...
+```
+
+---
+
+## スクリプトからの読み込みパターン
+
+`SCRIPTS/r2c-*.sh` は以下のパターンで読み込む（既実装済み）:
+
+```bash
+R2C_CONFIG="${CLAUDE_CONFIG_DIR:-${HOME}/.claude-r2c-config}"
+SECRETS_FILE="${R2C_CONFIG}/secrets/r2c-loop.env"
+
+if [[ -f "${SECRETS_FILE}" ]]; then
+    # shellcheck source=/dev/null
+    source "${SECRETS_FILE}"
+else
+    echo "WARNING: ${SECRETS_FILE} not found. Using environment variables." >&2
+fi
+```
+
+---
+
+## Smoke Test（Tier S 完了後 30 分以内に実施）
+
+```bash
+# secrets 読み込み確認
+source ~/.claude-r2c-config/secrets/r2c-loop.env
+echo "ASANA: ${ASANA_ACCESS_TOKEN:0:10}..."
+echo "PUSHOVER_TOKEN: ${PUSHOVER_TOKEN:0:6}..."
+echo "PUSHOVER_USER: ${PUSHOVER_USER:0:6}..."
+echo "SLACK_WEBHOOK_URL: ${SLACK_WEBHOOK_URL:0:30}..."
+
+# Pushover 疎通確認（dry-run）
+bash SCRIPTS/r2c-pushover.sh --dry-run --priority 0 \
+    --title "R2C Smoke Test" \
+    --message "Secrets configured successfully"
+
+# Asana 疎通確認
+bash SCRIPTS/r2c-asana-poll.sh --dry-run
+
+# Slack 疎通確認
+bash SCRIPTS/r2c-slack-notify.sh --dry-run \
+    --message "R2C smoke test: OK"
+
+# Health check
+bash SCRIPTS/r2c-health-check.sh
+```
+
+---
+
+## Secrets ローテーション手順
+
+| 変数 | ローテーション間隔 | 手順 |
+|---|---|---|
+| `ASANA_ACCESS_TOKEN` | 90 日ごと | app.asana.com → My Apps → revoke + 再発行 |
+| `PUSHOVER_TOKEN` | 1 年ごと（または漏洩時） | pushover.net → App 管理 → Regenerate Token |
+| `PUSHOVER_USER` | ローテーション不要（アカウント紐づき） | アカウント削除時のみ変更 |
+| `SLACK_WEBHOOK_URL` | 漏洩時のみ | Slack App → Incoming Webhooks → Revoke + 再生成 |
+| `SLACK_BOT_TOKEN` | 漏洩時のみ | Slack App → OAuth & Permissions → Reinstall |
+
+### Aikido Plugin との連携
+
+Aikido Security が `secrets/` ディレクトリをスキャンする場合、
+`.gitignore` に `~/.claude-r2c-config/` が登録されているため **git リポジトリには含まれない**。
+Aikido の対象はリポジトリ内ファイルのみなので、このファイルはスキャン対象外。
+
+ローテーション実施後:
+1. `~/.claude-r2c-config/secrets/r2c-loop.env` を更新
+2. `chmod 600 ~/.claude-r2c-config/secrets/r2c-loop.env` を再実行
+3. smoke test を再実行して疎通確認
+
+---
+
+## 関連ドキュメント
+
+- `docs/PUSHOVER_SETUP_GUIDE.md` — Pushover アカウント作成 + Token 取得手順
+- `docs/24H_AUTOMATION_RUNBOOK_R2C.md` — 24h ループ全体仕様
+- `docs/24H_LOOP_RETRY_AND_NOTIFICATION_SPEC.md` — Pushover priority 仕様
+- `docs/PHASE1_ACCOUNT_MIGRATION_RUNBOOK.md` — Tier S アカウント分離手順

--- a/docs/PUSHOVER_SETUP_GUIDE.md
+++ b/docs/PUSHOVER_SETUP_GUIDE.md
@@ -1,0 +1,204 @@
+# Pushover セットアップガイド — R2C 24h Loop
+
+> **対応 Asana**: GID `1214888719608975`（[Tier B] docs: 24hループ secrets 配備手順）
+> **作成**: 2026-05-18
+> **対象読者**: hkobayashi（手動セットアップ実施者）
+> **前提**: Tier S アカウント分離（2026-05-19 06:05）完了後に実施
+
+---
+
+## 概要
+
+Pushover は iOS/Android プッシュ通知サービス（$5 one-time + 7 日無料トライアル）。
+`SCRIPTS/r2c-pushover.sh` が 24h ループの Lane 完了・失敗・緊急アラートを
+hkobayashi の iPhone に送信する。
+
+---
+
+## Step 1: Pushover アカウント作成
+
+1. **ブラウザで** [https://pushover.net/](https://pushover.net/) を開く
+2. 右上「Sign Up」をクリック
+3. 登録フォーム:
+   - **Name**: hkobayashi（任意）
+   - **Email**: hkobayashi@mooores.com
+   - **Password**: 任意（強度の高いものを使用）
+4. 登録完了メールを確認 → メール内リンクをクリックして認証
+5. ログイン後、ダッシュボードの **User Key** をメモする（30 文字の英数字）
+   - 例: `uQiRzpo4DXghDmr9QzzfQu` → これが `PUSHOVER_USER`
+
+---
+
+## Step 2: iOS アプリのインストールと User Key 確認
+
+1. App Store で「Pushover」を検索してインストール
+2. アプリを開き、Step 1 で作成したアカウントでログイン
+3. 設定 → Your Devices: デバイス名が登録されることを確認
+   - デバイス名（例: `iphone`）は `PUSHOVER_DEVICE` に設定可能（任意）
+4. アプリ内でも User Key を確認可能: 設定 → アカウント → User Key
+
+---
+
+## Step 3: R2C 専用 Application の作成
+
+1. ブラウザで [https://pushover.net/apps/build](https://pushover.net/apps/build) を開く
+2. 以下を入力:
+
+   | フィールド | 値 |
+   |---|---|
+   | **Name** | R2C 24h Loop |
+   | **Type** | Application |
+   | **Description** | R2C autonomous development loop notifications |
+   | **URL** | https://api.r2c.biz |
+   | **Icon** | （オプション、R2C ロゴ画像をアップロード） |
+
+3. Agree to Terms of Service にチェック
+4. 「Create Application」をクリック
+5. 次のページに **API Token / Key** が表示される（30 文字の英数字）
+   - 例: `azGDORePK8gMaC0QOYAMyEEuzJnyUi` → これが `PUSHOVER_TOKEN`
+
+---
+
+## Step 4: Secrets ファイルへの記入
+
+`docs/24H_LOOP_SECRETS_TEMPLATE.md` の手順に従い、以下を記入:
+
+```bash
+export PUSHOVER_TOKEN=<Step 3 の API Token>
+export PUSHOVER_USER=<Step 1 の User Key>
+# export PUSHOVER_DEVICE=<Step 2 のデバイス名（任意）>
+```
+
+---
+
+## Step 5: テスト送信（疎通確認）
+
+secrets ファイルを作成した後、以下で動作確認:
+
+### curl での直接テスト
+
+```bash
+# secrets を読み込む
+source ~/.claude-r2c-config/secrets/r2c-loop.env
+
+# テスト送信
+curl -s \
+    --form-string "token=${PUSHOVER_TOKEN}" \
+    --form-string "user=${PUSHOVER_USER}" \
+    --form-string "title=R2C Test" \
+    --form-string "message=Pushover setup successful! 🎉" \
+    --form-string "priority=0" \
+    https://api.pushover.net/1/messages.json
+```
+
+期待レスポンス:
+
+```json
+{"status":1,"request":"xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"}
+```
+
+`status: 1` = 送信成功。iPhone に通知が届くことを確認。
+
+### r2c-pushover.sh での疎通確認
+
+```bash
+# dry-run（実際には送信しない）
+bash SCRIPTS/r2c-pushover.sh --dry-run --priority 0 \
+    --title "R2C Test" \
+    --message "Smoke test from r2c-pushover.sh"
+
+# 実際に送信
+bash SCRIPTS/r2c-pushover.sh --priority 0 \
+    --title "R2C Test" \
+    --message "Real send test from r2c-pushover.sh"
+```
+
+---
+
+## Step 6: Priority 別 iOS 通知の見え方確認
+
+`docs/24H_LOOP_RETRY_AND_NOTIFICATION_SPEC.md` Section 2 より:
+
+| Priority | 値 | iOS での見え方 | 用途 |
+|---|---|---|---|
+| Lowest | `-2` | バナーなし（通知センターのみ）| morning-report サマリ |
+| Low | `-1` | 通知音なし | Lane 完了（正常） |
+| Normal | `0` | 通常通知音 | 警告・要注意 |
+| High | `1` | 通知音 + バイブ（サイレント無視）| Lane 失敗 2 回目 |
+| Emergency | `2` | 30 秒ごとに繰り返し + 確認必須 | Tier S 失敗・Critical アラート |
+
+各 priority で送信して iOS の挙動を確認:
+
+```bash
+source ~/.claude-r2c-config/secrets/r2c-loop.env
+
+# -2: サイレント（朝レポート相当）
+bash SCRIPTS/r2c-pushover.sh --priority -2 \
+    --title "R2C [-2] Lowest" --message "サイレント通知テスト"
+
+# -1: 低優先（Lane 完了相当）
+bash SCRIPTS/r2c-pushover.sh --priority -1 \
+    --title "R2C [-1] Low" --message "Lane 完了通知テスト"
+
+# 0: 通常（警告相当）
+bash SCRIPTS/r2c-pushover.sh --priority 0 \
+    --title "R2C [0] Normal" --message "通常通知テスト"
+
+# 1: 高優先（Lane 失敗相当）—— サイレントモード中も鳴る
+bash SCRIPTS/r2c-pushover.sh --priority 1 \
+    --title "R2C [1] High" --message "Lane 失敗通知テスト"
+
+# 2: 緊急（Critical アラート相当）—— 確認するまで繰り返す
+# ※ 確認後は Pushover アプリ内で「Acknowledge」を押すこと
+bash SCRIPTS/r2c-pushover.sh --priority 2 \
+    --title "R2C [2] Emergency" --message "緊急アラートテスト（要確認）"
+```
+
+---
+
+## 料金
+
+| 項目 | 費用 |
+|---|---|
+| Pushover iOS アプリ | $5.00 (one-time、7 日無料トライアル後) |
+| API 使用料 | 無料（月 10,000 メッセージまで） |
+| Emergency priority (priority=2) | 無料枠内 |
+
+---
+
+## トラブルシューティング
+
+### 通知が届かない
+
+1. `curl` でのテスト送信で `status: 1` を確認
+2. iPhone の設定 → 通知 → Pushover → 許可されていることを確認
+3. `PUSHOVER_DEVICE` を指定している場合はデバイス名のスペルを確認
+4. `PUSHOVER_TOKEN` が Application Token（`xxxxxxxx` 形式）であることを確認（User Key と混同しない）
+
+### curl エラー: invalid token
+
+```
+{"token":"invalid","status":0,"errors":["application token is invalid"]}
+```
+
+→ `PUSHOVER_TOKEN` が誤り。pushover.net → Apps → R2C 24h Loop → API Token を再確認。
+
+### priority 2 の Emergency が止まらない
+
+Pushover アプリを開き、通知をタップ → 「Acknowledge」ボタンを押す。
+または curl で confirm:
+
+```bash
+# RECEIPT は priority 2 の送信レスポンスに含まれる
+curl -s "https://api.pushover.net/1/receipts/${RECEIPT}/acknowledge.json" \
+    --form-string "token=${PUSHOVER_TOKEN}"
+```
+
+---
+
+## 関連ドキュメント
+
+- `docs/24H_LOOP_SECRETS_TEMPLATE.md` — secrets テンプレート全体
+- `docs/24H_LOOP_RETRY_AND_NOTIFICATION_SPEC.md` — Pushover priority 仕様（正本）
+- `docs/24H_AUTOMATION_RUNBOOK_R2C.md` — 24h ループ全体仕様
+- `SCRIPTS/r2c-pushover.sh` — 実装スクリプト

--- a/docs/R2C_DEVELOPMENT_PLAYBOOK.md
+++ b/docs/R2C_DEVELOPMENT_PLAYBOOK.md
@@ -589,6 +589,8 @@ R2C 専用の `~/.claude-r2c-config/` を使用する。
 - **移行評価**: `docs/24H_AUTOMATION_R2C_GAP_ANALYSIS.md` §8
 - **手順書**: `docs/PHASE1_ACCOUNT_MIGRATION_RUNBOOK.md`（2026-05-19 06:05 実施済）
 - **検証スクリプト**: `scripts/verify-account-isolation.sh`
+- **シークレット配備手順**: `docs/24H_LOOP_SECRETS_TEMPLATE.md`（Tier S 完了後に hkobayashi 手動実施）
+- **Pushover セットアップ**: `docs/PUSHOVER_SETUP_GUIDE.md`（iOS アプリ + App Token 取得）
 
 ### 日常運用
 


### PR DESCRIPTION
## Summary

- `docs/24H_LOOP_SECRETS_TEMPLATE.md` 新規: `~/.claude-r2c-config/secrets/r2c-loop.env` のテンプレート（ASANA_ACCESS_TOKEN / PUSHOVER_TOKEN / PUSHOVER_USER / SLACK_WEBHOOK_URL 等）、作成手順、smoke test、ローテーション手順
- `docs/PUSHOVER_SETUP_GUIDE.md` 新規: pushover.net 登録 → iOS アプリ → R2C App 作成 → Token 取得 → priority -2〜2 の疎通確認手順
- `docs/R2C_DEVELOPMENT_PLAYBOOK.md` 追記: §15 アカウント分離手順末尾に上記 2 ファイルへのリンク追加

## Gate

- Gate 1 (secrets leak): `grep -E "(token|key|secret).*[a-zA-Z0-9]{20,}"` → 0 件
- docs only → typecheck/lint/test 該当なし（許容）

## Asana

GID: 1214888719608975 — [Tier B] docs: 24hループ secrets 配備手順 + Pushover アカウント作成手順ドキュメント

🤖 Generated with [Claude Code](https://claude.com/claude-code)