### PR TITLE
docs(1214919722342111): Phase70-E 24h 自走プロンプトテンプレート作成

### DIFF
--- a/.claude/prompts/24h-autonomous.md
+++ b/.claude/prompts/24h-autonomous.md
@@ -1,0 +1,137 @@
+# R2C 24h 自走プロンプト
+
+<!-- 使い方: このファイルの内容をそのまま Claude Code CLI のプロンプトとして貼り付ける -->
+<!-- 事前条件: bash SCRIPTS/24h-mode-on.sh 実行済み、Cloudflare Pages 停止済み -->
+<!-- docs/24H_AUTONOMOUS_PLAYBOOK.md を必ず通読してから起動すること -->
+
+---
+
+```
+dispatch --model sonnet
+
+## 推奨モデル: Sonnet 4.6
+
+<!-- タスクが Opus 4.7 推奨の場合は asana-watcher.sh 取得後に適宜切り替え -->
+
+## 前提(重要・必読)
+- 24h 自走モード ON 中 (`~/.r2c-24h-mode` 存在)
+- branch protection: main への direct push 禁止
+- CLAUDE.md「24h 自走中の禁止操作」Out of scope 10項目 を厳守すること
+- docs/24H_AUTONOMOUS_PLAYBOOK.md §7 Slack 通知パターンを参照すること
+
+## タスク: R2C 24h 自走 — {{START_DATE}} 夜間自走
+
+実行期間: ~24h (Phase 0〜4)
+Asana Project: RAJIUCE Development (1213607637045514)
+
+---
+
+## Phase 0: 環境整備 (目安 30分)
+
+1. `.wolf/cerebrum.md` を read し Do-Not-Repeat と Key Learnings を確認
+2. `~/.claude/projects/.../memory/MEMORY.md` を read して直近の文脈を確認
+3. `git status` + `gh pr list` でリポジトリ状態を把握
+4. `bash SCRIPTS/24h-mode-on.sh` の実行状態確認 (`~/.r2c-24h-mode` 存在確認)
+5. Slack 通知 (開始):
+   `bash SCRIPTS/notify-slack.sh "🚀 24h 自走開始: {{START_DATE}} — Phase 0 完了" --color info`
+
+---
+
+## Phase 1: GitHub 最新化 (目安 1〜2h)
+
+1. `gh pr list --state open` で滞留 PR を確認
+2. 各 PR のレビュー状況を確認:
+   - Gate 2.5 (Codex) 未実行の PR → `/codex:review --base main --background` 実行
+   - Codex P0/P1 指摘がある PR → 修正 commit 追加
+   - レビュー承認済みで merge 待ちの PR → **merge 禁止 (main merge は人間専権)**
+3. Slack 通知 (Phase 完了):
+   `bash SCRIPTS/notify-slack.sh "✅ Phase 1 完了: 滞留 PR {{N}}件を処理" --color success`
+
+---
+
+## Phase 2〜3: Asana Watcher 経由でタスク消化 (目安 ～22h)
+
+### タスク取得ループ
+
+```bash
+# 次タスクを取得
+bash SCRIPTS/asana-watcher.sh --limit 1
+```
+
+取得したタスクに対して:
+1. Asana GID を確認し `Asana:get_task <GID>` で詳細を読む
+2. タスクの Tier と 24h-eligible タグを確認
+   - Tier S: **自走禁止** → skip して次タスクへ
+   - DB migration 必要: **自走禁止** → skip
+3. タスクの `## 推奨モデル` を確認して適切なモデルで実行
+4. `docs/templates/` から対応するテンプレートを選択して実行:
+   - 機能追加 → `docs/templates/cli-prompt-feature.md`
+   - バグ修正 → `docs/templates/cli-prompt-bugfix.md`
+   - リファクタ → `docs/templates/cli-prompt-refactor.md`
+   - docs 更新 → `docs/templates/cli-prompt-docs.md`
+   - 事前調査 → `docs/templates/cli-prompt-investigation.md`
+5. PR 作成後に Slack 通知:
+   `bash SCRIPTS/notify-slack.sh "✅ PR #N pushed: <title>, ready for Gate 2.5" --color success`
+6. 次タスクへ → ループ継続
+
+### 3回ルール
+同一タスクで 3回失敗した場合:
+1. `bash SCRIPTS/notify-slack.sh "⚠️ Blocker: <タスク名> — 3回失敗でスキップ" --color warning`
+2. Asana コメントに状況を投稿
+3. 次タスクへ移行 (このタスクはスキップ)
+
+---
+
+## Phase 4: 朝報告 (目安 30分)
+
+1. `gh pr list --state open --label 24h-loop` で夜間生成 PR を一覧表示
+2. 作業サマリを作成 (完了タスク数、生成 PR 数、スキップタスク)
+3. Slack 通知 (完成宣言):
+   `bash SCRIPTS/notify-slack.sh "🌅 24h 自走完了: PR {{N}}件 ready for review — READY-FOR-REVIEW" --color success`
+4. `.wolf/memory.md` にセッションサマリを記録 (Read-Only 制限中は MEMORY.md に記録)
+
+---
+
+## R2C 固有 Out of Scope (絶対禁止)
+
+| # | 禁止操作 |
+|---|---|
+| 1 | VPS (65.108.159.161 / api.r2c.biz) への接続試行 |
+| 2 | main branch への merge (PR merge 含む) |
+| 3 | DB マイグレーションの自動実行 |
+| 4 | .env / secrets / *.key の編集 |
+| 5 | git push --force / git reset --hard origin/main |
+| 6 | avatar-agent プロセス操作 |
+| 7 | Cloudflare Pages の設定変更 |
+| 8 | 依存ライブラリのメジャーバージョン変更 |
+| 9 | 法務・契約関連ドキュメント編集 |
+| 10 | パートナー本番テナント影響操作 |
+
+## Stop Conditions
+
+以下に該当した場合、**即座に作業を停止**して HUMAN-REVIEW-REQUIRED を投稿:
+
+1. Out of Scope 操作を誤って実行しようとした
+2. `deploy_guard.py` に BLOCKED された
+3. 認証情報 (.env / API key / secret) をコードに含めようとした
+4. 同一問題で 5回以上繰り返し失敗した
+
+停止手順:
+```bash
+bash SCRIPTS/notify-slack.sh "🛑 Stopped: <reason>" --color error
+gh api -X POST repos/milechy/commerce-faq-tasks/issues \
+  -f title="HUMAN-REVIEW-REQUIRED: <reason>" \
+  -f body="24h 自走中に Stop condition が発火しました。詳細: <reason>"
+# 以降 Bash tool 呼び出しを一切行わない
+```
+
+## Slack 通知ポイント (5箇所)
+
+| # | タイミング | コマンド |
+|---|---|---|
+| 1 | 自走開始 (Phase 0 完了) | `notify-slack.sh "🚀 24h 自走開始 ..." --color info` |
+| 2 | Phase 完了 | `notify-slack.sh "✅ Phase N 完了 ..." --color success` |
+| 3 | Blocker 発生 | `notify-slack.sh "⚠️ Blocker: ..." --color warning` |
+| 4 | PR 作成 | `notify-slack.sh "✅ PR #N pushed ..." --color success` |
+| 5 | 完成宣言 (Phase 4) | `notify-slack.sh "🌅 24h 完了 ... READY-FOR-REVIEW" --color success` |
+```

--- a/docs/24H_AUTONOMOUS_PLAYBOOK.md
+++ b/docs/24H_AUTONOMOUS_PLAYBOOK.md
@@ -224,6 +224,36 @@ echo '{"tool_name":"Edit","tool_input":{"file_path":".wolf/cerebrum.md","old_str
 ```
 exit 2 + BLOCKED が出れば正常。出なければ deny リストに追加を検討。
 
