### PR TITLE
Phase70-A: 24h 自走の安全装置 (論理層) 実装

### DIFF
--- a/.claude/hooks/deploy_guard.py
+++ b/.claude/hooks/deploy_guard.py
@@ -29,9 +29,13 @@ MODE_24H_BLOCK_PATTERNS = [
 ]
 
 # ssh がコマンドトークンとして現れるか検出するための正規表現。
-# これにより ssh "root@host" のように引用符でホストを囲んでいるケースも補捉できる。
+# コマンド境界: 行頭 / && / ; / || / | / $( (コマンド置換) / ` (バックティック置換)
+# これにより以下のケースを全てブロックできる:
+#   ssh "root@host" "cmd"            — 引用符付きホスト (行頭)
+#   echo $(ssh "root@host" "cmd")    — $() コマンド置換内
+#   echo `ssh root@host free`        — バックティック置換内
 # echo "use ssh root@host" のようにコマンド本体が ssh でないケースは除外される。
-_SSH_AS_CMD_RE = re.compile(r'(?:^|&&|;|\|\||\|)\s*ssh\s', re.MULTILINE)
+_SSH_AS_CMD_RE = re.compile(r'(?:^|&&|;|\|\||\||\$\(|`)\s*ssh\s', re.MULTILINE)
 
 
 def is_24h_mode() -> bool:

