### PR TITLE
fix(avatar): Path B — avatarConfigId を room metadata 経由で agent.py に伝搬

### DIFF
--- a/avatar-agent/agent.py
+++ b/avatar-agent/agent.py
@@ -57,13 +57,18 @@ SYSTEM_PROMPT = (
 
 
 # --- Groq LLM 直接呼び出し ---
-async def fetch_avatar_config(tenant_id: str, api_url: str) -> dict | None:
-    """テナント別アバター設定を内部APIから取得。失敗時はNoneを返す。"""
+async def fetch_avatar_config(tenant_id: str, api_url: str, avatar_config_id: str | None = None) -> dict | None:
+    """テナント別アバター設定を内部APIから取得。失敗時はNoneを返す。
+    avatar_config_id 指定時は特定アバターを取得（テスト用途）。
+    """
+    params: dict[str, str] = {"tenantId": tenant_id}
+    if avatar_config_id:
+        params["avatarConfigId"] = avatar_config_id
     try:
         async with aiohttp.ClientSession() as http:
             async with http.get(
                 f"{api_url}/api/internal/avatar-config",
-                params={"tenantId": tenant_id},
+                params=params,
                 headers={"X-Internal-Request": "1"},
                 timeout=aiohttp.ClientTimeout(total=5),
             ) as resp:
@@ -304,11 +309,24 @@ async def entrypoint(ctx: agents.JobContext) -> None:
     tenant_id = _extract_tenant_id(ctx.room.name)
     logger.info(f"[entrypoint] extracted tenant_id={tenant_id!r} from room={ctx.room.name!r}")
 
+    # room metadata から avatarConfigId を取得（テストチャットで特定アバターを指定された場合）
+    import json as _json
+    _meta: dict = {}
+    try:
+        _meta = _json.loads(ctx.room.metadata or "{}")
+    except Exception:
+        pass
+    import re as _re
+    _raw_cfg_id = _meta.get("avatarConfigId")
+    _UUID_RE = _re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$", _re.IGNORECASE)
+    avatar_config_id: str | None = str(_raw_cfg_id) if isinstance(_raw_cfg_id, str) and _UUID_RE.match(_raw_cfg_id) else None
+    logger.info(f"[entrypoint] avatar_config_id={'[redacted-uuid]' if avatar_config_id else None} from room metadata")
+
     # アバター設定を動的取得
     api_url = os.environ.get("RAJIUCE_API_URL", "http://localhost:3100")
     avatar_config = None
     if tenant_id:
-        avatar_config = await fetch_avatar_config(tenant_id, api_url)
+        avatar_config = await fetch_avatar_config(tenant_id, api_url, avatar_config_id)
 
     # 設定を適用（fallback: 環境変数のデフォルト）
     effective_system_prompt = (

--- a/src/api/avatar/livekitTokenRoutes.test.ts
+++ b/src/api/avatar/livekitTokenRoutes.test.ts
@@ -4,6 +4,9 @@
 // 修正内容(Phase66):
 //   Q2: OR is_default = true → OR tenant_id = 'r2c_default' (クロステナント誤表示修正)
 //   Q3: ORDER BY created_at DESC 追加 (非決定的LIMIT防止)
+//
+// 修正内容(Path B fix / GID1215114990855142):
+//   avatarConfigId を room metadata に埋め込み → agent.py が特定アバターを選択できる
 
 import express from "express";
 import request from "supertest";
@@ -14,12 +17,15 @@ import { registerLiveKitTokenRoutes } from "./livekitTokenRoutes";
 jest.mock("../../lib/db", () => ({
   pool: { query: jest.fn() },
 }));
+const mockCreateRoom = jest.fn().mockResolvedValue({});
+const mockCreateDispatch = jest.fn().mockResolvedValue({ id: "dispatch-1", room: "room-1" });
+
 jest.mock("livekit-server-sdk", () => ({
   RoomServiceClient: jest.fn().mockImplementation(() => ({
-    createRoom: jest.fn().mockResolvedValue({}),
+    createRoom: mockCreateRoom,
   })),
   AgentDispatchClient: jest.fn().mockImplementation(() => ({
-    createDispatch: jest.fn().mockResolvedValue({ id: "dispatch-1", room: "room-1" }),
+    createDispatch: mockCreateDispatch,
   })),
 }));
 
@@ -61,6 +67,8 @@ describe("POST /api/avatar/room-token", () => {
     savedEnv = { ...process.env };
     Object.assign(process.env, LIVEKIT_ENV);
     mockQuery.mockReset();
+    mockCreateRoom.mockReset().mockResolvedValue({});
+    mockCreateDispatch.mockReset().mockResolvedValue({ id: "dispatch-1", room: "room-1" });
   });
 
   afterEach(() => {
@@ -159,6 +167,40 @@ describe("POST /api/avatar/room-token", () => {
 
       expect(res.body.enabled).toBe(true);
       expect(res.body.imageUrl).toBeNull();
+    });
+  });
+
+  describe("Path B fix: room metadata への avatarConfigId 伝搬", () => {
+    it("avatarConfigId 指定時: createRoom が metadata={avatarConfigId} で呼ばれる", async () => {
+      mockQuery
+        .mockResolvedValueOnce({ rows: [TENANT_ROW], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [{ image_url: "https://example.com/sam.png", name: "SAM" }] });
+
+      const app = makeApp("tenant-a");
+      await request(app)
+        .post("/api/avatar/room-token")
+        .send({ avatarConfigId: "config-sam-uuid" });
+
+      expect(mockCreateRoom).toHaveBeenCalledTimes(1);
+      const createRoomArg = mockCreateRoom.mock.calls[0][0] as { metadata?: string };
+      expect(createRoomArg.metadata).toBeDefined();
+      const meta = JSON.parse(createRoomArg.metadata!);
+      expect(meta.avatarConfigId).toBe("config-sam-uuid");
+    });
+
+    it("avatarConfigId 未指定時: createRoom の metadata は undefined", async () => {
+      mockQuery
+        .mockResolvedValueOnce({ rows: [TENANT_ROW], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const app = makeApp("tenant-a");
+      await request(app)
+        .post("/api/avatar/room-token")
+        .send({});
+
+      expect(mockCreateRoom).toHaveBeenCalledTimes(1);
+      const createRoomArg = mockCreateRoom.mock.calls[0][0] as { metadata?: string };
+      expect(createRoomArg.metadata).toBeUndefined();
     });
   });
 });

--- a/src/api/avatar/livekitTokenRoutes.test.ts
+++ b/src/api/avatar/livekitTokenRoutes.test.ts
@@ -128,6 +128,16 @@ describe("POST /api/avatar/room-token", () => {
       expect(res.body.enabled).toBe(true);
       expect(res.body.imageUrl).toBeNull();
       expect(res.body.avatarName).toBeNull();
+
+      // Q2 SQL が tenant_id 制約で他テナントを排除していることを検証
+      // (mockPool([]) の決め打ちではなく、WHERE句が実際に組み込まれていることを確認)
+      const q2Call = mockQuery.mock.calls[1];
+      const sql: string = q2Call[0];
+      const params: unknown[] = q2Call[1];
+      expect(sql).toContain("tenant_id = $2");
+      expect(sql).toContain("tenant_id = 'r2c_default'");
+      expect(params[0]).toBe("config-from-other-tenant"); // $1 = avatarConfigId
+      expect(params[1]).toBe("tenant-a");                 // $2 = requestingTenantId (排除の主体)
     });
   });
 
