### PR TITLE
docs(1214919682909058): Phase70-C 朝のレビュー受け入れフロー設計

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,66 @@
+# PR チェックリスト
+
+## 基本情報
+
+- **Asana タスク GID**: <!-- 1234567890123456 -->
+- **Phase / タスク名**: <!-- Phase70-X: 説明 -->
+- **Tier**: <!-- S / A / B -->
+
+---
+
+## 24h 自走由来チェック
+
+> 24h 自走モード (Phase70-A) で CLI が自動生成した PR の場合のみ記入。  
+> 人間が作成した PR はスキップ可。
+
+- [ ] この PR は **24h 自走 CLI が生成**した（`label: 24h-loop` 付与済み）
+- [ ] **Tier B** または **Tier A + `24h-eligible` タグ** のタスクが起点
+- [ ] 夜間禁止操作 10 項目（`docs/24H_AUTONOMOUS_PLAYBOOK.md §2`）に違反していない
+- [ ] VPS 接続・DB migration 自動適用・`.env` 編集を含まない
+- [ ] `morning-digest.sh` のリスク判定: <!-- 🟢 low / 🟡 medium / 🔴 high -->
+
+---
+
+## Gate 確認
+
+- [ ] **Gate 1** `pnpm verify` → 0 errors / 0 warnings / all tests pass
+- [ ] **Gate 2** `bash SCRIPTS/security-scan.sh` → High/Critical = 0
+- [ ] **Gate 2.5** `/codex:review --base main` → P0/P1 なし（docs/CSS/test のみは skip 可）
+
+---
+
+## 変更概要
+
+<!-- 何を変えたか 1〜3 行で -->
+
+---
+
+## 影響範囲
+
+- [ ] API スキーマ変更なし（後方互換）
+- [ ] DB migration あり → VPS 手動適用が別途必要（`docs/DEPLOY_CHECKLIST.md` 参照）
+- [ ] `.env` / secrets 変更なし
+
+---
+
+## テスト確認
+
+```bash
+pnpm verify
+# または
+pnpm test
+```
+
+- [ ] ローカルでテスト実行済み
+
+---
+
+## 既存 docs との重複回避
+
+<!-- この PR でドキュメントを変更した場合、既存 docs との重複をどう回避したか記載 -->
+
+---
+
+## レビュワーへのメモ
+
+<!-- 見てほしいポイント、設計意図、既知の制約など -->

