### PR TITLE
fix(cron-wrapper): setsid(2) で launchd session 分離、罠6 解消

### DIFF
--- a/SCRIPTS/r2c-cron-wrapper.sh
+++ b/SCRIPTS/r2c-cron-wrapper.sh
@@ -111,10 +111,22 @@ set +e
 # 親 env が継承されると、後段 dispatch.sh:190 の `cat prompt | claude --bg ...`
 # の stdin pipe が claude プロセスに届かなくなり、Lane が
 # `(idle — send a prompt to start)` で待機 → 45min stuck → rollback する罠が判明。
-# 実機検証 (2026-05-28) で、`env -i` で env を必要最小限に絞ると cron-wrapper 経由
-# でも cat | claude --bg の stdin pipe が機能することを確認。
-# よって target script を env -i で起動し、必要な変数のみ明示的に渡す。
+# `env -i` で env を必要最小限に絞り、interactive shell 由来 env (TMUX/ITERM_*/
+# BASH_*/SHELLOPTS 等) や launchd 由来 env の継承を断つ。
+#
+# 2026-05-28 罠6 対応: env -i だけでは launchd 実起動経由でなお spawn が失敗
+# (e2e #5 task 44 で session_id NULL のまま 0byte log 確認)。env では制御
+# できない launchd domain の session/process group attribute が子プロセス
+# ツリーに伝播し claude --bg の bg-spare daemon socket 接続を阻害していた。
+# `setsid(2)` で新しい session leader を作って launchd session attribute を
+# 断ち切ることで launchd 実起動経由でも cat | claude --bg が機能することを
+# 実証 (e2e trap6-launchd task 46: 30 秒で session_id 取得 + result 生成)。
+# macOS には setsid(1) が無いため /usr/bin/python3 で setsid(2) を呼ぶ。
 # 詳細: docs/postmortem/2026-05-28-oauth-fail/
+
+# setsid + exec を行う Python ワンライナー (macOS で setsid(1) の代替)
+SETSID_EXEC='import os, sys; os.setsid(); os.execvp(sys.argv[1], sys.argv[1:])'
+
 if [ "${#PASS_THROUGH[@]}" -gt 0 ]; then
     env -i \
         HOME="${HOME}" \
@@ -123,7 +135,8 @@ if [ "${#PASS_THROUGH[@]}" -gt 0 ]; then
         R2C_CONFIG="${R2C_CONFIG}" \
         CLAUDE_CONFIG_DIR="${CLAUDE_CONFIG_DIR:-${R2C_CONFIG}}" \
         CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS="${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-1}" \
-        bash "SCRIPTS/${SCRIPT}" "${PASS_THROUGH[@]}" >> "${TARGET_LOG}" 2>&1
+        /usr/bin/python3 -c "${SETSID_EXEC}" \
+            bash "SCRIPTS/${SCRIPT}" "${PASS_THROUGH[@]}" >> "${TARGET_LOG}" 2>&1
 else
     env -i \
         HOME="${HOME}" \
@@ -132,7 +145,8 @@ else
         R2C_CONFIG="${R2C_CONFIG}" \
         CLAUDE_CONFIG_DIR="${CLAUDE_CONFIG_DIR:-${R2C_CONFIG}}" \
         CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS="${CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS:-1}" \
-        bash "SCRIPTS/${SCRIPT}" >> "${TARGET_LOG}" 2>&1
+        /usr/bin/python3 -c "${SETSID_EXEC}" \
+            bash "SCRIPTS/${SCRIPT}" >> "${TARGET_LOG}" 2>&1
 fi
 EXIT_CODE=$?
 set -e


### PR DESCRIPTION
## 背景

PR #220 で罠5 (cron-wrapper の親 env 継承で stdin pipe が壊れる) を
`env -i` で解消したが、**e2e #5 (task 44) で launchd 実起動経由のみ依然
spawn 失敗**を確認: `lane-44.log` 0byte / `session_id` NULL / result 未生成。

interactive shell から修正版 cron-wrapper を呼ぶと完全動作することから、
**env では制御できない属性が犯人**と判明。

## 真因 (罠6)

launchd domain で起動された `cron-wrapper.sh` の子プロセスツリー
(`dispatch.sh → nohup bash -c "cat prompt | claude --bg ..."`) は、
launchd の **session / process group attribute** を継承している。
これが `claude --bg` の bg-spare daemon との socket 接続を阻害する。

## 罠6 確証 (PR 前の必須ゲート、これまでの PR で欠けていた検証)

PR を作る前に修正案を **一時適用** して **launchd 実起動経由で動くこと** を実測:

