### PR TITLE
chore(authz): remove dead requireOwnTenant() helper (Phase44-46 audit)

### DIFF
--- a/src/api/middleware/roleAuth.test.ts
+++ b/src/api/middleware/roleAuth.test.ts
@@ -4,7 +4,6 @@ import type { NextFunction, Request, Response } from "express";
 import {
   roleAuthMiddleware,
   requireRole,
-  requireOwnTenant,
   type AuthenticatedUser,
 } from "./roleAuth";
 
@@ -268,82 +267,6 @@ describe("requireRole", () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// requireOwnTenant
-// ---------------------------------------------------------------------------
-describe("requireOwnTenant", () => {
-  it("allows super_admin to access any tenant", () => {
-    const req = mockReq({
-      user: { id: "u1", email: "a@a.com", role: "super_admin", tenantId: null },
-      query: { tenant: "some-other-tenant" },
-    });
-    const res = mockRes();
-    requireOwnTenant()(req, res, next);
-
-    expect(next).toHaveBeenCalled();
-    expect(res.status).not.toHaveBeenCalled();
-  });
-
-  it("allows client_admin to access own tenant via query param", () => {
-    const req = mockReq({
-      user: { id: "u2", email: "c@c.com", role: "client_admin", tenantId: "tenant-xyz" },
-      query: { tenant: "tenant-xyz" },
-    });
-    const res = mockRes();
-    requireOwnTenant()(req, res, next);
-
-    expect(next).toHaveBeenCalled();
-  });
-
-  it("returns 403 when client_admin accesses another tenant", () => {
-    const req = mockReq({
-      user: { id: "u2", email: "c@c.com", role: "client_admin", tenantId: "tenant-xyz" },
-      query: { tenant: "other-tenant" },
-    });
-    const res = mockRes();
-    requireOwnTenant()(req, res, next);
-
-    expect(res.status).toHaveBeenCalledWith(403);
-    expect((res.json as jest.Mock).mock.calls[0][0]).toMatchObject({
-      error: "forbidden",
-    });
-    expect(next).not.toHaveBeenCalled();
-  });
-
-  it("auto-injects tenantId when client_admin provides no tenant param", () => {
-    const req = mockReq({
-      user: { id: "u2", email: "c@c.com", role: "client_admin", tenantId: "tenant-xyz" },
-      query: {},
-    });
-    const res = mockRes();
-    requireOwnTenant()(req, res, next);
-
-    expect(next).toHaveBeenCalled();
-    expect((req as any).query.tenant).toBe("tenant-xyz");
-  });
-
-  it("allows client_admin access when tenant matches x-tenant-id header", () => {
-    const req = mockReq({
-      user: { id: "u2", email: "c@c.com", role: "client_admin", tenantId: "tenant-abc" },
-      query: {},
-      headers: { "x-tenant-id": "tenant-abc" },
-    });
-    const res = mockRes();
-    requireOwnTenant()(req, res, next);
-
-    expect(next).toHaveBeenCalled();
-  });
-
-  it("returns 403 when client_admin header tenant mismatches", () => {
-    const req = mockReq({
-      user: { id: "u2", email: "c@c.com", role: "client_admin", tenantId: "tenant-abc" },
-      query: {},
-      headers: { "x-tenant-id": "tenant-other" },
-    });
-    const res = mockRes();
-    requireOwnTenant()(req, res, next);
-
-    expect(res.status).toHaveBeenCalledWith(403);
-    expect(next).not.toHaveBeenCalled();
-  });
-});
+// NOTE: requireOwnTenant() ヘルパー削除に伴い、対応する describe ブロックは撤去。
+// テナント分離の retest は per-tenant ルートのテスト（例: knowledgeGapAuthGuard.test.ts,
+// evaluationsAuthGuard.test.ts, optionsAuthGuard.test.ts 等）でカバーされている。

--- a/src/api/middleware/roleAuth.ts
+++ b/src/api/middleware/roleAuth.ts
@@ -97,38 +97,10 @@ export function requireRole(...roles: UserRole[]) {
   };
 }
 
