### PR TITLE
feat(authz): avatar generation 3ルート認可欠落を修正 (GID1215114475058706)

### DIFF
--- a/src/api/admin/avatar/avatarGenerationAuthGuard.test.ts
+++ b/src/api/admin/avatar/avatarGenerationAuthGuard.test.ts
@@ -144,6 +144,19 @@ describe('avatar generation routes — allow-path: client_admin passes authz', (
   });
 });
 
+// ── fail-closed: client_admin with no tenant_id → 403 (roleAuthMiddleware early return) ──
+
+describe('avatar generation routes — fail-closed: client_admin without tenant_id → 403', () => {
+  GENERATION_ENDPOINTS.forEach(({ method, path, body }) => {
+    it(`${method.toUpperCase()} ${path} — client_admin no tenant → 403`, async () => {
+      // roleAuthMiddleware returns 403 early when client_admin has no tenant_id
+      const app = makeApp({ app_metadata: { role: 'client_admin' }, email: 'ca-notenant@t.com' });
+      const res = await (request(app) as any)[method](path).send(body);
+      expect(res.status).toBe(403);
+    });
+  });
+});
+
 // ── allow-path: 認可通過時にログが出ないこと ─────────────────────────────────
 
 describe('avatar generation routes — allow-path: no authz warn on success', () => {

--- a/src/api/admin/avatar/avatarGenerationAuthGuard.test.ts
+++ b/src/api/admin/avatar/avatarGenerationAuthGuard.test.ts
@@ -1,0 +1,161 @@
+// src/api/admin/avatar/avatarGenerationAuthGuard.test.ts
+// GID1215114475058706: avatar generation 3ルート認可ガードテスト
+// 既存の avatarAuthGuard.test.ts (routes.ts向け) には一切触れない
+
+jest.mock('../../../lib/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock('../../../admin/http/supabaseAuthMiddleware', () => ({
+  supabaseAuthMiddleware: (req: any, _res: any, next: any) => {
+    req.supabaseUser = req._mockUser ?? null;
+    next();
+  },
+}));
+jest.mock('../../../auth/supabaseClient', () => ({
+  supabaseAdmin: null,
+}));
+jest.mock('../../../lib/billing/usageTracker', () => ({
+  trackUsage: jest.fn(),
+}));
+jest.mock('../../../lib/contentGuard', () => ({
+  containsBannedWord: jest.fn().mockReturnValue(false),
+}));
+jest.mock('../../../lib/magnific', () => ({
+  upscaleWithMagnific: jest.fn().mockResolvedValue(null),
+}));
+
+import express from 'express';
+import request from 'supertest';
+import { logger } from '../../../lib/logger';
+import { registerAvatarGenerationRoutes } from './generationRoutes';
+import { registerFalGenerationRoutes } from './falGenerationRoutes';
+import { registerPremiumGenerationRoutes } from './premiumGenerationRoutes';
+
+const mockFetch = jest.fn();
+(global as any).fetch = mockFetch;
+
+function makeApp(user: Record<string, unknown> | null) {
+  const fakeDb = {
+    query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+    connect: jest.fn().mockResolvedValue({
+      query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+      release: jest.fn(),
+    }),
+  };
+  const app = express();
+  app.use(express.json());
+  app.use((req: any, _res: any, next: any) => {
+    req._mockUser = user;
+    next();
+  });
+  registerAvatarGenerationRoutes(app, fakeDb);
+  registerFalGenerationRoutes(app);
+  registerPremiumGenerationRoutes(app);
+  return app;
+}
+
+const GENERATION_ENDPOINTS = [
+  { method: 'post' as const, path: '/v1/admin/avatar/generate-image',   body: { description: 'professional headshot' } },
+  { method: 'post' as const, path: '/v1/admin/avatar/match-voice',      body: { description: 'calm professional voice' } },
+  { method: 'post' as const, path: '/v1/admin/avatar/generate-prompt',  body: { rules: 'You are a helpful assistant. Be professional and friendly.' } },
+  { method: 'post' as const, path: '/v1/admin/avatar/fal/generate',     body: { prompt: 'professional headshot portrait of a business person' } },
+  { method: 'post' as const, path: '/v1/admin/avatar/generate-premium', body: { prompt: 'professional headshot portrait of a business person' } },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockFetch.mockResolvedValue({
+    ok: false,
+    status: 500,
+    json: async () => ({}),
+    text: async () => '',
+    arrayBuffer: async () => new ArrayBuffer(0),
+    headers: { get: () => null },
+  });
+});
+
+// ── fail-closed: 認可されないロール → 403 ─────────────────────────────────────
+
+describe('avatar generation routes — fail-closed: unauthorized → 403', () => {
+  GENERATION_ENDPOINTS.forEach(({ method, path, body }) => {
+    it(`${method.toUpperCase()} ${path} — null user → 403`, async () => {
+      const app = makeApp(null);
+      const res = await (request(app) as any)[method](path).send(body);
+      expect(res.status).toBe(403);
+    });
+
+    it(`${method.toUpperCase()} ${path} — viewer role → 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'viewer', tenant_id: 't1' }, email: 'v@t.com' });
+      const res = await (request(app) as any)[method](path).send(body);
+      expect(res.status).toBe(403);
+    });
+
+    it(`${method.toUpperCase()} ${path} — stale JWT (user_metadata only) → 403`, async () => {
+      const app = makeApp({ user_metadata: { role: 'super_admin', tenant_id: 't1' }, email: 's@t.com' });
+      const res = await (request(app) as any)[method](path).send(body);
+      expect(res.status).toBe(403);
+    });
+
+    it(`${method.toUpperCase()} ${path} — anonymous role → 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'anonymous' }, email: 'anon@t.com' });
+      const res = await (request(app) as any)[method](path).send(body);
+      expect(res.status).toBe(403);
+    });
+  });
+});
+
+// ── observability: 認可拒否時にログが出る ────────────────────────────────────
+
+describe('avatar generation routes — observability: logger.warn on denial', () => {
+  GENERATION_ENDPOINTS.forEach(({ method, path, body }) => {
+    it(`${method.toUpperCase()} ${path} — viewer denied → logger.warn called`, async () => {
+      const app = makeApp({ app_metadata: { role: 'viewer', tenant_id: 't1' }, email: 'v@t.com' });
+      await (request(app) as any)[method](path).send(body);
+      expect(logger.warn).toHaveBeenCalled();
+    });
+
+    it(`${method.toUpperCase()} ${path} — null user denied → logger.warn called`, async () => {
+      const app = makeApp(null);
+      await (request(app) as any)[method](path).send(body);
+      expect(logger.warn).toHaveBeenCalled();
+    });
+  });
+});
+
+// ── allow-path: super_admin / client_admin は 403 にならない ─────────────────
+
+describe('avatar generation routes — allow-path: super_admin passes authz', () => {
+  GENERATION_ENDPOINTS.forEach(({ method, path, body }) => {
+    it(`${method.toUpperCase()} ${path} — super_admin → not 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'super_admin' }, email: 'sa@t.com' });
+      const res = await (request(app) as any)[method](path).send(body);
+      expect(res.status).not.toBe(403);
+    });
+  });
+});
+
+describe('avatar generation routes — allow-path: client_admin passes authz', () => {
+  GENERATION_ENDPOINTS.forEach(({ method, path, body }) => {
+    it(`${method.toUpperCase()} ${path} — client_admin with tenant → not 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'client_admin', tenant_id: 't1' }, email: 'ca@t.com' });
+      const res = await (request(app) as any)[method](path).send(body);
+      expect(res.status).not.toBe(403);
+    });
+  });
+});
+
+// ── allow-path: 認可通過時にログが出ないこと ─────────────────────────────────
+
+describe('avatar generation routes — allow-path: no authz warn on success', () => {
+  GENERATION_ENDPOINTS.forEach(({ method, path, body }) => {
+    it(`${method.toUpperCase()} ${path} — super_admin → logger.warn NOT called for authz denial`, async () => {
+      const app = makeApp({ app_metadata: { role: 'super_admin' }, email: 'sa@t.com' });
+      await (request(app) as any)[method](path).send(body);
+      const warnCalls = (logger.warn as jest.Mock).mock.calls;
+      const authzWarnCalled = warnCalls.some(
+        (args) => typeof args[0] === 'object' && args[0]?.event?.includes('authz_denied')
+      );
+      expect(authzWarnCalled).toBe(false);
+    });
+  });
+});

