### PR TITLE
fix(deploy): rsync exclude に slack-listener/ を追加 — VPS専用実行時dirを主デプロイから除外

### DIFF
--- a/SCRIPTS/deploy-vps.sh
+++ b/SCRIPTS/deploy-vps.sh
@@ -115,6 +115,7 @@ rsync -avz --delete \
   --exclude 'avatar-agent/venv/' \
   --exclude 'docs/investigation/' \
   --exclude '.wolf/' \
+  --exclude 'slack-listener/' \
   ./ "${VPS}:${REMOTE_DIR}/"
 
 # rsync後の所有者正規化: Mac側UID(501)がrsync -a で転送されてもroot:rootに上書き


### PR DESCRIPTION
## Summary
- `deploy-vps.sh` [1/5] rsync の `--delete` が VPS の `/opt/rajiuce/slack-listener/` を削除しようとして `cannot delete non-empty directory: slack-listener` で停止していた件の根本対処。
- `slack-listener/` は `SCRIPTS/deploy-slack-listener.sh` が VPS 側で `mkdir -p` する**VPS専用実行時ディレクトリ**で、リポジトリには存在しない。exclude リストに無いため rsync が削除対象と誤判定していた。
- 既存の `avatar-agent/venv/` / `docs/investigation/` / `.wolf/` と同じ「VPS or local 専用ディレクトリは主デプロイから除外」原則に揃え、`--exclude 'slack-listener/'` を1行追加するのみ。

## Changes
- `SCRIPTS/deploy-vps.sh`: rsync exclude 群 (`--exclude '.wolf/'` の次行) に `--exclude 'slack-listener/'` を1行追加。

## Why this is safe
- `git ls-files | grep slack-listener` → `SCRIPTS/deploy-slack-listener.sh` (デプロイヘルパー1本) のみ。`slack-listener/` ディレクトリはリポジトリ非追跡。
- `slack-listener` のライフサイクルは `SCRIPTS/deploy-slack-listener.sh` 専管で、PM2 非管理の独立 nohup プロセス。主デプロイから除外しても稼働継続。
- VPS 側の `/opt/rajiuce/slack-listener/{slack_listener.py, slack_listener.pid, slack_listener.log}` は無事のまま残る (本来 rsync が触ってはいけない領域)。

## Gate
- Gate 1: `bash -n SCRIPTS/deploy-vps.sh` PASS / diff = `+1 行のみ`
- shellcheck の SC2029 warnings は info-level の既存事項 (SSH コマンド内変数のクライアント側展開) で本変更とは無関係
- Gate 2.5 (Codex review): スキップ可 — 設定ファイル1行追加、認可/セキュリティ系の本体変更なし
- Gate 3 (build): bash script のみのため不要

## Test plan
- [x] `bash -n SCRIPTS/deploy-vps.sh` で syntax OK
- [x] `git diff` で意図通り `--exclude 'slack-listener/'` のみが追加されていることを目視確認
- [ ] (人間 merge後) `bash SCRIPTS/deploy-vps.sh` を実行し、[1/5] rsync が `slack-listener` で停止せず最後まで完走することを確認
- [ ] (人間 merge後) `/opt/rajiuce/slack-listener/slack_listener.py` が rsync 後も無事に残っていることを確認、3456/tcp の slack_listener プロセスが稼働継続していることを確認

## 関連
- PR #206 / #207 は merge 済みだが未デプロイ。本 PR merge 後、人間が `bash SCRIPTS/deploy-vps.sh` で 3 PR まとめてデプロイ可能。

🤖 Generated with [Claude Code](https://claude.com/claude-code)