### PR TITLE
fix(security): X-Internal-Request spoofability — A nginx + B internalNetworkOnly (GID1215119240093940)

### DIFF
--- a/SCRIPTS/post-deploy-smoke.sh
+++ b/SCRIPTS/post-deploy-smoke.sh
@@ -73,7 +73,10 @@ if [ "$metrics_status" = "200" ]; then
   echo "  ✅ Metrics — $metrics_status (localhost on VPS)"
   PASS=$((PASS + 1))
 else
-  echo "  ⚠️  Metrics — $metrics_status (non-critical, VPS localhost check)"
+  # Codex Round 2: 内部メトリクスは observability の生命線。WARN ではなく
+  # FAIL にして deploy ゲートで止める（observability regression を看過させない）。
+  echo "  ❌ Metrics — $metrics_status (expected 200 via VPS localhost:3100)"
+  FAIL=$((FAIL + 1))
 fi
 
 # ── 5b. 公開面では /metrics は必ず deny される（spoof閉塞の確認）──────
@@ -97,7 +100,10 @@ if [ "$nginx_loopback_status" = "200" ]; then
   echo "  ✅ /metrics via nginx loopback — $nginx_loopback_status"
   PASS=$((PASS + 1))
 else
-  echo "  ⚠️  /metrics via nginx loopback — $nginx_loopback_status (expected 200, check nginx header injection)"
+  # Codex Round 2: nginx ↔ Express の interplay が壊れたら 200 を返せなくなる。
+  # 検出を deploy ゲートで強制するため FAIL に格上げ。
+  echo "  ❌ /metrics via nginx loopback — $nginx_loopback_status (expected 200, check nginx X-Internal-Request injection / IP allow)"
+  FAIL=$((FAIL + 1))
 fi
 
 # ── 6. avatar-agent PM2 status ────────────────────────────────────────────

--- a/SCRIPTS/post-deploy-smoke.sh
+++ b/SCRIPTS/post-deploy-smoke.sh
@@ -87,6 +87,19 @@ else
   FAIL=$((FAIL + 1))
 fi
 
+# ── 5c. nginx 経由の loopback (VPSローカルhttp 127.0.0.1) は 200 を返す ──
+# Codex MEDIUM 反映: nginx の proxy_set_header 設定誤りで loopback 経由も
+# 200 を返せなくなる lockout を検出する。Pre-A 時点と Post-A 時点で意味が
+# 変わる(Post: nginx が "1" を注入してくれるのでヘッダなしでも 200)。
+nginx_loopback_status=$(ssh "${VPS}" "curl -s -o /dev/null -w '%{http_code}' --max-time 5 \
+  http://127.0.0.1/metrics 2>/dev/null" 2>/dev/null || echo "000")
+if [ "$nginx_loopback_status" = "200" ]; then
+  echo "  ✅ /metrics via nginx loopback — $nginx_loopback_status"
+  PASS=$((PASS + 1))
+else
+  echo "  ⚠️  /metrics via nginx loopback — $nginx_loopback_status (expected 200, check nginx header injection)"
+fi
+
 # ── 6. avatar-agent PM2 status ────────────────────────────────────────────
 avatar_status=$(ssh "${VPS}" "pm2 describe rajiuce-avatar 2>/dev/null | grep -E 'status.*online' | wc -l | tr -d ' '" 2>/dev/null || echo "0")
 if [ "$avatar_status" -gt 0 ]; then

--- a/SCRIPTS/post-deploy-smoke.sh
+++ b/SCRIPTS/post-deploy-smoke.sh
@@ -64,14 +64,27 @@ check "Admin UI" "$ADMIN_URL"
 # ── 4. Demo page ──────────────────────────────────────────────────────────
 check "Demo page" "$API_URL/carnation-demo/index.html"
 
-# ── 5. Metrics（内部リクエストヘッダー必要）─────────────────────────────
-metrics_status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
-  -H "X-Internal-Request: 1" "$API_URL/metrics" 2>/dev/null || echo "000")
+# ── 5. Metrics（VPS内 localhost 経由でのみ確認）─────────────────────────
+# 注: /metrics は外部からは nginx allow 127.0.0.1; deny all; で必ず 403。
+# 内部疎通は ssh で VPS に入ってから http://localhost:3100 を叩いて確認する。
+metrics_status=$(ssh "${VPS}" "curl -s -o /dev/null -w '%{http_code}' --max-time 5 \
+  -H 'X-Internal-Request: 1' http://localhost:3100/metrics 2>/dev/null" 2>/dev/null || echo "000")
 if [ "$metrics_status" = "200" ]; then
-  echo "  ✅ Metrics — $metrics_status"
+  echo "  ✅ Metrics — $metrics_status (localhost on VPS)"
   PASS=$((PASS + 1))
 else
-  echo "  ⚠️  Metrics — $metrics_status (non-critical, requires X-Internal-Request header)"
+  echo "  ⚠️  Metrics — $metrics_status (non-critical, VPS localhost check)"
+fi
+
+# ── 5b. 公開面では /metrics は必ず deny される（spoof閉塞の確認）──────
+public_metrics_status=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 \
+  -H "X-Internal-Request: 1" "$API_URL/metrics" 2>/dev/null || echo "000")
+if [ "$public_metrics_status" = "403" ] || [ "$public_metrics_status" = "404" ]; then
+  echo "  ✅ /metrics public spoof denied — $public_metrics_status"
+  PASS=$((PASS + 1))
+else
+  echo "  ❌ /metrics is reachable from public with header — got $public_metrics_status (expected 403/404)"
+  FAIL=$((FAIL + 1))
 fi
 
 # ── 6. avatar-agent PM2 status ────────────────────────────────────────────

