### PR TITLE
fix(db): faq_embedding orphan クリーンアップ手順 + ON DELETE CASCADE 再発防止 (Phase69-2-D GID 1214820948023240)

### DIFF
--- a/docs/postmortem/2026-05-31-faq-embedding-orphan/INVESTIGATION.md
+++ b/docs/postmortem/2026-05-31-faq-embedding-orphan/INVESTIGATION.md
@@ -1,0 +1,166 @@
+# Phase69-2-D: faq_embedding orphan 調査レポート
+
+調査日: 2026-05-31  
+担当: CLI Lane (GID 1214820948023240)  
+実機作業: hkobayashi (VPS 手動 SQL 実行)
+
+---
+
+## 1. 事象
+
+Phase69-2-A Round3 の VPS DB 調査で、`faq_embeddings` テーブルに orphan 行を 1件検出。
+
+検出 SQL:
+```sql
+SELECT fe.id, fe.tenant_id, fe.metadata
+FROM faq_embeddings fe
+LEFT JOIN faq_docs fd ON fd.id = (fe.metadata->>'faq_id')::bigint
+WHERE fe.metadata->>'faq_id' ~ '^[0-9]+$' AND fd.id IS NULL;
+```
+
+`fe.metadata->>'faq_id'` が指す `faq_docs` 行が存在しない = orphan。
+
+---
+
+## 2. 根本原因の調査結果
+
+### 2-A. DB 制約（ON DELETE CASCADE）の有無
+
+**結論: DB 制約なし。**
+
+- `docs/sql/0002_faq_embeddings_pgvector.sql` — `faq_embeddings` テーブル定義。`faq_id` 列が存在せず、faq_id は `metadata JSONB` 内の `metadata->>'faq_id'` として格納されている。
+- `docs/db-schema.md` には将来の理想形として `faq_id BIGINT NOT NULL REFERENCES faq_docs(id)` が記載されているが、**実際の DDL には存在しない**。
+- 全マイグレーション SQL (`src/migrations/*.sql`) に `FOREIGN KEY ... faq_docs` への参照なし。
+- `ON DELETE CASCADE` は `faq_embeddings <-> faq_docs` 間には一切設定されていない。
+
+### 2-B. アプリ層の連鎖削除の有無
+
+**結論: 新ルートは実装済み。旧ルートが欠落。**
+
+| エンドポイント | ファイル | faq_embeddings 削除 |
+|---|---|---|
+| `DELETE /v1/admin/knowledge/:id` | `src/api/admin/knowledge/routes.ts:396` | あり (`metadata->>'faq_id'` で削除) |
+| `DELETE /v1/admin/knowledge/faq/:id` | `src/api/admin/knowledge/faqCrudRoutes.ts:592` | あり (`metadata->>'faq_id'` で削除) |
+| `DELETE /v1/admin/knowledge/faq/bulk` | `src/api/admin/knowledge/faqCrudRoutes.ts:524` | あり (トランザクション内で削除) |
+| **`DELETE /admin/faqs/:id`** | **`src/admin/http/faqAdminRoutes.ts:426`** | **なし（欠落）** |
+
+`faqAdminRoutes.ts:437` にはコメントが残っている:
+```typescript
+// embeddings 側を faq_id などで紐付けるようにしたら、ここで一緒に削除
+```
+これは「TODO のまま放置された」状態。このエンドポイントが本番で使用された時に orphan が発生したと推定される。
+
+### 2-C. orphan 発生経路の推定
+
+```
+1. POST /admin/faqs で FAQ 作成 → faq_docs + faq_embeddings (metadata.faq_id) を挿入
+2. DELETE /admin/faqs/:id で FAQ 削除 → faq_docs のみ削除、faq_embeddings は残る
+3. faq_embeddings が orphan 化
+```
+
+---
+
+## 3. 対応方針
+
+### 3-1. 今回の orphan クリーンアップ（hkobayashi 手動実行）
+
+手順: `src/migrations/phase69_2d_faq_embedding_orphan_cleanup.sql` を参照。
+
+```
+Step 1: orphan 検出確認 → Step 2: DELETE トランザクション → Step 4: 0件確認
+```
+
+### 3-2. 再発防止（優先度順）
+
+#### 優先度 HIGH: 旧ルートの連鎖削除欠落を修正
+
+`src/admin/http/faqAdminRoutes.ts` の `DELETE /admin/faqs/:id` に、faq_embeddings の削除を追加する。
+
+修正案（アプリ層、今後の PR で対応）:
+```typescript
+// faq_docs 削除前に faq_embeddings を削除
+await db.query(
+  `DELETE FROM faq_embeddings
+   WHERE tenant_id = $1
+     AND (metadata->>'faq_id')::bigint = $2`,
+  [tenantId, id]
+);
+// 既存の faq_docs 削除
+// DELETE FROM faq_docs WHERE id = $1 AND tenant_id = $2 ...
+```
+
+#### 優先度 MEDIUM: DB 制約（将来対応）
+
+`faq_embeddings` に `faq_doc_id BIGINT REFERENCES faq_docs(id) ON DELETE CASCADE` 列を追加することで DB レベルで保証できる。ただし:
+- 既存の `metadata->>'faq_id'` を物理列に移行するデータマイグレーションが必要
+- book/web 等の非 FAQ embedding (faq_id なし) の扱いを考慮する必要がある
+- このマイグレーションは大規模かつリスクが高いため、別 Phase で計画的に実施推奨
+
+**今回の判断: DB 制約追加は「将来対応」として scope 外。アプリ層の連鎖削除欠落補完を優先とする。**
+
+理由:
+- `metadata JSONB` 内の文字列 faq_id に FK 制約は追加不可
+- 物理列追加は破壊的変更でありリスクが高い
+- 既に新ルート（`/v1/admin/knowledge/` 系）はアプリ層で連鎖削除を実装済み
+- 旧ルート (`/admin/faqs/:id`) の修正のほうがコスト対効果が高い
+
+---
+
+## 4. hkobayashi 手動作業（VPS）
+
+### 4-1. 事前バックアップ
+
+```bash
+psql $DATABASE_URL -c "\
+COPY (SELECT * FROM faq_embeddings WHERE metadata->>'faq_id' ~ '^[0-9]+\$') \
+  TO '/tmp/faq_embeddings_backup_$(date +%Y%m%d).csv' CSV HEADER;"
+```
+
+### 4-2. orphan 検出確認
+
+```sql
+SELECT fe.id, fe.tenant_id, fe.metadata
+FROM faq_embeddings fe
+LEFT JOIN faq_docs fd ON fd.id = (fe.metadata->>'faq_id')::bigint
+WHERE fe.metadata->>'faq_id' ~ '^[0-9]+$' AND fd.id IS NULL;
+```
+
+0件なら既に解消済みのため以降の削除不要。
+
+### 4-3. orphan 削除（1件確認後に実行）
+
+```sql
+BEGIN;
+
+DELETE FROM faq_embeddings fe
+WHERE fe.metadata->>'faq_id' ~ '^[0-9]+$'
+  AND NOT EXISTS (
+    SELECT 1 FROM faq_docs fd
+    WHERE fd.id = (fe.metadata->>'faq_id')::bigint
+  );
+
+COMMIT;
+```
+
+### 4-4. 削除後確認
+
+```sql
+SELECT COUNT(*) AS orphan_count
+FROM faq_embeddings fe
+LEFT JOIN faq_docs fd ON fd.id = (fe.metadata->>'faq_id')::bigint
+WHERE fe.metadata->>'faq_id' ~ '^[0-9]+$' AND fd.id IS NULL;
+-- 期待値: 0
+```
+
+---
+
+## 5. 関連ファイル
+
+| ファイル | 役割 |
+|---|---|
+| `src/migrations/phase69_2d_faq_embedding_orphan_cleanup.sql` | クリーンアップ + 将来の CASCADE テンプレート |
+| `src/admin/http/faqAdminRoutes.ts:426` | 旧ルート (faq_embeddings 削除欠落) |
+| `src/api/admin/knowledge/routes.ts:396` | 新ルート (連鎖削除実装済み) |
+| `src/api/admin/knowledge/faqCrudRoutes.ts:592` | 新ルート (連鎖削除実装済み) |
+| `docs/sql/0002_faq_embeddings_pgvector.sql` | faq_embeddings テーブル定義 (FK なし) |
+| `docs/db-schema.md` | 理想スキーマ記載 (faq_id 物理列、未実装) |

