### PR TITLE
fix(phase70): launchd TCC 検証(WorkingDirectory不可/FDA必須) + queue schema 永続化

### DIFF
--- a/SCRIPTS/launchd/com.r2c.dispatch.plist
+++ b/SCRIPTS/launchd/com.r2c.dispatch.plist
@@ -7,6 +7,12 @@
         雛形配置: SCRIPTS/launchd/com.r2c.dispatch.plist (tracked)
         実体配置: ~/Library/LaunchAgents/com.r2c.dispatch.plist (hkobayashi が手動 cp + load)
 
+        ⚠️ 前提 (macOS Sequoia TCC, 実機検証 2026-05-22): launchd は ~/Documents 配下の
+           ファイルを読めず、load しても "Operation not permitted" (exit 126) で失敗する。
+           WorkingDirectory では回避不可。対策のいずれか:
+             (a) /bin/bash に Full Disk Access を付与 (System Settings → Privacy)
+             (b) repo を ~/Documents 外 (~/projects 等、稼働中の UATa/DIA1000 と同じ) へ移設
+
           cp SCRIPTS/launchd/com.r2c.dispatch.plist ~/Library/LaunchAgents/
           launchctl load -w ~/Library/LaunchAgents/com.r2c.dispatch.plist
 

--- a/SCRIPTS/launchd/com.r2c.morning-report.plist
+++ b/SCRIPTS/launchd/com.r2c.morning-report.plist
@@ -7,6 +7,12 @@
         雛形配置: SCRIPTS/launchd/com.r2c.morning-report.plist (tracked)
         実体配置: ~/Library/LaunchAgents/com.r2c.morning-report.plist (hkobayashi が手動 cp + load)
 
+        ⚠️ 前提 (macOS Sequoia TCC, 実機検証 2026-05-22): launchd は ~/Documents 配下の
+           ファイルを読めず、load しても "Operation not permitted" (exit 126) で失敗する。
+           WorkingDirectory では回避不可。対策のいずれか:
+             (a) /bin/bash に Full Disk Access を付与 (System Settings → Privacy)
+             (b) repo を ~/Documents 外 (~/projects 等、稼働中の UATa/DIA1000 と同じ) へ移設
+
           cp SCRIPTS/launchd/com.r2c.morning-report.plist ~/Library/LaunchAgents/
           launchctl load -w ~/Library/LaunchAgents/com.r2c.morning-report.plist
 

--- a/SCRIPTS/launchd/com.r2c.poll.plist
+++ b/SCRIPTS/launchd/com.r2c.poll.plist
@@ -7,6 +7,12 @@
         雛形配置: SCRIPTS/launchd/com.r2c.poll.plist (tracked)
         実体配置: ~/Library/LaunchAgents/com.r2c.poll.plist (hkobayashi が手動 cp + load)
 
+        ⚠️ 前提 (macOS Sequoia TCC, 実機検証 2026-05-22): launchd は ~/Documents 配下の
+           ファイルを読めず、load しても "Operation not permitted" (exit 126) で失敗する。
+           WorkingDirectory では回避不可。対策のいずれか:
+             (a) /bin/bash に Full Disk Access を付与 (System Settings → Privacy)
+             (b) repo を ~/Documents 外 (~/projects 等、稼働中の UATa/DIA1000 と同じ) へ移設
+
           cp SCRIPTS/launchd/com.r2c.poll.plist ~/Library/LaunchAgents/
           launchctl load -w ~/Library/LaunchAgents/com.r2c.poll.plist
           launchctl list | grep r2c

--- a/SCRIPTS/launchd/com.r2c.supervisor.plist
+++ b/SCRIPTS/launchd/com.r2c.supervisor.plist
@@ -7,6 +7,12 @@
         雛形配置: SCRIPTS/launchd/com.r2c.supervisor.plist (tracked)
         実体配置: ~/Library/LaunchAgents/com.r2c.supervisor.plist (hkobayashi が手動 cp + load)
 
+        ⚠️ 前提 (macOS Sequoia TCC, 実機検証 2026-05-22): launchd は ~/Documents 配下の
+           ファイルを読めず、load しても "Operation not permitted" (exit 126) で失敗する。
+           WorkingDirectory では回避不可。対策のいずれか:
+             (a) /bin/bash に Full Disk Access を付与 (System Settings → Privacy)
+             (b) repo を ~/Documents 外 (~/projects 等、稼働中の UATa/DIA1000 と同じ) へ移設
+
           cp SCRIPTS/launchd/com.r2c.supervisor.plist ~/Library/LaunchAgents/
           launchctl load -w ~/Library/LaunchAgents/com.r2c.supervisor.plist
 