+## 9. CLI プロンプトテンプレート (Phase70-E)
+
+24h 自走中に各タスクを処理する際は、タスク種別に応じたテンプレートを使用すること。
+
+### 起動プロンプト (マスター)
+
+- **`.claude/prompts/24h-autonomous.md`** — 24h 自走一括起動プロンプト。Phase 0〜4 の全フロー、Stop conditions、Slack 通知ポイント 5箇所を定義。
+
+### タスク種別テンプレート (`docs/templates/`)
+
+| ファイル | 用途 | Gate | 推奨モデル |
+|---|---|---|---|
+| `cli-prompt-feature.md` | 機能追加 | 1/1.5/2/2.5/3 | Sonnet / Opus (複雑) |
+| `cli-prompt-bugfix.md` | バグ修正 | 1/1.5/2/2.5/3 | Sonnet / Opus (根本不明) |
+| `cli-prompt-refactor.md` | リファクタ | 1/1.5/2/2.5/3 | Sonnet / Opus (横断) |
+| `cli-prompt-docs.md` | docs 更新 | 1 のみ | Sonnet 4.6 固定 |
+| `cli-prompt-investigation.md` | 事前調査 | 不要 | Sonnet 4.6 固定 |
+
+### 使い方 (Phase 2〜3 タスクループ内)
+
+```bash
+# 1. asana-watcher.sh でタスクを取得
+bash SCRIPTS/asana-watcher.sh --limit 1
+
+# 2. タスクの性質を確認して対応テンプレートのプレースホルダを埋める
+# 3. dispatch --model <model> でテンプレート内容を実行
+```
+
+詳細な Slack 通知パターンは §7 を参照。
+
 ## 6. 設計判断ログ
 
 - **物理停止 NG → 論理多層防御**: dev 環境ないため。
