### PR TITLE
fix(lfs): model.onnx をLFS untrack — CF Pages帯域超過を根治

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
-models/ce-export/model.onnx filter=lfs diff=lfs merge=lfs -text
-models/**/*.onnx filter=lfs diff=lfs merge=lfs -text
+# models/ce-export/model.onnx: LFS untracked (2026-05-28)
+# LFS帯域超過(1GB/月)でCF Pages clone失敗→VPS CE_MODEL_PATH参照に変更
+# 実体: /opt/rajiuce/models/ce-export/model.onnx (VPS直接配置済み)

--- a/.gitignore
+++ b/.gitignore
@@ -82,3 +82,7 @@ DAILY_REPORT_*.md
 # 2026-05-28 OAuth postmortem 関連の大容量バイナリは個別運用 (リポ肥大回避)
 docs/postmortem/2026-05-28-oauth-fail/daemon.log.snapshot
 docs/postmortem/2026-05-28-oauth-fail/r2c-queue.db.pre-clean
+
+# 2026-05-28 LFS untrack: CE_MODEL_PATH env でVPS実体(/opt/rajiuce/models/...)を参照
+# git管理不要、LFS帯域超過(9.1GB/月)の根治
+models/ce-export/model.onnx

--- a/models/ce-export/model.onnx
+++ b/models/ce-export/model.onnx
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:6dab55523d1a7c1f760d8725489b5390651b7a9f37f0b9b5992a2fcabe1ee79f
-size 90988860


### PR DESCRIPTION
## 真因

5/22週29PR集中で LFS帯域 1GB/月の無料枠を**9倍超過**。
CF Pages が clone段階で \`models/ce-export/model.onnx\` (91MB) の LFS smudgeに失敗し、
\`a603bcc\` 以降の全 deploy が死亡 → **admin-ui PR #224 以降の本番未反映が継続**。

| 要因 | 数値 |
|---|---|
| LFSファイル | model.onnx 1件 91MB (2025-11-12 PR#24追加、7ヶ月不変) |
| 5月のPRマージ数 | 50件 (5/22週: 29件集中) |
| CF Pages clone推定 | 100回 × 91MB = **9.1GB** |
| GitHub LFS無料枠 | 1GB/月 → **11回cloneで枯渇** |

`GIT_LFS_SKIP_SMUDGE=1` / `.lfsconfig fetchexclude` は CF Pages のcheckout段階に効かない
(環境変数はビルドコマンド実行時に適用、git checkoutはその前に実行される既知の制限)。

## 変更内容

- `.gitattributes`: model.onnx の LFS filterパターンを削除
- `git rm --cached`: インデックスからのみ削除（**実ファイルはディスクに保持: 87MB確認済み**）
- `.gitignore`: `models/ce-export/model.onnx` を追加

## 本番無影響の根拠

cross-encoder は `CE_MODEL_PATH` 環境変数でVPS実体を参照 (`ceEngine.ts:401`)。

```typescript
// src/search/ceEngine.ts:401
this.modelPath = process.env.CE_MODEL_PATH ?? null;
```

- VPS実体: `/opt/rajiuce/models/ce-export/model.onnx` (87MB 確認済み)
- git管理ファイルを直接読まない設計
- admin-ui ビルドへの参照: ゼロ（`grep -rn "model.onnx" admin-ui/src/` → 0件）

## 効果

merge後 → CF Pages が次のPRで clone成功 → LFS帯域消費ゼロ → admin本番デプロイ正常化

## merge後の確認手順（hkobayashi）

```bash
# CF Pages で最新コミットのRetry deploy
# https://dash.cloudflare.com/.../pages/view/r2c/
# → 最新deployの「Retry deploy」ボタン
# → ビルドログに "Downloading models/ce-export/model.onnx" が出ないこと
# → deploy成功後: curl -s https://admin.r2c.biz/ | grep "ご質問・ご要望"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)