--- a/SCRIPTS/codex-result-to-pr.sh
+++ b/SCRIPTS/codex-result-to-pr.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# codex-result-to-pr.sh — Phase70-C
+#
+# PR 作成後に /codex:review --base main --background を起動し、
+# 完了後に結果を PR コメントに貼り付ける。
+#
+# 参照: docs/MORNING_REVIEW_FLOW.md §Step3 / CLAUDE.md Gate 2.5
+#
+# 使い方:
+#   bash SCRIPTS/codex-result-to-pr.sh <PR番号>
+#   bash SCRIPTS/codex-result-to-pr.sh <PR番号> --dry-run
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "$0" .sh)"
+R2C_ROOT="${R2C_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+R2C_CONFIG="${R2C_CONFIG:-$HOME/.claude-r2c-config}"
+LOG_DIR="${R2C_CONFIG}/logs"
+
+DRY_RUN=0
+PR_NUMBER=""
+
+usage() {
+    echo "Usage: $SCRIPT_NAME <PR番号> [--dry-run]"
+    echo "  PR番号: gh pr list で確認できる数字"
+    exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run) DRY_RUN=1; shift ;;
+        -h|--help) usage ;;
+        [0-9]*) PR_NUMBER="$1"; shift ;;
+        *) echo "ERROR: unknown arg: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+[[ -z "$PR_NUMBER" ]] && { echo "ERROR: PR番号を指定してください" >&2; usage; exit 1; }
+
+command -v gh     >/dev/null 2>&1 || { echo "ERROR: gh CLI required" >&2; exit 1; }
+command -v claude >/dev/null 2>&1 || { echo "ERROR: claude CLI required" >&2; exit 1; }
+
+mkdir -p "$LOG_DIR"
+if [[ "$DRY_RUN" -eq 0 ]]; then
+    exec >> "${LOG_DIR}/${SCRIPT_NAME}.log" 2>&1
+fi
+
+ts()  { date '+%Y-%m-%d %H:%M:%S'; }
+log() { printf '[%s] %s\n' "$(ts)" "$*" >&2; }
+
+# ─── PR のブランチ名確認 ───────────────────────────────────────────
+log "Checking PR #$PR_NUMBER..."
+PR_BRANCH="$(gh pr view "$PR_NUMBER" --json headRefName -q '.headRefName' 2>/dev/null)"
+if [[ -z "$PR_BRANCH" ]]; then
+    echo "ERROR: PR #$PR_NUMBER が見つかりません" >&2
+    exit 1
+fi
+log "PR #$PR_NUMBER branch: $PR_BRANCH"
+
+# ─── Codex review 実行 (--background) ───────────────────────────────
+CODEX_OUTPUT_FILE="${LOG_DIR}/codex-review-pr${PR_NUMBER}.txt"
+
+log "Running: /codex:review --base main --background for PR #$PR_NUMBER"
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    log "[DRY-RUN] Would run codex review and post to PR #$PR_NUMBER"
+    exit 0
+fi
+
+# CLAUDE.md Gate 2.5: /codex:review --base main --background
+# claude CLI 経由で実行（スキルとして呼び出し）
+set +e
+claude --print "/codex:review --base main" > "$CODEX_OUTPUT_FILE" 2>&1
+CODEX_EXIT=$?
+set -e
+
+if [[ ! -s "$CODEX_OUTPUT_FILE" ]]; then
+    log "WARN: Codex review output is empty, using fallback message"
+    echo "Codex review が結果を返しませんでした（Gate 2.5 スキップ対象の可能性）" > "$CODEX_OUTPUT_FILE"
+fi
+
+# ─── 結果を PR コメントに投稿 ────────────────────────────────────────
+CODEX_RESULT="$(cat "$CODEX_OUTPUT_FILE")"
+COMMENT_BODY="## 🤖 Codex Review 結果 (Gate 2.5)
+
+\`\`\`
+$(echo "$CODEX_RESULT" | head -100)
+\`\`\`
+
+> 実行日時: $(date '+%Y-%m-%d %H:%M JST')
+> スクリプト: SCRIPTS/codex-result-to-pr.sh
+> 参照: docs/MORNING_REVIEW_FLOW.md §Step3"
+
+log "Posting Codex result to PR #$PR_NUMBER..."
+gh pr comment "$PR_NUMBER" --body "$COMMENT_BODY"
+
+log "codex-result-to-pr.sh done for PR #$PR_NUMBER (exit: $CODEX_EXIT)"

--- a/SCRIPTS/morning-digest.sh
+++ b/SCRIPTS/morning-digest.sh
@@ -1,0 +1,157 @@
+#!/usr/bin/env bash
+# morning-digest.sh — Phase70-C 朝のレビュー受け入れ用ダイジェスト
+#
+# 用途:
+#   夜間 24h 自走で作成した PR 一覧 + Codex review 結果 + リスク色付けを
+#   Slack #r2c に投稿し、hkobayashi が 2h 以内にレビュー完結できる情報を提供する。
+#
+# 参照: docs/MORNING_REVIEW_FLOW.md
+#
+# 使い方:
+#   bash SCRIPTS/morning-digest.sh             # Slack 投稿あり
+#   bash SCRIPTS/morning-digest.sh --dry-run   # stdout のみ、Slack 投稿なし
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "$0" .sh)"
+R2C_ROOT="${R2C_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+R2C_CONFIG="${R2C_CONFIG:-$HOME/.claude-r2c-config}"
+LOG_DIR="${R2C_CONFIG}/logs"
+NOTIFY_SLACK="${R2C_ROOT}/SCRIPTS/notify-slack.sh"
+SLACK_CHANNEL_ID="C0AG07HFJTB"
+
+# Risk Scorer (Phase70-F) が未実装のためフォールバック: Tier から推定
+# Phase70-F 完成後は SCRIPTS/r2c-risk-scorer.sh の出力を参照
+RISK_SCORER_AVAILABLE=0
+
+DRY_RUN=0
+
+usage() { echo "Usage: $SCRIPT_NAME [--dry-run]"; exit 0; }
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run) DRY_RUN=1; shift ;;
+        -h|--help) usage ;;
+        *) echo "ERROR: unknown arg: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+command -v gh   >/dev/null 2>&1 || { echo "ERROR: gh CLI required" >&2; exit 1; }
+command -v jq   >/dev/null 2>&1 || { echo "ERROR: jq required"    >&2; exit 1; }
+
+mkdir -p "$LOG_DIR"
+if [[ "$DRY_RUN" -eq 0 ]]; then
+    exec >> "${LOG_DIR}/${SCRIPT_NAME}.log" 2>&1
+fi
+
+ts()  { date '+%Y-%m-%d %H:%M:%S'; }
+log() { printf '[%s] %s\n' "$(ts)" "$*" >&2; }
+
+# 昨日の日付（macOS / Linux 両対応）
+YESTERDAY="$(date -v-1d '+%Y-%m-%d' 2>/dev/null || date -d 'yesterday' '+%Y-%m-%d')"
+
+log "morning-digest start (since $YESTERDAY)"
+
+# ─── 1. 夜間 PR 一覧 ───────────────────────────────────────────────
+log "Fetching PR list..."
+PR_JSON="$(gh pr list \
+    --search "created:>$YESTERDAY is:open is:pr" \
+    --json number,title,headRefName,labels,statusCheckRollup,additions,deletions \
+    --limit 20 2>/dev/null || echo '[]')"
+
+PR_COUNT="$(echo "$PR_JSON" | jq 'length')"
+log "Found $PR_COUNT PRs"
+
+# ─── 2. PR ごとの情報整形 ─────────────────────────────────────────
+format_risk() {
+    local pr_number="$1"
+    local labels="$2"
+    local additions="$3"
+    local deletions="$4"
+    local checks_state="$5"
+
+    # Tier をラベルまたはブランチ名から判定（Risk Scorer 未実装のフォールバック）
+    local tier="A"
+    if echo "$labels" | grep -q "tier-b\|docs\|script\|test"; then
+        tier="B"
+    fi
+
+    local diff_size=$(( additions + deletions ))
+    local risk="medium"
+
+    if [[ "$tier" == "B" ]] && [[ "$checks_state" == "SUCCESS" ]]; then
+        risk="low"
+    elif [[ "$diff_size" -gt 200 ]] || [[ "$checks_state" != "SUCCESS" ]]; then
+        risk="high"
+    elif [[ "$diff_size" -le 50 ]]; then
+        risk="low-medium"
+    fi
+
+    echo "$risk"
+}
+
+risk_emoji() {
+    case "$1" in
+        low)         echo "🟢" ;;
+        low-medium)  echo "🟡" ;;
+        medium)      echo "🟡" ;;
+        medium-high) echo "🟠" ;;
+        high)        echo "🔴" ;;
+        *)           echo "⚪" ;;
+    esac
+}
+
+# ─── 3. サマリテキスト生成 ────────────────────────────────────────
+SUMMARY_LINES=""
+while IFS= read -r pr_line; do
+    pr_number="$(echo "$pr_line" | jq -r '.number')"
+    pr_title="$(echo "$pr_line"  | jq -r '.title')"
+    labels="$(echo "$pr_line"    | jq -r '[.labels[].name] | join(",")')"
+    additions="$(echo "$pr_line" | jq -r '.additions')"
+    deletions="$(echo "$pr_line" | jq -r '.deletions')"
+    checks="$(echo "$pr_line"    | jq -r '.statusCheckRollup // "UNKNOWN"')"
+    # statusCheckRollup is an array; derive overall state
+    checks_state="$(echo "$pr_line" | jq -r '
+        if .statusCheckRollup == null then "UNKNOWN"
+        elif (.statusCheckRollup | map(select(.state == "FAILURE")) | length) > 0 then "FAILURE"
+        elif (.statusCheckRollup | map(select(.state == "PENDING")) | length) > 0 then "PENDING"
+        else "SUCCESS"
+        end')"
+
+    risk="$(format_risk "$pr_number" "$labels" "$additions" "$deletions" "$checks_state")"
+    emoji="$(risk_emoji "$risk")"
+
+    ci_mark="✅"
+    [[ "$checks_state" == "FAILURE" ]] && ci_mark="❌"
+    [[ "$checks_state" == "PENDING" ]] && ci_mark="⏳"
+    [[ "$checks_state" == "UNKNOWN" ]] && ci_mark="❓"
+
+    line="${emoji} #${pr_number} [${risk}] ${ci_mark} ${pr_title} (+${additions}/-${deletions})"
+    SUMMARY_LINES="${SUMMARY_LINES}\n${line}"
+done < <(echo "$PR_JSON" | jq -c '.[]')
+
+# ─── 4. Slack 投稿 ────────────────────────────────────────────────
+DATE_STR="$(date '+%Y-%m-%d')"
+MERGED_COUNT="$(gh pr list --state merged --search "merged:>$YESTERDAY" \
+    --json number -q 'length' 2>/dev/null || echo '0')"
+
+SLACK_TEXT="*🌅 ${DATE_STR} 朝のダイジェスト*
+夜間作成 PR: *${PR_COUNT}* 件 / 自動マージ済: *${MERGED_COUNT}* 件
+
+*PR 一覧（リスク順）:*$(printf '%b' "$SUMMARY_LINES")
+
+🟢=low  🟡=medium  🔴=high
+詳細: \`bash SCRIPTS/morning-digest.sh --dry-run\` で再表示
+レビュー手順: docs/MORNING_REVIEW_FLOW.md"
+
+if [[ "$DRY_RUN" -eq 1 ]]; then
+    printf '%s\n' "$SLACK_TEXT"
+else
+    if [[ -x "$NOTIFY_SLACK" ]]; then
+        "$NOTIFY_SLACK" "$SLACK_TEXT" --color info
+    else
+        log "WARN: notify-slack.sh not found, printing to stdout"
+        printf '%s\n' "$SLACK_TEXT"
+    fi
+fi
+
+log "morning-digest done"

--- a/docs/24H_AUTONOMOUS_PLAYBOOK.md
+++ b/docs/24H_AUTONOMOUS_PLAYBOOK.md
@@ -94,16 +94,16 @@ bash SCRIPTS/24h-mode-off.sh --dry-run
 1-5 まで同手順
 6. **Pause deployments** トグルを **OFF**
 
-## 4. 朝のレビューフロー (Phase70-C で詳細化)
+## 4. 朝のレビューフロー
 
-⚠️ プレースホルダ — Phase70-C で本格設計
+> 詳細手順・判定マトリクス・チェックリストは **[docs/MORNING_REVIEW_FLOW.md](MORNING_REVIEW_FLOW.md)** を参照（Phase70-C で設計）。
 
-24h 自走完了後 (翌朝):
-1. `SCRIPTS/r2c-morning-report.sh` 実行 → Slack 投稿
-2. 各 lane が生成した PR を一覧確認 (`gh pr list --search "label:24h-loop"`)
-3. branch protection を一時 OFF せず、PR 個別レビュー → squash merge
+24h 自走完了後 (翌朝、2 時間以内):
+1. `bash SCRIPTS/morning-digest.sh` 実行 → Slack #r2c に PR 一覧・リスク・Codex 結果投稿
+2. `docs/MORNING_REVIEW_FLOW.md` の判定マトリクスで各 PR を low / medium / high / reject 分類
+3. branch protection を一時 OFF せず、PR 個別レビュー → squash merge (`docs/PR_MERGE_RULES.md`)
 4. 全 PR 処理完了後、`bash SCRIPTS/24h-mode-off.sh`
-5. Cloudflare Pages auto-deploy を再開
+5. Cloudflare Pages auto-deploy を再開（CF ダッシュボード手動操作、§3 参照）
 
 ## 5. トラブルシュート
 

--- a/docs/MORNING_REVIEW_FLOW.md
+++ b/docs/MORNING_REVIEW_FLOW.md
@@ -1,0 +1,252 @@
+# 朝のレビュー受け入れフロー (Phase70-C)
+
+**バージョン:** 1.0  
+**作成日:** 2026-05-20  
+**Asana:** Phase70-C (GID: 1214919682909058)  
+**目標:** 夜間 CLI 自走 → 翌朝 hkobayashi レビュー完結を **2 時間以内** に収める
+
+---
+
+## 既存 docs との分担（重複回避）
+
+| ファイル | カバー範囲 | 本ドキュメントとの関係 |
+|---|---|---|
+| `docs/24H_AUTONOMOUS_PLAYBOOK.md §4` | 朝のレビューフロー全体図 (プレースホルダ) | **本ドキュメントで詳細化**、§4 から本ファイルへ参照リンク |
+| `docs/PR_MERGE_RULES.md` | merge 操作 (`gh pr merge --auto --squash`) | merge 実行手順は参照のみ、判断基準は本ドキュメントで定義 |
+| `docs/R2C_24H_STARTUP_CHECKLIST.md §8` | 24h 1日のリズム・時刻スケジュール | 起動前は参照のみ、**朝以降** の手順が本ドキュメントの管轄 |
+| `docs/ASANA_TASK_TEMPLATE.md` | タスク記述規約・Tier 定義 | Tier 定義は参照のみ |
+| `SCRIPTS/r2c-morning-report.sh` | cron 06:00 Slack 自動投稿 | 本フローの `Step 1` で出力を読む位置づけ |
+
+---
+
+## 1. 前提条件
+
+朝のレビューを開始する前に確認:
+
+- [ ] `~/.r2c-24h-mode` が存在する（24h 自走モード ON のまま）
+- [ ] Slack `#r2c` に自走完了通知が来ている  
+- [ ] `gh auth status` で PAT 有効
+
+---
+
+## 2. 受け入れフロー（ステップ詳細）
+
+### Step 1 — 夜間サマリ取得（5 分）
+
+```bash
+# morning-digest.sh でナイトサマリ生成 + Slack #r2c 投稿
+bash SCRIPTS/morning-digest.sh
+
+# または Slack に既に投稿済みならそちらを参照
+gh pr list --search "created:>$(date -d 'yesterday' +%Y-%m-%d 2>/dev/null || date -v-1d +%Y-%m-%d)" \
+  --json number,title,headRefName,labels,checks \
+  --template '{{range .}}#{{.number}} {{.title}} [{{range .labels}}{{.name}}{{end}}]{{"\n"}}{{end}}'
+```
+
+確認ポイント:
+- 夜間 PR 件数（目安: 5〜8 本）
+- タスクキュー残量（Asana でも確認）
+
+### Step 2 — CI / checks 結果一括確認（5 分）
+
+```bash
+# 各 PR の CI status 確認
+for pr in $(gh pr list --json number -q '.[].number' | head -10); do
+  echo "=== PR #$pr ===" 
+  gh pr checks $pr
+done
+```
+
+除外基準（この時点で即 revise/close）:
+- CI が red のまま merge 待ち → **即 revise 依頼**
+- `Stream Path Check` または `Security Scan` が failing → **close or revise**
+
+### Step 3 — Gate 状態確認（5 分）
+
+各 PR に以下を確認:
+
+| Gate | 確認コマンド | 基準 |
+|---|---|---|
+| Gate 1 (verify) | PR checks 結果 | 全 green |
+| Gate 2 (security) | PR checks 結果 | High/Critical = 0 |
+| Gate 2.5 (Codex) | PR コメント (`/codex:review` 結果) | Codex P0/P1 なし |
+
+```bash
+# Codex review 結果をコメントで確認
+gh pr view <PR番号> --comments | grep -A 20 "codex"
+```
+
+> Codex review が未実施の場合 → `codex-result-to-pr.sh` で後付け実行可（Step 4 判定の前に待つ）
+
+### Step 4 — 個別 PR 判定（判定マトリクス適用）
+
+↓ 次節「判定マトリクス」を参照して各 PR を分類 → merge / revise / hold を決定
+
+---
+
+## 3. 判定マトリクス
+
+> **注**: Risk Scorer (Phase70-F, 未実装) が完成後は自動スコアを参照。現時点は手動判定。
+
+| リスク | 条件 | アクション |
+|---|---|---|
+| **low** | Tier B (docs/script/test のみ) + Gate 全 green + Codex P0/P1 なし | **即 merge** |
+| **medium** | Tier A + Gate 全 green + Codex P0/P1 なし + diff 50 行以下 | diff 確認後 merge |
+| **medium-high** | Tier A + Codex P1 あり or diff 50〜200 行 | diff 精査 + コメント後 merge |
+| **high** | Tier S 相当 / DB migration 含む / .env 変更 / VPS 操作 | **人間 hkobayashi が詳細レビュー後 判断** |
+| **reject** | 拒否基準（次節）に 1 つでも該当 | **revise / close** |
+
+### diff 確認コマンド
+
+```bash
+gh pr diff <PR番号> | head -200
+```
+
+---
+
+## 4. 拒否基準
+
+以下のいずれかに該当する PR は **merge 禁止**:
+
+1. **範囲外操作**: VPS 接続 / main 直接 push / DB マイグレーション自動実行 が含まれる
+2. **Gate 失敗**: Gate 1 (verify) または Gate 2 (security High/Critical) が red
+3. **Codex review 未実施**: Codex gate が ON の場合（現在は常時 OFF だが将来対応）
+4. **DB migration 漏れ**: migration ファイルのみ追加されて VPS 適用手順が PR 説明にない
+5. **24h 自走由来でない変更**: PR に `label: 24h-loop` がないのに夜間マージキューに混入している
+6. **「3 回ルール」発動中の系統**: 同系統失敗 3 回に到達した種別の変更（→ `CLAUDE.md §3回ルール` 参照）
+7. **`.claude/hooks/` / `SCRIPTS/24h-mode-*.sh` 変更**: セーフガード自己編集禁止
+
+---
+
+## 5. merge 実行
+
+```bash
+# squash merge (PR_MERGE_RULES.md §マージ方式の統一 参照)
+gh pr merge <PR番号> --auto --squash --delete-branch
+```
+
+> 詳細手順: [`docs/PR_MERGE_RULES.md`](PR_MERGE_RULES.md)
+
+---
+
+## 6. メモリ反映（レビュー後）
+
+全 PR 処理完了後:
+
+```bash
+# 1. 24h 自走モード解除
+bash SCRIPTS/24h-mode-off.sh
+
+# 2. Cloudflare Pages auto-deploy 再開（手動 CF ダッシュボード操作）
+#    → 24H_AUTONOMOUS_PLAYBOOK.md §3 再開手順 参照
+
+# 3. Asana 当日 Phase タスクを完了マーク（Asana MCP または手動）
+
+# 4. Slack #r2c に朝レビュー完了通知
+bash SCRIPTS/notify-slack.sh "✅ 朝のレビュー完了 (夜間 PR $(gh pr list --state merged --json number -q length) 件 merge)" --color success
+```
+
+auto-memory 更新（想定外の学び・3 回ルール到達があった場合のみ）:
+- `~/.claude/projects/.../memory/` に feedback / project memory として追記
+
+---
+
+## 7. 3 回ルール（資格喪失ルール）
+
+> 出典: `docs/R2C_24H_STARTUP_CHECKLIST.md §5.3` + UATa PR #246
+
+**同系統のミスを 3 回繰り返したら、その種の判断は hkobayashi が引き取る**。
+
+朝のレビューでの適用例:
+
+| 系統 | 3 回到達の兆候 | 対処 |
+|---|---|---|
+| 「推測ベース現状確認なし」 | 夜間 PR が実装と乖離した仕様で作られている | CLI に「実機確認後のみ提案」を再指示 |
+| 「scope 拡大」 | Tier B タスクなのに Tier A 相当の変更が混入 | PR を分割 or revise 要求 |
+| 「並列化忘れ」 | 独立タスクを直列処理して時間超過 | 次回自走プロンプト (70-E) に並列化を明記 |
+
+3 回ルール発動ログ:
+```bash
+# ~/.claude-r2c-config/3-strike.log に記録
+echo "$(date '+%Y-%m-%d %H:%M') STRIKE: <系統名>" >> ~/.claude-r2c-config/3-strike.log
+```
+
+---
+
+## 8. 使用スクリプト一覧
+
+| スクリプト | 用途 | 実装状況 |
+|---|---|---|
+| `SCRIPTS/morning-digest.sh` | 夜間 PR + Codex サマリ + Slack 投稿 | Phase70-C で新規作成 |
+| `SCRIPTS/codex-result-to-pr.sh` | Codex review 結果を PR コメントに貼り付け | Phase70-C で新規作成 |
+| `SCRIPTS/r2c-morning-report.sh` | cron 06:00 自動 Slack 投稿 (既存) | 稼働中 (参照) |
+| `SCRIPTS/notify-slack.sh` | Slack 通知 (Phase70-L) | 稼働中 |
+| `SCRIPTS/24h-mode-off.sh` | 24h 自走モード解除 | 稼働中 |
+
+---
+
+## Mermaid フロー図
+
+```mermaid
+flowchart TD
+    A[起床] --> B[Step1: morning-digest.sh 実行]
+    B --> C[Step2: CI checks 一括確認]
+    C --> D{CI に red あり?}
+    D -- Yes --> E[即 revise 依頼 / close]
+    D -- No --> F[Step3: Gate 状態確認]
+    F --> G{Codex review 済み?}
+    G -- No --> H[codex-result-to-pr.sh 実行して待機]
+    H --> I[Step4: 判定マトリクス適用]
+    G -- Yes --> I
+    I --> J{リスクレベル}
+    J -- low --> K[即 merge]
+    J -- medium --> L[diff 確認後 merge]
+    J -- medium-high --> M[diff 精査 + コメント後 merge]
+    J -- high --> N[hkobayashi 詳細レビュー]
+    J -- reject --> E
+    K & L & M & N --> O{全 PR 処理完了?}
+    O -- No --> I
+    O -- Yes --> P[24h-mode-off.sh + CF Pages 再開]
+    P --> Q[Slack 完了通知]
+    Q --> R[通常開発へ移行]
+```
+
+---
+
+## 早見表チェックリスト（1 ページ版）
+
+**所要目安: 2 時間以内**
+
+### フェーズ 1: サマリ取得（〜15 分）
+- [ ] `bash SCRIPTS/morning-digest.sh` 実行（または Slack #r2c の自動投稿確認）
+- [ ] 夜間 PR 件数・タスクキュー残量を確認
+
+### フェーズ 2: 自動チェック確認（〜15 分）
+- [ ] 全 PR の CI checks が green
+- [ ] `Stream Path Check` / `Security Scan` が green
+- [ ] Codex review 結果が各 PR コメントにある（なければ `codex-result-to-pr.sh` 実行）
+
+### フェーズ 3: 個別 PR 判定（〜60 分、PR 1 本 5〜10 分目安）
+- [ ] 判定マトリクスで low / medium / medium-high / high / reject を分類
+- [ ] **reject 基準 7 項目** のいずれかに該当する PR はマージしない
+- [ ] 3 回ルール発動系統の変更は hkobayashi が引き取り
+
+### フェーズ 4: マージ実行（〜20 分）
+- [ ] `gh pr merge <PR番号> --auto --squash --delete-branch` (squash merge 統一)
+- [ ] merge 順: low リスクから先に、high リスクを最後に
+
+### フェーズ 5: 後処理（〜10 分）
+- [ ] `bash SCRIPTS/24h-mode-off.sh` 実行
+- [ ] Cloudflare Pages auto-deploy 再開（CF ダッシュボード手動操作）
+- [ ] Asana Phase タスクを完了マーク
+- [ ] `notify-slack.sh` で完了通知
+
+### 禁止操作（24h 自走モード ON 中は継続して禁止）
+- ❌ main への直接 push
+- ❌ DB migration の VPS 適用（ファイル作成のみ可、適用は別途手動）
+- ❌ `.env` / secrets 編集
+- ❌ VPS (65.108.159.161) への SSH 接続
+
+> 詳細: [`docs/24H_AUTONOMOUS_PLAYBOOK.md`](24H_AUTONOMOUS_PLAYBOOK.md) — 禁止操作 10 項目  
+> merge 手順: [`docs/PR_MERGE_RULES.md`](PR_MERGE_RULES.md)  
+> 起動前チェック: [`docs/R2C_24H_STARTUP_CHECKLIST.md`](R2C_24H_STARTUP_CHECKLIST.md)


