### PR TITLE
feat(1214955168745278): Gate 8 統合 smoke test 実装 (Phase70-J)

### DIFF
--- a/.github/workflows/gate-8-post-merge.yml
+++ b/.github/workflows/gate-8-post-merge.yml
@@ -1,0 +1,34 @@
+name: Gate 8 — 統合 smoke (post-merge)
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  gate-8-smoke:
+    name: Gate 8 Integration Smoke
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run Gate 8 smoke
+        env:
+          API_URL: https://api.r2c.biz
+        run: bash SCRIPTS/gate-8-integration-smoke.sh
+
+      - name: Slack alert on failure
+        if: failure()
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_R2C }}
+        run: |
+          COMMIT_SHA="${{ github.sha }}"
+          SHORT_SHA="${COMMIT_SHA:0:7}"
+          PR_TITLE="${{ github.event.head_commit.message }}"
+          MSG="⛔ *Gate 8 FAIL* (post-merge smoke)\ncommit: \`${SHORT_SHA}\`\nmsg: ${PR_TITLE}\n\n直近 PR の rollback を検討してください。\nhttps://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          if [[ -n "${SLACK_WEBHOOK_URL:-}" ]]; then
+            curl -s -X POST "${SLACK_WEBHOOK_URL}" \
+              -H 'Content-type: application/json' \
+              --data "{\"text\":\"${MSG}\"}" || true
+          fi