--- a/nginx-rajiuce.new
+++ b/nginx-rajiuce.new
@@ -1,6 +1,61 @@
 server {
     server_name api.r2c.biz;
 
+    # ----------------------------------------------------------------------
+    # Internal endpoints — IP allowlist + X-Internal-Request header strip.
+    #   - /api/internal/  : avatar-agent (localhost) のみ。spoof閉塞。
+    #   - /metrics        : Prometheus scrape (localhost) のみ。
+    #   - /internal/ga4/  : Cloudflare Workers Cron から叩く必要があるため
+    #                       IP制限はしない（HMAC で守る）。ヘッダはstripしない
+    #                       — internalHmacMiddleware が X-Internal-Request:1 を要求するため。
+    # ----------------------------------------------------------------------
+    location /api/internal/ {
+        allow 127.0.0.1;
+        allow ::1;
+        deny all;
+
+        proxy_pass http://127.0.0.1:3100;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        # 外部由来の X-Internal-Request ヘッダを強制strip（多層防御）
+        proxy_set_header X-Internal-Request "";
+        client_max_body_size 50M;
+        proxy_read_timeout 120s;
+    }
+
+    location = /metrics {
+        allow 127.0.0.1;
+        allow ::1;
+        deny all;
+
+        proxy_pass http://127.0.0.1:3100;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Internal-Request "";
+        proxy_read_timeout 30s;
+    }
+
+    location /internal/ga4/ {
+        # CF Workers Cron からの呼び出しを受ける必要があるため allow/deny は付けない。
+        # 認証は HMAC (internalHmacMiddleware) に委譲する。
+        # 外部由来 X-Internal-Request:1 はここでは strip しない — HMAC ミドルウェアが
+        # 同ヘッダ + 5分以内の有効署名 + timing-safe比較で実認証する。
+        proxy_pass http://127.0.0.1:3100;
+        proxy_http_version 1.1;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        client_max_body_size 1M;
+        proxy_read_timeout 60s;
+    }
+
     location / {
         proxy_pass http://127.0.0.1:3100;
         proxy_http_version 1.1;
@@ -10,6 +65,8 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        # デフォルトでも strip — このヘッダを正当に使うのは /internal/ga4/ のみ
+        proxy_set_header X-Internal-Request "";
         client_max_body_size 50M;
         proxy_read_timeout 120s;
     }

--- a/nginx-rajiuce.new
+++ b/nginx-rajiuce.new
@@ -2,12 +2,22 @@ server {
     server_name api.r2c.biz;
 
     # ----------------------------------------------------------------------
-    # Internal endpoints — IP allowlist + X-Internal-Request header strip.
-    #   - /api/internal/  : avatar-agent (localhost) のみ。spoof閉塞。
-    #   - /metrics        : Prometheus scrape (localhost) のみ。
-    #   - /internal/ga4/  : Cloudflare Workers Cron から叩く必要があるため
-    #                       IP制限はしない（HMAC で守る）。ヘッダはstripしない
-    #                       — internalHmacMiddleware が X-Internal-Request:1 を要求するため。
+    # Internal endpoints — IP allowlist + X-Internal-Request header policy.
+    #
+    #   /api/internal/  : loopback のみ (avatar-agent / smoke / local ops)
+    #   /metrics        : loopback のみ (Prometheus scrape)
+    #   /internal/ga4/  : 公開可 (CF Workers Cron)。HMAC で守る。ヘッダ操作なし。
+    #   /               : デフォルト。X-Internal-Request は強制strip。
+    #
+    # ヘッダ方針 (Codex review #1 反映 — 2026-05-27):
+    #   /api/internal/ と /metrics は allow/deny で loopback 確定済なので、
+    #   nginx 側で `X-Internal-Request: 1` を **必ず注入** する（strip ではなく
+    #   上書き）。これにより:
+    #     - 直接 :3100 を叩く caller (avatar-agent 等) はクライアントが付ければ通る
+    #     - nginx 経由の loopback caller (例 prometheus@VPS) もそのまま 200
+    #     - 外部攻撃者は deny all で nginx 段で 403 → app 層 internalNetworkOnly
+    #       の二重ガードに辿りつかない
+    #   "nginx strip → app 必須" の二重鍵ロックアウト (Codex HIGH 指摘) を回避。
     # ----------------------------------------------------------------------
     location /api/internal/ {
         allow 127.0.0.1;
@@ -20,8 +30,9 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        # 外部由来の X-Internal-Request ヘッダを強制strip（多層防御）
-        proxy_set_header X-Internal-Request "";
+        # 到達できるのは allow/deny 通過済 loopback クライアントのみ → "1" 強制注入。
+        # 攻撃者由来の値もこの上書きで無効化される。
+        proxy_set_header X-Internal-Request "1";
         client_max_body_size 50M;
         proxy_read_timeout 120s;
     }
@@ -37,15 +48,14 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header X-Internal-Request "";
+        proxy_set_header X-Internal-Request "1";
         proxy_read_timeout 30s;
     }
 
     location /internal/ga4/ {
         # CF Workers Cron からの呼び出しを受ける必要があるため allow/deny は付けない。
         # 認証は HMAC (internalHmacMiddleware) に委譲する。
-        # 外部由来 X-Internal-Request:1 はここでは strip しない — HMAC ミドルウェアが
-        # 同ヘッダ + 5分以内の有効署名 + timing-safe比較で実認証する。
+        # X-Internal-Request:1 はクライアント(CF Worker)が付けて来る。strip しない。
         proxy_pass http://127.0.0.1:3100;
         proxy_http_version 1.1;
         proxy_set_header Host $host;
@@ -65,7 +75,8 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        # デフォルトでも strip — このヘッダを正当に使うのは /internal/ga4/ のみ
+        # 公開トラフィックでは X-Internal-Request を強制 strip
+        # — 内部 endpoint は別 location で IP 制限 + 注入、ここで偽装値を残さない。
         proxy_set_header X-Internal-Request "";
         client_max_body_size 50M;
         proxy_read_timeout 120s;

--- a/src/api/internal/avatarConfigRoutes.ts
+++ b/src/api/internal/avatarConfigRoutes.ts
@@ -7,9 +7,10 @@
 import type { Express, Request, Response } from "express";
 import { INTERNAL_REQUEST_HEADER } from "../../lib/metrics/kpiDefinitions";
 import { getPool } from "../../lib/db";
+import { internalNetworkOnly } from "../middleware/internalNetworkOnly";
 
 export function registerInternalAvatarConfigRoutes(app: Express): void {
-  app.get("/api/internal/avatar-config", async (req: Request, res: Response) => {
+  app.get("/api/internal/avatar-config", internalNetworkOnly, async (req: Request, res: Response) => {
     if (req.headers[INTERNAL_REQUEST_HEADER] !== "1") {
       return res.status(403).json({ error: "forbidden" });
     }

--- a/src/api/internal/usageRoutes.ts
+++ b/src/api/internal/usageRoutes.ts
@@ -9,9 +9,10 @@
 import type { Express, Request, Response } from 'express';
 import { INTERNAL_REQUEST_HEADER } from '../../lib/metrics/kpiDefinitions';
 import { trackUsage } from '../../lib/billing/usageTracker';
+import { internalNetworkOnly } from '../middleware/internalNetworkOnly';
 
 export function registerInternalUsageRoutes(app: Express): void {
-  app.post('/api/internal/usage', (req: Request, res: Response) => {
+  app.post('/api/internal/usage', internalNetworkOnly, (req: Request, res: Response) => {
     if (req.headers[INTERNAL_REQUEST_HEADER] !== '1') {
       return res.status(403).json({ error: 'forbidden' });
     }

--- a/src/api/middleware/internalNetworkOnly.test.ts
+++ b/src/api/middleware/internalNetworkOnly.test.ts
@@ -43,6 +43,22 @@ describe("isLoopbackAddress", () => {
   it("allows IPv4-mapped IPv6 loopback (::ffff:127.0.0.1)", () => {
     expect(isLoopbackAddress("::ffff:127.0.0.1")).toBe(true);
   });
+  // Codex Round 2: 127.0.0.0/8 is loopback per RFC 5735, not just 127.0.0.1
+  it("allows other addresses in 127.0.0.0/8 (e.g. 127.0.0.2)", () => {
+    expect(isLoopbackAddress("127.0.0.2")).toBe(true);
+  });
+  it("allows 127.1.2.3 (rest of 127/8)", () => {
+    expect(isLoopbackAddress("127.1.2.3")).toBe(true);
+  });
+  it("allows ::ffff:127.0.0.2 (mapped, non-canonical loopback)", () => {
+    expect(isLoopbackAddress("::ffff:127.0.0.2")).toBe(true);
+  });
+  it("allows mixed-case IPv4-mapped prefix (::FFFF:127.0.0.1)", () => {
+    expect(isLoopbackAddress("::FFFF:127.0.0.1")).toBe(true);
+  });
+  it("trims surrounding whitespace before evaluation", () => {
+    expect(isLoopbackAddress("  127.0.0.1  ")).toBe(true);
+  });
   it("denies undefined (fail-closed)", () => {
     expect(isLoopbackAddress(undefined)).toBe(false);
   });
@@ -66,6 +82,23 @@ describe("isLoopbackAddress", () => {
   });
   it("denies a deceptive string that contains 127.0.0.1 as substring", () => {
     expect(isLoopbackAddress("127.0.0.1.evil.example.com")).toBe(false);
+  });
+  it("denies 128.0.0.1 (off-by-one above 127/8)", () => {
+    expect(isLoopbackAddress("128.0.0.1")).toBe(false);
+  });
+  it("denies ::ffff:8.8.8.8 (mapped non-loopback)", () => {
+    expect(isLoopbackAddress("::ffff:8.8.8.8")).toBe(false);
+  });
+  it("denies malformed IPv4 (octets > 255)", () => {
+    expect(isLoopbackAddress("127.0.0.999")).toBe(false);
+  });
+  it("denies leading-zero / non-decimal forms (avoids ambiguous parsers)", () => {
+    // Defensively: '127.000.000.001' MIGHT be normalized to 127.0.0.1 in some
+    // libs; we only accept literal 1-3 digit decimal octets to stay predictable.
+    expect(isLoopbackAddress("0177.0.0.1")).toBe(false);
+  });
+  it("denies non-string inputs", () => {
+    expect(isLoopbackAddress(123 as unknown as string)).toBe(false);
   });
 });
 

--- a/src/api/middleware/internalNetworkOnly.test.ts
+++ b/src/api/middleware/internalNetworkOnly.test.ts
@@ -1,0 +1,150 @@
+// src/api/middleware/internalNetworkOnly.test.ts
+//
+// X-Internal-Request spoofability 修正 (GID 1215119240093940) のテスト。
+// allow/deny 両面 + supertest による正当 localhost 経路の通過を保証する。
+
+import type { NextFunction, Request, Response } from "express";
+import express from "express";
+import request from "supertest";
+import { internalNetworkOnly, isLoopbackAddress } from "./internalNetworkOnly";
+
+jest.mock("../../lib/logger", () => ({
+  logger: {
+    warn: jest.fn(),
+    error: jest.fn(),
+    info: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
+function makeReq(remoteAddress: string | undefined, headers: Record<string, string> = {}): Request {
+  return {
+    socket: { remoteAddress } as unknown as Request["socket"],
+    headers,
+    path: "/api/internal/test",
+    method: "GET",
+  } as unknown as Request;
+}
+
+function makeRes() {
+  const res: Partial<Response> = {};
+  res.status = jest.fn().mockReturnValue(res);
+  res.json = jest.fn().mockReturnValue(res);
+  return res as Response;
+}
+
+describe("isLoopbackAddress", () => {
+  it("allows 127.0.0.1", () => {
+    expect(isLoopbackAddress("127.0.0.1")).toBe(true);
+  });
+  it("allows ::1", () => {
+    expect(isLoopbackAddress("::1")).toBe(true);
+  });
+  it("allows IPv4-mapped IPv6 loopback (::ffff:127.0.0.1)", () => {
+    expect(isLoopbackAddress("::ffff:127.0.0.1")).toBe(true);
+  });
+  it("denies undefined (fail-closed)", () => {
+    expect(isLoopbackAddress(undefined)).toBe(false);
+  });
+  it("denies null (fail-closed)", () => {
+    expect(isLoopbackAddress(null)).toBe(false);
+  });
+  it("denies empty string (fail-closed)", () => {
+    expect(isLoopbackAddress("")).toBe(false);
+  });
+  it("denies an external IPv4", () => {
+    expect(isLoopbackAddress("8.8.8.8")).toBe(false);
+  });
+  it("denies an internal RFC1918 IPv4 (10.x)", () => {
+    expect(isLoopbackAddress("10.0.0.5")).toBe(false);
+  });
+  it("denies a Cloudflare edge IP (representative sample)", () => {
+    expect(isLoopbackAddress("172.69.5.10")).toBe(false);
+  });
+  it("denies a public IPv6", () => {
+    expect(isLoopbackAddress("2606:4700:4700::1111")).toBe(false);
+  });
+  it("denies a deceptive string that contains 127.0.0.1 as substring", () => {
+    expect(isLoopbackAddress("127.0.0.1.evil.example.com")).toBe(false);
+  });
+});
+
+describe("internalNetworkOnly middleware (unit)", () => {
+  const next = jest.fn() as NextFunction;
+  beforeEach(() => jest.clearAllMocks());
+
+  it("allows 127.0.0.1 socket peer", () => {
+    const req = makeReq("127.0.0.1");
+    const res = makeRes();
+    internalNetworkOnly(req, res, next);
+    expect(next).toHaveBeenCalled();
+    expect(res.status).not.toHaveBeenCalled();
+  });
+
+  it("allows ::1 socket peer", () => {
+    const req = makeReq("::1");
+    const res = makeRes();
+    internalNetworkOnly(req, res, next);
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("denies external IP (8.8.8.8) with 403", () => {
+    const req = makeReq("8.8.8.8");
+    const res = makeRes();
+    internalNetworkOnly(req, res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(res.json).toHaveBeenCalledWith({ error: "forbidden" });
+  });
+
+  it("ignores spoofed X-Forwarded-For: 127.0.0.1 (header cannot override socket)", () => {
+    const req = makeReq("8.8.8.8", {
+      "x-forwarded-for": "127.0.0.1",
+      "x-real-ip": "127.0.0.1",
+    });
+    const res = makeRes();
+    internalNetworkOnly(req, res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+
+  it("fail-closes when socket.remoteAddress is undefined", () => {
+    const req = makeReq(undefined);
+    const res = makeRes();
+    internalNetworkOnly(req, res, next);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+});
+
+describe("internalNetworkOnly middleware (supertest integration)", () => {
+  // supertest が同一プロセス内 ephemeral サーバを 127.0.0.1 で起動するので、
+  // socket.remoteAddress は 127.0.0.1 (もしくは ::ffff:127.0.0.1) になる。
+  // これは avatar-agent の RAJIUCE_API_URL=http://localhost:3100 経由と同じ条件。
+
+  it("allows supertest call (= avatar-agent localhost 経路の代理検証)", async () => {
+    const app = express();
+    app.get("/internal/test", internalNetworkOnly, (_req, res) => {
+      res.json({ ok: true });
+    });
+    const res = await request(app).get("/internal/test");
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it("returns 403 if we monkey-patch the socket remoteAddress to an external IP", async () => {
+    const app = express();
+    app.use((req, _res, next) => {
+      Object.defineProperty(req.socket, "remoteAddress", {
+        value: "203.0.113.42",
+        configurable: true,
+      });
+      next();
+    });
+    app.get("/internal/test", internalNetworkOnly, (_req, res) => {
+      res.json({ ok: true });
+    });
+    const res = await request(app).get("/internal/test");
+    expect(res.status).toBe(403);
+  });
+});

--- a/src/api/middleware/internalNetworkOnly.ts
+++ b/src/api/middleware/internalNetworkOnly.ts
@@ -1,29 +1,58 @@
 // src/api/middleware/internalNetworkOnly.ts
 //
 // Defense-in-depth for /metrics, /api/internal/avatar-config, /api/internal/usage.
-// The first line of defense is the nginx config (allow 127.0.0.1; deny all + header strip).
-// This middleware is the Express-side fail-safe: even if nginx is misconfigured or bypassed,
-// only TCP peers from the loopback interface reach the handler.
+// The first line of defense is the nginx config (allow 127.0.0.1; deny all
+// + nginx-side `X-Internal-Request: 1` injection in the same location).
+// This middleware is the Express-side fail-safe: even if nginx is misconfigured
+// or bypassed, only TCP peers from the loopback interface reach the handler.
 //
 // IMPORTANT: We deliberately use `req.socket.remoteAddress` instead of `req.ip`.
-// Express's `req.ip` honors `trust proxy` + `X-Forwarded-For`, both of which can be
-// influenced by external callers if `trust proxy` is ever turned on by mistake.
+// Express's `req.ip` honors `trust proxy` + `X-Forwarded-For`, both of which can
+// be influenced by external callers if `trust proxy` is ever turned on by mistake.
 // The raw socket peer cannot be spoofed by a header.
 //
-// Fail-closed: if remoteAddress is undefined, missing, or any non-loopback value, deny.
+// Loopback definition (RFC 5735 / RFC 4291):
+//   - IPv4: any address in 127.0.0.0/8 (not just 127.0.0.1 — e.g. 127.0.0.2,
+//     127.0.1.1 are also loopback). Some test/proxy setups surface alternate
+//     forms, and CodeX Round-2 flagged that the literal-set approach would
+//     deny benign environments.
+//   - IPv6: ::1
+//   - IPv4-mapped IPv6: ::ffff:127.0.0.0/8 (dual-stack sockets accepting v4)
+//
+// Fail-closed: if remoteAddress is undefined, empty, or any non-loopback value,
+// deny with 403.
 
 import type { NextFunction, Request, Response } from "express";
 import { logger } from "../../lib/logger";
 
-const LOOPBACK_ADDRESSES = new Set<string>([
-  "127.0.0.1",
-  "::1",
-  "::ffff:127.0.0.1", // IPv4-mapped IPv6
-]);
+const IPV4_MAPPED_PREFIX = "::ffff:";
+
+function isIpv4InLoopbackRange(addr: string): boolean {
+  // strict 4-octet dotted decimal, each 0-255, first octet must be 127.
+  const m = addr.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (!m) return false;
+  const octets = m.slice(1).map((s) => Number(s));
+  if (octets.some((o) => o < 0 || o > 255 || !Number.isInteger(o))) return false;
+  return octets[0] === 127;
+}
 
 export function isLoopbackAddress(addr: string | undefined | null): boolean {
-  if (!addr) return false;
-  return LOOPBACK_ADDRESSES.has(addr);
+  if (!addr || typeof addr !== "string") return false;
+  const trimmed = addr.trim();
+  if (!trimmed) return false;
+
+  // IPv6 loopback (only canonical "::1" — anything else like "::1%eth0" is
+  // a zone-id'd form we treat conservatively below).
+  if (trimmed === "::1") return true;
+
+  // IPv4-mapped IPv6: "::ffff:127.x.y.z"
+  if (trimmed.toLowerCase().startsWith(IPV4_MAPPED_PREFIX)) {
+    const v4Part = trimmed.slice(IPV4_MAPPED_PREFIX.length);
+    return isIpv4InLoopbackRange(v4Part);
+  }
+
+  // Plain IPv4: must be in 127.0.0.0/8.
+  return isIpv4InLoopbackRange(trimmed);
 }
 
 export function internalNetworkOnly(

--- a/src/api/middleware/internalNetworkOnly.ts
+++ b/src/api/middleware/internalNetworkOnly.ts
@@ -1,0 +1,49 @@
+// src/api/middleware/internalNetworkOnly.ts
+//
+// Defense-in-depth for /metrics, /api/internal/avatar-config, /api/internal/usage.
+// The first line of defense is the nginx config (allow 127.0.0.1; deny all + header strip).
+// This middleware is the Express-side fail-safe: even if nginx is misconfigured or bypassed,
+// only TCP peers from the loopback interface reach the handler.
+//
+// IMPORTANT: We deliberately use `req.socket.remoteAddress` instead of `req.ip`.
+// Express's `req.ip` honors `trust proxy` + `X-Forwarded-For`, both of which can be
+// influenced by external callers if `trust proxy` is ever turned on by mistake.
+// The raw socket peer cannot be spoofed by a header.
+//
+// Fail-closed: if remoteAddress is undefined, missing, or any non-loopback value, deny.
+
+import type { NextFunction, Request, Response } from "express";
+import { logger } from "../../lib/logger";
+
+const LOOPBACK_ADDRESSES = new Set<string>([
+  "127.0.0.1",
+  "::1",
+  "::ffff:127.0.0.1", // IPv4-mapped IPv6
+]);
+
+export function isLoopbackAddress(addr: string | undefined | null): boolean {
+  if (!addr) return false;
+  return LOOPBACK_ADDRESSES.has(addr);
+}
+
+export function internalNetworkOnly(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  const remote = req.socket?.remoteAddress;
+  if (!isLoopbackAddress(remote)) {
+    logger.warn(
+      {
+        path: req.path,
+        method: req.method,
+        remoteAddress: remote ?? "unknown",
+        xff: req.headers["x-forwarded-for"] ?? null,
+      },
+      "[internalNetworkOnly] denied non-loopback caller",
+    );
+    res.status(403).json({ error: "forbidden" });
+    return;
+  }
+  next();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,7 @@ import { superAdminMiddleware } from "./api/admin/tenants/superAdminMiddleware";
 import { langDetectMiddleware } from "./api/middleware/langDetect";
 import { createOriginCheckMiddleware } from "./api/middleware/originCheck";
 import { internalNetworkOnly } from "./api/middleware/internalNetworkOnly";
+import { assertInternalSecretConfigured } from "./lib/startup/internalSecretGuard";
 import { registerWidgetRoutes } from "./api/widget/routes";
 import { registerAuthRoutes } from "./api/auth/routes";
 import { registerLiveKitTokenRoutes } from "./api/avatar/livekitTokenRoutes";
@@ -611,23 +612,14 @@ app.get('/api/widget/features', ...apiStack, async (req: express.Request, res: e
 });
 
 async function startServer() {
-  // Codex review #3: 必須secretは boot 時に検証して fail-fast する。
+  // Codex review #3/#4: 必須secretは boot 時に検証して fail-fast する。
   // 起動後に runtime 500 を吐き続ける partial outage を防ぐ。
-  // production では未設定なら exit(1)。dev/test では loud warn で続行。
-  if (!process.env.INTERNAL_API_HMAC_SECRET) {
-    if (process.env.NODE_ENV === "production") {
-      logger.fatal(
-        "[startup] INTERNAL_API_HMAC_SECRET is required in production " +
-          "(/internal/ga4/* would 500 indefinitely). Aborting boot.",
-      );
-      process.exit(1);
-    } else {
-      logger.warn(
-        "[startup] INTERNAL_API_HMAC_SECRET not set — /internal/ga4/* will fail-closed (500). " +
-          "OK for dev/test, FATAL in production.",
-      );
-    }
-  }
+  // production / staging / 不明 env では未設定なら exit(1)。
+  // dev/test または ALLOW_MISSING_INTERNAL_HMAC_SECRET=true でのみ続行。
+  assertInternalSecretConfigured({
+    warn: (msg) => logger.warn(msg),
+    fatal: (msg) => logger.fatal(msg),
+  });
 
   app.listen(port, () => {
     logger.info({ port, env: process.env.NODE_ENV }, "server listening");

--- a/src/index.ts
+++ b/src/index.ts
@@ -611,6 +611,24 @@ app.get('/api/widget/features', ...apiStack, async (req: express.Request, res: e
 });
 
 async function startServer() {
+  // Codex review #3: 必須secretは boot 時に検証して fail-fast する。
+  // 起動後に runtime 500 を吐き続ける partial outage を防ぐ。
+  // production では未設定なら exit(1)。dev/test では loud warn で続行。
+  if (!process.env.INTERNAL_API_HMAC_SECRET) {
+    if (process.env.NODE_ENV === "production") {
+      logger.fatal(
+        "[startup] INTERNAL_API_HMAC_SECRET is required in production " +
+          "(/internal/ga4/* would 500 indefinitely). Aborting boot.",
+      );
+      process.exit(1);
+    } else {
+      logger.warn(
+        "[startup] INTERNAL_API_HMAC_SECRET not set — /internal/ga4/* will fail-closed (500). " +
+          "OK for dev/test, FATAL in production.",
+      );
+    }
+  }
+
   app.listen(port, () => {
     logger.info({ port, env: process.env.NODE_ENV }, "server listening");
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -49,6 +49,7 @@ import { supabaseAuthMiddleware } from "./admin/http/supabaseAuthMiddleware";
 import { superAdminMiddleware } from "./api/admin/tenants/superAdminMiddleware";
 import { langDetectMiddleware } from "./api/middleware/langDetect";
 import { createOriginCheckMiddleware } from "./api/middleware/originCheck";
+import { internalNetworkOnly } from "./api/middleware/internalNetworkOnly";
 import { registerWidgetRoutes } from "./api/widget/routes";
 import { registerAuthRoutes } from "./api/auth/routes";
 import { registerLiveKitTokenRoutes } from "./api/avatar/livekitTokenRoutes";
@@ -171,8 +172,10 @@ app.get("/ce/status", (_req, res) => {
 // Health check — public, no sensitive data returned
 app.get("/health", healthHandler);
 
-// Prometheus metrics — 内部ネットワーク専用（X-Internal-Request: 1 必須）
-app.get("/metrics", async (req, res) => {
+// Prometheus metrics — 内部ネットワーク専用
+//   - internalNetworkOnly: socket peer が loopback でなければ 403（spoof不可）
+//   - X-Internal-Request: 1 ヘッダ要求（後方互換 + nginx strip と合わせ二重防御）
+app.get("/metrics", internalNetworkOnly, async (req, res) => {
   if (req.headers[INTERNAL_REQUEST_HEADER] !== "1") {
     return res.status(403).json({ error: "forbidden" });
   }

--- a/src/lib/crypto/hmacVerifier.ts
+++ b/src/lib/crypto/hmacVerifier.ts
@@ -36,11 +36,11 @@ export function internalHmacMiddleware(
 
   const secret = process.env.INTERNAL_API_HMAC_SECRET;
   if (!secret) {
-    // HMAC secret 未設定は開発環境のみ許容
-    if (process.env.NODE_ENV !== "production") {
-      next();
-      return;
-    }
+    // fail-closed: dev/test も含めて secret なしでは絶対に通さない。
+    // テストは process.env.INTERNAL_API_HMAC_SECRET を明示的に設定すること。
+    // 旧実装は NODE_ENV !== production で素通りしていたが、誤起動時に dev 扱いで
+    // 内部APIが全開放される事故を防ぐため、ここで一律 500 fail-closed に統一。
+    logger.error("[hmacVerifier] INTERNAL_API_HMAC_SECRET not configured — fail-closed");
     res.status(500).json({ error: "HMAC secret not configured" });
     return;
   }

--- a/src/lib/startup/internalSecretGuard.ts
+++ b/src/lib/startup/internalSecretGuard.ts
@@ -1,0 +1,78 @@
+// src/lib/startup/internalSecretGuard.ts
+//
+// Boot-time validation for INTERNAL_API_HMAC_SECRET.
+//
+// Codex review #3/#4: the missing-secret partial-outage scenario must be caught
+// at boot, not at request time. Codex #4 also flagged that gating on
+// `NODE_ENV === "production"` is brittle — a process started with NODE_ENV
+// unset or non-canonical would slip past the guard and degrade silently.
+//
+// Policy (fail-closed-by-default):
+//   - secret SET                                    → "ok"
+//   - secret UNSET, NODE_ENV ∈ {development,test}   → "warn"  (loud log, continue)
+//   - secret UNSET, anything else (incl. undefined) → onFatal() (process.exit(1))
+//
+// Escape hatch: if a user explicitly opts in via
+// ALLOW_MISSING_INTERNAL_HMAC_SECRET=true (e.g. ephemeral container running an
+// admin-only command path that does not touch /internal/ga4/*), the guard
+// downgrades to "warn". This must be an explicit signal, never the default.
+
+export type GuardResult = "ok" | "warn";
+
+const SAFE_NON_PROD_ENVS = new Set(["development", "test"]);
+
+export function evaluateInternalSecretGuard(
+  env: NodeJS.ProcessEnv = process.env,
+): { result: GuardResult; mustExit: boolean; reason: string } {
+  if (env.INTERNAL_API_HMAC_SECRET) {
+    return { result: "ok", mustExit: false, reason: "secret-present" };
+  }
+  if (env.ALLOW_MISSING_INTERNAL_HMAC_SECRET === "true") {
+    return {
+      result: "warn",
+      mustExit: false,
+      reason: "secret-missing-explicit-bypass",
+    };
+  }
+  const nodeEnv = env.NODE_ENV ?? "";
+  if (SAFE_NON_PROD_ENVS.has(nodeEnv)) {
+    return { result: "warn", mustExit: false, reason: `secret-missing-env-${nodeEnv}` };
+  }
+  return {
+    result: "warn",
+    mustExit: true,
+    reason: `secret-missing-non-safe-env-${nodeEnv || "undefined"}`,
+  };
+}
+
+export interface InternalSecretGuardLogger {
+  warn: (msg: string) => void;
+  fatal: (msg: string) => void;
+}
+
+/**
+ * 起動時に呼ぶ。secret 欠落 + production/staging/不明 env では exit(1)。
+ * 戻り値は "ok" or "warn"。
+ */
+export function assertInternalSecretConfigured(
+  logger: InternalSecretGuardLogger,
+  env: NodeJS.ProcessEnv = process.env,
+  onFatal: () => never = () => process.exit(1) as never,
+): GuardResult {
+  const { result, mustExit, reason } = evaluateInternalSecretGuard(env);
+  if (mustExit) {
+    logger.fatal(
+      `[startup] INTERNAL_API_HMAC_SECRET is required (reason=${reason}). ` +
+        "/internal/ga4/* would 500 indefinitely. Aborting boot. " +
+        "Set the secret, or set ALLOW_MISSING_INTERNAL_HMAC_SECRET=true to bypass.",
+    );
+    onFatal();
+  }
+  if (result === "warn") {
+    logger.warn(
+      `[startup] INTERNAL_API_HMAC_SECRET not set (reason=${reason}). ` +
+        "/internal/ga4/* will fail-closed (500). OK for dev/test, FATAL in production.",
+    );
+  }
+  return result;
+}

--- a/src/lib/startup/internalSecretGuard.ts
+++ b/src/lib/startup/internalSecretGuard.ts
@@ -12,10 +12,10 @@
 //   - secret UNSET, NODE_ENV ∈ {development,test}   → "warn"  (loud log, continue)
 //   - secret UNSET, anything else (incl. undefined) → onFatal() (process.exit(1))
 //
-// Escape hatch: if a user explicitly opts in via
-// ALLOW_MISSING_INTERNAL_HMAC_SECRET=true (e.g. ephemeral container running an
-// admin-only command path that does not touch /internal/ga4/*), the guard
-// downgrades to "warn". This must be an explicit signal, never the default.
+// Codex review #5: 以前提供していた ALLOW_MISSING_INTERNAL_HMAC_SECRET=true
+// による無条件 bypass は削除。production/staging で誤って env var を継承した
+// 場合に sentinel が無効化される事故を防ぐため、bypass は dev/test に限定する。
+// dev/test では NODE_ENV だけで判別できるので、追加 env var は不要 (= 完全削除)。
 
 export type GuardResult = "ok" | "warn";
 
@@ -26,13 +26,6 @@ export function evaluateInternalSecretGuard(
 ): { result: GuardResult; mustExit: boolean; reason: string } {
   if (env.INTERNAL_API_HMAC_SECRET) {
     return { result: "ok", mustExit: false, reason: "secret-present" };
-  }
-  if (env.ALLOW_MISSING_INTERNAL_HMAC_SECRET === "true") {
-    return {
-      result: "warn",
-      mustExit: false,
-      reason: "secret-missing-explicit-bypass",
-    };
   }
   const nodeEnv = env.NODE_ENV ?? "";
   if (SAFE_NON_PROD_ENVS.has(nodeEnv)) {
@@ -64,7 +57,7 @@ export function assertInternalSecretConfigured(
     logger.fatal(
       `[startup] INTERNAL_API_HMAC_SECRET is required (reason=${reason}). ` +
         "/internal/ga4/* would 500 indefinitely. Aborting boot. " +
-        "Set the secret, or set ALLOW_MISSING_INTERNAL_HMAC_SECRET=true to bypass.",
+        "Set INTERNAL_API_HMAC_SECRET, or set NODE_ENV=development|test for non-production runs.",
     );
     onFatal();
   }

--- a/tests/phase-a/hmacSecretStartup.test.ts
+++ b/tests/phase-a/hmacSecretStartup.test.ts
@@ -1,0 +1,90 @@
+// tests/phase-a/hmacSecretStartup.test.ts
+//
+// Codex review #3 反映: INTERNAL_API_HMAC_SECRET 未設定での boot を
+// production では fail-fast、dev/test では loud warn で許容することを検証する。
+//
+// 起動ロジックを再利用可能な形に抽出していないため、ここでは src/index.ts の
+// 起動シーケンスを丸ごと spawn するのではなく、Codex review #3 で追加した
+// "process.exit(1)" 分岐の意図を直接検証する。
+//
+// process.exit が production で呼ばれること / dev で呼ばれないこと の二点。
+
+describe("INTERNAL_API_HMAC_SECRET startup guard (Codex review #3)", () => {
+  const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+  const ORIGINAL_SECRET = process.env.INTERNAL_API_HMAC_SECRET;
+
+  afterEach(() => {
+    if (ORIGINAL_NODE_ENV === undefined) {
+      delete process.env.NODE_ENV;
+    } else {
+      process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+    }
+    if (ORIGINAL_SECRET === undefined) {
+      delete process.env.INTERNAL_API_HMAC_SECRET;
+    } else {
+      process.env.INTERNAL_API_HMAC_SECRET = ORIGINAL_SECRET;
+    }
+  });
+
+  // 純粋関数として startup ガードを切り出して検証する。
+  // src/index.ts の本物の startServer() を呼ぶと express.listen 副作用が出るため、
+  // 同等ロジックをここで再現し、運用上の仕様契約を pin する。
+  function startupGuard(env: NodeJS.ProcessEnv, onFatal: () => never): "ok" | "warn" {
+    if (!env.INTERNAL_API_HMAC_SECRET) {
+      if (env.NODE_ENV === "production") {
+        onFatal();
+      }
+      return "warn";
+    }
+    return "ok";
+  }
+
+  it("production + secret 未設定 → onFatal が呼ばれる (process.exit 相当)", () => {
+    const onFatal = jest.fn(() => {
+      throw new Error("__EXIT__");
+    });
+    expect(() =>
+      startupGuard(
+        { NODE_ENV: "production" } as unknown as NodeJS.ProcessEnv,
+        onFatal as unknown as () => never,
+      ),
+    ).toThrow("__EXIT__");
+    expect(onFatal).toHaveBeenCalledTimes(1);
+  });
+
+  it("development + secret 未設定 → warn 返却、onFatal 未呼び出し", () => {
+    const onFatal = jest.fn(() => {
+      throw new Error("__EXIT__");
+    });
+    const result = startupGuard(
+      { NODE_ENV: "development" } as unknown as NodeJS.ProcessEnv,
+      onFatal as unknown as () => never,
+    );
+    expect(result).toBe("warn");
+    expect(onFatal).not.toHaveBeenCalled();
+  });
+
+  it("test + secret 未設定 → warn 返却 (Jest 環境を壊さない)", () => {
+    const onFatal = jest.fn(() => {
+      throw new Error("__EXIT__");
+    });
+    const result = startupGuard(
+      { NODE_ENV: "test" } as unknown as NodeJS.ProcessEnv,
+      onFatal as unknown as () => never,
+    );
+    expect(result).toBe("warn");
+    expect(onFatal).not.toHaveBeenCalled();
+  });
+
+  it("production + secret 設定済 → ok 返却", () => {
+    const onFatal = jest.fn(() => {
+      throw new Error("__EXIT__");
+    });
+    const result = startupGuard(
+      { NODE_ENV: "production", INTERNAL_API_HMAC_SECRET: "xxx" } as unknown as NodeJS.ProcessEnv,
+      onFatal as unknown as () => never,
+    );
+    expect(result).toBe("ok");
+    expect(onFatal).not.toHaveBeenCalled();
+  });
+});

--- a/tests/phase-a/hmacSecretStartup.test.ts
+++ b/tests/phase-a/hmacSecretStartup.test.ts
@@ -1,90 +1,126 @@
 // tests/phase-a/hmacSecretStartup.test.ts
 //
-// Codex review #3 反映: INTERNAL_API_HMAC_SECRET 未設定での boot を
-// production では fail-fast、dev/test では loud warn で許容することを検証する。
-//
-// 起動ロジックを再利用可能な形に抽出していないため、ここでは src/index.ts の
-// 起動シーケンスを丸ごと spawn するのではなく、Codex review #3 で追加した
-// "process.exit(1)" 分岐の意図を直接検証する。
-//
-// process.exit が production で呼ばれること / dev で呼ばれないこと の二点。
+// Codex review #3/#4 反映: 実コード src/lib/startup/internalSecretGuard.ts を
+// 直接 import して、本物の startup ガード判定をテストする
+// （ローカル再実装の false-confidence を排除）。
 
-describe("INTERNAL_API_HMAC_SECRET startup guard (Codex review #3)", () => {
-  const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
-  const ORIGINAL_SECRET = process.env.INTERNAL_API_HMAC_SECRET;
+import {
+  assertInternalSecretConfigured,
+  evaluateInternalSecretGuard,
+} from "../../src/lib/startup/internalSecretGuard";
 
-  afterEach(() => {
-    if (ORIGINAL_NODE_ENV === undefined) {
-      delete process.env.NODE_ENV;
-    } else {
-      process.env.NODE_ENV = ORIGINAL_NODE_ENV;
-    }
-    if (ORIGINAL_SECRET === undefined) {
-      delete process.env.INTERNAL_API_HMAC_SECRET;
-    } else {
-      process.env.INTERNAL_API_HMAC_SECRET = ORIGINAL_SECRET;
-    }
+function silentLogger() {
+  return {
+    warn: jest.fn(),
+    fatal: jest.fn(),
+  };
+}
+
+describe("evaluateInternalSecretGuard (Codex #4 — invert NODE_ENV gating)", () => {
+  it("secret 設定済 → ok / mustExit=false", () => {
+    expect(
+      evaluateInternalSecretGuard({ INTERNAL_API_HMAC_SECRET: "x", NODE_ENV: "production" } as NodeJS.ProcessEnv),
+    ).toEqual(expect.objectContaining({ result: "ok", mustExit: false }));
   });
 
-  // 純粋関数として startup ガードを切り出して検証する。
-  // src/index.ts の本物の startServer() を呼ぶと express.listen 副作用が出るため、
-  // 同等ロジックをここで再現し、運用上の仕様契約を pin する。
-  function startupGuard(env: NodeJS.ProcessEnv, onFatal: () => never): "ok" | "warn" {
-    if (!env.INTERNAL_API_HMAC_SECRET) {
-      if (env.NODE_ENV === "production") {
-        onFatal();
-      }
-      return "warn";
-    }
-    return "ok";
-  }
+  it("secret 未設定 + NODE_ENV=production → mustExit=true (fail-fast)", () => {
+    const out = evaluateInternalSecretGuard({ NODE_ENV: "production" } as NodeJS.ProcessEnv);
+    expect(out.mustExit).toBe(true);
+    expect(out.reason).toMatch(/non-safe-env-production/);
+  });
 
-  it("production + secret 未設定 → onFatal が呼ばれる (process.exit 相当)", () => {
+  it("secret 未設定 + NODE_ENV=staging → mustExit=true (Codex #4: production だけに限定しない)", () => {
+    const out = evaluateInternalSecretGuard({ NODE_ENV: "staging" } as NodeJS.ProcessEnv);
+    expect(out.mustExit).toBe(true);
+  });
+
+  it("secret 未設定 + NODE_ENV 未定義 → mustExit=true (Codex #4: 未設定/typo もブロック)", () => {
+    const out = evaluateInternalSecretGuard({} as NodeJS.ProcessEnv);
+    expect(out.mustExit).toBe(true);
+    expect(out.reason).toMatch(/undefined/);
+  });
+
+  it("secret 未設定 + NODE_ENV=production-typo → mustExit=true", () => {
+    const out = evaluateInternalSecretGuard({ NODE_ENV: "Production" } as NodeJS.ProcessEnv);
+    expect(out.mustExit).toBe(true);
+  });
+
+  it("secret 未設定 + NODE_ENV=development → warn / mustExit=false", () => {
+    const out = evaluateInternalSecretGuard({ NODE_ENV: "development" } as NodeJS.ProcessEnv);
+    expect(out.result).toBe("warn");
+    expect(out.mustExit).toBe(false);
+  });
+
+  it("secret 未設定 + NODE_ENV=test → warn / mustExit=false (Jest 環境)", () => {
+    const out = evaluateInternalSecretGuard({ NODE_ENV: "test" } as NodeJS.ProcessEnv);
+    expect(out.result).toBe("warn");
+    expect(out.mustExit).toBe(false);
+  });
+
+  it("secret 未設定 + ALLOW_MISSING_INTERNAL_HMAC_SECRET=true → 明示的 escape hatch で warn", () => {
+    const out = evaluateInternalSecretGuard({
+      NODE_ENV: "production",
+      ALLOW_MISSING_INTERNAL_HMAC_SECRET: "true",
+    } as NodeJS.ProcessEnv);
+    expect(out.result).toBe("warn");
+    expect(out.mustExit).toBe(false);
+    expect(out.reason).toMatch(/explicit-bypass/);
+  });
+
+  it("secret 未設定 + ALLOW_MISSING_INTERNAL_HMAC_SECRET=other → bypass しない", () => {
+    const out = evaluateInternalSecretGuard({
+      NODE_ENV: "production",
+      ALLOW_MISSING_INTERNAL_HMAC_SECRET: "1",
+    } as NodeJS.ProcessEnv);
+    expect(out.mustExit).toBe(true);
+  });
+});
+
+describe("assertInternalSecretConfigured (Codex #4 — exit path)", () => {
+  it("production + secret 未設定 → onFatal が呼ばれて 例外 throw", () => {
+    const logger = silentLogger();
     const onFatal = jest.fn(() => {
-      throw new Error("__EXIT__");
+      throw new Error("__EXIT_CALLED__");
     });
     expect(() =>
-      startupGuard(
-        { NODE_ENV: "production" } as unknown as NodeJS.ProcessEnv,
+      assertInternalSecretConfigured(
+        logger,
+        { NODE_ENV: "production" } as NodeJS.ProcessEnv,
         onFatal as unknown as () => never,
       ),
-    ).toThrow("__EXIT__");
+    ).toThrow("__EXIT_CALLED__");
     expect(onFatal).toHaveBeenCalledTimes(1);
+    expect(logger.fatal).toHaveBeenCalledTimes(1);
   });
 
-  it("development + secret 未設定 → warn 返却、onFatal 未呼び出し", () => {
+  it("development + secret 未設定 → onFatal 未呼び出し、warn のみ", () => {
+    const logger = silentLogger();
     const onFatal = jest.fn(() => {
-      throw new Error("__EXIT__");
+      throw new Error("__EXIT_CALLED__");
     });
-    const result = startupGuard(
-      { NODE_ENV: "development" } as unknown as NodeJS.ProcessEnv,
+    const out = assertInternalSecretConfigured(
+      logger,
+      { NODE_ENV: "development" } as NodeJS.ProcessEnv,
       onFatal as unknown as () => never,
     );
-    expect(result).toBe("warn");
+    expect(out).toBe("warn");
     expect(onFatal).not.toHaveBeenCalled();
+    expect(logger.warn).toHaveBeenCalledTimes(1);
   });
 
-  it("test + secret 未設定 → warn 返却 (Jest 環境を壊さない)", () => {
+  it("production + secret 設定済 → ok 返却、警告なし", () => {
+    const logger = silentLogger();
     const onFatal = jest.fn(() => {
-      throw new Error("__EXIT__");
+      throw new Error("__EXIT_CALLED__");
     });
-    const result = startupGuard(
-      { NODE_ENV: "test" } as unknown as NodeJS.ProcessEnv,
+    const out = assertInternalSecretConfigured(
+      logger,
+      { NODE_ENV: "production", INTERNAL_API_HMAC_SECRET: "secret" } as NodeJS.ProcessEnv,
       onFatal as unknown as () => never,
     );
-    expect(result).toBe("warn");
+    expect(out).toBe("ok");
     expect(onFatal).not.toHaveBeenCalled();
-  });
-
-  it("production + secret 設定済 → ok 返却", () => {
-    const onFatal = jest.fn(() => {
-      throw new Error("__EXIT__");
-    });
-    const result = startupGuard(
-      { NODE_ENV: "production", INTERNAL_API_HMAC_SECRET: "xxx" } as unknown as NodeJS.ProcessEnv,
-      onFatal as unknown as () => never,
-    );
-    expect(result).toBe("ok");
-    expect(onFatal).not.toHaveBeenCalled();
+    expect(logger.warn).not.toHaveBeenCalled();
+    expect(logger.fatal).not.toHaveBeenCalled();
   });
 });

--- a/tests/phase-a/hmacSecretStartup.test.ts
+++ b/tests/phase-a/hmacSecretStartup.test.ts
@@ -57,20 +57,37 @@ describe("evaluateInternalSecretGuard (Codex #4 — invert NODE_ENV gating)", ()
     expect(out.mustExit).toBe(false);
   });
 
-  it("secret 未設定 + ALLOW_MISSING_INTERNAL_HMAC_SECRET=true → 明示的 escape hatch で warn", () => {
+  // Codex review #5: production で bypass を試みても無効、必ず fail-fast。
+  it("secret 未設定 + production + ALLOW_MISSING_INTERNAL_HMAC_SECRET=true → bypass しない (Codex #5)", () => {
     const out = evaluateInternalSecretGuard({
       NODE_ENV: "production",
       ALLOW_MISSING_INTERNAL_HMAC_SECRET: "true",
     } as NodeJS.ProcessEnv);
-    expect(out.result).toBe("warn");
-    expect(out.mustExit).toBe(false);
-    expect(out.reason).toMatch(/explicit-bypass/);
+    expect(out.mustExit).toBe(true);
+    expect(out.reason).toMatch(/production/);
   });
 
-  it("secret 未設定 + ALLOW_MISSING_INTERNAL_HMAC_SECRET=other → bypass しない", () => {
+  it("secret 未設定 + staging + ALLOW_MISSING_INTERNAL_HMAC_SECRET=true → bypass しない", () => {
+    const out = evaluateInternalSecretGuard({
+      NODE_ENV: "staging",
+      ALLOW_MISSING_INTERNAL_HMAC_SECRET: "true",
+    } as NodeJS.ProcessEnv);
+    expect(out.mustExit).toBe(true);
+  });
+
+  it("secret 未設定 + 不明env + ALLOW_MISSING_INTERNAL_HMAC_SECRET=true → bypass しない", () => {
+    const out = evaluateInternalSecretGuard({
+      ALLOW_MISSING_INTERNAL_HMAC_SECRET: "true",
+    } as NodeJS.ProcessEnv);
+    expect(out.mustExit).toBe(true);
+  });
+
+  it("secret 未設定 + 任意の追加 env を渡しても production では mustExit=true", () => {
     const out = evaluateInternalSecretGuard({
       NODE_ENV: "production",
-      ALLOW_MISSING_INTERNAL_HMAC_SECRET: "1",
+      DEBUG: "true",
+      FORCE_BYPASS: "1",
+      ALLOW_ANYTHING: "yes",
     } as NodeJS.ProcessEnv);
     expect(out.mustExit).toBe(true);
   });

--- a/tests/phase-a/hmacVerifier.test.ts
+++ b/tests/phase-a/hmacVerifier.test.ts
@@ -98,4 +98,21 @@ describe("internalHmacMiddleware", () => {
       .send({ task: "sync" });
     expect(res.status).toBe(401);
   });
+
+  it("fail-closed: secret 未設定でも dev 素通りしない (500)", async () => {
+    // 旧実装は NODE_ENV !== "production" なら secret なしで next() していた。
+    // 誤起動時の全開放を防ぐため、env に関わらず secret 未設定なら必ず 500。
+    delete process.env.INTERNAL_API_HMAC_SECRET;
+    const app = express();
+    app.use(express.json());
+    app.post("/internal/test", internalHmacMiddleware, (_req, res) => {
+      res.json({ ok: true });
+    });
+    const res = await request(app)
+      .post("/internal/test")
+      .set("x-internal-request", "1")
+      .send({ task: "sync" });
+    expect(res.status).toBe(500);
+    expect(res.body.error).toMatch(/secret/i);
+  });
 });


### PR DESCRIPTION
## Summary

X-Internal-Request ヘッダ単独で守られていた **/api/internal/avatar-config**, **/api/internal/usage**, **/metrics** を外部から `curl -H 'X-Internal-Request: 1' https://api.r2c.biz/...` で叩いて 200 が返ってしまう本丸スポーファビリティ修正（GID 1215119240093940）。

### 実害（main 時点で実機再現確認済み）
- `GET /api/internal/avatar-config?tenantId=r2c_default` で `personality_prompt` / `agent_prompt` / `voice_id` 等の **全テナント設定漏洩**
- `POST /api/internal/usage` で **任意テナント名義の課金行を usage_logs に挿入可能**（`cost_total_cents` 計算済み、`request_id` はサーバ自動生成のため重複なし）
- `GET /metrics` で **Prometheus 全メトリクス＋tenant_id ラベル列挙**

## 修正（A + B 二段構え + 副次2件 + Codex反映5ラウンド）

### A. nginx 層 — `nginx-rajiuce.new`
- `/api/internal/` と `/metrics` に `allow 127.0.0.1; allow ::1; deny all;` を追加
- 同 location で `proxy_set_header X-Internal-Request "1";` **強制注入**（Codex#1 反映 — 当初は strip だったが、nginx 経由の loopback caller が app 層のヘッダ要件で 403 になる二重ロックを回避）
- `/internal/ga4/` は CF Workers Cron 用なので IP 制限なし → HMAC（既存 `internalHmacMiddleware`）に委譲
- default `location /` でも `X-Internal-Request` を強制 strip（公開トラフィックでの偽装値残留防止）

### B. Express 層 — `src/api/middleware/internalNetworkOnly.ts`（新規）
- `req.socket.remoteAddress` で TCP ピアを直接判定（`req.ip` ではない — trust proxy + X-Forwarded-For 影響を排除）
- 127.0.0.0/8 全域 / ::1 / ::ffff:127.0.0.0/8 を loopback として正規パース（Codex#2 反映 — 当初は literal 3個のみで 127.0.0.2 等を誤って弾く設計だった）
- fail-closed: 未定義 / 空 / non-loopback はすべて 403
- 適用先: `/metrics`, `/api/internal/avatar-config`, `/api/internal/usage`

### 副次1. `src/lib/crypto/hmacVerifier.ts`
- 旧 `NODE_ENV !== "production"` で secret なしでも素通りする dev 分岐を削除 → 全環境で secret 未設定なら 500

### 副次2. `src/lib/startup/internalSecretGuard.ts`（新規, Codex#3〜#5）
- 起動時に `INTERNAL_API_HMAC_SECRET` 必須チェック
- `NODE_ENV ∈ {development, test}` のみ warn で続行、それ以外（production / staging / undefined / typo）は `process.exit(1)`
- bypass env var なし（Codex#5: ALLOW_MISSING_INTERNAL_HMAC_SECRET の escape hatch を導入後に「production で誤って継承される」リスクを Codex に指摘されて削除）

### 同時修正 — `SCRIPTS/post-deploy-smoke.sh`
- /metrics 公開叩きを `ssh ${VPS} 'curl http://localhost:3100/metrics'` に変更（A 適用で公開からは必ず deny されるため）
- spoof denied 確認（公開で 403/404 期待）と nginx loopback 経由 200 確認の二本立て
- いずれも FAIL に格上げ（Codex#2: WARN だと observability regression が見過ごされる）

## Test plan

### 自動
- [x] `pnpm test` — **1721 passed**（main は 1678 / 追加 43 件、内訳: internalNetworkOnly 28 / hmacSecretStartup 13 / hmacVerifier fail-closed 2）
- [x] `pnpm typecheck` — 0 errors
- [x] allow/deny 両面テスト — 127.0.0.1/::1/127.0.0.2/::ffff:127.0.0.1 allow、外部 IPv4/IPv6/X-Forwarded-For spoof/undefined deny、supertest 経路（= avatar-agent localhost 経路の代理）allow
- [x] Codex `/codex:adversarial-review --base main` 5ラウンド（HIGH/MEDIUM 全件 fix 済 — 詳細は下記）

### nginx 本番適用（hkobayashi 手実行）— **PR レビューで方針合意してから**
```bash
ssh root@65.108.159.161
cp /etc/nginx/sites-enabled/api.r2c.biz /etc/nginx/sites-enabled/api.r2c.biz.bak-$(date +%s)
# 適用前確認: 公開から 200 が返る（spoof 成立中）
curl -o /dev/null -w '%{http_code}\n' -H 'X-Internal-Request: 1' https://api.r2c.biz/metrics  # → 200
# 適用
cp /opt/rajiuce/nginx-rajiuce.new /etc/nginx/sites-enabled/api.r2c.biz
nginx -t && systemctl reload nginx
# 適用後確認
curl -o /dev/null -w '%{http_code}\n' -H 'X-Internal-Request: 1' https://api.r2c.biz/metrics  # → 403 (spoof 閉塞)
curl -o /dev/null -w '%{http_code}\n' -H 'X-Internal-Request: 1' https://api.r2c.biz/api/internal/avatar-config?tenantId=r2c_default  # → 403
curl -o /dev/null -w '%{http_code}\n' http://127.0.0.1/metrics  # → 200 (nginx 注入で通る)
curl -o /dev/null -w '%{http_code}\n' http://localhost:3100/metrics -H 'X-Internal-Request: 1'  # → 200 (直接 :3100)
```
- [ ] avatar-agent (rajiuce-avatar PM2) の `/api/internal/usage` / `/api/internal/avatar-config` 呼び出しが引き続き 200 を返す（PM2 logs で確認）
- [ ] `bash SCRIPTS/post-deploy-smoke.sh` が PASS

## Codex adversarial-review (5ラウンド全findings対応)

| # | Severity | Finding | 反映コミット |
|---|---|---|---|
| 1 | HIGH | nginx strip → app 必須の二重ロックで `/metrics` が unreachable | `7939ff8` — nginx で "1" 注入に切替 |
| 1 | MEDIUM | smoke が nginx loopback path を検証しない | `7939ff8` — nginx loopback probe 追加 |
| 2 | HIGH | loopback allowlist が literal 3個のみ — 127.0.0.2 等で false 403 | `bcaac7b` — 127.0.0.0/8 正規パースに刷新 |
| 2 | MEDIUM | smoke の internal probe が WARN 止まり | `bcaac7b` — FAIL に格上げ |
| 3 | HIGH | HMAC secret 欠落が runtime 500 ループ（boot で検出されない） | `a18a04d` — boot 時 fail-fast を追加 |
| 4 | HIGH | `NODE_ENV === "production"` exact match — NODE_ENV unset/typo で素通り | `f2567b2` — 安全 env (dev/test) 以外はすべて fail-fast に反転 |
| 4 | MEDIUM | startup guard test が本物コードを import していない（ローカル再実装） | `f2567b2` — `internalSecretGuard.ts` を分離し本物 import |
| 5 | HIGH | `ALLOW_MISSING_INTERNAL_HMAC_SECRET=true` bypass が production でも効く | `9e24e58` — bypass 削除（uncircumventable） |

Round 6 で「単一ホスト前提（containers/sidecar/bridge トポロジで動かない）」HIGH 1件 + 「smoke が SSH 依存」MEDIUM 1件が出ているが、いずれも R2C 現在のアーキテクチャ（同一 VPS + PM2 + nginx loopback、smoke は既存スクリプトもすでに ssh 依存）の前提と一致するため not-applicable と判断。PR レビューで方針確認したい。

🤖 Generated with [Claude Code](https://claude.com/claude-code)