### PR TITLE
fix(1214919682795187): Risk Scorer 空配列 JSON bug → [] 修正

### DIFF
--- a/SCRIPTS/pr-risk-scorer.sh
+++ b/SCRIPTS/pr-risk-scorer.sh
@@ -254,10 +254,14 @@ fi
 log "Risk: $RISK | auto_merge_eligible: $AUTO_MERGE"
 
 # ─── JSON 組み立て ─────────────────────────────────────────────────────────
-REASON_JSON="$(printf '%s\n' "${RISK_REASONS[@]}" | jq -R . | jq -s .)"
-HIGH_JSON="$(printf '%s\n' "${AFFECTED_HIGH[@]+"${AFFECTED_HIGH[@]}"}" | jq -R . | jq -s .)"
-MEDIUM_JSON="$(printf '%s\n' "${AFFECTED_MEDIUM[@]+"${AFFECTED_MEDIUM[@]}"}" | jq -R . | jq -s .)"
-LOW_JSON="$(printf '%s\n' "${AFFECTED_LOW[@]+"${AFFECTED_LOW[@]}"}" | jq -R . | jq -s .)"
+arr_to_json() {
+    if [[ $# -eq 0 ]]; then echo "[]"; return; fi
+    printf '%s\n' "$@" | jq -R . | jq -s .
+}
+REASON_JSON="$(arr_to_json "${RISK_REASONS[@]+"${RISK_REASONS[@]}"}")"
+HIGH_JSON="$(arr_to_json "${AFFECTED_HIGH[@]+"${AFFECTED_HIGH[@]}"}")"
+MEDIUM_JSON="$(arr_to_json "${AFFECTED_MEDIUM[@]+"${AFFECTED_MEDIUM[@]}"}")"
+LOW_JSON="$(arr_to_json "${AFFECTED_LOW[@]+"${AFFECTED_LOW[@]}"}")"
 
 OUTPUT_JSON="$(jq -n \
     --arg ts "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \


### PR DESCRIPTION
## Summary

Phase70-F Risk Scorer (#186) の軽微な bug fix。

- `affected_paths.high/medium/low` が空のとき `[""]` が出力されていた
- `arr_to_json` ヘルパを追加し、`$# -eq 0` のとき `[]` を返すよう修正

## 確認済み

live dry-run テスト:
- PR #185: `affected_paths.high: []` ✅ (high 判定だが path 由来でなく diff size 由来)
- PR #178: `affected_paths: { high: [], medium: [], low: [...] }` ✅
- PR #183: 全パス正常 ✅
- PR #184: 全パス正常 ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)