### PR TITLE
fix(dead-code-check): バグA/B修正 — unregistered route 見逃し + test-only dead export 誤判定 (GID1215114283888681)

### DIFF
--- a/SCRIPTS/dead-code-check.sh
+++ b/SCRIPTS/dead-code-check.sh
@@ -44,7 +44,7 @@ for line in lines:
     name = m.group(1)
     # count references in src/ outside the declaring file
     result = subprocess.run(
-        ['grep', '-rn', '--include=*.ts', '--', name, 'src/'],
+        ['grep', '-rn', '--include=*.ts', '--exclude=*.test.ts', '--', name, 'src/'],
         capture_output=True, text=True
     )
     refs = [l for l in result.stdout.strip().split('\n')
@@ -80,9 +80,9 @@ UNREGISTERED=0
 while IFS= read -r route_file; do
   base=$(basename "$route_file" .ts)
   # src/index.ts に直接登録、または他の *.ts ファイルから import されているか確認
-  refs=$(grep -rn --include="*.ts" -- "$base" src/ 2>/dev/null | grep -v "^${route_file}:" | grep -c "" || echo "0")
-  if [ "$refs" = "0" ]; then
-    echo "  ⚠️  $route_file (no references found in src/)"
+  ref_count=$(grep -rn --include="*.ts" -- "$base" src/ 2>/dev/null | grep -v "^${route_file}:" | wc -l)
+  if [ "${ref_count// /}" = "0" ]; then
+    echo "  ⚠️  $route_file (no references found outside itself in src/)"
     UNREGISTERED=$((UNREGISTERED + 1))
   fi
 done < <(find src/api/ -name "*.ts" | grep -i "routes\|router" | grep -v "\.test\.ts" || true)


### PR DESCRIPTION
## Summary

- **バグA (L83)**: `grep -c "" || echo "0"` の複合バグ — `set -o pipefail` 下で0件時に `refs="0\n0"` になり `[ "$refs" = "0" ]` が false → 未登録ルートを **完全に見逃す**
- **バグB (Python L46-51)**: 参照検索がテストファイルを除外しない — テストのみから参照される dead export を「生存」と **誤判定**

## 修正内容

| バグ | 変更前 | 変更後 |
|---|---|---|
| A (L83) | `grep -c "" \|\| echo "0"` + `[ "$refs" = "0" ]` | `wc -l` + `[ "${ref_count// /}" = "0" ]` |
| B (Python L47) | `--include=*.ts` | `--include=*.ts --exclude=*.test.ts` |

## 再現確認

**バグA**: `refs='0\n0'` (3bytes) → `MISSED` / 修正後: `ref_count='0'` → `DETECTED`  
**バグB**: test-only refs=2 → `ALIVE(誤)` / 修正後: refs=0 → `DEAD(正)`

## Test plan

- [x] Gate 1: `pnpm verify` → 142 suites / 1721 tests passed / security PASS
- [x] Gate 1.5: `bash SCRIPTS/dead-code-check.sh` → 正常完了 (exit 0)
- [x] バグA再現テスト: 未参照ルート `DETECTED` を確認
- [x] バグB再現テスト: test-only export が `DEAD` 判定に変わることを確認

## スコープ外 (別タスク)

- lint 実効化 (ESLint config 新規 + `pnpm lint` + `verify` 組込) は本 PR に含まない

🤖 Generated with [Claude Code](https://claude.com/claude-code)