@@ -208,14 +218,24 @@ describe("POST /api/avatar/room-token", () => {
         .mockResolvedValueOnce({ rows: [TENANT_ROW], rowCount: 1 })
         .mockResolvedValueOnce({ rows: [] }); // Q2 0件 = 他テナント非デフォルト → アクセス拒否
 
+      const CROSS_TENANT_UUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
       const app = makeApp("tenant-a");
       await request(app)
         .post("/api/avatar/room-token")
-        .send({ avatarConfigId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" });
+        .send({ avatarConfigId: CROSS_TENANT_UUID });
 
+      // Q2 SQL が tenant_id = $2 で tenant-a 以外を排除していることを検証
+      const q2Call = mockQuery.mock.calls[1];
+      const sql: string = q2Call[0];
+      const params: unknown[] = q2Call[1];
+      expect(sql).toContain("tenant_id = $2");
+      expect(sql).toContain("tenant_id = 'r2c_default'");
+      expect(params[0]).toBe(CROSS_TENANT_UUID); // $1 = avatarConfigId
+      expect(params[1]).toBe("tenant-a");         // $2 = requestingTenantId
+
+      // SQL ownership check が通らなかった UUID は room metadata に載らない
       expect(mockCreateRoom).toHaveBeenCalledTimes(1);
       const createRoomArg = mockCreateRoom.mock.calls[0][0] as { metadata?: string };
-      // SQL ownership check が通らなかった UUID は room metadata に載らない
       expect(createRoomArg.metadata).toBeUndefined();
     });
   });

--- a/src/api/avatar/livekitTokenRoutes.test.ts
+++ b/src/api/avatar/livekitTokenRoutes.test.ts
@@ -75,6 +75,11 @@ describe("POST /api/avatar/room-token", () => {
     process.env = savedEnv;
   });
 
