### PR TITLE
fix(rag): principleSearch に global tenant 対応追加 (他RAG経路と一貫性確保)

### DIFF
--- a/HANDOFF.md
+++ b/HANDOFF.md
@@ -1,9 +1,46 @@
 # RAJIUCE Handoff Document
 
 ## Quick State
-- Phase 70: 24h 自走ループ確立済み (2026-05-28) ✅ 完全自走確定
-- Active: Phase53残 (book id=1 VPS復旧) → Phase54 billing → pipelineQueue永続化
-- 24h Loop: Tier-S id=4 試運転中 (3日連続成功で正式承認、14日でDoD)
+- Phase 70: 24h 自走ループ確立済み (2026-05-28) ✅
+- Active: 昨夜残務・インフラ復旧完了 (2026-05-29)。dispatch 停止中 → #237 merge 後に hkobayashi が手動再開予定。
+- 24h Loop: dispatch/poll/supervisor bootout 中（launchd 停止）。monitor は #233 版で LastExitStatus=0 で稼働中。
+
+## 残人手タスク (hkobayashi 実行)
+1. **dispatch 再開** (#237 merge 後):
+   ```
+   sqlite3 ~/projects/commerce-faq-tasks/.claude/queue/r2c-queue.db \
+     "INSERT OR REPLACE INTO automation_state(key,value) VALUES('pause_dispatching','0');"
+   for l in dispatch poll supervisor; do
+     launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.r2c.$l.plist
+   done
+   ```
+2. book id=1 VPS復旧: `POST /v1/admin/knowledge/book-pdf/1/process` (super_admin JWT)
+3. Phase44 P2 VPS: `psql $DATABASE_URL < src/migrations/phase44_book_uploads.sql` → deploy
+
+## 2026-05-29 成果サマリ
+
+### インフラ復旧 (昨夜残務 ①②③)
+
+**① Gate1 OOM 根治 PR #236** (sha=5b0e2c7d0d19) — merged ✅
+- 切り分け: docs-only PR でも OOM → main 由来確定。
+- 真因: `bookPdfRoutes.test.ts` が `pipelineQueue.enqueue` を未 mock → DB-backed queue(#227) と mock db が非同期無限ループ → JS heap OOM。Gate1 赤化は #227 merge と時期一致。
+- 修正: test に `jest.mock(pipelineQueue)` (本番無変更) + `isolatedModules:true` + CI `NODE_OPTIONS=6144`。142 suites/1721 tests 全通過。Gate1 5分 OOM → 1分完走。
+
+**② supervisor 誤 rollback 根治 PR #237** (sha=9ec767c78251) — merged ✅
+- 真因: running>45min 検出時に PR 存在確認なし。Lane が PR を出しても state 遷移漏れで running のまま → 5 レーン (id=49/50/52/53/54) が auto_rollback された。
+- 修正: kill 前に `gh pr list --head <branch>` で確認。OPEN=pr_created / MERGED=merged / CLOSED=フォールスルー。
+- Codex Gate 2.5: P0/P1 なし、P2 指摘(CLOSED→pr_created 非終端放置)を修正済み。
+- キュー整合済: 49/50→merged, 52/53/54→pr_created (+pr_number)。
+
+**③ Codex Gate 2.5 復旧確定** — #237 で実走・完走ログ取得・PR コメント投稿済み ✅
+
+### その他 merged PR (2026-05-29)
+| PR | sha | 内容 |
+|---|---|---|
+| #233 | 7a2d155c77dd | fix(monitor): bash 5.3.3 `$current。` 誤展開修正 → monitor LastExitStatus=0 ✅ |
+| #232 | eed25ebc5dd9 | docs(postmortem): Tier-S id=4 固着 + single-slot 調査レポート |
+| #234 | a1c64b58a84b | fix(supervisor): started_at=NULL stuck 検出漏れ修正 |
+| #235 | fa302f4fb001 | docs(gitleaks): allowlist + docs org UUID redact |
 
 ## 2026-05-28 成果サマリ
 

--- a/src/agent/psychology/principleSearch.test.ts
+++ b/src/agent/psychology/principleSearch.test.ts
@@ -1,0 +1,62 @@
+// src/agent/psychology/principleSearch.test.ts
+// id=48: principleSearch.ts の global tenant 対応（他RAG経路と一貫性）回帰テスト
+
+import { Pool } from 'pg';
+import { searchPrincipleChunks } from './principleSearch';
+
+// pg Pool を db 引数注入でモック（外部依存はモックする方針）
+function makePoolMock(rows: Array<Record<string, string | null>>) {
+  const query = jest.fn().mockResolvedValue({ rows });
+  return { pool: { query } as unknown as InstanceType<typeof Pool>, query };
+}
+
+describe('searchPrincipleChunks', () => {
+  it('SQL は tenant_id = $1 OR tenant_id = \'global\' で共有テナントも対象にする', async () => {
+    const { pool, query } = makePoolMock([]);
+    await searchPrincipleChunks('tenant-A', ['アンカリング効果'], pool);
+
+    const sql = query.mock.calls[0][0] as string;
+    expect(sql).toMatch(/tenant_id = \$1\s+OR\s+tenant_id = 'global'/);
+    // パラメータは [tenantId, principles] のまま（global はリテラル）
+    expect(query.mock.calls[0][1]).toEqual(['tenant-A', ['アンカリング効果']]);
+  });
+
+  it('global テナントの book チャンクを返却できる', async () => {
+    const { pool } = makePoolMock([
+      {
+        principle: 'アンカリング効果',
+        situation: '価格提示の前に基準値を示す',
+        example: '通常価格を先に見せる',
+        contraindication: '誇大広告は禁止',
+      },
+    ]);
+    const result = await searchPrincipleChunks('tenant-A', ['アンカリング効果'], pool);
+    expect(result).toHaveLength(1);
+    expect(result[0].principle).toBe('アンカリング効果');
+  });
+
+  it('全テキストフィールドに slice(0, 200) を適用する（書籍内容漏洩防止）', async () => {
+    const long = 'あ'.repeat(500);
+    const { pool } = makePoolMock([
+      { principle: long, situation: long, example: long, contraindication: long },
+    ]);
+    const result = await searchPrincipleChunks('tenant-A', ['x'], pool);
+    expect(result[0].situation.length).toBe(200);
+    expect(result[0].example.length).toBe(200);
+    expect(result[0].contraindication.length).toBe(200);
+  });
+
+  it('principles が空なら DB を叩かず空配列を返す', async () => {
+    const { pool, query } = makePoolMock([]);
+    const result = await searchPrincipleChunks('tenant-A', [], pool);
+    expect(result).toEqual([]);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it('DB エラー時は空配列を返す（書籍内容をログに出さない）', async () => {
+    const query = jest.fn().mockRejectedValue(new Error('db down'));
+    const pool = { query } as unknown as InstanceType<typeof Pool>;
+    const result = await searchPrincipleChunks('tenant-A', ['x'], pool);
+    expect(result).toEqual([]);
+  });
+});

--- a/src/agent/psychology/principleSearch.ts
+++ b/src/agent/psychology/principleSearch.ts
@@ -19,6 +19,8 @@ function getPool(db?: InstanceType<typeof Pool>): InstanceType<typeof Pool> {
 /**
  * pgvector の faq_embeddings テーブルから心理学原則チャンクを取得する。
  * metadata.source = 'book' かつ metadata.principle が principles 配列に含まれるレコードを検索。
+ * tenant_id は当該テナント または共有の 'global' テナントを対象とする
+ * （他RAG経路 pgvector / langRouter / knowledgeSearchUtil と一貫: `tenant_id = $1 OR 'global'`）。
  * 各テキストフィールドに ragExcerpt.slice(0, 200) を適用（書籍内容漏洩防止）。
  */
 export async function searchPrincipleChunks(
@@ -47,7 +49,7 @@ export async function searchPrincipleChunks(
         metadata->>'example' as example,
         metadata->>'contraindication' as contraindication
        FROM faq_embeddings
-       WHERE tenant_id = $1
+       WHERE (tenant_id = $1 OR tenant_id = 'global')
          AND metadata->>'source' = 'book'
          AND metadata->>'principle' = ANY($2)
        LIMIT 3`,


### PR DESCRIPTION
## 背景 (queue id=48 / Asana GID 1215190503585022)
`principleSearch.ts` は `faq_embeddings` を `WHERE tenant_id = $1` のみで検索しており、共有の `'global'` テナントに属する書籍チャンクを取得できなかった。

他のRAG経路はすべて `WHERE (tenant_id = $1 OR tenant_id = 'global')` で統一済み:
- `src/search/pgvector.ts:106`
- `src/search/langRouter.ts:210`
- `src/search/pgvectorSearch.ts:57`
- `src/lib/knowledgeSearchUtil.ts:51`
- `src/api/admin/knowledge/routes.ts:376`

`principleSearch.ts` だけがこの規約から欠落していた不整合を是正する。

## 変更
- `principleSearch.ts`: WHERE 句に `OR tenant_id = 'global'` を追加（パラメータ不変、`'global'` はSQLリテラルなので injection リスクなし）
- `principleSearch.test.ts`: 新規。SQL検証 / global返却 / `slice(0,200)` / 空配列 / DBエラー の5ケース

## Gate
- Gate 1: typecheck クリーン / 新規テスト 5/5 パス
- Gate 2: security-scan PASS (SQL injection check PASS)

## テナント分離への影響
`'global'` は設計上の共有テナント（他RAG全経路と同一扱い）。他顧客テナントのデータ越境ではなく、共有書籍知識の取得経路を他経路と揃えるもの。

🤖 Generated with [Claude Code](https://claude.com/claude-code)