--- a/SCRIPTS/gate-8-integration-smoke.sh
+++ b/SCRIPTS/gate-8-integration-smoke.sh
@@ -1,0 +1,131 @@
+#!/usr/bin/env bash
+# SCRIPTS/gate-8-integration-smoke.sh — Gate 8: 統合 smoke test (Phase70-J)
+#
+# 目的: 並列 merge 後の統合状態を 3-5 分で検証する
+# 実行タイミング: main push 時 (GitHub Actions gate-8-post-merge.yml)
+# 手動実行:  bash SCRIPTS/gate-8-integration-smoke.sh
+#
+# 終了コード: 0=全 PASS, 1=1 件以上 FAIL
+
+set -euo pipefail
+
+API_URL="${API_URL:-https://api.r2c.biz}"
+PASS=0
+FAIL=0
+FAIL_MSGS=()
+
+# ─────────────────────────────────────────────────────────────────────────────
+pass() { echo "  ✅ $1"; PASS=$((PASS + 1)); }
+fail() { echo "  ❌ $1"; FAIL=$((FAIL + 1)); FAIL_MSGS+=("$1"); }
+http_status() {
+  curl -s -o /dev/null -w "%{http_code}" --max-time 15 "$1" 2>/dev/null || echo "000"
+}
+
+http_post_status() {
+  curl -s -o /dev/null -w "%{http_code}" --max-time 15 -X POST \
+    -H "Content-Type: application/json" -d '{}' "$1" 2>/dev/null || echo "000"
+}
+
+echo "=== Gate 8: 統合 smoke test ($(date '+%Y-%m-%d %H:%M:%S')) ==="
+echo "  API: ${API_URL}"
+echo ""
+
+# ─────────────────────────────────────────────────────────────────────────────
+# A. /health — 基本死活確認
+# ─────────────────────────────────────────────────────────────────────────────
+echo "── A. /health 確認"
+health_body=$(curl -s --max-time 15 "${API_URL}/health" 2>/dev/null || echo '{}')
+health_status=$(echo "${health_body}" | jq -r '.status // empty' 2>/dev/null || echo "")
+
+if [[ "${health_status}" == "ok" ]]; then
+  pass "/health → status=ok"
+else
+  fail "/health → status='${health_status}' (expected 'ok')"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# B. /health/business — ビジネスロジック健全性 (タスク 1214955323125956 完了後有効)
+# ─────────────────────────────────────────────────────────────────────────────
+echo "── B. /health/business 確認"
+biz_code=$(http_status "${API_URL}/health/business")
+if [[ "${biz_code}" == "200" ]]; then
+  biz_body=$(curl -s --max-time 15 "${API_URL}/health/business" 2>/dev/null || echo '{}')
+  warnings=$(echo "${biz_body}" | jq -r '.warnings | length' 2>/dev/null || echo "0")
+  if [[ "${warnings:-0}" -gt 0 ]]; then
+    warn_list=$(echo "${biz_body}" | jq -r '.warnings[]' 2>/dev/null | head -3 | tr '\n' '; ')
+    fail "/health/business → warnings=${warnings}: ${warn_list}"
+  else
+    pass "/health/business → 200, warnings=0"
+  fi
+elif [[ "${biz_code}" == "404" ]]; then
+  # エンドポイント未実装時は SKIP
+  echo "  ⏭  /health/business → 404 SKIP (エンドポイント未実装)"
+else
+  fail "/health/business → HTTP ${biz_code}"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# C. chat エンドポイント probe — POST 認証なしで 401/400/405 を確認 (存在確認)
+#    GET は 404 だが POST は 401 を返す正常動作
+# ─────────────────────────────────────────────────────────────────────────────
+echo "── C. chat エンドポイント probe"
+chat_code=$(http_post_status "${API_URL}/api/chat")
+case "${chat_code}" in
+  200|401|400|405)
+    pass "POST /api/chat → HTTP ${chat_code} (エンドポイント存在確認 OK)" ;;
+  *)
+    fail "POST /api/chat → HTTP ${chat_code} (unexpected)" ;;
+esac
+
+# ─────────────────────────────────────────────────────────────────────────────
+# D. widget endpoint — carnation-demo + widget.js 配信確認
+# ─────────────────────────────────────────────────────────────────────────────
+echo "── D. widget endpoint 確認"
+demo_code=$(http_status "${API_URL}/carnation-demo/")
+case "${demo_code}" in
+  200|301|302)
+    pass "/carnation-demo/ → ${demo_code}" ;;
+  *)
+    fail "/carnation-demo/ → HTTP ${demo_code} (expected 200/3xx)" ;;
+esac
+
+wjs_code=$(http_status "${API_URL}/widget.js")
+if [[ "${wjs_code}" == "200" ]]; then
+  pass "/widget.js → 200"
+else
+  fail "/widget.js → HTTP ${wjs_code} (expected 200)"
+fi
+
+# ─────────────────────────────────────────────────────────────────────────────
+# E. avatar-agent token probe — 認証なし 401/403 を確認 (auth guard 生存確認)
+# ─────────────────────────────────────────────────────────────────────────────
+echo "── E. avatar-agent endpoint probe"
+avatar_code=$(http_status "${API_URL}/api/internal/avatar-config/token")
+case "${avatar_code}" in
+  401|403)
+    pass "/api/internal/avatar-config/token → ${avatar_code} (auth guard OK)" ;;
+  404)
+    echo "  ⏭  /api/internal/avatar-config/token → 404 SKIP (ルート未実装)" ;;
+  *)
+    fail "/api/internal/avatar-config/token → HTTP ${avatar_code} (unexpected)" ;;
+esac
+
+# ─────────────────────────────────────────────────────────────────────────────
+# 結果サマリ
+# ─────────────────────────────────────────────────────────────────────────────
+echo ""
+echo "─────────────────────────────────────────"
+echo "Gate 8 結果: PASS=${PASS} / FAIL=${FAIL}"
+
+if [[ ${FAIL} -gt 0 ]]; then
+  echo ""
+  echo "⛔ 失敗項目:"
+  for msg in "${FAIL_MSGS[@]}"; do
+    echo "  - ${msg}"
+  done
+  echo ""
+  echo "❌ Gate 8 FAIL — 直近 PR の rollback を検討してください"
+  exit 1
+fi
+
+echo "✅ Gate 8 PASS"

--- a/docs/MORNING_REVIEW_FLOW.md
+++ b/docs/MORNING_REVIEW_FLOW.md
@@ -70,6 +70,21 @@ done
 | Gate 1 (verify) | PR checks 結果 | 全 green |
 | Gate 2 (security) | PR checks 結果 | High/Critical = 0 |
 | Gate 2.5 (Codex) | PR コメント (`/codex:review` 結果) | Codex P0/P1 なし |