@@ -234,4 +264,4 @@ exit 2 + BLOCKED が出れば正常。出なければ deny リストに追加を
 
 ---
 
-更新: 2026-05-19 (Phase70-A 初版)
+更新: 2026-05-20 (Phase70-E: CLI プロンプトテンプレート §9 追加)

--- a/docs/templates/cli-prompt-bugfix.md
+++ b/docs/templates/cli-prompt-bugfix.md
@@ -1,0 +1,78 @@
+# CLI Prompt Template: バグ修正 (Bugfix)
+
+<!-- サンプル元 Asana GID: Phase70-A (1214919660483265) — deploy_guard.py P1修正 (comment 1214921247806605) -->
+
+---
+
+```
+dispatch --model {{MODEL}}
+
+## 推奨モデル: {{MODEL}}
+
+<!--
+モデル選択指針:
+- Sonnet 4.6: 既知の単純バグ修正、型エラー、lint 修正
+- Opus 4.7:   根本原因が不明瞭、セキュリティ関連バグ、複数ファイル連鎖修正
+-->
+
+## 前提(重要)
+このプロンプトを書いた Claude.ai 側は以下を **実機 read していない**:
+- .wolf/buglog.json の過去ログ
+- 実際のエラーメッセージ / スタックトレース
+
+→ 下記「作業」のステップ 1 で buglog.json を必ず確認し、既知修正がないか調べる。
+
+## タスク
+{{PHASE_NAME}}: {{BUG_SUMMARY}}
+
+Asana GID: {{ASANA_GID}} (due {{DUE_DATE}})
+親: {{PARENT_PHASE}} ({{PARENT_GID}})
+
+## 症状・再現手順
+- 発生条件: {{TRIGGER_CONDITION}}
+- エラーメッセージ: {{ERROR_MESSAGE}}
+- 期待動作: {{EXPECTED_BEHAVIOR}}
+
+## 作業
+1. **実機 read(必須、最初に実行)**:
+   - `.wolf/buglog.json` — 同一エラーの既知修正を確認
+   - `.wolf/cerebrum.md` Do-Not-Repeat セクション確認
+   - `Asana:get_task` で {{ASANA_GID}} を読み、要件確認
+   - `git blame` + `git log --oneline -10 -- {{AFFECTED_FILE}}` で発生コミット特定
+   - {{ADDITIONAL_READ_TARGETS}}
+
+2. **原因特定**:
+   - {{ROOT_CAUSE_INVESTIGATION}}
+
+3. **修正**:
+   - {{FIX_STEP_1}}
+   - テストを追加または更新して再発防止
+
+4. **Gate → push → PR**:
+   - Gate 1: `pnpm verify` (typecheck + lint + test 全パス)
+   - Gate 1.5: `@cleanup` (dead exports / any 型 / as any 除去)
+   - Gate 2: `bash SCRIPTS/security-scan.sh` (High/Critical = 0)
+   - Gate 2.5: `/codex:review --base main --background` (git push 前)
+   - Gate 3: `pnpm build && cd admin-ui && pnpm build`
+   - `git checkout -b fix/{{ASANA_GID}}-{{SHORT_SLUG}}`
+   - `git push -u origin HEAD`
+   - `gh pr create` (PR description に Asana GID + 根本原因 明記)
+   - `bash SCRIPTS/notify-slack.sh "✅ PR #N pushed: fix {{BUG_SUMMARY}}, ready for Gate 2.5" --color success`
+
+5. **.wolf/buglog.json に記録**:
+   - error_message / root_cause / fix / tags を必ず追記
+
+## ガードレール
+- buglog.json 未確認での修正着手禁止
+- テストなし修正禁止（再発防止のため必ず追加）
+- 範囲外: {{OUT_OF_SCOPE_ITEMS}}
+- 3回ルール適用
+- 24h 自走中: VPS 接続 / main merge 禁止
+
+## 完了基準
+- バグが再現しなくなっている
+- 再発防止テスト追加済み
+- `.wolf/buglog.json` に修正記録済み
+- Gate 1/1.5/2.5 グリーン
+- PR description に Asana GID + 根本原因 明記
+```

