### PR TITLE
feat(phase70): launchd 自走スケジューラ plist 4本 + cron-wrapper 空配列バグ修正

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,9 @@ Thumbs.db
 .claude/worktrees/
 /tmp-*.png
 
+# 24h ループ実行時 SQLite キュー（r2c-queue-init.sh で初期化、コミット禁止）
+.claude/queue/
+
 # Phase70-A 24h 自走モード一時ファイル (HOME 直下が本体だが、誤って repo に置かれた場合の保険)
 .r2c-24h-mode
 .r2c-24h-mode-*

--- a/SCRIPTS/launchd/com.r2c.dispatch.plist
+++ b/SCRIPTS/launchd/com.r2c.dispatch.plist
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!--
+        R2C 24h Loop - Dispatch (1 分間隔、--auto)
+        雛形配置: SCRIPTS/launchd/com.r2c.dispatch.plist (tracked)
+        実体配置: ~/Library/LaunchAgents/com.r2c.dispatch.plist (hkobayashi が手動 cp + load)
+
+          cp SCRIPTS/launchd/com.r2c.dispatch.plist ~/Library/LaunchAgents/
+          launchctl load -w ~/Library/LaunchAgents/com.r2c.dispatch.plist
+
+        役割: r2c-cron-wrapper.sh 経由で r2c-dispatch.sh --auto を起動。
+              prompt_generated タスクを Lane (claude --bg) に払い出す (MAX_SLOTS=3)。
+              CLAUDE_CONFIG_DIR を env で渡し、Lane が R2C 専用アカウントで動くことを保証。
+    -->
+    <key>Label</key>
+    <string>com.r2c.dispatch</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/hkobayashi/Documents/GitHub/commerce-faq-tasks/SCRIPTS/r2c-cron-wrapper.sh</string>
+        <string>--script</string>
+        <string>r2c-dispatch.sh</string>
+        <string>--</string>
+        <string>--auto</string>
+    </array>
+
+    <!-- 1 分間隔 -->
+    <key>StartInterval</key>
+    <integer>60</integer>
+
+    <key>StandardOutPath</key>
+    <string>/Users/hkobayashi/.claude-r2c-config/logs/launchd-dispatch.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/hkobayashi/.claude-r2c-config/logs/launchd-dispatch-err.log</string>
+
+    <!-- launchd 最小環境への注入: PATH + アカウント分離 (CLAUDE_CONFIG_DIR) -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>HOME</key>
+        <string>/Users/hkobayashi</string>
+        <key>CLAUDE_CONFIG_DIR</key>
+        <string>/Users/hkobayashi/.claude-r2c-config</string>
+        <key>CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS</key>
+        <string>1</string>
+    </dict>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/hkobayashi/Documents/GitHub/commerce-faq-tasks</string>
+
+    <key>KeepAlive</key>
+    <false/>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>60</integer>
+    <key>Nice</key>
+    <integer>10</integer>
+</dict>
+</plist>

--- a/SCRIPTS/launchd/com.r2c.morning-report.plist
+++ b/SCRIPTS/launchd/com.r2c.morning-report.plist
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!--
+        R2C 24h Loop - Morning Report (毎日 06:00)
+        雛形配置: SCRIPTS/launchd/com.r2c.morning-report.plist (tracked)
+        実体配置: ~/Library/LaunchAgents/com.r2c.morning-report.plist (hkobayashi が手動 cp + load)
+
+          cp SCRIPTS/launchd/com.r2c.morning-report.plist ~/Library/LaunchAgents/
+          launchctl load -w ~/Library/LaunchAgents/com.r2c.morning-report.plist
+
+        役割: r2c-cron-wrapper.sh 経由で r2c-morning-report.sh を起動。
+              L1-L6 集計 → Slack #r2c Block Kit 投稿 + Pushover priority -2。
+              RunAtLoad=false: load 時には即時投稿せず、06:00 ちょうどにのみ発火。
+    -->
+    <key>Label</key>
+    <string>com.r2c.morning-report</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/hkobayashi/Documents/GitHub/commerce-faq-tasks/SCRIPTS/r2c-cron-wrapper.sh</string>
+        <string>--script</string>
+        <string>r2c-morning-report.sh</string>
+    </array>
+
+    <!-- 毎日 06:00 -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>6</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/Users/hkobayashi/.claude-r2c-config/logs/launchd-morning-report.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/hkobayashi/.claude-r2c-config/logs/launchd-morning-report-err.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>HOME</key>
+        <string>/Users/hkobayashi</string>
+        <key>CLAUDE_CONFIG_DIR</key>
+        <string>/Users/hkobayashi/.claude-r2c-config</string>
+        <key>CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS</key>
+        <string>1</string>
+    </dict>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/hkobayashi/Documents/GitHub/commerce-faq-tasks</string>
+
+    <key>KeepAlive</key>
+    <false/>
+    <!-- 06:00 ちょうどのみ。load 時の即時発火を防ぐ -->
+    <key>RunAtLoad</key>
+    <false/>
+    <key>Nice</key>
+    <integer>10</integer>
+</dict>
+</plist>

