### PR TITLE
docs(1214921011377118): Phase70-K PLAYBOOK + SKILL 整理 + STARTUP_CHECKLIST v1.1 正式化

### DIFF
--- a/.claude/skills/r2c-deploy-prompt/SKILL.md
+++ b/.claude/skills/r2c-deploy-prompt/SKILL.md
@@ -7,6 +7,29 @@ description: R2C のデプロイフロー（bash SCRIPTS/deploy-vps.sh のみ使
 
 R2Cの開発フローは Claude.ai / CLI / hkobayashi の役割分担が厳密。このルールを破ると deploy_guard でブロックされたり、デプロイ失敗・再発防止漏れにつながる。
 
+## このスキルと PLAYBOOK の役割境界（Phase70-K 追加）
+
+| ドキュメント | 対象読者 | 内容 |
+|---|---|---|
+| **この SKILL.md** | Claude.ai (dispatch 起点) | デプロイ・CLIプロンプト生成の即時ルールと禁止事項。Claude.ai がトリガー時に参照 |
+| **R2C_DEVELOPMENT_PLAYBOOK.md** | Claude.ai (セッション全般) | 完全な開発ワークフロー、Asana運用、アーキテクチャ制約、CLIプロンプトテンプレート。セッション開始時の包括的リファレンス |
+
+**要約:** SKILL.md = Trigger 時の即時チェックリスト。PLAYBOOK = セッション全体のリファレンス。重複がある場合は PLAYBOOK を正とし、SKILL.md は要点のポインタとして機能する。
+
+## Phase70 体制（2026-05-20 追加）
+
+R2C では Phase70 以降、24h 自走ループを導入。並列実行には 2 系統あり混同禁止:
+
+| 種別 | 起動 | 用途 | コスト |
+|---|---|---|---|
+| **Agent View** | `claude agents` / 左矢印 → [New] | 独立 Lane (K/E/C 等)、背景実行 | 通常 |
+| **Agent Teams** | `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` 必須 | cross-domain 連携 | 3-4 倍 |
+
+- R2C 方針: 独立 Lane = Agent View 基本。cross-domain 連携必要時のみ Agent Teams
+- `dispatch --model X` は疑似コマンド（UI 経由で session 起動が正しい操作）
+- 24h 自走中の禁止操作・安全境界: `docs/24H_AUTONOMOUS_PLAYBOOK.md`
+- Gate 2.5 = `/codex:review --base main --background`（R2C は旧 `/codex:review` 継続、`code-review` plugin は他プロジェクトのみ）
+
 ## 役割分担（再掲）
 
 | 担当 | やること |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,8 +69,9 @@ This project uses OpenWolf for context management. Read and follow .wolf/OPENWOL
 
 Gate順序:
 - Gate 1: `pnpm verify` (typecheck + lint + test 全パス)
+- Gate 1.5: `bash SCRIPTS/dead-code-check.sh` (孤立コード確認)
 - Gate 2: `bash SCRIPTS/security-scan.sh` (High/Critical = 0)
-- Gate 2.5: `/codex:review --base main --background` (**git push前**に実行)
+- Gate 2.5: `/codex:review --base main --background` (**git push前**に実行、`--base main` 省略禁止)
 - Gate 3: `pnpm build && cd admin-ui && pnpm build`
 - git commit + push (Gate 1-3通過後のみ)
 
@@ -130,6 +131,18 @@ ON/OFF 操作:
 - ON: `bash SCRIPTS/24h-mode-on.sh` (dry-run: `--dry-run`)
 - OFF: `bash SCRIPTS/24h-mode-off.sh`
 - 検知 hook: `.claude/hooks/deploy_guard.py` が `R2C_24H_MODE` を読み追加ブロック実施
+
+## 3 回ルール（UATa PR #246 教訓 — Phase70-K 追加）
+
+**同系統のミスを 3 回繰り返したら、その判断は hkobayashi が引き取る。**
+
+適用されるミスタイプ（例）:
+1. **推測ベース書き換え** — 実機確認せずに変更 → 確認後に提案
+2. **メモリ盲信** — memory 参照後に実機状態を未確認 → 対応ファイル・コマンドで確認
+3. **並列化忘れ** — セッション開始時に並列可能性を未検討 → 初手でマトリクス化
+
+資格喪失後の再開条件: ガード/監視の実装完了後。
+詳細: `docs/R2C_24H_STARTUP_CHECKLIST.md §5.3`
 
 ## 学習セクション (Auto-updated by Claude Code)
 

--- a/docs/24H_AUTONOMOUS_PLAYBOOK.md
+++ b/docs/24H_AUTONOMOUS_PLAYBOOK.md
@@ -4,6 +4,19 @@ R2C は dev/staging を持たず本番 VPS (65.108.159.161) のみ。
 UATa テンプレ v1.0 §2.1「本番への接続を物理的に閉じる」が適用不能なので、
 論理層の多層防御で代替する。
 
