### PR TITLE
feat(1214921011388648): Phase70-L Slack 通知整備 (notify-slack.sh + 3段フォールバック + 通知パターン)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -158,6 +158,8 @@ INTERNAL_API_HMAC_SECRET=
 
 # ==== Monitoring ====
 SLACK_WEBHOOK_URL=
+# R2C #r2c チャンネル専用 Incoming Webhook (24h 自走通知用)
+SLACK_WEBHOOK_URL_R2C=
 SENTIMENT_SERVICE_URL=
 
 # ==== Knowledge Encryption ====

--- a/SCRIPTS/notify-slack.sh
+++ b/SCRIPTS/notify-slack.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# notify-slack.sh — CLI 自走通知ヘルパ (Phase70-L)
+#
+# 用途:
+#   24h 自走中の CLI が Slack #r2c (C0AG07HFJTB) へ確実に通知を届ける。
+#   MCP 経由 (SLACK_BOT_TOKEN) → curl webhook → stderr の 3段フォールバック。
+#
+# 使い方:
+#   notify-slack.sh <message> [--color info|success|warning|error]
+#                             [--channel <id>] [--dry-run]
+#
+# 環境変数 (秘匿値は ~/.claude-r2c-config/secrets/r2c-loop.env に保管):
+#   SLACK_BOT_TOKEN      — Bot OAuth token xoxb-... (Slack MCP 経由の第1試行)
+#   SLACK_WEBHOOK_URL_R2C — #r2c 専用 Incoming Webhook URL (第2試行 優先)
+#   SLACK_WEBHOOK_URL     — 汎用 Incoming Webhook URL (第2試行 フォールバック)
+#
+# 通知パターン (CLI 自走プロンプト用):
+#   PR 作成完了  : notify-slack.sh "✅ PR #N pushed: <title>, ready for Gate 2.5" --color success
+#   Gate 失敗    : notify-slack.sh "⚠️ Gate failed at <step>: <error>" --color warning
+#   Stop 発火    : notify-slack.sh "🛑 Stopped: <reason>" --color error
+#
+# セキュリティ注記:
+#   - Webhook URL は stderr にも stdout にも出力しない
+#   - Stop signal 後の連投防止: ~/.r2c-notified-stop が存在すれば exit 0
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "$0" .sh)"
+R2C_CONFIG="${R2C_CONFIG:-$HOME/.claude-r2c-config}"
+LOG_DIR="${R2C_CONFIG}/logs"
+DEFAULT_CHANNEL="C0AG07HFJTB"
+STOP_NOTIFIED_FILE="${R2C_CONFIG}/.r2c-notified-stop"
+
+MESSAGE=""
+COLOR="info"
+CHANNEL="$DEFAULT_CHANNEL"
+DRY_RUN=0
+
+usage() {
+    cat <<'USAGE'
+Usage: notify-slack.sh <message> [--color info|success|warning|error]
+                                 [--channel <id>] [--dry-run]
+USAGE
+}
+
+# ─── 引数パース ───
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --color)   COLOR="${2:-info}"; shift 2 ;;
+        --channel) CHANNEL="${2:-$DEFAULT_CHANNEL}"; shift 2 ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        --*)       echo "ERROR: unknown option: $1" >&2; usage; exit 1 ;;
+        *)
+            if [[ -z "$MESSAGE" ]]; then
+                MESSAGE="$1"
+            else
+                echo "ERROR: unexpected positional arg: $1" >&2
+                usage; exit 1
+            fi
+            shift ;;
+    esac
+done
+
+if [[ -z "$MESSAGE" ]]; then
+    echo "ERROR: <message> required" >&2
+    usage; exit 1
+fi
+
+case "$COLOR" in
+    info)    HEX_COLOR="#36a64f" ;;
+    success) HEX_COLOR="#2eb886" ;;
+    warning) HEX_COLOR="#daa520" ;;
+    error)   HEX_COLOR="#cc0000" ;;
+    *)       echo "ERROR: --color must be info|success|warning|error" >&2; exit 1 ;;
+esac
+
+# ─── 環境変数ロード ───
+# shellcheck disable=SC1091
+[[ -f "${R2C_CONFIG}/secrets/r2c-loop.env" ]] \
+    && source "${R2C_CONFIG}/secrets/r2c-loop.env"
+
+# ─── Stop 連投防止 ───
+# Stop signal 通知済みフラグがあれば重複投稿しない
+if [[ "$COLOR" == "error" ]] && [[ -f "$STOP_NOTIFIED_FILE" ]]; then
+    echo "[${SCRIPT_NAME}] Stop already notified, skipping duplicate." >&2
+    exit 0
+fi
+
+mkdir -p "$LOG_DIR"
+
+ts() { date '+%Y-%m-%d %H:%M:%S'; }
+log() { printf '[%s] [%s] %s\n' "$(ts)" "$SCRIPT_NAME" "$*"; }
+
+# ─── Dry-run ───
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    cat <<DRY
+[dry-run] notify-slack.sh
+  channel : $CHANNEL
+  color   : $COLOR ($HEX_COLOR)
+  message : $MESSAGE
+DRY
+    exit 0
+fi
+
+exec >> "${LOG_DIR}/${SCRIPT_NAME}.log" 2>&1
+
+# ─── ペイロード構築 (Attachment 形式、color 対応) ───
+build_payload_json() {
+    local channel="$1" message="$2" hex_color="$3"
+    printf '{"channel":"%s","attachments":[{"color":"%s","text":"%s","mrkdwn_in":["text"]}]}' \
+        "$channel" "$hex_color" \
+        "$(printf '%s' "$message" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+}
+
+PAYLOAD="$(build_payload_json "$CHANNEL" "$MESSAGE" "$HEX_COLOR")"
+
+# ─── 第1試行: Slack Bot Token (MCP 経由の代替 — chat.postMessage) ───
+send_via_bot_token() {
+    local token="$1" payload="$2"
+    local resp
+    resp="$(curl -sS --max-time 15 \
+        -X POST \
+        -H "Authorization: Bearer ${token}" \
+        -H 'Content-Type: application/json; charset=utf-8' \
+        --data "$payload" \
+        'https://slack.com/api/chat.postMessage' 2>&1)" || return 1
+    printf '%s' "$resp" | grep -q '"ok":true' || return 1
+    return 0
+}
+
+if [[ -n "${SLACK_BOT_TOKEN:-}" ]]; then
+    if send_via_bot_token "$SLACK_BOT_TOKEN" "$PAYLOAD"; then
+        log "Sent via bot token (attempt 1): $MESSAGE"
+        [[ "$COLOR" == "error" ]] && touch "$STOP_NOTIFIED_FILE"
+        exit 0
+    fi
+    log "WARN: bot token send failed, trying webhook (attempt 2)"
+fi
+
+# ─── 第2試行: curl Incoming Webhook ───
+WEBHOOK_URL="${SLACK_WEBHOOK_URL_R2C:-${SLACK_WEBHOOK_URL:-}}"
+
+send_via_webhook() {
+    local url="$1" payload="$2"
+    local resp
+    resp="$(curl -sS --max-time 15 \
+        -X POST \
+        -H 'Content-Type: application/json' \
+        --data "$payload" \
+        "$url" 2>&1)" || return 1
+    [[ "$resp" == "ok" ]] || return 1
+    return 0
+}
+
+if [[ -n "${WEBHOOK_URL:-}" ]]; then
+    if send_via_webhook "$WEBHOOK_URL" "$PAYLOAD"; then
+        log "Sent via webhook (attempt 2): $MESSAGE"
+        [[ "$COLOR" == "error" ]] && touch "$STOP_NOTIFIED_FILE"
+        exit 0
+    fi
+    log "WARN: webhook send failed, falling back to stderr (attempt 3)"
+fi
+
+# ─── 第3試行: stderr 書き出し + 終了コード 1 ───
+log "ERROR: all Slack send attempts failed for: $MESSAGE"
+printf '[%s] [%s] SLACK_SEND_FAILED color=%s channel=%s message=%s\n' \
+    "$(ts)" "$SCRIPT_NAME" "$COLOR" "$CHANNEL" "$MESSAGE" >&2
+exit 1

--- a/docs/24H_AUTONOMOUS_PLAYBOOK.md
+++ b/docs/24H_AUTONOMOUS_PLAYBOOK.md
@@ -137,6 +137,49 @@ echo '{"tool_name":"Bash","tool_input":{"command":"bash SCRIPTS/deploy-vps.sh"}}
 2. `gh api -X DELETE repos/milechy/commerce-faq-tasks/branches/main/protection`
 3. `bash SCRIPTS/r2c-slack-notify.sh --text "⚠️ 24h-mode 緊急解除 by hkobayashi"`
 
+## 7. CLI 自走通知パターン (Phase70-L)
+
+### notify-slack.sh の使い方
+
+```bash
+# 基本
+bash SCRIPTS/notify-slack.sh "<message>" --color <info|success|warning|error>
+
+# dry-run (実際には送信しない)
+bash SCRIPTS/notify-slack.sh "<message>" --color info --dry-run
+
+# チャンネル指定 (デフォルト: C0AG07HFJTB = #r2c)
+bash SCRIPTS/notify-slack.sh "<message>" --color info --channel C0AG07HFJTB
+```
+
+3段フォールバック:
+1. `SLACK_BOT_TOKEN` — `chat.postMessage` API (Slack MCP 相当)
+2. `SLACK_WEBHOOK_URL_R2C` or `SLACK_WEBHOOK_URL` — Incoming Webhook curl
+3. stderr 書き出し + 終了コード 1
+
+### 標準通知パターン (CLI 自走プロンプトに組み込む)
+
+| イベント | コマンド |
+|---|---|
+| PR 作成完了 | `bash SCRIPTS/notify-slack.sh "✅ PR #N pushed: <title>, ready for Gate 2.5" --color success` |
+| Gate 失敗 | `bash SCRIPTS/notify-slack.sh "⚠️ Gate failed at <step>: <error>" --color warning` |
+| Stop condition 発火 | `bash SCRIPTS/notify-slack.sh "🛑 Stopped: <reason>" --color error` |
+| HUMAN-REVIEW-REQUIRED | `bash SCRIPTS/r2c-slack-notify.sh --text "HUMAN-REVIEW-REQUIRED: <reason>"` |
+
+### Stop 後の通知ループ防止
+
+- `--color error` で送信成功すると `~/.claude-r2c-config/.r2c-notified-stop` が作成される。
+- 同ファイルが存在する間、`--color error` の重複投稿は **skip (exit 0)** される。
+- `bash SCRIPTS/24h-mode-off.sh` 実行時にこのフラグファイルを削除すること。
+- Stop signal が発火したら **新規 Bash tool 呼び出しを一切行わず**、当該作業を即時停止する。
+
+### Slack 通知が来ない場合
+
+`SLACK_BOT_TOKEN` と `SLACK_WEBHOOK_URL_R2C` の両方が `~/.claude-r2c-config/secrets/r2c-loop.env` に設定されているか確認:
+```bash
+bash SCRIPTS/notify-slack.sh "test" --color info --dry-run
+```
+
 ## 6. 設計判断ログ
 
 - **物理停止 NG → 論理多層防御**: dev 環境ないため。


### PR DESCRIPTION
## Summary
- `SCRIPTS/notify-slack.sh` 新規作成: Bot Token (MCP相当) → curl Webhook → stderr の3段フォールバック
- `.env.example` に `SLACK_WEBHOOK_URL_R2C=` 追加
- `docs/24H_AUTONOMOUS_PLAYBOOK.md` §7 追加: CLI 自走通知パターン 3種 + Stop 連投防止

## 変更詳細

### SCRIPTS/notify-slack.sh
- 引数: `<message> [--color info|success|warning|error] [--channel <id>] [--dry-run]`
- 第1試行: `SLACK_BOT_TOKEN` → `chat.postMessage` API (Slack MCP 相当)
- 第2試行: `SLACK_WEBHOOK_URL_R2C` or `SLACK_WEBHOOK_URL` → curl Incoming Webhook
- 第3試行: stderr 書き出し + exit 1
- Stop 連投防止: `--color error` 送信成功後に `~/.claude-r2c-config/.r2c-notified-stop` を作成
- shellcheck PASS / dry-run 動作確認済み
- Webhook URL を stderr に出力しない (セキュリティ)

### 標準通知パターン (Playbook §7)
| イベント | color |
|---|---|
| PR 作成完了: `✅ PR #N pushed: <title>, ready for Gate 2.5` | success |
| Gate 失敗: `⚠️ Gate failed at <step>: <error>` | warning |
| Stop 発火: `🛑 Stopped: <reason>` | error |

## Test plan
- [x] shellcheck PASS (`notify-slack.sh`)
- [x] dry-run 3パターン確認 (success/warning/error)
- [x] Gate 1: pnpm typecheck + test (1617 tests pass)
- [x] Gate 2: security-scan PASS (Critical/High=0)
- [x] Gate 3: pnpm build + admin-ui build PASS
- [ ] 実環境テスト: `SLACK_BOT_TOKEN` または `SLACK_WEBHOOK_URL_R2C` 設定後に実送信確認 (人間が実施)

## Gate 2.5
bash スクリプト + docs のみ変更。skip-OK 条件に合致。

🤖 Generated with [Claude Code](https://claude.com/claude-code)