--- a/SCRIPTS/launchd/com.r2c.poll.plist
+++ b/SCRIPTS/launchd/com.r2c.poll.plist
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!--
+        R2C 24h Loop - Asana Poll (5 分間隔)
+        雛形配置: SCRIPTS/launchd/com.r2c.poll.plist (tracked)
+        実体配置: ~/Library/LaunchAgents/com.r2c.poll.plist (hkobayashi が手動 cp + load)
+
+          cp SCRIPTS/launchd/com.r2c.poll.plist ~/Library/LaunchAgents/
+          launchctl load -w ~/Library/LaunchAgents/com.r2c.poll.plist
+          launchctl list | grep r2c
+          launchctl unload ~/Library/LaunchAgents/com.r2c.poll.plist  # 停止
+
+        役割: r2c-cron-wrapper.sh 経由で r2c-asana-poll.sh を起動。
+              Asana project 1213607637045514 から新規タスクを queue に取り込む。
+    -->
+    <key>Label</key>
+    <string>com.r2c.poll</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/hkobayashi/Documents/GitHub/commerce-faq-tasks/SCRIPTS/r2c-cron-wrapper.sh</string>
+        <string>--script</string>
+        <string>r2c-asana-poll.sh</string>
+    </array>
+
+    <!-- 5 分間隔 -->
+    <key>StartInterval</key>
+    <integer>300</integer>
+
+    <key>StandardOutPath</key>
+    <string>/Users/hkobayashi/.claude-r2c-config/logs/launchd-poll.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/hkobayashi/.claude-r2c-config/logs/launchd-poll-err.log</string>
+
+    <!-- launchd 最小環境への注入: PATH + アカウント分離 (CLAUDE_CONFIG_DIR) -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>HOME</key>
+        <string>/Users/hkobayashi</string>
+        <key>CLAUDE_CONFIG_DIR</key>
+        <string>/Users/hkobayashi/.claude-r2c-config</string>
+        <key>CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS</key>
+        <string>1</string>
+    </dict>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/hkobayashi/Documents/GitHub/commerce-faq-tasks</string>
+
+    <key>KeepAlive</key>
+    <false/>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>60</integer>
+    <key>Nice</key>
+    <integer>10</integer>
+</dict>
+</plist>

--- a/SCRIPTS/launchd/com.r2c.supervisor.plist
+++ b/SCRIPTS/launchd/com.r2c.supervisor.plist
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!--
+        R2C 24h Loop - Supervisor (1 分間隔)
+        雛形配置: SCRIPTS/launchd/com.r2c.supervisor.plist (tracked)
+        実体配置: ~/Library/LaunchAgents/com.r2c.supervisor.plist (hkobayashi が手動 cp + load)
+
+          cp SCRIPTS/launchd/com.r2c.supervisor.plist ~/Library/LaunchAgents/
+          launchctl load -w ~/Library/LaunchAgents/com.r2c.supervisor.plist
+
+        役割: r2c-cron-wrapper.sh 経由で r2c-supervisor.sh を起動。
+              running 状態の Lane を監視し、MAX_RUN_MINUTES=45 超過の stuck Lane を
+              auto-retry / rollback する (1 分間隔ポーリング)。
+    -->
+    <key>Label</key>
+    <string>com.r2c.supervisor</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/bin/bash</string>
+        <string>/Users/hkobayashi/Documents/GitHub/commerce-faq-tasks/SCRIPTS/r2c-cron-wrapper.sh</string>
+        <string>--script</string>
+        <string>r2c-supervisor.sh</string>
+    </array>
+
+    <!-- 1 分間隔 -->
+    <key>StartInterval</key>
+    <integer>60</integer>
+
+    <key>StandardOutPath</key>
+    <string>/Users/hkobayashi/.claude-r2c-config/logs/launchd-supervisor.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/hkobayashi/.claude-r2c-config/logs/launchd-supervisor-err.log</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <key>HOME</key>
+        <string>/Users/hkobayashi</string>
+        <key>CLAUDE_CONFIG_DIR</key>
+        <string>/Users/hkobayashi/.claude-r2c-config</string>
+        <key>CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS</key>
+        <string>1</string>
+    </dict>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/hkobayashi/Documents/GitHub/commerce-faq-tasks</string>
+
+    <key>KeepAlive</key>
+    <false/>
+    <key>RunAtLoad</key>
+    <true/>
+    <key>ThrottleInterval</key>
+    <integer>60</integer>
+    <key>Nice</key>
+    <integer>10</integer>
+</dict>
+</plist>

