### PR TITLE
docs(phase1-stepf-t2): OpenClaw使用禁止ポリシー明文化

### DIFF
--- a/docs/R2C_DEVELOPMENT_PLAYBOOK.md
+++ b/docs/R2C_DEVELOPMENT_PLAYBOOK.md
@@ -619,3 +619,22 @@ bash scripts/verify-account-isolation.sh
   - Section 3: 構造化 JSON 通知本文ルール
   - Section 4: morning-report Slack Block Kit JSON schema
 - **正本**: `docs/R2C_CLAUDE_AI_INSTRUCTIONS_V1.md` §16
+
+---
+
+## 使わないツール・禁止ライブラリ
+
+> 追加: 2026-05-18（Phase1 Step-F — セキュリティポリシー強化）
+
+### OpenClaw 系統（全面禁止）
+
+- **OpenClaw** — CVE-2026-25253 (CVSS 8.8): WebSocket トークン漏洩
+- **ClawHub** — ClawHavoc Attack: 341 悪意 skill がデフォルト有効
+- **OpenClaw Plugins** — 上記リスクを継承する全プラグイン
+
+詳細は `docs/SECURITY_SCAN_ALLOWLIST.md §使用禁止ツール` を参照。
+
+インストール試みを検出した場合:
+1. 即時 `npm uninstall / pip uninstall`
+2. `git diff` で意図しない依存追加がないか確認
+3. Asana に "セキュリティインシデント" タスク起票

--- a/docs/SECURITY_SCAN_ALLOWLIST.md
+++ b/docs/SECURITY_SCAN_ALLOWLIST.md
@@ -70,3 +70,35 @@
 - `docs/R2C_CLAUDE_AI_INSTRUCTIONS_V1.md` §7 — Claude.ai 月次レビューフロー
 - `.github/workflows/security-scan.yml` — CI security-scan の実装
 - `SCRIPTS/security-scan.sh` — ローカル実行スクリプト
+
+---
+
+## 使用禁止ツール・ライブラリ
+
+> 追加: 2026-05-18（Phase1 Step-F T2）
+
+以下のツール・ライブラリは R2C プロジェクトで**一切使用禁止**とする。
+
+### OpenClaw / ClawHub / OpenClaw Plugins
+
+**禁止理由（複数の重大インシデント）:**
+
+| 識別子 | 深刻度 | 概要 |
+|---|---|---|
+| CVE-2026-25253 | CVSS 8.8 (High) | WebSocket トークン漏洩 — セッショントークンが第三者サーバーへ平文送信される |
+| ClawHavoc Attack | Critical | 341 の悪意ある skill がデフォルト有効化されており、外部コマンド実行・ファイル流出が可能 |
+
+**参照警告:**
+- Koi Security: "OpenClaw Plugin Architecture Allows Arbitrary Code Execution" (2026-03)
+- Microsoft Security Blog: "ClawHavoc — Lessons from a Compromised AI Dev Tool" (2026-04)
+- Cisco Talos: "CVE-2026-25253 — OpenClaw WebSocket Token Exfiltration" (2026-04)
+
+**検出 grep ルール（Aikido Plugin trial 追記依頼として記録）:**
+```
+# package.json / requirements.txt での検出
+grep -r "openclaw\|clawhub\|claw-hub\|@claw/" . --include="*.json" --include="*.txt"
+```
+
+**代替ツール:**
+- Claude Code CLI 公式プラグイン（`claude mcp add`）のみ使用
+- MCP サーバーは `.claude/settings.json` の `mcpServers` で明示管理


### PR DESCRIPTION
## Summary
- docs/SECURITY_SCAN_ALLOWLIST.md に「使用禁止ツール」セクション追加
- docs/R2C_DEVELOPMENT_PLAYBOOK.md に「使わないツール」セクション追加
- CVE-2026-25253 (CVSS 8.8 WebSocketトークン漏洩) + ClawHavoc (341悪意skill) を明記
- Koi Security / Microsoft / Cisco Talos の警告を引用

## Test plan
- [ ] SECURITY_SCAN_ALLOWLIST.md に「使用禁止ツール」セクションが存在する
- [ ] R2C_DEVELOPMENT_PLAYBOOK.md に「使わないツール」セクションが存在する
- [ ] CVE-2026-25253 と ClawHavoc の記述がある
- [ ] 他ファイルを変更していない

🤖 Generated with Claude Code (Team Agent)