### PR TITLE
fix(groq): replace EOL model llama3-8b-8192 with llama-3.1-8b-instant

### DIFF
--- a/src/agent/judge/evaluationAnalyzer.ts
+++ b/src/agent/judge/evaluationAnalyzer.ts
@@ -8,7 +8,7 @@ import { createEvaluationRepository } from './evaluationRepository';
 
 const logger = pino();
 
-const ANALYZER_MODEL = 'llama3-8b-8192';
+const ANALYZER_MODEL = 'llama-3.1-8b-instant';
 
 export interface SuggestedRule {
   triggerPattern: string;

--- a/src/agent/objection/objectionDetector.ts
+++ b/src/agent/objection/objectionDetector.ts
@@ -93,7 +93,7 @@ export async function saveObjectionPatterns(
     try {
       const normalized = await callGroqWith429Retry(
         {
-          model: 'llama3-8b-8192',
+          model: 'llama-3.1-8b-instant',
           messages: [
             {
               role: 'system',

--- a/src/agent/psychology/principleDetector.ts
+++ b/src/agent/psychology/principleDetector.ts
@@ -23,7 +23,7 @@ export interface PrincipleDetectionResult {
 
 /**
  * 直近3件のユーザーメッセージからキーワードマッチで心理学原則を検出する。
- * マッチなし → Groq 8b (llama3-8b-8192) でLLM判定（フォールバック）。
+ * マッチなし → Groq 8b (llama-3.1-8b-instant) でLLM判定（フォールバック）。
  * salesStage が propose/recommend/close の場合、最低1原則を返す。
  *
  * セキュリティ: LLMに渡すメッセージ内容は slice(0,500) でトリミング
@@ -81,7 +81,7 @@ async function detectWithLlm(
 
   try {
     const response = await groqClient.call({
-      model: "llama3-8b-8192",
+      model: "llama-3.1-8b-instant",
       messages: [
         {
           role: "system",


### PR DESCRIPTION
## Summary

- Groq officially deprecated `llama3-8b-8192` on **2025-08-30** (deadline already passed — EOL 済み)
- 公式推奨後継 `llama-3.1-8b-instant` へ 3箇所を置換
- コードベース内の他の全呼び出しパスはすでに `llama-3.1-8b-instant` を使用済み

### 変更箇所

| ファイル | 種別 |
|---|---|
| `src/agent/judge/evaluationAnalyzer.ts:11` | `ANALYZER_MODEL` 定数（Judge 系統） |
| `src/agent/objection/objectionDetector.ts:96` | 異議オブジェクト正規化呼び出し |
| `src/agent/psychology/principleDetector.ts:84` | LLM フォールバック（コメントも更新） |

## Gate 結果

- **Gate 1** (`pnpm verify`): ✅ Test Suites 138 passed / Tests 1617 passed / typecheck 0 errors / security scan PASS
- **Gate 2.5** (Codex review `--base main`): ✅ "I did not find a discrete, actionable regression introduced by this diff."

## 背景

廃止期日（2025-08-30）経過後も旧モデルIDが残存しており、これら3機能は実質的にエラー応答またはサービス拒否状態だった疑いがある（Groq が廃止モデルへのリクエストを reject する仕様）。

## Test plan

- [ ] `pnpm verify` 全パス確認済み（CI で再確認）
- [ ] objectionDetector / principleDetector / evaluationAnalyzer の各テストが PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)