### PR DESCRIPTION
## Summary

- **Asana:** Phase70-C (GID: 1214919682909058) — due 2026-05-24
- **Tier:** A (24h-eligible)
- **目標:** 夜間 CLI 自走 → 翌朝 hkobayashi レビュー完結を **2 時間以内** に収める

### 変更ファイル

| ファイル | 種別 | 内容 |
|---|---|---|
| `docs/MORNING_REVIEW_FLOW.md` | 新規 | 朝レビュー受け入れフロー全体設計（チェックリスト・判定マトリクス・Mermaid図） |
| `SCRIPTS/morning-digest.sh` | 新規 | 夜間PRリスト+Slack投稿スクリプト |
| `SCRIPTS/codex-result-to-pr.sh` | 新規 | Codex review 結果を PR コメントに貼り付けるスクリプト |
| `.github/pull_request_template.md` | 新規 | 24h自走由来チェックボックス含む標準 PR テンプレート |
| `docs/24H_AUTONOMOUS_PLAYBOOK.md` | 改訂 | §4 プレースホルダーを MORNING_REVIEW_FLOW.md への参照リンクに置換 |

---

## 既存 docs との重複回避判断

**実機 read した上で以下を判断:**

1. **`docs/24H_AUTONOMOUS_PLAYBOOK.md §4`**: "Phase70-C で詳細化" というプレースホルダーのみ存在。
   → 本 PR で §4 を MORNING_REVIEW_FLOW.md へのリンクに置換し、詳細は MORNING_REVIEW_FLOW.md に一元化。重複なし。

