### PR TITLE
fix(gate1): jest OOM 根治 — bookPdfRoutes の未mock pipelineQueue 無限ループを遮断

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,10 @@ jobs:
     name: Gate 1 — typecheck + lint + test
     runs-on: ubuntu-latest
     timeout-minutes: 15
+    # jest --runInBand が大規模スイートで node 既定ヒープ(~4GB)を超え OOM (FATAL heap limit / exit 134) するため明示拡張。
+    # 症状: docs-only PR でも同一の OOM で Gate 1 が落ちる = main 由来の CI 環境問題 (PR 内容と無関係)。
+    env:
+      NODE_OPTIONS: --max-old-space-size=6144
 
     steps:
       - uses: actions/checkout@v4

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -8,6 +8,11 @@ module.exports = {
     "ts-jest": {
       // Mirror tsc --noEmit behaviour: emit warnings but don't fail the test suite
       diagnostics: { warnOnly: true },
+      // 型チェックを test 実行から外しトランスパイルのみ行う (メモリ単調増加→OOM の根治)。
+      // 150 スイート × jest --runInBand で ts-jest の per-file 型チェックがヒープを
+      // 累積させ、6GB でも JS heap OOM (exit 134) していた。型安全性は別ステップ
+      // `pnpm typecheck` (tsc --noEmit) が担保するため、test 側での型チェックは冗長。
+      isolatedModules: true,
     },
   },
 

--- a/src/api/admin/knowledge/bookPdfRoutes.test.ts
+++ b/src/api/admin/knowledge/bookPdfRoutes.test.ts
@@ -23,6 +23,15 @@ jest.mock("../../../lib/logger", () => ({
   createLogger: jest.fn(() => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn(), debug: jest.fn() })),
 }));
 
+// pipelineQueue をモック（重要）:
+// 本テストはルートの責務のみを検証する。実 pipelineQueue.enqueue を走らせると、
+// 全クエリが canned 値を返すモック db と DB-backed queue (#227) が組み合わさり、
+// バックグラウンドの非同期処理が無限ループ化 → jest ヒープ OOM (exit 134) を起こす
+// (Gate 1 赤化の根本原因)。enqueue を no-op 化して副作用を遮断する。
+jest.mock("../../../lib/book-pipeline/pipelineQueue", () => ({
+  pipelineQueue: { enqueue: jest.fn().mockResolvedValue(undefined) },
+}));
+
 import { supabaseAdmin } from "../../../auth/supabaseClient";
 import { logger } from "../../../lib/logger";
 


### PR DESCRIPTION
## 切り分け結果（① main 由来か否か）
`Gate 1 — typecheck + lint + test` が docs-only PR (#232/#235) でも同一 OOM で赤 = **PR 内容と無関係・main 由来**を確定。失敗ステップは `pnpm test` の `JS heap out of memory (exit 134)`。

## 真因（深掘り）
当初 heap 不足を疑い NODE_OPTIONS=6144 を試すも **6GB でも OOM**（より進んでから落ちる）。スイート単位で二分 → **`src/api/admin/knowledge/bookPdfRoutes.test.ts` 単独で 4GB 超**を消費と特定。

スタックトレースが `ThrowCalledNonCallable` → `AsyncFunctionAwaitResolveClosure` → `RunMicrotasks` の**非同期マイクロタスク無限ループ**を示す。原因は、201 成功テストが **実 `pipelineQueue.enqueue` を起動**していたこと。全クエリが canned 値を返す mock db と **DB-backed queue (#227 で merged)** が噛み合い、バックグラウンド処理が無限ループ化して OOM。**Gate 1 赤化の時期が #227 merge と一致**。

## 修正
- `bookPdfRoutes.test.ts`: `pipelineQueue.enqueue` を no-op mock 化（**テストのみ・本番コード無変更**）
- `jest.config.cjs`: `isolatedModules: true`（test からの型チェックを外しメモリ/速度改善。型安全性は別ステップ `pnpm typecheck` が担保）
- `ci.yml`: `NODE_OPTIONS=--max-old-space-size=6144`（安全マージン）

## 検証（ローカル node24）
- bookPdfRoutes 単独: 4GB でも OOM → 修正後 **57MB で PASS**
- フルスイート: **142 suites / 1721 tests を heap 4096 で全 PASS**（CI は node20 + 6144）

## 効果
main 取込後、main 由来で赤だった #232 / #233 / #235 が再実行で緑化 → merge 可能に。
本番ランタイムコードは変更なし（Gate 2.5: test/CI 設定のみ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)