-/**
- * client_admin が自テナントのデータのみアクセスできるようにする
- * super_admin はすべてのテナントにアクセス可能
- */
-export function requireOwnTenant() {
-  return (req: Request, res: Response, next: NextFunction): void => {
-    const user = (req as AuthedReq).user;
-
-    // super_admin はすべてのテナントにアクセス可能
-    if (user?.role === "super_admin") {
-      return next();
-    }
-
-    const requestedTenant =
-      (req.params.tenantId as string | undefined) ||
-      (req.query.tenant as string | undefined) ||
-      (req.query.tenant_id as string | undefined) ||
-      (req.headers["x-tenant-id"] as string | undefined);
-
-    if (requestedTenant && requestedTenant !== user?.tenantId) {
-      res.status(403).json({
-        error: "forbidden",
-        message: "他のテナントのデータにはアクセスできません",
-      });
-      return;
-    }
-
-    // client_admin のリクエストに tenant_id が未指定なら自動付与
-    if (!requestedTenant && user?.tenantId) {
-      req.query.tenant = user.tenantId;
-    }
-
-    next();
-  };
-}
+// NOTE: 旧 `requireOwnTenant()` ヘルパーは削除済み（Phase70 / Phase44-46 棚卸し結論）。
+// テナント分離は各 per-tenant ルート内で個別に実装されている等価ロジックで担保されており、
+// 一律ミドルウェアの再配線は不要と確認した。代表例:
+//   - src/api/admin/knowledge/routes.ts:282 `requireKnowledgeTenant`
+//   - src/api/admin/chatTest/routes.ts:78    インライン check
+//   - src/api/admin/chat-history/routes.ts:54 `app_metadata.tenant_id` を直接 SQL フィルタに使用
+// 詳細: PR #207 (feature/1215114203188918-remove-dead-requireOwnTenant)


### PR DESCRIPTION
## Summary
- Phase44-46 棚卸し 60件中の最優先 2 件のうち、認可ヘルパー 1 件の棚卸し結果。
- `requireOwnTenant()` は **dead helper** であり、配線不要と確認。
- 本 PR では dead 関数 + 6 件の専用テストを撤去し、判断根拠をコメントとして `roleAuth.ts` に残す。

## 調査事実
| 観点 | 事実 |
|---|---|
| 定義 | `src/api/middleware/roleAuth.ts:104` で export |
| 本番 import | `grep -rn "requireOwnTenant" src/` → 自己 export と test のみ。**本番経路ゼロ** |
| 代替経路 (1) | `src/api/admin/knowledge/routes.ts:282` `requireKnowledgeTenant` がほぼ同等の query/header/params チェック |
| 代替経路 (2) | `src/api/admin/chatTest/routes.ts:78-85` のインライン client_admin チェック |
| 代替経路 (3) | `chat-history/routes.ts` ほか多数 — `app_metadata.tenant_id` を直接 SQL の WHERE フィルタとして使用し、リクエストから tenantId を受け付けない (より強い分離) |
| 既存テスト網 | 15 個の `*AuthGuard.test.ts` が per-tenant ルートのテナント分離を回帰カバー |

## とった判断
**配線不要** — 全 per-tenant ルートは JWT (app_metadata.tenant_id) ベースで等価以上の分離を実装済み。一律ミドルウェアの再配線は (a) リスク (60 ルートのレグレッション) と (b) 効果 (既存と同じ動作) のバランスで採択しない。

## 対応
- `requireOwnTenant()` 関数本体を削除。判断根拠と代替実装の参照先 (3 ファイル) を NOTE コメントとして `roleAuth.ts` に残す。
- `roleAuth.test.ts` から `requireOwnTenant` describe ブロック (6 it) と import を撤去。`*AuthGuard.test.ts` 群が retest を担う旨を NOTE で明記。

## Gate 結果
- Gate 1 (`pnpm typecheck`): PASS (0 errors)
- Gate 1 (`pnpm test`): PASS (138 suites / 1611 tests — 6 件減は撤去した requireOwnTenant 専用テスト)
- Gate 1.5 (dead-code-check): 本 PR が dead 関数撤去そのもの
- Gate 2 (`bash SCRIPTS/security-scan.sh`): PASS (CRITICAL/HIGH = 0)
- Gate 2.5 (Codex review): **認可系の deletion につき推奨**。merge 前に `/codex:review --base main` 実行を依頼

## 側で発見した別件 (out-of-scope, 人間判断へ)
本調査の途中で auth-only (役割チェック欠落) の admin 経路を 3 件発見:
- `src/api/admin/avatar/generationRoutes.ts` (Phase41 — Leonardo 画像生成)
- `src/api/admin/avatar/falGenerationRoutes.ts` (Phase64 — fal.ai)
- `src/api/admin/avatar/premiumGenerationRoutes.ts` (Phase64 — Flux 2 Pro)

いずれも `supabaseAuthMiddleware` のみで `requireRole(...)` 等の役割チェックが無い。`avatarAuthGuard.test.ts` がカバーしているのは `routes.ts` (config) のみで、上記 3 ファイルは未カバー。fal.ai/Flux/Leonardo の課金 API を呼ぶため、認証済みユーザの role が `anonymous` でも実行可能。Phase42/64 範囲のため別 Asana タスク化を提案します (本 PR には含めません)。

## Test plan
- [x] `pnpm typecheck` で 0 error
- [x] `pnpm test` で 1611 tests pass
- [x] `bash SCRIPTS/security-scan.sh` PASS
- [ ] (人間) `/codex:review --base main` で認可系撤去の妥当性確認
- [ ] (人間) 側別件のアバター生成系 3 ファイルを別タスクに切り出し

## 親タスク
Asana: 1215114203188918「Phase44–46 未配線機能の検知と回収」配下

🤖 Generated with [Claude Code](https://claude.com/claude-code)