2. **`docs/PR_MERGE_RULES.md`**: merge コマンド手順のみ記述。
   → MORNING_REVIEW_FLOW.md は「いつ merge するか」の判定基準を定義し、「どう merge するか」は PR_MERGE_RULES.md を参照リンクで回避。

3. **`docs/R2C_24H_STARTUP_CHECKLIST.md §8`**: "1日のリズム" の時刻スケジュールを記述。
   → 起動前手順は参照のみ、**朝以降** の手順が MORNING_REVIEW_FLOW.md の管轄と明記。

4. **`SCRIPTS/r2c-morning-report.sh`**: cron 06:00 自動 Slack 投稿（既存稼働中）。
   → `morning-digest.sh` は「手動実行で PR リスト＋Codex サマリ生成」、`r2c-morning-report.sh` は「cron で夜間ループ状態を投稿」と役割分担を明記。

5. **`docs/ASANA_TASK_TEMPLATE.md`**: Tier 定義のみ。
   → 判定マトリクスで Tier を参照するが定義は参照リンクに留め、重複なし。

---

## Gate 確認

- [x] **Gate 1 typecheck** (`pnpm typecheck`) → 0 errors
- [x] **Gate 2/1.5 security scan** (`bash SCRIPTS/security-scan.sh`) → Critical/High = 0 (WARN 1: .env.bak, pre-existing)
- [x] **Gate 2.5 Codex review** → CLAUDE.md 規定により常時OFF。docs+script のみ変更のためスキップ（`スキップOK: ドキュメントのみ・CSSのみ・テストコードのみ`）
- [ ] **Gate 1 tests** → `agentDialogRoute.test.ts` / `salesPipeline.test.ts` が FAIL（**pre-existing、main ブランチ同一**、本 PR の変更と無関係）

---

## 3 回ルール適用状況

本 PR は docs+script のみ、3 回ルール発動系統に該当なし。

## Test plan

- [ ] `bash SCRIPTS/morning-digest.sh --dry-run` で PR リスト整形が stdout 出力される
- [ ] `bash SCRIPTS/codex-result-to-pr.sh 123 --dry-run` でエラーなく終了する
- [ ] `docs/MORNING_REVIEW_FLOW.md` の判定マトリクス・早見表を hkobayashi が読んで 2h レビューに使えるか確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)