+  // ── 有効な UUID テストフィクスチャ (strict UUID validation 対応) ──
+  const UUID_SAM       = "87ca75df-8fd5-4e41-b3e4-1cbdc2d97462";
+  const UUID_DEFAULT   = "d0d3722c-e033-4d91-8eb2-66a06978548a";
+  const UUID_OTHER     = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
   describe("avatarConfigId 指定時 (Q2)", () => {
     it("同テナントの avatarConfigId を指定すると image_url/name を返す", async () => {
       mockQuery
@@ -86,16 +91,17 @@ describe("POST /api/avatar/room-token", () => {
       const app = makeApp("tenant-a");
       const res = await request(app)
         .post("/api/avatar/room-token")
-        .send({ avatarConfigId: "config-123" });
+        .send({ avatarConfigId: UUID_SAM });
 
       expect(res.body.enabled).toBe(true);
       expect(res.body.imageUrl).toBe("https://example.com/img.png");
       expect(res.body.avatarName).toBe("Haruka");
 
-      // Q2クエリが r2c_default 条件を使っていることを検証
+      // Q2クエリが r2c_default 条件 + is_active 必須を含むことを検証
       const q2Call = mockQuery.mock.calls[1];
       const sql: string = q2Call[0];
       expect(sql).toContain("tenant_id = 'r2c_default'");
+      expect(sql).toContain("is_active = true");
       expect(sql).not.toContain("is_default = true");
     });
 
@@ -109,7 +115,7 @@ describe("POST /api/avatar/room-token", () => {
       const app = makeApp("other-tenant");
       const res = await request(app)
         .post("/api/avatar/room-token")
-        .send({ avatarConfigId: "r2c-default-config-id" });
+        .send({ avatarConfigId: UUID_DEFAULT });
 
       expect(res.body.enabled).toBe(true);
       expect(res.body.avatarName).toBe("SAM");
@@ -123,7 +129,7 @@ describe("POST /api/avatar/room-token", () => {
       const app = makeApp("tenant-a");
       const res = await request(app)
         .post("/api/avatar/room-token")
-        .send({ avatarConfigId: "config-from-other-tenant" });
+        .send({ avatarConfigId: UUID_OTHER });
 
       expect(res.body.enabled).toBe(true);
       expect(res.body.imageUrl).toBeNull();
@@ -136,8 +142,90 @@ describe("POST /api/avatar/room-token", () => {
       const params: unknown[] = q2Call[1];
       expect(sql).toContain("tenant_id = $2");
       expect(sql).toContain("tenant_id = 'r2c_default'");
-      expect(params[0]).toBe("config-from-other-tenant"); // $1 = avatarConfigId
+      expect(sql).toContain("is_active = true");
+      expect(params[0]).toBe(UUID_OTHER);                 // $1 = avatarConfigId
       expect(params[1]).toBe("tenant-a");                 // $2 = requestingTenantId (排除の主体)
+    });
+
+    it("inactive な自テナント avatarConfigId は is_active=true 制約で 0件 (Codex MEDIUM #210)", async () => {
+      mockQuery
+        .mockResolvedValueOnce({ rows: [TENANT_ROW], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [] }); // 0件: 無効化済み config は復活させない
+
+      const app = makeApp("tenant-a");
+      const res = await request(app)
+        .post("/api/avatar/room-token")
+        .send({ avatarConfigId: UUID_SAM });
+
+      expect(res.body.enabled).toBe(true);
+      expect(res.body.imageUrl).toBeNull();
+      expect(res.body.avatarName).toBeNull();
+
+      // Q2 SQL に is_active = true が含まれることを検証
+      const q2Call = mockQuery.mock.calls[1];
+      const sql: string = q2Call[0];
+      expect(sql).toContain("is_active = true");
+
+      // 無効化済み config は room metadata にも伝搬しない (verifiedAvatarConfigId = null)
+      expect(mockCreateRoom).toHaveBeenCalledTimes(1);
+      const createRoomArg = mockCreateRoom.mock.calls[0][0] as { metadata?: string };
+      expect(createRoomArg.metadata).toBeUndefined();
+    });
+  });
+
+  describe("UUID validation (Codex LOW #210)", () => {
+    it("不正な avatarConfigId (非UUID文字列) は 400", async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [TENANT_ROW], rowCount: 1 });
+
+      const app = makeApp("tenant-a");
+      const res = await request(app)
+        .post("/api/avatar/room-token")
+        .send({ avatarConfigId: "not-a-uuid" });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toMatch(/UUID/);
+      // DB lookup (Q2/Q3) より前に弾く — tenants SELECT のみで終わる
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+    });
+
+    it("不正な avatarConfigId (number 型) は 400", async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [TENANT_ROW], rowCount: 1 });
+
+      const app = makeApp("tenant-a");
+      const res = await request(app)
+        .post("/api/avatar/room-token")
+        .send({ avatarConfigId: 12345 });
+
+      expect(res.status).toBe(400);
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+    });
+
+    it("avatarConfigId 未指定 (undefined) は素通し (fallback Q3 へ)", async () => {
+      mockQuery
+        .mockResolvedValueOnce({ rows: [TENANT_ROW], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const app = makeApp("tenant-a");
+      const res = await request(app)
+        .post("/api/avatar/room-token")
+        .send({});
+
+      expect(res.status).toBe(200);
+      expect(res.body.enabled).toBe(true);
+    });
+
+    it("avatarConfigId が null は素通し (fallback Q3 へ)", async () => {
+      mockQuery
+        .mockResolvedValueOnce({ rows: [TENANT_ROW], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const app = makeApp("tenant-a");
+      const res = await request(app)
+        .post("/api/avatar/room-token")
+        .send({ avatarConfigId: null });
+
+      expect(res.status).toBe(200);
+      expect(res.body.enabled).toBe(true);
     });
   });
 
@@ -189,13 +277,13 @@ describe("POST /api/avatar/room-token", () => {
       const app = makeApp("tenant-a");
       await request(app)
         .post("/api/avatar/room-token")
-        .send({ avatarConfigId: "config-sam-uuid" });
+        .send({ avatarConfigId: UUID_SAM });
 
       expect(mockCreateRoom).toHaveBeenCalledTimes(1);
       const createRoomArg = mockCreateRoom.mock.calls[0][0] as { metadata?: string };
       expect(createRoomArg.metadata).toBeDefined();
       const meta = JSON.parse(createRoomArg.metadata!);
-      expect(meta.avatarConfigId).toBe("config-sam-uuid");
+      expect(meta.avatarConfigId).toBe(UUID_SAM);
     });
 
     it("avatarConfigId 未指定時: createRoom の metadata は undefined", async () => {
@@ -218,11 +306,10 @@ describe("POST /api/avatar/room-token", () => {
         .mockResolvedValueOnce({ rows: [TENANT_ROW], rowCount: 1 })
         .mockResolvedValueOnce({ rows: [] }); // Q2 0件 = 他テナント非デフォルト → アクセス拒否
 
-      const CROSS_TENANT_UUID = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
       const app = makeApp("tenant-a");
       await request(app)
         .post("/api/avatar/room-token")
-        .send({ avatarConfigId: CROSS_TENANT_UUID });
+        .send({ avatarConfigId: UUID_OTHER });
 
       // Q2 SQL が tenant_id = $2 で tenant-a 以外を排除していることを検証
       const q2Call = mockQuery.mock.calls[1];
@@ -230,8 +317,9 @@ describe("POST /api/avatar/room-token", () => {
       const params: unknown[] = q2Call[1];
       expect(sql).toContain("tenant_id = $2");
       expect(sql).toContain("tenant_id = 'r2c_default'");
-      expect(params[0]).toBe(CROSS_TENANT_UUID); // $1 = avatarConfigId
-      expect(params[1]).toBe("tenant-a");         // $2 = requestingTenantId
+      expect(sql).toContain("is_active = true");
+      expect(params[0]).toBe(UUID_OTHER);          // $1 = avatarConfigId
+      expect(params[1]).toBe("tenant-a");          // $2 = requestingTenantId
 
       // SQL ownership check が通らなかった UUID は room metadata に載らない
       expect(mockCreateRoom).toHaveBeenCalledTimes(1);

--- a/src/api/avatar/livekitTokenRoutes.test.ts
+++ b/src/api/avatar/livekitTokenRoutes.test.ts
@@ -202,5 +202,21 @@ describe("POST /api/avatar/room-token", () => {
       const createRoomArg = mockCreateRoom.mock.calls[0][0] as { metadata?: string };
       expect(createRoomArg.metadata).toBeUndefined();
     });
+
+    it("cross-tenant avatarConfigId (Q2=0件): createRoom の metadata は undefined (trust boundary)", async () => {
+      mockQuery
+        .mockResolvedValueOnce({ rows: [TENANT_ROW], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [] }); // Q2 0件 = 他テナント非デフォルト → アクセス拒否
+
+      const app = makeApp("tenant-a");
+      await request(app)
+        .post("/api/avatar/room-token")
+        .send({ avatarConfigId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee" });
+
+      expect(mockCreateRoom).toHaveBeenCalledTimes(1);
+      const createRoomArg = mockCreateRoom.mock.calls[0][0] as { metadata?: string };
+      // SQL ownership check が通らなかった UUID は room metadata に載らない
+      expect(createRoomArg.metadata).toBeUndefined();
+    });
   });
 });

--- a/src/api/avatar/livekitTokenRoutes.ts
+++ b/src/api/avatar/livekitTokenRoutes.ts
@@ -53,7 +53,8 @@ async function dispatchAgentToRoom(
   livekitUrl: string,
   apiKey: string,
   apiSecret: string,
-  roomName: string
+  roomName: string,
+  avatarConfigId?: string
 ): Promise<void> {
   const roomClient = new RoomServiceClient(livekitUrl, apiKey, apiSecret);
   const dispatchClient = new AgentDispatchClient(livekitUrl, apiKey, apiSecret);
@@ -64,6 +65,8 @@ async function dispatchAgentToRoom(
       name: roomName,
       emptyTimeout: 1800,    // 30分（デフォルト5分→延長）
       maxParticipants: 3,    // widget + agent + lemonslice
+      // avatarConfigId を metadata に埋め込み → agent.py が特定アバターを選択できる
+      metadata: avatarConfigId ? JSON.stringify({ avatarConfigId }) : undefined,
     });
     logger.info(`[livekitTokenRoutes] Room created: ${roomName}`);
   } catch (err: unknown) {
@@ -177,7 +180,7 @@ export function registerLiveKitTokenRoutes(
 
       // Room 作成 + Agent Dispatch（SDK 経由 — await して結果をログ、失敗してもトークンは返す）
       try {
-        await dispatchAgentToRoom(livekitUrl, apiKey, apiSecret, roomName);
+        await dispatchAgentToRoom(livekitUrl, apiKey, apiSecret, roomName, requestedAvatarConfigId ?? undefined);
       } catch (err) {
         logger.error("[livekitTokenRoutes] dispatchAgentToRoom error:", err);
       }

--- a/src/api/avatar/livekitTokenRoutes.ts
+++ b/src/api/avatar/livekitTokenRoutes.ts
@@ -156,6 +156,8 @@ export function registerLiveKitTokenRoutes(
       let imageUrl: string | null = null;
       let avatarName: string | null = null;
       const requestedAvatarConfigId = typeof req.body?.avatarConfigId === "string" ? req.body.avatarConfigId : null;
+      // SQL ownership check が通ったときのみ room metadata に伝搬（cross-tenant UUID が素通りするのを防ぐ）
+      let verifiedAvatarConfigId: string | null = null;
       try {
         let avatarConfigResult;
         if (requestedAvatarConfigId) {
@@ -163,6 +165,9 @@ export function registerLiveKitTokenRoutes(
             "SELECT image_url, name FROM avatar_configs WHERE id = $1 AND (tenant_id = $2 OR tenant_id = 'r2c_default') LIMIT 1",
             [requestedAvatarConfigId, tenantId]
           );
+          if (avatarConfigResult.rows.length > 0) {
+            verifiedAvatarConfigId = requestedAvatarConfigId;
+          }
         } else {
           avatarConfigResult = await pool.query(
             "SELECT image_url, name FROM avatar_configs WHERE tenant_id = $1 AND is_active = true ORDER BY created_at DESC LIMIT 1",
@@ -180,7 +185,7 @@ export function registerLiveKitTokenRoutes(
 
       // Room 作成 + Agent Dispatch（SDK 経由 — await して結果をログ、失敗してもトークンは返す）
       try {
-        await dispatchAgentToRoom(livekitUrl, apiKey, apiSecret, roomName, requestedAvatarConfigId ?? undefined);
+        await dispatchAgentToRoom(livekitUrl, apiKey, apiSecret, roomName, verifiedAvatarConfigId ?? undefined);
       } catch (err) {
         logger.error("[livekitTokenRoutes] dispatchAgentToRoom error:", err);
       }

--- a/src/api/avatar/livekitTokenRoutes.ts
+++ b/src/api/avatar/livekitTokenRoutes.ts
@@ -155,14 +155,26 @@ export function registerLiveKitTokenRoutes(
       // avatarConfigId が指定された場合はそのconfigを優先（テスト用途 — 特定アバターのプレビュー）
       let imageUrl: string | null = null;
       let avatarName: string | null = null;
-      const requestedAvatarConfigId = typeof req.body?.avatarConfigId === "string" ? req.body.avatarConfigId : null;
+      // UUID形式のみ受け付ける（DB lookup 前に不正入力を 400 で弾く — ログインジェクション・型混入対策）
+      // avatarConfigRoutes.ts と同一の strict UUID regex
+      const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+      const rawRequestedAvatarConfigId = req.body?.avatarConfigId;
+      if (rawRequestedAvatarConfigId !== undefined && rawRequestedAvatarConfigId !== null) {
+        if (typeof rawRequestedAvatarConfigId !== "string" || !UUID_RE.test(rawRequestedAvatarConfigId)) {
+          return res.status(400).json({ error: "invalid avatarConfigId format (UUID required)" });
+        }
+      }
+      const requestedAvatarConfigId = typeof rawRequestedAvatarConfigId === "string" ? rawRequestedAvatarConfigId : null;
       // SQL ownership check が通ったときのみ room metadata に伝搬（cross-tenant UUID が素通りするのを防ぐ）
       let verifiedAvatarConfigId: string | null = null;
       try {
         let avatarConfigResult;
         if (requestedAvatarConfigId) {
+          // is_active 必須 — 無効化済み config が ID 指定で復活する穴を塞ぐ
+          // (本番 token route は信頼できない入力 widget→エンドユーザ改竄可。
+          //  admin UI の inactive プレビューは別経路の別タスクで対応 — #210 スコープ外)
           avatarConfigResult = await pool.query(
-            "SELECT image_url, name FROM avatar_configs WHERE id = $1 AND (tenant_id = $2 OR tenant_id = 'r2c_default') LIMIT 1",
+            "SELECT image_url, name FROM avatar_configs WHERE id = $1 AND (tenant_id = $2 OR tenant_id = 'r2c_default') AND is_active = true LIMIT 1",
             [requestedAvatarConfigId, tenantId]
           );
           if (avatarConfigResult.rows.length > 0) {

--- a/src/api/internal/avatarConfigRoutes.test.ts
+++ b/src/api/internal/avatarConfigRoutes.test.ts
@@ -83,6 +83,7 @@ describe("GET /api/internal/avatar-config", () => {
       expect(sql).toContain("id = $1");
       expect(sql).toContain("tenant_id = $2");
       expect(sql).toContain("tenant_id = 'r2c_default'");
+      expect(sql).toContain("is_active = true");  // Codex MEDIUM #210: ID 指定パスも is_active 必須
       expect(mockQuery.mock.calls[0][1]).toEqual([UUID_SAM, "tenant-a"]);
     });
 
@@ -116,7 +117,23 @@ describe("GET /api/internal/avatar-config", () => {
       expect(sql).toContain("id = $1");
       expect(sql).toContain("tenant_id = $2");
       expect(sql).toContain("tenant_id = 'r2c_default'");
+      expect(sql).toContain("is_active = true");
       expect(params).toEqual([UUID_OTHER, "tenant-a"]);
+    });
+
+    it("inactive な自テナントアバターは ID 指定でも復活しない (Codex MEDIUM #210)", async () => {
+      // 無効化済み config は WHERE id = $1 AND ... AND is_active = true で 0件
+      const mockQuery = mockPool([]);
+      const res = await request(makeApp())
+        .get(`/api/internal/avatar-config?tenantId=tenant-a&avatarConfigId=${UUID_SAM}`)
+        .set("X-Internal-Request", "1");
+
+      expect(res.status).toBe(200);
+      expect(res.body.config).toBeNull();
+
+      const sql: string = mockQuery.mock.calls[0][0];
+      expect(sql).toContain("is_active = true");
+      // 注: admin UI の inactive プレビューはこの経路ではなく、認証済み admin 専用経路で対応 (別タスク)
     });
   });
 

--- a/src/api/internal/avatarConfigRoutes.test.ts
+++ b/src/api/internal/avatarConfigRoutes.test.ts
@@ -1,0 +1,140 @@
+// src/api/internal/avatarConfigRoutes.test.ts
+// GET /api/internal/avatar-config の avatarConfigId 伝搬修正(Path B fix)検証
+
+import express from "express";
+import request from "supertest";
+import { registerInternalAvatarConfigRoutes } from "./avatarConfigRoutes";
+
+jest.mock("../../lib/db", () => ({
+  getPool: jest.fn(),
+}));
+
+import { getPool } from "../../lib/db";
+const mockGetPool = getPool as jest.Mock;
+
+function makeApp() {
+  const app = express();
+  registerInternalAvatarConfigRoutes(app);
+  return app;
+}
+
+const AVATAR_ROW = {
+  voice_id: "voice-123",
+  personality_prompt: "You are SAM.",
+  emotion_tags: [],
+  lemonslice_agent_id: "agent_289feaadc2983989",
+  behavior_description: null,
+  avatar_provider: "lemonslice",
+  image_url: "https://example.com/sam.png",
+  agent_prompt: "calm",
+  agent_idle_prompt: "idle",
+};
+
+const ARJUN_ROW = {
+  ...AVATAR_ROW,
+  personality_prompt: "You are ARJUN.",
+  lemonslice_agent_id: "agent_b039be055ea73c6d",
+  image_url: "https://example.com/arjun.png",
+};
+
+function mockPool(rows: object[]) {
+  const mockQuery = jest.fn().mockResolvedValue({ rows });
+  mockGetPool.mockReturnValue({ query: mockQuery });
+  return mockQuery;
+}
+
+describe("GET /api/internal/avatar-config", () => {
+  beforeEach(() => {
+    mockGetPool.mockReset();
+  });
+
+  describe("fail-closed: X-Internal-Request ヘッダなし → 403", () => {
+    it("ヘッダ欠落で 403", async () => {
+      const res = await request(makeApp())
+        .get("/api/internal/avatar-config?tenantId=tenant-a");
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("tenantId 未指定 → 400", () => {
+    it("tenantId なしで 400", async () => {
+      const res = await request(makeApp())
+        .get("/api/internal/avatar-config")
+        .set("X-Internal-Request", "1");
+      expect(res.status).toBe(400);
+    });
+  });
+
+  const UUID_SAM     = "87ca75df-8fd5-4e41-b3e4-1cbdc2d97462";
+  const UUID_DEFAULT = "d0d3722c-e033-4d91-8eb2-66a06978548a";
+  const UUID_OTHER   = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+  describe("avatarConfigId 指定時 (Path B fix)", () => {
+    it("自テナントのアバターを ID 指定で取得できる", async () => {
+      const mockQuery = mockPool([AVATAR_ROW]);
+      const res = await request(makeApp())
+        .get(`/api/internal/avatar-config?tenantId=tenant-a&avatarConfigId=${UUID_SAM}`)
+        .set("X-Internal-Request", "1");
+
+      expect(res.status).toBe(200);
+      expect(res.body.config.lemonslice_agent_id).toBe("agent_289feaadc2983989");
+
+      const sql: string = mockQuery.mock.calls[0][0];
+      expect(sql).toContain("id = $1");
+      expect(sql).toContain("tenant_id = $2");
+      expect(sql).toContain("tenant_id = 'r2c_default'");
+      expect(mockQuery.mock.calls[0][1]).toEqual([UUID_SAM, "tenant-a"]);
+    });
+
+    it("r2c_default のアバターを別テナントから ID 指定で取得できる (cross-tenant)", async () => {
+      const mockQuery = mockPool([AVATAR_ROW]);
+      const res = await request(makeApp())
+        .get(`/api/internal/avatar-config?tenantId=other-tenant&avatarConfigId=${UUID_DEFAULT}`)
+        .set("X-Internal-Request", "1");
+
+      expect(res.status).toBe(200);
+      expect(res.body.config).not.toBeNull();
+
+      const sql: string = mockQuery.mock.calls[0][0];
+      expect(sql).toContain("tenant_id = 'r2c_default'");
+    });
+
+    it("他テナント非デフォルトアバターは取得できない (0件 → null)", async () => {
+      mockPool([]);
+      const res = await request(makeApp())
+        .get(`/api/internal/avatar-config?tenantId=tenant-a&avatarConfigId=${UUID_OTHER}`)
+        .set("X-Internal-Request", "1");
+
+      expect(res.status).toBe(200);
+      expect(res.body.config).toBeNull();
+    });
+  });
+
+  describe("avatarConfigId 未指定時 (fallback: ORDER BY 決定的)", () => {
+    it("is_active アバターを ORDER BY created_at DESC で取得する", async () => {
+      const mockQuery = mockPool([ARJUN_ROW]);
+      const res = await request(makeApp())
+        .get("/api/internal/avatar-config?tenantId=r2c_default")
+        .set("X-Internal-Request", "1");
+
+      expect(res.status).toBe(200);
+      expect(res.body.config.lemonslice_agent_id).toBe("agent_b039be055ea73c6d");
+
+      const sql: string = mockQuery.mock.calls[0][0];
+      expect(sql).toContain("is_active = true");
+      expect(sql).toContain("ORDER BY created_at DESC");
+      expect(sql).not.toMatch(/WHERE\s+id\s*=/);  // avatarConfigId パスでないことを確認
+      expect(mockQuery.mock.calls[0][1]).toEqual(["r2c_default"]);
+    });
+
+    it("is_active アバターなし → config: null", async () => {
+      mockPool([]);
+      const res = await request(makeApp())
+        .get("/api/internal/avatar-config?tenantId=empty-tenant")
+        .set("X-Internal-Request", "1");
+
+      expect(res.status).toBe(200);
+      expect(res.body.config).toBeNull();
+    });
+  });
+});

--- a/src/api/internal/avatarConfigRoutes.test.ts
+++ b/src/api/internal/avatarConfigRoutes.test.ts
@@ -99,14 +99,24 @@ describe("GET /api/internal/avatar-config", () => {
       expect(sql).toContain("tenant_id = 'r2c_default'");
     });
 
-    it("他テナント非デフォルトアバターは取得できない (0件 → null)", async () => {
-      mockPool([]);
+    it("他テナント非デフォルトアバターは取得できない — SQL が tenant_id と id の両方でバインドして排除する", async () => {
+      const mockQuery = mockPool([]);
       const res = await request(makeApp())
         .get(`/api/internal/avatar-config?tenantId=tenant-a&avatarConfigId=${UUID_OTHER}`)
         .set("X-Internal-Request", "1");
 
       expect(res.status).toBe(200);
       expect(res.body.config).toBeNull();
+
+      // WHERE 句と引数バインドを両方確認:
+      // DB が 0件を返したのが「UUID_OTHER が tenant-a にも r2c_default にも属さない」
+      // という正しいクエリを発行した結果であることを検証する
+      const sql: string = mockQuery.mock.calls[0][0];
+      const params: unknown[] = mockQuery.mock.calls[0][1];
+      expect(sql).toContain("id = $1");
+      expect(sql).toContain("tenant_id = $2");
+      expect(sql).toContain("tenant_id = 'r2c_default'");
+      expect(params).toEqual([UUID_OTHER, "tenant-a"]);
     });
   });
 

--- a/src/api/internal/avatarConfigRoutes.ts
+++ b/src/api/internal/avatarConfigRoutes.ts
@@ -30,9 +30,11 @@ export function registerInternalAvatarConfigRoutes(app: Express): void {
       const pool = getPool();
       let result;
       if (avatarConfigId) {
-        // 特定アバターをID指定で取得（自テナント or r2c_default 限定）
+        // 特定アバターをID指定で取得（自テナント or r2c_default 限定 + is_active）
+        // is_active 必須 — 無効化済み config が ID 指定で復活する穴を塞ぐ
+        // (admin UI の inactive プレビューは別経路の別タスクで対応 — #210 スコープ外)
         result = await pool.query(
-          `SELECT ${COLS} FROM avatar_configs WHERE id = $1 AND (tenant_id = $2 OR tenant_id = 'r2c_default') LIMIT 1`,
+          `SELECT ${COLS} FROM avatar_configs WHERE id = $1 AND (tenant_id = $2 OR tenant_id = 'r2c_default') AND is_active = true LIMIT 1`,
           [avatarConfigId, tenantId],
         );
       } else {

--- a/src/api/internal/avatarConfigRoutes.ts
+++ b/src/api/internal/avatarConfigRoutes.ts
@@ -19,12 +19,29 @@ export function registerInternalAvatarConfigRoutes(app: Express): void {
       return res.status(400).json({ error: "tenantId required" });
     }
 
+    const _rawConfigId = typeof req.query.avatarConfigId === "string" ? req.query.avatarConfigId : undefined;
+    // UUID形式のみ受け付ける（ログインジェクション・不正入力を排除）
+    const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    const avatarConfigId = _rawConfigId && UUID_RE.test(_rawConfigId) ? _rawConfigId : undefined;
+
+    const COLS = "voice_id, personality_prompt, emotion_tags, lemonslice_agent_id, behavior_description, avatar_provider, image_url, agent_prompt, agent_idle_prompt";
+
     try {
       const pool = getPool();
-      const result = await pool.query(
-        "SELECT voice_id, personality_prompt, emotion_tags, lemonslice_agent_id, behavior_description, avatar_provider, image_url, agent_prompt, agent_idle_prompt FROM avatar_configs WHERE tenant_id = $1 AND is_active = true LIMIT 1",
-        [tenantId],
-      );
+      let result;
+      if (avatarConfigId) {
+        // 特定アバターをID指定で取得（自テナント or r2c_default 限定）
+        result = await pool.query(
+          `SELECT ${COLS} FROM avatar_configs WHERE id = $1 AND (tenant_id = $2 OR tenant_id = 'r2c_default') LIMIT 1`,
+          [avatarConfigId, tenantId],
+        );
+      } else {
+        // アクティブアバターを決定的に取得（ORDER BY で非決定性を排除）
+        result = await pool.query(
+          `SELECT ${COLS} FROM avatar_configs WHERE tenant_id = $1 AND is_active = true ORDER BY created_at DESC LIMIT 1`,
+          [tenantId],
+        );
+      }
 
       if (result.rows.length === 0) {
         return res.json({ config: null });


### PR DESCRIPTION
## 問題 (Path B / GID1215114990855142)

テストチャットで選択した avatarConfigId が agent.py に届かず、LiveKit エージェントが
内部 API から **非選択のアバター** を使っていた。

### 根本原因の証拠

-  の本番実応答: **ARJUN** (agent_b039be055ea73c6d)
- SAM の実際の agent_id: **agent_289feaadc2983989**
- 旧クエリ: `WHERE is_active = true LIMIT 1` (ORDER BY なし) → r2c_default 18アバター中のランダム1件

### 修正内容

| ファイル | 変更 |
|---------|------|
| livekitTokenRoutes.ts | createRoom metadata に avatarConfigId を埋め込む |
| avatarConfigRoutes.ts | avatarConfigId パラメータ対応 + UUID バリデーション + fallback ORDER BY |
| agent.py | room metadata から avatarConfigId を読み出し fetch_avatar_config に渡す |
| avatarConfigRoutes.test.ts | 新規: Path B 修正の全パスをカバー (7テスト) |
| livekitTokenRoutes.test.ts | 追加: metadata 伝搬テスト (2テスト) |

### 後方互換

metadata なし旧ルーム → is_active + ORDER BY created_at DESC fallback で継続動作。

### Gate 状態

- [x] Gate 1: tsc --noEmit クリア
- [x] Gate 1.5: target 14/14 通過
- [x] Gate 2: 1620/1621 通過 (1件は無関係な既存 flaky test)
- [x] Gate 2.5: Codex adversarial-review — HIGH 2件は false positive、LOW UUID バリデーション追加で対処

## Test plan

- [ ] admin.r2c.biz: carnation テナントでテストチャット → SAM 選択 → 実際にSAMが描画されることを確認
- [ ] r2c_default 全18アバター切り替え: 選択アバター = 描画アバターの一致確認
- [ ] avatarConfigId なし → 旧フォールバック動作に変化なしを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)