### PR TITLE
fix(tooling): dead-code-check を全リポジトリ横断で分類し false positive を排除

### DIFF
--- a/SCRIPTS/dead-code-check.sh
+++ b/SCRIPTS/dead-code-check.sh
@@ -20,56 +20,94 @@ grep -rn "^export function\|^export const\|^export class\|^export async function
   src/ --include="*.ts" | grep -v "\.test\.ts:" > /tmp/_dead_exports.txt 2>/dev/null || true
 
 DEAD_RESULT=$(python3 - << 'PYEOF'
-import subprocess, re, sys
+import subprocess, re, os
 
 with open('/tmp/_dead_exports.txt') as f:
     lines = f.read().strip().split('\n')
 
-dead = []
+# 参照探索のルート（リポジトリ全域）。
+# 注意: テストは src/**/*.test.ts と トップレベル tests/ の両方に存在する。
+# tests/ を含めないと test seam を誤って truly-dead 判定してしまう（実害: 削除でテスト破壊）。
+roots = ['src/', 'SCRIPTS/', 'tests/']
+if os.path.isdir('admin-ui/src'):
+    roots.append('admin-ui/src/')
+
+def ref_files(name):
+    r = subprocess.run(
+        ['grep', '-rIl', '--include=*.ts', '--include=*.tsx', '-w', '--', name] + roots,
+        capture_output=True, text=True,
+    )
+    return [l for l in r.stdout.strip().split('\n') if l]
+
+def in_file_uses(decl, name):
+    r = subprocess.run(['grep', '-nw', '--', name, decl], capture_output=True, text=True)
+    cnt = 0
+    for l in r.stdout.strip().split('\n'):
+        if not l:
+            continue
+        content = l.split(':', 1)[1] if ':' in l else l
+        if re.search(r'\bexport\b', content):  # 宣言行は除外
+            continue
+        cnt += 1
+    return cnt
+
+cats = {'TRULY_DEAD': [], 'OVER_EXPORT': [], 'TEST_SEAM': [], 'SCRIPTS': [], 'ADMIN_UI': []}
 for line in lines:
     if not line.strip():
         continue
-    # filepath:linenum:content
     colon1 = line.index(':')
     colon2 = line.index(':', colon1 + 1)
     filepath = line[:colon1]
-    content  = line[colon2+1:]
-    # extract exported symbol name
-    m = re.search(
-        r'export\s+(?:async\s+)?(?:function|const|class)\s+([A-Za-z_][A-Za-z0-9_]*)',
-        content
-    )
+    content = line[colon2 + 1:]
+    m = re.search(r'export\s+(?:async\s+)?(?:function|const|class)\s+([A-Za-z_][A-Za-z0-9_]*)', content)
     if not m:
         continue
     name = m.group(1)
-    # count references in src/ outside the declaring file
-    result = subprocess.run(
-        ['grep', '-rn', '--include=*.ts', '--exclude=*.test.ts', '--', name, 'src/'],
-        capture_output=True, text=True
-    )
-    refs = [l for l in result.stdout.strip().split('\n')
-            if l and not l.startswith(filepath + ':')]
-    if not refs:
-        dead.append(f"  ⚠️  {filepath} → {name}")
+    others = [f for f in ref_files(name) if f != filepath]
+    src_nt = [f for f in others if f.startswith('src/') and '.test.' not in f]
+    # テスト参照: src/**/*.test.ts と トップレベル tests/ の両方を test seam とみなす。
+    src_t = [f for f in others if (f.startswith('src/') and '.test.' in f) or f.startswith('tests/')]
+    scr = [f for f in others if f.startswith('SCRIPTS/')]
+    adm = [f for f in others if f.startswith('admin-ui/')]
+    if src_nt:
+        continue  # 実際に他の本番ファイルから使われている → dead ではない
+    if scr:
+        cats['SCRIPTS'].append((filepath, name))       # SCRIPTS/ が消費 → 保持
+    elif adm:
+        cats['ADMIN_UI'].append((filepath, name))      # admin-ui が消費 → 保持
+    elif src_t:
+        cats['TEST_SEAM'].append((filepath, name))     # テストseam → 保持（export 妥当）
+    elif in_file_uses(filepath, name) > 0:
+        cats['OVER_EXPORT'].append((filepath, name))   # 同ファイル内使用のみ → export を外せる
+    else:
+        cats['TRULY_DEAD'].append((filepath, name))    # 全域で未参照 → 削除候補
 
-for d in dead:
-    print(d)
-print(f"__DEAD_COUNT__:{len(dead)}")
+# TRULY_DEAD のみを「警告対象」とし、他は参考情報として静かに分類する。
+for fp, nm in cats['TRULY_DEAD']:
+    print(f"  ⚠️  {fp} → {nm}")
+print(f"__DEAD_COUNT__:{len(cats['TRULY_DEAD'])}")
+print(f"__INFO__:OVER_EXPORT={len(cats['OVER_EXPORT'])} (export を外せる) | "
+      f"TEST_SEAM={len(cats['TEST_SEAM'])} (テスト専用・保持) | "
+      f"SCRIPTS={len(cats['SCRIPTS'])} (SCRIPTS/消費・保持) | "
+      f"ADMIN_UI={len(cats['ADMIN_UI'])} (admin-ui消費・保持)")
 PYEOF
 )
 
 rm -f /tmp/_dead_exports.txt
 
 DEAD_COUNT=$(echo "$DEAD_RESULT" | grep "__DEAD_COUNT__:" | sed 's/__DEAD_COUNT__://')
