### PR TITLE
feat(pipelineQueue): in-memory→DB-backed queue で PM2再起動stuck job 撲滅 (Phase70K)

### DIFF
--- a/docs/PIPELINE_QUEUE_DB_BACKED_DESIGN.md
+++ b/docs/PIPELINE_QUEUE_DB_BACKED_DESIGN.md
@@ -1,0 +1,232 @@
+# pipelineQueue 永続化設計: in-memory → DB-backed queue
+
+> Asana GID: 1215190233020663
+> 対象フェーズ: Phase47 Stream C 後続
+> 優先度: P2（PM2 再起動時の stuck job 撲滅）
+
+---
+
+## 1. 根本原因
+
+`src/lib/book-pipeline/pipelineQueue.ts` は Node.js プロセスメモリ上に配列を持つ純粋な in-memory キューである。
+
+```
+class PipelineQueue {
+  private queue: Array<{ bookId: number; deps: PipelineDeps }> = [];
+  private running = false;
+  ...
+}
+```
+
+PM2 による再起動（クラッシュ・デプロイ・OOM）が発生すると:
+
+| タイミング | queue の状態 | 影響 |
+|---|---|---|
+| ジョブが `queue` に積まれているが `processNext` 未着手 | 配列が消滅 | ジョブは実行されず、`book_uploads.status` は `uploaded` のまま永遠に放置される |
+| `processNext` が実行中（`status = 'processing'`）| プロセス強制終了 | `book_uploads.status` が `processing` のまま固まる（stuck job） |
+
+具体的な stuck 条件（`pipeline.ts` の status 遷移より）:
+
+```
+uploaded → [enqueue] → processing → chunked → embedded
+                                          ↑ ここで PM2 再起動 → processing のまま永続
+```
+
+stuck job は Admin UI に「処理中」と表示され続け、再実行不可。手動 SQL (`UPDATE book_uploads SET status='uploaded' WHERE id=?`) で修復するまで放置される。
+
+---
+
+## 2. 現状のステータス遷移
+
+```
+uploaded     — アップロード完了、キュー投入前 or キュー待ち
+processing   — pipeline.ts 実行中 (stuck の温床)
+chunked      — PDF 分割完了
+embedded     — embedding 完了 (終端)
+error        — エラー終端 (error_message に記録)
+```
+
+`uploaded` と `processing` が「復旧対象ステータス」である。
+
+---
+
+## 3. 解決方針
+
+### Option A（推奨・最小変更）: 起動時リカバリ + status ベースの永続化
+
+既存の `book_uploads.status` を single source of truth として扱い、新規テーブル不要で永続化を実現する。
+
+#### 実装骨子
+
+**① 起動時リカバリ（`src/lib/book-pipeline/pipelineQueue.ts`）**
+
+```typescript
+// アプリ起動時 (src/index.ts) に呼び出す
+export async function recoverStalledJobs(db: Pool): Promise<void> {
+  // 1. processing のまま止まっているジョブをリセット
+  await db.query(
+    `UPDATE book_uploads SET status = 'uploaded', error_message = 'recovered: PM2 restart'
+     WHERE status = 'processing'`
+  );
+
+  // 2. uploaded 状態のジョブをキューに再投入
+  const { rows } = await db.query<{ id: number }>(
+    `SELECT id FROM book_uploads WHERE status = 'uploaded' ORDER BY created_at ASC`
+  );
+  for (const row of rows) {
+    await pipelineQueue.enqueue(row.id, { db });
+  }
+}
+```
+
+**② `enqueue` の冪等性確保**
+
+同一 `bookId` が重複投入されないよう `Set<number>` で pending 管理する。
+
+```typescript
+class PipelineQueue {
+  private queue: Array<{ bookId: number; deps: PipelineDeps }> = [];
+  private pending: Set<number> = new Set();   // 追加
+  private running = false;
+
+  async enqueue(bookId: number, deps: PipelineDeps): Promise<void> {
+    if (this.pending.has(bookId)) return;      // 重複スキップ
+    this.pending.add(bookId);
+    this.queue.push({ bookId, deps });
+    if (!this.running) void this.processNext();
+  }
+
+  private async processNext(): Promise<void> {
+    if (this.queue.length === 0) { this.running = false; return; }
+    this.running = true;
+    const job = this.queue.shift()!;
+    this.pending.delete(job.bookId);           // 開始時に pending から除去
+    try {
+      await runBookPipeline(job.bookId, job.deps);
+    } catch (err) {
+      logger.error("[pipelineQueue] error book_id=%d:", job.bookId,
+        err instanceof Error ? err.message : String(err));
+    }
+    void this.processNext();
+  }
+}
+```
+
+**③ `src/index.ts` への組み込み**
+
+```typescript
+// Express app 起動後、PM2 ready シグナル前に実行
+import { recoverStalledJobs } from './lib/book-pipeline/pipelineQueue';
+await recoverStalledJobs(db);  // 数行で済む
+```
+
+#### メリット / デメリット
+
+| | 内容 |
+|---|---|
+| ✅ メリット | マイグレーション不要（既存テーブル・カラムのみ使用）|
+| ✅ メリット | コード変更量が最小（~50行）|
+| ✅ メリット | stuck job が目視で確認できる（`SELECT status, COUNT(*) FROM book_uploads GROUP BY status`）|
+| ⚠️ デメリット | 水平スケール（複数プロセス）では advisory lock なしに競合が起きる可能性 |
+| ⚠️ デメリット | キューの retry 回数・遅延などの細かい制御が難しい |
+
+現状はシングルプロセス（PM2 `instances: 1`）のため Option A で十分。
+
+---
+
+### Option B（将来拡張）: `pipeline_jobs` テーブルによる本格 DB キュー
+
+複数インスタンスや retry/backoff が必要になった場合のための設計。
+
+#### スキーマ案
+
+```sql
+CREATE TABLE pipeline_jobs (
+  id           BIGSERIAL PRIMARY KEY,
+  book_id      BIGINT      NOT NULL REFERENCES book_uploads(id),
+  tenant_id    TEXT        NOT NULL,
+  status       TEXT        NOT NULL DEFAULT 'queued',
+  -- queued / running / done / failed
+  attempts     INT         NOT NULL DEFAULT 0,
+  max_attempts INT         NOT NULL DEFAULT 3,
+  claimed_at   TIMESTAMPTZ,
+  claimed_by   TEXT,           -- worker ID（将来の複数プロセス対応）
+  error        TEXT,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX ON pipeline_jobs (status, created_at);
+CREATE INDEX ON pipeline_jobs (book_id);
+```
+
+#### SELECT FOR UPDATE SKIP LOCKED による advisory locking
+
+```sql
+-- キューから次のジョブを取得（競合なし・アトミック）
+UPDATE pipeline_jobs
+SET status = 'running', claimed_at = NOW(), claimed_by = $worker_id, attempts = attempts + 1
+WHERE id = (
+  SELECT id FROM pipeline_jobs
+  WHERE status = 'queued'
+    AND attempts < max_attempts
+  ORDER BY created_at
+  FOR UPDATE SKIP LOCKED
+  LIMIT 1
+)
+RETURNING *;
+```
+
+このアプローチは PostgreSQL 9.5+ で動作し、複数 worker の競合を完全回避できる。
+
+---
+
+## 4. 実装優先順位
+
+| Phase | 作業 | 担当 | 状態 |
+|---|---|---|---|
+| P2 | Option A 実装（起動時リカバリ + 冪等 enqueue）| Lane | 未着手 |
+| P2 | `recoverStalledJobs` の統合テスト追加 | Lane | 未着手 |
+| 将来 | Option B（`pipeline_jobs` テーブル + SKIP LOCKED）| Tier A Lane | 未着手 |
+
+---
+
+## 5. テスト設計（Option A）
+
+```typescript
+describe("recoverStalledJobs", () => {
+  test("processing 状態のジョブを uploaded にリセットし enqueue する");
+  test("uploaded 状態のジョブを enqueue する");
+  test("embedded / error 状態のジョブには触れない");
+  test("同一 bookId の重複 enqueue がスキップされる");
+});
+```
+
+---
+
+## 6. 監視クエリ（運用参照用）
+
+```sql
+-- stuck job 確認
+SELECT id, title, status, updated_at
+FROM book_uploads
+WHERE status IN ('processing', 'uploaded')
+ORDER BY updated_at;
+
+-- ステータス分布
+SELECT status, COUNT(*)
+FROM book_uploads
+GROUP BY status
+ORDER BY status;
+```
+
+---
+
+## 7. 変更ファイル一覧（Option A 実装時）
+
+| ファイル | 変更種別 | 内容 |
+|---|---|---|
+| `src/lib/book-pipeline/pipelineQueue.ts` | 改修 | `pending: Set<number>` 追加、`recoverStalledJobs()` 追加 |
+| `src/lib/book-pipeline/pipelineQueue.test.ts` | 改修 | リカバリ・冪等テスト追加 |
+| `src/index.ts` | 改修 | 起動時 `recoverStalledJobs(db)` 呼び出し |
+| DBマイグレーション | **不要** | 既存カラムのみ使用 |

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,6 +45,7 @@ import { registerBillingAdminRoutes } from "./lib/billing/billingApi";
 import { createStripeWebhookHandler } from "./lib/billing/stripeWebhook";
 import { initUsageTracker } from "./lib/billing/usageTracker";
 import { reportUsageToStripe } from "./lib/billing/stripeSync";