--- a/SCRIPTS/r2c-queue-init.sh
+++ b/SCRIPTS/r2c-queue-init.sh
@@ -70,6 +70,9 @@ CREATE TABLE IF NOT EXISTS tasks (
     attempt_count INTEGER NOT NULL DEFAULT 0,
     max_attempts INTEGER NOT NULL DEFAULT 3,
     night_mode_allowed INTEGER NOT NULL DEFAULT 1 CHECK (night_mode_allowed IN (0,1)),
+    -- dispatch / supervisor が遷移ごとに記録する運用列 (手動 ALTER を schema 化し --reset で消えないように)
+    last_action TEXT,
+    error_message TEXT,
     created_at TEXT NOT NULL DEFAULT (datetime('now')),
     updated_at TEXT NOT NULL DEFAULT (datetime('now')),
     started_at TEXT,

--- a/SCRIPTS/r2c-queue-init.sh
+++ b/SCRIPTS/r2c-queue-init.sh
@@ -140,6 +140,18 @@ fi
 printf '%s\n' "$SCHEMA_SQL" | sqlite3 "$QUEUE_DB"
 log "  schema applied (idempotent)"
 
+# 既存 DB への idempotent migration: CREATE TABLE IF NOT EXISTS は既存テーブルに
+# 列を追加しないため、不足している運用列 (dispatch/supervisor が UPDATE する) を補う。
+ensure_column() {
+    local col="$1" decl="$2"
+    if ! sqlite3 "$QUEUE_DB" "PRAGMA table_info(tasks);" | cut -d'|' -f2 | grep -qx "$col"; then
+        sqlite3 "$QUEUE_DB" "ALTER TABLE tasks ADD COLUMN ${col} ${decl};"
+        log "  migrate: added column tasks.${col}"
+    fi
+}
+ensure_column last_action "TEXT"
+ensure_column error_message "TEXT"
+
 INTEGRITY=$(sqlite3 "$QUEUE_DB" "PRAGMA integrity_check;")
 log "  PRAGMA integrity_check: $INTEGRITY"
 if [ "$INTEGRITY" != "ok" ]; then


### PR DESCRIPTION
## Summary
launchd の poll/dispatch/supervisor が **exit 126** で起動失敗していた問題を実機検証し、原因と対策を確定。併せて queue schema のドリフトを恒久修正。

### 1. TCC 検証（実機・推測なし）
hkobayashi が load した実ジョブのログ:
```
/bin/bash: .../SCRIPTS/r2c-cron-wrapper.sh: Operation not permitted
shell-init: getcwd: cannot access parent directories: Operation not permitted
```
throwaway launchd プローブで切り分け:
| テスト | 結果 |
|---|---|
| launchd から ~/Documents 配下のファイル read | ❌ Operation not permitted |
| launchd から ~/Documents へ cd | ✅ OK（chdir は通る） |
| launchd から ~/.claude-r2c-config (Documents外) read | ✅ OK |

**結論: macOS Sequoia TCC が launchd の ~/Documents 読取をブロック。WorkingDirectory では回避不可**（chdir は通るが read が拒否されるため）。morning-report の exit=0 は RunAtLoad=false で未実行なだけ＝偽の成功（06:00 に同様に失敗する）。稼働中の UATa/DIA1000 launchd が動くのは `~/projects`（TCC対象外）にあるため。

4本の plist comment に前提と対策を明記。

### 2. queue schema 永続化
`last_action` / `error_message`（dispatch/supervisor が UPDATE する列）が `CREATE TABLE` に無く、手動 ALTER が --reset で消える状態だった。CREATE TABLE に追加 + **既存DB向けの冪等 ALTER 移行 `ensure_column()`** を追加（Gate 2.5 指摘対応。CREATE TABLE IF NOT EXISTS は既存テーブルに列を足さないため）。

## Gate
- Gate 1: plutil 全4 plist OK / shellcheck (queue-init) clean
- Gate 2.5: codex adversarial-review 2周 — schema drift の Medium 指摘を ensure_column で解消、最終 material finding なし。TCC 記述の正確性も確認

## ⚠️ hkobayashi 手動ステップ（System操作 / 本番DB）
1. **TCC 解除（いずれか）**:
   - (a) System Settings → Privacy & Security → Full Disk Access に **/bin/bash** を追加（簡単・広め）
   - (b) repo を `~/Documents` 外（`~/projects` 等、UATa/DIA1000 と同じ）へ移設（FDA不要・既存の動作実績パターン。plist の絶対パスも要更新）
2. **plist 再 cp + reload**: `cp SCRIPTS/launchd/com.r2c.*.plist ~/Library/LaunchAgents/` → 各 `launchctl unload`→`load -w`
3. **live DB 列補完**: `bash SCRIPTS/r2c-queue-init.sh`（--reset なし）で現行 `.claude/queue/r2c-queue.db` に last_action/error_message を冪等追加（既存21 pending + 1 needs_approval_critical は保持）

## Test plan
- [x] plutil / shellcheck clean
- [x] throwaway launchd プローブで TCC 挙動を実証（read FAIL / cd OK / 対照 OK）
- [x] 旧schema DB に migration が列追加・既存データ保持・再実行で冪等を実機確認
- [ ] hkobayashi: FDA付与 or repo移設 → reload → launchctl list で exit 0 確認
- [ ] hkobayashi: live DB 列補完後、dispatch/supervisor の UPDATE がエラーなく通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)