### PR TITLE
fix(cron-wrapper): env -i で env isolation し罠5 cron context spawn 不能を解消

### DIFF
--- a/SCRIPTS/r2c-cron-wrapper.sh
+++ b/SCRIPTS/r2c-cron-wrapper.sh
@@ -106,10 +106,33 @@ set +e
 # bash 3.2 (macOS) では空配列の "${arr[@]:-}" が空文字列1個に展開され、
 # 引数なし起動のはずの script に "" が渡って "unknown arg" で落ちる。
 # pass-through の有無で分岐し、空配列時は引数を一切渡さない。
+#
+# 2026-05-28 罠5 対応: interactive shell から呼ばれた場合や launchd 経由実起動で
+# 親 env が継承されると、後段 dispatch.sh:190 の `cat prompt | claude --bg ...`
+# の stdin pipe が claude プロセスに届かなくなり、Lane が
+# `(idle — send a prompt to start)` で待機 → 45min stuck → rollback する罠が判明。
+# 実機検証 (2026-05-28) で、`env -i` で env を必要最小限に絞ると cron-wrapper 経由
+# でも cat | claude --bg の stdin pipe が機能することを確認。
+# よって target script を env -i で起動し、必要な変数のみ明示的に渡す。
+# 詳細: docs/postmortem/2026-05-28-oauth-fail/
 if [ "${#PASS_THROUGH[@]}" -gt 0 ]; then
-    bash "SCRIPTS/${SCRIPT}" "${PASS_THROUGH[@]}" >> "${TARGET_LOG}" 2>&1
+    env -i \
+        HOME="${HOME}" \
+        PATH="${PATH}" \
+        R2C_ROOT="${R2C_ROOT}" \
+        R2C_CONFIG="${R2C_CONFIG}" \
+        CLAUDE_CONFIG_DIR="${CLAUDE_CONFIG_DIR:-${R2C_CONFIG}}" \
+        CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS="${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-1}" \
+        bash "SCRIPTS/${SCRIPT}" "${PASS_THROUGH[@]}" >> "${TARGET_LOG}" 2>&1
 else
-    bash "SCRIPTS/${SCRIPT}" >> "${TARGET_LOG}" 2>&1
+    env -i \
+        HOME="${HOME}" \
+        PATH="${PATH}" \
+        R2C_ROOT="${R2C_ROOT}" \
+        R2C_CONFIG="${R2C_CONFIG}" \
+        CLAUDE_CONFIG_DIR="${CLAUDE_CONFIG_DIR:-${R2C_CONFIG}}" \
+        CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS="${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-1}" \
+        bash "SCRIPTS/${SCRIPT}" >> "${TARGET_LOG}" 2>&1
 fi
 EXIT_CODE=$?
 set -e


### PR DESCRIPTION
## 背景

PR #197/#217/#218/#219 で罠1-3 を解消したが、24h ループの **cron 経由自走**
(launchd → cron-wrapper → dispatch.sh) では Lane spawn 後も
`session_id` NULL のまま 45min stuck → rollback が継続。

**手動 dispatch** (interactive shell から `bash dispatch.sh --task-id N`) は
完全動作する状態が e2e #4 / #4-retry で **2 回連続再現**された
(docs/postmortem/2026-05-28-oauth-fail/ 参照)。

## 真因 (罠5)

`SCRIPTS/r2c-cron-wrapper.sh` から target script を起動する際、
親 shell の env が継承されると、後段 `SCRIPTS/r2c-dispatch.sh:190` の

```bash
cat '${prompt_path}' | claude --bg ...
```

の stdin pipe が claude プロセスに届かなくなり、Lane が
`(idle — send a prompt to start)` 状態で待機する。

PR #219 で罠3 (`export PATH=` が stdin pipe を壊す) を dispatch.sh 側で
撤廃したが、**同じ罠が cron-wrapper.sh:24 の `export PATH=` および
interactive 由来 env 継承で再発**していた。

## 真因切り分け実機マトリクス (2026-05-28)

| 経路 | env | 結果 |
|---|---|---|
| `bash dispatch.sh --task-id N` | interactive 継承 | ✅ `E2E4_FINAL_OK` |
| `env -i bash dispatch.sh --auto` | minimal | ✅ `TRAP5_INVESTIGATION_OK` |
| `bash cron-wrapper.sh dispatch.sh -- --auto` | interactive 継承 | ❌ idle |
| `env -i bash cron-wrapper.sh dispatch.sh -- --auto` | minimal | ✅ `TRAP5B_OK` |
| `env -i (launchd env 模倣) bash cron-wrapper.sh dispatch.sh -- --auto` | launchd 模倣 | ✅ `TRAP5C_LAUNCHD_OK` |
| **修正版 cron-wrapper (env -i 化)** | **interactive 継承** | **✅ `TRAP5_FIXED_OK`** |