+import { pipelineQueue } from "./lib/book-pipeline/pipelineQueue";
 import { supabaseAuthMiddleware } from "./admin/http/supabaseAuthMiddleware";
 import { superAdminMiddleware } from "./api/admin/tenants/superAdminMiddleware";
 import { langDetectMiddleware } from "./api/middleware/langDetect";
@@ -670,6 +671,22 @@ async function startServer() {
       });
     }, STRIPE_REPORT_INTERVAL_MS);
     logger.info("[startup] Stripe usage reporter scheduled (24h interval)");
+  }
+
+  // Phase70K: pipelineQueue self-heal — PM2再起動で stuck した job を自動復旧
+  if (db) {
+    const dbPool = db;
+    pipelineQueue.selfHeal(dbPool).catch((err) => {
+      logger.error({ err }, "[pipelineQueue] selfHeal failed");
+    });
+
+    const STUCK_JOB_CHECK_INTERVAL_MS = 10 * 60 * 1000; // 10分
+    setInterval(() => {
+      pipelineQueue.checkStuckJobs(dbPool).catch((err) => {
+        logger.error({ err }, "[pipelineQueue] checkStuckJobs failed");
+      });
+    }, STUCK_JOB_CHECK_INTERVAL_MS);
+    logger.info("[startup] pipelineQueue selfHeal + stuck-job monitor started");
   }
 }
 

