### PR TITLE
feat(1214954523638712): R2C stuck-detector daemon

### DIFF
--- a/SCRIPTS/r2c-stuck-detector.sh
+++ b/SCRIPTS/r2c-stuck-detector.sh
@@ -1,0 +1,405 @@
+#!/usr/bin/env bash
+# r2c-stuck-detector.sh — 24h 自走 stuck 検知 daemon (Phase70-?)
+#
+# 機能:
+#   1. ~/.claude-r2c-config/heartbeat mtime を監視
+#   2. ~/.claude/projects/<path>/*.jsonl 最新 mtime を監視
+#   3. 30分更新なし → Slack #r2c 警告
+#   4. 90分超 → session kill + worktree クリーンアップ + 再dispatch (3回上限)
+#   5. 3回失敗 → Slack HIGH + Pushover
+#
+# 制約: SSH コマンド使用禁止 / DB migration 禁止 / set-e + ${VAR:-0} ガード必須
+#
+# 使い方:
+#   bash SCRIPTS/r2c-stuck-detector.sh [--dry-run] [--one-shot] [--verbose]
+#
+# 環境変数オーバーライド:
+#   STUCK_WARN_THRESHOLD   警告閾値(秒) デフォルト 1800 (30分)
+#   STUCK_KILL_THRESHOLD   kill 閾値(秒) デフォルト 5400 (90分)
+#   STUCK_POLL_INTERVAL    ポーリング間隔(秒) デフォルト 60
+#   MAX_DISPATCH_ATTEMPTS  最大 dispatch 試行回数 デフォルト 3
+#   DISPATCH_COMMAND       再dispatch コマンド (未設定時は Slack 通知のみ)
+#   HEARTBEAT_FILE         heartbeat ファイルパス (デフォルト: R2C_CONFIG/heartbeat)
+#   CLAUDE_PROJECTS_DIR    jsonl 検索ベースディレクトリ (デフォルト: ~/.claude/projects)
+#
+# Phase: 70-? (Asana GID 1214954523638712)
+
+# shellcheck disable=SC2155
+set -euo pipefail
+
+SCRIPT_NAME="$(basename "$0" .sh)"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# ─── Config paths ─────────────────────────────────────────────────────────────
+R2C_CONFIG="${R2C_CONFIG:-$HOME/.claude-r2c-config}"
+LOG_DIR="${R2C_CONFIG}/logs"
+NOTIFY="${NOTIFY_SCRIPT:-${SCRIPT_DIR}/notify-slack.sh}"
+
+HEARTBEAT_FILE="${HEARTBEAT_FILE:-${R2C_CONFIG}/heartbeat}"
+CLAUDE_PROJECTS_DIR="${CLAUDE_PROJECTS_DIR:-${HOME}/.claude/projects}"
+REPO_DIR="${REPO_DIR:-$(cd "${SCRIPT_DIR}/.." && pwd)}"
+
+# ─── Thresholds ───────────────────────────────────────────────────────────────
+WARN_THRESHOLD="${STUCK_WARN_THRESHOLD:-1800}"    # 30 min
+KILL_THRESHOLD="${STUCK_KILL_THRESHOLD:-5400}"    # 90 min
+MAX_DISPATCH="${MAX_DISPATCH_ATTEMPTS:-3}"
+POLL_INTERVAL="${STUCK_POLL_INTERVAL:-60}"        # 1 min
+
+# ─── State files ─────────────────────────────────────────────────────────────
+DISPATCH_COUNT_FILE="${R2C_CONFIG}/.stuck-dispatch-count"
+DISPATCH_LOCK_FILE="${R2C_CONFIG}/.stuck-dispatch-locked"
+
+# ─── CLI options ─────────────────────────────────────────────────────────────
+DRY_RUN=0
+ONE_SHOT=0
+VERBOSE=0
+
+usage() {
+    cat <<'USAGE'
+Usage: r2c-stuck-detector.sh [options]
+
+Options:
+  --dry-run    検知のみ実行(kill/dispatch は行わない)
+  --one-shot   1 サイクルだけ実行して終了(テスト用)
+  --verbose    詳細ログ出力
+  -h, --help   このヘルプを表示
+
+環境変数:
+  STUCK_WARN_THRESHOLD  警告閾値(秒) デフォルト 1800
+  STUCK_KILL_THRESHOLD  kill 閾値(秒) デフォルト 5400
+  STUCK_POLL_INTERVAL   ポーリング間隔(秒) デフォルト 60
+  MAX_DISPATCH_ATTEMPTS 最大 dispatch 試行回数 デフォルト 3
+  DISPATCH_COMMAND      再dispatch コマンド
+USAGE
+}
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --dry-run)  DRY_RUN=1; shift ;;
+        --one-shot) ONE_SHOT=1; shift ;;
+        --verbose)  VERBOSE=1; shift ;;
+        -h|--help)  usage; exit 0 ;;
+        *) printf 'ERROR: unknown option: %s\n' "$1" >&2; usage; exit 1 ;;
+    esac
+done
+
+# ─── Logging ─────────────────────────────────────────────────────────────────
+mkdir -p "$LOG_DIR"
+LOG_FILE="${LOG_DIR}/${SCRIPT_NAME}.log"
+# Redirect stdout/stderr to log only when not in one-shot/test mode
+if [[ "${ONE_SHOT:-0}" -eq 0 && "${STUCK_DETECTOR_SOURCED:-0}" -eq 0 ]]; then
+    exec >> "$LOG_FILE" 2>&1
+fi
+
+ts()   { date '+%Y-%m-%d %H:%M:%S'; }
+log()  { printf '[%s] [%s] %s\n' "$(ts)" "$SCRIPT_NAME" "$*"; }
+vlog() { [[ "${VERBOSE:-0}" -eq 1 ]] && log "$*" || true; }
+
+# ─── File mtime (macOS stat -f / Linux stat -c) ───────────────────────────────
+get_file_mtime() {
+    local file="${1:-}"
+    [[ -f "${file}" ]] || { echo "0"; return 0; }
+    local mtime
+    mtime=$(stat -f %m "${file}" 2>/dev/null \
+        || stat -c %Y "${file}" 2>/dev/null \
+        || echo "0")
+    echo "${mtime:-0}"
+}
+
+# ─── Heartbeat mtime ─────────────────────────────────────────────────────────
+get_heartbeat_mtime() {
+    get_file_mtime "${HEARTBEAT_FILE}"
+}
+
+# ─── Newest JSONL mtime under ~/.claude/projects/ ────────────────────────────
+get_newest_jsonl_mtime() {
+    local projects_dir="${1:-$CLAUDE_PROJECTS_DIR}"
+    [[ -d "${projects_dir}" ]] || { echo "0"; return 0; }
+    local newest=0
+    local mtime
+    while IFS= read -r -d '' f; do
+        mtime=$(get_file_mtime "${f}")
+        mtime="${mtime:-0}"
+        if [[ "${mtime:-0}" -gt "${newest:-0}" ]]; then
+            newest="${mtime}"
+        fi
+    done < <(find "${projects_dir}" -name "*.jsonl" -maxdepth 4 -print0 2>/dev/null || true)
+    echo "${newest:-0}"
+}
+
+# ─── sqlite3 count guard (UATa 事例 #2: 空文字列 → 整数比較 SIGFPE 防止) ────────
+# 呼び出し: get_sqlite_count <db_path> <query>
+# 返値: 整数(0以上)。DB不在・空文字・非整数は 0 を返す。
+get_sqlite_count() {
+    local db="${1:-}" query="${2:-SELECT 1}"
+    [[ -f "${db}" ]] || { echo "0"; return 0; }
+    local count
+    count=$(sqlite3 "${db}" "${query}" 2>/dev/null || echo "0")
+    count="${count:-0}"
+    # Guard: 非整数は 0 に正規化
+    if ! [[ "${count}" =~ ^[0-9]+$ ]]; then
+        count=0
+    fi
+    echo "${count:-0}"
+}
+
+# ─── Latest activity: max(heartbeat mtime, newest jsonl mtime) ───────────────
+get_latest_activity() {
+    local hb_mtime jsonl_mtime
+    hb_mtime=$(get_heartbeat_mtime)
+    hb_mtime="${hb_mtime:-0}"
+    jsonl_mtime=$(get_newest_jsonl_mtime)
+    jsonl_mtime="${jsonl_mtime:-0}"
+    if [[ "${hb_mtime:-0}" -gt "${jsonl_mtime:-0}" ]]; then
+        echo "${hb_mtime:-0}"
+    else
+        echo "${jsonl_mtime:-0}"
+    fi
+}
+
+# ─── Stale seconds (0 を返す場合はハートビートなし ─ false-alarm 防止) ────────
+get_stale_secs() {
+    local latest now stale
+    latest=$(get_latest_activity)
+    latest="${latest:-0}"
+    if [[ "${latest:-0}" -eq 0 ]]; then
+        # heartbeat ファイルが一切存在しない = 24h 自走未開始とみなし false-alarm 防止
+        echo "0"
+        return 0
+    fi
+    now=$(date +%s)
+    now="${now:-0}"
+    stale=$(( ${now:-0} - ${latest:-0} ))
+    echo "${stale:-0}"
+}
+
+# ─── Dispatch attempt tracking ───────────────────────────────────────────────
+get_dispatch_count() {
+    [[ -f "${DISPATCH_COUNT_FILE}" ]] || { echo "0"; return 0; }
+    local count
+    count=$(cat "${DISPATCH_COUNT_FILE}" 2>/dev/null || echo "0")
+    count="${count:-0}"
+    if ! [[ "${count}" =~ ^[0-9]+$ ]]; then
+        count=0
+    fi
+    echo "${count:-0}"
+}
+
+increment_dispatch_count() {
+    local current
+    current=$(get_dispatch_count)
+    current="${current:-0}"
+    printf '%d\n' "$(( ${current:-0} + 1 ))" > "${DISPATCH_COUNT_FILE}"
+}
+
+reset_dispatch_count() {
+    printf '0\n' > "${DISPATCH_COUNT_FILE}"
+    [[ -f "${DISPATCH_LOCK_FILE}" ]] && rm -f "${DISPATCH_LOCK_FILE}" || true
+}
+
+# ─── Session kill (SIGTERM → 3秒待機 → SIGKILL) ───────────────────────────────
+kill_session() {
+    log "Killing stuck Claude session..."
+    if [[ "${DRY_RUN:-0}" -eq 1 ]]; then
+        log "[dry-run] would: pkill -TERM -f 'node.*claude'"
+        return 0
+    fi
+    pkill -TERM -f "node.*claude" 2>/dev/null || true
+    sleep 3
+    pkill -KILL -f "node.*claude" 2>/dev/null || true
+    log "Session kill sent."
+}
+
+# ─── Worktree cleanup ─────────────────────────────────────────────────────────
+cleanup_worktrees() {
+    log "Cleaning up worktrees in ${REPO_DIR}..."
+    if [[ "${DRY_RUN:-0}" -eq 1 ]]; then
+        log "[dry-run] would: git worktree remove --force <non-main worktrees>"
+        return 0
+    fi
+    [[ -d "${REPO_DIR}/.git" ]] || {
+        log "WARN: ${REPO_DIR} is not a git repo root, skipping worktree cleanup"
+        return 0
+    }
+    local main_path wt_path
+    main_path="$(cd "${REPO_DIR}" && git rev-parse --show-toplevel 2>/dev/null || echo "${REPO_DIR}")"
+    main_path="${main_path:-${REPO_DIR}}"
+    (
+        cd "${REPO_DIR}" || exit 0
+        git worktree list --porcelain 2>/dev/null \
+            | grep "^worktree" \
+            | awk '{print $2}' \
+            | while IFS= read -r wt_path; do
+                if [[ "${wt_path}" != "${main_path}" ]]; then
+                    log "Removing worktree: ${wt_path}"
+                    git worktree remove --force "${wt_path}" 2>/dev/null || true
+                fi
+            done
+        git worktree prune 2>/dev/null || true
+    )
+    log "Worktree cleanup done."
+}
+
+# ─── Re-dispatch (attempts をインクリメントしてから実行) ─────────────────────
+dispatch_session() {
+    local current_count new_count
+    current_count=$(get_dispatch_count)
+    current_count="${current_count:-0}"
+
+    if [[ "${current_count:-0}" -ge "${MAX_DISPATCH:-3}" ]]; then
+        log "ERROR: max dispatch attempts (${MAX_DISPATCH:-3}) reached."
+        return 1
+    fi
+
+    increment_dispatch_count
+    new_count=$(get_dispatch_count)
+    new_count="${new_count:-0}"
+    log "Dispatching new session (attempt ${new_count:-0}/${MAX_DISPATCH:-3})..."
+
+    if [[ "${DRY_RUN:-0}" -eq 1 ]]; then
+        log "[dry-run] would dispatch: DISPATCH_COMMAND=${DISPATCH_COMMAND:-<unset>}"
+        return 0
+    fi
+
+    # heartbeat リセット (再 dispatch を記録)
+    mkdir -p "$(dirname "${HEARTBEAT_FILE}")"
+    touch "${HEARTBEAT_FILE}" 2>/dev/null || true
+
+    local dispatch_cmd="${DISPATCH_COMMAND:-}"
+    if [[ -n "${dispatch_cmd}" ]]; then
+        log "Executing: ${dispatch_cmd}"
+        eval "${dispatch_cmd}" &
+        disown 2>/dev/null || true
+    else
+        log "WARN: DISPATCH_COMMAND not configured. Manual restart required."
+        "$NOTIFY" \
+            "⚠️ stuck-detector: session kill 完了 (attempt ${new_count:-0}/${MAX_DISPATCH:-3})。DISPATCH_COMMAND 未設定のため手動再起動してください。" \
+            --color warning 2>/dev/null || true
+    fi
+    return 0
+}
+
+# ─── Pushover (credentials 未設定時は silent skip) ───────────────────────────
+notify_pushover() {
+    local message="${1:-}"
+    # shellcheck disable=SC1091
+    [[ -f "${R2C_CONFIG}/secrets/r2c-loop.env" ]] \
+        && source "${R2C_CONFIG}/secrets/r2c-loop.env" || true
+    local token="${PUSHOVER_APP_TOKEN:-}"
+    local user="${PUSHOVER_USER_KEY:-}"
+    if [[ -z "${token}" || -z "${user}" ]]; then
+        log "WARN: Pushover credentials not set (PUSHOVER_APP_TOKEN / PUSHOVER_USER_KEY)"
+        return 0
+    fi
+    if [[ "${DRY_RUN:-0}" -eq 1 ]]; then
+        log "[dry-run] Pushover: ${message}"
+        return 0
+    fi
+    curl -sS --max-time 10 \
+        -F "token=${token}" \
+        -F "user=${user}" \
+        -F "message=${message}" \
+        -F "priority=1" \
+        "https://api.pushover.net/1/messages.json" > /dev/null 2>&1 \
+        || log "WARN: Pushover notification failed"
+}
+
+# ─── Action: 30分警告 ─────────────────────────────────────────────────────────
+action_warn() {
+    local stale_secs="${1:-0}"
+    local stale_mins=$(( ${stale_secs:-0} / 60 ))
+    log "WARN: 30分以上更新なし (${stale_mins:-0}分経過)"
+    if [[ "${DRY_RUN:-0}" -eq 1 ]]; then
+        log "[dry-run] would: notify-slack warning"
+        return 0
+    fi
+    "$NOTIFY" \
+        "⚠️ R2C stuck-detector: ${stale_mins:-0}分間 heartbeat 更新なし。セッションが止まっている可能性があります。" \
+        --color warning 2>/dev/null || true
+}
+
+# ─── Action: 90分 kill + dispatch ─────────────────────────────────────────────
+action_kill_and_dispatch() {
+    local stale_secs="${1:-0}"
+    local stale_mins=$(( ${stale_secs:-0} / 60 ))
+    local attempt
+    attempt=$(get_dispatch_count)
+    attempt="${attempt:-0}"
+    local next_attempt=$(( ${attempt:-0} + 1 ))
+
+    log "ERROR: ${stale_mins:-0}分無応答 — kill + dispatch 開始 (attempt ${next_attempt:-1}/${MAX_DISPATCH:-3})"
+
+    if [[ "${DRY_RUN:-0}" -eq 1 ]]; then
+        log "[dry-run] would: Slack error, kill_session, cleanup_worktrees, dispatch_session"
+        return 0
+    fi
+
+    "$NOTIFY" \
+        "🔴 R2C stuck-detector: ${stale_mins:-0}分無応答。session kill + worktree cleanup → 再dispatch (attempt ${next_attempt:-1}/${MAX_DISPATCH:-3})" \
+        --color error 2>/dev/null || true
+
+    kill_session
+    cleanup_worktrees
+
+    if ! dispatch_session; then
+        # 3回上限到達 → HIGH + Pushover
+        log "ERROR: max dispatch attempts reached — HUMAN-REVIEW-REQUIRED"
+        "$NOTIFY" \
+            "🚨 R2C stuck-detector: 再dispatch ${MAX_DISPATCH:-3}回失敗。HUMAN-REVIEW-REQUIRED。手動確認してください。" \
+            --color error 2>/dev/null || true
+        notify_pushover "R2C stuck-detector: ${MAX_DISPATCH:-3}回 re-dispatch 失敗。HUMAN-REVIEW-REQUIRED。"
+        touch "${DISPATCH_LOCK_FILE}"
+    fi
+}
+
+# ─── 1サイクル ────────────────────────────────────────────────────────────────
+run_check() {
+    local stale_secs
+    stale_secs=$(get_stale_secs)
+    stale_secs="${stale_secs:-0}"
+
+    vlog "stale=${stale_secs:-0}s warn=${WARN_THRESHOLD:-1800}s kill=${KILL_THRESHOLD:-5400}s"
+
+    # dispatch がロックされていれば何もしない
+    if [[ -f "${DISPATCH_LOCK_FILE}" ]]; then
+        vlog "dispatch locked (max attempts reached), skipping"
+        return 0
+    fi
+
+    if [[ "${stale_secs:-0}" -ge "${KILL_THRESHOLD:-5400}" ]]; then
+        action_kill_and_dispatch "${stale_secs}"
+    elif [[ "${stale_secs:-0}" -ge "${WARN_THRESHOLD:-1800}" ]]; then
+        action_warn "${stale_secs}"
+    else
+        vlog "healthy (stale=${stale_secs:-0}s)"
+        # 正常稼働中は dispatch カウントをリセット
+        if [[ -f "${DISPATCH_COUNT_FILE}" ]]; then
+            reset_dispatch_count
+        fi
+    fi
+}
+
+# ─── メインループ ─────────────────────────────────────────────────────────────
+main() {
+    log "r2c-stuck-detector start (warn=${WARN_THRESHOLD:-1800}s kill=${KILL_THRESHOLD:-5400}s poll=${POLL_INTERVAL:-60}s dry_run=${DRY_RUN:-0} one_shot=${ONE_SHOT:-0})"
+
+    # secrets ロード
+    # shellcheck disable=SC1091
+    [[ -f "${R2C_CONFIG}/secrets/r2c-loop.env" ]] \
+        && source "${R2C_CONFIG}/secrets/r2c-loop.env" || true
+
+    mkdir -p "${R2C_CONFIG}"
+
+    if [[ "${ONE_SHOT:-0}" -eq 1 ]]; then
+        run_check
+        return 0
+    fi
+
+    while true; do
+        run_check
+        sleep "${POLL_INTERVAL:-60}"
+    done
+}
+
+# テスト用 source 時はメイン実行しない
+[[ "${STUCK_DETECTOR_SOURCED:-0}" -eq 1 ]] || main

