### PR TITLE
fix(dispatch): --prompt-file 廃止対応、stdin pipe へ移行

### DIFF
--- a/SCRIPTS/r2c-dispatch.sh
+++ b/SCRIPTS/r2c-dispatch.sh
@@ -175,13 +175,17 @@ dispatch_one() {
 
     mkdir -p "$(dirname "$log_file")"
 
+    # claude-code v2.1.152 で --prompt-file フラグが silently 削除された対応。
+    # 旧形式 `--prompt-file '${prompt_path}'` は unknown flag として無視され、
+    # claude --bg は prompt 無しで idle 起動 → 45min stuck → rollback していた。
+    # 詳細: docs/postmortem/2026-05-28-oauth-fail/
+    # stdin pipe で渡す形式に変更 (claude --help: `claude [options] [command] [prompt]`)。
     nohup bash -c "
         cd '${worktree_path}'
         export PATH='/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:\$PATH'
-        claude --bg --name '${lane_name}' \\
+        cat '${prompt_path}' | claude --bg --name '${lane_name}' \\
             --model '${resolved_model}' \\
-            --permission-mode '${perm_mode}' \\
-            --prompt-file '${prompt_path}' > '${log_file}' 2>&1
+            --permission-mode '${perm_mode}' > '${log_file}' 2>&1
     " > /dev/null 2>&1 &
     disown
 


### PR DESCRIPTION
## 背景

2026-05-28 e2e 検証で 24h ループの Lane が prompt 実行せず idle のまま
45min × 3 で `auto_rollback` している事実を発見。

**真因は claude-code v2.1.152 で `--prompt-file` フラグが silently 削除**
されており、`dispatch.sh:184` の `--prompt-file '${prompt_path}'` が
unknown flag として無視されていたこと。`claude --bg` は prompt 無しで
idle 起動 → 45min stuck → rollback、というループが
**5月途中の claude-code バージョン更新以降ずっと継続していた可能性**。

2026-05-26 OAuth fail はこの構造の上で起きた誘発要因
(詳細: `docs/postmortem/2026-05-28-oauth-fail/`)。

## 修正

`SCRIPTS/r2c-dispatch.sh:184` の起動形式を stdin pipe に変更:

```diff
- claude --bg ... --prompt-file '${prompt_path}' > log 2>&1
+ cat '${prompt_path}' | claude --bg ... > log 2>&1
```

`claude --help` は positional prompt と stdin pipe をサポート、
`--prompt-file` は存在しない:

```
Usage: claude [options] [command] [prompt]
```

## 検証

| Gate | 結果 |
|---|---|
| interactive shell + stdin pipe → 結果ファイル生成 | ✅ `/tmp/r2c-s5-result.md` に "S5_OK" |
| `nohup bash -c` (dispatch.sh と同形式) + stdin pipe → 結果ファイル生成 | ✅ "S5_OK" |
| `claude agents --json` で s5-nohup-verify が idle で残留 | ✅ sessionId `6a056e34-da6d-4c8a-abac-1cc9a266cf77` 取得可 |
| `shellcheck SCRIPTS/r2c-dispatch.sh` | ✅ no issues |
| `bash -n SCRIPTS/r2c-dispatch.sh` | ✅ syntax OK |

## 関連

- `docs/postmortem/2026-05-28-oauth-fail/`
- PR #217 (session_id resolver、本修正で初めて機能発揮)

## マージ後

end-to-end 再検証 (safe Tier-B タスク投入 → session_id 取得 +
Lane が prompt 完走 + result file 生成 確認) を hkobayashi が手動で実施。
確認できれば 24h ループ正式稼働可能。

## マージ方針

**自動 merge しない。** 朝レビューで hkobayashi が判断。dispatch.sh の
変更は Lane 起動経路に直結するため、merge 前に上記検証ログ
(S5_OK 生成) を必ず確認すること。

🤖 Generated with [Claude Code](https://claude.com/claude-code)