### PR TITLE
fix(supervisor): started_at=NULL タスクの stuck 検出漏れを修正 (GID 1215236154458123)

### DIFF
--- a/SCRIPTS/monitor-claude-health.sh
+++ b/SCRIPTS/monitor-claude-health.sh
@@ -178,7 +178,7 @@ check_axis_d() {
 check_axis_e() {
     [ -f "$QUEUE_DB" ] || return
     local count
-    count=$(sqlite3 "$QUEUE_DB" "SELECT COUNT(*) FROM tasks WHERE state='running' AND (session_id IS NULL OR session_id='') AND started_at < datetime('now', '-60 seconds');" 2>/dev/null || echo 0)
+    count=$(sqlite3 "$QUEUE_DB" "SELECT COUNT(*) FROM tasks WHERE state='running' AND (session_id IS NULL OR session_id='') AND COALESCE(started_at, updated_at, created_at) < datetime('now', '-60 seconds');" 2>/dev/null || echo 0)
     if [ -z "$count" ] || ! [[ "$count" =~ ^[0-9]+$ ]]; then count=0; fi
     if [ "$count" -ge 3 ]; then
         notify critical E "session_id 未取得多発 (罠5/6 兆候)" "running task が ${count} 件 session_id NULL のまま 60s 超。cron context spawn 不能の可能性。"

--- a/SCRIPTS/r2c-supervisor.sh
+++ b/SCRIPTS/r2c-supervisor.sh
@@ -86,8 +86,7 @@ notify() {
 STUCK=$(SQ "SELECT id, asana_gid, asana_name, session_id, COALESCE(attempt_count,0), worktree_path
             FROM tasks
             WHERE state = 'running'
-              AND started_at IS NOT NULL
-              AND started_at < datetime('now', '-${MAX_RUN_MINUTES} minutes');")
+              AND COALESCE(started_at, updated_at, created_at) < datetime('now', '-${MAX_RUN_MINUTES} minutes');")
 
 STUCK_COUNT=0
 if [ -n "$STUCK" ]; then


### PR DESCRIPTION
## 調査結果サマリー (GID 1215236154458123)

### 問題①: Tier-S id=4 が session 未アタッチのまま running 固着

**根本原因**: `dispatch_one` を通さず手動 SQL で直接 `state='running'` に変更されたため。

証拠:
- `attempt_count=0` → dispatch_one は必ず `COALESCE(attempt_count,0)+1` する
- `session_id=空` → dispatch_one は r2c-lane-session-resolver.sh を起動する
- dispatch.log に id=4 の 5/28 dispatch 記録なし（5/29 09:41 JST の1件のみ）
- lane_events に `needs_approval_critical` 以降の state_change なし

**なぜ supervisor が捕捉しなかったか**:
手動 UPDATE が `started_at=NULL` のまま（dispatch_one の `started_at=datetime('now')` が実行されていない）。
supervisor の stuck 検出クエリが `AND started_at IS NOT NULL` を必須条件としていたため、
NULL タスクは永久に素通りした。

### 問題②: single running slot の head-of-line blocking

**結論: blocking ではなかった**。

MAX_SLOTS=3 中 running=1 (id=4) → 空き 2 スロット。dispatch は "No dispatchable tasks (pending=0)" を
一貫して報告。overnight に pending タスクがゼロだったことが真因（blocking ではなく空振り）。

### 問題③: rollback が fail-safe か誤判定か

**結論: (a) fail-safe が正常動作**。

id=48-51 はすべて:
- session_id 設定済み（Lane は実際に起動した）
- 45min × 3 回 = 135min リトライ後に rollback
- 人間が完遂したタスク (#227/#228/#230/#231) は Lane が詰まった後の takeover

supervisor の rollback は誤判定なし。PR 検知ロジックの問題なし。

### 問題④: monitor 軸E と com.r2c.monitor exit=1

軸E クエリも `started_at < datetime(...)` を使用しており、started_at=NULL タスクを検出不能。
本 PR で同時修正。exit=1 の詳細は id=52 の parallel lane が調査中。

### 問題⑤: 再発防止（本 PR の修正内容）

`started_at=NULL` のタスクが永久にスロットを占有する構造欠陥を修正。

---

## 変更内容

**supervisor.sh**: stuck 検出クエリを `COALESCE(started_at, updated_at, created_at)` に変更
- started_at=NULL → updated_at にフォールバック
- updated_at も NULL → created_at にフォールバック（created_at は NOT NULL DEFAULT）

**monitor-claude-health.sh 軸E**: 同様の COALESCE 修正

```sql
-- 修正前
AND started_at IS NOT NULL
AND started_at < datetime('now', '-45 minutes')

-- 修正後
AND COALESCE(started_at, updated_at, created_at) < datetime('now', '-45 minutes')
```

## Gate 結果

- Gate 1: typecheck ✅ (0 errors), test ⚠️ (Node 24 vs Node 20 既存クラッシュ - shell 変更と無関係)
- Gate 1.5: dead-code-check ✅ (79 warnings は既存)
- Gate 2: security-scan ✅ PASS
- Gate 2.5: スキップ (Codex review gate 常時 OFF)

## 備考

手動 SQL での `state='running'` 直接変更は引き続き禁止事項。
`needs_approval_critical` → `running` は dispatch_one 経由でのみ実施すること。

🤖 Generated with [Claude Code](https://claude.com/claude-code)