--- a/src/lib/book-pipeline/pipelineQueue.test.ts
+++ b/src/lib/book-pipeline/pipelineQueue.test.ts
@@ -1,51 +1,140 @@
 // src/lib/book-pipeline/pipelineQueue.test.ts
-// Phase47 Stream C: pipelineQueue テスト
+// Phase70K: DB-backed pipelineQueue テスト
 
 jest.mock("./pipeline");
 jest.mock("../logger", () => ({
   logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
   createLogger: jest.fn(() => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() })),
 }));
+jest.mock("../alerts/slackNotifier", () => ({
+  sendSlackAlert: jest.fn().mockResolvedValue(undefined),
+}));
+
 import { runBookPipeline } from "./pipeline";
-import { logger } from "../logger";
 
-const mockRunBookPipeline = runBookPipeline as jest.MockedFunction<typeof runBookPipeline>;
+interface MockJob {
+  id: number;
+  book_id: number;
+  attempts: number;
+  status: string;
+  enqueued_at: number;
+}
 
-// pipelineQueue はモック後にインポートする必要があるため動的に取得
+/**
+ * in-memory job store で DB 操作をシミュレートするモック。
+ * re-enqueue (backoff) したジョブは enqueued_at を未来に設定して
+ * 直後のポーリングでは拾われないようにする。
+ */
+function makeDbMock() {
+  const jobs: MockJob[] = [];
+  let nextId = 1;
+
+  const db = {
+    query: jest.fn(async (sql: string, params: unknown[] = []) => {
+      // INSERT INTO book_pipeline_jobs (enqueue)
+      if (/INSERT INTO book_pipeline_jobs/i.test(sql)) {
+        jobs.push({
+          id: nextId++,
+          book_id: params[0] as number,
+          attempts: 0,
+          status: "enqueued",
+          enqueued_at: Date.now(),
+        });
+        return { rows: [] };
+      }
+
+      // UPDATE ... RETURNING (processNext がジョブをアトミックにクレーム)
+      if (/UPDATE book_pipeline_jobs[\s\S]*RETURNING/i.test(sql)) {
+        const now = Date.now();
+        const job = jobs.find(
+          (j) => j.status === "enqueued" && j.enqueued_at <= now
+        );
+        if (!job) return { rows: [] };
+        job.status = "running";
+        job.attempts++;
+        return {
+          rows: [{ id: job.id, book_id: job.book_id, attempts: job.attempts }],
+        };
+      }
+
+      // UPDATE done
+      if (/SET status = 'done'/i.test(sql)) {
+        const job = jobs.find((j) => j.id === (params[0] as number));
+        if (job) job.status = "done";
+        return { rows: [] };
+      }
+
+      // UPDATE failed
+      if (/SET status = 'failed'/i.test(sql)) {
+        const job = jobs.find((j) => j.id === (params[0] as number));
+        if (job) job.status = "failed";
+        return { rows: [] };
+      }
+
+      // UPDATE re-enqueue (backoff) — enqueued_at を 1h 先に設定して直後は拾われない
+      if (/SET status = 'enqueued'.*last_error/is.test(sql)) {
+        const job = jobs.find((j) => j.id === (params[0] as number));
+        if (job) {
+          job.status = "enqueued";
+          job.enqueued_at = Date.now() + 3_600_000; // 1h 先
+        }
+        return { rows: [] };
+      }
+
+      return { rows: [] };
+    }),
+    _jobs: jobs,
+  };
+
+  return db as unknown as import("pg").Pool & {
+    _jobs: MockJob[];
+    query: jest.Mock;
+  };
+}
+
 async function freshQueue() {
   jest.resetModules();
   jest.mock("./pipeline");
   jest.mock("../logger", () => ({
-    logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() },
-    createLogger: jest.fn(() => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() })),
+    logger: {
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    },
+    createLogger: jest.fn(() => ({
+      info: jest.fn(),
+      warn: jest.fn(),
+      error: jest.fn(),
+      debug: jest.fn(),
+    })),
+  }));
+  jest.mock("../alerts/slackNotifier", () => ({
+    sendSlackAlert: jest.fn().mockResolvedValue(undefined),
   }));
   const { runBookPipeline: rp } = await import("./pipeline");
   const { pipelineQueue: q } = await import("./pipelineQueue");
   const { logger: logMock } = await import("../logger");
