### PR TITLE
fix(phase70): 24h-mode protection 再設計 — 1人開発で詰まない安全弁へ

### DIFF
--- a/SCRIPTS/24h-mode-off.sh
+++ b/SCRIPTS/24h-mode-off.sh
@@ -1,14 +1,22 @@
 #!/usr/bin/env bash
 # 24h-mode-off.sh — 24h 自走モード OFF
 #
-# Phase70-A: 24h 自走の安全装置 (論理層) — on.sh の全逆操作
+# Phase70-A: 24h 自走の安全装置 (論理層) — on.sh の autonomy 部分のみを解除
 #
 # 機能:
-#   1. main branch protection を削除
-#   2. repository allow_auto_merge ON 復帰
+#   1. main branch protection を「安全ベースライン」へ更新
+#      (force/main直push/削除禁止 は ON/OFF 通じて永続)
+#   2. repository allow_auto_merge を元の値に復帰
 #   3. ~/.r2c-24h-mode を削除
 #   4. Slack #r2c にモード OFF 通知
 #   5. Cloudflare Pages の再開手順を出力
+#
+# 設計方針:
+#   旧版は backup から pre-on 状態を復元していたが、pre-on が無保護だと OFF 中に
+#   main が無防備 (force push / 直push 可) になり「main直push禁止・force禁止」
+#   invariant が ON/OFF 切替で消える問題があった。
+#   このため OFF でも force/直push/削除禁止は維持し、autonomy 特有の縛り
+#   (Security Scan 必須・conversation_resolution・auto-merge OFF) のみを解く。
 #
 # 冪等性:
 #   モードファイルが無い場合は warn を出して続行 (リソース側の clean-up は試みる)
@@ -44,6 +52,7 @@ run() {
 }
 
 command -v gh >/dev/null 2>&1 || { echo "ERROR: gh CLI required" >&2; exit 1; }
+command -v jq >/dev/null 2>&1 || { echo "ERROR: jq required" >&2; exit 1; }
 
 NOW_ISO="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
 
@@ -53,104 +62,61 @@ else
     log "Found mode file: $MODE_FILE"
 fi
 
-# ─── 0. バックアップから復元値を先読みする ───
-# allow_auto_merge の元の値は branch protection 復元 (バックアップ削除) より前に読む必要がある
+# ─── 0. バックアップから allow_auto_merge の元の値を先読み (backup 削除前に必要) ───
 ORIG_AUTO_MERGE="true"  # fallback: 元の値が不明な場合は true (最もよくある設定)
 if [[ "$DRY_RUN" -eq 0 ]] && [[ -f "$BACKUP_FILE" ]]; then
     ORIG_AUTO_MERGE=$(jq -r '.original_allow_auto_merge // true' "$BACKUP_FILE" 2>/dev/null || echo "true")
 fi
 
-# ─── 1. branch protection 復元 (on.sh バックアップから元設定を復元) ───
-log "Restoring branch protection on $GH_REPO main…"
+# ─── 1. branch protection を「安全ベースライン」へ更新 ───
+# ベースライン (ON/OFF 通じて永続): force禁止 / 削除禁止 / PR必須(direct push禁止) /
+#   enforce_admins:false / approval:0 / required_status_checks:null
+# (旧版は backup から pre-on を復元していたが、pre-on が無保護だと OFF 中に
+#  main が無防備になるため、ベースラインを必ず適用する設計に変更)
+log "Applying safety baseline branch protection on $GH_REPO main…"
+
+BASELINE_PAYLOAD=$(jq -nc '{
+    required_status_checks: null,
+    enforce_admins: false,
+    required_pull_request_reviews: {
+        dismiss_stale_reviews: true,
+        require_code_owner_reviews: false,
+        required_approving_review_count: 0
+    },
+    restrictions: null,
+    required_linear_history: false,
+    allow_force_pushes: false,
+    allow_deletions: false,
+    required_conversation_resolution: false
+}')
+
 if [[ "$DRY_RUN" -eq 1 ]]; then
-    if [[ -f "$BACKUP_FILE" ]]; then
-        printf '[dry-run] restore branch protection from %s\n' "$BACKUP_FILE"
-    else
-        printf '[dry-run] gh api -X DELETE repos/%s/branches/main/protection (no backup found)\n' "$GH_REPO"
-    fi
+    printf '[dry-run] gh api -X PUT repos/%s/branches/main/protection --input <baseline>\n' "$GH_REPO"
+    echo '[dry-run] payload:'
+    printf '%s' "$BASELINE_PAYLOAD" | jq .
 else