-echo "$DEAD_RESULT" | grep -v "__DEAD_COUNT__:" || true
+DEAD_INFO=$(echo "$DEAD_RESULT" | grep "__INFO__:" | sed 's/__INFO__://')
+echo "$DEAD_RESULT" | grep -vE "__DEAD_COUNT__:|__INFO__:" || true
 
 echo ""
 if [ "${DEAD_COUNT:-0}" -gt 0 ]; then
-  echo "⚠️  Found $DEAD_COUNT potentially unused export(s)"
-  echo "   NOTE: false positives possible (runtime catch clauses, external callers, etc.)"
-  echo "   Review manually before deleting."
+  echo "⚠️  Found $DEAD_COUNT truly-dead export(s) — 全リポジトリ(src/SCRIPTS/admin-ui/test/同ファイル)で未参照"
+  echo "   削除前に「未配線の機能」でないか確認すること（DB書込み等の意図的実装の可能性）。"
 else
-  echo "✅ No dead exports detected"
+  echo "✅ No truly-dead exports detected"
+fi
+if [ -n "$DEAD_INFO" ]; then
+  echo "   分類(保持OK/警告対象外): $DEAD_INFO"
 fi
 
 # ── 2. 未登録ルート ────────────────────────────────────────────────────────


### PR DESCRIPTION
## 背景（B群: dead exports 整理）
`dead-code-check.sh` が **80件の未使用 export 警告**を出していたが、調査の結果**実際の dead は 1件のみ**。残り79件は検出器の探索漏れによる false positive だった。

## 主因
検出器が参照を **`src/` の非testファイルのみ**で数えていた。実際には export は以下から消費される:
- **トップレベル `tests/`**（このプロジェクトはテストが `src/**/*.test.ts` と `tests/` の両方に存在）
- `SCRIPTS/`（例: `runWeeklyReport` ← `SCRIPTS/weekly-report.ts`）
- `admin-ui/`
- 同ファイル内（過剰exportだが dead ではない。例: `graphNodes` の各 node は同ファイルの `dialogGraph.addNode()` で使用）

`tests/` 見落としが最も危険: test seam を truly-dead と誤判定 → 削除でテスト破壊。**本対応中、実際に2件の test helper（`_resetClientForTest` / `_resetPostHogClientForTest`）を一旦削除 → `tests/phase-a` のテストが赤化 → 復元、で発見**。`recordAndDedupe`（`conversion_attributions` へ書く実装、テスト有り）も誤って TRULY_DEAD 候補に入っていた。

## 変更（`SCRIPTS/dead-code-check.sh` のみ・**本番コード無変更**）
- 参照探索ルートに `tests/` `SCRIPTS/` `admin-ui/` を追加
- export を5分類: `TRULY_DEAD`（全域未参照）/ `OVER_EXPORT`（同ファイル内のみ→export外せる）/ `TEST_SEAM` / `SCRIPTS` / `ADMIN_UI`
- 警告対象を `TRULY_DEAD` のみに限定。「削除前に未配線の機能か確認」注記を追加
- warning-only（exit 0、Gate 1.5 非ブロック）は維持

## 結果
| 区分 | 件数 | 扱い |
|---|---|---|
| **TRULY_DEAD** | **1**（`flushPostHog`、PostHog auto-flush で代替・要 shutdown 配線判断） | 警告 |
| OVER_EXPORT | 16 | export を外せる（任意） |
| TEST_SEAM | 60 | テスト専用・保持 |
| SCRIPTS | 4 | SCRIPTS/消費・保持 |
| ADMIN_UI | 1 | admin-ui消費・保持 |

→ 80 noise が **actionable 1件 + 正しく分類**に。今後の誤削除を防ぐ。

## 検証
- 全テスト **1721/1721 pass**（復元後）/ 検出器 self-test OK / exit 0 維持

🤖 Generated with [Claude Code](https://claude.com/claude-code)