+## 関連ドキュメント (24H_* ファイル群)
+
+| ファイル | 役割 |
+|---|---|
+| **このファイル** `24H_AUTONOMOUS_PLAYBOOK.md` | 論理ブロック安全装置・起動/停止スクリプト・Cloudflare Pages 手動停止手順 |
+| `R2C_24H_STARTUP_CHECKLIST.md` | **24h 自走起動前チェックリスト v1.1** — 16 項目全 ✓ が起動条件。UATa 26 件失敗パターン・3 回ルール・タスクキュー管理 |
+| `24H_AUTOMATION_R2C_GAP_ANALYSIS.md` | UATa vs R2C ギャップ分析・アカウント分離手順 |
+| `24H_AUTOMATION_RUNBOOK_R2C.md` | R2C 24h 自走 初期構築手順書 |
+| `24H_LOOP_LEARNING_INTEGRATION.md` | 学習ループ統合仕様 |
+| `24H_LOOP_RETRY_AND_NOTIFICATION_SPEC.md` | Lane retry 戦略 (1回目5分/2回目30分/3回目停止) + Pushover priority |
+
+**Phase70-H 起動前は必ず `R2C_24H_STARTUP_CHECKLIST.md` §9 の 16 項目を全て確認すること。**
+
 ## 関連 Asana
 - Phase70 親: 1214919472827777
 - Phase70-A 本タスク: 1214919660483265

--- a/docs/R2C_24H_STARTUP_CHECKLIST.md
+++ b/docs/R2C_24H_STARTUP_CHECKLIST.md
@@ -1,12 +1,16 @@
-> **⚠️ DRAFT v1.1 (2026-05-19) - 要 hkobayashi レビュー、70-K で正式整理予定**
-
 # R2C 24h 自走 起動チェックリスト v1.1
 
-**版数:** 1.1
-**作成日:** 2026-05-19 v1.0、改訂 2026-05-19 v1.1
+**版数:** 1.1 (正式版 — Phase70-K 2026-05-20)
+**作成日:** 2026-05-19 v1.0、改訂 2026-05-19 v1.1、正式化 2026-05-20 Phase70-K
 **位置づけ:** Phase70-H 初回 12h パイロット起動の前提条件
 **出典:** UATa 24h 自走運用テンプレ v1.0 (2026-05-19 09:00 JST) + UATa 1日実体験生記録 v1.0 (2026-05-19 18:00 JST) を R2C 固有の制約に合わせてカスタマイズ
-**関連:** docs/PHASE70_AI_CROSSCHECK.md §5.5 (24h 起動の足場整備という発見)
+**関連ドキュメント:**
+- `docs/24H_AUTONOMOUS_PLAYBOOK.md` — 論理ブロック安全装置 + 起動/停止スクリプト操作手順
+- `docs/24H_AUTOMATION_R2C_GAP_ANALYSIS.md` — UATa vs R2C ギャップ分析
+- `docs/24H_AUTOMATION_RUNBOOK_R2C.md` — R2C 24h 自走 初期構築手順書
+- `docs/24H_LOOP_LEARNING_INTEGRATION.md` — 学習ループ統合仕様
+- `docs/24H_LOOP_RETRY_AND_NOTIFICATION_SPEC.md` — Lane retry 戦略 + Pushover 通知仕様
+- `docs/PHASE70_AI_CROSSCHECK.md` §5.5 (24h 起動の足場整備という発見)
 
 ---
 
@@ -227,8 +231,8 @@ R2C 採用案 (Gemini 案、Phase70-B で `.wolf/OPENWOLF.md` に反映済):
 ### 3.4 知識ベース (Claude.ai プロジェクト) の整理 (R2C 固有)
 
 R2C のプロジェクト知識ベース現状:
-- R2C_DEVELOPMENT_PLAYBOOK.md (388 行) ⚠️ §11/§12 が 1 ヶ月古い
-- SKILL.md (251 行) ⚠️ PLAYBOOK と内容重複
+- R2C_DEVELOPMENT_PLAYBOOK.md (654 行) ✅ §11/§12 を Asana 参照化済み (70-K)
+- SKILL.md (302 行) ✅ PLAYBOOK との役割境界明文化済み (70-K)
 - TEST_DEPLOY_GATE.md (520 行) ⚠️ Claude in Chrome 前提、Playwright MCP に未追従
 - SECURITY_SCAN_POLICY.md (75 行) ✅
 - PHASE38_COMPLETION.md (52 行) ⚠️ 単発 Phase、知識ベースに残す必要性低
