### PR TITLE
feat(1214919682795187): Phase70-F PR Risk Scorer — diff から low/medium/high 自動判定

### DIFF
--- a/SCRIPTS/morning-digest.sh
+++ b/SCRIPTS/morning-digest.sh
@@ -19,9 +19,11 @@ LOG_DIR="${R2C_CONFIG}/logs"
 NOTIFY_SLACK="${R2C_ROOT}/SCRIPTS/notify-slack.sh"
 SLACK_CHANNEL_ID="C0AG07HFJTB"
 
-# Risk Scorer (Phase70-F) が未実装のためフォールバック: Tier から推定
-# Phase70-F 完成後は SCRIPTS/r2c-risk-scorer.sh の出力を参照
+# Risk Scorer (Phase70-F): SCRIPTS/pr-risk-scorer.sh を使用
+# フォールバック: pr-risk-scorer.sh が存在しない or 失敗時は Tier から推定
+RISK_SCORER_PATH="${R2C_ROOT}/SCRIPTS/pr-risk-scorer.sh"
 RISK_SCORER_AVAILABLE=0
+[[ -x "$RISK_SCORER_PATH" ]] && RISK_SCORER_AVAILABLE=1
 
 DRY_RUN=0
 
@@ -69,16 +71,30 @@ format_risk() {
     local deletions="$4"
     local checks_state="$5"
 
-    # Tier をラベルまたはブランチ名から判定（Risk Scorer 未実装のフォールバック）
+    # Phase70-F Risk Scorer を優先使用、失敗時はフォールバック
+    if [[ "$RISK_SCORER_AVAILABLE" -eq 1 ]]; then
+        local scorer_json
+        scorer_json="$(bash "$RISK_SCORER_PATH" "$pr_number" --json-only --dry-run 2>/dev/null)" || scorer_json=""
+        if [[ -n "$scorer_json" ]]; then
+            echo "$scorer_json" | jq -r '.risk // "medium"'
+            return
+        fi
+    fi
+
+    # フォールバック: Tier + diff size から推定
     local tier="A"
-    if echo "$labels" | grep -q "tier-b\|docs\|script\|test"; then
+    if echo "$labels" | grep -q "tier-b\|docs\|script\|test\|risk:low"; then
         tier="B"
     fi
 
     local diff_size=$(( additions + deletions ))
     local risk="medium"
 
-    if [[ "$tier" == "B" ]] && [[ "$checks_state" == "SUCCESS" ]]; then
+    if echo "$labels" | grep -q "risk:high"; then
+        risk="high"
+    elif echo "$labels" | grep -q "risk:low"; then
+        risk="low"
+    elif [[ "$tier" == "B" ]] && [[ "$checks_state" == "SUCCESS" ]]; then
         risk="low"
     elif [[ "$diff_size" -gt 200 ]] || [[ "$checks_state" != "SUCCESS" ]]; then
         risk="high"

--- a/SCRIPTS/pr-risk-scorer.sh
+++ b/SCRIPTS/pr-risk-scorer.sh
@@ -1,0 +1,394 @@
+#!/usr/bin/env bash
+# pr-risk-scorer.sh — Phase70-F
+#
+# PR diff からリスクレベル(low/medium/high)を判定し、GitHub ラベルを付与する。
+# 朝の人間レビュー(docs/MORNING_REVIEW_FLOW.md)で「何から見るか」を即座に判断可能にする。
+#
+# 判定基準:
+#   low    = docs/*, *.md, tests/*, *.test.ts のみ変更
+#   medium = src/ 単一機能変更, admin-ui/ 表示調整, 差分 ≤ 200 行
+#   high   = src/middleware/, src/api/auth*, DB schema関連, security-scan.sh,
+#            deploy*, .env*, .claude/hooks/, 複数 module 跨ぎ, 差分 > 200 行 + 本番影響
+#
+# 出力:
+#   stdout: JSON { risk, reason, affected_paths, auto_merge_eligible, diff_stats }
+#   GitHub: risk:low / risk:medium / risk:high ラベルを PR に付与
+#   PR comment: リスク判定結果をコメント投稿(--no-comment で抑制)
+#
+# 使い方:
+#   bash SCRIPTS/pr-risk-scorer.sh <PR番号>
+#   bash SCRIPTS/pr-risk-scorer.sh <PR番号> --dry-run      # ラベル付与・コメント投稿なし
+#   bash SCRIPTS/pr-risk-scorer.sh <PR番号> --no-comment   # コメント投稿なし(ラベルは付与)
+#   bash SCRIPTS/pr-risk-scorer.sh <PR番号> --json-only    # JSON のみ stdout (ラベル・コメントなし)
+#   bash SCRIPTS/pr-risk-scorer.sh --self-test             # 過去 PR サンプルで動作確認
+#
+# 環境変数:
+#   GITHUB_TOKEN (gh CLI が使うもの、通常は gh auth login 済みで不要)
+#   PR_RISK_NO_LABEL=1  ラベル付与をスキップ
+#   PR_RISK_NO_COMMENT=1 コメント投稿をスキップ
+#
+# 依存: gh CLI, jq
+#
+# Asana: Phase70-F (GID 1214919682795187)
+# 連携: morning-digest.sh (Phase70-C), Mergify (Phase70-I インターフェース合意済み)
+
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "$0" .sh)"
+R2C_ROOT="${R2C_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+
+# ─── 引数 ──────────────────────────────────────────────────────────────────
+PR_NUMBER=""
+DRY_RUN=0
+NO_COMMENT=0
+JSON_ONLY=0
+SELF_TEST=0
+VERBOSE=0
+
+usage() {
+    cat <<EOF
+Usage: $SCRIPT_NAME <PR番号> [--dry-run] [--no-comment] [--json-only] [-v]
+       $SCRIPT_NAME --self-test
+
+Options:
+  --dry-run      ラベル付与・コメント投稿を行わない(判定のみ)
+  --no-comment   コメント投稿なし(ラベルは付与)
+  --json-only    JSON のみ stdout(ラベル・コメントなし)
+  --self-test    過去 PR サンプルで動作確認
+  -v, --verbose  詳細ログを stderr に出力
+EOF
+    exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)    DRY_RUN=1; shift ;;
+        --no-comment) NO_COMMENT=1; shift ;;
+        --json-only)  JSON_ONLY=1; DRY_RUN=1; shift ;;
+        --self-test)  SELF_TEST=1; shift ;;
+        -v|--verbose) VERBOSE=1; shift ;;
+        -h|--help)    usage ;;
+        [0-9]*)       PR_NUMBER="$1"; shift ;;
+        *)            echo "ERROR: unknown arg: $1" >&2; usage; exit 1 ;;
+    esac
+done
+
+log() { [[ "$VERBOSE" -eq 1 ]] && printf '[%s][%s] %s\n' "$(date '+%H:%M:%S')" "$SCRIPT_NAME" "$*" >&2 || true; }
+err() { printf '[%s][%s] ERROR: %s\n' "$(date '+%H:%M:%S')" "$SCRIPT_NAME" "$*" >&2; }
+
+# ─── 依存チェック ──────────────────────────────────────────────────────────
+for cmd in gh jq; do
+    command -v "$cmd" >/dev/null 2>&1 || { err "required command not found: $cmd"; exit 1; }
+done
+
+# ─── セルフテスト ──────────────────────────────────────────────────────────
+if [[ "$SELF_TEST" -eq 1 ]]; then
+    bash "${BASH_SOURCE[0]%.sh}.test.sh" 2>&1
+    exit $?
+fi
+
+[[ -z "$PR_NUMBER" ]] && { err "PR番号を指定してください"; usage; exit 1; }
+
+# ─── PR 情報取得 ───────────────────────────────────────────────────────────
+log "Fetching PR #$PR_NUMBER info..."
+
+PR_META="$(gh pr view "$PR_NUMBER" \
+    --json number,title,headRefName,additions,deletions,labels,files \
+    2>/dev/null)" || { err "PR #$PR_NUMBER が見つかりません"; exit 1; }
+
+PR_TITLE="$(echo "$PR_META" | jq -r '.title')"
+PR_BRANCH="$(echo "$PR_META" | jq -r '.headRefName')"
+ADDITIONS="$(echo "$PR_META" | jq -r '.additions')"
+DELETIONS="$(echo "$PR_META" | jq -r '.deletions')"
+TOTAL_DIFF=$(( ADDITIONS + DELETIONS ))
+
+# 変更ファイル一覧(パスのみ)
+CHANGED_FILES="$(echo "$PR_META" | jq -r '.files[].path')"
+
+log "PR #$PR_NUMBER: '$PR_TITLE' (+$ADDITIONS/-$DELETIONS, $(echo "$CHANGED_FILES" | wc -l | tr -d ' ') files)"
+
+# ─── リスク判定ロジック ────────────────────────────────────────────────────
+# 判定は「high パスに 1 件でも該当 → high」、
+# 「medium パスに 1 件でも該当 → medium」、
+# 「それ以外全て low/safe パスのみ → low」の優先順位で行う。
+
+RISK_REASONS=()
+AFFECTED_HIGH=()
+AFFECTED_MEDIUM=()
+AFFECTED_LOW=()
+
+# ── high リスクパターン ────────────────────────────────────────────────────
+HIGH_PATTERNS=(
+    # セキュリティ・認証
+    "^src/middleware/"
+    "^src/api/auth"
+    "^src/agent/security"
+    # DB/スキーマ
+    "migration"
+    "\.sql$"
+    "schema"
+    # デプロイ・設定
+    "^SCRIPTS/deploy"
+    "^SCRIPTS/security-scan"
+    "^SCRIPTS/24h-mode"
+    "^\.env"
+    # セーフガード(自己編集禁止)
+    "^\.claude/hooks/"
+    # GitHub Actions (CI 改変)
+    "^\.github/workflows/"
+)
+
+# ── medium リスクパターン (high に該当しない場合) ──────────────────────────
+MEDIUM_PATTERNS=(
+    "^src/"
+    "^admin-ui/src/"
+    "^admin-ui/.*\.(ts|tsx|js|jsx)$"
+    "^SCRIPTS/"
+    "^\.claude/"
+    "package\.json$"
+    "pnpm-lock\.yaml$"
+    "tsconfig"
+    "vite\.config"
+    "ecosystem\.config"
+)
+
+# ── low リスクパターン(全ファイルがこれだけなら low) ──────────────────────
+LOW_PATTERNS=(
+    "^docs/"
+    "\.md$"
+    "^tests/"
+    "\.test\.(ts|tsx|js)$"
+    "^\.wolf/"
+    "^DAILY_REPORT"
+)
+
+classify_file() {
+    local f="$1"
+    # high チェック(最優先)
+    for pat in "${HIGH_PATTERNS[@]}"; do
+        if echo "$f" | grep -qE "$pat"; then
+            echo "high"
+            return
+        fi
+    done
+    # .claude/(hooks 以外)は設定ファイルのため medium(.md でも上書き)
+    if echo "$f" | grep -qE "^\.claude/" && ! echo "$f" | grep -qE "^\.claude/hooks/"; then
+        echo "medium"
+        return
+    fi
+    # low パターンを先にチェック(test ファイルが src/ 配下でも low にする)
+    for pat in "${LOW_PATTERNS[@]}"; do
+        if echo "$f" | grep -qE "$pat"; then
+            echo "low"
+            return
+        fi
+    done
+    # medium チェック
+    for pat in "${MEDIUM_PATTERNS[@]}"; do
+        if echo "$f" | grep -qE "$pat"; then
+            echo "medium"
+            return
+        fi
+    done
+    # デフォルト low
+    echo "low"
+}
+
+HAS_HIGH=0
+HAS_MEDIUM=0
+
+while IFS= read -r file; do
+    [[ -z "$file" ]] && continue
+    cls="$(classify_file "$file")"
+    case "$cls" in
+        high)
+            AFFECTED_HIGH+=("$file")
+            HAS_HIGH=1
+            ;;
+        medium)
+            AFFECTED_MEDIUM+=("$file")
+            HAS_MEDIUM=1
+            ;;
+        *)
+            AFFECTED_LOW+=("$file")
+            ;;
+    esac
+done <<< "$CHANGED_FILES"
+
+# ── 最終リスク決定 ─────────────────────────────────────────────────────────
+RISK="low"
+AUTO_MERGE=true
+
+if [[ "$HAS_HIGH" -eq 1 ]]; then
+    RISK="high"
+    AUTO_MERGE=false
+    for f in "${AFFECTED_HIGH[@]}"; do
+        RISK_REASONS+=("high-risk path: $f")
+    done
+elif [[ "$HAS_MEDIUM" -eq 1 ]]; then
+    RISK="medium"
+    AUTO_MERGE=false
+    # diff 行数で更に判定
+    if [[ "$TOTAL_DIFF" -gt 200 ]]; then
+        RISK="high"
+        AUTO_MERGE=false
+        RISK_REASONS+=("large diff: +${ADDITIONS}/-${DELETIONS} (${TOTAL_DIFF} lines)")
+    fi
+    for f in "${AFFECTED_MEDIUM[@]}"; do
+        RISK_REASONS+=("medium-risk path: $f")
+    done
+else
+    # low のみ
+    RISK="low"
+    AUTO_MERGE=true
+    RISK_REASONS+=("docs/tests/md only")
+fi
+
+# low でも diff が極端に大きければ medium に昇格
+if [[ "$RISK" == "low" ]] && [[ "$TOTAL_DIFF" -gt 500 ]]; then
+    RISK="medium"
+    AUTO_MERGE=false
+    RISK_REASONS+=("large diff even in docs: +${ADDITIONS}/-${DELETIONS}")
+fi
+
+log "Risk: $RISK | auto_merge_eligible: $AUTO_MERGE"
+
+# ─── JSON 組み立て ─────────────────────────────────────────────────────────
+REASON_JSON="$(printf '%s\n' "${RISK_REASONS[@]}" | jq -R . | jq -s .)"
+HIGH_JSON="$(printf '%s\n' "${AFFECTED_HIGH[@]+"${AFFECTED_HIGH[@]}"}" | jq -R . | jq -s .)"
+MEDIUM_JSON="$(printf '%s\n' "${AFFECTED_MEDIUM[@]+"${AFFECTED_MEDIUM[@]}"}" | jq -R . | jq -s .)"
+LOW_JSON="$(printf '%s\n' "${AFFECTED_LOW[@]+"${AFFECTED_LOW[@]}"}" | jq -R . | jq -s .)"
+
+OUTPUT_JSON="$(jq -n \
+    --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    --argjson pr_number "$PR_NUMBER" \
+    --arg pr_title "$PR_TITLE" \
+    --arg pr_branch "$PR_BRANCH" \
+    --arg risk "$RISK" \
+    --argjson reason "$REASON_JSON" \
+    --argjson high_paths "$HIGH_JSON" \
+    --argjson medium_paths "$MEDIUM_JSON" \
+    --argjson low_paths "$LOW_JSON" \
+    --argjson auto_merge "$AUTO_MERGE" \
+    --argjson additions "$ADDITIONS" \
+    --argjson deletions "$DELETIONS" \
+    --argjson total_diff "$TOTAL_DIFF" \
+    '{
+        scored_at:           $ts,
+        pr_number:           $pr_number,
+        pr_title:            $pr_title,
+        pr_branch:           $pr_branch,
+        risk:                $risk,
+        reason:              $reason,
+        affected_paths: {
+            high:   $high_paths,
+            medium: $medium_paths,
+            low:    $low_paths
+        },
+        auto_merge_eligible: $auto_merge,
+        diff_stats: {
+            additions: $additions,
+            deletions: $deletions,
+            total:     $total_diff
+        },
+        scorer_version: "1.0.0",
+        scorer_script:  "SCRIPTS/pr-risk-scorer.sh"
+    }')"
+
+# JSON を stdout に出力
+echo "$OUTPUT_JSON"
+
+# json-only モードはここで終了
+[[ "$JSON_ONLY" -eq 1 ]] && exit 0
+
+# ─── GitHub ラベル付与 ─────────────────────────────────────────────────────
+LABEL="risk:${RISK}"
+REMOVE_LABELS=()
+case "$RISK" in
+    low)    REMOVE_LABELS=("risk:medium" "risk:high") ;;
+    medium) REMOVE_LABELS=("risk:low"    "risk:high") ;;
+    high)   REMOVE_LABELS=("risk:low"    "risk:medium") ;;
+esac
+
+if [[ "$DRY_RUN" -eq 0 ]] && [[ "${PR_RISK_NO_LABEL:-0}" -ne 1 ]]; then
+    log "Applying label: $LABEL to PR #$PR_NUMBER"
+
+    # ラベルが存在しない場合は自動作成
+    for lbl in "risk:low" "risk:medium" "risk:high"; do
+        if ! gh label list --json name -q '.[].name' 2>/dev/null | grep -q "^${lbl}$"; then
+            case "$lbl" in
+                "risk:low")    COLOR="0e8a16" ;;
+                "risk:medium") COLOR="e6b800" ;;
+                "risk:high")   COLOR="d93f0b" ;;
+            esac
+            gh label create "$lbl" --color "$COLOR" --description "Risk Scorer: $lbl" 2>/dev/null || true
+            log "Created label: $lbl"
+        fi
+    done
+
+    gh pr edit "$PR_NUMBER" --add-label "$LABEL" 2>/dev/null || \
+        log "WARN: Failed to add label $LABEL"
+
+    # 旧ラベルを除去
+    for old_lbl in "${REMOVE_LABELS[@]}"; do
+        if echo "$PR_META" | jq -r '.labels[].name' | grep -q "^${old_lbl}$"; then
+            gh pr edit "$PR_NUMBER" --remove-label "$old_lbl" 2>/dev/null || true
+            log "Removed old label: $old_lbl"
+        fi
+    done
+else
+    log "[DRY-RUN] Would apply label: $LABEL"
+fi
+
+# ─── PR コメント投稿 ───────────────────────────────────────────────────────
+risk_emoji() {
+    case "$1" in
+        low)    echo "🟢" ;;
+        medium) echo "🟡" ;;
+        high)   echo "🔴" ;;
+        *)      echo "⚪" ;;
+    esac
+}
+
+EMOJI="$(risk_emoji "$RISK")"
+AUTO_MERGE_TEXT="$([ "$AUTO_MERGE" = "true" ] && echo "✅ auto-merge 候補" || echo "❌ 人間レビュー必要")"
+
+REASON_TEXT="$(printf '%s\n' "${RISK_REASONS[@]}" | head -5 | sed 's/^/- /')"
+[[ ${#AFFECTED_HIGH[@]} -gt 0 ]] && HIGH_TEXT="$(printf '%s\n' "${AFFECTED_HIGH[@]}" | head -5 | sed 's/^/  - /')" || HIGH_TEXT="(なし)"
+[[ ${#AFFECTED_MEDIUM[@]} -gt 0 ]] && MEDIUM_TEXT="$(printf '%s\n' "${AFFECTED_MEDIUM[@]}" | head -5 | sed 's/^/  - /')" || MEDIUM_TEXT="(なし)"
+
+COMMENT_BODY="## ${EMOJI} Risk Scorer 判定 (Phase70-F)
+
+**リスクレベル: \`${RISK}\`** ${EMOJI} | ${AUTO_MERGE_TEXT}
+
+### 判定根拠
+${REASON_TEXT}
+
+### 影響パス
+**high リスクパス:**
+${HIGH_TEXT}
+
+**medium リスクパス (上位5件):**
+${MEDIUM_TEXT}
+
+### diff 統計
+- 追加行: +${ADDITIONS}
+- 削除行: -${DELETIONS}
+- 合計: ${TOTAL_DIFF} 行
+
+### 参照
+- 判定基準: \`docs/MORNING_REVIEW_FLOW.md §3. 判定マトリクス\`
+- スクリプト: \`SCRIPTS/pr-risk-scorer.sh\`
+- JSON 出力: \`bash SCRIPTS/pr-risk-scorer.sh ${PR_NUMBER} --json-only\`
+
+> 自動判定 by Phase70-F Risk Scorer v1.0.0 | $(date '+%Y-%m-%d %H:%M JST')"
+
+if [[ "$DRY_RUN" -eq 0 ]] && [[ "$NO_COMMENT" -eq 0 ]] && [[ "${PR_RISK_NO_COMMENT:-0}" -ne 1 ]]; then
+    log "Posting comment to PR #$PR_NUMBER..."
+    gh pr comment "$PR_NUMBER" --body "$COMMENT_BODY" 2>/dev/null || \
+        log "WARN: Failed to post comment"
+else
+    log "[DRY-RUN/NO-COMMENT] Would post comment to PR #$PR_NUMBER"
+fi
+
+log "Done. PR #$PR_NUMBER risk=$RISK auto_merge_eligible=$AUTO_MERGE"

--- a/SCRIPTS/pr-risk-scorer.test.sh
+++ b/SCRIPTS/pr-risk-scorer.test.sh
@@ -1,0 +1,362 @@
+#!/usr/bin/env bash
+# pr-risk-scorer.test.sh — Phase70-F セルフテスト
+#
+# 過去 PR(#176/#178/#179/#181/#183/#185)を sample に判定実行し、
+# 人間判断と整合するかを検証する。
+#
+# 使い方:
+#   bash SCRIPTS/pr-risk-scorer.test.sh           # 全テスト実行
+#   bash SCRIPTS/pr-risk-scorer.test.sh --live    # 実 PR に接続してテスト(gh CLI 必要)
+#
+# ドライラン(mock)モードでは、PR メタデータを内部で定義して gh CLI を使わずに判定ロジックを検証する。
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCORER="${SCRIPT_DIR}/pr-risk-scorer.sh"
+LIVE=0
+
+[[ "${1:-}" == "--live" ]] && LIVE=1 || true
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+assert_risk() {
+    local label="$1"
+    local pr_number="$2"
+    local expected_risk="$3"
+    local description="$4"
+
+    TOTAL=$(( TOTAL + 1 ))
+    printf '  TEST [%d] %s\n' "$TOTAL" "$label"
+
+    if [[ "$LIVE" -eq 1 ]]; then
+        # 実 gh CLI で判定
+        local actual_json
+        actual_json="$(bash "$SCORER" "$pr_number" --json-only --dry-run 2>/dev/null)" || {
+            printf '    SKIP (gh CLI error or PR not accessible)\n'
+            return
+        }
+        local actual_risk
+        actual_risk="$(echo "$actual_json" | jq -r '.risk')"
+    else
+        # mock モード: テスト用データで判定ロジックを直接検証
+        actual_risk="$(mock_score "$pr_number")"
+    fi
+
+    if [[ "$actual_risk" == "$expected_risk" ]]; then
+        printf '    PASS: risk=%s (expected=%s) — %s\n' "$actual_risk" "$expected_risk" "$description"
+        PASS=$(( PASS + 1 ))
+    else
+        printf '    FAIL: risk=%s (expected=%s) — %s\n' "$actual_risk" "$expected_risk" "$description"
+        FAIL=$(( FAIL + 1 ))
+    fi
+}
+
+# ─── Mock 判定ロジック(ユニットテスト用) ──────────────────────────────────
+# 実際の pr-risk-scorer.sh の判定ロジックをシミュレート
+# 各 PR の変更ファイルリストを内部で定義して判定する
+
+mock_score() {
+    local pr="$1"
+
+    declare -a files=()
+    local additions=0
+    local deletions=0
+
+    case "$pr" in
+        176)
+            # Phase70-A: 24h 安全装置(704 additions, 0 deletions)
+            # docs/, SCRIPTS/24h-mode-*.sh, .claude/hooks/deploy_guard.py
+            files=(
+                "docs/24H_AUTONOMOUS_PLAYBOOK.md"
+                "SCRIPTS/24h-mode-on.sh"
+                "SCRIPTS/24h-mode-off.sh"
+                ".claude/hooks/deploy_guard.py"
+            )
+            additions=704; deletions=0
+            ;;
+        178)
+            # Phase70-J: Asana タスク記述規約(221+0)
+            # docs/ のみ
+            files=(
+                "docs/ASANA_TASK_TEMPLATE.md"
+                "docs/ASANA_24H_ELIGIBLE_TAGS.md"
+            )
+            additions=221; deletions=0
+            ;;
+        179)
+            # Phase70-L: Slack 通知整備(213+0)
+            # SCRIPTS/notify-slack.sh が新規
+            files=(
+                "SCRIPTS/notify-slack.sh"
+                "docs/SLACK_NOTIFY_PATTERNS.md"
+            )
+            additions=213; deletions=0
+            ;;
+        180)
+            # Phase70-B: CLAUDE.md auto-memory(138+336)
+            # CLAUDE.md + docs/ のみ
+            files=(
+                "CLAUDE.md"
+                "docs/PHASE70_B_MEMO.md"
+            )
+            additions=138; deletions=336
+            ;;
+        181)
+            # Phase70-D: Asana Watcher(835+336)
+            # SCRIPTS/asana-watcher.sh が大きい変更
+            files=(
+                "SCRIPTS/asana-watcher.sh"
+                "docs/ASANA_WATCHER_SPEC.md"
+            )
+            additions=835; deletions=336
+            ;;
+        183)
+            # Phase70-E: 24h プロンプトテンプレート(518+0)
+            # docs/ のみ
+            files=(
+                "docs/24H_PROMPT_TEMPLATES.md"
+                "docs/24H_AUTONOMOUS_PLAYBOOK.md"
+            )
+            additions=518; deletions=0
+            ;;
+        185)
+            # Phase70-C: 朝のレビュー受け入れフロー(578+7)
+            # docs/ のみ
+            files=(
+                "docs/MORNING_REVIEW_FLOW.md"
+                "SCRIPTS/morning-digest.sh"
+                "SCRIPTS/codex-result-to-pr.sh"
+            )
+            additions=578; deletions=7
+            ;;
+        *)
+            echo "unknown"
+            return
+            ;;
+    esac
+
+    # 判定ロジックをシミュレート
+    local has_high=0
+    local has_medium=0
+
+    local HIGH_PATS=(
+        "^src/middleware/"
+        "^src/api/auth"
+        "migration"
+        "\.sql$"
+        "schema"
+        "^SCRIPTS/deploy"
+        "^SCRIPTS/security-scan"
+        "^SCRIPTS/24h-mode"
+        "^\.env"
+        "^\.claude/hooks/"
+        "^\.github/workflows/"
+    )
+    local MEDIUM_PATS=(
+        "^src/"
+        "^admin-ui/src/"
+        "^SCRIPTS/"
+        "^\.claude/"
+        "package\.json$"
+        "pnpm-lock\.yaml$"
+        "tsconfig"
+        "ecosystem\.config"
+    )
+
+    local LOW_PATS=(
+        "^docs/"
+        "\.md$"
+        "^tests/"
+        "\.test\.(ts|tsx|js)$"
+        "^\.wolf/"
+        "^DAILY_REPORT"
+    )
+
+    for f in "${files[@]}"; do
+        local cls="low"
+        for pat in "${HIGH_PATS[@]}"; do
+            if echo "$f" | grep -qE "$pat"; then
+                cls="high"; break
+            fi
+        done
+        if [[ "$cls" == "low" ]]; then
+            # low パターンを先にチェック
+            for pat in "${LOW_PATS[@]}"; do
+                if echo "$f" | grep -qE "$pat"; then
+                    cls="low"; break
+                fi
+            done
+            if [[ "$cls" == "low" ]]; then
+                for pat in "${MEDIUM_PATS[@]}"; do
+                    if echo "$f" | grep -qE "$pat"; then
+                        cls="medium"; break
+                    fi
+                done
+            fi
+        fi
+        [[ "$cls" == "high" ]] && has_high=1
+        [[ "$cls" == "medium" ]] && has_medium=1
+    done
+
+    local total=$(( additions + deletions ))
+
+    if [[ "$has_high" -eq 1 ]]; then
+        echo "high"
+    elif [[ "$has_medium" -eq 1 ]]; then
+        if [[ "$total" -gt 200 ]]; then
+            echo "high"
+        else
+            echo "medium"
+        fi
+    else
+        if [[ "$total" -gt 500 ]]; then
+            echo "medium"
+        else
+            echo "low"
+        fi
+    fi
+}
+
+# ─── テストケース定義 ──────────────────────────────────────────────────────
+echo ""
+echo "=== pr-risk-scorer.test.sh (Phase70-F) ==="
+echo "Mode: $([ "$LIVE" -eq 1 ] && echo 'LIVE (real gh CLI)' || echo 'MOCK (internal simulation)')"
+echo ""
+echo "--- Past PR Sample Tests ---"
+echo ""
+
+# PR #176: 24h 安全装置(SCRIPTS/24h-mode-*.sh + .claude/hooks/ あり) → high
+assert_risk "PR#176 Phase70-A 24h-safety" 176 "high" \
+    "24h-mode-*.sh (.high) + .claude/hooks/ (.high) → high"
+
+# PR #178: Asana タスク記述規約(docs/ のみ) → low
+assert_risk "PR#178 Phase70-J docs-only" 178 "low" \
+    "docs/*.md のみ → low"
+
+# PR #179: Slack 通知(SCRIPTS/notify-slack.sh, 213+0=213行) → high
+# SCRIPTS/ は medium だが diff 213 > 200 → high に昇格
+assert_risk "PR#179 Phase70-L SCRIPTS-only" 179 "high" \
+    "SCRIPTS/*.sh medium + diff 213 > 200 → high"
+
+# PR #180: CLAUDE.md + docs/(138+336=474行) → low
+# CLAUDE.md は medium パターンに該当しない(.claudeルール適用なし) → low でも diff=474 < 500 → low
+assert_risk "PR#180 Phase70-B claude-md" 180 "low" \
+    "CLAUDE.md + docs/ (474 lines, < 500) → low"
+
+# PR #181: SCRIPTS/asana-watcher.sh(835+336=1171行) → high (diff > 200 + SCRIPTS = medium で 1171 > 200)
+assert_risk "PR#181 Phase70-D asana-watcher" 181 "high" \
+    "SCRIPTS/ medium + diff 1171 lines > 200 → high"
+
+# PR #183: docs/ のみ(518+0=518行) → medium (diff 518 > 500 → low から medium に昇格)
+assert_risk "PR#183 Phase70-E docs-only" 183 "medium" \
+    "docs/*.md のみ, diff 518 > 500 → medium (large docs diff)"
+
+# PR #185: docs/ + SCRIPTS/(578+7=585行) → SCRIPTS があるため medium 以上、diff=585 > 200 → high
+assert_risk "PR#185 Phase70-C morning-review" 185 "high" \
+    "SCRIPTS/ medium + diff 585 > 200 → high"
+
+echo ""
+echo "--- Unit Tests: Edge Cases ---"
+echo ""
+
+# ─── エッジケースユニットテスト ───────────────────────────────────────────
+unit_test_classify() {
+    local label="$1"
+    local file="$2"
+    local expected="$3"
+
+    TOTAL=$(( TOTAL + 1 ))
+
+    local result
+    result="$(classify_single_file "$file")"
+
+    if [[ "$result" == "$expected" ]]; then
+        printf '  PASS [%d] %s: %s → %s\n' "$TOTAL" "$label" "$file" "$result"
+        PASS=$(( PASS + 1 ))
+    else
+        printf '  FAIL [%d] %s: %s → %s (expected: %s)\n' "$TOTAL" "$label" "$file" "$result" "$expected"
+        FAIL=$(( FAIL + 1 ))
+    fi
+}
+
+classify_single_file() {
+    local f="$1"
+    local HIGH_PATS=(
+        "^src/middleware/"
+        "^src/api/auth"
+        "migration"
+        "\.sql$"
+        "schema"
+        "^SCRIPTS/deploy"
+        "^SCRIPTS/security-scan"
+        "^SCRIPTS/24h-mode"
+        "^\.env"
+        "^\.claude/hooks/"
+        "^\.github/workflows/"
+    )
+    local LOW_PATS=(
+        "^docs/"
+        "\.md$"
+        "^tests/"
+        "\.test\.(ts|tsx|js)$"
+        "^\.wolf/"
+        "^DAILY_REPORT"
+    )
+    local MEDIUM_PATS=(
+        "^src/"
+        "^admin-ui/src/"
+        "^SCRIPTS/"
+        "^\.claude/"
+        "package\.json$"
+        "pnpm-lock\.yaml$"
+        "tsconfig"
+        "ecosystem\.config"
+    )
+    # high 最優先
+    for pat in "${HIGH_PATS[@]}"; do
+        echo "$f" | grep -qE "$pat" && { echo "high"; return; }
+    done
+    # .claude/(hooks 以外)は設定ファイルのため medium(.md でも上書き)
+    if echo "$f" | grep -qE "^\.claude/" && ! echo "$f" | grep -qE "^\.claude/hooks/"; then
+        echo "medium"; return
+    fi
+    # low を medium より先にチェック(test ファイルが src/ 配下でも low)
+    for pat in "${LOW_PATS[@]}"; do
+        echo "$f" | grep -qE "$pat" && { echo "low"; return; }
+    done
+    for pat in "${MEDIUM_PATS[@]}"; do
+        echo "$f" | grep -qE "$pat" && { echo "medium"; return; }
+    done
+    echo "low"
+}
+
+unit_test_classify "middleware → high"        "src/middleware/auth.ts"            "high"
+unit_test_classify "api/auth → high"          "src/api/authRouter.ts"             "high"
+unit_test_classify "migration → high"         "migrations/20260520_add_col.sql"   "high"
+unit_test_classify ".env → high"              ".env.production"                   "high"
+unit_test_classify "hooks → high"             ".claude/hooks/deploy_guard.py"     "high"
+unit_test_classify "workflows → high"         ".github/workflows/ci.yml"          "high"
+unit_test_classify "deploy script → high"     "SCRIPTS/deploy-vps.sh"             "high"
+unit_test_classify "security-scan → high"     "SCRIPTS/security-scan.sh"          "high"
+unit_test_classify "24h-mode → high"          "SCRIPTS/24h-mode-on.sh"            "high"
+unit_test_classify "src/ → medium"            "src/agent/llm/groqClient.ts"       "medium"
+unit_test_classify "admin-ui/src → medium"    "admin-ui/src/components/Table.tsx" "medium"
+unit_test_classify "SCRIPTS/ non-deploy →m"   "SCRIPTS/morning-digest.sh"         "medium"
+unit_test_classify ".claude/ non-hooks → m"   ".claude/agents/gate-runner.md"     "medium"
+unit_test_classify "package.json → medium"    "package.json"                      "medium"
+unit_test_classify "tsconfig → medium"        "tsconfig.json"                     "medium"
+unit_test_classify "docs → low"               "docs/MORNING_REVIEW_FLOW.md"       "low"
+unit_test_classify "*.md → low"               "README.md"                         "low"
+unit_test_classify "tests/ → low"             "tests/integration/auth.test.ts"    "low"
+unit_test_classify "*.test.ts → low"          "src/api/__tests__/faq.test.ts"     "low"
+unit_test_classify ".wolf/ → low"             ".wolf/memory.md"                   "low"
+
+echo ""
+echo "─────────────────────────────────────────────"
+echo "Results: ${PASS} passed, ${FAIL} failed, ${TOTAL} total"
+echo "─────────────────────────────────────────────"
+
+[[ "$FAIL" -eq 0 ]] && { echo "✅ All tests passed"; exit 0; } || { echo "❌ Some tests FAILED"; exit 1; }

--- a/docs/MORNING_REVIEW_FLOW.md
+++ b/docs/MORNING_REVIEW_FLOW.md
@@ -86,7 +86,7 @@ gh pr view <PR番号> --comments | grep -A 20 "codex"
 
 ## 3. 判定マトリクス
 
-> **注**: Risk Scorer (Phase70-F, 未実装) が完成後は自動スコアを参照。現時点は手動判定。
+> **Risk Scorer (Phase70-F 実装済み)**: `bash SCRIPTS/pr-risk-scorer.sh <PR番号>` で自動判定・ラベル付与。手動判定のフォールバックとして本マトリクスを使用。JSON 出力: `bash SCRIPTS/pr-risk-scorer.sh <PR番号> --json-only`
 
 | リスク | 条件 | アクション |
 |---|---|---|
@@ -179,6 +179,8 @@ echo "$(date '+%Y-%m-%d %H:%M') STRIKE: <系統名>" >> ~/.claude-r2c-config/3-s
 |---|---|---|
 | `SCRIPTS/morning-digest.sh` | 夜間 PR + Codex サマリ + Slack 投稿 | Phase70-C で新規作成 |
 | `SCRIPTS/codex-result-to-pr.sh` | Codex review 結果を PR コメントに貼り付け | Phase70-C で新規作成 |
+| `SCRIPTS/pr-risk-scorer.sh` | PR diff から risk:low/medium/high を自動判定 + GitHub ラベル付与 | **Phase70-F で新規作成** |
+| `SCRIPTS/pr-risk-scorer.test.sh` | Risk Scorer の mock/unit テスト | Phase70-F で新規作成 |
 | `SCRIPTS/r2c-morning-report.sh` | cron 06:00 自動 Slack 投稿 (既存) | 稼働中 (参照) |
 | `SCRIPTS/notify-slack.sh` | Slack 通知 (Phase70-L) | 稼働中 |
 | `SCRIPTS/24h-mode-off.sh` | 24h 自走モード解除 | 稼働中 |


### PR DESCRIPTION
## Summary

- `SCRIPTS/pr-risk-scorer.sh` 新規作成（Phase70-F Asana GID: 1214919682795187）
- `SCRIPTS/pr-risk-scorer.test.sh` 新規作成（過去 PR 7件 mock + unit 20件 = 27/27 PASS）
- `SCRIPTS/morning-digest.sh` に Risk Scorer 連携を追加（Phase70-C との独立を維持しつつインターフェース合意）
- `docs/MORNING_REVIEW_FLOW.md` に Phase70-F 実装済み旨を反映

## 実装方式選定根拠

**シェルスクリプト (`SCRIPTS/pr-risk-scorer.sh`) を採用**

| 案 | 長所 | 短所 | 採否 |
|---|---|---|---|
| シェルスクリプト | gh CLI のみ。LLM コスト 0。CI/cron/morning-digest から呼びやすい | 複雑パターンに限界 | ✅ 採用 |
| Claude Code agent | LLM で自然言語判定 | Sonnet 呼び出しコスト毎 PR。10% ルール違反リスク | ❌ |
| GitHub Actions | CI 統合が容易 | PR 作成時のみ。ローカル dry-run 不可 | ❌ (将来拡張候補) |

Asana タスク要件が `SCRIPTS/pr-risk-scorer.sh` と明示していたため、上記を確認して採用。

## 判定ロジック（MORNING_REVIEW_FLOW.md 判定マトリクスと整合）

```
判定優先順位:
  1. high: src/middleware/, src/api/auth*, migration, *.sql, schema,
           SCRIPTS/deploy*, SCRIPTS/security-scan*, SCRIPTS/24h-mode*,
           .env*, .claude/hooks/, .github/workflows/
  2. .claude/ (hooks 以外): medium (設定ファイルのため *.md でも上書き)
  3. low パターン先行: docs/*, *.md, tests/*, *.test.ts, .wolf/ → low
     (src/ 配下の *.test.ts も low になるよう medium より先にチェック)
  4. medium: src/, admin-ui/src/, SCRIPTS/, .claude/, package.json, tsconfig 等
  5. diff 量による昇格: medium + diff > 200行 → high / low + diff > 500行 → medium
```

## 過去 PR サンプルテスト結果（mock モード 27/27 PASS）

| PR | タイトル | 期待 | 実際 | 根拠 |
|---|---|---|---|---|
| #176 | Phase70-A 24h-safety | high | **high** | 24h-mode-*.sh + .claude/hooks/ |
| #178 | Phase70-J docs-only | low | **low** | docs/*.md のみ |
| #179 | Phase70-L Slack 通知 | high | **high** | SCRIPTS/ + diff 213行 > 200 |
| #180 | Phase70-B CLAUDE.md | low | **low** | CLAUDE.md + docs/ (474行 < 500) |
| #181 | Phase70-D Asana Watcher | high | **high** | SCRIPTS/ + diff 1171行 > 200 |
| #183 | Phase70-E 24h テンプレ | medium | **medium** | docs/ のみ diff 518行 > 500 |
| #185 | Phase70-C 朝レビューフロー | high | **high** | SCRIPTS/ + diff 585行 > 200 |

## 70-I Mergify 連携インターフェース（合意済み）

```json
{
  "risk": "low|medium|high",
  "reason": ["high-risk path: src/middleware/auth.ts"],
  "affected_paths": {
    "high": ["src/middleware/auth.ts"],
    "medium": [],
    "low": ["docs/README.md"]
  },
  "auto_merge_eligible": true,
  "diff_stats": { "additions": 10, "deletions": 5, "total": 15 },
  "scorer_version": "1.0.0",
  "scorer_script": "SCRIPTS/pr-risk-scorer.sh"
}
```

Mergify 側は `.github/mergify.yml` の条件式で `auto_merge_eligible: true` かつ `risk: low` のみ auto-merge を許可する想定（Phase70-I で実装）。

## Gate 結果

| Gate | 結果 | 詳細 |
|---|---|---|
| Gate 1 (typecheck) | ✅ 0 errors | bash/docs のみ変更、TS ファイル不変 |
| Gate 1 (tests) | ✅ | 変更ファイルは bash/docs のみ。main で 1617/1617 PASS 確認済み |
| Gate 1.5 (dead-code) | ✅ | 新規孤立なし(既存 37件は Phase70-F 追加分ではない) |
| Gate 2 (security) | ✅ | Critical/High 0 |
| Gate 3 (build) | ✅ | API build + admin-ui build 成功 |

## 使い方

```bash
# PR のリスク判定 + GitHub ラベル付与 + PR コメント投稿
bash SCRIPTS/pr-risk-scorer.sh <PR番号>

# JSON のみ取得(ラベル・コメント不要)
bash SCRIPTS/pr-risk-scorer.sh <PR番号> --json-only

# dry-run(判定のみ、副作用なし)
bash SCRIPTS/pr-risk-scorer.sh <PR番号> --dry-run

# テスト実行
bash SCRIPTS/pr-risk-scorer.test.sh
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)