1. `cron-wrapper.sh` を一時的に `/usr/bin/python3 -c 'os.setsid(); execvp...'` 経由起動に sed で書換 (commit せず実機適用)
2. test task (`trap6-launchd-2026-05-28`) を queue に投入
3. **手動 dispatch 一切なし、launchd cron 1分毎の自然拾いを 120 秒待機**
4. 結果 (30 秒で全項目達成):

| 判定項目 | 結果 |
|---|---|
| state=running | ✅ |
| session_id 非null | ✅ `cfb3c31b-bce2-4c32-b2e4-c113b12d0d08` |
| `lane-46.log`: backgrounded バナー (idle バナーなし → prompt 到達) | ✅ |
| `lane-46.log.sid`: `"session_id resolved: task=46 sid=cfb3c31b..."` | ✅ |
| `/tmp/r2c-trap6-launchd-result.md`: `"TRAP6_LAUNCHD_OK"` | ✅ |

→ **これは PR #217/#218/#219/#220 では取れていなかった "launchd 実起動経由で動いた" 本物の証拠**。

確証後、一時パッチを `git checkout` で revert、worktree で正式適用して本 PR を作成。

## 修正

`SCRIPTS/r2c-cron-wrapper.sh:118-145` の target script 起動に **setsid(2)** を挟む:

```diff
+ # setsid + exec を行う Python ワンライナー (macOS で setsid(1) の代替)
+ SETSID_EXEC='import os, sys; os.setsid(); os.execvp(sys.argv[1], sys.argv[1:])'
+
  env -i \
      HOME="${HOME}" PATH="${PATH}" R2C_ROOT="${R2C_ROOT}" ... \
+     /usr/bin/python3 -c "${SETSID_EXEC}" \
          bash "SCRIPTS/${SCRIPT}" "${PASS_THROUGH[@]}" >> "${TARGET_LOG}" 2>&1
```

**macOS には `setsid(1)` コマンドが無い**ため `/usr/bin/python3` (macOS 標準) で `setsid(2)` を呼ぶ。Python は setsid 後に bash を `execvp` で置換し、新 session leader として bash が稼働する。

## 検証

| Gate | 結果 |
|---|---|
| `shellcheck SCRIPTS/r2c-cron-wrapper.sh` | ✅ no issues |
| `bash -n SCRIPTS/r2c-cron-wrapper.sh` | ✅ syntax OK |
| **launchd 実起動経由 e2e (task 46)** | **✅ 30秒で session_id+result 全達成** |
| 一時パッチ revert (git checkout) → worktree で正式適用 | ✅ |

## 関連 (罠 6 層 全カバー宣言)

| PR | 内容 | 罠 |
|---|---|---|
| #197 ✅ merged | auth fail-fast | 1 |
| #217 ✅ merged | session_id resolver | 4 安全装置 |
| #218 ✅ merged | stdin pipe 化 | 2 |
| #219 ✅ merged | dispatch.sh の export PATH 撤廃 | 3 |
| #220 ✅ merged | cron-wrapper の env -i 化 | 5 |
| **本 PR** | **setsid で launchd session 分離** | **6 (最後のピース)** |

`docs/postmortem/2026-05-28-oauth-fail/MEMORY_27_DRAFT.md` に 6 罠の切り分け手順を保存。

## マージ後 (e2e #6 手順 — 24h ループ完全自走確定の最終確認)

```bash
cat > /tmp/r2c-e2e6.md <<'P'
Write /tmp/r2c-e2e6-result.md with "E2E6_OK" and exit.
P
sqlite3 .claude/queue/r2c-queue.db "INSERT INTO tasks (asana_gid, asana_name, task_type, tier, state, prompt_path, created_at, updated_at) VALUES ('e2e-6', 'E2E #6: 罠1-6 全カバー launchd 自走 final', 'other', 'B', 'prompt_generated', '/tmp/r2c-e2e6.md', datetime('now'), datetime('now'));"

# 手動 dispatch 厳禁、最大 90 秒 launchd 自然拾い待機
sleep 90
sqlite3 .claude/queue/r2c-queue.db "SELECT id, state, session_id FROM tasks WHERE asana_gid='e2e-6';"
cat /tmp/r2c-e2e6-result.md
ls -la ~/.claude-r2c-config/logs/lane-*.log.sid | tail -1
```

全 ✅ なら **24h ループ完全自走確定 → Tier-S id=4 承認可**。

## マージ方針

**自動 merge しない。** 朝レビューで hkobayashi が判断。本 PR は罠 6 層の最終ピースなので merge 後の e2e #6 で全カバー実証を必ず実施すること。

🤖 Generated with [Claude Code](https://claude.com/claude-code)