--- a/src/migrations/phase69_2d_faq_embedding_orphan_cleanup.sql
+++ b/src/migrations/phase69_2d_faq_embedding_orphan_cleanup.sql
@@ -1,0 +1,89 @@
+-- Phase69-2-D: faq_embedding orphan クリーンアップ + ON DELETE CASCADE 再発防止
+-- 調査日: 2026-05-31
+-- 実行担当: hkobayashi (VPS 手動実行)
+-- 対象: VPS PostgreSQL (65.108.159.161)
+--
+-- 背景:
+--   Phase69-2-A Round3 の VPS DB 調査で orphan faq_embedding 1件を検出。
+--   faq_embeddings.metadata->>'faq_id' が指す faq_docs 行が存在しない。
+--   根本原因: faq_embeddings に faq_docs.id への FOREIGN KEY (ON DELETE CASCADE) が無く、
+--             さらに旧 API エンドポイント DELETE /admin/faqs/:id (faqAdminRoutes.ts) が
+--             faq_docs を削除する際に faq_embeddings の連鎖削除をしていない。
+--
+-- このファイルの構成:
+--   Step 1: orphan 検出 (確認用 SELECT)
+--   Step 2: orphan クリーンアップ (BEGIN/COMMIT トランザクション)
+--   Step 3: ON DELETE CASCADE 制約追加 (再発防止)
+--   Step 4: 確認クエリ
+
+-- ============================================================
+-- Step 1: orphan 検出クエリ（実行前に必ず確認すること）
+-- ============================================================
+-- 実行して件数・内容を確認してから Step 2 に進むこと。
+--
+-- SELECT fe.id, fe.tenant_id, fe.metadata
+-- FROM faq_embeddings fe
+-- LEFT JOIN faq_docs fd ON fd.id = (fe.metadata->>'faq_id')::bigint
+-- WHERE fe.metadata->>'faq_id' ~ '^[0-9]+$' AND fd.id IS NULL;
+--
+-- 期待値: 1件（Phase69-2-A Round3 調査結果）
+-- 0件なら既に手動削除済みのため Step 2 はスキップしてよい。
+-- 2件以上なら hkobayashi が内容を精査してから削除すること。
+
+-- ============================================================
+-- Step 2: orphan クリーンアップ
+-- ============================================================
+-- 前提: Step 1 の確認が完了していること。
+-- バックアップ推奨:
+--   psql $DATABASE_URL -c "COPY (SELECT * FROM faq_embeddings WHERE metadata->>'faq_id' ~ '^[0-9]+$') TO '/tmp/faq_embeddings_backup_$(date +%Y%m%d).csv' CSV HEADER;"
+
+BEGIN;
+
+-- orphan embedding を削除（faq_docs に対応行が存在しない faq_id 持ち embedding）
+DELETE FROM faq_embeddings fe
+WHERE fe.metadata->>'faq_id' ~ '^[0-9]+$'
+  AND NOT EXISTS (
+    SELECT 1 FROM faq_docs fd
+    WHERE fd.id = (fe.metadata->>'faq_id')::bigint
+  );
+
+-- 削除件数確認（COMMIT 前に確認可能）
+-- \echo 'Deleted rows:'
+-- SELECT changes();  -- psql では ROW_COUNT を確認
+
+COMMIT;
+
+-- ============================================================
+-- Step 3: ON DELETE CASCADE 制約追加（再発防止）
+-- ============================================================
+-- 注意:
+--   現在の faq_embeddings テーブルは metadata JSONB 内に faq_id を格納しており、
+--   物理的な FOREIGN KEY 列 (faq_id BIGINT) が存在しない。
+--   そのため、通常の ALTER TABLE ... ADD FOREIGN KEY は追加できない。
+--
+--   対応方針: アプリ層連鎖削除（現状の新ルート）を正として、
+--             旧ルート DELETE /admin/faqs/:id に欠落している連鎖削除を補完する。
+--             DB制約としての FK 追加は将来マイグレーションで faq_id 列を追加する際に実施。
+--
+-- [将来対応用テンプレート - 今回は実行しない]
+-- ALTER TABLE faq_embeddings
+--   ADD COLUMN IF NOT EXISTS faq_doc_id BIGINT
+--     REFERENCES faq_docs(id) ON DELETE CASCADE;
+-- UPDATE faq_embeddings
+--   SET faq_doc_id = (metadata->>'faq_id')::bigint
+--   WHERE metadata->>'faq_id' ~ '^[0-9]+$';
+-- -- faq_doc_id への INDEX
+-- CREATE INDEX IF NOT EXISTS idx_faq_embeddings_faq_doc_id
+--   ON faq_embeddings (faq_doc_id);
+
+-- ============================================================
+-- Step 4: 確認クエリ（クリーンアップ後に実行）
+-- ============================================================
+-- orphan が 0 件になっていることを確認:
+--
+-- SELECT COUNT(*) AS orphan_count
+-- FROM faq_embeddings fe
+-- LEFT JOIN faq_docs fd ON fd.id = (fe.metadata->>'faq_id')::bigint
+-- WHERE fe.metadata->>'faq_id' ~ '^[0-9]+$' AND fd.id IS NULL;
+--
+-- 期待値: 0


