### PR TITLE
test(e2e): widget FAB テストのURL設定整理 (未使用定数除去 + 非アバター経路URL分離)

### DIFF
--- a/tests/e2e/widget-fab-avatar.spec.ts
+++ b/tests/e2e/widget-fab-avatar.spec.ts
@@ -13,7 +13,12 @@ const E2E_ENABLED = process.env.E2E_ENABLED === '1' || !!process.env.CI;
 test.describe('Widget FAB — Avatar persistence on chat open/close', () => {
   test.skip(!E2E_ENABLED, 'E2E tests require E2E_ENABLED=1 or CI=true');
 
-  const CHAT_TEST_URL = process.env.E2E_CHAT_TEST_URL || 'https://admin.r2c.biz';
+  // アバター設定済みテナントのデモページ (test 1/2 が使用)
+  const AVATAR_DEMO_URL =
+    process.env.E2E_CHAT_TEST_URL || 'https://api.r2c.biz/carnation-demo/index.html';
+  // 非アバターテナントのページ (test 3 が使用)。CI で実 URL を注入すると非アバター経路を実検証できる。
+  // 未指定時はアバター版にフォールバック → test 3 は従来どおり skip される（誤検証を防ぐ）。
+  const NON_AVATAR_DEMO_URL = process.env.E2E_NON_AVATAR_TEST_URL || AVATAR_DEMO_URL;
 
   /** Wait for FAB to appear inside the widget Shadow DOM */
   async function getFabState(page: any) {
@@ -34,7 +39,7 @@ test.describe('Widget FAB — Avatar persistence on chat open/close', () => {
 
   test('FAB retains avatar image after chat close (single cycle)', async ({ page }) => {
     // Navigate to carnation demo — widget initializes with avatar config
-    const resp = await page.goto('https://api.r2c.biz/carnation-demo/index.html');
+    const resp = await page.goto(AVATAR_DEMO_URL);
     expect(resp?.status()).toBe(200);
 
     // Wait for widget init + avatar config prefetch (max 8s)
@@ -87,7 +92,7 @@ test.describe('Widget FAB — Avatar persistence on chat open/close', () => {
   });
 
   test('FAB retains avatar image across multiple open/close cycles', async ({ page }) => {
-    const resp = await page.goto('https://api.r2c.biz/carnation-demo/index.html');
+    const resp = await page.goto(AVATAR_DEMO_URL);
     expect(resp?.status()).toBe(200);
 
     await page.waitForFunction(
@@ -132,7 +137,7 @@ test.describe('Widget FAB — Avatar persistence on chat open/close', () => {
   test('FAB shows chat SVG icon for non-avatar tenant (demo page without avatar)', async ({ page }) => {
     // Demo page uses a different tenant without avatar configuration
     // If FAB has no avatar image initially, it should have chat SVG — open/close should keep it
-    const resp = await page.goto('https://api.r2c.biz/carnation-demo/index.html');
+    const resp = await page.goto(NON_AVATAR_DEMO_URL);
     expect(resp?.status()).toBe(200);
 
     await page.waitForFunction(


### PR DESCRIPTION
## 背景（Asana #5 / #6 — widget FAB E2E）
`tests/e2e/widget-fab-avatar.spec.ts` の2つの test-only 課題を一括是正。

### #5 未使用定数 CHAT_TEST_URL
`const CHAT_TEST_URL = ... 'https://admin.r2c.biz'` が定義のみで**一度も使われず**、各 test は `https://api.r2c.biz/carnation-demo/index.html` をハードコードしていた。→ `AVATAR_DEMO_URL` にリネームし test 1/2 から参照。

### #6 非アバターテナント test が常にスキップ
test 3「FAB shows chat SVG icon for non-avatar tenant」が**アバター有の carnation-demo** へ遷移し、`if (hasImg||hasVideo) test.skip()`(line 154) で**毎回スキップ** → 非アバター経路を一度も検証できていなかった。→ `NON_AVATAR_DEMO_URL`（env `E2E_NON_AVATAR_TEST_URL`）を導入し test 3 から参照。CI で実 URL を注入すれば実検証可能。未指定時はアバター版にフォールバックし従来どおり安全に skip。

## 変更
- `tests/e2e/widget-fab-avatar.spec.ts` のみ（**本番コード無変更**）

## Gate
- typecheck クリーン / `playwright test --list` で3テスト正常コンパイル
- test-only のため Gate 2.5 (Codex) skip 対象（CLAUDE.md 準拠）

🤖 Generated with [Claude Code](https://claude.com/claude-code)