--- a/docs/templates/cli-prompt-docs.md
+++ b/docs/templates/cli-prompt-docs.md
@@ -1,0 +1,64 @@
+# CLI Prompt Template: ドキュメント更新 (Docs)
+
+<!-- サンプル元 Asana GID: Phase70-B (1214919520878307), Phase70-J (1214921248316216) -->
+
+---
+
+```
+dispatch --model sonnet
+
+## 推奨モデル: Sonnet 4.6
+
+<!--
+モデル選択指針:
+- Sonnet 4.6: docs 作成・更新は常に Sonnet 4.6
+- Opus 4.7: 不要（docs-only タスクで重量モデルを使わない）
+Gate 2.5 スキップ可: docs-only / typo 修正 / CSS-only は Codex review 不要
+-->
+
+## 前提(重要)
+このプロンプトを書いた Claude.ai 側は以下を **実機 read していない**:
+- {{TARGET_DOCS_FILE}} の現在の内容
+- 関連する既存ドキュメントの構成
+
+→ 下記「作業」のステップ 1 で対象ファイルを read してから書く。推測ベースで上書きしない。
+
+## タスク
+{{PHASE_NAME}}: {{SHORT_DESCRIPTION}}
+
+Asana GID: {{ASANA_GID}} (due {{DUE_DATE}})
+親: {{PARENT_PHASE}} ({{PARENT_GID}})
+
+## 作業
+1. **実機 read(必須、最初に実行)**:
+   - `Asana:get_task` で {{ASANA_GID}} を読み、要件確認
+   - 対象ファイル {{TARGET_DOCS_FILE}} を read
+   - 関連ドキュメント ({{RELATED_DOCS}}) を anatomy.md 記述で確認
+   - {{ADDITIONAL_READ_TARGETS}}
+
+2. **ドキュメント更新**:
+   - {{DOCS_CHANGE_1}}
+   - {{DOCS_CHANGE_2}}
+   - 既存リンク・参照が壊れていないか確認
+
+3. **Gate → push → PR**:
+   - Gate 1: `pnpm verify` (typecheck + lint + test 全パス)
+   - Gate 2: `bash SCRIPTS/security-scan.sh` (High/Critical = 0) — 省略可(docs-only)
+   - ~~Gate 2.5~~: docs-only のため Codex review スキップ
+   - `git checkout -b docs/{{ASANA_GID}}-{{SHORT_SLUG}}`
+   - `git push -u origin HEAD`
+   - `gh pr create` (PR description に Asana GID 明記)
+   - `bash SCRIPTS/notify-slack.sh "✅ PR #N pushed: docs {{SHORT_DESCRIPTION}}, ready for review" --color success`
+
+## ガードレール
+- コード変更禁止（docs ファイルのみ編集）
+- 既存リンクを壊さない
+- 範囲外: {{OUT_OF_SCOPE_ITEMS}}
+- 24h 自走中: VPS 接続 / main merge 禁止
+
+## 完了基準
+- {{TARGET_DOCS_FILE}} が更新されている
+- {{ACCEPTANCE_CRITERION}}
+- Gate 1 グリーン (docs-only = typecheck/lint/test のみ)
+- PR description に Asana GID 明記
+```

