### PR TITLE
fix(supervisor): PR-aware guard で stuck 誤判定 auto_rollback を防止 (dispatch 再開の前提)

### DIFF
--- a/SCRIPTS/r2c-supervisor.sh
+++ b/SCRIPTS/r2c-supervisor.sh
@@ -83,7 +83,7 @@ notify() {
 }
 
 # ─── 1. Stuck Lane 検出 ──────────────────────────────────────────────────
-STUCK=$(SQ "SELECT id, asana_gid, asana_name, session_id, COALESCE(attempt_count,0), worktree_path
+STUCK=$(SQ "SELECT id, asana_gid, asana_name, session_id, COALESCE(attempt_count,0), worktree_path, COALESCE(branch,'')
             FROM tasks
             WHERE state = 'running'
               AND COALESCE(started_at, updated_at, created_at) < datetime('now', '-${MAX_RUN_MINUTES} minutes');")
@@ -106,9 +106,31 @@ if [ "$DRY_RUN" -eq 1 ]; then
 fi
 
 if [ -n "$STUCK" ]; then
-    while IFS='|' read -r TID GID NAME SID ATTEMPT WORKTREE; do
+    while IFS='|' read -r TID GID NAME SID ATTEMPT WORKTREE BRANCH; do
         [ -z "$TID" ] && continue
         echo "Stuck task ${TID} (gid=${GID:-NA}, attempt=${ATTEMPT}, session=${SID:-NA}): ${NAME}"
+
+        # ─── PR-aware guard: 既に PR を作成済みなら "stuck" ではない (誤 rollback 防止) ───
+        # Lane が PR を出したのに state が running のまま残る (pr_created へ未遷移) と、
+        # supervisor が "running > 45min" と誤検出し、成果物ごと auto_rollback してしまう
+        # (2026-05-29 に id=49/50 が merged 済、52/53/54 が PR open のまま誤 rollback された事案)。
+        # kill/cleanup/retry/rollback を行う前に、branch に対応する PR の有無を確認する。
+        if [ -n "${BRANCH:-}" ]; then
+            PR_JSON=$(cd "$R2C_ROOT" && gh pr list --head "$BRANCH" --state all --json number,state --limit 1 2>/dev/null || echo '[]')
+            PR_NUM=$(printf '%s' "$PR_JSON" | jq -r '.[0].number // empty' 2>/dev/null || true)
+            PR_STATE=$(printf '%s' "$PR_JSON" | jq -r '.[0].state // empty' 2>/dev/null || true)
+            if [ -n "${PR_NUM:-}" ]; then
+                if [ "$PR_STATE" = "MERGED" ]; then
+                    RECONCILED_STATE="merged"
+                else
+                    RECONCILED_STATE="pr_created"
+                fi
+                SQ "UPDATE tasks SET state='${RECONCILED_STATE}', pr_number=${PR_NUM}, error_message='supervisor: PR #${PR_NUM} (${PR_STATE}) 検出 — stuck 誤判定を回避', last_action='pr_reconciled', updated_at=datetime('now') WHERE id = ${TID};"
+                echo "  → reconciled to ${RECONCILED_STATE} (PR #${PR_NUM} ${PR_STATE} 存在; stuck ではない)"
+                notify 0 "R2C Lane reconciled" "Task ${TID}: PR #${PR_NUM} (${PR_STATE}) 検出。stuck 誤判定を回避し ${RECONCILED_STATE} へ遷移: ${NAME}"
+                continue
+            fi
+        fi
 
         # claude session kill (best-effort)
         if [ -n "$SID" ]; then

--- a/SCRIPTS/r2c-supervisor.sh
+++ b/SCRIPTS/r2c-supervisor.sh
@@ -119,12 +119,16 @@ if [ -n "$STUCK" ]; then
             PR_JSON=$(cd "$R2C_ROOT" && gh pr list --head "$BRANCH" --state all --json number,state --limit 1 2>/dev/null || echo '[]')
             PR_NUM=$(printf '%s' "$PR_JSON" | jq -r '.[0].number // empty' 2>/dev/null || true)
             PR_STATE=$(printf '%s' "$PR_JSON" | jq -r '.[0].state // empty' 2>/dev/null || true)
-            if [ -n "${PR_NUM:-}" ]; then
-                if [ "$PR_STATE" = "MERGED" ]; then
-                    RECONCILED_STATE="merged"
-                else
-                    RECONCILED_STATE="pr_created"
-                fi
+            # OPEN→pr_created / MERGED→merged のみ正規化する。
+            # CLOSED(未merge) や PR 無しは既存 stuck 処理 (retry/rollback) にフォールスルー。
+            # (Codex Gate 2.5 [P2]: CLOSED を pr_created にすると非終端で取り残され復旧不能)
+            RECONCILED_STATE=""
+            if [ "$PR_STATE" = "MERGED" ]; then
+                RECONCILED_STATE="merged"
+            elif [ "$PR_STATE" = "OPEN" ]; then
+                RECONCILED_STATE="pr_created"
+            fi
+            if [ -n "${PR_NUM:-}" ] && [ -n "$RECONCILED_STATE" ]; then
                 SQ "UPDATE tasks SET state='${RECONCILED_STATE}', pr_number=${PR_NUM}, error_message='supervisor: PR #${PR_NUM} (${PR_STATE}) 検出 — stuck 誤判定を回避', last_action='pr_reconciled', updated_at=datetime('now') WHERE id = ${TID};"
                 echo "  → reconciled to ${RECONCILED_STATE} (PR #${PR_NUM} ${PR_STATE} 存在; stuck ではない)"
                 notify 0 "R2C Lane reconciled" "Task ${TID}: PR #${PR_NUM} (${PR_STATE}) 検出。stuck 誤判定を回避し ${RECONCILED_STATE} へ遷移: ${NAME}"


### PR DESCRIPTION
## 問題 (本日 2026-05-29 観測)
24h ループの supervisor が、**成果を出した 5 Lane を誤って auto_rollback** していた:

| queue id | branch | 実態 | 旧 state |
|---|---|---|---|
| 49 | b-49 pipelinequeue | **#227 merged 済** | rollbacked ❌ |
| 50 | b-50 env placeholder | **#228 merged 済** | rollbacked ❌ |
| 52 | b-52 monitor | **#233 open/mergeable** | rollbacked ❌ |
| 53 | b-53 tier-s postmortem | **#232 open/mergeable** | rollbacked ❌ |
| 54 | b-54 gitleaks | **#235 open/mergeable** | rollbacked ❌ |

error_message は全て `stuck > 45min for 3 attempts`。実際は Lane が PR を作った後、
queue state を `running`→`pr_created` へ遷移できず `running` に留まり、
supervisor が「45分以上 running = stuck」と誤検出して破壊していた。

## 修正
`SCRIPTS/r2c-supervisor.sh` の stuck 処理ループに **PR-aware guard** を追加:
kill/cleanup/retry/rollback の前に `gh pr list --head <branch>` で PR 有無を確認。
- PR open → `pr_created` に正規化 (+pr_number)
- PR MERGED → `merged` に正規化 (+pr_number)
- いずれも `continue` で破壊的処理を skip
- gh/jq 失敗時は従来動作にフォールバック (フェイルセーフ)

## 影響 / 安全性
- ロールバックを**抑止する方向のみ**。新規の破壊的動作なし。
- 直列・冪等。bash -n / shellcheck(-S error) クリーン、--dry-run 正常。
- **dispatch 再開はこの修正 merge が前提**（未修正のまま再開すると同じ誤 rollback が再発）。

## follow-up
- 実 running Lane での統合テスト（現在 queue に running 行が無いため未実走）。
- 45分閾値の妥当性（CI 完了待ちとの兼ね合い）は別途。

🤖 Generated with [Claude Code](https://claude.com/claude-code)