--- a/.claude/hooks/deploy_guard.py
+++ b/.claude/hooks/deploy_guard.py
@@ -30,11 +30,11 @@ MODE_24H_BLOCK_PATTERNS = [
 
 # ssh がコマンドトークンとして現れるか検出するための正規表現。
 # コマンド境界: 行頭 / && / ; / || / | / $( (コマンド置換) / ` (バックティック置換)
-# これにより以下のケースを全てブロックできる:
-#   ssh "root@host" "cmd"            — 引用符付きホスト (行頭)
-#   echo $(ssh "root@host" "cmd")    — $() コマンド置換内
-#   echo `ssh root@host free`        — バックティック置換内
-# echo "use ssh root@host" のようにコマンド本体が ssh でないケースは除外される。
+# strip_quoted_strings 後の文字列に対して適用することで:
+#   - ssh "root@host" "cmd"         → strip後 ssh "" "" → ^ssh\s でブロック
+#   - echo $(ssh "root@h" "cmd")    → strip後 echo $(ssh "" "") → \$\( でブロック
+#   - echo `ssh root@host free`     → strip後 変化なし (バックティック外) → ` でブロック
+#   - echo "x | ssh root@host"      → strip後 echo "" → | が消えて誤マッチしない (P2対策)
 _SSH_AS_CMD_RE = re.compile(r'(?:^|&&|;|\|\||\||\$\(|`)\s*ssh\s', re.MULTILINE)
 
 
@@ -54,15 +54,16 @@ def is_24h_mode() -> bool:
 def is_blocked_in_24h_mode(cmd: str) -> bool:
     """24h モード時の追加ブロックパターン照合。
 
-    quote 除去後のパターンマッチに加え、raw コマンドに対しても
-    ssh がコマンドトークンとして現れるか確認する (_SSH_AS_CMD_RE)。
-    これにより ssh "root@host" "cmd" のような引用符付きホストも確実にブロックできる。
-    echo "use ssh root@host" のような文字列内への言及は除外される。
+    全チェックを strip_quoted_strings 後の文字列に対して行う。
+    - MODE_24H_BLOCK_PATTERNS: 通常の ssh / deploy-vps.sh を検出
+    - _SSH_AS_CMD_RE: 引用符付きホスト・コマンド置換内 ssh を検出
+      strip 後も $( や ` はコマンド外に残るため置換内 ssh を捕捉できる。
+      一方 echo "x | ssh root@host" → strip 後 echo "" で | が消え誤ブロックしない。
     """
     cmd_unquoted = strip_quoted_strings(cmd)
     if any(re.search(pattern, cmd_unquoted) for pattern in MODE_24H_BLOCK_PATTERNS):
         return True
-    return bool(_SSH_AS_CMD_RE.search(cmd))
+    return bool(_SSH_AS_CMD_RE.search(cmd_unquoted))
 
 # Keywords that classify a command as deploy-related.
 # Note: 'deploy' alone is intentionally omitted — too broad (matches script names).

--- a/.claude/hooks/deploy_guard.py
+++ b/.claude/hooks/deploy_guard.py
@@ -22,10 +22,13 @@ ALLOWED_DEPLOY_COMMANDS = [
 # Phase70-A: 24h 自走モード中は更に厳格化
 # R2C_24H_MODE=1 または ~/.r2c-24h-mode 存在時、以下も全てブロック
 # (通常時 allowlist で通っていた deploy-vps.sh / ssh root@* も遮断)
+#
+# P1修正: ^ アンカー除去 + strip_quoted_strings 適用 (is_blocked_in_24h_mode 内)
+# → "pnpm build && ssh root@..." のようなチェーンコマンドを24h専用チェックで確実に捕捉
 MODE_24H_BLOCK_PATTERNS = [
-    r'^bash\s+SCRIPTS/deploy-vps\.sh',
-    r'^\s*ssh\s+root@',
-    r'^\s*ssh\s+\S+@65\.108\.159\.161',
+    r'bash\s+SCRIPTS/deploy-vps\.sh',
+    r'ssh\s+root@',
+    r'ssh\s+\S+@65\.108\.159\.161',
 ]
 
 
@@ -43,8 +46,14 @@ def is_24h_mode() -> bool:
 
 
 def is_blocked_in_24h_mode(cmd: str) -> bool:
-    """24h モード時の追加ブロックパターン照合。"""
-    return any(re.search(pattern, cmd) for pattern in MODE_24H_BLOCK_PATTERNS)
+    """24h モード時の追加ブロックパターン照合。
+
+    quote 除去後の文字列に対して全パターンを検索する。
+    チェーンコマンド (pnpm build && ssh root@...) も確実に捕捉するため
+    ^ アンカーなしの re.search を使用。
+    """
+    cmd_unquoted = strip_quoted_strings(cmd)
+    return any(re.search(pattern, cmd_unquoted) for pattern in MODE_24H_BLOCK_PATTERNS)
 
 # Keywords that classify a command as deploy-related.
 # Note: 'deploy' alone is intentionally omitted — too broad (matches script names).

--- a/.claude/hooks/deploy_guard.py
+++ b/.claude/hooks/deploy_guard.py
@@ -8,6 +8,7 @@ Any deploy-related command not in ALLOWED_DEPLOY_COMMANDS is blocked.
 Fails closed on malformed/missing input.
 """
 import json
+import os
 import re
 import sys
 
@@ -17,6 +18,33 @@ ALLOWED_DEPLOY_COMMANDS = [
     r'^bash\s+SCRIPTS/deploy-vps\.sh',       # Only official deploy method
     r'^pm2\s+restart\s+rajiuce-avatar',       # Avatar agent individual restart only
 ]
+
+# Phase70-A: 24h 自走モード中は更に厳格化
+# R2C_24H_MODE=1 または ~/.r2c-24h-mode 存在時、以下も全てブロック
+# (通常時 allowlist で通っていた deploy-vps.sh / ssh root@* も遮断)
+MODE_24H_BLOCK_PATTERNS = [
+    r'^bash\s+SCRIPTS/deploy-vps\.sh',
+    r'^\s*ssh\s+root@',
+    r'^\s*ssh\s+\S+@65\.108\.159\.161',
+]
+
+
+def is_24h_mode() -> bool:
+    """24h 自走モードが有効か判定。
+
+    優先順位: 環境変数 R2C_24H_MODE=1 > $HOME/.r2c-24h-mode ファイル存在
+    """
+    if os.environ.get("R2C_24H_MODE") == "1":
+        return True
+    mode_file = os.path.expanduser(
+        os.environ.get("R2C_24H_MODE_FILE", "~/.r2c-24h-mode")
+    )
+    return os.path.isfile(mode_file)
+
+
+def is_blocked_in_24h_mode(cmd: str) -> bool:
+    """24h モード時の追加ブロックパターン照合。"""
+    return any(re.search(pattern, cmd) for pattern in MODE_24H_BLOCK_PATTERNS)
 
 # Keywords that classify a command as deploy-related.
 # Note: 'deploy' alone is intentionally omitted — too broad (matches script names).
@@ -131,6 +159,16 @@ try:
         sys.exit(0)
 
     command = tool_input.get("command", "")
+
+    # Phase70-A: 24h 自走モード中は最初に厳格ブロックを実施
+    if is_24h_mode() and is_blocked_in_24h_mode(command):
+        print(
+            f"[deploy_guard] BLOCKED (24h-mode): destructive command not permitted\n"
+            f"  command: {command[:200]}\n"
+            "  24h 自走モード中。解除は: bash SCRIPTS/24h-mode-off.sh",
+            file=sys.stderr,
+        )
+        sys.exit(2)
 
     if is_deploy_command(command):
         if is_allowed_deploy(command) or is_read_only_ssh_allowed(command):

--- a/.claude/hooks/deploy_guard.py
+++ b/.claude/hooks/deploy_guard.py
@@ -22,14 +22,16 @@ ALLOWED_DEPLOY_COMMANDS = [
 # Phase70-A: 24h 自走モード中は更に厳格化
 # R2C_24H_MODE=1 または ~/.r2c-24h-mode 存在時、以下も全てブロック
 # (通常時 allowlist で通っていた deploy-vps.sh / ssh root@* も遮断)
-#
-# P1修正: ^ アンカー除去 + strip_quoted_strings 適用 (is_blocked_in_24h_mode 内)
-# → "pnpm build && ssh root@..." のようなチェーンコマンドを24h専用チェックで確実に捕捉
 MODE_24H_BLOCK_PATTERNS = [
     r'bash\s+SCRIPTS/deploy-vps\.sh',
     r'ssh\s+root@',
     r'ssh\s+\S+@65\.108\.159\.161',
 ]
+
+# ssh がコマンドトークンとして現れるか検出するための正規表現。
+# これにより ssh "root@host" のように引用符でホストを囲んでいるケースも補捉できる。
+# echo "use ssh root@host" のようにコマンド本体が ssh でないケースは除外される。
+_SSH_AS_CMD_RE = re.compile(r'(?:^|&&|;|\|\||\|)\s*ssh\s', re.MULTILINE)
 
 
 def is_24h_mode() -> bool:
@@ -48,12 +50,15 @@ def is_24h_mode() -> bool:
 def is_blocked_in_24h_mode(cmd: str) -> bool:
     """24h モード時の追加ブロックパターン照合。
 
-    quote 除去後の文字列に対して全パターンを検索する。
-    チェーンコマンド (pnpm build && ssh root@...) も確実に捕捉するため
-    ^ アンカーなしの re.search を使用。
+    quote 除去後のパターンマッチに加え、raw コマンドに対しても
+    ssh がコマンドトークンとして現れるか確認する (_SSH_AS_CMD_RE)。
+    これにより ssh "root@host" "cmd" のような引用符付きホストも確実にブロックできる。
+    echo "use ssh root@host" のような文字列内への言及は除外される。
     """
     cmd_unquoted = strip_quoted_strings(cmd)
-    return any(re.search(pattern, cmd_unquoted) for pattern in MODE_24H_BLOCK_PATTERNS)
+    if any(re.search(pattern, cmd_unquoted) for pattern in MODE_24H_BLOCK_PATTERNS):
+        return True
+    return bool(_SSH_AS_CMD_RE.search(cmd))
 
 # Keywords that classify a command as deploy-related.
 # Note: 'deploy' alone is intentionally omitted — too broad (matches script names).

--- a/.claude/hooks/test_deploy_guard.sh
+++ b/.claude/hooks/test_deploy_guard.sh
@@ -115,6 +115,42 @@ test_case "blocked: pm2 env (exposes production secrets)" \
 test_case "blocked: cat npm debug log (may contain tokens)" \
   '{"tool_name":"Bash","tool_input":{"command":"ssh root@65.108.159.161 \"cat /root/.npm/_logs/2026-04-17T10_00_00_000Z-debug-0.log\""}}' 2
 
+# --- 24h モード追加テスト (P1修正: ^ アンカー除去 + strip_quoted_strings適用) ---
+test_case_24h() {
+  local desc="$1"
+  local input="$2"
+  local expected_exit="$3"
+
+  echo "$input" | R2C_24H_MODE=1 python3 "$GUARD" 2>/dev/null
+  actual=$?
+
+  if [ "$actual" -eq "$expected_exit" ]; then
+    echo "✅ [24h] $desc (exit=$actual)"
+    ((PASS++))
+  else
+    echo "❌ [24h] $desc (expected=$expected_exit, actual=$actual)"
+    ((FAIL++))
+  fi
+}
+
+test_case_24h "allowed: normal command in 24h mode" \
+  '{"tool_name":"Bash","tool_input":{"command":"pnpm verify"}}' 0
+
+test_case_24h "blocked: deploy-vps.sh in 24h mode" \
+  '{"tool_name":"Bash","tool_input":{"command":"bash SCRIPTS/deploy-vps.sh"}}' 2
+
+test_case_24h "blocked: ssh root@ in 24h mode (even read-only)" \
+  '{"tool_name":"Bash","tool_input":{"command":"ssh root@65.108.159.161 \"pm2 list\""}}' 2
+
+test_case_24h "blocked: chained ssh after pnpm in 24h mode" \
+  '{"tool_name":"Bash","tool_input":{"command":"pnpm build && ssh root@65.108.159.161 \"pm2 list\""}}' 2
+
+test_case_24h "blocked: semicolon-chained ssh in 24h mode" \
+  '{"tool_name":"Bash","tool_input":{"command":"echo done; ssh root@65.108.159.161 \"free -h\""}}' 2
+
+test_case_24h "allowed: echo with quoted ssh string in 24h mode" \
+  '{"tool_name":"Bash","tool_input":{"command":"echo \"use ssh root@host to connect\""}}' 0
+
 # fail-closed
 test_case "fail-closed: malformed JSON" \
   'not valid json' 2

--- a/.claude/hooks/test_deploy_guard.sh
+++ b/.claude/hooks/test_deploy_guard.sh
@@ -151,6 +151,9 @@ test_case_24h "blocked: semicolon-chained ssh in 24h mode" \
 test_case_24h "allowed: echo with quoted ssh string in 24h mode" \
   '{"tool_name":"Bash","tool_input":{"command":"echo \"use ssh root@host to connect\""}}' 0
 
+test_case_24h "blocked: ssh with quoted host in 24h mode" \
+  '{"tool_name":"Bash","tool_input":{"command":"ssh \"root@65.108.159.161\" \"pm2 list\""}}' 2
+
 # fail-closed
 test_case "fail-closed: malformed JSON" \
   'not valid json' 2

--- a/.claude/hooks/test_deploy_guard.sh
+++ b/.claude/hooks/test_deploy_guard.sh
@@ -151,6 +151,9 @@ test_case_24h "blocked: semicolon-chained ssh in 24h mode" \
 test_case_24h "allowed: echo with quoted ssh string in 24h mode" \
   '{"tool_name":"Bash","tool_input":{"command":"echo \"use ssh root@host to connect\""}}' 0
 
+test_case_24h "allowed: pipe symbol inside quoted string (P2 false-positive guard)" \
+  '{"tool_name":"Bash","tool_input":{"command":"echo \"x | ssh root@65.108.159.161\""}}' 0
+
 test_case_24h "blocked: ssh with quoted host in 24h mode" \
   '{"tool_name":"Bash","tool_input":{"command":"ssh \"root@65.108.159.161\" \"pm2 list\""}}' 2
 

--- a/.claude/hooks/test_deploy_guard.sh
+++ b/.claude/hooks/test_deploy_guard.sh
@@ -154,6 +154,12 @@ test_case_24h "allowed: echo with quoted ssh string in 24h mode" \
 test_case_24h "blocked: ssh with quoted host in 24h mode" \
   '{"tool_name":"Bash","tool_input":{"command":"ssh \"root@65.108.159.161\" \"pm2 list\""}}' 2
 
+test_case_24h "blocked: ssh via \$() substitution in 24h mode" \
+  '{"tool_name":"Bash","tool_input":{"command":"echo $(ssh \"root@65.108.159.161\" \"pm2 list\")"}}' 2
+
+test_case_24h "blocked: ssh via backtick substitution in 24h mode" \
+  '{"tool_name":"Bash","tool_input":{"command":"echo `ssh root@65.108.159.161 free`"}}' 2
+
 # fail-closed
 test_case "fail-closed: malformed JSON" \
   'not valid json' 2

--- a/.claudeignore
+++ b/.claudeignore
@@ -1,0 +1,33 @@
+# .claudeignore — Claude Code が読み書きしてはいけないパス
+# Phase70-A 24h 自走中に意図せず秘密情報を読み込まないようガードする
+# (ローカル開発でも常時適用)
+
+# Secrets
+.env
+.env.*
+secrets/
+**/secrets/
+**/credentials/
+*.key
+*-private.key
+*.pem
+*.p12
+
+# Build / generated artifacts (token waste 防止)
+.wolf/
+node_modules/
+dist/
+admin-ui/dist/
+admin-ui/.vite/
+*.log
+playwright-report/
+
+# 一時的な調査メモ・本番ログ
+docs/investigation/
+logs/
+reports/
+
+# ユーザー設定 / 認証情報
+~/.ssh/
+.claude/settings.local.json
+.mcp.json

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,7 @@ Thumbs.db
 # 24h ループ worktree（claude agents / Phase 1 並列作業用）
 .claude/worktrees/
 /tmp-*.png
+
+# Phase70-A 24h 自走モード一時ファイル (HOME 直下が本体だが、誤って repo に置かれた場合の保険)
+.r2c-24h-mode
+.r2c-24h-mode-*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -426,3 +426,19 @@ Playwright MCPで現象確認してから修正。推測で修正しない。
 | OpenClaw 使用禁止ポリシー | ✅ | #172 | docs/SECURITY_SCAN_ALLOWLIST.md §使用禁止ツール |
 | Memory Tool 評価レポート | ✅ | #170 | docs/MEMORY_TOOL_EVALUATION.md |
 | アカウント分離 (Tier S 実行) | ⏳ 2026-05-19 06:05 | - | docs/PHASE1_ACCOUNT_MIGRATION_RUNBOOK.md |
+
+## 24h 自走中の禁止操作（Phase70-A — 必読）
+
+24h 自走モード ON 中 (`~/.r2c-24h-mode` 存在時 または `R2C_24H_MODE=1`) は
+以下の操作を **絶対に実施しない**。違反検知時は Slack #r2c に `HUMAN-REVIEW-REQUIRED`
+投稿して自身を停止すること。
+
+Out of scope 10項目: VPS 接続 / main merge / DB migration / .env 編集 / git force /
+avatar-agent 操作 / Cloudflare 設定変更 / 依存メジャー bump / 法務文書編集 / 本番テナント影響。
+
+詳細・運用手順・トラブルシュートは **`docs/24H_AUTONOMOUS_PLAYBOOK.md`** を必ず読むこと。
+
+ON/OFF 操作:
+- ON: `bash SCRIPTS/24h-mode-on.sh` (dry-run: `--dry-run`)
+- OFF: `bash SCRIPTS/24h-mode-off.sh`
+- 検知 hook: `.claude/hooks/deploy_guard.py` が `R2C_24H_MODE` を読み追加ブロック実施

--- a/SCRIPTS/24h-mode-off.sh
+++ b/SCRIPTS/24h-mode-off.sh
@@ -80,15 +80,41 @@ else
             rm -f "$BACKUP_FILE"
             log "  ✓ backup file removed"
         else
-            # 元の protection 設定を PUT 形式に変換して復元。
-            # GET レスポンスのネストされたオブジェクト (.enabled) をフラット化し、
-            # PUT で受け付ける全フィールドを漏れなく含める。
-            # フィールド追加時は on.sh の PROTECTION_PAYLOAD との対称性を維持すること。
+            # GET レスポンスを GitHub branch-protection PUT スキーマに変換して復元。
+            # - ネストされた .enabled をフラット化 (enforce_admins 等)
+            # - GET 専用の read-only フィールド (url, enforcement_level, contexts_url 等) を除去
+            # - restrictions / required_pull_request_reviews のフルオブジェクトから
+            #   PUT が受け付けるフィールドのみを抽出 (API が URL 等を拒否するため)
             RESTORE_PAYLOAD=$(jq '{
-                required_status_checks: .required_status_checks,
+                required_status_checks: (
+                    if .required_status_checks == null then null
+                    else {
+                        strict: (.required_status_checks.strict // false),
+                        contexts: (.required_status_checks.contexts // []),
+                        checks: (.required_status_checks.checks // [])
+                    }
+                    end
+                ),
                 enforce_admins: (.enforce_admins.enabled // false),
-                required_pull_request_reviews: .required_pull_request_reviews,
-                restrictions: .restrictions,
+                required_pull_request_reviews: (
+                    if .required_pull_request_reviews == null then null
+                    else {
+                        dismiss_stale_reviews: (.required_pull_request_reviews.dismiss_stale_reviews // false),
+                        require_code_owner_reviews: (.required_pull_request_reviews.require_code_owner_reviews // false),
+                        required_approving_review_count: (.required_pull_request_reviews.required_approving_review_count // 0),
+                        require_last_push_approval: (.required_pull_request_reviews.require_last_push_approval // false)
+                    }
+                    end
+                ),
+                restrictions: (
+                    if .restrictions == null then null
+                    else {
+                        users: ([.restrictions.users[]?.login] // []),
+                        teams: ([.restrictions.teams[]?.slug] // []),
+                        apps:  ([.restrictions.apps[]?.slug]  // [])
+                    }
+                    end
+                ),
                 required_linear_history: (.required_linear_history.enabled // false),
                 allow_force_pushes: (.allow_force_pushes.enabled // false),
                 allow_deletions: (.allow_deletions.enabled // false),

--- a/SCRIPTS/24h-mode-off.sh
+++ b/SCRIPTS/24h-mode-off.sh
@@ -73,7 +73,10 @@ else
             rm -f "$BACKUP_FILE"
             log "  ✓ backup file removed"
         else
-            # 元の protection 設定を PUT 形式に変換して復元
+            # 元の protection 設定を PUT 形式に変換して復元。
+            # GET レスポンスのネストされたオブジェクト (.enabled) をフラット化し、
+            # PUT で受け付ける全フィールドを漏れなく含める。
+            # フィールド追加時は on.sh の PROTECTION_PAYLOAD との対称性を維持すること。
             RESTORE_PAYLOAD=$(jq '{
                 required_status_checks: .required_status_checks,
                 enforce_admins: (.enforce_admins.enabled // false),
@@ -81,7 +84,10 @@ else
                 restrictions: .restrictions,
                 required_linear_history: (.required_linear_history.enabled // false),
                 allow_force_pushes: (.allow_force_pushes.enabled // false),
-                allow_deletions: (.allow_deletions.enabled // false)
+                allow_deletions: (.allow_deletions.enabled // false),
+                required_conversation_resolution: (.required_conversation_resolution.enabled // false),
+                block_creations: (.block_creations.enabled // false),
+                lock_branch: (.lock_branch.enabled // false)
             }' "$BACKUP_FILE")
             if printf '%s' "$RESTORE_PAYLOAD" | gh api -X PUT "repos/$GH_REPO/branches/main/protection" --input - >/dev/null 2>&1; then
                 log "  ✓ branch protection restored from backup"

--- a/SCRIPTS/24h-mode-off.sh
+++ b/SCRIPTS/24h-mode-off.sh
@@ -31,6 +31,7 @@ done
 
 GH_REPO="${GH_REPO:-milechy/commerce-faq-tasks}"
 MODE_FILE="${R2C_24H_MODE_FILE:-$HOME/.r2c-24h-mode}"
+BACKUP_FILE="${HOME}/.r2c-24h-mode-protection-backup.json"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 log() { printf '[24h-mode-off] %s\n' "$*"; }
@@ -52,15 +53,50 @@ else
     log "Found mode file: $MODE_FILE"
 fi
 
-# ─── 1. branch protection 削除 ───
-log "Removing branch protection on $GH_REPO main…"
+# ─── 1. branch protection 復元 (P2: on.sh バックアップから元設定を復元) ───
+log "Restoring branch protection on $GH_REPO main…"
 if [[ "$DRY_RUN" -eq 1 ]]; then
-    printf '[dry-run] gh api -X DELETE repos/%s/branches/main/protection\n' "$GH_REPO"
-else
-    if gh api -X DELETE "repos/$GH_REPO/branches/main/protection" >/dev/null 2>&1; then
-        log "  ✓ branch protection removed"
+    if [[ -f "$BACKUP_FILE" ]]; then
+        printf '[dry-run] restore branch protection from %s\n' "$BACKUP_FILE"
     else
-        log "  WARN: failed to remove (may already be off, or admin permission missing)"
+        printf '[dry-run] gh api -X DELETE repos/%s/branches/main/protection (no backup found)\n' "$GH_REPO"
+    fi
+else
+    if [[ -f "$BACKUP_FILE" ]]; then
+        if jq -e '.no_protection == true' "$BACKUP_FILE" >/dev/null 2>&1; then
+            # 24h-mode 有効化前に protection がなかった → 削除して元の状態に戻す
+            if gh api -X DELETE "repos/$GH_REPO/branches/main/protection" >/dev/null 2>&1; then
+                log "  ✓ branch protection removed (was none before 24h-mode)"
+            else
+                log "  WARN: failed to remove (may already be off)"
+            fi
+        else
+            # 元の protection 設定を PUT 形式に変換して復元
+            RESTORE_PAYLOAD=$(jq '{
+                required_status_checks: .required_status_checks,
+                enforce_admins: (.enforce_admins.enabled // false),
+                required_pull_request_reviews: .required_pull_request_reviews,
+                restrictions: .restrictions,
+                required_linear_history: (.required_linear_history.enabled // false),
+                allow_force_pushes: (.allow_force_pushes.enabled // false),
+                allow_deletions: (.allow_deletions.enabled // false)
+            }' "$BACKUP_FILE")
+            if printf '%s' "$RESTORE_PAYLOAD" | gh api -X PUT "repos/$GH_REPO/branches/main/protection" --input - >/dev/null 2>&1; then
+                log "  ✓ branch protection restored from backup"
+            else
+                log "  WARN: restore failed — falling back to DELETE"
+                gh api -X DELETE "repos/$GH_REPO/branches/main/protection" >/dev/null 2>&1 || true
+            fi
+        fi
+        rm -f "$BACKUP_FILE"
+        log "  ✓ backup file removed"
+    else
+        # バックアップなし (on.sh が古い版の場合など) → 従来通り削除
+        if gh api -X DELETE "repos/$GH_REPO/branches/main/protection" >/dev/null 2>&1; then
+            log "  ✓ branch protection removed (no backup found)"
+        else
+            log "  WARN: failed to remove (may already be off, or admin permission missing)"
+        fi
     fi
 fi
 

--- a/SCRIPTS/24h-mode-off.sh
+++ b/SCRIPTS/24h-mode-off.sh
@@ -70,6 +70,8 @@ else
             else
                 log "  WARN: failed to remove (may already be off)"
             fi
+            rm -f "$BACKUP_FILE"
+            log "  ✓ backup file removed"
         else
             # 元の protection 設定を PUT 形式に変換して復元
             RESTORE_PAYLOAD=$(jq '{
@@ -83,13 +85,19 @@ else
             }' "$BACKUP_FILE")
             if printf '%s' "$RESTORE_PAYLOAD" | gh api -X PUT "repos/$GH_REPO/branches/main/protection" --input - >/dev/null 2>&1; then
                 log "  ✓ branch protection restored from backup"
+                rm -f "$BACKUP_FILE"
+                log "  ✓ backup file removed"
             else
-                log "  WARN: restore failed — falling back to DELETE"
-                gh api -X DELETE "repos/$GH_REPO/branches/main/protection" >/dev/null 2>&1 || true
+                echo "ERROR: Failed to restore branch protection from backup." >&2
+                echo "  Current protection is NOT modified — main branch remains protected." >&2
+                echo "  Backup preserved at: $BACKUP_FILE" >&2
+                echo "  To restore manually:" >&2
+                echo "    1. Inspect backup: cat $BACKUP_FILE" >&2
+                echo "    2. Re-run after fixing the issue: bash SCRIPTS/24h-mode-off.sh" >&2
+                echo "  Or restore via GitHub UI: https://github.com/$GH_REPO/settings/branches" >&2
+                exit 1
             fi
         fi
-        rm -f "$BACKUP_FILE"
-        log "  ✓ backup file removed"
     else
         # バックアップなし (on.sh が古い版の場合など) → 従来通り削除
         if gh api -X DELETE "repos/$GH_REPO/branches/main/protection" >/dev/null 2>&1; then

--- a/SCRIPTS/24h-mode-off.sh
+++ b/SCRIPTS/24h-mode-off.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env bash
+# 24h-mode-off.sh — 24h 自走モード OFF
+#
+# Phase70-A: 24h 自走の安全装置 (論理層) — on.sh の全逆操作
+#
+# 機能:
+#   1. main branch protection を削除
+#   2. repository allow_auto_merge ON 復帰
+#   3. ~/.r2c-24h-mode を削除
+#   4. Slack #r2c にモード OFF 通知
+#   5. Cloudflare Pages の再開手順を出力
+#
+# 冪等性:
+#   モードファイルが無い場合は warn を出して続行 (リソース側の clean-up は試みる)
+#
+# Usage:
+#   bash SCRIPTS/24h-mode-off.sh
+#   bash SCRIPTS/24h-mode-off.sh --dry-run
+set -euo pipefail
+
+DRY_RUN=0
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=1 ;;
+        -h|--help)
+            sed -n '2,/^set -euo/p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0 ;;
+        *) echo "ERROR: unknown arg: $arg" >&2; exit 1 ;;
+    esac
+done
+
+GH_REPO="${GH_REPO:-milechy/commerce-faq-tasks}"
+MODE_FILE="${R2C_24H_MODE_FILE:-$HOME/.r2c-24h-mode}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+log() { printf '[24h-mode-off] %s\n' "$*"; }
+run() {
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        printf '[dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+command -v gh >/dev/null 2>&1 || { echo "ERROR: gh CLI required" >&2; exit 1; }
+
+NOW_ISO="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+if [[ ! -f "$MODE_FILE" ]]; then
+    log "WARN: $MODE_FILE not found (mode may already be OFF). Continuing cleanup…"
+else
+    log "Found mode file: $MODE_FILE"
+fi
+
+# ─── 1. branch protection 削除 ───
+log "Removing branch protection on $GH_REPO main…"
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    printf '[dry-run] gh api -X DELETE repos/%s/branches/main/protection\n' "$GH_REPO"
+else
+    if gh api -X DELETE "repos/$GH_REPO/branches/main/protection" >/dev/null 2>&1; then
+        log "  ✓ branch protection removed"
+    else
+        log "  WARN: failed to remove (may already be off, or admin permission missing)"
+    fi
+fi
+
+# ─── 2. allow_auto_merge 復帰 ───
+log "Re-enabling repository auto-merge…"
+run "gh api -X PATCH 'repos/$GH_REPO' -f allow_auto_merge=true >/dev/null"
+log "  ✓ allow_auto_merge=true"
+
+# ─── 3. モードファイル削除 ───
+log "Removing mode file: $MODE_FILE"
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    printf '[dry-run] rm -f %s\n' "$MODE_FILE"
+else
+    rm -f "$MODE_FILE"
+    log "  ✓ mode file removed"
+fi
+
+# ─── 4. Slack 通知 ───
+SLACK_HELPER="$SCRIPT_DIR/r2c-slack-notify.sh"
+SLACK_MSG="🔓 *R2C 24h 自走モード OFF* — 解除時刻 \`$NOW_ISO\` (repo: $GH_REPO)"
+if [[ -x "$SLACK_HELPER" ]]; then
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        printf '[dry-run] %s --text %q\n' "$SLACK_HELPER" "$SLACK_MSG"
+    else
+        if ! "$SLACK_HELPER" --text "$SLACK_MSG" 2>/dev/null; then
+            log "  WARN: Slack notify failed (continuing)"
+        else
+            log "  ✓ Slack notified"
+        fi
+    fi
+else
+    log "  WARN: $SLACK_HELPER not executable — skipping Slack notify"
+fi
+
+# ─── 5. Cloudflare Pages 再開手順 ───
+cat <<'CF'
+
+────────────────────────────────────────────────────────
+ℹ️  手動操作: Cloudflare Pages auto-deploy 再開
+────────────────────────────────────────────────────────
+  1. https://dash.cloudflare.com にログイン
+  2. Workers & Pages → admin-r2c → Settings → Builds & deployments
+  3. "Production branch" の "Pause deployments" を OFF
+────────────────────────────────────────────────────────
+CF
+
+log "Done. 24h-mode is OFF."

--- a/SCRIPTS/24h-mode-off.sh
+++ b/SCRIPTS/24h-mode-off.sh
@@ -53,7 +53,14 @@ else
     log "Found mode file: $MODE_FILE"
 fi
 
-# ─── 1. branch protection 復元 (P2: on.sh バックアップから元設定を復元) ───
+# ─── 0. バックアップから復元値を先読みする ───
+# allow_auto_merge の元の値は branch protection 復元 (バックアップ削除) より前に読む必要がある
+ORIG_AUTO_MERGE="true"  # fallback: 元の値が不明な場合は true (最もよくある設定)
+if [[ "$DRY_RUN" -eq 0 ]] && [[ -f "$BACKUP_FILE" ]]; then
+    ORIG_AUTO_MERGE=$(jq -r '.original_allow_auto_merge // true' "$BACKUP_FILE" 2>/dev/null || echo "true")
+fi
+
+# ─── 1. branch protection 復元 (on.sh バックアップから元設定を復元) ───
 log "Restoring branch protection on $GH_REPO main…"
 if [[ "$DRY_RUN" -eq 1 ]]; then
     if [[ -f "$BACKUP_FILE" ]]; then
@@ -114,10 +121,10 @@ else
     fi
 fi
 
-# ─── 2. allow_auto_merge 復帰 ───
-log "Re-enabling repository auto-merge…"
-run "gh api -X PATCH 'repos/$GH_REPO' -f allow_auto_merge=true >/dev/null"
-log "  ✓ allow_auto_merge=true"
+# ─── 2. allow_auto_merge を元の値に復帰 ───
+log "Restoring repository auto-merge to original value (${ORIG_AUTO_MERGE})…"
+run "gh api -X PATCH 'repos/$GH_REPO' -f allow_auto_merge=${ORIG_AUTO_MERGE} >/dev/null"
+log "  ✓ allow_auto_merge=${ORIG_AUTO_MERGE}"
 
 # ─── 3. モードファイル削除 ───
 log "Removing mode file: $MODE_FILE"

--- a/SCRIPTS/24h-mode-on.sh
+++ b/SCRIPTS/24h-mode-on.sh
@@ -39,6 +39,7 @@ done
 GH_REPO="${GH_REPO:-milechy/commerce-faq-tasks}"
 STATUS_CHECKS="${STATUS_CHECKS:-Stream Path Check,Security Scan}"
 MODE_FILE="${R2C_24H_MODE_FILE:-$HOME/.r2c-24h-mode}"
+BACKUP_FILE="${HOME}/.r2c-24h-mode-protection-backup.json"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 log() { printf '[24h-mode-on] %s\n' "$*"; }
@@ -62,6 +63,21 @@ command -v gh >/dev/null 2>&1 || { echo "ERROR: gh CLI required" >&2; exit 1; }
 command -v jq >/dev/null 2>&1 || { echo "ERROR: jq required" >&2; exit 1; }
 
 NOW_ISO="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# ─── 0. 現在の branch protection をバックアップ (P2: 解除時に元設定を復元するため) ───
+log "Backing up current branch protection to ${BACKUP_FILE}..."
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    printf '[dry-run] gh api repos/%s/branches/main/protection → %s\n' "$GH_REPO" "$BACKUP_FILE"
+else
+    if gh api "repos/$GH_REPO/branches/main/protection" > "$BACKUP_FILE" 2>/dev/null; then
+        chmod 600 "$BACKUP_FILE"
+        log "  ✓ existing protection backed up"
+    else
+        printf '{"no_protection":true}\n' > "$BACKUP_FILE"
+        chmod 600 "$BACKUP_FILE"
+        log "  ✓ no existing protection — sentinel saved"
+    fi
+fi
 
 # ─── 1. main branch protection ON ───
 log "Enabling branch protection on $GH_REPO main…"

--- a/SCRIPTS/24h-mode-on.sh
+++ b/SCRIPTS/24h-mode-on.sh
@@ -64,18 +64,37 @@ command -v jq >/dev/null 2>&1 || { echo "ERROR: jq required" >&2; exit 1; }
 
 NOW_ISO="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
-# ─── 0. 現在の branch protection をバックアップ (P2: 解除時に元設定を復元するため) ───
+# ─── 0. 現在の branch protection をバックアップ (解除時に元設定を復元するため) ───
+# 再実行安全性: バックアップが既に存在する場合は上書きしない。
+# 初回実行途中で失敗して再実行した場合に、既に変更済みの設定を元の設定と
+# 誤認識してしまう問題を防ぐ。
 log "Backing up current branch protection to ${BACKUP_FILE}..."
 if [[ "$DRY_RUN" -eq 1 ]]; then
     printf '[dry-run] gh api repos/%s/branches/main/protection → %s\n' "$GH_REPO" "$BACKUP_FILE"
+    printf '[dry-run] gh api repos/%s --jq .allow_auto_merge → %s (original_allow_auto_merge)\n' "$GH_REPO" "$BACKUP_FILE"
 else
-    if gh api "repos/$GH_REPO/branches/main/protection" > "$BACKUP_FILE" 2>/dev/null; then
-        chmod 600 "$BACKUP_FILE"
-        log "  ✓ existing protection backed up"
+    if [[ -f "$BACKUP_FILE" ]]; then
+        log "  ✓ backup already exists — preserving original (re-run of failed activation detected)"
     else
-        printf '{"no_protection":true}\n' > "$BACKUP_FILE"
-        chmod 600 "$BACKUP_FILE"
-        log "  ✓ no existing protection — sentinel saved"
+        if gh api "repos/$GH_REPO/branches/main/protection" > "$BACKUP_FILE" 2>/dev/null; then
+            chmod 600 "$BACKUP_FILE"
+            log "  ✓ existing protection backed up"
+        else
+            printf '{"no_protection":true}\n' > "$BACKUP_FILE"
+            chmod 600 "$BACKUP_FILE"
+            log "  ✓ no existing protection — sentinel saved"
+        fi
+        # allow_auto_merge の元の値をバックアップに追記 (off.sh で正確に復元するため)
+        ORIG_AUTO_MERGE=$(gh api "repos/$GH_REPO" --jq '.allow_auto_merge // false' 2>/dev/null || echo "false")
+        _tmp=$(mktemp)
+        if jq --argjson val "$ORIG_AUTO_MERGE" '. + {original_allow_auto_merge: $val}' "$BACKUP_FILE" > "$_tmp"; then
+            mv "$_tmp" "$BACKUP_FILE"
+            chmod 600 "$BACKUP_FILE"
+            log "  ✓ original allow_auto_merge=$ORIG_AUTO_MERGE saved to backup"
+        else
+            rm -f "$_tmp"
+            log "  WARN: failed to save allow_auto_merge to backup (will default to true on restore)"
+        fi
     fi
 fi
 

--- a/SCRIPTS/24h-mode-on.sh
+++ b/SCRIPTS/24h-mode-on.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# 24h-mode-on.sh — 24h 自走モード ON
+#
+# Phase70-A: 24h 自走の安全装置 (論理層)
+#
+# 機能:
+#   1. main branch protection を有効化 (PRレビュー1必須/admin含むdirect push禁止)
+#   2. repository allow_auto_merge OFF
+#   3. 既存 open PR の auto-merge フラグ解除
+#   4. ~/.r2c-24h-mode に R2C_24H_MODE=1 + 起動時刻を書く
+#   5. Slack #r2c にモード ON 通知
+#   6. Cloudflare Pages の手動停止手順を出力 (自動化はしない)
+#
+# 冪等性:
+#   既に ON 状態 (~/.r2c-24h-mode 存在) なら何もせず exit 0
+#
+# Usage:
+#   bash SCRIPTS/24h-mode-on.sh
+#   bash SCRIPTS/24h-mode-on.sh --dry-run
+#
+# 環境変数:
+#   GH_REPO              — owner/repo (default: milechy/commerce-faq-tasks)
+#   STATUS_CHECKS        — required status checks (CSV, default: "Stream Path Check,Security Scan")
+#   SLACK_WEBHOOK_URL    — Slack incoming webhook (なければ通知スキップ)
+#   R2C_24H_MODE_FILE    — モードファイルパス (default: $HOME/.r2c-24h-mode)
+set -euo pipefail
+
+DRY_RUN=0
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=1 ;;
+        -h|--help)
+            sed -n '2,/^set -euo/p' "$0" | sed 's/^# \{0,1\}//'
+            exit 0 ;;
+        *) echo "ERROR: unknown arg: $arg" >&2; exit 1 ;;
+    esac
+done
+
+GH_REPO="${GH_REPO:-milechy/commerce-faq-tasks}"
+STATUS_CHECKS="${STATUS_CHECKS:-Stream Path Check,Security Scan}"
+MODE_FILE="${R2C_24H_MODE_FILE:-$HOME/.r2c-24h-mode}"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+log() { printf '[24h-mode-on] %s\n' "$*"; }
+run() {
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        printf '[dry-run] %s\n' "$*"
+    else
+        eval "$@"
+    fi
+}
+
+# ─── 冪等チェック ───
+if [[ -f "$MODE_FILE" ]]; then
+    log "Already ON (found $MODE_FILE) — exit 0"
+    cat "$MODE_FILE"
+    exit 0
+fi
+
+# ─── 依存チェック ───
+command -v gh >/dev/null 2>&1 || { echo "ERROR: gh CLI required" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "ERROR: jq required" >&2; exit 1; }
+
+NOW_ISO="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# ─── 1. main branch protection ON ───
+log "Enabling branch protection on $GH_REPO main…"
+
+CHECKS_JSON=$(printf '%s' "$STATUS_CHECKS" | jq -Rcs 'split(",") | map(gsub("^\\s+|\\s+$"; "")) | map({context: ., app_id: -1})')
+
+PROTECTION_PAYLOAD=$(jq -nc \
+    --argjson checks "$CHECKS_JSON" \
+    '{
+        required_status_checks: { strict: true, checks: $checks },
+        enforce_admins: true,
+        required_pull_request_reviews: {
+            dismiss_stale_reviews: true,
+            require_code_owner_reviews: false,
+            required_approving_review_count: 1
+        },
+        restrictions: null,
+        required_linear_history: false,
+        allow_force_pushes: false,
+        allow_deletions: false,
+        required_conversation_resolution: true
+    }')
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    printf '[dry-run] gh api -X PUT repos/%s/branches/main/protection --input <payload>\n' "$GH_REPO"
+    echo '[dry-run] payload:'
+    printf '%s' "$PROTECTION_PAYLOAD" | jq .
+else
+    if ! printf '%s' "$PROTECTION_PAYLOAD" | gh api -X PUT "repos/$GH_REPO/branches/main/protection" --input - >/tmp/24h-mode-on-protection.json 2>&1; then
+        echo "ERROR: failed to enable branch protection. gh CLI may lack admin permission." >&2
+        echo "  Manual setup: https://github.com/$GH_REPO/settings/branches" >&2
+        cat /tmp/24h-mode-on-protection.json >&2
+        exit 1
+    fi
+    log "  ✓ branch protection ON"
+fi
+
+# ─── 2. repository allow_auto_merge OFF ───
+log "Disabling repository auto-merge…"
+run "gh api -X PATCH 'repos/$GH_REPO' -f allow_auto_merge=false >/dev/null"
+log "  ✓ allow_auto_merge=false"
+
+# ─── 3. 既存 open PR の auto-merge 解除 ───
+log "Disabling auto-merge on existing open PRs…"
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    printf '[dry-run] gh pr list --repo %s --state open --json number,autoMergeRequest --jq <filter>\n' "$GH_REPO"
+else
+    AUTO_PRS=$(gh pr list --repo "$GH_REPO" --state open --json number,autoMergeRequest --jq '.[] | select(.autoMergeRequest != null) | .number' || echo "")
+    if [[ -n "$AUTO_PRS" ]]; then
+        while IFS= read -r pr_num; do
+            [[ -z "$pr_num" ]] && continue
+            log "  disabling auto-merge on PR #$pr_num"
+            gh pr merge "$pr_num" --repo "$GH_REPO" --disable-auto || log "    WARN: failed (PR may not have auto-merge)"
+        done <<< "$AUTO_PRS"
+    else
+        log "  ✓ no PRs with auto-merge enabled"
+    fi
+fi
+
+# ─── 4. モードファイル作成 ───
+log "Writing mode file: $MODE_FILE"
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    printf '[dry-run] write %s with:\n  R2C_24H_MODE=1\n  R2C_24H_MODE_STARTED_AT=%s\n' "$MODE_FILE" "$NOW_ISO"
+else
+    cat > "$MODE_FILE" <<EOF
+R2C_24H_MODE=1
+R2C_24H_MODE_STARTED_AT=$NOW_ISO
+EOF
+    chmod 600 "$MODE_FILE"
+    log "  ✓ mode file created (perm 600)"
+fi
+
+# ─── 5. Slack 通知 ───
+SLACK_HELPER="$SCRIPT_DIR/r2c-slack-notify.sh"
+SLACK_MSG="🔒 *R2C 24h 自走モード ON* — 起動時刻 \`$NOW_ISO\` (repo: $GH_REPO)"
+if [[ -x "$SLACK_HELPER" ]]; then
+    if [[ "$DRY_RUN" -eq 1 ]]; then
+        printf '[dry-run] %s --text %q\n' "$SLACK_HELPER" "$SLACK_MSG"
+    else
+        if ! "$SLACK_HELPER" --text "$SLACK_MSG" 2>/dev/null; then
+            log "  WARN: Slack notify failed (continuing)"
+        else
+            log "  ✓ Slack notified"
+        fi
+    fi
+else
+    log "  WARN: $SLACK_HELPER not executable — skipping Slack notify"
+fi
+
+# ─── 6. Cloudflare Pages 手動停止手順 ───
+cat <<'CF'
+
+────────────────────────────────────────────────────────
+⚠️  手動操作必須: Cloudflare Pages auto-deploy 停止
+────────────────────────────────────────────────────────
+  1. https://dash.cloudflare.com にログイン
+  2. Workers & Pages → admin-r2c (Pages project) を選択
+  3. Settings → Builds & deployments
+  4. "Production branch" の "Pause deployments" を ON
+  5. 解除は SCRIPTS/24h-mode-off.sh 実行後に同画面で OFF
+────────────────────────────────────────────────────────
+CF
+
+log "Done. 24h-mode is ON."

--- a/docs/24H_AUTONOMOUS_PLAYBOOK.md
+++ b/docs/24H_AUTONOMOUS_PLAYBOOK.md
@@ -1,0 +1,150 @@
+# 24h 自走 Playbook (Phase70-A 論理層 安全装置)
+
+R2C は dev/staging を持たず本番 VPS (65.108.159.161) のみ。
+UATa テンプレ v1.0 §2.1「本番への接続を物理的に閉じる」が適用不能なので、
+論理層の多層防御で代替する。
+
+## 関連 Asana
+- Phase70 親: 1214919472827777
+- Phase70-A 本タスク: 1214919660483265
+- Phase70-H 初回 24h 自走 (利用先): 別途
+
+## 24h 自走中の禁止操作 (Out of Scope 10項目)
+
+24h 自走モード中、Claude Code CLI および全サブエージェントは
+以下の操作を **絶対に行ってはならない**。違反検知時は **Slack #r2c に
+`HUMAN-REVIEW-REQUIRED` を投稿し、自身を停止する**。
+
+| # | 禁止操作 | 検知/防御 |
+|---|---|---|
+| 1 | VPS (65.108.159.161 / api.r2c.biz) への一切の接続試行 | deploy_guard.py R2C_24H_MODE |
+| 2 | main branch への merge 操作 (PR merge 含む) | GitHub branch protection |
+| 3 | DB マイグレーションの自動実行 | 人間手動運用ルール |
+| 4 | .env / secrets / *.key の編集 | .claudeignore |
+| 5 | git push --force / git reset --hard origin/main | 運用ルール + branch protection |
+| 6 | avatar-agent プロセス操作 (start/stop/restart) | deploy_guard.py SSH ブロック |
+| 7 | Cloudflare Pages の設定変更 | 手動停止 (本ドキュメント §3) |
+| 8 | 依存ライブラリのメジャーバージョン変更 | コードレビュー / Codex |
+| 9 | 法務・契約関連ドキュメント編集 (docs/legal/, docs/contracts/ 等) | 運用ルール |
+| 10 | パートナー本番テナント (live tenant) 影響操作 | tenantId 検証 + L1-L4 |
+
+各項目に違反した場合の動作:
+1. 即座に `gh api -X POST repos/milechy/commerce-faq-tasks/issues -f title="HUMAN-REVIEW-REQUIRED ..."` で Issue 作成
+2. `bash SCRIPTS/r2c-slack-notify.sh --text "HUMAN-REVIEW-REQUIRED: <reason>"` 投稿
+3. 当該作業を即時停止 (新規 Bash tool 呼び出しを行わない)
+
+## 1. SCRIPTS/24h-mode-on.sh の使い方
+
+```bash
+# 通常実行 (実 ON)
+bash SCRIPTS/24h-mode-on.sh
+
+# dry-run (副作用なしで実行内容を確認)
+bash SCRIPTS/24h-mode-on.sh --dry-run
+```
+
+実行内容:
+1. GitHub main branch protection を有効化 (PR レビュー 1必須, admin 含む direct push 禁止, status check 必須)
+2. リポジトリの `allow_auto_merge=false`
+3. 既存 open PR の auto-merge フラグを解除
+4. `~/.r2c-24h-mode` (perm 600) に `R2C_24H_MODE=1` と起動時刻を書き込み
+5. Slack `#r2c` (C0AG07HFJTB) に「🔒 24h 自走モード ON」通知
+6. Cloudflare Pages の手動停止手順を標準出力 (自動化はしない)
+
+冪等性: `~/.r2c-24h-mode` が既存なら何もせず exit 0。
+
+環境変数オーバーライド:
+- `GH_REPO` — 対象リポジトリ (default: `milechy/commerce-faq-tasks`)
+- `STATUS_CHECKS` — 必須 status checks CSV (default: `Stream Path Check,Security Scan`)
+- `R2C_24H_MODE_FILE` — モードファイルパス (default: `~/.r2c-24h-mode`)
+
+## 2. SCRIPTS/24h-mode-off.sh の使い方
+
+```bash
+# 通常実行
+bash SCRIPTS/24h-mode-off.sh
+
+# dry-run
+bash SCRIPTS/24h-mode-off.sh --dry-run
+```
+
+実行内容: on.sh の全逆操作。
+1. main branch protection 削除
+2. `allow_auto_merge=true` 復帰
+3. `~/.r2c-24h-mode` 削除
+4. Slack 「🔓 24h 自走モード OFF」通知
+5. Cloudflare Pages 再開手順を出力
+
+## 3. Cloudflare Pages の手動停止手順
+
+⚠️ wrangler/IaC でコード管理されていないため、自動化対象外。Phase70-H 開始前に必ず手動実施すること。
+
+### 停止 (24h 自走開始時)
+
+1. https://dash.cloudflare.com にログイン (hkobayashi アカウント)
+2. 左ペイン: **Workers & Pages**
+3. プロジェクト一覧から `admin-r2c` を選択
+4. 上部タブ: **Settings**
+5. 左サイドバー: **Builds & deployments**
+6. **Production branch** セクションの **Pause deployments** トグルを **ON**
+7. 確認: Deployments タブで "Pending" が新規発生しないこと
+
+### 再開 (24h 自走終了時)
+
+1-5 まで同手順
+6. **Pause deployments** トグルを **OFF**
+
+## 4. 朝のレビューフロー (Phase70-C で詳細化)
+
+⚠️ プレースホルダ — Phase70-C で本格設計
+
+24h 自走完了後 (翌朝):
+1. `SCRIPTS/r2c-morning-report.sh` 実行 → Slack 投稿
+2. 各 lane が生成した PR を一覧確認 (`gh pr list --search "label:24h-loop"`)
+3. branch protection を一時 OFF せず、PR 個別レビュー → squash merge
+4. 全 PR 処理完了後、`bash SCRIPTS/24h-mode-off.sh`
+5. Cloudflare Pages auto-deploy を再開
+
+## 5. トラブルシュート
+
+### 24h-mode-on.sh が「Already ON」で停止する
+→ 期待通り (冪等性)。実際に branch protection が掛かっているか確認:
+```
+gh api repos/milechy/commerce-faq-tasks/branches/main/protection
+```
+
+### gh CLI が admin 権限不足エラー
+→ `gh auth status` で scope に `repo` があるか確認。
+無ければ `gh auth refresh -s repo,admin:repo` 実行。
+それでも失敗するなら GitHub Web UI から手動で branch protection を設定:
+- https://github.com/milechy/commerce-faq-tasks/settings/branches
+
+### Slack 通知が来ない
+→ `SLACK_WEBHOOK_URL` が `~/.claude-r2c-config/secrets/r2c-loop.env` にあるか確認。
+`SCRIPTS/r2c-slack-notify.sh --text "test" --dry-run` で payload 確認。
+
+### deploy_guard.py が 24h-mode を検知しない
+→ `R2C_24H_MODE=1` が export されているか、または `~/.r2c-24h-mode` が存在するか確認。
+hook 動作確認:
+```
+echo '{"tool_name":"Bash","tool_input":{"command":"bash SCRIPTS/deploy-vps.sh"}}' | \
+  R2C_24H_MODE=1 python3 .claude/hooks/deploy_guard.py
+```
+→ exit 2 で `BLOCKED (24h-mode)` が出れば正常。
+
+### 緊急で 24h-mode を強制解除したい
+1. `rm -f ~/.r2c-24h-mode`
+2. `gh api -X DELETE repos/milechy/commerce-faq-tasks/branches/main/protection`
+3. `bash SCRIPTS/r2c-slack-notify.sh --text "⚠️ 24h-mode 緊急解除 by hkobayashi"`
+
+## 6. 設計判断ログ
+
+- **物理停止 NG → 論理多層防御**: dev 環境ないため。
+- **branch protection: enforce_admins=true**: admin 自身も誤って push しないため。
+- **STATUS_CHECKS デフォルト 2 件のみ**: PR で確実に走る workflow に限定。`perf-gate.yml` は workflow_dispatch のみで実行されないため除外。`Claude PR Review` はタイミングが不安定なため除外。
+- **Cloudflare Pages 自動化なし**: wrangler.toml / API token がコード管理されていない。Phase70-H 直前に hkobayashi が手動操作するのが安全。
+- **deploy_guard env-var + file 二重判定**: env var が忘れられても、ファイル存在で fail-safe に動作。
+
+---
+
+更新: 2026-05-19 (Phase70-A 初版)


### PR DESCRIPTION
## Summary
- **Asana**: [Phase70-A (1214919660483265)](https://app.asana.com/0/0/1214919660483265)
- dev/staging を持たない R2C で 24h 自走中の事故を防ぐ論理多層防御を構築
- ON/OFF スクリプト + .claudeignore + deploy_guard.py 拡張 + Playbook ドキュメント

## 変更内容

### 新規ファイル
- \`SCRIPTS/24h-mode-on.sh\` — main branch protection ON + auto-merge OFF + Slack 通知 + Cloudflare 手動停止指示 (\`--dry-run\` 対応、冪等)
- \`SCRIPTS/24h-mode-off.sh\` — 全逆操作 (\`--dry-run\` 対応)
- \`.claudeignore\` — secrets / .env / .key / .wolf/ などを Claude Code 読み込みから除外
- \`docs/24H_AUTONOMOUS_PLAYBOOK.md\` — Out of scope 10項目, 運用手順, トラブルシュート

### 更新
- \`.claude/hooks/deploy_guard.py\` — \`R2C_24H_MODE=1\` または \`~/.r2c-24h-mode\` 存在時に \`deploy-vps.sh\` と \`ssh root@*\` を追加ブロック
- \`CLAUDE.md\` — 24h 自走中禁止操作 § 追加 (詳細は Playbook へポインタ)
- \`.gitignore\` — \`.r2c-24h-mode\` 保険追加

## Gate 結果

| Gate | 結果 | 備考 |
|---|---|---|
| Gate 1: typecheck | ✅ PASS | tsc --noEmit 0 errors |
| Gate 1: test | ✅ PASS | 1617 / 1617 tests (main checkout で再検証) |
| Gate 1.5: dead-code | ⚠ 37件 warning | pre-existing、本 PR と無関係 |
| Gate 2: security-scan | ✅ PASS | CRITICAL/HIGH = 0 |
| Gate 3: pnpm build (API) | ✅ PASS | tsc 完走 |
| Gate 3: admin-ui build | ✅ PASS | vite 2.66s |

⚠️ **worktree パス制約**: worktree 名に \`+\` を含むと \`jest testPathIgnorePatterns\` の正規表現に干渉し、本来 ignore されるレガシーテスト (\`langGraphOrchestrator.test.ts\` 他) が走ってしまう。これは pre-existing な制約のため、main checkout で再検証して 1617 テスト全 PASS を確認済み。

## Dry-run 検証

\`\`\`bash
$ bash SCRIPTS/24h-mode-on.sh --dry-run
[24h-mode-on] Enabling branch protection on milechy/commerce-faq-tasks main…
[dry-run] gh api -X PUT repos/milechy/commerce-faq-tasks/branches/main/protection --input <payload>
[dry-run] payload: { ...required_status_checks, enforce_admins, required_pull_request_reviews... }
[24h-mode-on] Disabling repository auto-merge…
[24h-mode-on] Disabling auto-merge on existing open PRs…
[24h-mode-on] Writing mode file: /Users/hkobayashi/.r2c-24h-mode
[24h-mode-on] [Slack notify dry-run]
[Cloudflare 手動停止手順表示]
[24h-mode-on] Done.

$ bash SCRIPTS/24h-mode-off.sh --dry-run
[24h-mode-off] Removing branch protection ...
[24h-mode-off] Re-enabling repository auto-merge ...
[24h-mode-off] Removing mode file ...
[Cloudflare 再開手順表示]
[24h-mode-off] Done.

# deploy_guard.py 24h-mode ブロック検証
$ R2C_24H_MODE=1 python3 .claude/hooks/deploy_guard.py <<< '{"tool_name":"Bash","tool_input":{"command":"bash SCRIPTS/deploy-vps.sh"}}'
[deploy_guard] BLOCKED (24h-mode): destructive command not permitted
  command: bash SCRIPTS/deploy-vps.sh
  24h 自走モード中。解除は: bash SCRIPTS/24h-mode-off.sh
exit=2

# 既存 32 テストも全パス維持
$ bash .claude/hooks/test_deploy_guard.sh
Results: 32 passed, 0 failed
\`\`\`

## Out of Scope (24h 自走中の禁止操作 10 項目)
詳細は \`docs/24H_AUTONOMOUS_PLAYBOOK.md\` を参照:
VPS 接続 / main merge / DB migration / .env 編集 / git force /
avatar-agent 操作 / Cloudflare 設定変更 / 依存メジャー bump / 法務文書編集 / 本番テナント影響

## 設計判断
- **物理停止 NG → 論理多層防御**: dev 環境ないため
- **branch protection: enforce_admins=true**: admin 自身も誤って push しないため
- **Cloudflare Pages 自動化なし**: wrangler.toml 未管理。Phase70-H 直前に hkobayashi が手動操作するのが安全
- **deploy_guard env-var + file 二重判定**: env var が忘れられても、ファイル存在で fail-safe

## Test plan
- [ ] Codex review (Gate 2.5): \`/codex:review --base main --background\`
- [ ] Phase70-H 当日に hkobayashi が \`bash SCRIPTS/24h-mode-on.sh\` で実 ON 試行
- [ ] 24h 自走終了後に \`bash SCRIPTS/24h-mode-off.sh\` で OFF 復帰確認
- [ ] Phase70-C で朝のレビューフローを Playbook §4 に追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)