-  return { q, rp: rp as jest.MockedFunction<typeof runBookPipeline>, logMock };
+  return {
+    q,
+    rp: rp as jest.MockedFunction<typeof runBookPipeline>,
+    logMock,
+  };
 }
 
-const DUMMY_DEPS = { db: {} as any };
-
-describe("pipelineQueue", () => {
+describe("pipelineQueue (DB-backed)", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
   test("1: キューに2つのジョブを入れた場合、順次実行される", async () => {
-    const order: number[] = [];
-    let resolveFirst!: () => void;
-    const firstStarted = new Promise<void>((res) => {
-      resolveFirst = res;
-    });
-
     const { q, rp } = await freshQueue();
+    const db = makeDbMock();
+    const order: number[] = [];
 
-    // 1つ目: firstStarted を通知してから完了
+    // 1つ目: 20ms 待ってから完了（2つ目が割り込まないことを確認）
     rp.mockImplementationOnce(async (bookId) => {
       order.push(bookId);
-      resolveFirst();
-      // 少し待つ（2つ目が割り込まないことを確認）
       await new Promise<void>((r) => setTimeout(r, 20));
       return { chunkCount: 1, pageCount: 1 };
     });
@@ -56,14 +145,11 @@ describe("pipelineQueue", () => {
       return { chunkCount: 1, pageCount: 1 };
     });
 
-    q.enqueue(1, DUMMY_DEPS);
-    q.enqueue(2, DUMMY_DEPS);
+    q.enqueue(1, { db });
+    q.enqueue(2, { db });
 
-    // 1つ目が開始されるまで待つ
-    await firstStarted;
-
-    // 両方が完了するまで待つ
-    await new Promise<void>((r) => setTimeout(r, 100));
+    // 両方が完了するまで待つ (job1=20ms, job2=即時 → 200ms は十分)
+    await new Promise<void>((r) => setTimeout(r, 200));
 
     expect(order).toEqual([1, 2]);
     expect(rp).toHaveBeenCalledTimes(2);
@@ -71,28 +157,29 @@ describe("pipelineQueue", () => {
 
   test("2: エラーが発生しても次のジョブが処理される", async () => {
     const { q, rp, logMock } = await freshQueue();
+    const db = makeDbMock();
 
-    // 1つ目: エラーを投げる
+    // 1つ目: エラーを投げる (attempts=1 < MAX_RETRIES=3 → backoff再エンキュー)
     rp.mockRejectedValueOnce(new Error("pipeline failed"));
 
     // 2つ目: 正常完了
     rp.mockResolvedValueOnce({ chunkCount: 2, pageCount: 3 });
 
-    q.enqueue(10, DUMMY_DEPS);
-    q.enqueue(20, DUMMY_DEPS);
+    q.enqueue(10, { db });
+    q.enqueue(20, { db });
 
-    // 両方が完了するまで待つ
     await new Promise<void>((r) => setTimeout(r, 100));
 
     // 2つ目も実行されたこと
     expect(rp).toHaveBeenCalledTimes(2);
-    expect(rp).toHaveBeenNthCalledWith(1, 10, DUMMY_DEPS);
-    expect(rp).toHaveBeenNthCalledWith(2, 20, DUMMY_DEPS);
+    expect(rp).toHaveBeenNthCalledWith(1, 10, { db });
+    expect(rp).toHaveBeenNthCalledWith(2, 20, { db });
 
-    // エラーログが出たこと（書籍内容は含まれない）
+    // エラーログが出たこと（書籍内容は含まれない — Anti-Slop）
     expect(logMock.error as jest.Mock).toHaveBeenCalledWith(
-      expect.stringContaining("[pipelineQueue] error book_id=%d:"),
+      expect.stringContaining("[pipelineQueue] error book_id=%d attempt=%d:"),
       10,
+      1,
       "pipeline failed"
     );
   });

--- a/src/lib/book-pipeline/pipelineQueue.ts
+++ b/src/lib/book-pipeline/pipelineQueue.ts
@@ -1,50 +1,164 @@
 // src/lib/book-pipeline/pipelineQueue.ts
+// Phase70K: DB-backed pipeline queue — PM2再起動による stuck job 撲滅
+// in-memory キュー (Phase47) を書き換え。外部依存: book_pipeline_jobs テーブル
 
-// Phase47 Stream C: in-memory パイプラインキュー（外部依存なし）
-// 同時実行を1に制限し、複数PDFアップロード時のレート制限・メモリ問題を防ぐ
-
+import type { Pool } from "pg";
 import { runBookPipeline } from "./pipeline";
 import type { PipelineDeps } from "./pipeline";
 import { logger } from '../logger';
+import { sendSlackAlert } from '../alerts/slackNotifier';
+
+const MAX_RETRIES = 3;
+
+interface JobRow {
+  id: number;
+  book_id: number;
+  attempts: number;
+}
 
 class PipelineQueue {
-  private queue: Array<{ bookId: number; deps: PipelineDeps }> = [];
   private running = false;
-  private readonly concurrency = 1; // 同時実行1
 
   async enqueue(bookId: number, deps: PipelineDeps): Promise<void> {
-    this.queue.push({ bookId, deps });
+    await deps.db.query(
+      `INSERT INTO book_pipeline_jobs (book_id, status, enqueued_at)
+       VALUES ($1, 'enqueued', NOW())`,
+      [bookId]
+    );
     if (!this.running) {
-      void this.processNext();
+      this.running = true;
+      void this.processNext(deps);
     }
   }
 
-  private async processNext(): Promise<void> {
-    if (this.queue.length === 0) {
-      this.running = false;
-      return;
-    }
-    this.running = true;
-    const job = this.queue.shift()!;
-    try {
-      await runBookPipeline(job.bookId, job.deps);
-    } catch (err) {
-      logger.error(
-        "[pipelineQueue] error book_id=%d:",
-        job.bookId,
-        err instanceof Error ? err.message : String(err)
+  /**
+   * 起動時 self-heal:
+   * 1. orphaned 'running' ジョブ（サーバークラッシュで放置）を 'enqueued' にリセット
+   * 2. book_uploads.status='uploaded' かつ active なジョブがない書籍を再エンキュー
+   */
+  async selfHeal(db: Pool): Promise<void> {
+    await db.query(
+      `UPDATE book_pipeline_jobs SET status = 'enqueued', started_at = NULL
+       WHERE status = 'running'`
+    );
+
+    const { rows } = await db.query<{ id: number }>(
+      `SELECT bu.id
+       FROM book_uploads bu
+       WHERE bu.status = 'uploaded'
+         AND bu.created_at < NOW() - INTERVAL '5 minutes'
+         AND NOT EXISTS (
+           SELECT 1 FROM book_pipeline_jobs bpj
+           WHERE bpj.book_id = bu.id
+             AND bpj.status IN ('enqueued', 'running')
+         )`
+    );
+
+    for (const { id } of rows) {
+      await db.query(
+        `INSERT INTO book_pipeline_jobs (book_id, status, enqueued_at)
+         VALUES ($1, 'enqueued', NOW())`,
+        [id]
       );
     }
-    void this.processNext();
+
+    if (rows.length > 0) {
+      logger.info('[pipelineQueue] selfHeal: re-enqueued %d stuck jobs', rows.length);
+    }
+
+    if (!this.running) {
+      this.running = true;
+      void this.processNext({ db });
+    }
   }
 
-  /** テスト用: キューの状態を確認 */
-  get queueLength(): number {
-    return this.queue.length;
+  /** 10分毎ヘルスチェック: running 1時間超のジョブを Slack 通知 */
+  async checkStuckJobs(db: Pool): Promise<void> {
+    const { rows } = await db.query<{ book_id: number; started_at: string }>(
+      `SELECT book_id, started_at FROM book_pipeline_jobs
+       WHERE status = 'running'
+         AND started_at < NOW() - INTERVAL '1 hour'`
+    );
+    for (const row of rows) {
+      sendSlackAlert({
+        ruleId: 'pipeline_job_stuck',
+        name: 'PipelineJob stuck 1時間超',
+        level: 'WARNING',
+        status: 'FIRING',
+        details: `book_id=${row.book_id} started_at=${row.started_at}`,
+      }).catch(() => {});
+    }
   }
 
-  get isRunning(): boolean {
-    return this.running;
+  private async processNext(deps: PipelineDeps): Promise<void> {
+    try {
+      while (true) {
+        // 次の enqueued ジョブをアトミックにクレーム (FOR UPDATE SKIP LOCKED で競合回避)
+        const { rows } = await deps.db.query<JobRow>(
+          `UPDATE book_pipeline_jobs
+           SET status = 'running', started_at = NOW(), attempts = attempts + 1
+           WHERE id = (
+             SELECT id FROM book_pipeline_jobs
+             WHERE status = 'enqueued' AND enqueued_at <= NOW()
+             ORDER BY enqueued_at
+             LIMIT 1
+             FOR UPDATE SKIP LOCKED
+           )
+           RETURNING id, book_id, attempts`
+        );
+
+        if (rows.length === 0) break;
+        const job = rows[0];
+
+        try {
+          await runBookPipeline(job.book_id, deps);
+          await deps.db.query(
+            `UPDATE book_pipeline_jobs SET status = 'done' WHERE id = $1`,
+            [job.id]
+          );
+        } catch (err) {
+          await this.handleJobError(job, err, deps.db);
+        }
+      }
+    } finally {
+      this.running = false;
+    }
+  }
+
+  private async handleJobError(job: JobRow, err: unknown, db: Pool): Promise<void> {
+    const message = err instanceof Error ? err.message : String(err);
+    const safeMessage = message.slice(0, 200);
+
+    logger.error(
+      '[pipelineQueue] error book_id=%d attempt=%d:',
+      job.book_id,
+      job.attempts,
+      safeMessage
+    );
+
+    if (job.attempts >= MAX_RETRIES) {
+      await db.query(
+        `UPDATE book_pipeline_jobs SET status = 'failed', last_error = $2 WHERE id = $1`,
+        [job.id, safeMessage]
+      );
+      sendSlackAlert({
+        ruleId: 'pipeline_job_failed',
+        name: 'PipelineJob 全リトライ失敗',
+        level: 'CRITICAL',
+        status: 'FIRING',
+        details: `book_id=${job.book_id} attempts=${job.attempts}: ${safeMessage}`,
+      }).catch(() => {});
+    } else {
+      // 指数バックオフ: 1分 → 2分 → 4分
+      const backoffSeconds = Math.pow(2, job.attempts - 1) * 60;
+      await db.query(
+        `UPDATE book_pipeline_jobs
+         SET status = 'enqueued', last_error = $2,
+             enqueued_at = NOW() + ($3 * INTERVAL '1 second')
+         WHERE id = $1`,
+        [job.id, safeMessage, backoffSeconds]
+      );
+    }
   }
 }
 

--- a/src/migrations/phase70k_book_pipeline_jobs.sql
+++ b/src/migrations/phase70k_book_pipeline_jobs.sql
@@ -1,0 +1,47 @@
+-- Phase70K: book_pipeline_jobs テーブル作成
+-- pipelineQueue 永続化 — PM2再起動による stuck job 撲滅
+-- 根拠: in-memory キューはPM2 restart / crash でジョブが消失し
+--       book_uploads.status='uploaded' が永久停滞する（Phase53調査）
+
+-- ============================================================
+-- 1. book_pipeline_jobs テーブル
+-- ============================================================
+CREATE TABLE IF NOT EXISTS book_pipeline_jobs (
+  id           SERIAL         PRIMARY KEY,
+
+  -- 対応する書籍（外部キー）
+  book_id      INTEGER        NOT NULL REFERENCES book_uploads(id),
+
+  -- キュー状態
+  -- enqueued: 処理待ち / running: 実行中 / done: 完了 / failed: リトライ上限到達
+  status       VARCHAR(20)    NOT NULL DEFAULT 'enqueued'
+                 CONSTRAINT book_pipeline_jobs_status_check
+                 CHECK (status IN ('enqueued', 'running', 'done', 'failed')),
+
+  -- リトライ管理
+  attempts     INTEGER        NOT NULL DEFAULT 0,
+  last_error   TEXT,
+
+  -- タイムスタンプ
+  enqueued_at  TIMESTAMPTZ    NOT NULL DEFAULT NOW(),
+  started_at   TIMESTAMPTZ
+);
+
+COMMENT ON TABLE book_pipeline_jobs IS 'Phase70K: DB-backed pipeline queue。PM2再起動でジョブを消失させない。';
+COMMENT ON COLUMN book_pipeline_jobs.status IS 'enqueued→running→done / failed。attempts>=3 で failed。';
+COMMENT ON COLUMN book_pipeline_jobs.attempts IS 'SELECT FOR UPDATE SKIP LOCKED でクレーム時にインクリメント。';
+COMMENT ON COLUMN book_pipeline_jobs.enqueued_at IS '指数バックオフ再試行時は NOW()+backoff に更新される。';
+
+-- ============================================================
+-- 2. インデックス
+-- ============================================================
+
+-- processNext() の SELECT FOR UPDATE SKIP LOCKED で使用
+CREATE INDEX IF NOT EXISTS idx_book_pipeline_jobs_enqueued
+  ON book_pipeline_jobs (enqueued_at)
+  WHERE status = 'enqueued';
+
+-- checkStuckJobs() の running 1h超 監視で使用
+CREATE INDEX IF NOT EXISTS idx_book_pipeline_jobs_running
+  ON book_pipeline_jobs (started_at)
+  WHERE status = 'running';


### PR DESCRIPTION
## Summary
- `book_pipeline_jobs` テーブルで enqueue/run/done/failed を永続化。PM2 restart でキューが消失しなくなる
- 起動時 `selfHeal`: orphaned 'running' ジョブをリセット + `book_uploads.status='uploaded'` 書籍を自動再エンキュー
- `SELECT ... FOR UPDATE SKIP LOCKED` でアトミッククレーム。最大3リトライ + 指数バックオフ（1分→2分→4分）
- stuck 1h超・全リトライ失敗 → Slack WARNING/CRITICAL 通知

## 変更ファイル
| ファイル | 変更内容 |
|---|---|
| `src/migrations/phase70k_book_pipeline_jobs.sql` | 新規: book_pipeline_jobs テーブル + インデックス |
| `src/lib/book-pipeline/pipelineQueue.ts` | in-memory → DB-backed PipelineQueue |
| `src/lib/book-pipeline/pipelineQueue.test.ts` | DB モック対応テストに更新 |
| `src/index.ts` | 起動時 selfHeal + 10分毎 checkStuckJobs 追加 |

## Test plan
- [x] typecheck: 0 errors
- [x] pipelineQueue.test.ts: 2/2 passed (順次実行 + エラー回復)
- [ ] VPS migration apply: `psql ... -f src/migrations/phase70k_book_pipeline_jobs.sql` (hkobayashi 手動実行)
- [ ] 統合テスト: サーバー再起動後に stuck book_id=1 が自動復旧することを確認

## Asana GID
1215190233020663

## Gate 結果
- Gate 1: ✓ (typecheck 0 errors, tests 2/2)
- Gate 2.5: skip (Asana GID 1215190233020663)
- Gate 3: typecheck pass で代替 (VPS build は hkobayashi がデプロイ時確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)