+| **Gate 8 (統合 smoke)** | GitHub Actions `gate-8-post-merge.yml` 結果 | 全チェック PASS |
+
+**Gate 8 確認コマンド (直近 24h の結果):**
+
+```bash
+# GitHub Actions の最新 Gate 8 実行結果
+gh run list --workflow=gate-8-post-merge.yml --limit 5 \
+  --json status,conclusion,createdAt,headCommit \
+  --template '{{range .}}{{.createdAt}} {{.conclusion}} ({{.headCommit.message}})\n{{end}}'
+
+# 失敗していた場合: ログ確認
+gh run view --workflow=gate-8-post-merge.yml --log-failed
+```
+
+> Gate 8 が失敗している場合 → 直近 merge した PR を特定して rollback 検討。手動実行: `bash SCRIPTS/gate-8-integration-smoke.sh`
 
 ```bash
 # Codex review 結果をコメントで確認
@@ -184,6 +199,7 @@ echo "$(date '+%Y-%m-%d %H:%M') STRIKE: <系統名>" >> ~/.claude-r2c-config/3-s
 | `SCRIPTS/r2c-morning-report.sh` | cron 06:00 自動 Slack 投稿 (既存) | 稼働中 (参照) |
 | `SCRIPTS/notify-slack.sh` | Slack 通知 (Phase70-L) | 稼働中 |
 | `SCRIPTS/24h-mode-off.sh` | 24h 自走モード解除 | 稼働中 |
+| `SCRIPTS/gate-8-integration-smoke.sh` | Gate 8 統合 smoke (Phase70-J) | **Phase70-J で新規作成** |
 
 ---
 
@@ -227,6 +243,7 @@ flowchart TD
 - [ ] 全 PR の CI checks が green
 - [ ] `Stream Path Check` / `Security Scan` が green
 - [ ] Codex review 結果が各 PR コメントにある（なければ `codex-result-to-pr.sh` 実行）
+- [ ] **直近 24h の Gate 8 結果が PASS** (`gh run list --workflow=gate-8-post-merge.yml --limit 5`)
 
 ### フェーズ 3: 個別 PR 判定（〜60 分、PR 1 本 5〜10 分目安）
 - [ ] 判定マトリクスで low / medium / medium-high / high / reject を分類

--- a/docs/TEST_DEPLOY_GATE.md
+++ b/docs/TEST_DEPLOY_GATE.md
@@ -66,6 +66,12 @@ Gate 6: UI調査（UI変更Phase: 必須）
   │  ★ UI変更がないPhaseではスキップ可
   │
   ▼
+Gate 8: 統合 smoke（自動・main push 後）
+  │  bash SCRIPTS/gate-8-integration-smoke.sh
+  │  (GitHub Actions gate-8-post-merge.yml が自動実行)
+  │  FAIL → Slack #r2c alert + rollback 検討
+  │
+  ▼
 完了 → Asanaタスク完了 → PHASE_ROADMAP.md更新
 ```
 
@@ -269,16 +275,64 @@ Gate 4bと同様、UI変更がないPhaseではスキップ可。
 
 ---
 
+## 9.5. Gate 8: 統合 smoke（自動・main push 後）
+
+> UATa 事例 #11「並列後の統合検証なし」由来 (Phase70-J)
+
+### 目的
+
+複数 PR の並列 merge 後に、統合された状態で主要エンドポイントが正常に動作することを確認する。  
+Gate 1-6 は各 PR 単体の品質を担保するが、Gate 8 は **merge 後の統合状態** を検証する。
+
+### 実行タイミング
+
+- **自動**: `.github/workflows/gate-8-post-merge.yml` が main push 時に実行
+- **手動**: `bash SCRIPTS/gate-8-integration-smoke.sh`
+
+### チェック内容（3-5 分で完走）
+
+| ステップ | 確認内容 | 期待値 |
+|---|---|---|
+| A. /health | 基本死活確認 | status=ok |
+| B. /health/business | ビジネスロジック健全性 | warnings=0 (未実装時 SKIP) |
+| C. /api/chat | chat エンドポイント存在確認 | 200/401/400/405 |
+| D. /carnation-demo/ + /widget.js | widget 配信確認 | 200/3xx |
+| E. avatar-agent token | auth guard 生存確認 | 401/403 (未実装時 SKIP) |
+
+### 失敗時のアクション
+
+1. GitHub Actions の失敗通知が Slack `#r2c` に届く
+2. 失敗項目を確認し、直近 merge した PR との関係を調査
+3. 問題 PR の rollback を検討（`gh pr revert <PR番号>`）
+4. 修正 PR を作成して再 merge
+
+```bash
+# 手動実行
+bash SCRIPTS/gate-8-integration-smoke.sh
+
+# 特定環境向け
+API_URL=https://staging.r2c.biz bash SCRIPTS/gate-8-integration-smoke.sh
+```
+
+### 制約・設計方針
+
+- Playwright / ブラウザは使わない（Gate 4b/6 と区別、軽量化重視）
+- VPS 操作なし（GitHub Actions / ローカル smoke のみ）
+- 既存 Gate 1-6 / 1.6 とは独立した別系統
+- 認証が必要な機能は「エンドポイント存在確認」のみ（API キー不要）
+
+---
+
 ## 10. 組み合わせパターン
 
 > ★ Gate 1-3 は @gate-runner で一括実行可能（.claude/agents/gate-runner.md）
 
 | Phase種別 | Gate順序 |
 |---|---|
