### PR TITLE
fix(ci): pnpm version二重指定 + lint未存在ステップ削除

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:
@@ -29,9 +27,6 @@ jobs:
 
       - name: Typecheck
         run: pnpm typecheck
-
-      - name: Lint
-        run: pnpm lint
 
       - name: Test
         run: pnpm test
@@ -46,8 +41,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## 問題
`pnpm/action-setup@v4` が `version: 9`(yaml) と `packageManager: pnpm@9.15.9`(package.json) の二重指定でエラー:
```
Error: Multiple versions of pnpm specified
```

## 修正
- `version: 9` を両ジョブから削除 → package.json の `packageManager` フィールドを自動参照
- `pnpm lint` ステップを削除 (backend に ESLint config なし、ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL で空振り)

## 備考
Cloudflare Pages FAILURE は PR #222/#223 からの既存問題 (本PRとは無関係)

🤖 Generated with [Claude Code](https://claude.com/claude-code)