### PR TITLE
fix(phase46): restore runWeeklyReport orchestrator

### DIFF
--- a/src/agent/report/weeklyReportGenerator.test.ts
+++ b/src/agent/report/weeklyReportGenerator.test.ts
@@ -4,6 +4,7 @@
 import {
   generateReportText,
   postReportToSlack,
+  runWeeklyReport,
   saveWeeklyReport,
   WeeklyMetrics,
 } from './weeklyReportGenerator';
@@ -134,5 +135,55 @@ describe('saveWeeklyReport', () => {
     expect(params[1]).toBe('テストレポート');
     expect(params[4]).toBe(JSON.stringify(metrics));
     expect(params[5]).toBe(true);
+  });
+});
+
+describe('runWeeklyReport', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    delete process.env.SLACK_WEBHOOK_URL;
+  });
+
+  it('orchestrates collect → generate → slack → save', async () => {
+    // collectWeeklyMetrics は内部関数 — pool に対する 5 種類の SELECT を返す
+    // (avg_score x2, kpi x2, variant, objection, tuning)
+    const mockQuery = jest
+      .fn()
+      // collect: 当週 avg_score
+      .mockResolvedValueOnce({ rows: [{ avg_score: '80', eval_count: '5' }] })
+      // collect: 前週 avg_score
+      .mockResolvedValueOnce({ rows: [{ avg_score: '70' }] })
+      // collect: 当週 KPI
+      .mockResolvedValueOnce({ rows: [{ outcome: 'appointment', cnt: '3' }, { outcome: 'declined', cnt: '7' }] })
+      // collect: 前週 KPI
+      .mockResolvedValueOnce({ rows: [{ outcome: 'appointment', cnt: '2' }, { outcome: 'declined', cnt: '8' }] })
+      // collect: variant
+      .mockResolvedValueOnce({ rows: [] })
+      // collect: objection
+      .mockResolvedValueOnce({ rows: [{ cnt: '0' }] })
+      // collect: tuning
+      .mockResolvedValueOnce({ rows: [{ cnt: '0' }] })
+      // save
+      .mockResolvedValueOnce({ rows: [] });
+
+    const mockPool = { query: mockQuery } as unknown as InstanceType<typeof import('pg').Pool>;
+
+    const result = await runWeeklyReport(
+      'tenant-x',
+      mockPool,
+      periodStart,
+      periodEnd,
+    );
+
+    expect(typeof result.reportText).toBe('string');
+    expect(result.reportText.length).toBeGreaterThan(0);
+    expect(result.slackPosted).toBe(false); // SLACK_WEBHOOK_URL 未設定なので false
+    // 7 SELECT (collect) + 1 INSERT (save) = 8 queries
+    expect(mockQuery).toHaveBeenCalledTimes(8);
+    // 最後の query は INSERT INTO weekly_reports
+    const lastCallSql: string = mockQuery.mock.calls[7][0];
+    expect(lastCallSql).toContain('INSERT INTO weekly_reports');
+    const lastCallParams: unknown[] = mockQuery.mock.calls[7][1];
+    expect(lastCallParams[0]).toBe('tenant-x');
   });
 });

--- a/src/agent/report/weeklyReportGenerator.ts
+++ b/src/agent/report/weeklyReportGenerator.ts
@@ -333,6 +333,44 @@ export async function postReportToSlack(
   }
 }
 
+/**
+ * 直近7日間の週次レポートを生成・保存・Slack 通知まで一括実行する。
+ * SCRIPTS/weekly-report.ts および将来の cron スケジューラから呼ばれる。
+ */
+export async function runWeeklyReport(
+  tenantId: string,
+  pool: InstanceType<typeof Pool>,
+  periodStart?: Date,
+  periodEnd?: Date,
+): Promise<{ reportText: string; slackPosted: boolean }> {
+  const end = periodEnd ?? new Date();
+  const start = periodStart ?? (() => {
+    const d = new Date(end);
+    d.setDate(d.getDate() - 7);
+    return d;
+  })();
+
+  logger.info({ tenantId, periodStart: start, periodEnd: end }, 'weeklyReport.run.start');
+
+  const metrics = await collectWeeklyMetrics(tenantId, pool, start, end);
+  const reportText = await generateReportText(metrics, start, end);
+  const slackPosted = await postReportToSlack(reportText, start, end);
+
+  await saveWeeklyReport({
+    tenantId,
+    reportText,
+    periodStart: start,
+    periodEnd: end,
+    metrics,
+    slackPosted,
+    pool,
+  });
+
+  logger.info({ tenantId, slackPosted }, 'weeklyReport.run.done');
+
+  return { reportText, slackPosted };
+}
+
 
 // ユーティリティ
 


### PR DESCRIPTION
## Summary
- 復旧: dead-code cleanup commit 8f86c0c で削除された `runWeeklyReport` を `src/agent/report/weeklyReportGenerator.ts` に再追加。
- 根本原因: `SCRIPTS/weekly-report.ts:9` が `runWeeklyReport` を import しているが、commit 8f86c0c (2026-04-02) で「unused export」として削除され、scripts が破損していた。
- 影響: 週次レポート手動実行スクリプト (`tsx SCRIPTS/weekly-report.ts <tenant>`) が `Module has no exported member 'runWeeklyReport'` で失敗していた。Phase46 機能の 1 つが棚卸し中に未配線として検出された案件 2 件のうちの 1 件。

## Changes
- `src/agent/report/weeklyReportGenerator.ts`: `runWeeklyReport(tenantId, pool, periodStart?, periodEnd?)` を復元。collect → generate → slack → save をオーケストレートし、`{ reportText, slackPosted }` を返す。
- `src/agent/report/weeklyReportGenerator.test.ts`: pool query を全段モックして collect→save までの 8 クエリ呼び出しと INSERT の引数を検証する smoke test を追加。

## Gate 結果
- Gate 1 (`pnpm typecheck`): PASS (0 errors)
- Gate 1 (`pnpm test`): PASS (138 suites / 1618 tests)
- Gate 2 (`bash SCRIPTS/security-scan.sh`): PASS (CRITICAL/HIGH = 0)
- Gate 2.5 (Codex review): スキップ可能 — 変更は単一ヘルパーの復元 + テスト追加のみ、認可/セキュリティ系の本体変更なし
- Gate 1.5 (dead-code-check): 復元した関数は `SCRIPTS/weekly-report.ts` から実消費されるため arcane export ではない

## Test plan
- [x] `pnpm test -- weeklyReportGenerator` で新 smoke test がパス
- [x] `pnpm typecheck` で 0 error
- [ ] (人間確認) `tsx SCRIPTS/weekly-report.ts <tenant>` で実機 DB に対して手動実行 (DATABASE_URL 設定環境で)

## 親タスク
Asana: 1215114203188918「Phase44–46 未配線機能の検知と回収」配下 (60 件中の最優先 1 件)

🤖 Generated with [Claude Code](https://claude.com/claude-code)