-    if [[ -f "$BACKUP_FILE" ]]; then
-        if jq -e '.no_protection == true' "$BACKUP_FILE" >/dev/null 2>&1; then
-            # 24h-mode 有効化前に protection がなかった → 削除して元の状態に戻す
-            if gh api -X DELETE "repos/$GH_REPO/branches/main/protection" >/dev/null 2>&1; then
-                log "  ✓ branch protection removed (was none before 24h-mode)"
-            else
-                log "  WARN: failed to remove (may already be off)"
-            fi
-            rm -f "$BACKUP_FILE"
-            log "  ✓ backup file removed"
-        else
-            # GET レスポンスを GitHub branch-protection PUT スキーマに変換して復元。
-            # - ネストされた .enabled をフラット化 (enforce_admins 等)
-            # - GET 専用の read-only フィールド (url, enforcement_level, contexts_url 等) を除去
-            # - restrictions / required_pull_request_reviews のフルオブジェクトから
-            #   PUT が受け付けるフィールドのみを抽出 (API が URL 等を拒否するため)
-            RESTORE_PAYLOAD=$(jq '{
-                required_status_checks: (
-                    if .required_status_checks == null then null
-                    else {
-                        strict: (.required_status_checks.strict // false),
-                        contexts: (.required_status_checks.contexts // []),
-                        checks: (.required_status_checks.checks // [])
-                    }
-                    end
-                ),
-                enforce_admins: (.enforce_admins.enabled // false),
-                required_pull_request_reviews: (
-                    if .required_pull_request_reviews == null then null
-                    else {
-                        dismiss_stale_reviews: (.required_pull_request_reviews.dismiss_stale_reviews // false),
-                        require_code_owner_reviews: (.required_pull_request_reviews.require_code_owner_reviews // false),
-                        required_approving_review_count: (.required_pull_request_reviews.required_approving_review_count // 0),
-                        require_last_push_approval: (.required_pull_request_reviews.require_last_push_approval // false)
-                    }
-                    end
-                ),
-                restrictions: (
-                    if .restrictions == null then null
-                    else {
-                        users: ([.restrictions.users[]?.login] // []),
-                        teams: ([.restrictions.teams[]?.slug] // []),
-                        apps:  ([.restrictions.apps[]?.slug]  // [])
-                    }
-                    end
-                ),
-                required_linear_history: (.required_linear_history.enabled // false),
-                allow_force_pushes: (.allow_force_pushes.enabled // false),
-                allow_deletions: (.allow_deletions.enabled // false),
-                required_conversation_resolution: (.required_conversation_resolution.enabled // false),
-                block_creations: (.block_creations.enabled // false),
-                lock_branch: (.lock_branch.enabled // false)
-            }' "$BACKUP_FILE")
-            if printf '%s' "$RESTORE_PAYLOAD" | gh api -X PUT "repos/$GH_REPO/branches/main/protection" --input - >/dev/null 2>&1; then
-                log "  ✓ branch protection restored from backup"
-                rm -f "$BACKUP_FILE"
-                log "  ✓ backup file removed"
-            else
-                echo "ERROR: Failed to restore branch protection from backup." >&2
-                echo "  Current protection is NOT modified — main branch remains protected." >&2
-                echo "  Backup preserved at: $BACKUP_FILE" >&2
-                echo "  To restore manually:" >&2
-                echo "    1. Inspect backup: cat $BACKUP_FILE" >&2
-                echo "    2. Re-run after fixing the issue: bash SCRIPTS/24h-mode-off.sh" >&2
-                echo "  Or restore via GitHub UI: https://github.com/$GH_REPO/settings/branches" >&2
-                exit 1
-            fi
-        fi
+    if printf '%s' "$BASELINE_PAYLOAD" | gh api -X PUT "repos/$GH_REPO/branches/main/protection" --input - >/tmp/24h-mode-off-protection.json 2>&1; then
+        log "  ✓ safety baseline applied (force/main直push/削除禁止 持続, 人間 merge 可)"
     else
-        # バックアップなし (on.sh が古い版の場合など) → 従来通り削除
-        if gh api -X DELETE "repos/$GH_REPO/branches/main/protection" >/dev/null 2>&1; then
-            log "  ✓ branch protection removed (no backup found)"
-        else
-            log "  WARN: failed to remove (may already be off, or admin permission missing)"
-        fi
+        echo "ERROR: Failed to apply safety baseline protection." >&2
+        cat /tmp/24h-mode-off-protection.json >&2
+        echo "  Backup preserved at: $BACKUP_FILE" >&2
+        echo "  Manual restore via: https://github.com/$GH_REPO/settings/branches" >&2
+        exit 1
     fi
 fi
 
 # ─── 2. allow_auto_merge を元の値に復帰 ───
+# 注: backup 削除は PATCH 成功後まで遅延 (失敗時に元の値で再試行できるよう保持)。
 log "Restoring repository auto-merge to original value (${ORIG_AUTO_MERGE})…"
 run "gh api -X PATCH 'repos/$GH_REPO' -f allow_auto_merge=${ORIG_AUTO_MERGE} >/dev/null"
 log "  ✓ allow_auto_merge=${ORIG_AUTO_MERGE}"
+
+# ─── 2.5. backup file 削除 (PATCH 成功後、復元不可能性を回避) ───
+if [[ "$DRY_RUN" -eq 0 ]] && [[ -f "$BACKUP_FILE" ]]; then
+    rm -f "$BACKUP_FILE"
+    log "  ✓ backup file removed (mode fully reverted)"
+fi
 
 # ─── 3. モードファイル削除 ───
 log "Removing mode file: $MODE_FILE"

--- a/SCRIPTS/24h-mode-on.sh
+++ b/SCRIPTS/24h-mode-on.sh
@@ -4,12 +4,22 @@
 # Phase70-A: 24h 自走の安全装置 (論理層)
 #
 # 機能:
-#   1. main branch protection を有効化 (PRレビュー1必須/admin含むdirect push禁止)
+#   1. main branch protection を有効化 (PR必須=direct push禁止 / force・削除禁止 /
+#      admin は手動merge可 [enforce_admins=false] / approval 0 / Security Scan 非必須)
 #   2. repository allow_auto_merge OFF
 #   3. 既存 open PR の auto-merge フラグ解除
 #   4. ~/.r2c-24h-mode に R2C_24H_MODE=1 + 起動時刻を書く
 #   5. Slack #r2c にモード ON 通知
 #   6. Cloudflare Pages の手動停止手順を出力 (自動化はしない)
+#
+# 設計方針 (Phase70 安全弁の本質):
+#   Lane の main 到達阻止は (a) settings.json deny 層 [git push origin main /
+#   force / gh pr merge] と (b) branch protection の force/main直push/削除禁止 +
+#   PR必須 + auto-merge OFF の二重で担保。
+#   一方で 1人開発では approval 必須 + enforce_admins=true は人間 merge を阻害
+#   して詰むため、approval=0 / enforce_admins=false に。Security Scan は既存依存
+#   20件で常時 FAIL のため required から外し、人間が朝レビューで内訳判断する
+#   (UATa/DIA1000 と同方針)。
 #
 # 冪等性:
 #   既に ON 状態 (~/.r2c-24h-mode 存在) なら何もせず exit 0
@@ -20,7 +30,7 @@
 #
 # 環境変数:
 #   GH_REPO              — owner/repo (default: milechy/commerce-faq-tasks)
-#   STATUS_CHECKS        — required status checks (CSV, default: "Stream Path Check,Security Scan")
+#   STATUS_CHECKS        — required status checks (CSV, default: "Stream Path Check")
 #   SLACK_WEBHOOK_URL    — Slack incoming webhook (なければ通知スキップ)
 #   R2C_24H_MODE_FILE    — モードファイルパス (default: $HOME/.r2c-24h-mode)
 set -euo pipefail
@@ -37,7 +47,7 @@ for arg in "$@"; do
 done
 
 GH_REPO="${GH_REPO:-milechy/commerce-faq-tasks}"
-STATUS_CHECKS="${STATUS_CHECKS:-Stream Path Check,Security Scan}"
+STATUS_CHECKS="${STATUS_CHECKS:-Stream Path Check}"
 MODE_FILE="${R2C_24H_MODE_FILE:-$HOME/.r2c-24h-mode}"
 BACKUP_FILE="${HOME}/.r2c-24h-mode-protection-backup.json"
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -99,6 +109,9 @@ else
 fi
 
 # ─── 1. main branch protection ON ───
+# 設計の核 (Phase70 安全弁): Lane 阻止は settings.json deny 層が主役。
+# branch protection は (a) PR必須=direct push禁止 (b) force/削除禁止 を担保し、
+# 人間 admin が手動merge できる状態 (approval=0, enforce_admins=false) を保つ。
 log "Enabling branch protection on $GH_REPO main…"
 
 CHECKS_JSON=$(printf '%s' "$STATUS_CHECKS" | jq -Rcs 'split(",") | map(gsub("^\\s+|\\s+$"; "")) | map({context: ., app_id: -1})')
@@ -107,11 +120,11 @@ PROTECTION_PAYLOAD=$(jq -nc \
     --argjson checks "$CHECKS_JSON" \
     '{
         required_status_checks: { strict: true, checks: $checks },
-        enforce_admins: true,
+        enforce_admins: false,
         required_pull_request_reviews: {
             dismiss_stale_reviews: true,
             require_code_owner_reviews: false,
-            required_approving_review_count: 1
+            required_approving_review_count: 0
         },
         restrictions: null,
         required_linear_history: false,


### PR DESCRIPTION
## Summary
旧 `24h-mode-on.sh` は branch protection に `approval=1` 必須 + `enforce_admins=true` + 常時FAILの `Security Scan` を required に設定し、結果として hkobayashi が自分の PR を merge できず詰む状態だった（今日 PR #196〜#202 は off→merge→on で凌いでいた）。設計の核を整理して再実装。

### 設計の核 (Phase70 安全弁)
- **Lane の main 到達阻止** = `settings.json` deny 層が主役（`git push origin main:*` / force / `gh pr merge:*` ブロック）
- **branch protection** = 補強層: PR必須(direct push禁止) + force/削除禁止 + auto-merge OFF
- approval/enforce_admins/Security Scan は **人間 merge 阻害要因** なので外す（UATa/DIA1000 と同方針）

### 変更
- **on.sh**: `enforce_admins:true→false`、`required_approving_review_count:1→0`、`STATUS_CHECKS` default を `"Stream Path Check,Security Scan"→"Stream Path Check"` に短縮。`allow_force_pushes:false` / `allow_deletions:false` / `required_pull_request_reviews` 存在(=direct push禁止) / repo `allow_auto_merge=false` + PR auto-merge 解除は **残す**
- **off.sh**: 旧版は pre-on backup へ復元していたが、pre-on が無保護だと OFF 中に main が無防備になる。force/削除/main直push 禁止を **ON/OFF 通じて永続** させるため、安全ベースラインを必ず PUT する設計に変更。`allow_auto_merge` のみ backup から元値復元

## Gate 結果
- Gate 1: shellcheck OK（既存の SC2294 warning のみ、機能差なし）
- Gate 2.5 (codex adversarial-review): 2件指摘
  - ✅ **Medium 修正**: off.sh で backup 削除を `allow_auto_merge` PATCH 成功後まで遅延し、PATCH 失敗時に元値で再試行できるよう変更
  - ⚠️ **High 既承認リスク**: `enforce_admins=false` により Lane の main 到達阻止が settings.json deny 層への**単一依存**になる。現状 deny は `git push origin main:*` / force / `gh pr merge` を blocks するが、`git push origin HEAD:main`（refspec変則）や `gh api -X PUT ...merges...` 等の bypass 経路は明示 deny されていない。**hkobayashi がこの risk を許容、UATa/DIA1000 と同方針で進行を選択**（事前協議済）

## ⚠️ この PR をどう merge するか（現状 protection が詰んでいる）
現在 main protection は **旧設計（enforce_admins=true / approval=1 / Security Scan required）**で運用中のため、本 PR も普通には merge できない。以下のいずれかで unstick:

**(A) 今日と同じ off→merge→on を最後にもう一度** (推奨):
```bash
bash SCRIPTS/24h-mode-off.sh   # 旧 off は pre-on backup を復元 (おそらく no_protection)
gh pr merge 203 --squash --delete-branch   # この PR (番号確認後)
bash SCRIPTS/24h-mode-on.sh    # 新 on で正しい protection が掛かる
# 以降は普通の `gh pr merge` が通る
```

**(B) GitHub UI で protection を一時無効化**: Settings → Branches → Disable protection → merge → Re-enable via `bash SCRIPTS/24h-mode-on.sh`

## Test plan
- [x] shellcheck clean (pre-existing SC2294 warning のみ)
- [x] dry-run で on.sh / off.sh の payload を実機確認（enforce_admins=false / count=0 / force=false / deletions=false / direct push禁止 を確認）
- [x] Gate 2.5 codex review: Medium 解消、High はリスク承認済
- [ ] hkobayashi が上記 (A) または (B) で merge
- [ ] merge 後、新 on.sh で再 ON → `gh pr merge` が普通に通ることを次の PR で確認
- [ ] (follow-up 推奨) settings.json deny 層に bypass 経路パターン追加 (`git push * HEAD:main` / `gh api ... merges` 等)

🤖 Generated with [Claude Code](https://claude.com/claude-code)