--- a/SCRIPTS/r2c-stuck-detector.test.sh
+++ b/SCRIPTS/r2c-stuck-detector.test.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# r2c-stuck-detector.test.sh
+# テスト対象: SCRIPTS/r2c-stuck-detector.sh
+#
+# カバー範囲:
+#   1. get_heartbeat_mtime — heartbeat ファイル不在 → 0
+#   2. get_newest_jsonl_mtime — 空ディレクトリ → 0
+#   3. get_sqlite_count — sqlite3 空文字返却 / DB不在 → 0
+#   4. get_stale_secs — heartbeat 不在 → false-alarm 防止で 0
+#   5. get_stale_secs — 新鮮なファイル → 0〜WARN 未満
+#   6. stuck 判定 — 30分閾値テスト (STUCK_WARN_THRESHOLD=5)
+#   7. stuck 判定 — 90分閾値テスト (STUCK_KILL_THRESHOLD=10)
+#   8. get_sqlite_count — 非整数文字列 → 0 (ガード確認)
+#   9. get_dispatch_count — ファイル不在 → 0
+#  10. increment/reset dispatch count
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DETECTOR="${SCRIPT_DIR}/r2c-stuck-detector.sh"
+
+# ─── テストフレームワーク ─────────────────────────────────────────────────────
+PASS=0
+FAIL=0
+SKIP=0
+
+assert_eq() {
+    local desc="$1" expected="$2" actual="$3"
+    if [[ "${expected}" == "${actual}" ]]; then
+        printf '  PASS: %s\n' "${desc}"
+        (( PASS++ )) || true
+    else
+        printf '  FAIL: %s\n    expected=%q  actual=%q\n' "${desc}" "${expected}" "${actual}"
+        (( FAIL++ )) || true
+    fi
+}
+
+assert_ge() {
+    local desc="$1" min="$2" actual="$3"
+    if [[ "${actual:-0}" -ge "${min:-0}" ]]; then
+        printf '  PASS: %s\n' "${desc}"
+        (( PASS++ )) || true
+    else
+        printf '  FAIL: %s (expected>=%s, actual=%s)\n' "${desc}" "${min}" "${actual}"
+        (( FAIL++ )) || true
+    fi
+}
+
+assert_lt() {
+    local desc="$1" max="$2" actual="$3"
+    if [[ "${actual:-0}" -lt "${max:-0}" ]]; then
+        printf '  PASS: %s\n' "${desc}"
+        (( PASS++ )) || true
+    else
+        printf '  FAIL: %s (expected<%s, actual=%s)\n' "${desc}" "${max}" "${actual}"
+        (( FAIL++ )) || true
+    fi
+}
+
+# ─── 一時環境 ─────────────────────────────────────────────────────────────────
+TMPDIR_TEST="$(mktemp -d /tmp/stuck-detector-test-XXXXXX)"
+cleanup() { rm -rf "${TMPDIR_TEST}"; }
+trap cleanup EXIT
+
+# スクリプトを source してテスト用関数を展開
+export STUCK_DETECTOR_SOURCED=1
+export R2C_CONFIG="${TMPDIR_TEST}/r2c-config"
+export HEARTBEAT_FILE="${TMPDIR_TEST}/heartbeat"
+export CLAUDE_PROJECTS_DIR="${TMPDIR_TEST}/projects"
+export REPO_DIR="${TMPDIR_TEST}/repo"
+export LOG_DIR="${TMPDIR_TEST}/logs"
+export DRY_RUN=1
+export ONE_SHOT=1
+
+mkdir -p "${R2C_CONFIG}/logs" "${CLAUDE_PROJECTS_DIR}" "${REPO_DIR}"
+
+# shellcheck disable=SC1090
+source "${DETECTOR}"
+
+# ─── テスト 1: heartbeat 不在 → 0 ────────────────────────────────────────────
+printf '\n[T1] get_heartbeat_mtime — heartbeat ファイル不在\n'
+rm -f "${HEARTBEAT_FILE}"
+result=$(get_heartbeat_mtime)
+assert_eq "heartbeat不在 → 0" "0" "${result}"
+
+# ─── テスト 2: get_newest_jsonl_mtime — 空ディレクトリ → 0 ───────────────────
+printf '\n[T2] get_newest_jsonl_mtime — jsonl ファイルなし\n'
+result=$(get_newest_jsonl_mtime "${TMPDIR_TEST}/empty_dir_$$")
+assert_eq "jsonlなし → 0" "0" "${result}"
+
+# ─── テスト 3: get_sqlite_count — DB 不在 → 0 ────────────────────────────────
+printf '\n[T3] get_sqlite_count — DB ファイル不在\n'
+result=$(get_sqlite_count "${TMPDIR_TEST}/nonexistent.db" "SELECT COUNT(*) FROM foo")
+assert_eq "DB不在 → 0" "0" "${result}"
+
+# ─── テスト 4: get_sqlite_count — sqlite3 空文字返却 → 0 (UATa 事例 #2) ──────
+printf '\n[T4] get_sqlite_count — 空文字フォールバック (空テーブル)\n'
+SQLITE_DB="${TMPDIR_TEST}/test.db"
+sqlite3 "${SQLITE_DB}" "CREATE TABLE t (v INTEGER);" 2>/dev/null || true
+result=$(get_sqlite_count "${SQLITE_DB}" "SELECT COUNT(*) FROM t")
+assert_eq "空テーブル → 0" "0" "${result}"
+
+# ─── テスト 5: get_sqlite_count — 非整数文字列 → 0 ───────────────────────────
+printf '\n[T5] get_sqlite_count — 非整数返却 → ガード確認\n'
+sqlite3 "${SQLITE_DB}" "CREATE TABLE s (v TEXT); INSERT INTO s VALUES ('abc');" 2>/dev/null || true
+result=$(get_sqlite_count "${SQLITE_DB}" "SELECT v FROM s LIMIT 1")
+assert_eq "非整数 → 0 (ガード)" "0" "${result}"
+
+# ─── テスト 6: get_stale_secs — heartbeat 不在 → 0 (false-alarm 防止) ─────────
+printf '\n[T6] get_stale_secs — heartbeat 不在 → false-alarm 防止で 0\n'
+rm -f "${HEARTBEAT_FILE}"
+result=$(get_stale_secs)
+assert_eq "heartbeat不在 → stale=0" "0" "${result}"
+
+# ─── テスト 7: get_stale_secs — 新鮮な heartbeat → stale 小さい ─────────────
+printf '\n[T7] get_stale_secs — 直前に touch した heartbeat → stale < 5\n'
+touch "${HEARTBEAT_FILE}"
+result=$(get_stale_secs)
+assert_lt "新鮮なheartbeat → stale<5" "5" "${result}"
+
+# ─── テスト 8: 30分閾値 (STUCK_WARN_THRESHOLD=5) ────────────────────────────
+printf '\n[T8] stuck 判定 — 30分閾値テスト (STUCK_WARN_THRESHOLD=5秒)\n'
+WARN_ACTIONS=""
+action_warn() {
+    local secs="${1:-0}"
+    WARN_ACTIONS="warn:${secs}"
+}
+# heartbeat を 10秒前に更新
+HB_OLD="${TMPDIR_TEST}/heartbeat_old"
+touch -t "$(date -v-10S '+%Y%m%d%H%M.%S' 2>/dev/null || date -d '10 seconds ago' '+%Y%m%d%H%M.%S' 2>/dev/null || echo '')" "${HB_OLD}" 2>/dev/null || {
+    # touch -t が使えない環境: Python で 10秒前 mtime をセット
+    python3 -c "import os,time; os.utime('${HB_OLD}', (time.time()-10, time.time()-10))" 2>/dev/null \
+        || { printf '  SKIP: mtime操作不可環境\n'; (( SKIP++ )) || true; }
+}
+if [[ -f "${HB_OLD}" ]]; then
+    export HEARTBEAT_FILE="${HB_OLD}"
+    export STUCK_WARN_THRESHOLD=5
+    export STUCK_KILL_THRESHOLD=9999
+    WARN_THRESHOLD=5
+    KILL_THRESHOLD=9999
+    run_check
+    if [[ "${WARN_ACTIONS}" == warn:* ]]; then
+        printf '  PASS: 30分閾値テスト — warn action 発火\n'
+        (( PASS++ )) || true
+    else
+        printf '  FAIL: 30分閾値テスト — warn action 未発火 (WARN_ACTIONS=%s)\n' "${WARN_ACTIONS}"
+        (( FAIL++ )) || true
+    fi
+    # 後始末
+    export HEARTBEAT_FILE="${TMPDIR_TEST}/heartbeat"
+    export STUCK_WARN_THRESHOLD=1800
+    export STUCK_KILL_THRESHOLD=5400
+    WARN_THRESHOLD=1800
+    KILL_THRESHOLD=5400
+fi
+unset -f action_warn 2>/dev/null || true
+
+# ─── テスト 9: 90分閾値 (STUCK_KILL_THRESHOLD=10) ───────────────────────────
+printf '\n[T9] stuck 判定 — 90分閾値テスト (STUCK_KILL_THRESHOLD=10秒)\n'
+KILL_ACTIONS=""
+action_kill_and_dispatch() {
+    local secs="${1:-0}"
+    KILL_ACTIONS="kill:${secs}"
+}
+HB_OLDER="${TMPDIR_TEST}/heartbeat_older"
+python3 -c "import os,time; open('${HB_OLDER}','w').close(); os.utime('${HB_OLDER}', (time.time()-20, time.time()-20))" 2>/dev/null || {
+    printf '  SKIP: python3 mtime操作不可\n'; (( SKIP++ )) || true
+}
+if [[ -f "${HB_OLDER}" ]]; then
+    export HEARTBEAT_FILE="${HB_OLDER}"
+    export STUCK_WARN_THRESHOLD=5
+    export STUCK_KILL_THRESHOLD=10
+    WARN_THRESHOLD=5
+    KILL_THRESHOLD=10
+    run_check
+    if [[ "${KILL_ACTIONS}" == kill:* ]]; then
+        printf '  PASS: 90分閾値テスト — kill action 発火\n'
+        (( PASS++ )) || true
+    else
+        printf '  FAIL: 90分閾値テスト — kill action 未発火 (KILL_ACTIONS=%s)\n' "${KILL_ACTIONS}"
+        (( FAIL++ )) || true
+    fi
+    export HEARTBEAT_FILE="${TMPDIR_TEST}/heartbeat"
+    export STUCK_WARN_THRESHOLD=1800
+    export STUCK_KILL_THRESHOLD=5400
+    export WARN_THRESHOLD=1800
+    export KILL_THRESHOLD=5400
+fi
+unset -f action_kill_and_dispatch 2>/dev/null || true
+
+# ─── テスト 10: dispatch count 管理 ──────────────────────────────────────────
+printf '\n[T10] dispatch count — increment / reset\n'
+export DISPATCH_COUNT_FILE="${TMPDIR_TEST}/dispatch-count"
+rm -f "${DISPATCH_COUNT_FILE}"
+
+c=$(get_dispatch_count); assert_eq "初期count=0" "0" "${c}"
+increment_dispatch_count
+c=$(get_dispatch_count); assert_eq "increment後=1" "1" "${c}"
+increment_dispatch_count
+c=$(get_dispatch_count); assert_eq "increment後=2" "2" "${c}"
+reset_dispatch_count
+c=$(get_dispatch_count); assert_eq "reset後=0" "0" "${c}"
+
+# ─── 結果サマリ ───────────────────────────────────────────────────────────────
+printf '\n─────────────────────────────────────────────\n'
+printf 'Result: PASS=%d  FAIL=%d  SKIP=%d\n' "${PASS}" "${FAIL}" "${SKIP}"
+printf '─────────────────────────────────────────────\n'
+
+if [[ "${FAIL:-0}" -gt 0 ]]; then
+    exit 1
+fi
+exit 0