--- a/src/api/admin/avatar/falGenerationRoutes.test.ts
+++ b/src/api/admin/avatar/falGenerationRoutes.test.ts
@@ -23,7 +23,7 @@ function makeApp(tenantId = "tenant-a") {
   const app = express();
   app.use(express.json());
   app.use((req: any, _res: any, next: any) => {
-    req.supabaseUser = { app_metadata: { tenant_id: tenantId } };
+    req.supabaseUser = { app_metadata: { tenant_id: tenantId, role: 'client_admin' } };
     req.requestId = "req-test-001";
     next();
   });

--- a/src/api/admin/avatar/falGenerationRoutes.ts
+++ b/src/api/admin/avatar/falGenerationRoutes.ts
@@ -56,9 +56,11 @@ async function uploadImageFromUrl(
 
 // ── 認可ミドルウェア ───────────────────────────────────────────────────────────
 
+const FAL_GEN_ALLOWED_ROLES = ['super_admin', 'client_admin'] as const;
+
 function falGenAuthzLogger(req: Request, _res: Response, next: NextFunction): void {
   const user = (req as AuthedReq).user;
-  if (!user || !(['super_admin', 'client_admin'] as string[]).includes(user.role)) {
+  if (!user || !(FAL_GEN_ALLOWED_ROLES as readonly string[]).includes(user.role)) {
     logger.warn({
       event: 'avatar_fal_generation_authz_denied',
       path: req.path,
@@ -70,7 +72,7 @@ function falGenAuthzLogger(req: Request, _res: Response, next: NextFunction): vo
   next();
 }
 
-const FAL_GEN_AUTHZ = [roleAuthMiddleware, falGenAuthzLogger, requireRole('super_admin', 'client_admin')];
+const FAL_GEN_AUTHZ = [roleAuthMiddleware, falGenAuthzLogger, requireRole(...FAL_GEN_ALLOWED_ROLES)];
 
 // ── ルート登録 ────────────────────────────────────────────────────────────────
 

--- a/src/api/admin/avatar/falGenerationRoutes.ts
+++ b/src/api/admin/avatar/falGenerationRoutes.ts
@@ -1,11 +1,12 @@
 // src/api/admin/avatar/falGenerationRoutes.ts
 // Phase64 タスク4: fal.ai Flux Pro v1.1 を使ったアバター画像生成API
 
-import type { Express, Request, Response } from "express";
+import type { Express, NextFunction, Request, Response } from "express";
 import { z } from "zod";
 import { supabaseAuthMiddleware } from "../../../admin/http/supabaseAuthMiddleware";
 import { supabaseAdmin } from "../../../auth/supabaseClient";
 import { logger } from "../../../lib/logger";
+import { roleAuthMiddleware, requireRole, type AuthedReq } from "../../middleware/roleAuth";
 
 type AuthReq = Request & { supabaseUser?: Record<string, unknown>; requestId?: string };
 
@@ -53,6 +54,24 @@ async function uploadImageFromUrl(
   }
 }
 
+// ── 認可ミドルウェア ───────────────────────────────────────────────────────────
+
+function falGenAuthzLogger(req: Request, _res: Response, next: NextFunction): void {
+  const user = (req as AuthedReq).user;
+  if (!user || !(['super_admin', 'client_admin'] as string[]).includes(user.role)) {
+    logger.warn({
+      event: 'avatar_fal_generation_authz_denied',
+      path: req.path,
+      method: req.method,
+      actor_role: user?.role ?? 'unknown',
+      actor_email: user?.email ? user.email.slice(0, 3) + '***' : 'unknown',
+    });
+  }
+  next();
+}
+
+const FAL_GEN_AUTHZ = [roleAuthMiddleware, falGenAuthzLogger, requireRole('super_admin', 'client_admin')];
+
 // ── ルート登録 ────────────────────────────────────────────────────────────────
 
 export function registerFalGenerationRoutes(app: Express): void {
@@ -61,6 +80,7 @@ export function registerFalGenerationRoutes(app: Express): void {
   // POST /v1/admin/avatar/fal/generate
   app.post(
     "/v1/admin/avatar/fal/generate",
+    ...FAL_GEN_AUTHZ,
     async (req: Request, res: Response) => {
       const parsed = generateSchema.safeParse(req.body ?? {});
       if (!parsed.success) {

--- a/src/api/admin/avatar/generationRoutes.ts
+++ b/src/api/admin/avatar/generationRoutes.ts
@@ -2,11 +2,12 @@
 
 // Phase41: Avatar Customization Studio — 画像生成・声マッチング・プロンプト生成API
 
-import type { Express, Request, Response } from "express";
+import type { Express, NextFunction, Request, Response } from "express";
 
 type AvatarReq = Request & { supabaseUser?: Record<string, unknown>; requestId?: string };
 import { z } from "zod";
 import { supabaseAuthMiddleware } from "../../../admin/http/supabaseAuthMiddleware";
+import { roleAuthMiddleware, requireRole, type AuthedReq } from "../../middleware/roleAuth";
 import { trackUsage } from "../../../lib/billing/usageTracker";
 import { logger } from '../../../lib/logger';
 import { containsBannedWord } from '../../../lib/contentGuard';
@@ -61,6 +62,26 @@ const generatePromptSchema = z.object({
 });
 
 // ---------------------------------------------------------------------------
+// Authorization middleware
+// ---------------------------------------------------------------------------
+
+function avatarGenAuthzLogger(req: Request, _res: Response, next: NextFunction): void {
+  const user = (req as AuthedReq).user;
+  if (!user || !(['super_admin', 'client_admin'] as string[]).includes(user.role)) {
+    logger.warn({
+      event: 'avatar_generation_authz_denied',
+      path: req.path,
+      method: req.method,
+      actor_role: user?.role ?? 'unknown',
+      actor_email: user?.email ? user.email.slice(0, 3) + '***' : 'unknown',
+    });
+  }
+  next();
+}
+
+const AVATAR_GEN_AUTHZ = [roleAuthMiddleware, avatarGenAuthzLogger, requireRole('super_admin', 'client_admin')];
+
+// ---------------------------------------------------------------------------
 // Route registration
 // ---------------------------------------------------------------------------
 
@@ -72,6 +93,7 @@ export function registerAvatarGenerationRoutes(app: Express, _db: any): void {
   // -----------------------------------------------------------------------
   app.post(
     "/v1/admin/avatar/generate-image",
+    ...AVATAR_GEN_AUTHZ,
     async (req: Request, res: Response) => {
       const parsed = generateImageSchema.safeParse(req.body ?? {});
       if (!parsed.success) {
@@ -221,6 +243,7 @@ Output ONLY the English prompt, nothing else.`,
   // -----------------------------------------------------------------------
   app.post(
     "/v1/admin/avatar/match-voice",
+    ...AVATAR_GEN_AUTHZ,
     async (req: Request, res: Response) => {
       const parsed = matchVoiceSchema.safeParse(req.body ?? {});
       if (!parsed.success) {
@@ -350,6 +373,7 @@ JSONのみ返してください。`,
   // -----------------------------------------------------------------------
   app.post(
     "/v1/admin/avatar/generate-prompt",
+    ...AVATAR_GEN_AUTHZ,
     async (req: Request, res: Response) => {
       const parsed = generatePromptSchema.safeParse(req.body ?? {});
       if (!parsed.success) {

--- a/src/api/admin/avatar/generationRoutes.ts
+++ b/src/api/admin/avatar/generationRoutes.ts
@@ -65,9 +65,11 @@ const generatePromptSchema = z.object({
 // Authorization middleware
 // ---------------------------------------------------------------------------
 
+const AVATAR_GEN_ALLOWED_ROLES = ['super_admin', 'client_admin'] as const;
+
 function avatarGenAuthzLogger(req: Request, _res: Response, next: NextFunction): void {
   const user = (req as AuthedReq).user;
-  if (!user || !(['super_admin', 'client_admin'] as string[]).includes(user.role)) {
+  if (!user || !(AVATAR_GEN_ALLOWED_ROLES as readonly string[]).includes(user.role)) {
     logger.warn({
       event: 'avatar_generation_authz_denied',
       path: req.path,
@@ -79,7 +81,7 @@ function avatarGenAuthzLogger(req: Request, _res: Response, next: NextFunction):
   next();
 }
 
-const AVATAR_GEN_AUTHZ = [roleAuthMiddleware, avatarGenAuthzLogger, requireRole('super_admin', 'client_admin')];
+const AVATAR_GEN_AUTHZ = [roleAuthMiddleware, avatarGenAuthzLogger, requireRole(...AVATAR_GEN_ALLOWED_ROLES)];
 
 // ---------------------------------------------------------------------------
 // Route registration

--- a/src/api/admin/avatar/premiumGenerationRoutes.test.ts
+++ b/src/api/admin/avatar/premiumGenerationRoutes.test.ts
@@ -34,7 +34,7 @@ function makeApp(tenantId = "tenant-a") {
   const app = express();
   app.use(express.json());
   app.use((req: any, _res: any, next: any) => {
-    req.supabaseUser = { app_metadata: { tenant_id: tenantId } };
+    req.supabaseUser = { app_metadata: { tenant_id: tenantId, role: 'client_admin' } };
     req.requestId = "req-premium-001";
     next();
   });

--- a/src/api/admin/avatar/premiumGenerationRoutes.ts
+++ b/src/api/admin/avatar/premiumGenerationRoutes.ts
@@ -1,13 +1,14 @@
 // src/api/admin/avatar/premiumGenerationRoutes.ts
 // Phase64 タスク5: Flux 2 Pro + Magnific AI プレミアムアバター生成API
 
-import type { Express, Request, Response } from "express";
+import type { Express, NextFunction, Request, Response } from "express";
 import { z } from "zod";
 import { supabaseAuthMiddleware } from "../../../admin/http/supabaseAuthMiddleware";
 import { supabaseAdmin } from "../../../auth/supabaseClient";
 import { logger } from "../../../lib/logger";
 import { upscaleWithMagnific } from "../../../lib/magnific";
 import { trackUsage } from "../../../lib/billing/usageTracker";
+import { roleAuthMiddleware, requireRole, type AuthedReq } from "../../middleware/roleAuth";
 
 type AuthReq = Request & { supabaseUser?: Record<string, unknown>; requestId?: string };
 
@@ -78,13 +79,31 @@ async function uploadUrlToStorage(
   }
 }
 
+// ── 認可ミドルウェア ───────────────────────────────────────────────────────────
+
+function premiumGenAuthzLogger(req: Request, _res: Response, next: NextFunction): void {
+  const user = (req as AuthedReq).user;
+  if (!user || !(['super_admin', 'client_admin'] as string[]).includes(user.role)) {
+    logger.warn({
+      event: 'avatar_premium_generation_authz_denied',
+      path: req.path,
+      method: req.method,
+      actor_role: user?.role ?? 'unknown',
+      actor_email: user?.email ? user.email.slice(0, 3) + '***' : 'unknown',
+    });
+  }
+  next();
+}
+
+const PREMIUM_GEN_AUTHZ = [roleAuthMiddleware, premiumGenAuthzLogger, requireRole('super_admin', 'client_admin')];
+
 // ── ルート登録 ────────────────────────────────────────────────────────────────
 
 export function registerPremiumGenerationRoutes(app: Express): void {
   app.use("/v1/admin/avatar/generate-premium", supabaseAuthMiddleware);
 
   // POST /v1/admin/avatar/generate-premium
-  app.post("/v1/admin/avatar/generate-premium", async (req: Request, res: Response) => {
+  app.post("/v1/admin/avatar/generate-premium", ...PREMIUM_GEN_AUTHZ, async (req: Request, res: Response) => {
     const parsed = premiumSchema.safeParse(req.body ?? {});
     if (!parsed.success) {
       return res.status(400).json({ error: "invalid_request", details: parsed.error.issues });

--- a/src/api/admin/avatar/premiumGenerationRoutes.ts
+++ b/src/api/admin/avatar/premiumGenerationRoutes.ts
@@ -81,9 +81,11 @@ async function uploadUrlToStorage(
 
 // ── 認可ミドルウェア ───────────────────────────────────────────────────────────
 
+const PREMIUM_GEN_ALLOWED_ROLES = ['super_admin', 'client_admin'] as const;
+
 function premiumGenAuthzLogger(req: Request, _res: Response, next: NextFunction): void {
   const user = (req as AuthedReq).user;
-  if (!user || !(['super_admin', 'client_admin'] as string[]).includes(user.role)) {
+  if (!user || !(PREMIUM_GEN_ALLOWED_ROLES as readonly string[]).includes(user.role)) {
     logger.warn({
       event: 'avatar_premium_generation_authz_denied',
       path: req.path,
@@ -95,7 +97,7 @@ function premiumGenAuthzLogger(req: Request, _res: Response, next: NextFunction)
   next();
 }
 
-const PREMIUM_GEN_AUTHZ = [roleAuthMiddleware, premiumGenAuthzLogger, requireRole('super_admin', 'client_admin')];
+const PREMIUM_GEN_AUTHZ = [roleAuthMiddleware, premiumGenAuthzLogger, requireRole(...PREMIUM_GEN_ALLOWED_ROLES)];
 
 // ── ルート登録 ────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

-  /  /  の全エンドポイント(5本)に  後段で  + 認可拒否ロガー +  を配線
- 認可拒否時に構造化ログ()を出力(observability)
-  は import参照のみ(変更なし)

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
|  | AUTHZ配線(3エンドポイント) |
|  | AUTHZ配線(1エンドポイント) |
|  | AUTHZ配線(1エンドポイント) |
|  | **新規** 45テスト(fail-closed/observability/allow-path) |
|  | 既存機能テストにrole追加(CI維持) |
|  | 既存機能テストにrole追加(CI維持) |

## Test plan

- [x]  45テスト全合格
  - fail-closed: null/viewer/stale-JWT/anonymous → 403
  - observability: viewer/null →  呼び出し確認
  - allow-path:  → 403にならない
  - allow-path:  → 403にならない
  - allow-path: で authz warn が出ないこと確認
- [x] 既存スイート 1657テスト全合格(139スイート)
- [x] TypeScript 型チェック通過

## Gate

Gate 1 → 1.5 → 2 → **2.5 Codex adversarial-review --base main 必須** → 3 → merge(人間承認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)