### PR TITLE
docs(phase69-2): AVAS連携向け excluded_ids API仕様の整備 (GID 1214819998397674)

### DIFF
--- a/docs/PARTNER_ROLLOUT_PLAYBOOK.md
+++ b/docs/PARTNER_ROLLOUT_PLAYBOOK.md
@@ -22,7 +22,8 @@
 10. [KPI](#10-kpi)
     - [10.5 費用・プラン説明テンプレート（低優先）](#105-費用プラン説明テンプレート低優先)
 11. [トラブルシューティング FAQ](#11-トラブルシューティング-faq)
-12. [Appendix: carnation demo site での自己検証手順](#12-appendix-carnation-demo-site-での自己検証手順)
+12. [ゼロ知識検索 — AVAS / 外部連携向け](#12-ゼロ知識検索-zero-knowledge-exclusion-search--avas--外部連携向け)
+13. [Appendix: carnation demo site での自己検証手順](#13-appendix-carnation-demo-site-での自己検証手順)
 
 ---
 
@@ -734,7 +735,96 @@ Access to fetch at 'https://api.r2c.biz/api/events' from origin
 
 ---
 
-## 12. Appendix: carnation demo site での自己検証手順
+## 12. ゼロ知識検索 (Zero-Knowledge Exclusion Search) — AVAS / 外部連携向け
+
+> **対象**: AVAS 等の外部システムと R2C を API 連携させる担当者。
+> **前提**: Phase69-2-A で実装済み。詳細仕様は `docs/PHASE69_2_API_SPEC.md` を参照。
+
+### 12.1 この機能の目的
+
+R2C の検索 API に「特定ナレッジ ID を結果から除外する」機能を追加した。AVAS / Hermes 等の外部システムが R2C 検索を利用する際に、自社内で管理しているセンシティブなナレッジリストを R2C 側に渡さず、除外 ID のリストだけを指定できる。
+
+**責務分担**:
+
+| 領域 | R2C 側 | 外部システム (AVAS 等) |
+|---|---|---|
+| FAQ / ナレッジの実体保持 | ✅ | ❌ |
+| 除外 ID リストの保持 | ❌ | ✅ |
+| 除外判定・フィルタリング | ✅ | ❌ |
+| 除外対象の内容を外部システムに返却 | ❌ (ゼロ知識保証) | - |
+
+### 12.2 除外 ID の指定方法
+
+#### `/agent.search` を使う場合
+
+```bash
+curl -X POST "https://api.r2c.biz/agent.search" \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: <API_KEY>" \
+  -d '{
+    "q": "返品ポリシーを教えてください",
+    "excluded_ids": [
+      "550e8400-e29b-41d4-a716-446655440000",
+      "550e8400-e29b-41d4-a716-446655440001"
+    ]
+  }'
+```
+
+#### `/dialog/turn` を使う場合 (`excluded_ids` は `options` 配下)
+
+```bash
+curl -X POST "https://api.r2c.biz/dialog/turn" \
+  -H "Content-Type: application/json" \
+  -H "x-api-key: <API_KEY>" \
+  -d '{
+    "message": "返品ポリシーを教えてください",
+    "options": {
+      "excluded_ids": ["550e8400-e29b-41d4-a716-446655440000"]
+    }
+  }'
+```
+
+### 12.3 制約
+
+| 項目 | 制限 |
+|---|---|
+| `excluded_ids` 最大要素数 | **500 件** (超過時は 400 エラー) |
+| `excluded_ids` が null / 未指定 | 除外なし (全件検索) |
+| 存在しない ID を指定 | エラーにならない (無視される) |
+| 他テナントの ID を混入 | 無効 (テナント境界で自動隔離) |
+
+### 12.4 Admin API: 個別 FAQ の永続除外フラグ設定
+
+Admin UI 操作または API 経由で、個別 FAQ を「常に検索結果から除外」に設定できる。
+
+```bash
+# FAQ ID 42 を検索対象外に設定
+curl -X PATCH "https://api.r2c.biz/v1/admin/knowledge/faq/42/exclude?tenant=<TENANT_ID>" \
+  -H "Authorization: Bearer <JWT>" \
+  -H "Content-Type: application/json" \
+  -d '{"is_excluded_from_search": true}'
+
+# レスポンス
+# {"id": 42, "is_excluded_from_search": true}
+```
+
+この設定は `faq_docs` と `faq_embeddings` に atomic に反映され、以降すべての検索リクエストで当該 FAQ が自動除外される。
+
+### 12.5 ゼロ知識保証の確認
+
+レスポンス内に除外した FAQ の内容 (title / answer / metadata) は**一切含まれない**。除外件数のカウントフィールドも返却されない。
+
+外部システム側で除外数を追跡する場合は `excluded_ids` 配列の長さを参照すること。
+
+### 12.6 テナント分離の保証
+
+- `excluded_ids` に他テナントの ID を混入させても、自テナント外のデータにはアクセスできない
+- 検索は常に認証済みテナントの範囲内でのみ実行される
+- 詳細: `docs/PHASE69_2_API_SPEC.md §5`
+
+---
+
+## 13. Appendix: carnation demo site での自己検証手順
 
 > **目的**: 実パートナー導入前に、R2C 側の担当者が本書に従って手順をなぞり、動作確認できるようにする。
 
@@ -799,4 +889,4 @@ demo site で上記5シナリオがすべて通った段階で、本書全体の
 
 ---
 
-*最終更新: 2026-04-22 / Phase: Partner Rollout Playbook 初版*
+*最終更新: 2026-05-31 / Phase69-2-C: ゼロ知識検索節 (§12) 追加*

--- a/docs/PHASE69_2_API_SPEC.md
+++ b/docs/PHASE69_2_API_SPEC.md
@@ -1,7 +1,7 @@
 # Phase69-2 API 拡張仕様 — AVAS チーム連携用
 
 **作成日:** 2026-05-19
-**バージョン:** 1.1
+**バージョン:** 1.2
 **ステータス:** Phase69-2-A 本番稼働中 (PR #152 merge済)
 **作成者:** R2C (RAJIUCE) チーム
 **共有先:** AVAS チーム
@@ -96,12 +96,31 @@ POST /dialog/turn
 
 ### 2.4 動作仕様
 
+#### 現状の実装 (Phase69-2-A 時点)
+
+リクエストの `excluded_ids` のみが検索フィルターに適用される:
+
 ```
-最終的な除外リスト = テナントの default_excluded_ids ∪ リクエスト excluded_ids
+実際の除外リスト = リクエスト excluded_ids (フィルタ後の空文字除去済み)
 ```
 
-→ 両者は **OR 結合**。`default_excluded_ids` だけでも除外される。
-→ リクエストで `excluded_ids: []` を送っても `default_excluded_ids` は適用される。
+`pgvector.ts` の実装:
+```sql
+AND fe.id::text != ALL($4::text[])  -- リクエスト excluded_ids のみ
+```
+
+#### 設計上の将来仕様 (Phase69-2-E 以降で実装予定)
+
+```
+設計上の除外リスト = テナントの default_excluded_ids ∪ リクエスト excluded_ids
+```
+
+> **⚠️ 注意 (2026-05-31 時点):** `tenants.default_excluded_ids` カラムは DB スキーマに追加済みだが、
+> TypeScript 側でこのカラムを検索時に読み込んでマージする実装はまだ存在しない。
+> 現時点では `default_excluded_ids` はデータモデルとして定義されているのみで、検索動作への影響はない。
+> AVAS チームは `excluded_ids` パラメータを使った「リクエストスコープ除外」のみ利用可能。
+
+→ `default_excluded_ids` の永続統合（§7.2）は Phase69-2-E 対応後に利用可能になる予定。
 
 ### 2.5 サンプルリクエスト ★ 実装確認済み
 
@@ -447,7 +466,7 @@ WHERE tenant_id = '<your-tenant-id>';
 |---|---|
 | 検索 API rate limit | テナントの `rateLimit` (デフォルト 60 req/min) |
 | `excluded_ids` 上限 | **500 要素** ★ 実装確認済み (Zod `z.array(z.string()).max(500)`) |
-| `default_excluded_ids` の適用タイミング | リクエストごとに DB から取得 (インメモリキャッシュなし) |
+| `default_excluded_ids` の適用タイミング | **未実装** (DB スキーマのみ定義済み。Phase69-2-E 以降で実装予定) |
 | Admin API (PATCH exclude) DB lock timeout | 3秒 (`SET LOCAL lock_timeout = '3s'`) |
 
 ---
@@ -471,6 +490,7 @@ WHERE tenant_id = '<your-tenant-id>';
 |---|---|---|---|
 | 1.0 | 2026-05-19 | 初版作成、Phase69-2-A 本番稼働後の仕様確定版 | R2C チーム |
 | 1.1 | 2026-05-19 | PR #152 実装に基づく精緻化、推測ベースの値を実装値に置換: max要素数1000→500、`q`フィールド名修正、dialog `options`配下に修正、PATCH response形式修正 (`reason`/`updated_at`/`updated_by` 削除)、faq_docs カラム追加記載、インデックス条件修正 (`= true`)、excluded_count/excluded_default_count 削除、audit_log 記載修正、409エラー追加 | R2C チーム (CLI) |
+| 1.2 | 2026-05-31 | Phase69-2-C AVAS連携対応: `default_excluded_ids` の実装状況を実機照合で訂正 (DB スキーマのみ定義済み、TypeScript 側でのマージ実装は未着手)。§2.4 動作仕様に「現状実装」と「将来設計」を分離記載、§8 パフォーマンス表の適用タイミングを未実装と明記。PARTNER_ROLLOUT_PLAYBOOK.md にゼロ知識検索節を追記。 | R2C チーム (CLI) |
 
 ---
 


### PR DESCRIPTION
## Summary

- `docs/PHASE69_2_API_SPEC.md` を v1.1 → v1.2 に更新: 実機照合により `default_excluded_ids` の実装状況の乖離を修正
- `docs/PARTNER_ROLLOUT_PLAYBOOK.md` に §12 ゼロ知識検索節を新規追加

## 変更詳細

### PHASE69_2_API_SPEC.md (v1.2)
- **重要な乖離修正**: `default_excluded_ids` は DB スキーマに定義済みだが、TypeScript 側でこのカラムを読み込んで検索時にマージする実装は未着手。§2.4 動作仕様に「現状実装」と「将来設計」を分離して記載。
- §8 パフォーマンス表: `default_excluded_ids` の適用タイミングを「未実装 (Phase69-2-E 以降で実装予定)」と明記。
- バージョン履歴に v1.2 エントリ追加。

### PARTNER_ROLLOUT_PLAYBOOK.md
- §12「ゼロ知識検索 — AVAS / 外部連携向け」を新規追加:
  - 機能の目的・責務分担表
  - `/agent.search` / `/dialog/turn` の使用例
  - 制約 (最大 500 件・null 挙動・テナント分離)
  - Admin API (PATCH exclude) の使い方
  - テナント分離の保証説明

## 実機照合結果

- `excluded_ids` 最大 500: `src/agent/http/agentSearchRoute.ts:14` — `z.array(z.string()).max(500)` で確認
- dialog `options` 配下: `src/agent/http/agentDialogRoute.ts:28` で確認
- `default_excluded_ids` 未実装: `src/` 全 TypeScript ファイルに `default_excluded_ids` を読み込む SELECT が存在しないことを grep で確認

## Gate

- Gate 1 (pnpm verify): docs-only のためスキップ
- Gate 2 (gitleaks): `gitleaks protect --staged` → 0 leaks
- Gate 2.5 (Codex): docs-only のためスキップ
- Gate 3 (build): docs-only のためスキップ

## 残作業 (人手)

- **Slack #r2c での AVAS チームへの共有は hkobayashi 手動**
- `default_excluded_ids` の TypeScript 実装 (Phase69-2-E 以降)

🤖 Generated with [Claude Code](https://claude.com/claude-code)