--- a/docs/templates/cli-prompt-feature.md
+++ b/docs/templates/cli-prompt-feature.md
@@ -1,0 +1,68 @@
+# CLI Prompt Template: 機能追加 (Feature)
+
+<!-- サンプル元 Asana GID: Phase70-A (1214919660483265), Phase70-D (1214919660548852), Phase70-L (1214921011388648) -->
+
+---
+
+```
+dispatch --model {{MODEL}}
+
+## 推奨モデル: {{MODEL}}
+
+<!--
+モデル選択指針:
+- Sonnet 4.6: 既存パターン踏襲の追加、docs/bash スクリプト/TypeScript 軽量変更
+- Opus 4.7:   セキュリティ層変更、Asana API 連携、新アーキテクチャ、複雑ロジック
+- Plan Mode (+ Opus 4.7): 影響範囲が広い変更、複数ファイル横断の設計変更
+-->
+
+## 前提(重要)
+このプロンプトを書いた Claude.ai 側は以下を **実機 read していない**:
+- {{LIST_OF_UNREAD_FILES}}
+- 関連 Phase の既実装内容
+
+→ 下記「作業」のステップ 1 で必ず実機を read し、推測ベースで実装しない。
+
+## タスク
+{{PHASE_NAME}}: {{SHORT_DESCRIPTION}}
+
+Asana GID: {{ASANA_GID}} (due {{DUE_DATE}})
+親: {{PARENT_PHASE}} ({{PARENT_GID}})
+
+## 作業
+1. **実機 read(必須、最初に実行)**:
+   - `.wolf/anatomy.md` で対象ファイルを確認してから読む
+   - `.wolf/cerebrum.md` Do-Not-Repeat セクション確認
+   - `.wolf/buglog.json` で類似バグ既知解を確認
+   - `Asana:get_task` で {{ASANA_GID}} を読み、要件の正確な定義を確認
+   - {{ADDITIONAL_READ_TARGETS}}
+
+2. **実装**:
+   - {{IMPL_STEP_1}}
+   - {{IMPL_STEP_2}}
+   - {{IMPL_STEP_3}}
+
+3. **Gate → push → PR**:
+   - Gate 1: `pnpm verify` (typecheck + lint + test 全パス)
+   - Gate 1.5: `@cleanup` (dead exports / any 型 / as any 除去)
+   - Gate 2: `bash SCRIPTS/security-scan.sh` (High/Critical = 0)
+   - Gate 2.5: `/codex:review --base main --background` (git push 前)
+   - Gate 3: `pnpm build && cd admin-ui && pnpm build`
+   - `git checkout -b feature/{{ASANA_GID}}-{{SHORT_SLUG}}`
+   - `git push -u origin HEAD`
+   - `gh pr create` (PR description に Asana GID 明記)
+   - `bash SCRIPTS/notify-slack.sh "✅ PR #N pushed: {{SHORT_DESCRIPTION}}, ready for Gate 2.5" --color success`
+
+## ガードレール
+- 推測ベースで書かない、実 read 必須
+- 範囲外: {{OUT_OF_SCOPE_ITEMS}}
+- 3回ルール適用（同一ファイルを 3回以上編集したら .wolf/buglog.json に記録して立ち止まる）
+- 24h 自走中: VPS 接続 / main merge / DB migration / .env 編集 禁止
+
+## 完了基準
+- {{ACCEPTANCE_CRITERION_1}}
+- {{ACCEPTANCE_CRITERION_2}}
+- Gate 1/1.5/2.5 グリーン
+- PR description に Asana GID 明記
+- Slack #r2c に PR 作成完了通知済み
+```