### PR DESCRIPTION
## Summary

- Phase69-2-A Round3 で発見された orphan faq_embedding 1件の根本原因を特定
- クリーンアップ SQL（BEGIN/COMMIT + バックアップ手順付き）を生成
- 再発防止の調査結果と対応方針を postmortem に記録

## 調査結果: ON DELETE CASCADE 有無

**DB 制約: なし**
- `faq_embeddings` テーブルは `metadata JSONB` 内に `faq_id` を格納しており、物理的な FOREIGN KEY 列が存在しない（`docs/sql/0002_faq_embeddings_pgvector.sql` 参照）
- `ON DELETE CASCADE` は全マイグレーション SQL を通じて一切設定されていない

**アプリ層: 新ルートは実装済み、旧ルートが欠落**
- `DELETE /v1/admin/knowledge/:id` (routes.ts) — 連鎖削除あり
- `DELETE /v1/admin/knowledge/faq/:id` (faqCrudRoutes.ts) — 連鎖削除あり
- `DELETE /admin/faqs/:id` (faqAdminRoutes.ts:426) — **連鎖削除なし（TODO コメント放置）** ← orphan 発生経路

## 生成ファイル

- `src/migrations/phase69_2d_faq_embedding_orphan_cleanup.sql` — orphan 検出/削除 SQL（Step 1-4）
- `docs/postmortem/2026-05-31-faq-embedding-orphan/INVESTIGATION.md` — 根本原因・対応方針・VPS 手動手順