--- a/SCRIPTS/r2c-cron-wrapper.sh
+++ b/SCRIPTS/r2c-cron-wrapper.sh
@@ -103,7 +103,14 @@ cd "${R2C_ROOT}"
 
 START_TS=$(date +%s)
 set +e
-bash "SCRIPTS/${SCRIPT}" "${PASS_THROUGH[@]:-}" >> "${TARGET_LOG}" 2>&1
+# bash 3.2 (macOS) では空配列の "${arr[@]:-}" が空文字列1個に展開され、
+# 引数なし起動のはずの script に "" が渡って "unknown arg" で落ちる。
+# pass-through の有無で分岐し、空配列時は引数を一切渡さない。
+if [ "${#PASS_THROUGH[@]}" -gt 0 ]; then
+    bash "SCRIPTS/${SCRIPT}" "${PASS_THROUGH[@]}" >> "${TARGET_LOG}" 2>&1
+else
+    bash "SCRIPTS/${SCRIPT}" >> "${TARGET_LOG}" 2>&1
+fi
 EXIT_CODE=$?
 set -e
 END_TS=$(date +%s)


### PR DESCRIPTION
## Summary
- 24h 自走ループの定期実行を担う launchd plist を `SCRIPTS/launchd/` に tracked 配置（4本）:
  - `com.r2c.poll.plist` — `r2c-asana-poll.sh` を 300s 間隔
  - `com.r2c.dispatch.plist` — `r2c-dispatch.sh --auto` を 60s 間隔
  - `com.r2c.supervisor.plist` — `r2c-supervisor.sh` を 60s 間隔（MAX_RUN_MINUTES=45 stuck 監視）
  - `com.r2c.morning-report.plist` — `r2c-morning-report.sh` を毎日 06:00（RunAtLoad=false）
- 全 plist が `r2c-cron-wrapper.sh` 経由で起動。`EnvironmentVariables` で `CLAUDE_CONFIG_DIR=~/.claude-r2c-config` を渡し、Lane (`claude --bg`) のアカウント分離を保証。
- **cron-wrapper の bash 3.2 空配列展開バグを修正**（Gate 2.5 で検出）: `"${PASS_THROUGH[@]:-}"` が空配列を空文字列1個に展開し、引数なし起動の poll/supervisor/morning-report が毎tick `unknown arg` で exit 1 → スケジューラが起動しても心臓が動かない状態だった。
- 実行時 SQLite キュー `.claude/queue/` を `.gitignore` 追加（live DB の誤コミット防止）。

## 実体配置（hkobayashi 手動ステップ — launchctl はシステム操作）
\`\`\`bash
cp SCRIPTS/launchd/com.r2c.*.plist ~/Library/LaunchAgents/
for f in poll dispatch supervisor morning-report; do
  launchctl load -w ~/Library/LaunchAgents/com.r2c.$f.plist
done
launchctl list | grep r2c
\`\`\`

## ⚠️ 既知ブロッカー（このPR外・別途要対応）
`pending → prompt_generated` を駆動するものが存在しない（`r2c-generate-lane.sh` は `--task-id` 単発で、どのスクリプト/スケジューラからも呼ばれていない）。**この PR の plist を全て load しても、poll が入れた pending タスクは prompt_generated に昇格せず、dispatch は何も起動しない。** 別途 orchestration の配線が必要。

## Gate
- Gate 1: `plutil -lint` 全4 plist OK / `shellcheck SCRIPTS/r2c-cron-wrapper.sh` clean
- Gate 2.5: `codex exec` adversarial-review — パッチ自体に material finding なし（wrapper 修正・CLAUDE_CONFIG_DIR 伝播・double-fire なしを確認）。Critical は上記パッチ外の orchestration gap のみ。

## Test plan
- [x] 4 plist が plutil lint 通過・tracked
- [x] wrapper 経由で poll/supervisor/morning-report が exit 0（修正後）
- [x] wrapper 経由で dispatch --auto が正常パース（dry-run、`auto=1` 認識）
- [ ] hkobayashi が launchctl load 後、`launchctl list | grep r2c` で4本常駐確認
- [ ] generate-lane 配線後、最初の Lane が PR 止まりで動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)