### PR TITLE
fix(judge): judgeEvaluator も global 共有 tuning_rules を評価対象に含める

### DIFF
--- a/src/agent/judge/judgeEvaluator.test.ts
+++ b/src/agent/judge/judgeEvaluator.test.ts
@@ -128,6 +128,12 @@ describe('evaluateSession', () => {
     expect(result!.stage_progress_score).toBe(75);
     expect(result!.taboo_violation_score).toBe(90);
 
+    // tuning_rules SELECT (call index 2) must include the 'global' shared-tenant fallback
+    // so judge evaluates against the same rule set runtime applies (tenant + global)
+    const tuningSelectCall = mockPool.query.mock.calls[2]!;
+    expect(tuningSelectCall[0]).toContain('tuning_rules');
+    expect(tuningSelectCall[0]).toMatch(/tenant_id = \$1\s+OR\s+tenant_id = 'global'/);
+
     // INSERT was called with tenant_id and session_id (index 3 after Phase60-A tuning_rules SELECT)
     const insertCall = mockPool.query.mock.calls[3]!;
     expect(insertCall[1]).toContain('tenant-abc');

--- a/src/agent/judge/judgeEvaluator.ts
+++ b/src/agent/judge/judgeEvaluator.ts
@@ -175,7 +175,9 @@ export async function evaluateSession(sessionId: string): Promise<JudgeEvaluatio
         : Promise.resolve({ results: [] }),
       pool
         .query(
-          'SELECT trigger_pattern, expected_behavior FROM tuning_rules WHERE tenant_id = $1 AND is_active = true LIMIT 10',
+          // runtime (tuningRulesRepository) は tenant + 'global' 共有ルールを適用するため、
+          // judge も同じルール集合で psychology_fit を評価する (他RAG経路と一貫)。
+          "SELECT trigger_pattern, expected_behavior FROM tuning_rules WHERE (tenant_id = $1 OR tenant_id = 'global') AND is_active = true LIMIT 10",
           [tenantId],
         )
         .then((res: { rows: Array<{ trigger_pattern: string; expected_behavior: string }> }) => res.rows)


### PR DESCRIPTION
## 背景
tenant-scope 一貫性監査（PR #239 の principleSearch 修正に続く横展開）で発見。

`judgeEvaluator.ts` は psychology_fit 評価のため `tuning_rules` を `WHERE tenant_id = $1` のみで取得しており、共有の `'global'` テナントのチューニングルールを無視していた。

一方 runtime の `tuningRulesRepository.ts:67` は `WHERE tenant_id = $1 OR tenant_id = 'global'` で **tenant + global を適用**している。→ judge の評価基準と実際に適用されるルール集合が不一致だった。

## 変更
- `judgeEvaluator.ts`: tuning_rules SELECT に `OR tenant_id = 'global'` 追加（パラメータ不変、`'global'` はSQLリテラルで injection リスクなし）
- `judgeEvaluator.test.ts`: SELECT が global fallback を含むことを検証するアサーション追加

## 据え置き判断（重要）
同種クエリの `weeklyReportGenerator.ts:146`（承認待ち tuning_rules 件数）は**意図的に tenant-strict のまま据え置き**。これは「当該テナントの承認待ち件数」という per-tenant 業務メトリクスで、global を混入させると全テナントのレポートに当該テナントが対処できない数字を表示してしまうため。機械的な一貫性適用はここでは誤り。

## Gate
- Gate 1: typecheck クリーン / judge test 6/6 パス
- Gate 2: security-scan PASS
- Gate 2.5: Codex P0/P1 **none**
- Gate 3: build 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)