## 処理判断

**embedding 削除を推奨**（faq_docs が既に消えているため embedding の参照元が無効）。embedding を残しても RAG 検索時に `pgvector.ts` の faq_docs JOIN で除外されるが（Phase69-2 Round4 対応済み）、ストレージ・インデックス効率の観点から削除が望ましい。

## 再発防止の方針

1. **優先度 HIGH（次 PR）**: `src/admin/http/faqAdminRoutes.ts` の `DELETE /admin/faqs/:id` に faq_embeddings 連鎖削除を追加（アプリ層）
2. **優先度 MEDIUM（将来 Phase）**: faq_embeddings に `faq_doc_id BIGINT REFERENCES faq_docs(id) ON DELETE CASCADE` 物理列を追加（大規模マイグレーション、別 Phase で計画）

## hkobayashi 手動で残る作業（VPS 実行）

```bash
# 1. バックアップ
psql $DATABASE_URL -c "COPY (SELECT * FROM faq_embeddings WHERE metadata->>'faq_id' ~ '^[0-9]+$') TO '/tmp/faq_embeddings_backup_$(date +%Y%m%d).csv' CSV HEADER;"

# 2. orphan 確認（1件あることを確認）
psql $DATABASE_URL -c "
SELECT fe.id, fe.tenant_id, fe.metadata
FROM faq_embeddings fe
LEFT JOIN faq_docs fd ON fd.id = (fe.metadata->>'faq_id')::bigint
WHERE fe.metadata->>'faq_id' ~ '^[0-9]+\$' AND fd.id IS NULL;"

# 3. orphan 削除（src/migrations/phase69_2d_faq_embedding_orphan_cleanup.sql の Step 2 を実行）
psql $DATABASE_URL -f src/migrations/phase69_2d_faq_embedding_orphan_cleanup.sql
# ※ Step 1・Step 3 はコメントのため自動スキップ、Step 2 の BEGIN/COMMIT が実行される

# 4. 確認（0件であることを確認）
psql $DATABASE_URL -c "SELECT COUNT(*) AS orphan_count FROM faq_embeddings fe LEFT JOIN faq_docs fd ON fd.id = (fe.metadata->>'faq_id')::bigint WHERE fe.metadata->>'faq_id' ~ '^[0-9]+\$' AND fd.id IS NULL;"
```

## Test plan

- [ ] Step 1 確認クエリで 1件検出されることを確認
- [ ] Step 2 DELETE 実行後 COMMIT
- [ ] Step 4 確認クエリで 0件になることを確認
- [ ] `faqAdminRoutes.ts` 旧ルートの修正 PR を別途作成（フォローアップ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)