### PR TITLE
refactor(groq): モデルID集約カタログ + EOL検知層 (検知層優先)

### DIFF
--- a/SCRIPTS/check-groq-models.sh
+++ b/SCRIPTS/check-groq-models.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# SCRIPTS/check-groq-models.sh
+# EOL 検知層: Groq が decommission 済みのモデル ID が src/ (非 test) に混入していないか走査する。
+# 廃止モデルの実 ID 一覧は src/config/groqModels.ts#KNOWN_DEPRECATED_GROQ_MODELS が単一の真実。
+# 1件でも見つかれば file:line を表示して exit 1（CI / security-scan から呼べる）。
+#
+# 使い方: bash SCRIPTS/check-groq-models.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CATALOG="$ROOT/src/config/groqModels.ts"
+
+if [[ ! -f "$CATALOG" ]]; then
+  echo "[check-groq-models] catalog not found: $CATALOG" >&2
+  exit 2
+fi
+
+# KNOWN_DEPRECATED_GROQ_MODELS 配列のリテラル ('...' で始まる行) を抽出する。
+# 配列ブロック内の 'xxx', 行だけを拾うため、定数名で範囲を絞ってから quote 内を抜く。
+# 宣言行 (`... string[] = [`) は型注釈の `]` を含むため `next` でスキップし、
+# 終端は単独の `] as const` 行で判定する。中身の 'xxx' リテラルだけを抜く。
+mapfile -t DEPRECATED < <(
+  awk '/KNOWN_DEPRECATED_GROQ_MODELS/{f=1; next} f && /^\] as const/{f=0} f' "$CATALOG" \
+    | grep -oE "'[^']+'" | tr -d "'" | grep -vE '^$'
+)
+
+if [[ ${#DEPRECATED[@]} -eq 0 ]]; then
+  echo "[check-groq-models] no deprecated IDs parsed from catalog (nothing to enforce)."
+  exit 0
+fi
+
+echo "[check-groq-models] scanning src/ for ${#DEPRECATED[@]} deprecated Groq model IDs..."
+
+FOUND=0
+for id in "${DEPRECATED[@]}"; do
+  # src/ 配下の .ts のうち test とカタログ自身を除外して固定文字列検索。
+  HITS=$(grep -rn --include='*.ts' -F "$id" "$ROOT/src" 2>/dev/null \
+    | grep -v '\.test\.ts' \
+    | grep -v 'src/config/groqModels.ts' || true)
+  if [[ -n "$HITS" ]]; then
+    echo "----- DEPRECATED MODEL IN USE: $id -----"
+    echo "$HITS"
+    FOUND=1
+  fi
+done
+
+if [[ "$FOUND" -eq 1 ]]; then
+  echo ""
+  echo "[check-groq-models] FAIL — decommissioned Groq model(s) referenced in src/."
+  echo "  Migrate to an ACTIVE_GROQ_MODELS constant in src/config/groqModels.ts."
+  exit 1
+fi
+
+echo "[check-groq-models] PASS — no deprecated Groq model IDs in src/."
+exit 0

--- a/SCRIPTS/security-scan.sh
+++ b/SCRIPTS/security-scan.sh
@@ -133,6 +133,20 @@ if [[ -n "$ENV_BAK" ]]; then
 fi
 echo ''
 
+echo '--- [7] Groq EOL model check ---'
+if [[ -f "$(dirname "$0")/check-groq-models.sh" ]]; then
+  if bash "$(dirname "$0")/check-groq-models.sh" >/tmp/groq_eol_check.txt 2>&1; then
+    echo '[PASS] No decommissioned Groq model IDs in src/'
+  else
+    echo '[CRITICAL] Decommissioned Groq model ID(s) referenced in src/:'
+    grep -E 'DEPRECATED MODEL IN USE|src/' /tmp/groq_eol_check.txt || cat /tmp/groq_eol_check.txt
+    FAIL_COUNT=$((FAIL_COUNT + 1))
+  fi
+else
+  echo '[WARN] check-groq-models.sh not found, skipping'
+fi
+echo ''
+
 # -------------------------------------------------------------------
 # Summary
 # -------------------------------------------------------------------

--- a/src/agent/flow/llmMultiStepPlannerRuntime.ts
+++ b/src/agent/flow/llmMultiStepPlannerRuntime.ts
@@ -1,5 +1,6 @@
 // src/agent/flow/llmMultiStepPlannerRuntime.ts
 
+import { GPT_OSS_120B, GPT_OSS_20B } from '../../config/groqModels';
 import { routePlannerModel, type RouteContext } from '../../llm/modelRouter'
 import type { DialogMessage, MultiStepQueryPlan } from '../dialog/types'
 import type { MultiStepPlannerOptions } from './multiStepPlanner'
@@ -156,9 +157,9 @@ async function fetchLlmPlan(
   const endpoint = `${baseUrl.replace(/\/$/, '')}/chat/completions`
 
   const model20b =
-    process.env.LLM_MODEL_20B ?? 'openai/gpt-oss-20b'
+    process.env.LLM_MODEL_20B ?? GPT_OSS_20B
   const model120b =
-    process.env.LLM_MODEL_120B ?? 'openai/gpt-oss-120b'
+    process.env.LLM_MODEL_120B ?? GPT_OSS_120B
 
   const routeCtx = buildRouteContext(options)
   const routed = routePlannerModel(routeCtx)

--- a/src/agent/judge/conversationJudge.ts
+++ b/src/agent/judge/conversationJudge.ts
@@ -1,12 +1,13 @@
 // src/agent/judge/conversationJudge.ts
 // Phase45: Judge評価エンジン - Groq 70b (llama-3.3-70b-versatile) で会話を評価
 
+import { GROQ_VERSATILE_70B } from '../../config/groqModels';
 import pino from 'pino';
 import { callGroqWith429Retry } from '../llm/groqClient';
 
 const logger = pino();
 
-const JUDGE_MODEL = 'llama-3.3-70b-versatile';
+const JUDGE_MODEL = GROQ_VERSATILE_70B;
 
 export interface JudgeInput {
   tenantId: string;

--- a/src/agent/judge/evaluationAnalyzer.ts
+++ b/src/agent/judge/evaluationAnalyzer.ts
@@ -1,6 +1,7 @@
 // src/agent/judge/evaluationAnalyzer.ts
 // Phase45: 評価結果を分析してチューニングルールを提案する
 
+import { GROQ_INSTANT_8B } from '../../config/groqModels';
 import { Pool } from 'pg';
 import pino from 'pino';
 import { callGroqWith429Retry } from '../llm/groqClient';
@@ -8,7 +9,7 @@ import { createEvaluationRepository } from './evaluationRepository';
 
 const logger = pino();
 
-const ANALYZER_MODEL = 'llama-3.1-8b-instant';
+const ANALYZER_MODEL = GROQ_INSTANT_8B;
 
 export interface SuggestedRule {
   triggerPattern: string;

--- a/src/agent/judge/evaluationRepository.ts
+++ b/src/agent/judge/evaluationRepository.ts
@@ -1,6 +1,7 @@
 // src/agent/judge/evaluationRepository.ts
 // Phase45: Judge評価結果のDBリポジトリ
 
+import { GROQ_VERSATILE_70B } from '../../config/groqModels';
 import { Pool } from 'pg';
 import { getPool as _getDefaultPool } from '../../lib/db';
 
@@ -86,7 +87,7 @@ export function createEvaluationRepository(pool?: InstanceType<typeof Pool>) {
           JSON.stringify(evaluation.failedPrinciples),
           JSON.stringify(evaluation.evaluationAxes),
           evaluation.notes ?? null,
-          evaluation.modelUsed ?? 'llama-3.3-70b-versatile',
+          evaluation.modelUsed ?? GROQ_VERSATILE_70B,
         ],
       );
       return rowToEvaluation(result.rows[0]!);

--- a/src/agent/objection/objectionDetector.ts
+++ b/src/agent/objection/objectionDetector.ts
@@ -1,6 +1,7 @@
 // src/agent/objection/objectionDetector.ts
 // Phase46: 会話履歴から反論→対応→肯定パターンを自動検出し、objection_patternsに蓄積
 
+import { GROQ_INSTANT_8B } from '../../config/groqModels';
 import { Pool } from 'pg';
 import pino from 'pino';
 import { callGroqWith429Retry } from '../llm/groqClient';
@@ -93,7 +94,7 @@ export async function saveObjectionPatterns(
     try {
       const normalized = await callGroqWith429Retry(
         {
-          model: 'llama-3.1-8b-instant',
+          model: GROQ_INSTANT_8B,
           messages: [
             {
               role: 'system',

--- a/src/agent/orchestrator/llmCalls.ts
+++ b/src/agent/orchestrator/llmCalls.ts
@@ -1,6 +1,7 @@
 // src/agent/orchestrator/llmCalls.ts
 // プランナー・回答 LLM 呼び出し + プロンプトビルダー
 
+import { GROQ_COMPOUND, GROQ_COMPOUND_MINI } from '../../config/groqModels';
 import pino from 'pino';
 import { callGroqWith429Retry } from '../llm/groqClient';
 import type { PlannerPlan } from '../dialog/types';
@@ -155,8 +156,8 @@ export async function callPlannerLLM(
 ): Promise<PlannerPlan> {
   const model =
     route === '120b'
-      ? process.env.GROQ_PLANNER_120B_MODEL ?? 'groq/compound'
-      : process.env.GROQ_PLANNER_20B_MODEL ?? 'groq/compound-mini';
+      ? process.env.GROQ_PLANNER_120B_MODEL ?? GROQ_COMPOUND
+      : process.env.GROQ_PLANNER_20B_MODEL ?? GROQ_COMPOUND_MINI;
 
   const prompt = buildPlannerPrompt(payload);
 
@@ -274,8 +275,8 @@ export async function callAnswerLLM(
 ): Promise<string> {
   const model =
     route === '120b'
-      ? process.env.GROQ_ANSWER_120B_MODEL ?? 'groq/compound'
-      : process.env.GROQ_ANSWER_20B_MODEL ?? 'groq/compound-mini';
+      ? process.env.GROQ_ANSWER_120B_MODEL ?? GROQ_COMPOUND
+      : process.env.GROQ_ANSWER_20B_MODEL ?? GROQ_COMPOUND_MINI;
 
   const prompt = buildAnswerPrompt(payload);
   const maxTokens = payload.safeMode ? 320 : 256;

--- a/src/agent/orchestrator/ragRetrieval.ts
+++ b/src/agent/orchestrator/ragRetrieval.ts
@@ -1,6 +1,7 @@
 // src/agent/orchestrator/ragRetrieval.ts
 // RAG 検索 + 履歴要約
 
+import { GROQ_COMPOUND_MINI } from '../../config/groqModels';
 import pino from 'pino';
 import { callGroqWith429Retry } from '../llm/groqClient';
 import { runSearchAgent } from '../flow/searchAgent';
@@ -134,7 +135,7 @@ async function summarizeHistoryWithLLM(payload: {
 
   if (!older.length) return existingSummary ?? '';
 
-  const model = process.env.GROQ_PLANNER_20B_MODEL ?? 'groq/compound-mini';
+  const model = process.env.GROQ_PLANNER_20B_MODEL ?? GROQ_COMPOUND_MINI;
 
   const turnsText = older
     .map((m, idx) => `${idx + 1}. ${m.role}: ${m.content}`)

--- a/src/agent/psychology/principleDetector.ts
+++ b/src/agent/psychology/principleDetector.ts
@@ -2,6 +2,7 @@
 // Phase44: 心理学原則検出器
 // キーワードマッチング + Groq 8b LLMフォールバック
 
+import { GROQ_INSTANT_8B } from '../../config/groqModels';
 import { groqClient } from '../llm/groqClient';
 
 const KEYWORD_MAP: Record<string, string[]> = {
@@ -81,7 +82,7 @@ async function detectWithLlm(
 
   try {
     const response = await groqClient.call({
-      model: "llama-3.1-8b-instant",
+      model: GROQ_INSTANT_8B,
       messages: [
         {
           role: "system",

--- a/src/agent/report/weeklyReportGenerator.ts
+++ b/src/agent/report/weeklyReportGenerator.ts
@@ -1,13 +1,14 @@
 // src/agent/report/weeklyReportGenerator.ts
 // Phase46: 週次レポート自動生成（毎週月曜AM9:00）
 
+import { GROQ_VERSATILE_70B } from '../../config/groqModels';
 import { Pool } from 'pg';
 import pino from 'pino';
 import { callGroqWith429Retry } from '../llm/groqClient';
 
 const logger = pino();
 
-const REPORT_MODEL = 'llama-3.3-70b-versatile';
+const REPORT_MODEL = GROQ_VERSATILE_70B;
 
 export interface WeeklyMetrics {
   avgScore: number;

--- a/src/agent/tools/synthesisTool.ts
+++ b/src/agent/tools/synthesisTool.ts
@@ -1,5 +1,6 @@
 // src/agent/tools/synthesisTool.ts
 
+import { GROQ_VERSATILE_70B } from '../../config/groqModels';
 import type { RerankItem } from '../types';
 import { groqClient, type GroqUsage } from '../llm/groqClient';
 import {
@@ -286,7 +287,7 @@ export async function synthesizeAnswer(input: SynthesisInput): Promise<Synthesis
       : `お客様の質問: ${query}\n上記の応答ルールに従って、お客様の質問に自然な日本語で回答してください。`;
 
     const synthResult = await groqClient.callWithUsage({
-      model: 'llama-3.3-70b-versatile',
+      model: GROQ_VERSATILE_70B,
       messages: [
         { role: 'system', content: systemPrompt },
         { role: 'user', content: userPrompt },

--- a/src/api/admin/ai-assist/routes.ts
+++ b/src/api/admin/ai-assist/routes.ts
@@ -3,6 +3,7 @@
 // Phase43 P2: インテント振り分け + RAG統合
 // POST /v1/admin/ai-assist/chat
 
+import { GROQ_INSTANT_8B, GROQ_VERSATILE_70B } from '../../../config/groqModels';
 import type { Express, Request, Response } from "express";
 import { z } from "zod";
 import { supabaseAuthMiddleware } from "../../../admin/http/supabaseAuthMiddleware";
@@ -57,7 +58,7 @@ async function detectIntent(message: string): Promise<Intent> {
         Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify({
-        model: "llama-3.1-8b-instant",
+        model: GROQ_INSTANT_8B,
         messages: [
           {
             role: "user",
@@ -93,7 +94,7 @@ async function callGroq8b(userMessage: string): Promise<string> {
       Authorization: `Bearer ${apiKey}`,
     },
     body: JSON.stringify({
-      model: "llama-3.1-8b-instant",
+      model: GROQ_INSTANT_8B,
       messages: [
         { role: "system", content: ADMIN_AI_SYSTEM_PROMPT },
         { role: "user", content: userMessage },
@@ -141,7 +142,7 @@ ${ragContext}`
       Authorization: `Bearer ${apiKey}`,
     },
     body: JSON.stringify({
-      model: "llama-3.3-70b-versatile",
+      model: GROQ_VERSATILE_70B,
       messages: [
         { role: "system", content: systemPrompt },
         { role: "user", content: userMessage },

--- a/src/api/admin/avatar/generationRoutes.ts
+++ b/src/api/admin/avatar/generationRoutes.ts
@@ -2,6 +2,7 @@
 
 // Phase41: Avatar Customization Studio — 画像生成・声マッチング・プロンプト生成API
 
+import { GROQ_VERSATILE_70B } from '../../../config/groqModels';
 import type { Express, NextFunction, Request, Response } from "express";
 
 type AvatarReq = Request & { supabaseUser?: Record<string, unknown>; requestId?: string };
@@ -27,7 +28,7 @@ async function callGroqLLM(system: string, user: string): Promise<string> {
       Authorization: `Bearer ${apiKey}`,
     },
     body: JSON.stringify({
-      model: "llama-3.3-70b-versatile",
+      model: GROQ_VERSATILE_70B,
       messages: [
         { role: "system", content: system },
         { role: "user", content: user },
@@ -355,7 +356,7 @@ JSONのみ返してください。`,
           tenantId,
           requestId,
           featureUsed: "avatar_config_voice",
-          model: "llama-3.3-70b-versatile",
+          model: GROQ_VERSATILE_70B,
           inputTokens: 0,
           outputTokens: 0,
         });
@@ -420,7 +421,7 @@ JSONのみ返してください。`,
           tenantId,
           requestId,
           featureUsed: "avatar_config_prompt",
-          model: "llama-3.3-70b-versatile",
+          model: GROQ_VERSATILE_70B,
           inputTokens: 0,
           outputTokens: 0,
         });

--- a/src/api/admin/feedback/feedbackAI.ts
+++ b/src/api/admin/feedback/feedbackAI.ts
@@ -1,6 +1,7 @@
 // src/api/admin/feedback/feedbackAI.ts
 // Phase62: FAQチャット代行提案 + 試算フロー統合
 
+import { GROQ_INSTANT_8B } from '../../../config/groqModels';
 import { sanitizeOutput } from "../../../lib/security/inputSanitizer";
 import { trackUsage } from "../../../lib/billing/usageTracker";
 import { logger } from '../../../lib/logger';
@@ -9,7 +10,7 @@ import { estimateOptionPrice } from './optionEstimator';
 import { getPool } from '../../../lib/db';
 import { createNotification } from '../../../lib/notifications';
 
-const FEEDBACK_AI_MODEL = process.env.FEEDBACK_AI_MODEL ?? "llama-3.1-8b-instant";
+const FEEDBACK_AI_MODEL = process.env.FEEDBACK_AI_MODEL ?? GROQ_INSTANT_8B;
 
 // ---------------------------------------------------------------------------
 // システムプロンプト（Phase62: 代行案内ルール追加）

--- a/src/api/admin/feedback/optionEstimator.ts
+++ b/src/api/admin/feedback/optionEstimator.ts
@@ -1,6 +1,7 @@
 // src/api/admin/feedback/optionEstimator.ts
 // Phase62: オプションサービス料金試算（Groq 70B呼び出し）
 
+import { GROQ_VERSATILE_70B } from '../../../config/groqModels';
 import { logger } from '../../../lib/logger';
 
 const GROQ_API_BASE = 'https://api.groq.com/openai/v1/chat/completions';
@@ -49,7 +50,7 @@ export async function estimateOptionPrice(
         Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify({
-        model: process.env.GROQ_MODEL_70B ?? 'llama-3.3-70b-versatile',
+        model: process.env.GROQ_MODEL_70B ?? GROQ_VERSATILE_70B,
         messages: [
           { role: 'system', content: ESTIMATE_SYSTEM_PROMPT },
           { role: 'user', content: userPrompt },

--- a/src/api/admin/knowledge/routes.ts
+++ b/src/api/admin/knowledge/routes.ts
@@ -1,6 +1,7 @@
 // src/api/admin/knowledge/routes.ts
 
 // Phase29: カーネーション向けナレッジ管理API
+import { GROQ_VERSATILE_70B } from '../../../config/groqModels';
 import type { Express, NextFunction, Request, Response } from "express";
 import type { Pool } from "pg";
 import { z } from "zod";
@@ -88,7 +89,7 @@ async function textToFaqs(
   categoryOverride?: string | null,
   existingQuestions?: string[]
 ): Promise<FaqEntry[]> {
-  const model = process.env.GROQ_FAQ_GEN_MODEL ?? "llama-3.3-70b-versatile";
+  const model = process.env.GROQ_FAQ_GEN_MODEL ?? GROQ_VERSATILE_70B;
 
   const existingSection =
     existingQuestions && existingQuestions.length > 0

--- a/src/api/admin/tuning/routes.ts
+++ b/src/api/admin/tuning/routes.ts
@@ -2,6 +2,7 @@
 
 // Phase38 Step4-BE: チューニングルール CRUD API
 
+import { GROQ_INSTANT_8B } from '../../../config/groqModels';
 import type { Express, Request, Response } from "express";
 import type { AuthedReq } from "../../middleware/roleAuth";
 import { z } from "zod";
@@ -97,7 +98,7 @@ ${knowledgePart}${rulesPart}${crossTenantPart}${researchPart}
         Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify({
-        model: process.env.GROQ_MODEL_8B ?? "llama-3.1-8b-instant",
+        model: process.env.GROQ_MODEL_8B ?? GROQ_INSTANT_8B,
         messages: [{ role: "user", content: prompt }],
         temperature: 0.4,
         max_tokens: 400,

--- a/src/api/admin/tuning/testResponseRoutes.ts
+++ b/src/api/admin/tuning/testResponseRoutes.ts
@@ -1,13 +1,14 @@
 // src/api/admin/tuning/testResponseRoutes.ts
 // Phase6-B: チューニングルール LLMテスト返答生成API
 
+import { GROQ_VERSATILE_70B } from '../../../config/groqModels';
 import type { Express, Request, Response } from "express";
 import type { AuthedReq } from "../../middleware/roleAuth";
 import { supabaseAuthMiddleware } from "../../../admin/http/supabaseAuthMiddleware";
 import { getPool } from "../../../lib/db";
 import { logger } from "../../../lib/logger";
 
-const GROQ_MODEL_70B = "llama-3.3-70b-versatile";
+const GROQ_MODEL_70B = GROQ_VERSATILE_70B;
 
 // ---------------------------------------------------------------------------
 // ALLOWED_ROLES whitelist

--- a/src/api/avatar/anamChatStreamRoutes.ts
+++ b/src/api/avatar/anamChatStreamRoutes.ts
@@ -6,6 +6,7 @@
 //   widget.jsからの会話履歴を受け取り、Groq LLMでストリーミング応答を返す。
 //   Anam JS SDKのcreateTalkMessageStream()でTTS化される。
 
+import { GROQ_VERSATILE_70B } from '../../config/groqModels';
 import type { Express, Request, Response, RequestHandler } from 'express';
 import type { AuthedRequest } from '../../agent/http/authMiddleware';
 import { logger } from '../../lib/logger';
@@ -81,7 +82,7 @@ export function registerAnamChatStreamRoutes(app: Express, apiStack: RequestHand
           'Authorization': `Bearer ${groqApiKey}`,
         },
         body: JSON.stringify({
-          model: 'llama-3.3-70b-versatile',
+          model: GROQ_VERSATILE_70B,
           messages: groqMessages,
           stream: true,
           max_tokens: 150,

--- a/src/api/chat/route.ts
+++ b/src/api/chat/route.ts
@@ -1,3 +1,4 @@
+import { GROQ_VERSATILE_70B } from '../../config/groqModels';
 import type { Request, Response } from "express";
 import type { Logger } from "pino";
 import { z } from "zod";
@@ -17,7 +18,7 @@ import { checkTopic } from "../../middleware/topicGuard";
 import { guardOutput } from "../../middleware/outputGuard";
 
 // チャットリクエストで使用するデフォルトLLMモデル名（コスト計算用）
-const CHAT_LLM_MODEL = process.env.LLM_CHAT_MODEL ?? "llama-3.3-70b-versatile";
+const CHAT_LLM_MODEL = process.env.LLM_CHAT_MODEL ?? GROQ_VERSATILE_70B;
 
 // ---------------------------------------------------------------------------
 // ナレッジギャップ検出

--- a/src/api/internal/usageRoutes.ts
+++ b/src/api/internal/usageRoutes.ts
@@ -6,6 +6,7 @@
 //
 // Body: { tenantId, requestId?, ttsTextBytes?, avatarCredits?, avatarSessionMs? }
 
+import { GROQ_VERSATILE_70B } from '../../config/groqModels';
 import type { Express, Request, Response } from 'express';
 import { INTERNAL_REQUEST_HEADER } from '../../lib/metrics/kpiDefinitions';
 import { trackUsage } from '../../lib/billing/usageTracker';
@@ -33,7 +34,7 @@ export function registerInternalUsageRoutes(app: Express): void {
     trackUsage({
       tenantId,
       requestId: rid,
-      model: 'llama-3.3-70b-versatile',  // avatarセッションのLLM
+      model: GROQ_VERSATILE_70B,  // avatarセッションのLLM
       inputTokens: 0,
       outputTokens: 0,
       featureUsed: 'avatar',

--- a/src/config/groqModels.test.ts
+++ b/src/config/groqModels.test.ts
@@ -1,0 +1,59 @@
+// src/config/groqModels.test.ts
+// Groq モデルカタログ + EOL 検知ヘルパーのユニットテスト
+
+import {
+  ACTIVE_GROQ_MODELS,
+  ACTIVE_GROQ_MODEL_IDS,
+  KNOWN_DEPRECATED_GROQ_MODELS,
+  GROQ_INSTANT_8B,
+  GROQ_VERSATILE_70B,
+  isDeprecatedGroqModel,
+  assertActiveGroqModel,
+} from './groqModels';
+
+describe('groqModels catalog', () => {
+  it('アクティブ定数は実モデル ID と一致する（集約後も値が変わらない回帰ガード）', () => {
+    expect(GROQ_INSTANT_8B).toBe('llama-3.1-8b-instant');
+    expect(GROQ_VERSATILE_70B).toBe('llama-3.3-70b-versatile');
+  });
+
+  it('アクティブモデルは1件も EOL リストに含まれない', () => {
+    for (const id of ACTIVE_GROQ_MODEL_IDS) {
+      expect(isDeprecatedGroqModel(id)).toBe(false);
+    }
+  });
+
+  it('ACTIVE_GROQ_MODELS の status は全て active', () => {
+    expect(ACTIVE_GROQ_MODELS.every((m) => m.status === 'active')).toBe(true);
+  });
+
+  it('ID に重複がない', () => {
+    expect(new Set(ACTIVE_GROQ_MODEL_IDS).size).toBe(ACTIVE_GROQ_MODEL_IDS.length);
+  });
+});
+
+describe('isDeprecatedGroqModel', () => {
+  it('decommissioned モデルを true で検出する', () => {
+    expect(isDeprecatedGroqModel('llama-3.1-70b-versatile')).toBe(true);
+    expect(isDeprecatedGroqModel('mixtral-8x7b-32768')).toBe(true);
+  });
+
+  it('アクティブ / 未知のモデルは false', () => {
+    expect(isDeprecatedGroqModel(GROQ_VERSATILE_70B)).toBe(false);
+    expect(isDeprecatedGroqModel('some-future-model')).toBe(false);
+  });
+
+  it('EOL リストは空でない（検知層が機能する前提）', () => {
+    expect(KNOWN_DEPRECATED_GROQ_MODELS.length).toBeGreaterThan(0);
+  });
+});
+
+describe('assertActiveGroqModel', () => {
+  it('アクティブモデルは通過する', () => {
+    expect(() => assertActiveGroqModel(GROQ_INSTANT_8B)).not.toThrow();
+  });
+
+  it('EOL モデルは例外を投げる', () => {
+    expect(() => assertActiveGroqModel('llama-3.1-70b-versatile')).toThrow(/decommissioned/);
+  });
+});

--- a/src/config/groqModels.ts
+++ b/src/config/groqModels.ts
@@ -1,0 +1,83 @@
+// src/config/groqModels.ts
+// Groq / gpt-oss モデル ID の単一の正典（散在ハードコードの集約先）。
+//
+// 目的:
+//   1. 集約 — モデル ID をコード全体に散らさず、ここだけを更新すれば差し替えられる。
+//   2. EOL 検知 — Groq が decommission したモデルを KNOWN_DEPRECATED に列挙し、
+//      `SCRIPTS/check-groq-models.sh` が src/ にその文字列が混入したら CI を落とす。
+//
+// 追加・変更時のルール:
+//   - 新モデル採用: ACTIVE に定数を足し、call site をその定数経由に。
+//   - モデル廃止: Groq の deprecation 告知が出たら KNOWN_DEPRECATED に id を追記。
+//     検知層が src/ 内の残存使用を洗い出すので、移行漏れを防げる。
+
+/** 現在アクティブな Groq チャットモデル（実機で呼び出している実 ID）。値は実 ID と完全一致させること。 */
+export const GROQ_INSTANT_8B = 'llama-3.1-8b-instant';
+export const GROQ_VERSATILE_70B = 'llama-3.3-70b-versatile';
+export const GROQ_COMPOUND = 'groq/compound';
+export const GROQ_COMPOUND_MINI = 'groq/compound-mini';
+
+/** gpt-oss（Groq 経由）— アーキテクチャ上の 20B / 120B。 */
+export const GPT_OSS_20B = 'openai/gpt-oss-20b';
+export const GPT_OSS_120B = 'openai/gpt-oss-120b';
+
+export type GroqModelStatus = 'active' | 'deprecated';
+
+export interface GroqModelEntry {
+  id: string;
+  /** 用途の目安。集約後の選定で参照する。 */
+  tier: 'instant' | 'versatile' | 'compound' | 'compound-mini' | 'oss-20b' | 'oss-120b';
+  status: GroqModelStatus;
+}
+
+/** アクティブモデルのレジストリ（COST マップ・テスト・検知層が参照する単一の真実）。 */
+export const ACTIVE_GROQ_MODELS: readonly GroqModelEntry[] = [
+  { id: GROQ_INSTANT_8B, tier: 'instant', status: 'active' },
+  { id: GROQ_VERSATILE_70B, tier: 'versatile', status: 'active' },
+  { id: GROQ_COMPOUND, tier: 'compound', status: 'active' },
+  { id: GROQ_COMPOUND_MINI, tier: 'compound-mini', status: 'active' },
+  { id: GPT_OSS_20B, tier: 'oss-20b', status: 'active' },
+  { id: GPT_OSS_120B, tier: 'oss-120b', status: 'active' },
+] as const;
+
+export const ACTIVE_GROQ_MODEL_IDS: readonly string[] = ACTIVE_GROQ_MODELS.map((m) => m.id);
+
+/**
+ * Groq が decommission 済み / 廃止予定として告知したモデル ID。
+ * ここに載った ID が src/ (非 test) に残っていれば EOL 検知層が CI を落とす。
+ * 出典: Groq deprecations (https://console.groq.com/docs/deprecations)。
+ */
+export const KNOWN_DEPRECATED_GROQ_MODELS: readonly string[] = [
+  'llama-3.1-70b-versatile', // → llama-3.3-70b-versatile に移行済み
+  'llama3-70b-8192',
+  'llama3-8b-8192',
+  'mixtral-8x7b-32768',
+  'gemma-7b-it',
+  'gemma2-9b-it',
+  'llama-3.2-1b-preview',
+  'llama-3.2-3b-preview',
+  'llama-3.2-11b-vision-preview',
+  'llama-3.2-90b-vision-preview',
+  'llama-3.2-11b-text-preview',
+  'llama-3.2-90b-text-preview',
+] as const;
+
+const DEPRECATED_SET = new Set(KNOWN_DEPRECATED_GROQ_MODELS);
+
+/** 与えられたモデル ID が Groq の既知 EOL リストに含まれるか。 */
+export function isDeprecatedGroqModel(model: string): boolean {
+  return DEPRECATED_SET.has(model);
+}
+
+/**
+ * モデル ID がアクティブであることを保証する。EOL モデルなら例外を投げる。
+ * 起動時 / 設定読込時の fail-fast 用。
+ */
+export function assertActiveGroqModel(model: string): void {
+  if (isDeprecatedGroqModel(model)) {
+    throw new Error(
+      `[groqModels] decommissioned Groq model "${model}" is in use. ` +
+        `Migrate to an ACTIVE_GROQ_MODELS entry (see src/config/groqModels.ts).`,
+    );
+  }
+}

--- a/src/lib/book-pipeline/structurizer.ts
+++ b/src/lib/book-pipeline/structurizer.ts
@@ -3,6 +3,7 @@
 // Phase44: Groq 8b を使った 6 フィールド構造化モジュール
 // CLAUDE.md: 書籍内容をログに出力しない
 
+import { GROQ_INSTANT_8B } from '../../config/groqModels';
 import { groqClient } from "../../agent/llm/groqClient";
 import type { TextChunk } from "./chunkSplitter";
 import type { SchemaField } from "./contentAnalyzer";
@@ -26,7 +27,7 @@ export interface StructurizerDeps {
   schema?: SchemaField[];
 }
 
-const MODEL = "llama-3.1-8b-instant";
+const MODEL = GROQ_INSTANT_8B;
 const DELAY_MS = 200; // Groq レート制限対策
 
 const BASE_SYSTEM_PROMPT = `あなたは書籍コンテンツのFAQ化アシスタントです。

--- a/src/lib/posthog/llmAnalyticsTracker.ts
+++ b/src/lib/posthog/llmAnalyticsTracker.ts
@@ -1,5 +1,11 @@
 import { getPostHogClient } from "./posthogClient";
 import { logger } from "../logger";
+import {
+  GROQ_COMPOUND,
+  GROQ_COMPOUND_MINI,
+  GROQ_VERSATILE_70B,
+  GROQ_INSTANT_8B,
+} from "../../config/groqModels";
 
 export interface LlmAnalyticsEvent {
   tenantId: string;
@@ -12,10 +18,10 @@ export interface LlmAnalyticsEvent {
 }
 
 const COST_PER_1K: Record<string, { input: number; output: number }> = {
-  "groq/compound": { input: 0.0009, output: 0.0009 },
-  "groq/compound-mini": { input: 0.0006, output: 0.0006 },
-  "llama-3.3-70b-versatile": { input: 0.00059, output: 0.00079 },
-  "llama-3.1-8b-instant": { input: 0.00005, output: 0.00008 },
+  [GROQ_COMPOUND]: { input: 0.0009, output: 0.0009 },
+  [GROQ_COMPOUND_MINI]: { input: 0.0006, output: 0.0006 },
+  [GROQ_VERSATILE_70B]: { input: 0.00059, output: 0.00079 },
+  [GROQ_INSTANT_8B]: { input: 0.00005, output: 0.00008 },
 };
 
 function estimateCostUsd(

--- a/src/types/contracts.ts
+++ b/src/types/contracts.ts
@@ -2,6 +2,8 @@
 // types/contracts.ts の内容を src/ 以下に取り込んだもの。
 // tsconfig の rootDir: src に合わせるため、ここで再定義する。
 
+import type { GROQ_INSTANT_8B, GROQ_VERSATILE_70B } from '../config/groqModels';
+
 export interface TenantConfig {
   tenantId: string;
   name: string;
@@ -34,9 +36,8 @@ export interface ChatAction {
   url: string;
 }
 
-export type GroqModel =
-  | "llama-3.1-8b-instant"
-  | "llama-3.3-70b-versatile";
+// Groq モデル ID は src/config/groqModels.ts が単一の正典。型もそこから導出する。
+export type GroqModel = typeof GROQ_INSTANT_8B | typeof GROQ_VERSATILE_70B;
 
 export interface RagContextItem {
   score: number;


### PR DESCRIPTION
## 背景（Asana GID 1215113982686665）
Groq/gpt-oss モデル ID が **~20ファイルにハードコード散在**（`llama-3.3-70b-versatile` 19箇所 / `llama-3.1-8b-instant` 12箇所 等）。モデル差し替え時に全箇所手修正が必要で、Groq が decommission したモデルの混入を検知できなかった。

## 集約（src/config/groqModels.ts = 単一の正典）
- 実モデル6種を定数化（値は実 ID と**完全一致 → 挙動不変**）
- `ACTIVE_GROQ_MODELS` レジストリ + `KNOWN_DEPRECATED_GROQ_MODELS`（Groq deprecations 出典）+ `isDeprecatedGroqModel` / `assertActiveGroqModel`
- **21ファイルの call site を定数 import へ移行**（`?? 'literal'` の env fallback はデフォルトのみ置換、上書き挙動維持）
- 型 union `GroqModel`（contracts.ts）と `COST_PER_1K`（llmAnalyticsTracker）もカタログ由来に

## EOL 検知層（タスクの主目的「deprecations照合 検知層」）
- `SCRIPTS/check-groq-models.sh`: `KNOWN_DEPRECATED` を src/(非test) から走査、混入で **exit 1**（file:line 表示）。自己テストで FAIL 検出を確認
- `security-scan.sh` に **`[7] Groq EOL model check`** として組込み → CI/Gate2 で実走

## スコープ判断（精査結果）
- `gemma`/`mixtral` は costCalculator の **substring matcher** で実 ID でない → 非対象
- `llama-3.1-70b-versatile`（Groq EOL）は **costCalculator.test.ts のみ**で production 未使用 → 実害なし（ただし KNOWN_DEPRECATED に登録し将来の混入を検知）

## Gate（Node 20 = CI 一致）
- Gate 1: typecheck/build クリーン・**全テスト 1730/1730 pass**（+9 新規、既存全通過＝挙動不変）
- Gate 2: security-scan PASS（新 `[7]` 含む）
- Gate 2.5: Codex P0/P1 **none**（定数値=旧リテラル一致・import 健全性・COST キー保全・検知ロジックを検証）

🤖 Generated with [Claude Code](https://claude.com/claude-code)