### PR TITLE
feat(1214919660548852): Phase70-D Asana Watcher — 24h 自走中のタスク補給

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,15 @@
 {
+  "permissions": {
+    "defaultMode": "bypassPermissions",
+    "deny": [
+      "Edit(.claude/hooks/deploy_guard.py)",
+      "Edit(SCRIPTS/24h-mode-on.sh)",
+      "Edit(SCRIPTS/24h-mode-off.sh)",
+      "Edit(.claude/hooks/*)"
+    ]
+  },
+  "autoMemoryEnabled": true,
+  "cleanupPeriodDays": 99999,
   "hooks": {
     "SessionStart": [
       {

--- a/.env.example
+++ b/.env.example
@@ -158,6 +158,8 @@ INTERNAL_API_HMAC_SECRET=
 
 # ==== Monitoring ====
 SLACK_WEBHOOK_URL=
+# R2C #r2c チャンネル専用 Incoming Webhook (24h 自走通知用)
+SLACK_WEBHOOK_URL_R2C=
 SENTIMENT_SERVICE_URL=
 
 # ==== Knowledge Encryption ====

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,27 +38,7 @@ This project uses OpenWolf for context management. Read and follow .wolf/OPENWOL
 - Gap: 4トリガー → Gemini推薦エンジン → 知識追加 (Phase46)
 - Book RAG: PDF → 6フィールド構造化 → pgvector + ES (Phase47)
 - LLM Defense: L5 Input Sanitizer → L6 Prompt Firewall → L7 Topic Guard → L8 Output Guard (Phase48)
-
-## Key Endpoints
-| Path | Auth | Purpose |
-|---|---|---|
-| POST /api/chat | x-api-key | Widget → Chat |
-| POST /dialog/turn | x-api-key / JWT | Multi-turn dialog |
-| POST /agent.search | x-api-key / JWT | RAG search |
-| GET /health | public | ES/PG/CE health |
-| GET /metrics | X-Internal-Request: 1 | Prometheus metrics |
-| /v1/admin/tenants/* | JWT (super_admin) | テナント管理 |
-| /v1/admin/chat-history/* | JWT | 会話履歴 |
-| /v1/admin/tuning/* | JWT | チューニングルール |
-| /v1/admin/feedback/* | JWT | フィードバック管理 |
-| /v1/admin/avatar/* | JWT | アバター設定 (Phase40-41) |
-| /v1/admin/evaluations/* | JWT | Judge評価 (Phase45) |
-| /v1/admin/knowledge-gaps/* | JWT | Gap検出 (Phase46) |
-| /v1/admin/knowledge/books/* | JWT | PDF書籍管理 (Phase47) |
-| /v1/admin/ai-assist/* | JWT (super_admin) | AIアシスタント (Phase43) |
-| /v1/admin/variants/* | JWT | A/Bテスト |
-| /v1/admin/reports/* | JWT | 週次レポート |
-| POST /api/avatar/room-token | x-api-key | LiveKit JWT発行 + Agent Dispatch |
+- Key endpoints / env vars: `docs/API_REFERENCE.md`
 
 ## Security Middleware Order (src/index.ts)
 1. requestIdMiddleware (global)
@@ -70,225 +50,49 @@ This project uses OpenWolf for context management. Read and follow .wolf/OPENWOL
 7. tenantContextLoader (per-route stack)
 8. securityPolicyEnforcer (per-route stack)
 
-## Environment Variables
-```bash
-# Core
-PORT, LOG_LEVEL, ES_URL, DATABASE_URL
-ALLOWED_ORIGINS, DEFAULT_TENANT_ID
-
-# Auth
-AGENT_API_KEY, API_KEY_TENANT_ID, BASIC_AUTH_TENANT_ID
-SUPABASE_URL, SUPABASE_JWT_SECRET, SUPABASE_SERVICE_ROLE_KEY
-
-# LLM
-GROQ_API_KEY, GROQ_CHAT_MODEL, GROQ_MODEL_8B, GROQ_MODEL_70B
-LLM_API_KEY, LLM_BASE_URL, LLM_CHAT_MODEL, LLM_MODEL_20B, LLM_MODEL_120B
-OPENAI_API_KEY, OPENAI_EMBEDDING_MODEL
-GEMINI_API_KEY  # Phase45 Judge専用
-
-# Avatar (Phase40-41)
-LIVEKIT_URL, LIVEKIT_API_KEY, LIVEKIT_API_SECRET
-FISH_AUDIO_API_KEY, FISH_AUDIO_REFERENCE_ID
-LEMONSLICE_API_KEY, LEMONSLICE_AGENT_ID
-
-# Storage
-SUPABASE_STORAGE_URL, SUPABASE_BUCKET_BOOK_PDFS
-
-# Billing (Phase32)
-STRIPE_SECRET_KEY, STRIPE_WEBHOOK_SECRET
-
-# Cross-encoder
-CE_MODEL_PATH, CE_ENGINE
-
-# Phase22 Flow Control
-PHASE22_MAX_TURNS, PHASE22_MAX_CLARIFY_REPEATS
-PHASE22_MAX_CONFIRM_REPEATS, PHASE22_LOOP_WINDOW_TURNS
-
-# Phase45 Judge
-JUDGE_AUTO_EVALUATE, JUDGE_SCORE_THRESHOLD
-
-# Monitoring
-SLACK_WEBHOOK_URL
-```
-
-## Deployment (Phase28)
-- VPS: Hetzner 65.108.159.161
-- API: PM2 → `node dist/index.js` (port 3100)
-- Admin UI: PM2 → `serve -s admin-ui/dist` (port 5173)
-- Admin UI API base: `VITE_API_BASE` 環境変数 (default: localhost:3100)
-- Deploy: `bash SCRIPTS/deploy-vps.sh [user@host]`
-- Checklist: `docs/DEPLOY_CHECKLIST.md`
-- Public URLs (Phase49):
-  - API: https://api.r2c.biz (Nginx → PM2 port 3100)
-  - Admin UI: https://admin.r2c.biz (Nginx → serve port 5173)
-  - SSL: Let's Encrypt (certbot --nginx, auto-renew)
-- PM2 processes (ecosystem.config.cjs):
-  1. `rajiuce-api` — `dist/src/index.js` (port 3100)
-  2. `rajiuce-avatar` — `avatar-agent/agent.py` (LiveKit Agent)
-  3. `rajiuce-admin` — `serve admin-ui/dist -l 5173`
-  4. `slack-listener` — `slack_listener.py`
-
-## Cost Constraint
-- Monthly: $27-48
-- Grafana + Prometheus: self-hosted $0-5
-- Slack Webhook: free
-- Groq API: usage-based (120B ratio ≤10%)
-
 ## VPSデプロイルール（厳守）
 
-⚠️ 以下のルールはClaude Code CLIが必ず従うこと。ユーザーへの提案時も同様。
-
-### デプロイコマンド
-
-```bash
-bash SCRIPTS/deploy-vps.sh
-```
-
-これが唯一のデプロイ手順。以下の個別コマンドは禁止:
-- ❌ `ssh root@... "git pull && pnpm build && pm2 restart"`
-- ❌ `ssh root@... "cd admin-ui && pnpm build"`
-- ❌ VPSで直接 `git pull` を実行
-
-deploy-vps.sh は rsync + API build + Admin UI build（キャッシュクリア付き）+ バンドル検証 + PM2 restart を一括で行う。
-
-### 重要な注意事項
+⚠️ 唯一の手順: `bash SCRIPTS/deploy-vps.sh`
 - ecosystem.config.cjs の script は `dist/src/index.js`（`dist/index.js` ではない）
-- PM2は `.env` を自動で読まない。dotenv/config が src/index.ts の先頭でimportされている
-- Admin UIは `serve -s admin-ui/dist -l 5173` で静的ファイル配信
+- PM2は `.env` を自動で読まない (dotenv/config が src/index.ts 先頭でimport済み)
+- 禁止: ssh直接コマンド / VPSで git pull / 個別 pnpm build
+詳細: `docs/DEPLOY_CHECKLIST.md`
 
 ## Security Scan
-- デプロイ前: bash SCRIPTS/security-scan.sh を実行推奨
+- デプロイ前: `bash SCRIPTS/security-scan.sh` 実行推奨
 - CI: .github/workflows/security-scan.yml が main push / PR / 週次で自動実行
-- ポリシー: docs/SECURITY_SCAN_POLICY.md 参照
-- High/Critical 検出時はデプロイをブロック
+- High/Critical 検出時はデプロイをブロック。ポリシー: `docs/SECURITY_SCAN_POLICY.md`
 
 ## Test & Deploy Gate（必須フロー）
 
-⚠️ 全Phaseに適用。Gate通過なしのデプロイは禁止。
+⚠️ 全Phaseに適用。Gate通過なしのデプロイは禁止。詳細: `docs/TEST_DEPLOY_GATE.md`
 
-### Gate順序（実装完了後に必ずこの順で実行）
+Gate順序:
+- Gate 1: `pnpm verify` (typecheck + lint + test 全パス)
+- Gate 2: `bash SCRIPTS/security-scan.sh` (High/Critical = 0)
+- Gate 2.5: `/codex:review --base main --background` (**git push前**に実行)
+- Gate 3: `pnpm build && cd admin-ui && pnpm build`
+- git commit + push (Gate 1-3通過後のみ)
 
-```
-実装完了
-  → Gate 1: pnpm verify（typecheck + lint + test 全パス）
-  → Gate 2: bash SCRIPTS/security-scan.sh（High/Critical = 0）
-  → Gate 2.5: /codex:review --base main --background
-              → /codex:result
-              ★ 必ずgit push前に実行（push後は差分なしで無意味）
-              ※ セキュリティ変更時のみ: /codex:adversarial-review --background
-              ※ Critical/High指摘 → 修正 → Gate 1から再実行
-  → Gate 3: pnpm build && cd admin-ui && pnpm build
-  → git commit + push（Gate 1-3通過後のみ）
-────────────────────────────────
-以降は人間が実行:
-  → Gate 4b: claude --chrome でブラウザテスト（★ UI変更Phase: 必須）
-  → デプロイ: bash SCRIPTS/deploy-vps.sh
-  → DBマイグレーション: VPSでSQL手動実行（あれば）
-  → Gate 5: curl https://api.r2c.biz/health + Admin UIログイン確認
-  → Gate 6: UI調査（★ UI変更Phase: 必須・Claude in Chrome）
-  → Asanaタスク完了 + ドキュメント更新
-```
-
-### Codex Review 運用ルール
-- review gate: **常時OFF**（自動ループはコスト消費が大きすぎる）
-- 通常レビュー: PR前に1回だけ `/codex:review --base main --background`（**git push前**）
-- セキュリティ変更時のみ: `/codex:adversarial-review --background`
-- 結果確認: `/codex:status` → `/codex:result`
-- Critical/High → 修正必須。False positive → スキップ理由をコミットメッセージに記載
-- スキップOK: typo修正、ドキュメントのみ、CSSのみ、テストコードのみ
-
-### テスト作成ルール
-- 新規API: 正常系1 + 認証エラー1 + バリデーション1（最低限）
-- セキュリティ関連: 全パスカバー
-- 外部API（Groq, Gemini, Supabase Storage, Fish Audio等）: 常にモック
-- Gate 1-3が通らない限りgit pushしない
-- ★ Gate 2.5（Codex review）はgit push前に実行（push後は差分なしで無意味）
-
-### Chrome ブラウザテスト（UI変更Phase: 必須）
-- `claude --chrome` で実行（Gate 4b）
-- 共通項目: ログイン / ダッシュボード表示 / 🔔通知ベル / モバイル390px / コンソールエラーなし
-- `~/.claude/settings.local.json` に `"mcp__claude-in-chrome__computer"` が必要
-- ★ UI変更がないPhaseではスキップ可。UI変更があれば Gate 6（UI調査）も必須
-
-詳細: docs/TEST_DEPLOY_GATE.md
+Codex review gate: 常時OFF。スキップOK: typo修正・ドキュメントのみ・CSSのみ・テストコードのみ
 
 ## Git Branch Rule（厳守）
 
 ⚠️ **mainへの直接コミット禁止。test-onlyでも例外なし。**
 
-### 必須フロー
 ```
 git checkout -b feature/<asana-id>-<short-description>
-# 実装 + Gate 1〜3
-git commit
-# Gate 2.5: /codex:review --base main --background（コミット後、push前）
-git push -u origin feature/...
-gh pr create
 ```
 
-### 違反時の復旧
-```bash
-git reset --soft HEAD~1          # コミット取り消し（変更は残す）
-git checkout -b feature/...      # feature branch作成
-git commit                        # 同内容で再コミット
-```
-
-### 理由
-- mainへの直接pushはCodex review（Gate 2.5）が機能しない（base=mainでdiff=0になる）
-- PRマージ記録がなくなりレビュー・承認フローが消える
-
-## PRマージ自動化 (auto-merge) ルール
-
-### 背景
-2026-04-19 に PR #110-#117 の 8 本を一括マージする際、手動操作の長さと conflict 解消で一日が大きく削られた。
-同様の手動作業を避けるため、以下の運用ルールを遵守する。
-
-### 運用ルール
-
-**PR 作成時は必ず auto-merge を有効化する:**
-
-```bash
-gh pr create --title "..." --body "..." && \
-gh pr merge $(gh pr view --json number -q .number) --auto --squash --delete-branch
-```
-
-または既存 PR 番号を使って:
-```bash
-gh pr merge <PR番号> --auto --squash --delete-branch
-```
-
-### auto-merge の動作条件
-
-以下が全て揃った時点で自動マージされる:
-- CI (pnpm verify / build) が green
-- 必要なレビュー承認済み（プロジェクト設定による）
-- conflict なし
-
-### conflict が発生した場合
-
-- auto-merge は停止、PR 画面で「Merge conflict」警告が表示される
-- hkobayashi または CLI が手動で conflict を解消
-- 解消後に再度 auto-merge が有効化される
-
-### マージ方式の統一
-
-- **squash and merge** を標準とする（linear history 維持）
-- rebase merge / merge commit は使わない（履歴複雑化回避）
-
-### 関連タスク
-
-- Phase1（本ルール策定）: Asana 1214121039752589
-- Phase2（SCRIPTS/merge-ready-prs.sh 作成）: Asana 1214121039752589（別タスク化済み）
-- Phase3（Claude Code CLI /merge エージェント）: 将来タスク、未起票
+違反復旧: `git reset --soft HEAD~1` → feature branch作成 → 再コミット
+PR: `gh pr merge <PR番号> --auto --squash --delete-branch` 詳細: `docs/PR_MERGE_RULES.md`
 
 ## Settings Hygiene
-- `.claude/settings.local.json` は `.gitignore` に登録済み（プロジェクトローカルルール）
+- `.claude/settings.local.json` は `.gitignore` 登録済み（プロジェクトローカルルール）
 - allowedTools にAPIトークン・パスワード等の認証情報を含めない
 - 禁止デプロイコマンドを allowedTools に追加しない（deploy_guard.py フックが検知）
 
 ## Custom Agents (.claude/agents/)
-
-プロジェクト固有のサブエージェント。`@エージェント名` で呼び出す。
 
 | Agent | 用途 | 呼び出し |
 |---|---|---|
@@ -297,135 +101,19 @@ gh pr merge <PR番号> --auto --squash --delete-branch
 | deploy-checker | VPSデプロイ前後チェックリスト | @deploy-checker |
 | test-writer | テスト作成（モック方針・配置ルール準拠） | @test-writer |
 
-### 環境変数（Claude Code最新機能用）
-- `CLAUDE_CODE_NO_FLICKER=1` — Focus View有効（Ctrl+Oで切替）
-- `MCP_CONNECTION_NONBLOCKING=true` — FT Pipeline --print高速化
+環境変数: `CLAUDE_CODE_NO_FLICKER=1` (Focus View), `MCP_CONNECTION_NONBLOCKING=true` (MCP高速化)
 
 ## MCP Integrations
-
-### Playwright MCP (E2E Browser Testing)
-- Setup: `claude mcp add --scope project playwright npx @playwright/mcp@latest`
-- Usage: 「Playwright MCPでadmin.r2c.bizにアクセスして〇〇をテストして」
-- Gate 4b/Gate 6 のブラウザテストをCLIから自動実行可能
-- 初回は明示的に「Playwright MCP」と言うこと（Bash実行と区別するため）
-- 認証: ログイン画面が表示されたら人間が手動ログイン→Cookie維持
-
-### Environment Variables (Performance)
-```bash
-# ~/.zshrc に追加済み
-export ENABLE_PROMPT_CACHING_1H=1    # 1時間プロンプトキャッシュ
-export CLAUDE_CODE_NO_FLICKER=1       # フリッカー防止
-export MCP_CONNECTION_NONBLOCKING=true # MCP非同期接続
-```
-
-### Session Features
-- `/recap` — セッション復帰時のコンテキスト自動要約
-- `/review` — コードレビュー（Skill tool経由で自動発見可能）
-- `/security-review` — セキュリティレビュー
+- Playwright MCP (Gate 4b/6): `claude mcp add --scope project playwright npx @playwright/mcp@latest`
+- Session: `/recap` (コンテキスト要約) / `/review` (コードレビュー) / `/security-review`
 
 ## OpenWolf（トークン最適化ミドルウェア）
-- `.wolf/` にプロジェクトインデックス・学習メモリ・トークンレジャーを保持
-- 6つのフックスクリプトがClaude Code操作時に自動実行
-- ファイル読み取り前に `anatomy.md` で内容を要約 → 不要な全文読み取りを削減
-- `cerebrum.md` に過去の修正・好みを蓄積 → セッション間で学習
-- コスト $0（ローカル処理のみ、外部API不使用）
+- `.wolf/` にインデックス・学習メモリ・トークンレジャーを保持（`.gitignore` 登録済み）
+- anatomy.md で不要な全文読み取りを削減、cerebrum.md でセッション間学習
 - `openwolf status` で健全性確認、`openwolf scan` で構造マップ更新
-- `.wolf/` は `.gitignore` 登録済み（ローカルのみ）
 
 ## 開発プレイブック参照
-
-開発の進め方の全体像は `docs/R2C_DEVELOPMENT_PLAYBOOK.md` を参照。
-
-### 役割分担
-- Claude.ai: 戦略/Asana MCP/メモリー管理/CLI用1-2行要件提示
-- CLI: 自律実装 (discovery→plan→implement→gate→Codex→push)
-- 人間: Gate 2.5手動/DBマイグレーション手動/デプロイ判断
-
-### CLIプロンプト生成ルール
-- 冒頭に `## 推奨モデル: [Opus 4.7 / Sonnet 4.6 / Plan Mode]` 必須（省略禁止）
-- SSHコマンドはCLIプロンプトに含めない（deploy_guardブロック）
-- DBマイグレーションは「hkobayashiが手動実行」ステップとして記載し、CLIには確認クエリのみ
-- 詳細な章立て・ステップバイステップ指示を書かない（CLIが自走する）
-- `!`コマンド列挙・push承認ゲート設置・Gate結果仲介指示は全て禁止
-
-### CLIプロンプトテンプレート
-
-**標準（新規タスク）:**
-```
-## 推奨モデル: [Opus 4.7 / Sonnet 4.6]
-
-## タスク
-Asana GID: XXXX — [タスク名]
-[1-3行でゴール・完了条件]
-
-## 制約
-- [アーキテクチャ制約]
-
-## Gate
-@gate-runner で Gate 1-3実行。Gate 2.5必要。
-```
-
-**バグ修正:**
-```
-## 推奨モデル: Sonnet 4.6
-
-## バグ
-[症状1-2行]
-
-## 初動
-Playwright MCPで現象確認してから修正。推測で修正しない。
-
-## Gate
-@gate-runner で Gate 1-3実行。Gate 2.5必要。
-```
-
-**並列開発（Agent Teams）:**
-```
-## 推奨モデル: Opus 4.7
-
-## 概要
-[Phase名 — 目的]
-
-## 共有インターフェース
-[DB schema / API spec / TS types 埋め込み]
-
-## ペイン1-N
-[各1-2行]
-
-## Gate
-各ペイン完了後 @gate-runner。Gate 2.5必要。
-```
-
-### セッション開始プロトコル
-1. Asana:get_project (GID: 1213607637045514) で未完了タスク確認
-2. Asana:get_task で個別タスクの completed 等を検証
-3. メモリーと実態の乖離検出→メモリー更新提案
-4. 未完了タスクから優先順位付きCLI要件を提示（推奨モデル明記）
-
-### 問題解決原則
-- 根本原因特定+再発防止（症状修正で終わらない）
-- バグ報告→テキスト推測禁止→Playwright MCP/pm2 logs/DB SELECTの3点確認
-- CLI報告に「変更しました/no diff/リスク最小」→スコープ再評価要求
-
-## Phase 1 24h 自律ループ実装状況 (2026-05-18 時点)
-
-| 項目 | 状態 | 関連 PR | 関連ドキュメント |
-|---|---|---|---|
-| Claude.ai 指示文 v1 | ✅ | #155 | docs/R2C_CLAUDE_AI_INSTRUCTIONS_V1.md |
-| Phase 0 評価 | ✅ | #156 | docs/24H_AUTOMATION_R2C_GAP_ANALYSIS.md |
-| 移行手順書 + verify | ✅ | #157 | docs/PHASE1_ACCOUNT_MIGRATION_RUNBOOK.md |
-| 並列ベース整備 | ✅ | #158 | docs/PHASE1_PARALLEL_WORK_RULES.md |
-| SECURITY_SCAN_ALLOWLIST | ✅ | #159 | docs/SECURITY_SCAN_ALLOWLIST.md |
-| .wolf/hooks worktree 検知 | ✅ | #160 | .wolf/hooks/HOOK_BEHAVIOR.md |
-| lane-templates × 5 | ✅ | #162 | .claude/lane-templates/ |
-| retry + Pushover spec | ✅ | #161 | docs/24H_LOOP_RETRY_AND_NOTIFICATION_SPEC.md |
-| RUNBOOK_R2C 作成 | ✅ | #164 | docs/24H_AUTOMATION_RUNBOOK_R2C.md |
-| SCRIPTS/r2c-*.sh 16本 | ✅ | #165-168 | SCRIPTS/r2c-*.sh |
-| Secrets + Pushover セットアップ | ✅ | #169 | docs/24H_LOOP_SECRETS_TEMPLATE.md |
-| Managed Agents 申請ドラフト | ✅ | #171 | docs/MANAGED_AGENTS_APPLICATION.md |
-| OpenClaw 使用禁止ポリシー | ✅ | #172 | docs/SECURITY_SCAN_ALLOWLIST.md §使用禁止ツール |
-| Memory Tool 評価レポート | ✅ | #170 | docs/MEMORY_TOOL_EVALUATION.md |
-| アカウント分離 (Tier S 実行) | ⏳ 2026-05-19 06:05 | - | docs/PHASE1_ACCOUNT_MIGRATION_RUNBOOK.md |
+詳細 (役割分担・CLIプロンプトテンプレート・セッション開始プロトコル): `docs/R2C_DEVELOPMENT_PLAYBOOK.md`
 
 ## 24h 自走中の禁止操作（Phase70-A — 必読）
 
@@ -442,3 +130,14 @@ ON/OFF 操作:
 - ON: `bash SCRIPTS/24h-mode-on.sh` (dry-run: `--dry-run`)
 - OFF: `bash SCRIPTS/24h-mode-off.sh`
 - 検知 hook: `.claude/hooks/deploy_guard.py` が `R2C_24H_MODE` を読み追加ブロック実施
+
+## 学習セクション (Auto-updated by Claude Code)
+
+<!-- このセクションは Claude Code の auto-memory 機能により管理される -->
+<!-- 手動編集不要。memory path: ~/.claude/projects/-Users-hkobayashi-Documents-GitHub-commerce-faq-tasks/memory/ -->
+
+- **Memory path**: `~/.claude/projects/-Users-hkobayashi-Documents-GitHub-commerce-faq-tasks/memory/`
+- **OpenWolf 役割分離 (24h自走中)**:
+  - `.wolf/cerebrum.md` / `.wolf/memory.md` = Read-Only (24h自走中)
+  - `MEMORY.md` (auto-memory) = 唯一の書き込み可能領域
+- **設定**: `.claude/settings.json` の `autoMemoryEnabled: true` で有効化済み

--- a/SCRIPTS/asana-watcher.sh
+++ b/SCRIPTS/asana-watcher.sh
@@ -1,0 +1,251 @@
+#!/usr/bin/env bash
+# asana-watcher.sh
+# 用途: 24h 自走中に Asana から「自走可能な未完了タスク」を優先度順に取得し、JSON で stdout に出力する。
+#       CLI（Claude Code）が自走プロンプト内でこのスクリプトを呼び、次タスクを補給する想定。
+#
+# 設計:
+#   - Asana REST API を curl で直接叩く（Asana MCP の transient エラー時のフォールバック手段を兼ねる）
+#   - Project: RAJIUCE Development (GID 1213607637045514) の incomplete タスクのみ
+#   - フィルタ条件（docs/ASANA_TASK_TEMPLATE.md §24h-eligible タグ運用 準拠）:
+#       * Tier B → 常に自走対象（タグ不要）
+#       * Tier A + `24h-eligible` タグ (GID 1214922984195645) → 自走対象
+#       * Tier S → 常に除外（タグがあっても無効）
+#       * Tier 不明 → 安全側で除外
+#       * description / name に DB migration キーワード → 除外（人間専権）
+#   - 優先度: due_on asc (null は末尾) → Tier (A>B)
+#
+# 出力: JSON (stdout)
+#   {
+#     "generated_at": "...", "total_open": N, "eligible_count": N,
+#     "tasks":   [ { gid, name, tier, due_on, permalink_url, tag_names, reason, notes_excerpt } ],
+#     "skipped": [ { gid, name, reason } ]
+#   }
+#
+# 環境変数（${R2C_CONFIG:-~/.claude-r2c-config}/secrets/r2c-loop.env から自動読込）:
+#   ASANA_ACCESS_TOKEN  (必須)
+#
+# 呼び出し例:
+#   bash SCRIPTS/asana-watcher.sh                   # 通常実行（JSON to stdout）
+#   bash SCRIPTS/asana-watcher.sh --limit 5         # 上位 5 件のみ
+#   bash SCRIPTS/asana-watcher.sh --verbose         # 進捗ログ stderr
+#   bash SCRIPTS/asana-watcher.sh --dry-run         # API は叩くが処理サマリのみ stderr
+#   bash SCRIPTS/asana-watcher.sh --mock-file F     # F を Asana API レスポンスとして使用（テスト用）
+#
+# 一切しないこと:
+#   - Asana タスクの completed=true / description 書き換え
+#   - DB migration 必要タスクの補給
+#   - VPS 接続 / git push
+#
+# Phase70-D (Asana GID 1214919660548852)
+
+set -euo pipefail
+
+# ─── 定数 ──────────────────────────────────────────────────────────────────
+ASANA_PROJECT_GID="${ASANA_PROJECT_GID:-1213607637045514}"
+ELIGIBLE_TAG_GID="${ELIGIBLE_TAG_GID:-1214922984195645}"
+R2C_CONFIG="${R2C_CONFIG:-${CLAUDE_CONFIG_DIR:-$HOME/.claude-r2c-config}}"
+SECRETS_FILE="${R2C_CONFIG}/secrets/r2c-loop.env"
+ASANA_API_BASE="https://app.asana.com/api/1.0"
+
+# ─── 引数 ──────────────────────────────────────────────────────────────────
+DRY_RUN=0
+VERBOSE=0
+LIMIT=0
+MOCK_FILE=""
+
+print_help() { sed -n '2,40p' "$0"; }
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --dry-run)    DRY_RUN=1; VERBOSE=1; shift ;;
+        --verbose|-v) VERBOSE=1; shift ;;
+        --limit)      LIMIT="${2:?--limit requires a number}"; shift 2 ;;
+        --mock-file)  MOCK_FILE="${2:?--mock-file requires a path}"; shift 2 ;;
+        -h|--help)    print_help; exit 0 ;;
+        *) echo "ERROR: unknown arg: $1" >&2; print_help >&2; exit 2 ;;
+    esac
+done
+
+log() { [ "$VERBOSE" -eq 1 ] && echo "[asana-watcher] $*" >&2 || true; }
+
+# ─── 依存チェック ──────────────────────────────────────────────────────────
+for cmd in curl jq; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "ERROR: required command not found: $cmd" >&2
+        exit 3
+    fi
+done
+
+# ─── 環境変数読込 ─────────────────────────────────────────────────────────
+if [ -z "${ASANA_ACCESS_TOKEN:-}" ] && [ -f "$SECRETS_FILE" ]; then
+    # shellcheck disable=SC1090
+    source "$SECRETS_FILE"
+fi
+
+if [ -z "$MOCK_FILE" ] && [ -z "${ASANA_ACCESS_TOKEN:-}" ]; then
+    echo "ERROR: ASANA_ACCESS_TOKEN not set. Place 'export ASANA_ACCESS_TOKEN=...' in ${SECRETS_FILE}" >&2
+    exit 4
+fi
+
+# ─── 一時ファイル ──────────────────────────────────────────────────────────
+RAW=$(mktemp)
+trap 'rm -f "$RAW"' EXIT
+
+# ─── Asana API 呼び出し（または mock 読込） ────────────────────────────────
+if [ -n "$MOCK_FILE" ]; then
+    if [ ! -f "$MOCK_FILE" ]; then
+        echo "ERROR: mock file not found: $MOCK_FILE" >&2
+        exit 5
+    fi
+    log "Using mock file: $MOCK_FILE"
+    cp "$MOCK_FILE" "$RAW"
+else
+    OPT_FIELDS="gid,name,notes,due_on,completed,permalink_url,modified_at,tags.gid,tags.name"
+    URL="${ASANA_API_BASE}/tasks?project=${ASANA_PROJECT_GID}&completed_since=now&opt_fields=${OPT_FIELDS}&limit=100"
+    log "Fetching: $URL"
+
+    HTTP_STATUS=$(curl -sS --max-time 25 -o "$RAW" -w "%{http_code}" \
+        -H "Authorization: Bearer ${ASANA_ACCESS_TOKEN}" \
+        -H "Accept: application/json" \
+        "$URL" || echo "000")
+
+    if [ "$HTTP_STATUS" != "200" ]; then
+        echo "ERROR: Asana API returned HTTP ${HTTP_STATUS}" >&2
+        head -c 500 "$RAW" >&2 2>/dev/null || true
+        echo "" >&2
+        # 失敗時も valid JSON を返す（CLI が parse できるように）
+        jq -n --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --arg err "asana_api_http_${HTTP_STATUS}" \
+            '{generated_at:$ts, total_open:0, eligible_count:0, error:$err, tasks:[], skipped:[]}'
+        exit 6
+    fi
+fi
+
+# ─── jq parse 検証 (UATa asana-poll.sh の jq fix 教訓) ─────────────────────
+if ! jq -e '.data' < "$RAW" >/dev/null 2>&1; then
+    echo "ERROR: unexpected Asana response (first 500 bytes follow):" >&2
+    head -c 500 "$RAW" >&2; echo "" >&2
+    jq -n --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+        '{generated_at:$ts, total_open:0, eligible_count:0, error:"asana_response_parse_failed", tasks:[], skipped:[]}'
+    exit 7
+fi
+
+TOTAL_OPEN=$(jq '[.data[] | select(.completed == false)] | length' < "$RAW")
+log "Open tasks fetched: ${TOTAL_OPEN}"
+
+# ─── フィルタ・分類 (jq ワンショット) ──────────────────────────────────────
+# Tier 抽出: description の "Tier: [SAB]" 行を優先、なければ title の "[Tier S|A|B]" レガシー記法
+# DB migration 検出: name + notes に強キーワード（migration / alembic / マイグレーション /
+#   ALTER TABLE / CREATE TABLE / DROP TABLE）または title 接頭辞 "schema:" を含む場合
+#
+# DB migration 用キーワードは false-positive を避けるため、
+# 単独 "SQL" や "DB" のような弱キーワードは含めない（"NoSQL" や "DB 接続" を誤検出するため）。
+CLASSIFIED=$(jq --arg eligible_tag "$ELIGIBLE_TAG_GID" '
+    def excerpt(s; n): if (s|type)=="string" then s[0:n] else "" end;
+
+    def detect_tier(name; notes):
+        if (notes // "") | test("(^|\\n)\\s*Tier\\s*:\\s*S\\b"; "i") then "S"
+        elif (notes // "") | test("(^|\\n)\\s*Tier\\s*:\\s*A\\b"; "i") then "A"
+        elif (notes // "") | test("(^|\\n)\\s*Tier\\s*:\\s*B\\b"; "i") then "B"
+        elif (name  // "") | test("\\[Tier\\s*S\\]"; "i") then "S"
+        elif (name  // "") | test("\\[Tier\\s*A\\]"; "i") then "A"
+        elif (name  // "") | test("\\[Tier\\s*B\\]"; "i") then "B"
+        else "unknown"
+        end;
+
+    def db_migration_kw:
+        "migration|alembic|\\bALTER\\s+TABLE\\b|\\bCREATE\\s+TABLE\\b|\\bDROP\\s+TABLE\\b|マイグレーション|DBスキーマ変更|DB\\s*スキーマ変更";
+
+    def is_db_migration(name; notes):
+        ((name  // "") | test(db_migration_kw; "i")) or
+        ((notes // "") | test(db_migration_kw; "i")) or
+        ((name  // "") | test("^\\s*schema\\s*:"; "i"));
+
+    def has_eligible_tag(tags):
+        (tags // []) | map(.gid) | index($eligible_tag) != null;
+
+    [ .data[] | select(.completed == false) ] as $open
+    | $open
+    | map(
+        . as $t
+        | (detect_tier($t.name; $t.notes)) as $tier
+        | (has_eligible_tag($t.tags)) as $has_tag
+        | (is_db_migration($t.name; $t.notes)) as $is_mig
+        | (
+            if   $is_mig            then {eligible:false, reason:"db_migration"}
+            elif $tier == "S"       then {eligible:false, reason:"tier_s"}
+            elif $tier == "B"       then {eligible:true,  reason:"tier_b"}
+            elif $tier == "A" and $has_tag then {eligible:true, reason:"tier_a_with_tag"}
+            elif $tier == "A"       then {eligible:false, reason:"tier_a_no_tag"}
+            else                         {eligible:false, reason:"tier_unknown"}
+            end
+          ) as $cls
+        | {
+            gid:           $t.gid,
+            name:          ($t.name // ""),
+            tier:          $tier,
+            due_on:        ($t.due_on // null),
+            permalink_url: ($t.permalink_url // ""),
+            modified_at:   ($t.modified_at // null),
+            tag_names:     ((($t.tags // []) | map(.name))),
+            has_eligible_tag: $has_tag,
+            notes_excerpt: excerpt(($t.notes // ""); 200),
+            eligible:      $cls.eligible,
+            reason:        $cls.reason
+          }
+      )
+' < "$RAW")
+
+# ─── 並び替え（eligible のみ）+ skipped 抽出 ───────────────────────────────
+# 優先度: due_on asc (null 末尾) → Tier (A>B) → modified_at desc
+ELIGIBLE_SORTED=$(jq '
+    [ .[] | select(.eligible == true) ]
+    | sort_by(
+        (if .due_on == null or .due_on == "" then "9999-12-31" else .due_on end),
+        (if .tier == "A" then 0 elif .tier == "B" then 1 else 9 end),
+        (if .modified_at == null then "" else (-(.modified_at|fromdateiso8601? // 0)) end)
+      )
+    | map(del(.eligible))
+' <<< "$CLASSIFIED")
+
+SKIPPED=$(jq '
+    [ .[] | select(.eligible == false) | {gid, name, tier, reason} ]
+' <<< "$CLASSIFIED")
+
+# ─── --limit 適用 ──────────────────────────────────────────────────────────
+if [ "$LIMIT" -gt 0 ]; then
+    ELIGIBLE_SORTED=$(jq --argjson n "$LIMIT" '.[0:$n]' <<< "$ELIGIBLE_SORTED")
+fi
+
+ELIGIBLE_COUNT=$(jq 'length' <<< "$ELIGIBLE_SORTED")
+SKIPPED_COUNT=$(jq 'length' <<< "$SKIPPED")
+log "Eligible: ${ELIGIBLE_COUNT} / Skipped: ${SKIPPED_COUNT} (limit=${LIMIT})"
+
+# ─── 出力 ──────────────────────────────────────────────────────────────────
+if [ "$DRY_RUN" -eq 1 ]; then
+    {
+        echo "DRY-RUN summary:"
+        echo "  total_open    = ${TOTAL_OPEN}"
+        echo "  eligible      = ${ELIGIBLE_COUNT}"
+        echo "  skipped       = ${SKIPPED_COUNT}"
+        echo "Eligible top 5 (gid | tier | due | name):"
+        jq -r '.[0:5][] | "  \(.gid) | \(.tier) | \(.due_on // "—") | \(.name)"' <<< "$ELIGIBLE_SORTED"
+        echo "Skipped reasons:"
+        jq -r 'group_by(.reason) | map({reason: .[0].reason, count: length}) | .[] | "  \(.reason): \(.count)"' <<< "$SKIPPED"
+    } >&2
+fi
+
+jq -n \
+    --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --argjson total "$TOTAL_OPEN" \
+    --argjson elig_count "$ELIGIBLE_COUNT" \
+    --argjson tasks "$ELIGIBLE_SORTED" \
+    --argjson skipped "$SKIPPED" \
+    '{
+        generated_at: $ts,
+        project_gid:  "'"$ASANA_PROJECT_GID"'",
+        eligible_tag_gid: "'"$ELIGIBLE_TAG_GID"'",
+        total_open:     $total,
+        eligible_count: $elig_count,
+        tasks:          $tasks,
+        skipped:        $skipped
+    }'

--- a/SCRIPTS/asana-watcher.sh
+++ b/SCRIPTS/asana-watcher.sh
@@ -89,48 +89,100 @@ fi
 
 # ─── 一時ファイル ──────────────────────────────────────────────────────────
 RAW=$(mktemp)
-trap 'rm -f "$RAW"' EXIT
+ACCUMULATED=$(mktemp)
+trap 'rm -f "$RAW" "$ACCUMULATED" "${ACCUMULATED}.tmp"' EXIT
+printf '[]' > "$ACCUMULATED"
 
-# ─── Asana API 呼び出し（または mock 読込） ────────────────────────────────
-if [ -n "$MOCK_FILE" ]; then
-    if [ ! -f "$MOCK_FILE" ]; then
-        echo "ERROR: mock file not found: $MOCK_FILE" >&2
-        exit 5
+# ─── Asana API 呼び出し（または mock 読込）— next_page.offset pagination loop ──
+OPT_FIELDS="gid,name,notes,due_on,completed,permalink_url,modified_at,tags.gid,tags.name"
+PAGE_NUM=0
+OFFSET=""
+
+while true; do
+    PAGE_NUM=$((PAGE_NUM + 1))
+
+    if [ -n "$MOCK_FILE" ]; then
+        if [ "$PAGE_NUM" -eq 1 ]; then
+            PAGE_FILE="$MOCK_FILE"
+        else
+            PAGE_FILE="${MOCK_FILE%.json}-p${PAGE_NUM}.json"
+        fi
+
+        if [ ! -f "$PAGE_FILE" ]; then
+            if [ "$PAGE_NUM" -eq 1 ]; then
+                echo "ERROR: mock file not found: $PAGE_FILE" >&2
+                exit 5
+            fi
+            log "No mock file for page ${PAGE_NUM} (${PAGE_FILE}), stopping pagination"
+            break
+        fi
+        log "Using mock file (page ${PAGE_NUM}): $PAGE_FILE"
+        cp "$PAGE_FILE" "$RAW"
+    else
+        if [ -z "$OFFSET" ]; then
+            URL="${ASANA_API_BASE}/tasks?project=${ASANA_PROJECT_GID}&completed_since=now&opt_fields=${OPT_FIELDS}&limit=100"
+        else
+            URL_ENC_OFFSET=$(printf '%s' "$OFFSET" | jq -sRr @uri)
+            URL="${ASANA_API_BASE}/tasks?project=${ASANA_PROJECT_GID}&completed_since=now&opt_fields=${OPT_FIELDS}&limit=100&offset=${URL_ENC_OFFSET}"
+        fi
+        log "Fetching page ${PAGE_NUM}: $URL"
+
+        HTTP_STATUS=""
+        RETRY=0
+        while true; do
+            HTTP_STATUS=$(curl -sS --max-time 25 -o "$RAW" -w "%{http_code}" \
+                -H "Authorization: Bearer ${ASANA_ACCESS_TOKEN}" \
+                -H "Accept: application/json" \
+                "$URL" || echo "000")
+
+            if [ "$HTTP_STATUS" = "429" ] && [ "$RETRY" -lt 3 ]; then
+                RETRY=$((RETRY + 1))
+                WAIT=$((5 * (2 ** (RETRY - 1))))
+                log "Rate limited (429), retry ${RETRY}/3 in ${WAIT}s..."
+                sleep "$WAIT"
+            else
+                break
+            fi
+        done
+
+        if [ "$HTTP_STATUS" != "200" ]; then
+            echo "ERROR: Asana API returned HTTP ${HTTP_STATUS} on page ${PAGE_NUM}" >&2
+            head -c 500 "$RAW" >&2 2>/dev/null || true
+            echo "" >&2
+            jq -n --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --arg err "asana_api_http_${HTTP_STATUS}" \
+                '{generated_at:$ts, total_open:0, eligible_count:0, error:$err, tasks:[], skipped:[]}'
+            exit 6
+        fi
     fi
-    log "Using mock file: $MOCK_FILE"
-    cp "$MOCK_FILE" "$RAW"
-else
-    OPT_FIELDS="gid,name,notes,due_on,completed,permalink_url,modified_at,tags.gid,tags.name"
-    URL="${ASANA_API_BASE}/tasks?project=${ASANA_PROJECT_GID}&completed_since=now&opt_fields=${OPT_FIELDS}&limit=100"
-    log "Fetching: $URL"
 
-    HTTP_STATUS=$(curl -sS --max-time 25 -o "$RAW" -w "%{http_code}" \
-        -H "Authorization: Bearer ${ASANA_ACCESS_TOKEN}" \
-        -H "Accept: application/json" \
-        "$URL" || echo "000")
-
-    if [ "$HTTP_STATUS" != "200" ]; then
-        echo "ERROR: Asana API returned HTTP ${HTTP_STATUS}" >&2
-        head -c 500 "$RAW" >&2 2>/dev/null || true
-        echo "" >&2
-        # 失敗時も valid JSON を返す（CLI が parse できるように）
-        jq -n --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --arg err "asana_api_http_${HTTP_STATUS}" \
-            '{generated_at:$ts, total_open:0, eligible_count:0, error:$err, tasks:[], skipped:[]}'
-        exit 6
+    # ── jq parse 検証 (UATa asana-poll.sh の jq fix 教訓) ──────────────────
+    if ! jq -e '.data' < "$RAW" >/dev/null 2>&1; then
+        echo "ERROR: unexpected Asana response on page ${PAGE_NUM} (first 500 bytes):" >&2
+        head -c 500 "$RAW" >&2; echo "" >&2
+        jq -n --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            '{generated_at:$ts, total_open:0, eligible_count:0, error:"asana_response_parse_failed", tasks:[], skipped:[]}'
+        exit 7
     fi
-fi
 
-# ─── jq parse 検証 (UATa asana-poll.sh の jq fix 教訓) ─────────────────────
-if ! jq -e '.data' < "$RAW" >/dev/null 2>&1; then
-    echo "ERROR: unexpected Asana response (first 500 bytes follow):" >&2
-    head -c 500 "$RAW" >&2; echo "" >&2
-    jq -n --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-        '{generated_at:$ts, total_open:0, eligible_count:0, error:"asana_response_parse_failed", tasks:[], skipped:[]}'
-    exit 7
-fi
+    PAGE_COUNT=$(jq '[.data[] | select(.completed == false)] | length' < "$RAW")
+    log "Page ${PAGE_NUM}: ${PAGE_COUNT} incomplete tasks"
 
-TOTAL_OPEN=$(jq '[.data[] | select(.completed == false)] | length' < "$RAW")
-log "Open tasks fetched: ${TOTAL_OPEN}"
+    # Accumulate page .data into ACCUMULATED array
+    jq -s '.[0] + (.[1].data // [])' "$ACCUMULATED" "$RAW" > "${ACCUMULATED}.tmp"
+    mv "${ACCUMULATED}.tmp" "$ACCUMULATED"
+
+    # Check for next page
+    NEXT_OFFSET=$(jq -r '.next_page.offset // empty' < "$RAW")
+    if [ -z "$NEXT_OFFSET" ]; then
+        log "Pagination exhausted at page ${PAGE_NUM}"
+        break
+    fi
+    OFFSET="$NEXT_OFFSET"
+    log "Next page offset acquired, continuing to page $((PAGE_NUM + 1))"
+done
+
+TOTAL_OPEN=$(jq '[.[] | select(.completed == false)] | length' < "$ACCUMULATED")
+log "Total open tasks (all pages): ${TOTAL_OPEN}"
 
 # ─── フィルタ・分類 (jq ワンショット) ──────────────────────────────────────
 # Tier 抽出: description の "Tier: [SAB]" 行を優先、なければ title の "[Tier S|A|B]" レガシー記法
@@ -163,7 +215,7 @@ CLASSIFIED=$(jq --arg eligible_tag "$ELIGIBLE_TAG_GID" '
     def has_eligible_tag(tags):
         (tags // []) | map(.gid) | index($eligible_tag) != null;
 
-    [ .data[] | select(.completed == false) ] as $open
+    [ .[] | select(.completed == false) ] as $open
     | $open
     | map(
         . as $t
@@ -193,7 +245,7 @@ CLASSIFIED=$(jq --arg eligible_tag "$ELIGIBLE_TAG_GID" '
             reason:        $cls.reason
           }
       )
-' < "$RAW")
+' < "$ACCUMULATED")
 
 # ─── 並び替え（eligible のみ）+ skipped 抽出 ───────────────────────────────
 # 優先度: due_on asc (null 末尾) → Tier (A>B) → modified_at desc

--- a/SCRIPTS/notify-slack.sh
+++ b/SCRIPTS/notify-slack.sh
@@ -1,0 +1,168 @@
+#!/usr/bin/env bash
+# notify-slack.sh — CLI 自走通知ヘルパ (Phase70-L)
+#
+# 用途:
+#   24h 自走中の CLI が Slack #r2c (C0AG07HFJTB) へ確実に通知を届ける。
+#   MCP 経由 (SLACK_BOT_TOKEN) → curl webhook → stderr の 3段フォールバック。
+#
+# 使い方:
+#   notify-slack.sh <message> [--color info|success|warning|error]
+#                             [--channel <id>] [--dry-run]
+#
+# 環境変数 (秘匿値は ~/.claude-r2c-config/secrets/r2c-loop.env に保管):
+#   SLACK_BOT_TOKEN      — Bot OAuth token xoxb-... (Slack MCP 経由の第1試行)
+#   SLACK_WEBHOOK_URL_R2C — #r2c 専用 Incoming Webhook URL (第2試行 優先)
+#   SLACK_WEBHOOK_URL     — 汎用 Incoming Webhook URL (第2試行 フォールバック)
+#
+# 通知パターン (CLI 自走プロンプト用):
+#   PR 作成完了  : notify-slack.sh "✅ PR #N pushed: <title>, ready for Gate 2.5" --color success
+#   Gate 失敗    : notify-slack.sh "⚠️ Gate failed at <step>: <error>" --color warning
+#   Stop 発火    : notify-slack.sh "🛑 Stopped: <reason>" --color error
+#
+# セキュリティ注記:
+#   - Webhook URL は stderr にも stdout にも出力しない
+#   - Stop signal 後の連投防止: ~/.r2c-notified-stop が存在すれば exit 0
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "$0" .sh)"
+R2C_CONFIG="${R2C_CONFIG:-$HOME/.claude-r2c-config}"
+LOG_DIR="${R2C_CONFIG}/logs"
+DEFAULT_CHANNEL="C0AG07HFJTB"
+STOP_NOTIFIED_FILE="${R2C_CONFIG}/.r2c-notified-stop"
+
+MESSAGE=""
+COLOR="info"
+CHANNEL="$DEFAULT_CHANNEL"
+DRY_RUN=0
+
+usage() {
+    cat <<'USAGE'
+Usage: notify-slack.sh <message> [--color info|success|warning|error]
+                                 [--channel <id>] [--dry-run]
+USAGE
+}
+
+# ─── 引数パース ───
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --color)   COLOR="${2:-info}"; shift 2 ;;
+        --channel) CHANNEL="${2:-$DEFAULT_CHANNEL}"; shift 2 ;;
+        --dry-run) DRY_RUN=1; shift ;;
+        -h|--help) usage; exit 0 ;;
+        --*)       echo "ERROR: unknown option: $1" >&2; usage; exit 1 ;;
+        *)
+            if [[ -z "$MESSAGE" ]]; then
+                MESSAGE="$1"
+            else
+                echo "ERROR: unexpected positional arg: $1" >&2
+                usage; exit 1
+            fi
+            shift ;;
+    esac
+done
+
+if [[ -z "$MESSAGE" ]]; then
+    echo "ERROR: <message> required" >&2
+    usage; exit 1
+fi
+
+case "$COLOR" in
+    info)    HEX_COLOR="#36a64f" ;;
+    success) HEX_COLOR="#2eb886" ;;
+    warning) HEX_COLOR="#daa520" ;;
+    error)   HEX_COLOR="#cc0000" ;;
+    *)       echo "ERROR: --color must be info|success|warning|error" >&2; exit 1 ;;
+esac
+
+# ─── 環境変数ロード ───
+# shellcheck disable=SC1091
+[[ -f "${R2C_CONFIG}/secrets/r2c-loop.env" ]] \
+    && source "${R2C_CONFIG}/secrets/r2c-loop.env"
+
+# ─── Stop 連投防止 ───
+# Stop signal 通知済みフラグがあれば重複投稿しない
+if [[ "$COLOR" == "error" ]] && [[ -f "$STOP_NOTIFIED_FILE" ]]; then
+    echo "[${SCRIPT_NAME}] Stop already notified, skipping duplicate." >&2
+    exit 0
+fi
+
+mkdir -p "$LOG_DIR"
+
+ts() { date '+%Y-%m-%d %H:%M:%S'; }
+log() { printf '[%s] [%s] %s\n' "$(ts)" "$SCRIPT_NAME" "$*"; }
+
+# ─── Dry-run ───
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    cat <<DRY
+[dry-run] notify-slack.sh
+  channel : $CHANNEL
+  color   : $COLOR ($HEX_COLOR)
+  message : $MESSAGE
+DRY
+    exit 0
+fi
+
+exec >> "${LOG_DIR}/${SCRIPT_NAME}.log" 2>&1
+
+# ─── ペイロード構築 (Attachment 形式、color 対応) ───
+build_payload_json() {
+    local channel="$1" message="$2" hex_color="$3"
+    printf '{"channel":"%s","attachments":[{"color":"%s","text":"%s","mrkdwn_in":["text"]}]}' \
+        "$channel" "$hex_color" \
+        "$(printf '%s' "$message" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+}
+
+PAYLOAD="$(build_payload_json "$CHANNEL" "$MESSAGE" "$HEX_COLOR")"
+
+# ─── 第1試行: Slack Bot Token (MCP 経由の代替 — chat.postMessage) ───
+send_via_bot_token() {
+    local token="$1" payload="$2"
+    local resp
+    resp="$(curl -sS --max-time 15 \
+        -X POST \
+        -H "Authorization: Bearer ${token}" \
+        -H 'Content-Type: application/json; charset=utf-8' \
+        --data "$payload" \
+        'https://slack.com/api/chat.postMessage' 2>&1)" || return 1
+    printf '%s' "$resp" | grep -q '"ok":true' || return 1
+    return 0
+}
+
+if [[ -n "${SLACK_BOT_TOKEN:-}" ]]; then
+    if send_via_bot_token "$SLACK_BOT_TOKEN" "$PAYLOAD"; then
+        log "Sent via bot token (attempt 1): $MESSAGE"
+        [[ "$COLOR" == "error" ]] && touch "$STOP_NOTIFIED_FILE"
+        exit 0
+    fi
+    log "WARN: bot token send failed, trying webhook (attempt 2)"
+fi
+
+# ─── 第2試行: curl Incoming Webhook ───
+WEBHOOK_URL="${SLACK_WEBHOOK_URL_R2C:-${SLACK_WEBHOOK_URL:-}}"
+
+send_via_webhook() {
+    local url="$1" payload="$2"
+    local resp
+    resp="$(curl -sS --max-time 15 \
+        -X POST \
+        -H 'Content-Type: application/json' \
+        --data "$payload" \
+        "$url" 2>&1)" || return 1
+    [[ "$resp" == "ok" ]] || return 1
+    return 0
+}
+
+if [[ -n "${WEBHOOK_URL:-}" ]]; then
+    if send_via_webhook "$WEBHOOK_URL" "$PAYLOAD"; then
+        log "Sent via webhook (attempt 2): $MESSAGE"
+        [[ "$COLOR" == "error" ]] && touch "$STOP_NOTIFIED_FILE"
+        exit 0
+    fi
+    log "WARN: webhook send failed, falling back to stderr (attempt 3)"
+fi
+
+# ─── 第3試行: stderr 書き出し + 終了コード 1 ───
+log "ERROR: all Slack send attempts failed for: $MESSAGE"
+printf '[%s] [%s] SLACK_SEND_FAILED color=%s channel=%s message=%s\n' \
+    "$(ts)" "$SCRIPT_NAME" "$COLOR" "$CHANNEL" "$MESSAGE" >&2
+exit 1

--- a/docs/24H_AUTONOMOUS_PLAYBOOK.md
+++ b/docs/24H_AUTONOMOUS_PLAYBOOK.md
@@ -180,6 +180,50 @@ bash SCRIPTS/notify-slack.sh "<message>" --color info --channel C0AG07HFJTB
 bash SCRIPTS/notify-slack.sh "test" --color info --dry-run
 ```
 
+## 8. Auto-Memory 確認手順 (Phase70-B)
+
+### auto-memory とは
+
+Claude Code v2.1.143+ の永続メモリ機能。セッション間の学習内容を
+`~/.claude/projects/<project-hash>/memory/MEMORY.md` に自動保存する。
+
+24h 自走中は `.wolf/cerebrum.md` / `.wolf/memory.md` への書き込みを禁止し、
+auto-memory (`MEMORY.md`) が唯一の学習書き込み先となる（OpenWolf 役割分離）。
+
+### 設定確認コマンド
+
+```bash
+# 1. settings.json で有効化を確認
+cat .claude/settings.json | grep -A2 autoMemory
+# 期待値: "autoMemoryEnabled": true, "cleanupPeriodDays": 99999
+
+# 2. メモリファイルの存在確認
+ls ~/.claude/projects/-Users-hkobayashi-Documents-GitHub-commerce-faq-tasks/memory/
+# MEMORY.md が存在すること
+
+# 3. Claude Code CLI セッション内で /memory コマンドを実行して内容確認
+```
+
+### 24h 自走開始前チェックリスト (auto-memory 関連)
+
+- [ ] `autoMemoryEnabled: true` が `.claude/settings.json` にある
+- [ ] `cleanupPeriodDays: 99999` が設定されている (事実上永続)
+- [ ] `.wolf/cerebrum.md` が最新状態（自走開始後は Read-Only）
+- [ ] `~/.claude/projects/.../memory/MEMORY.md` が存在する
+
+### トラブルシュート
+
+**`/memory` で内容が表示されない**
+→ `autoMemoryEnabled` が `true` か確認。セッション再起動で有効化される。
+
+**24h 自走後に `.wolf/cerebrum.md` が書き換わっている**
+→ `deploy_guard.py` が `.wolf/cerebrum.md` への Edit をブロックしているか確認:
+```bash
+echo '{"tool_name":"Edit","tool_input":{"file_path":".wolf/cerebrum.md","old_string":"x","new_string":"y"}}' | \
+  R2C_24H_MODE=1 python3 .claude/hooks/deploy_guard.py
+```
+exit 2 + BLOCKED が出れば正常。出なければ deny リストに追加を検討。
+
 ## 6. 設計判断ログ
 
 - **物理停止 NG → 論理多層防御**: dev 環境ないため。

--- a/docs/24H_AUTONOMOUS_PLAYBOOK.md
+++ b/docs/24H_AUTONOMOUS_PLAYBOOK.md
@@ -137,6 +137,49 @@ echo '{"tool_name":"Bash","tool_input":{"command":"bash SCRIPTS/deploy-vps.sh"}}
 2. `gh api -X DELETE repos/milechy/commerce-faq-tasks/branches/main/protection`
 3. `bash SCRIPTS/r2c-slack-notify.sh --text "⚠️ 24h-mode 緊急解除 by hkobayashi"`
 
+## 7. CLI 自走通知パターン (Phase70-L)
+
+### notify-slack.sh の使い方
+
+```bash
+# 基本
+bash SCRIPTS/notify-slack.sh "<message>" --color <info|success|warning|error>
+
+# dry-run (実際には送信しない)
+bash SCRIPTS/notify-slack.sh "<message>" --color info --dry-run
+
+# チャンネル指定 (デフォルト: C0AG07HFJTB = #r2c)
+bash SCRIPTS/notify-slack.sh "<message>" --color info --channel C0AG07HFJTB
+```
+
+3段フォールバック:
+1. `SLACK_BOT_TOKEN` — `chat.postMessage` API (Slack MCP 相当)
+2. `SLACK_WEBHOOK_URL_R2C` or `SLACK_WEBHOOK_URL` — Incoming Webhook curl
+3. stderr 書き出し + 終了コード 1
+
+### 標準通知パターン (CLI 自走プロンプトに組み込む)
+
+| イベント | コマンド |
+|---|---|
+| PR 作成完了 | `bash SCRIPTS/notify-slack.sh "✅ PR #N pushed: <title>, ready for Gate 2.5" --color success` |
+| Gate 失敗 | `bash SCRIPTS/notify-slack.sh "⚠️ Gate failed at <step>: <error>" --color warning` |
+| Stop condition 発火 | `bash SCRIPTS/notify-slack.sh "🛑 Stopped: <reason>" --color error` |
+| HUMAN-REVIEW-REQUIRED | `bash SCRIPTS/r2c-slack-notify.sh --text "HUMAN-REVIEW-REQUIRED: <reason>"` |
+
+### Stop 後の通知ループ防止
+
+- `--color error` で送信成功すると `~/.claude-r2c-config/.r2c-notified-stop` が作成される。
+- 同ファイルが存在する間、`--color error` の重複投稿は **skip (exit 0)** される。
+- `bash SCRIPTS/24h-mode-off.sh` 実行時にこのフラグファイルを削除すること。
+- Stop signal が発火したら **新規 Bash tool 呼び出しを一切行わず**、当該作業を即時停止する。
+
+### Slack 通知が来ない場合
+
+`SLACK_BOT_TOKEN` と `SLACK_WEBHOOK_URL_R2C` の両方が `~/.claude-r2c-config/secrets/r2c-loop.env` に設定されているか確認:
+```bash
+bash SCRIPTS/notify-slack.sh "test" --color info --dry-run
+```
+
 ## 6. 設計判断ログ
 
 - **物理停止 NG → 論理多層防御**: dev 環境ないため。

--- a/docs/PR_MERGE_RULES.md
+++ b/docs/PR_MERGE_RULES.md
@@ -1,0 +1,48 @@
+# PR マージ自動化ルール
+
+## 背景
+
+2026-04-19 に PR #110-#117 の 8 本を一括マージする際、手動操作の長さと conflict 解消で一日が大きく削られた。
+同様の手動作業を避けるため、以下の運用ルールを遵守する。
+
+## 運用ルール
+
+**PR 作成時は必ず auto-merge を有効化する:**
+
+```bash
+gh pr create --title "..." --body "..." && \
+gh pr merge $(gh pr view --json number -q .number) --auto --squash --delete-branch
+```
+
+または既存 PR 番号を使って:
+```bash
+gh pr merge <PR番号> --auto --squash --delete-branch
+```
+
+## auto-merge の動作条件
+
+以下が全て揃った時点で自動マージされる:
+- CI (pnpm verify / build) が green
+- 必要なレビュー承認済み（プロジェクト設定による）
+- conflict なし
+
+## conflict が発生した場合
+
+- auto-merge は停止、PR 画面で「Merge conflict」警告が表示される
+- hkobayashi または CLI が手動で conflict を解消
+- 解消後に再度 auto-merge が有効化される
+
+## マージ方式の統一
+
+- **squash and merge** を標準とする（linear history 維持）
+- rebase merge / merge commit は使わない（履歴複雑化回避）
+
+## 関連タスク
+
+- Phase1（本ルール策定）: Asana 1214121039752589
+- Phase2（SCRIPTS/merge-ready-prs.sh 作成）: Asana 1214121039752589（別タスク化済み）
+- Phase3（Claude Code CLI /merge エージェント）: 将来タスク、未起票
+
+---
+
+更新: 2026-05-19 (CLAUDE.md から分離)

--- a/tests/scripts/asana-watcher.test.sh
+++ b/tests/scripts/asana-watcher.test.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# tests/scripts/asana-watcher.test.sh
+# asana-watcher.sh の pagination + フィルタロジックをユニットテスト（mock-file モード）
+# Phase70-D Codex Round 1 P1 対応: 100件超のページネーション動作確認を含む
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+SCRIPT="${REPO_ROOT}/SCRIPTS/asana-watcher.sh"
+TMPDIR_TEST="$(mktemp -d)"
+PASS=0
+FAIL=0
+
+ELIGIBLE_TAG_GID="1214922984195645"
+
+cleanup() { rm -rf "${TMPDIR_TEST}"; }
+trap cleanup EXIT
+
+ok()   { echo "  PASS: $1"; PASS=$((PASS+1)); }
+fail() { echo "  FAIL: $1"; FAIL=$((FAIL+1)); }
+
+chk_eq() {
+    local label="$1" got="$2" want="$3"
+    if [ "$got" = "$want" ]; then
+        ok "${label} = ${want}"
+    else
+        fail "${label}: expected ${want}, got ${got}"
+    fi
+}
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# Case 1: 単一ページ mock — eligible/skipped カウント確認
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+echo ""
+echo "Case 1: 単一ページ mock — 3タスク(Tier B/A+tag/S), next_page: null"
+MOCK1="${TMPDIR_TEST}/mock1.json"
+cat > "$MOCK1" <<EOF
+{
+  "data": [
+    {"gid":"t1","name":"Task 1","notes":"Tier: B\n","due_on":null,"completed":false,"permalink_url":"https://app.asana.com/t/1","modified_at":"2026-05-19T10:00:00.000Z","tags":[]},
+    {"gid":"t2","name":"Task 2","notes":"Tier: A\n","due_on":null,"completed":false,"permalink_url":"https://app.asana.com/t/2","modified_at":"2026-05-19T10:00:00.000Z","tags":[{"gid":"${ELIGIBLE_TAG_GID}","name":"24h-eligible"}]},
+    {"gid":"t3","name":"Task 3","notes":"Tier: S\n","due_on":null,"completed":false,"permalink_url":"https://app.asana.com/t/3","modified_at":"2026-05-19T10:00:00.000Z","tags":[]}
+  ],
+  "next_page": null
+}
+EOF
+OUTPUT1=$(bash "$SCRIPT" --mock-file "$MOCK1" 2>/dev/null)
+chk_eq "total_open" "$(printf '%s' "$OUTPUT1" | jq '.total_open')" "3"
+chk_eq "eligible_count" "$(printf '%s' "$OUTPUT1" | jq '.eligible_count')" "2"
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# Case 2: 2ページ mock — 100件超の全件取得確認
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+echo ""
+echo "Case 2: 2ページ mock — page1=100件 + page2=5件 → total_open=105"
+MOCK2="${TMPDIR_TEST}/mock2.json"
+MOCK2P2="${TMPDIR_TEST}/mock2-p2.json"
+
+# page1: 100件 Tier B + next_page.offset
+jq -n '[range(1; 101) | {
+    gid: ("p1_task_\(.)"),
+    name: "P1 Task \(.)",
+    notes: "Tier: B\n",
+    due_on: null,
+    completed: false,
+    permalink_url: "https://app.asana.com/t/p1_\(.)",
+    modified_at: "2026-05-19T10:00:00.000Z",
+    tags: []
+}] | {
+    data: .,
+    next_page: {
+        offset: "mock_cursor_page2",
+        path: "/tasks?offset=mock_cursor_page2",
+        uri: "https://app.asana.com/api/1.0/tasks?offset=mock_cursor_page2"
+    }
+}' > "$MOCK2"
+
+# page2: 5件 Tier B + next_page: null
+jq -n '[range(101; 106) | {
+    gid: ("p2_task_\(.)"),
+    name: "P2 Task \(.)",
+    notes: "Tier: B\n",
+    due_on: null,
+    completed: false,
+    permalink_url: "https://app.asana.com/t/p2_\(.)",
+    modified_at: "2026-05-19T10:00:00.000Z",
+    tags: []
+}] | {
+    data: .,
+    next_page: null
+}' > "$MOCK2P2"
+
+OUTPUT2=$(bash "$SCRIPT" --mock-file "$MOCK2" 2>/dev/null)
+chk_eq "total_open" "$(printf '%s' "$OUTPUT2" | jq '.total_open')" "105"
+chk_eq "eligible_count" "$(printf '%s' "$OUTPUT2" | jq '.eligible_count')" "105"
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# Case 3: --verbose でページ数ログ確認
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+echo ""
+echo "Case 3: --verbose でページ数ログ出力確認 (stderr)"
+VERBOSE_TMP="${TMPDIR_TEST}/verbose.log"
+bash "$SCRIPT" --mock-file "$MOCK2" --verbose >/dev/null 2>"$VERBOSE_TMP"
+
+if grep -q "Page 1:" "$VERBOSE_TMP"; then
+    ok "--verbose に 'Page 1:' ログ含む"
+else
+    fail "--verbose に 'Page 1:' ログなし"
+fi
+if grep -q "Page 2:" "$VERBOSE_TMP"; then
+    ok "--verbose に 'Page 2:' ログ含む"
+else
+    fail "--verbose に 'Page 2:' ログなし"
+fi
+if grep -q "Pagination exhausted" "$VERBOSE_TMP"; then
+    ok "--verbose に 'Pagination exhausted' ログ含む"
+else
+    fail "--verbose に 'Pagination exhausted' ログなし"
+fi
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# Case 4: --limit が pagination 後の eligible に適用されることを確認
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+echo ""
+echo "Case 4: --limit 3 で 105件 eligible から上位 3 件に制限"
+OUTPUT4=$(bash "$SCRIPT" --mock-file "$MOCK2" --limit 3 2>/dev/null)
+chk_eq "tasks length with --limit 3" "$(printf '%s' "$OUTPUT4" | jq '.tasks | length')" "3"
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# Case 5: mock file 不在 → exit 5
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+echo ""
+echo "Case 5: mock file 不在 → exit 5"
+MOCK_EXIT=0
+bash "$SCRIPT" --mock-file "${TMPDIR_TEST}/nonexistent.json" >/dev/null 2>&1 || MOCK_EXIT=$?
+chk_eq "exit code for missing mock" "$MOCK_EXIT" "5"
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# Case 6: DB migration キーワードを含む Tier B タスク → skipped
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+echo ""
+echo "Case 6: DB migration キーワード含む Tier B → skipped (reason=db_migration)"
+MOCK6="${TMPDIR_TEST}/mock6.json"
+cat > "$MOCK6" <<'JSONEOF'
+{
+  "data": [
+    {"gid":"mig1","name":"DB migration task","notes":"Tier: B\nmigration script needed","due_on":null,"completed":false,"permalink_url":"https://app.asana.com/t/mig1","modified_at":"2026-05-19T10:00:00.000Z","tags":[]}
+  ],
+  "next_page": null
+}
+JSONEOF
+OUTPUT6=$(bash "$SCRIPT" --mock-file "$MOCK6" 2>/dev/null)
+chk_eq "eligible_count for db_migration task" "$(printf '%s' "$OUTPUT6" | jq '.eligible_count')" "0"
+chk_eq "skipped reason" "$(printf '%s' "$OUTPUT6" | jq -r '.skipped[0].reason')" "db_migration"
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# Case 7: --dry-run で stderr サマリ出力、stdout は valid JSON
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+echo ""
+echo "Case 7: --dry-run で stderr に DRY-RUN summary、stdout は valid JSON"
+DRY_STDOUT="${TMPDIR_TEST}/dry_out.json"
+DRY_STDERR="${TMPDIR_TEST}/dry_err.log"
+bash "$SCRIPT" --mock-file "$MOCK1" --dry-run >"$DRY_STDOUT" 2>"$DRY_STDERR"
+if grep -q "DRY-RUN summary" "$DRY_STDERR"; then
+    ok "--dry-run に 'DRY-RUN summary' ログ含む"
+else
+    fail "--dry-run に 'DRY-RUN summary' ログなし"
+fi
+if jq -e '.tasks' < "$DRY_STDOUT" >/dev/null 2>&1; then
+    ok "--dry-run の stdout は valid JSON (.tasks あり)"
+else
+    fail "--dry-run の stdout が parse 不可"
+fi
+
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+# 結果サマリー
+# ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+echo ""
+echo "=== テスト結果: PASS=${PASS} FAIL=${FAIL} ==="
+[ "${FAIL}" -eq 0 ] && echo "全テスト通過" && exit 0
+echo "${FAIL}件失敗" && exit 1


### PR DESCRIPTION
## 目的
24h 自走中、CLI が Asana から自走可能タスクを優先度順に連続補給する SCRIPTS/asana-watcher.sh を実装。

## 主要変更
- SCRIPTS/asana-watcher.sh (新規) — curl + jq でフィルタロジック
- SCRIPTS/asana-watcher.test.sh (新規) — mock test
- 70-J 規約準拠: Tier B 常に / Tier A + 24h-eligible タグ / Tier S 除外
- DB migration キーワード除外 (人間専権タスク保護)
- jq parse 失敗時の fallback (UATa asana-poll.sh 教訓)
- JSON stdout 出力 (CLI parse 用)
- Codex Round 1 P1 対応: next_page.offset pagination 実装

## Gate
- Gate 1: shellcheck + bash -n + mock smoke ✅
- Gate 2: hardcoded secrets なし ✅
- Gate 3: build 不要 ✅
- Gate 2.5 (Codex review Round 2): No findings on this PR's actual changes

## Codex Round 2 ノイズ指摘について (acknowledged & out-of-scope)
Codex は SCRIPTS/notify-slack.sh:112 の JSON エスケープ不備を P2 検出しましたが、
これは PR #179 (Phase70-L) で既に main にマージ済の既存ファイルです。
本 PR のブランチベースが main より古い時点で派生していたため diff に紛れ込んだノイズです。

本指摘は別 Asana タスクで対処予定:
- GID: 1214924959113051
- "fix: notify-slack.sh JSON escape 強化 (改行・制御文字対応)"
- Tier B, due 2026-05-26

## 関連
- Asana: 1214919660548852 (Phase70-D)
- Parent: Phase70 (1214919472827777)
- Codex Round 1 Job ID: review-mpc8ouk3-u51jlp (P1: pagination)