### PR TITLE
fix(dispatch): export PATH= を撤廃、stdin pipe を機能させる

### DIFF
--- a/SCRIPTS/r2c-dispatch.sh
+++ b/SCRIPTS/r2c-dispatch.sh
@@ -178,11 +178,15 @@ dispatch_one() {
     # claude-code v2.1.152 で --prompt-file フラグが silently 削除された対応。
     # 旧形式 `--prompt-file '${prompt_path}'` は unknown flag として無視され、
     # claude --bg は prompt 無しで idle 起動 → 45min stuck → rollback していた。
-    # 詳細: docs/postmortem/2026-05-28-oauth-fail/
     # stdin pipe で渡す形式に変更 (claude --help: `claude [options] [command] [prompt]`)。
+    #
+    # export PATH=... は cron-wrapper.sh が既に Homebrew 含む PATH を設定済みで
+    # 完全に冗長な上、bash -c 内に置くと cat | claude --bg の stdin pipe が
+    # 切れて claude が prompt を受信せず idle 起動する問題が判明 (2026-05-28)。
+    # よって本ブロック内では export PATH を行わない。
+    # 詳細: docs/postmortem/2026-05-28-oauth-fail/
     nohup bash -c "
         cd '${worktree_path}'
-        export PATH='/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:\$PATH'
         cat '${prompt_path}' | claude --bg --name '${lane_name}' \\
             --model '${resolved_model}' \\
             --permission-mode '${perm_mode}' > '${log_file}' 2>&1


### PR DESCRIPTION
## 背景

PR #218 で `--prompt-file` → stdin pipe へ移行したが、24h ループの e2e 検証
(2026-05-28) で Lane が prompt 無しで idle 起動して result file 未生成、
`attempt_count=3 → rollback` する症状が継続していた。

## 真因

`SCRIPTS/r2c-dispatch.sh:185` の

```bash
export PATH='/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:$PATH'
```

を `bash -c "..."` の中で実行すると、後続の

```bash
cat '${prompt_path}' | claude --bg ...
```

の stdin pipe が claude プロセスに届かなくなり、claude --bg は
`(idle — send a prompt to start)` 状態で待機する。

### 実機検証マトリクス (2026-05-28)

| 試行 | cd worktree | export PATH= | stdin pipe | 結果 |
|---|---|---|---|---|
| eA | あり | あり | あり (継続行) | ❌ idle (prompt 未到達) |
| eB | あり | あり | あり (oneline) | ❌ idle (prompt 未到達) |
| eC | なし | なし | あり | ✅ result file 生成 |
| **eD** | **あり** | **なし** | **あり (oneline)** | **✅ result file 生成** |
| eE | あり | あり | あり (oneline) | ❌ idle (prompt 未到達) |

→ **export PATH= の有無 1 つで stdin pipe の通り/不通りが分岐**する。
原因メカニズムは未解明 (macOS 固有の subprocess env 設定 ↔ pipe
構造の干渉が疑われる)。

## 修正

`SCRIPTS/r2c-dispatch.sh:185` の `export PATH=` 1 行を削除。

### 冗長性の確認

- `SCRIPTS/r2c-cron-wrapper.sh:24` で既に PATH を完全に設定済み:
  ```bash
  export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin:${HOME}/.local/bin:..."
  ```
- `launchd` plist の `EnvironmentVariables` にも PATH 設定済み
  (`launchctl print` で確認: `/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:...`)
- したがって `dispatch.sh` 内の `export PATH=` は **重複かつ有害**。

## 検証

| Gate | 結果 |
|---|---|
| `shellcheck SCRIPTS/r2c-dispatch.sh` | ✅ no issues |
| `bash -n SCRIPTS/r2c-dispatch.sh` | ✅ syntax OK |
| 手動 spawn (eD パターン: `cd worktree + cat \| claude --bg`、export PATH 無し) | ✅ result file 生成 |
| end-to-end (cron 経由 dispatch) | merge 後に再検証 (本 PR スコープ外) |

## 関連

- PR #197 (auth fail-fast 化)
- PR #217 (session_id 自動発見、本修正で初めて完全機能)
- PR #218 (--prompt-file 廃止対応、本修正と組合せで初めて end-to-end 完成)
- `docs/postmortem/2026-05-28-oauth-fail/`
  - `MEMORY_27_DRAFT.md` (罠 4 層と切り分け手順)
  - `MONITOR_TASK_DRAFT.md` (4 軸監視拡張案)

## マージ方針

**自動 merge しない。** 朝レビューで hkobayashi が判断。

### merge 後の end-to-end #4 検証手順

```bash
# 1. テスト prompt 作成
cat > /tmp/r2c-e2e4-prompt.md <<'P'
Write /tmp/r2c-e2e4-result.md with "E2E4_OK" and exit. No repo modification.
P

# 2. queue 投入 (state=prompt_generated で dispatch 直行)
sqlite3 .claude/queue/r2c-queue.db "INSERT INTO tasks (asana_gid, asana_name, task_type, tier, state, prompt_path, created_at, updated_at) VALUES ('e2e-4', 'E2E #4', 'other', 'B', 'prompt_generated', '/tmp/r2c-e2e4-prompt.md', datetime('now'), datetime('now'));"

# 3. 90秒待機後の判定基準
sqlite3 .claude/queue/r2c-queue.db "SELECT state, session_id FROM tasks WHERE asana_gid='e2e-4';"
ls /tmp/r2c-e2e4-result.md && cat /tmp/r2c-e2e4-result.md
ls -la ~/.claude-r2c-config/logs/lane-*.log.sid

# 4. 全 ✅ なら 24h ループ正式稼働可
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)