--- a/docs/templates/cli-prompt-investigation.md
+++ b/docs/templates/cli-prompt-investigation.md
@@ -1,0 +1,67 @@
+# CLI Prompt Template: 事前調査 (Investigation)
+
+<!-- サンプル元 Asana GID: Phase70-A (1214919660483265) — 安全装置設計前調査パターン -->
+
+---
+
+```
+dispatch --model sonnet
+
+## 推奨モデル: Sonnet 4.6
+
+<!--
+モデル選択指針:
+- Sonnet 4.6: コード調査、ログ解析、ファイル探索、方針レポート
+- Opus 4.7: 深い設計判断が必要な調査、セキュリティリスク評価
+調査タスクにはコード変更 Gate (2, 2.5, 3) は不要。
+成果物はレポート (Asana コメント or docs/ ファイル) のみ。
+-->
+
+## 前提(重要)
+このプロンプトを書いた Claude.ai 側は以下を **実機 read していない**:
+- {{LIST_OF_UNREAD_FILES}}
+- 現状の実装詳細
+
+→ 調査フェーズ: read・grep・git blame・git log のみ。コード変更禁止。
+
+## タスク
+{{PHASE_NAME}}: {{INVESTIGATION_SUBJECT}} — 事前調査
+
+Asana GID: {{ASANA_GID}} (due {{DUE_DATE}})
+親: {{PARENT_PHASE}} ({{PARENT_GID}})
+
+## 調査対象
+- 目的: {{INVESTIGATION_PURPOSE}}
+- 仮説: {{HYPOTHESIS}}
+- 調査ファイル / コマンド: {{INVESTIGATION_TARGETS}}
+
+## 作業
+1. **実機 read(必須、最初に実行)**:
+   - `.wolf/anatomy.md` で関連ファイルを確認
+   - `.wolf/buglog.json` で類似問題の既知情報を確認
+   - `Asana:get_task` で {{ASANA_GID}} を読み、要件確認
+
+2. **調査**:
+   - {{INVESTIGATION_STEP_1}}
+   - {{INVESTIGATION_STEP_2}}
+   - grep / git log / git blame で実態を確認
+   - **コード変更禁止**
+
+3. **レポート**:
+   - 調査結果を Asana タスクコメントに投稿
+   - 必要なら `docs/investigation/{{ASANA_GID}}-findings.md` にも保存
+   - 推奨アクション（実装方針・懸念事項・所要時間見積もり）を明記
+   - `bash SCRIPTS/notify-slack.sh "🔍 Investigation complete: {{INVESTIGATION_SUBJECT}}" --color info`
+
+## ガードレール
+- **コード変更禁止**（調査のみ）
+- 発見した問題を「ついでに修正」しない → 別 Asana タスク化して報告
+- 範囲外: {{OUT_OF_SCOPE_ITEMS}}
+- 24h 自走中: VPS 接続 / main merge 禁止
+
+## 完了基準
+- 調査結果が Asana コメントに投稿されている
+- 推奨アクションと所要時間見積もりが明記されている
+- Slack #r2c に調査完了通知済み
+- **Gate 不要** (コード変更なし)
+```

