### PR TITLE
fix(phase70): dispatch --auto に pending→prompt_generated 配線 — 自走ループ欠落リンク補完

### DIFF
--- a/SCRIPTS/r2c-dispatch.sh
+++ b/SCRIPTS/r2c-dispatch.sh
@@ -191,7 +191,16 @@ dispatch_one() {
 
 if [ "$AUTO_MODE" -eq 1 ]; then
     SLOTS_USED=0
+    # 無限ループ防止: dispatch_one が state 未変化のまま失敗し続けても
+    # 1 サイクルで有限回しか試行しないよう上限化する。
+    ITER_GUARD=0
+    MAX_ITER=$((AVAILABLE_SLOTS * 3 + 5))
     while [ "$SLOTS_USED" -lt "$AVAILABLE_SLOTS" ]; do
+        ITER_GUARD=$((ITER_GUARD + 1))
+        if [ "$ITER_GUARD" -gt "$MAX_ITER" ]; then
+            echo "WARNING: dispatch loop guard hit (${ITER_GUARD} iters > ${MAX_ITER}), aborting cycle"
+            break
+        fi
         NEXT_ID=$(SQ "SELECT id FROM tasks
                       WHERE state = 'prompt_generated' ${NIGHT_FILTER}
                       ORDER BY CASE tier WHEN 'S' THEN 0 WHEN 'A' THEN 1 ELSE 2 END,
@@ -199,13 +208,40 @@ if [ "$AUTO_MODE" -eq 1 ]; then
                                id ASC
                       LIMIT 1;")
         if [ -z "$NEXT_ID" ]; then
-            echo "No more prompt_generated tasks (slots used=${SLOTS_USED}/${AVAILABLE_SLOTS})"
-            break
+            # prompt_generated が無ければ pending を 1 件昇格してから dispatch する。
+            # これが pending→prompt_generated の唯一の駆動点 (r2c-generate-lane.sh は
+            # 純粋テンプレ置換で claude 起動なし)。dispatch と同じ night filter / tier 順を適用。
+            PENDING_ID=$(SQ "SELECT id FROM tasks
+                          WHERE state = 'pending' ${NIGHT_FILTER}
+                          ORDER BY CASE tier WHEN 'S' THEN 0 WHEN 'A' THEN 1 ELSE 2 END,
+                                   COALESCE(asana_due_on, '9999-12-31') ASC,
+                                   id ASC
+                          LIMIT 1;")
+            if [ -z "$PENDING_ID" ]; then
+                echo "No dispatchable tasks (prompt_generated / pending とも 0, slots used=${SLOTS_USED}/${AVAILABLE_SLOTS})"
+                break
+            fi
+            if [ "$DRY_RUN" -eq 1 ]; then
+                echo "[dry-run] would promote pending task ${PENDING_ID} via r2c-generate-lane.sh, then dispatch"
+                break
+            fi
+            echo "Promoting pending task ${PENDING_ID} → prompt_generated (r2c-generate-lane.sh)"
+            if bash "${R2C_ROOT}/SCRIPTS/r2c-generate-lane.sh" --task-id "${PENDING_ID}"; then
+                NEXT_ID="${PENDING_ID}"
+            else
+                echo "WARNING: generate-lane failed for ${PENDING_ID}, marking failed"
+                SQ "UPDATE tasks SET state='failed', error_message='generate-lane failed', last_action='generate_failed' WHERE id = ${PENDING_ID};"
+                continue
+            fi
         fi
         if dispatch_one "$NEXT_ID"; then
             SLOTS_USED=$((SLOTS_USED + 1))
         else
-            echo "WARNING: dispatch_one failed for ${NEXT_ID}, continuing"
+            # dispatch_one が state を変えずに失敗した場合 (prompt_path 欠落等の
+            # early-return)、同一タスクが毎 iteration 再選択され他タスクが starve する。
+            # selectable な状態のままなら failed にして再選択を防ぐ (running/failed 等は不変)。
+            echo "WARNING: dispatch_one failed for ${NEXT_ID}, marking failed to avoid re-selection"
+            SQ "UPDATE tasks SET state='failed', error_message='dispatch_one failed', last_action='dispatch_failed' WHERE id = ${NEXT_ID} AND state IN ('pending','prompt_generated');"
         fi
     done
 


### PR DESCRIPTION
## Summary
24h 自走ループの **欠落リンク**を補完する。`r2c-asana-poll.sh` が `pending` で入れたタスクを `prompt_generated` に昇格させる駆動役が存在せず（`r2c-generate-lane.sh` は `--task-id` 単発で誰からも呼ばれていなかった）、launchd を全 load しても `dispatch --auto` が Lane を1本も起動できない状態だった（PR #199 で発覚、別途協議で本対応に決定）。

- `dispatch --auto` のループで `prompt_generated` が枯渇したら、次の eligible な `pending` を `r2c-generate-lane.sh --task-id <id>` で昇格 → そのまま dispatch。dispatch と同じ night filter / tier(S→A→B) / due 順を適用。
- generate-lane は純粋テンプレ置換（claude 起動なし、`state='prompt_generated'` + branch + prompt_path をセット）なので低コスト・副作用限定。
- dry-run は preview のみ（DB 変更なし）。

## Gate 2.5 (codex adversarial-review) 指摘と対応
- **無限ループ防止**: `dispatch_one` が state 未変化で失敗し続けるケースに備え `MAX_ITER = AVAILABLE_SLOTS*3+5` のイテレーションガードを追加。
- **starvation 解消**: `dispatch_one` 失敗時に当該タスクを `failed` マーク（`state IN ('pending','prompt_generated')` 限定で running/failed は不変）。同一タスクの毎iteration 再選択を防止（既存挙動のバグも同時修正）。
- night filter parity / slot cap / generate-lane 失敗の非再試行 / dry-run 安全性: material finding なし。

## Gate
- Gate 1: `shellcheck SCRIPTS/r2c-dispatch.sh` clean
- Gate 2.5: `codex exec` adversarial-review 実施 → 指摘1件を上記対応で解消

## ⚠️ 点火前の要判断（このPR外・hkobayashi マター）
現在 queue は **pending 22件（B:21 / S:1）**。dispatch の選択順は tier S→A→B のため、**最初の Lane が Tier S タスク id=4「[Tier S] prod_change: R2C 24h自律ループ導入」を掴む**。初回に重い Tier S（しかもループ自身の構築タスク）が走るのは想定外のはず。点火前に queue 調整（task 4 の hold / 並べ替え等）を推奨。Tier S は `needs_approval_critical` 止まりで auto-merge はされないが、初回観察対象としては不適。

## Test plan
- [x] shellcheck clean
- [x] dry-run で promote preview 表示・DB 不変を確認（queue 22 pending 維持）
- [ ] generate-lane 実促進 → 最初の Lane が PR 止まりで動作（queue 調整後に hkobayashi 観察）

🤖 Generated with [Claude Code](https://claude.com/claude-code)