@@ -509,6 +513,7 @@ R2C 適用済の差分:
 |---|---|---|---|
 | 1.0 | 2026-05-19 13:00 JST | UATa 24h 自走運用テンプレ v1.0 を R2C 用にカスタマイズ。R2C 固有 (staging 無し、CF Pages auto-deploy、論理ブロック 100% 依存) を反映。起動前チェックリストを 12 項目に拡張 (UATa §9 の 8 項目 + R2C 固有 4 項目) | claude.ai |
 | **1.1** | **2026-05-19 22:00 JST** | **UATa 1日実体験生記録 v1.0 (2026-05-19 18:00 JST) を反映**: ①§7.2 タスクキュー 30-50 本先積み追加 (UATa §5 #9)、②§9 起動前チェックリスト 12→16 項目に拡張 (VPS メモリ 4 項目追加、UATa §4.3 教訓)、③§5.1 UATa 14 件→21 件に拡張、④§5.3 「3 回ルール」明文化 (UATa PR #246)、⑤§10 R2C-G/H/I/J 4 項目追加 (deploy 失敗時 docker 生存確認 / 焼き込み grep / 3 回ルール / VPS メモリ余裕)。Phase70-A/B/D/J/L 完了状態も反映 (PR #176/#178/#179/#180/#181) | claude.ai |
+| **1.1 正式** | **2026-05-20 Phase70-K** | DRAFT マーカー削除・正式版昇格。関連ドキュメント一覧追加 (24H_* 5件相互参照)。§3.4 の PLAYBOOK/SKILL 行数を実機確認値に更新 (PLAYBOOK 654 行 / SKILL 302 行)。CLAUDE.md に「3 回ルール」セクション追加 (PR #182 → Phase70-K PR) | claude code cli |
 
 ---
 

--- a/docs/R2C_DEVELOPMENT_PLAYBOOK.md
+++ b/docs/R2C_DEVELOPMENT_PLAYBOOK.md
@@ -430,16 +430,45 @@ grep -rn "metadata.*source" src/api/
 
 ## 9. 並列開発パターン
 
-### Agent Teams（tmux並列）
+> **重要 (2026-05-20 追加):** Claude Code の並列実行には 2 系統あり、混同禁止。
 
-3つ以上の独立ストリームを持つ新フェーズで使用。
+### 9-A. Agent View（独立 Lane — R2C の基本方針）
+
+`claude agents` で起動（または既存セッションで左矢印キー → [New]）。
+
+**特徴:**
+- UI dashboard でタスク一覧管理
+- バックグラウンド session は書き込み前に `.claude/worktrees/<id>/` に自動分離（手動 `git worktree add` 不要）
+- supervisor process が管理 → 端末を閉じても継続
+- 全プラン利用可（Opus / Sonnet / Haiku）
+- `dispatch --model sonnet` は疑似コマンド。UI 経由で session 起動するのが正しい操作
+
+**R2C 用途:** Phase70 の独立 Lane (K/E/C/H 等) — 互いに依存しないタスクを並列実行
 
 **前提:**
-- 全ペインの共有インターフェース（DB schema, API spec, TypeScript types）を事前設計
-- 各ペインのプロンプトにインターフェースを直接埋め込む
-- ペイン間の通信依存を排除
+- 全 Lane の共有インターフェース（DB schema, API spec, TypeScript types）を事前設計
+- 各 Lane のプロンプトにインターフェースを直接埋め込む
+- Lane 間の通信依存を排除
 
-**使わない場面:**
+### 9-B. Agent Teams（cross-domain 連携 — experimental）
+
+環境変数 `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` が必須。Claude Code v2.1.32+。
+
+**特徴:**
+- 自然言語「create an agent team」で lead + teammate 自動生成
+- inter-agent messaging + shared task list
+- Opus 4.6+ 強制（全 agent が同モデル）
+- **3-4 倍トークン消費** → コスト注意
+- 実験的機能のため仕様変更リスクあり
+
+**R2C 方針:** cross-domain 連携が必要な場合のみ使用。独立タスクは Agent View を優先。
+
+### 9-C. Mac での起動メモ
+
+- `ulimit -n 2147483646 + launchctl 設定`は実体験ベース、公式 doc には明記なし
+- Mac ターミナル直起動でも動作実績あり（VSCode 経由でなくても可）
+
+**使わない場面（共通）:**
 - ファイル依存がある順次タスク
 - 2タスク以下
 - バグ修正
@@ -456,28 +485,30 @@ grep -rn "metadata.*source" src/api/
 
 ---
 
-## 11. 現在の未完了タスク（2026-04-24時点）
+## 11. 現在の未完了タスク（Asana 参照）
 
-1. PR#134 follow-up P2 E2E CHAT_TEST_URL（due 5/2）
-2. PR#134 follow-up P3 非アバターE2E（due 5/9）
-3. Phase65-Attribution GA4+PostHog+成果報酬MVP親タスク（due 5/15）
-4. TEST_DEPLOY_GATE.md Playwright整合（due 5/16）
-5. ts-jest30アップグレード（due 5/31）
+> ⚠️ 静的リストは陳腐化するため廃止。常に Asana を正とする。
 
-**完了済み:** Phase68（PR#136 Knowledge Attribution + PR#138 ORDER BY CTE alias修正）
+**確認手順:** Claude.ai セッション開始時の §2 プロトコル（Step 1-4）を実行すること。
+または Asana `RAJIUCE Development` (GID: 1213607637045514) を直接確認。
+
+**現在の主要 Phase（2026-05-20 時点）:**
+- Phase70: 24h 自走基盤整備（複数サブタスク進行中 — Asana 参照）
+- Phase69-2: 残件 B/D/E（Asana 参照）
 
 ---
 
-## 12. 今後の開発ロードマップ
+## 12. 今後の開発ロードマップ（Asana 参照）
 
-| タスク | due | 備考 |
+> ⚠️ 中長期計画は Asana タスクを正とする。以下は参考記録（2026-04-24 時点）。
+
+| タスク | 状況 | 備考 |
 |---|---|---|
-| GA4 MCP統合 | 6/30 | Asana未起票 |
-| LemonSlice Video Generation API（idle hover animation） | 5/30 | Asana未起票 |
-| Phase67候補: 自動パートナー通知（CV alert, KPI anomaly, Cloudflare Email） | 未定 | |
-| R2C仮想テナント: テストチャットセレクタに「R2C（デフォルト）」追加 | 未定 | |
-| 書籍管理→ナレッジ管理ページ統合 | 未定 | |
-| パートナー獲得: 初の実テナントオンボーディング（PARTNER_ROLLOUT_PLAYBOOK.md） | 未定 | |
+| Phase70: 24h 自走基盤 | **進行中** | Phase70-A〜L 複数サブタスク |
+| GA4 MCP統合 | 未起票 | Asana 参照 |
+| LemonSlice Video Generation API | 未起票 | Asana 参照 |
+| R2C仮想テナント | 未起票 | Asana 参照 |
+| パートナー獲得: 実テナントオンボーディング | 未定 | PARTNER_ROLLOUT_PLAYBOOK.md |
 
 ---
 


### PR DESCRIPTION
## Summary

- **STARTUP_CHECKLIST.md v1.1 正式化**: DRAFT マーカー削除、24H_* 5 件の相互参照マップ追加、§12 改訂履歴更新
- **PLAYBOOK §9 Agent View / Agent Teams 区別**: 公式確認済みの 2 系統を明文化（`dispatch --model X` は疑似コマンド等）
- **PLAYBOOK §11/§12 Asana 参照化**: 陳腐化する静的タスクリストを廃止、Asana GID 参照化
- **CLAUDE.md 強化**: Gate 1.5 追加、3 回ルールセクション追加（UATa PR #246 教訓）
- **SKILL.md 役割境界明文化**: PLAYBOOK との役割分担、Phase70 体制・Agent View/Teams を SKILL.md に追記
- **24H_AUTONOMOUS_PLAYBOOK.md**: 24H_* ファイル群の関係性マップ追加、STARTUP_CHECKLIST への相互リンク

## Claude.ai プロンプトとの CLI 実機照合差分

| 項目 | Claude.ai プロンプトの記述 | CLI 実機確認 |
|---|---|---|
| STARTUP_CHECKLIST のブランチ状態 | `chore/r2c-24h-startup-checklist-v1.1-draft` を push + PR 作成（fast-start 手順） | PR #182 で既に main マージ済み（commit 604f3c8）。fast-start 手順は不要 |
| PLAYBOOK 行数 | 388 行（STARTUP_CHECKLIST §3.4 記載） | 654 行（実機確認、大幅増加済み） |
| SKILL.md 行数 | 251 行（STARTUP_CHECKLIST §3.4 記載） | 302 行（実機確認） |
| dispatch コマンド | `dispatch --model sonnet` を使用 | 疑似コマンド。UI 経由で Agent View session 起動が正しい操作 |

## Gate Results

- **Gate 1**: typecheck 0 errors / 138 スイート 1617 テスト全パス
- **Gate 1.5**: 孤立 37件（既存 warning、新規追加なし）
- **Gate 2**: docs-only のためスキップ（CLAUDE.md: `スキップOK: ドキュメントのみ`）
- **Gate 2.5**: docs-only のためスキップ（CLAUDE.md: `Codex review gate: 常時OFF。スキップOK: ドキュメントのみ`）

## Asana

Phase70-K (GID: 1214921011377118, due 2026-05-24)
親: Phase70 (1214919472827777)

🤖 Generated with [Claude Code](https://claude.com/claude-code)