--- a/docs/templates/cli-prompt-refactor.md
+++ b/docs/templates/cli-prompt-refactor.md
@@ -1,0 +1,73 @@
+# CLI Prompt Template: リファクタ (Refactor)
+
+<!-- サンプル元 Asana GID: Phase70-B (1214919520878307) — CLAUDE.md + auto-memory 整備 -->
+
+---
+
+```
+dispatch --model {{MODEL}}
+
+## 推奨モデル: {{MODEL}}
+
+<!--
+モデル選択指針:
+- Sonnet 4.6: 命名変更、dead code 除去、型付け改善、単一ファイル整理
+- Opus 4.7:   モジュール分割、依存関係再設計、複数ファイル横断リファクタ
+- Plan Mode (+ Opus 4.7): アーキテクチャ変更を伴うリファクタ（実装前に計画承認が必要）
+-->
+
+## 前提(重要)
+このプロンプトを書いた Claude.ai 側は以下を **実機 read していない**:
+- {{LIST_OF_UNREAD_FILES}}
+- 現在の依存関係グラフ / 呼び出し箇所
+
+→ 下記「作業」のステップ 1 で必ず実機 read し、影響範囲を正確に把握してから着手する。
+**機能変更 = scope 外。リファクタは振る舞いを変えない。**
+
+## タスク
+{{PHASE_NAME}}: {{SHORT_DESCRIPTION}}
+
+Asana GID: {{ASANA_GID}} (due {{DUE_DATE}})
+親: {{PARENT_PHASE}} ({{PARENT_GID}})
+
+## 対象ファイル / 対象範囲
+- 変更してよい: {{ALLOWED_SCOPE}}
+- 変更してはならない: {{FORBIDDEN_SCOPE}} (振る舞い・公開 API・DB スキーマ)
+
+## 作業
+1. **実機 read(必須、最初に実行)**:
+   - `.wolf/anatomy.md` で対象ファイルの依存関係を確認
+   - `.wolf/cerebrum.md` Do-Not-Repeat + Key Learnings 確認
+   - `Asana:get_task` で {{ASANA_GID}} を読み、要件確認
+   - grep で対象シンボルの呼び出し箇所を全列挙
+   - {{ADDITIONAL_READ_TARGETS}}
+
+2. **リファクタ**:
+   - {{REFACTOR_STEP_1}}
+   - {{REFACTOR_STEP_2}}
+   - 変更前後で振る舞いが同一であることをテストで確認
+
+3. **Gate → push → PR**:
+   - Gate 1: `pnpm verify` (typecheck + lint + test 全パス)
+   - Gate 1.5: `@cleanup` (dead exports / any 型 / as any 除去) — リファクタの主目的と重複する場合は省略可
+   - Gate 2: `bash SCRIPTS/security-scan.sh` (High/Critical = 0)
+   - Gate 2.5: `/codex:review --base main --background` (git push 前)
+   - Gate 3: `pnpm build && cd admin-ui && pnpm build`
+   - `git checkout -b refactor/{{ASANA_GID}}-{{SHORT_SLUG}}`
+   - `git push -u origin HEAD`
+   - `gh pr create` (PR description に Asana GID 明記)
+   - `bash SCRIPTS/notify-slack.sh "✅ PR #N pushed: refactor {{SHORT_DESCRIPTION}}, ready for Gate 2.5" --color success`
+
+## ガードレール
+- 機能変更禁止（振る舞い同一を維持）
+- 「ついでに修正」禁止（発見バグは別 Asana タスク化）
+- 範囲外: {{OUT_OF_SCOPE_ITEMS}}
+- 3回ルール適用
+- 24h 自走中: VPS 接続 / main merge 禁止
+
+## 完了基準
+- 振る舞いが変わっていないことをテストで確認済み
+- {{ACCEPTANCE_CRITERION}}
+- Gate 1/1.5/2.5 グリーン
+- PR description に Asana GID 明記
+```


### PR DESCRIPTION
## Summary

- **`docs/templates/`** に 5 種類の CLI プロンプトテンプレートを追加 (feature / bugfix / refactor / docs / investigation)
- **`.claude/prompts/24h-autonomous.md`** を作成: Phase 0〜4 全フロー・Stop conditions・Slack 通知 5箇所・R2C 固有 Out of scope 10項目
- **`docs/24H_AUTONOMOUS_PLAYBOOK.md`** に §9「CLI プロンプトテンプレート」参照リンク追加

## 実プロンプト sample 元 Asana GID

テンプレート構造は以下の Phase70 タスクの実 CLI プロンプトから抽出:
- Phase70-A: `1214919660483265` — dispatch 構造 / Gate 順序 / 「一切しないこと」パターン
- Phase70-D: `1214919660548852` — Asana Watcher 連携 / asana-watcher.sh 呼び出しパターン
- Phase70-L: `1214921011388648` — Slack notify-slack.sh 通知パターン (§7 参照)

## Asana タスク

Phase70-E: `1214919722342111` (due 2026-05-24)
親: Phase70 `1214919472827777`

## Gate 結果

- Gate 1 typecheck: ✅ PASS
- Gate 1 test: ✅ 1616/1617 PASS (1 fail は feedbackAuthGuard ECONNRESET — Phase70-A 時点からの既存不具合)
- Gate 1.5 cleanup: ➖ スキップ (docs-only, TS 変更なし)
- Gate 2 security-scan: ➖ スキップ (docs-only)
- Gate 2.5 Codex review: ➖ スキップ (CLAUDE.md: ドキュメントのみ = スキップOK)
- Gate 3 build: ➖ スキップ (docs-only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)