### PR TITLE
fix(admin-ui): avatar一覧フィルタバグ — tenantFilter=r2c_defaultでis_default行が全消えする

### DIFF
--- a/admin-ui/src/pages/admin/avatar/index.tsx
+++ b/admin-ui/src/pages/admin/avatar/index.tsx
@@ -245,12 +245,9 @@ export default function AvatarListPage() {
   const displayedConfigs = useMemo(() => {
     let result = [...configs];
 
-    // テナントフィルタ: 特定テナント選択時はis_default=trueを除外（タイプ「デフォルト」選択時は除外しない）
+    // テナントフィルタ（strict tenant_id 一致のみ）
     if (tenantFilter !== "all") {
-      result = result.filter((c) => {
-        if (c.is_default && typeFilter !== "default") return false;
-        return (c.tenant_id ?? "") === tenantFilter;
-      });
+      result = result.filter((c) => (c.tenant_id ?? "") === tenantFilter);
     }
     // タイプフィルタ
     if (typeFilter === "default") result = result.filter((c) => c.is_default);


### PR DESCRIPTION
## 根本原因

`da2b5d3` (fix: exclude default avatars from tenant filter selection) で追加した早期 return が誤動作。

```typescript
// 問題のあったコード (admin-ui/src/pages/admin/avatar/index.tsx:251)
if (c.is_default && typeFilter !== "default") return false;
```

`typeFilter` の初期値は `"all"` なので `typeFilter !== "default"` が常に true となり、
**`tenantFilter` でテナントを選択するたびに `is_default=true` の行が全消えしていた。**

## 修正内容

早期 return を削除し、`tenant_id` strict 一致のみに戻す。
`is_default` の絞り込みは下段の `typeFilter === "custom"` ブロックが正しく担う。

```diff
-    // テナントフィルタ: 特定テナント選択時はis_default=trueを除外（タイプ「デフォルト」選択時は除外しない）
+    // テナントフィルタ（strict tenant_id 一致のみ）
     if (tenantFilter !== "all") {
-      result = result.filter((c) => {
-        if (c.is_default && typeFilter !== "default") return false;
-        return (c.tenant_id ?? "") === tenantFilter;
-      });
+      result = result.filter((c) => (c.tenant_id ?? "") === tenantFilter);
     }
```

## 検証結果

Node でフィルタロジックを単体検証（全シナリオ PASS）:

| シナリオ | tenantFilter | typeFilter | 期待 | 結果 |
|---------|-------------|-----------|------|------|
| A (バグ発生) | r2c_default | all | is_default行[1,2]表示 | ✅ [1,2] |
| B | r2c_default | custom | is_default行消える | ✅ [] |
| C | tenant_x | all | tenant_x行のみ | ✅ [3,4] |
| D | r2c_default | default + active | 1件のみ | ✅ [1] |
| E | all | all | 全5件 | ✅ [1,2,3,4,5] |
| バグ再現 (修正前) | r2c_default | all | — | 🐛 [] (空) |

## Test plan

- [x] Gate 1: `pnpm typecheck` (backend) 0 errors / `pnpm test` 1678 tests passed
- [x] admin-ui typecheck errors は pre-existing (変更ファイル外: AvatarWizard.tsx, wizard.tsx, engagement/index.tsx)
- [x] フィルタロジック単体検証 (Node) 全シナリオ PASS
- [x] Gate 2.5 スキップ (UIフィルタロジックのみ、docs相当)
- [ ] hkobayashi: admin.r2c.biz で「テナント選択→デフォルトアバターが表示される」UAT

🤖 Generated with [Claude Code](https://claude.com/claude-code)