--- a/docs/R2C_24H_STARTUP_CHECKLIST.md
+++ b/docs/R2C_24H_STARTUP_CHECKLIST.md
@@ -94,7 +94,107 @@ R2C 対応:
 - [ ] 24h 自走プロンプト (70-E) に「並列 tool call は最大 2 本」を明記
 - [ ] CLI 側 hook で heartbeat ファイル更新 (将来検討、70-H で必要性判断)
 - [ ] 初回 12h パイロット (70-H) では人間が 4h バッチで進捗確認
-- [ ] **【v1.1 追加】 stuck-detector daemon の R2C 版実装を別タスク化** (70-F の Risk Scorer と並走 or 独立)
+- [x] **【Phase70-? 完了】 stuck-detector daemon R2C 版実装**: `SCRIPTS/r2c-stuck-detector.sh`
+
+### 1.3.1 stuck-detector 起動方法 (R2C 版)
+
+`SCRIPTS/r2c-stuck-detector.sh` は 24h 自走開始と同時に **別プロセスとして起動** する。
+
+#### オプション A: launchd plist (推奨 — macOS 常駐)
+
+`~/Library/LaunchAgents/com.r2c.stuck-detector.plist` として配置:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.r2c.stuck-detector</string>
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/hkobayashi/Documents/GitHub/commerce-faq-tasks/SCRIPTS/r2c-stuck-detector.sh</string>
+    </array>
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>R2C_CONFIG</key>
+        <string>/Users/hkobayashi/.claude-r2c-config</string>
+        <key>STUCK_WARN_THRESHOLD</key>
+        <string>1800</string>
+        <key>STUCK_KILL_THRESHOLD</key>
+        <string>5400</string>
+        <key>STUCK_POLL_INTERVAL</key>
+        <string>60</string>
+    </dict>
+    <key>StandardOutPath</key>
+    <string>/Users/hkobayashi/.claude-r2c-config/logs/r2c-stuck-detector.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/hkobayashi/.claude-r2c-config/logs/r2c-stuck-detector.log</string>
+    <key>RunAtLoad</key>
+    <false/>
+    <key>KeepAlive</key>
+    <false/>
+</dict>
+</plist>
+```
+
+起動コマンド:
+```bash
+launchctl load ~/Library/LaunchAgents/com.r2c.stuck-detector.plist
+launchctl start com.r2c.stuck-detector
+```
+
+停止コマンド (24h 自走終了時):
+```bash
+launchctl stop com.r2c.stuck-detector
+launchctl unload ~/Library/LaunchAgents/com.r2c.stuck-detector.plist
+```
+
+#### オプション B: cron (シンプル版)
+
+```bash
+# 毎分実行 — one-shot モードで自前ループを持たせない場合
+* * * * * R2C_CONFIG=$HOME/.claude-r2c-config bash /path/to/SCRIPTS/r2c-stuck-detector.sh --one-shot >> $HOME/.claude-r2c-config/logs/r2c-stuck-detector.log 2>&1
+```
+
+#### オプション C: バックグラウンド起動 (24h-mode-on.sh から呼ぶ)
+
+```bash
+# SCRIPTS/24h-mode-on.sh の末尾に追加
+nohup bash SCRIPTS/r2c-stuck-detector.sh \
+    >> "${R2C_CONFIG}/logs/r2c-stuck-detector.log" 2>&1 &
+echo $! > "${R2C_CONFIG}/.stuck-detector.pid"
+echo "[24h-mode-on] stuck-detector started (PID $(cat ${R2C_CONFIG}/.stuck-detector.pid))"
+```
+
+停止 (24h-mode-off.sh に追加):
+```bash
+PID_FILE="${R2C_CONFIG}/.stuck-detector.pid"
+if [[ -f "$PID_FILE" ]]; then
+    kill "$(cat "$PID_FILE")" 2>/dev/null || true
+    rm -f "$PID_FILE"
+    echo "[24h-mode-off] stuck-detector stopped"
+fi
+```
+
+#### 環境変数チューニング例
+
+| 変数 | デフォルト | 説明 |
+|---|---|---|
+| `STUCK_WARN_THRESHOLD` | 1800 (30分) | Slack 警告発火までの秒数 |
+| `STUCK_KILL_THRESHOLD` | 5400 (90分) | session kill 発火までの秒数 |
+| `STUCK_POLL_INTERVAL` | 60 (1分) | heartbeat チェック間隔 |
+| `MAX_DISPATCH_ATTEMPTS` | 3 | 最大 re-dispatch 試行回数 |
+| `DISPATCH_COMMAND` | (未設定) | 再dispatch コマンド (未設定時は Slack 通知のみ) |
+| `PUSHOVER_APP_TOKEN` | (未設定) | Pushover 通知 token (3回失敗時に使用) |
+| `PUSHOVER_USER_KEY` | (未設定) | Pushover user key |
+
+✅ 起動前チェック項目 (§9 に追加):
+- [ ] `bash SCRIPTS/r2c-stuck-detector.sh --dry-run --one-shot --verbose` で dry-run 動作確認
+- [ ] `~/.claude-r2c-config/heartbeat` が 24h 自走プロンプトで定期 touch されることを確認
+- [ ] launchd / cron / nohup のどれを使うかを決定し起動方法を PLAYBOOK に記載
 
 ### 1.4 重要操作の自動禁止 (`.claude/settings.json` の `permissions.deny`)
 


### PR DESCRIPTION
## Summary

- `SCRIPTS/r2c-stuck-detector.sh` — heartbeat mtime + JSONL mtime 二重監視 daemon。30分警告 / 90分 kill+dispatch (3回上限) / 3回失敗で Slack HIGH + Pushover
- `SCRIPTS/r2c-stuck-detector.test.sh` — 13テスト all PASS: sqlite3 空文字/DB不在/非整数ガード・heartbeat 不在 false-alarm 防止・30分/90分閾値発火確認
- `docs/R2C_24H_STARTUP_CHECKLIST.md §1.3.1` — launchd plist / cron / nohup 3オプション + 環境変数チューニング表・起動前チェック項目追記

## 実装詳細

- **SSH 禁止**: SSH コマンド一切なし (deploy_guard 準拠)
- **set -euo pipefail + ${VAR:-0} ガード**: 全 sqlite3 / heartbeat mtime 取得箇所に適用 (UATa 事例 #2)
- **shellcheck SC2154 PASS**: 両スクリプト `-S warning` PASS
- **テスト可能設計**: `STUCK_DETECTOR_SOURCED=1` で source 可能 / 閾値を環境変数で上書き可能

## Test plan

- [x] `bash SCRIPTS/r2c-stuck-detector.test.sh` → 13/13 PASS
- [x] `shellcheck -S warning SCRIPTS/r2c-stuck-detector.sh` → PASS
- [x] `shellcheck -S warning SCRIPTS/r2c-stuck-detector.test.sh` → PASS
- [x] Gate 1: typecheck PASS (0 errors), 本体テスト 1617/1617 PASS (main branch 確認)
- [x] Gate 1.5: dead exports 37件 (warning, 全て既存)
- [x] Gate 2: security scan PASS (High/Critical 0)
- [x] Gate 2.5: SKIP (Codex review gate 常時OFF, bash script + docs のみ)
- [x] Gate 3: `pnpm build` PASS (dist/src/index.js 生成確認)

## Asana

1214954523638712

🤖 Generated with [Claude Code](https://claude.com/claude-code)