-| **UI変更を含むデプロイ（★ Phase54以降の標準）** | Gate 1-2 → Gate 2.5（Codex） → Gate 3 → git push → Gate 4b（Chrome） → デプロイ → Gate 5 + Gate 6 |
-| **API追加のみ（UI変更なし）** | Gate 1-2 → Gate 2.5（Codex） → Gate 3 → git push → デプロイ → Gate 5 |
-| **typo・ドキュメントのみ** | Gate 1 → git push → デプロイ → Gate 5 |
-| **セキュリティ変更** | Gate 1-2 → Gate 2.5（adversarial-review） → Gate 3 → git push → Gate 4b → デプロイ → Gate 5 + Gate 6 |
+| **UI変更を含むデプロイ（★ Phase54以降の標準）** | Gate 1-2 → Gate 2.5（Codex） → Gate 3 → git push → Gate 4b（Chrome） → デプロイ → Gate 5 + Gate 6 → **Gate 8（自動）** |
+| **API追加のみ（UI変更なし）** | Gate 1-2 → Gate 2.5（Codex） → Gate 3 → git push → デプロイ → Gate 5 → **Gate 8（自動）** |
+| **typo・ドキュメントのみ** | Gate 1 → git push → デプロイ → Gate 5 → **Gate 8（自動）** |
+| **セキュリティ変更** | Gate 1-2 → Gate 2.5（adversarial-review） → Gate 3 → git push → Gate 4b → デプロイ → Gate 5 + Gate 6 → **Gate 8（自動）** |
 
 **UI変更を含むPhaseでは Gate 4b と Gate 6 を絶対にスキップしない。**
 


### PR DESCRIPTION
## Summary

- `SCRIPTS/gate-8-integration-smoke.sh` 新規作成 — 3-5分で完走する軽量 smoke
- `.github/workflows/gate-8-post-merge.yml` 新規作成 — main push 後に自動実行、失敗時 Slack alert
- `docs/TEST_DEPLOY_GATE.md` Gate 8 章 (§9.5) 新設、フロー全体図・組み合わせパターン更新
- `docs/MORNING_REVIEW_FLOW.md` 朝レビューの Gate 8 確認手順・早見表チェックリスト追加

## 背景

UATa 事例 #11「並列後の統合検証なし」対応。複数 PR の並列 merge 後に統合状態が壊れても、既存 Gate 1-6 は個別 PR の品質しか担保しない問題を解消。

## Gate 8 smoke チェック内容

| ステップ | 確認内容 | 実測結果 |
|---|---|---|
| A. /health | 基本死活 | status=ok ✅ |
| B. /health/business | ビジネス健全性 | 404 SKIP (未実装) ⏭ |
| C. POST /api/chat | chat エンドポイント存在 | 401 ✅ |
| D. /carnation-demo/ + /widget.js | widget 配信 | 200 ✅ |
| E. avatar-agent token | auth guard | 404 SKIP (未実装) ⏭ |

**Gate 8 手動実行結果: PASS=4 / FAIL=0 ✅**

## ガードレール遵守確認

- ✅ Playwright 不使用 (curl のみ)
- ✅ VPS 操作なし
- ✅ 既存 Gate 1-6 / 1.6 に変更なし
- ✅ `.mergify.yml` への副作用なし (別 workflow ファイルとして追加)
- ✅ shellcheck PASS

## Test plan

- [ ] `shellcheck SCRIPTS/gate-8-integration-smoke.sh` → PASS
- [ ] `bash SCRIPTS/gate-8-integration-smoke.sh` → Gate 8 PASS (PASS=4/FAIL=0)
- [ ] `docs/TEST_DEPLOY_GATE.md` Gate 8 章の内容確認
- [ ] `docs/MORNING_REVIEW_FLOW.md` 早見表チェックリスト追加確認
- [ ] `.github/workflows/gate-8-post-merge.yml` 構文確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)