→ env を必要最小限に絞れば cron-wrapper 経由でも `cat | claude --bg` の
stdin pipe が正常に機能することを実証。

## 修正

`SCRIPTS/r2c-cron-wrapper.sh:104-119` の `bash` target 起動を
`env -i` で env isolation し、必要最小限の変数のみ明示的に渡す:

```diff
- bash "SCRIPTS/${SCRIPT}" "${PASS_THROUGH[@]}" >> "${TARGET_LOG}" 2>&1
+ env -i \
+     HOME="${HOME}" \
+     PATH="${PATH}" \
+     R2C_ROOT="${R2C_ROOT}" \
+     R2C_CONFIG="${R2C_CONFIG}" \
+     CLAUDE_CONFIG_DIR="${CLAUDE_CONFIG_DIR:-${R2C_CONFIG}}" \
+     CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS="${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-1}" \
+     bash "SCRIPTS/${SCRIPT}" "${PASS_THROUGH[@]}" >> "${TARGET_LOG}" 2>&1
```

これにより、interactive shell 由来 (`TMUX`, `ITERM_*`, `BASH_*`, `LC_*`) や
launchd 由来 (`XPC_SERVICE_NAME` 等) の env が継承されず、子プロセス
ツリーで `claude --bg` の stdin pipe が正常動作する。

## 検証

| Gate | 結果 |
|---|---|
| `shellcheck SCRIPTS/r2c-cron-wrapper.sh` | ✅ no issues |
| `bash -n SCRIPTS/r2c-cron-wrapper.sh` | ✅ syntax OK |
| 修正版 cron-wrapper を interactive shell から普通に呼び (task 43) | ✅ |
| └─ `state=running` | ✅ |
| └─ `session_id=ae1df8ea-7f61-4504-b74c-ef34635134ac` | ✅ resolver 動作 |
| └─ `lane-43.log`: backgrounded バナー (idle バナーなし=prompt到達) | ✅ |
| └─ `lane-43.log.sid`: `"session_id resolved: task=43 sid=ae1df8ea..."` | ✅ |
| └─ `/tmp/r2c-trap5-fixed-result.md`: `"TRAP5_FIXED_OK"` 生成 | ✅ |
| end-to-end (launchd 実起動 cron 1分毎) | merge 後の e2e #5 で実施 |

## メカニズム未解明部分

`env -i` で動く理由のメカニズムは未確定。仮説:
- interactive 由来 env (`TMUX`, `SHELLOPTS`, `BASH_*`) が bash subprocess の
  stdin handling を変える可能性
- `claude --bg` の daemon socket 接続時に特定の env を参照している可能性

追加調査は別 task で扱う (本 PR スコープ外)。

## 関連

- PR #197 (罠1: auth fail-fast)
- PR #217 (罠4: session_id resolver)
- PR #218 (罠2: `--prompt-file` 廃止 → stdin pipe)
- PR #219 (罠3: dispatch.sh の `export PATH=` 撤廃)
- **本 PR (罠5: cron-wrapper の env isolation、最後のピース)**
- `docs/postmortem/2026-05-28-oauth-fail/MEMORY_27_DRAFT.md` (罠 5 層 + 切り分け手順)

## マージ方針

**自動 merge しない。** 朝レビューで hkobayashi が判断。

### merge 後の e2e #5 手順 (24h ループ完全復活確認)

```bash
cat > /tmp/r2c-e2e5-prompt.md <<'P'
Write /tmp/r2c-e2e5-result.md with "E2E5_OK" and exit.
P
sqlite3 .claude/queue/r2c-queue.db "INSERT INTO tasks (asana_gid, asana_name, task_type, tier, state, prompt_path, created_at, updated_at) VALUES ('e2e-5', 'E2E #5: launchd 実起動 cron 経由 final verify', 'other', 'B', 'prompt_generated', '/tmp/r2c-e2e5-prompt.md', datetime('now'), datetime('now'));"

# launchd cron が拾うのを最大 90 秒待機 (手動 dispatch 実行しない)
sleep 90
sqlite3 .claude/queue/r2c-queue.db "SELECT id, state, session_id FROM tasks WHERE asana_gid='e2e-5';"
cat /tmp/r2c-e2e5-result.md
ls -la ~/.claude-r2c-config/logs/lane-*.log.sid | tail -3
```

判定: `session_id` 非 null + `result file` 生成 + `.sid` log 存在 全 ✅ なら
**24h ループ完全自走確定 → Tier-S id=4 承認可**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)