### PR TITLE
fix(es): write path を faq_${tenantId} に統一し read/write index 不整合を解消 (Phase69-2-E GID 1214821660260379)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,10 @@ DATABASE_URL=postgres://postgres:pass@127.0.0.1:5434/faq
 
 # ==== Elasticsearch ====
 ES_URL=http://localhost:9200
+# [DEPRECATED Phase69-2-E] ES_FAQ_INDEX は FAQ 検索では使用しない。
+# FAQ の ES index はテナント別 `faq_${tenantId}` に固定（read/write/reindex 全て一致）。
+# 命名規則の正典: src/search/langIndex.ts resolveFaqWriteIndex / SCRIPTS/sync-es.ts。
+# この変数は book-pipeline (Phase44/47) が暫定的に参照するのみ。新規コードでは使わないこと。
 ES_FAQ_INDEX=faq
 
 # ==== Hybrid Search ====

--- a/docs/VPS_OPS_GUIDE.md
+++ b/docs/VPS_OPS_GUIDE.md
@@ -180,12 +180,25 @@ ssh root@65.108.159.161 "cd /opt/rajiuce && psql \$DATABASE_URL -f src/migration
 Phase69-2 で ES mapping に `is_published` / `is_excluded_from_search` を明示追加した。
 既存インデックスは dynamic mapping のため、明示マッピングを反映するには re-index が必要。
 
-> **ES write path の注意 (Phase69-2 Round 5 / Phase69-2-E 参照)**
-> `upsertToEsAsync`（CRUD POST/PUT）・`syncIsExcludedToEsAsync`（/exclude PATCH）はいずれも
-> `is_excluded_from_search` を ES に伝搬する。ただし書き込み index は `ES_FAQ_INDEX || "faqs"` であり、
-> 検索 read path (`faq_<tenantId>`) とは index 名が異なる可能性がある（Phase33-c 起因の既存不整合）。
-> **この不整合により、Phase69-2-E 完了まで ES への除外同期は事実上機能しない可能性がある。**
-> pgvector 経由の除外フィルター（`WHERE fd.is_excluded_from_search = false`）は index 名に依存せず機能する。
+> **ES write path の不整合は Phase69-2-E で解消済み**
+> `upsertToEsAsync`（CRUD POST/PUT）・`syncIsExcludedToEsAsync`（/exclude PATCH）・`deleteFromEs`（DELETE）は
+> いずれも `is_excluded_from_search` を含む doc を ES に伝搬する。
+> **Phase69-2-E 以前は書き込み index が `ES_FAQ_INDEX || "faqs"`、検索 read path が `faq_<tenantId>` と
+> 異なっており（Phase33-c 起因）、ES への除外同期が事実上機能していなかった。**
+> Phase69-2-E で write path を read path と同じ `faq_<tenantId>` に統一した（後述の命名規則を参照）。
+> なお pgvector 経由の除外フィルター（`WHERE fd.is_excluded_from_search = false`）は index 名に依存せず常に機能する。
+
+##### ES index 命名規則（Phase69-2-E で確定）
+
+| 用途 | index 名 | 解決元 |
+|------|----------|--------|
+| FAQ 書き込み（upsert / delete / exclude 同期） | `faq_<tenantId>` | `src/search/langIndex.ts` の `resolveFaqWriteIndex(tenantId)` |
+| FAQ 検索 read path（hybrid / langRouter） | `faq_<tenantId>_<lang>`（プライマリ）→ `faq_<tenantId>`（フォールバック） | `resolveFallbackIndices(tenantId, lang)` |
+| reindex（全件再構築） | `faq_<tenantId>` | `SCRIPTS/sync-es.ts` の `syncTenant()` |
+
+- **正典は `resolveFaqWriteIndex` / `sync-es.ts` で、いずれも `faq_<tenantId>`。** 環境変数 `ES_FAQ_INDEX` による FAQ index の上書きは廃止した。
+- `ES_FAQ_INDEX` は book-pipeline（Phase44/47、`bookStructurizer.ts` / `embedAndStore.ts`）が暫定的に参照するのみ。FAQ 検索経路では一切使わない。
+- global ナレッジの delete は `faq_global` ではなく、doc が書き込まれたテナントの `faq_<recordTenantId>` を対象にする（write 時と同じ index）。
 
 ```bash
 ssh root@65.108.159.161 "cd /opt/rajiuce && pnpm ts-node SCRIPTS/sync-es.ts --all"

--- a/src/admin/http/faqAdminRoutes.ts
+++ b/src/admin/http/faqAdminRoutes.ts
@@ -4,6 +4,7 @@ import { embedText } from "../../agent/llm/openaiEmbeddingClient";
 import { pool } from "../../lib/db";
 import { supabaseAuthMiddleware } from "./supabaseAuthMiddleware";
 import { logger } from '../../lib/logger';
+import { resolveFaqWriteIndex } from "../../search/langIndex";
 
 
 
@@ -46,7 +47,8 @@ function resolveTenantId(req: Request): string | null {
 async function updateEsFaqDocument(row: FaqRow) {
   try {
     const esUrl = process.env.ES_URL;
-    const esFaqIndex = process.env.ES_FAQ_INDEX || "faqs";
+    // Phase69-2-E: write index を read path と同じ faq_${tenantId} に統一
+    const esFaqIndex = resolveFaqWriteIndex(row.tenant_id);
 
     if (!esUrl) {
       logger.warn("[updateEsFaqDocument] ES_URL is not set");

--- a/src/api/admin/knowledge-gaps/routes.ts
+++ b/src/api/admin/knowledge-gaps/routes.ts
@@ -10,6 +10,7 @@ import { superAdminMiddleware } from '../tenants/superAdminMiddleware';
 import { embedText } from '../../../agent/llm/openaiEmbeddingClient';
 import { generateRecommendations } from '../../../agent/gap/gapRecommender';
 import { callGeminiJudge } from '../../../lib/gemini/client';
+import { resolveFaqWriteIndex } from '../../../search/langIndex';
 
 const logger = pino();
 
@@ -79,7 +80,7 @@ function upsertToEsAsync(
   answer: string,
 ): void {
   const esUrl = process.env['ES_URL'];
-  const index = process.env['ES_FAQ_INDEX'] ?? 'faqs';
+  const index = resolveFaqWriteIndex(tenantId);
   if (!esUrl) return;
   const doc = { tenant_id: tenantId, question, answer, faq_id: faqId, is_published: true };
   const url = `${esUrl.replace(/\/$/, '')}/${index}/_doc/${faqId}_${tenantId}`;

--- a/src/api/admin/knowledge/faqCrudEsIndex.test.ts
+++ b/src/api/admin/knowledge/faqCrudEsIndex.test.ts
@@ -1,0 +1,179 @@
+// src/api/admin/knowledge/faqCrudEsIndex.test.ts
+// Phase69-2-E: FAQ CRUD の ES write path が read path と同じ faq_${tenantId} index を
+// 参照することの統合テスト。
+//
+// 検証対象:
+//   - POST   /v1/admin/knowledge/faq            → upsertToEsAsync  が faq_${tenantId}/_doc/ に PUT
+//   - PATCH  /v1/admin/knowledge/faq/:id/exclude → syncIsExcludedToEsAsync が faq_${tenantId}/_update/ に POST
+//   - DELETE /v1/admin/knowledge/faq/:id         → deleteFromEs が faq_${tenantId}/_doc/ に DELETE
+//
+// excludedIds.test.ts と同様、外部依存（DB / embedding / ES fetch）はモックする。
+
+jest.mock("../../../lib/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock("../../../agent/llm/openaiEmbeddingClient", () => ({
+  embedText: jest.fn().mockResolvedValue([0.1, 0.2, 0.3]),
+}));
+
+import express, { type Request, type Response, type NextFunction } from "express";
+import request from "supertest";
+import type { Pool } from "pg";
+import { registerFaqCrudRoutes } from "./faqCrudRoutes";
+import { resolveFaqWriteIndex } from "../../../search/langIndex";
+
+const TENANT = "demo";
+const ES_URL = "http://es.test:9200";
+
+// fetch をキャプチャ（ES への書き込み URL を記録）
+type Captured = { url: string; method: string };
+let captured: Captured[] = [];
+
+const originalFetch = global.fetch;
+
+function installFetchSpy() {
+  // best-effort write path は応答 ok を返すだけでよい
+  global.fetch = jest.fn(async (input: unknown, init?: { method?: string }) => {
+    const url = typeof input === "string" ? input : String(input);
+    captured.push({ url, method: init?.method ?? "GET" });
+    return {
+      ok: true,
+      status: 200,
+      text: async () => "",
+      json: async () => ({}),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+}
+
+// pass-through middleware（認証層は本テストの対象外）
+const passThrough = (_req: Request, _res: Response, next: NextFunction) => next();
+
+/** db.query / db.connect をモックする最小 Pool */
+function makeMockPool(): { pool: Pool; setQuery: (fn: jest.Mock) => void } {
+  const queryMock = jest.fn();
+  const clientQuery = jest.fn(async (sql: string) => {
+    if (/SELECT id, tenant_id FROM faq_docs WHERE id = \$1 FOR UPDATE/.test(sql)) {
+      return { rows: [{ id: 1, tenant_id: TENANT }], rowCount: 1 };
+    }
+    if (/UPDATE faq_docs SET is_excluded_from_search/.test(sql)) {
+      return { rows: [], rowCount: 1 };
+    }
+    return { rows: [], rowCount: 0 };
+  });
+  const pool = {
+    query: queryMock,
+    connect: jest.fn(async () => ({
+      query: clientQuery,
+      release: jest.fn(),
+    })),
+  } as unknown as Pool;
+  return { pool, setQuery: (fn) => { (pool.query as unknown) = fn; } };
+}
+
+function makeApp(pool: Pool) {
+  const app = express();
+  app.use(express.json());
+  registerFaqCrudRoutes(app, pool, passThrough, passThrough, passThrough);
+  return app;
+}
+
+const origEsUrl = process.env.ES_URL;
+const origEsIndex = process.env.ES_FAQ_INDEX;
+
+beforeEach(() => {
+  captured = [];
+  installFetchSpy();
+  process.env.ES_URL = ES_URL;
+  // 旧バグ再現防止: ES_FAQ_INDEX を別名にしても faq_${tenantId} に書くこと
+  process.env.ES_FAQ_INDEX = "faqs";
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  jest.clearAllMocks();
+});
+
+afterAll(() => {
+  if (origEsUrl !== undefined) process.env.ES_URL = origEsUrl; else delete process.env.ES_URL;
+  if (origEsIndex !== undefined) process.env.ES_FAQ_INDEX = origEsIndex; else delete process.env.ES_FAQ_INDEX;
+});
+
+describe("FAQ CRUD ES write path — index 統一 (Phase69-2-E)", () => {
+  it("POST /faq: upsert は faq_${tenantId}/_doc/ に書き込む（旧 'faqs' ではない）", async () => {
+    const { pool } = makeMockPool();
+    (pool.query as jest.Mock).mockResolvedValue({
+      rows: [{ id: 42, question: "q", answer: "a", is_published: true }],
+      rowCount: 1,
+    });
+    const app = makeApp(pool);
+
+    const res = await request(app)
+      .post(`/v1/admin/knowledge/faq?tenant=${TENANT}`)
+      .send({ question: "返品はできますか", answer: "30日以内なら可能です" });
+
+    expect(res.status).toBe(201);
+
+    // fire-and-forget の fetch が走るまで microtask を流す
+    await new Promise((r) => setImmediate(r));
+
+    const esWrites = captured.filter((c) => c.method === "PUT");
+    expect(esWrites.length).toBeGreaterThan(0);
+    const expectedIndex = resolveFaqWriteIndex(TENANT); // faq_demo
+    expect(esWrites[0].url).toContain(`/${expectedIndex}/_doc/`);
+    expect(esWrites[0].url).not.toContain("/faqs/_doc/");
+    // doc id は ${faqId}_${tenantId}
+    expect(esWrites[0].url).toContain(`/_doc/42_${TENANT}`);
+  });
+
+  it("PATCH /faq/:id/exclude: sync は faq_${tenantId}/_update/ に書き込む", async () => {
+    const { pool } = makeMockPool();
+    const app = makeApp(pool);
+
+    const res = await request(app)
+      .patch(`/v1/admin/knowledge/faq/1/exclude?tenant=${TENANT}`)
+      .send({ is_excluded_from_search: true });
+
+    expect(res.status).toBe(200);
+    await new Promise((r) => setImmediate(r));
+
+    const esUpdates = captured.filter((c) => c.method === "POST");
+    expect(esUpdates.length).toBeGreaterThan(0);
+    const expectedIndex = resolveFaqWriteIndex(TENANT);
+    expect(esUpdates[0].url).toContain(`/${expectedIndex}/_update/`);
+    expect(esUpdates[0].url).not.toContain("/faqs/_update/");
+    expect(esUpdates[0].url).toContain(`/_update/1_${TENANT}`);
+  });
+
+  it("DELETE /faq/:id: delete は faq_${tenantId}/_doc/ を対象にする", async () => {
+    const { pool } = makeMockPool();
+    (pool.query as jest.Mock).mockImplementation(async (sql: string) => {
+      if (/SELECT id, tenant_id FROM faq_docs WHERE id = \$1/.test(sql)) {
+        return { rows: [{ id: 7, tenant_id: TENANT }], rowCount: 1 };
+      }
+      return { rows: [], rowCount: 1 };
+    });
+    const app = makeApp(pool);
+
+    const res = await request(app).delete(`/v1/admin/knowledge/faq/7?tenant=${TENANT}`);
+    expect(res.status).toBe(200);
+    await new Promise((r) => setImmediate(r));
+
+    const esDeletes = captured.filter((c) => c.method === "DELETE");
+    expect(esDeletes.length).toBeGreaterThan(0);
+    const expectedIndex = resolveFaqWriteIndex(TENANT);
+    expect(esDeletes[0].url).toContain(`/${expectedIndex}/_doc/`);
+    expect(esDeletes[0].url).not.toContain("/faqs/_doc/");
+    expect(esDeletes[0].url).toContain(`/_doc/7_${TENANT}`);
+  });
+
+  it("PATCH /exclude 後、同じ index に対する hybrid 読み取りパスと write index が一致する", () => {
+    // write は faq_${tenantId}、read fallback の旧形式も faq_${tenantId}。
+    // 両者が一致しないと exclude 同期が検索 index に届かない（Phase33-c バグ）。
+    const writeIndex = resolveFaqWriteIndex(TENANT);
+    // resolveFallbackIndices は read path（hybrid.ts）が使う。ここでは直接 langIndex で照合。
+    const { resolveFallbackIndices } = jest.requireActual<typeof import("../../../search/langIndex")>(
+      "../../../search/langIndex"
+    );
+    expect(resolveFallbackIndices(TENANT, "ja")).toContain(writeIndex);
+  });
+});

--- a/src/api/admin/knowledge/faqCrudRoutes.ts
+++ b/src/api/admin/knowledge/faqCrudRoutes.ts
@@ -6,6 +6,7 @@ import { Pool } from "pg";
 import { z } from "zod";
 import { embedText } from "../../../agent/llm/openaiEmbeddingClient";
 import { logger } from '../../../lib/logger';
+import { resolveFaqWriteIndex } from "../../../search/langIndex";
 
 const CATEGORIES = ["inventory", "campaign", "coupon", "store_info"] as const;
 
@@ -16,10 +17,11 @@ function resolveTenantId(req: Request): string | null {
   return fromQuery || fromHeader || null;
 }
 
-/** ESインデックスからドキュメントを削除（best-effort） */
-async function deleteFromEs(esDocId: string): Promise<void> {
+/** ESインデックスからドキュメントを削除（best-effort）
+ * Phase69-2-E: write index を read path と同じ faq_${tenantId} に統一 */
+async function deleteFromEs(tenantId: string, esDocId: string): Promise<void> {
   const esUrl = process.env.ES_URL;
-  const index = process.env.ES_FAQ_INDEX || "faqs";
+  const index = resolveFaqWriteIndex(tenantId);
   if (!esUrl || !esDocId) return;
   const url = `${esUrl.replace(/\/$/, "")}/${index}/_doc/${encodeURIComponent(esDocId)}`;
   await fetch(url, { method: "DELETE" }).catch(() => {});
@@ -54,7 +56,7 @@ function upsertToEsAsync(
   isExcludedFromSearch = false
 ): void {
   const esUrl = process.env.ES_URL;
-  const index = process.env.ES_FAQ_INDEX || "faqs";
+  const index = resolveFaqWriteIndex(tenantId);
   if (!esUrl) return;
   const doc = { tenant_id: tenantId, question, answer, faq_id: faqId, is_published: isPublished, is_excluded_from_search: isExcludedFromSearch };
   const url = `${esUrl.replace(/\/$/, "")}/${index}/_doc/${faqId}_${tenantId}`;
@@ -77,7 +79,7 @@ function syncIsExcludedToEsAsync(
   isExcludedFromSearch: boolean
 ): void {
   const esUrl = process.env.ES_URL;
-  const index = process.env.ES_FAQ_INDEX || "faqs";
+  const index = resolveFaqWriteIndex(tenantId);
   if (!esUrl) return;
   const url = `${esUrl.replace(/\/$/, "")}/${index}/_update/${faqId}_${tenantId}`;
   fetch(url, {
@@ -543,7 +545,7 @@ export function registerFaqCrudRoutes(
       let failed = 0;
       for (const id of ids) {
         try {
-          await deleteFromEs(`${id}_${tenantId}`);
+          await deleteFromEs(tenantId, `${id}_${tenantId}`);
         } catch {
           failed++;
           logger.warn(`[DELETE /v1/admin/knowledge/faq/bulk] ES delete failed for id=${id}`);
@@ -603,7 +605,7 @@ export function registerFaqCrudRoutes(
       );
 
       // ES 削除（best-effort）
-      await deleteFromEs(`${id}_${tenantId}`);
+      await deleteFromEs(tenantId, `${id}_${tenantId}`);
 
       return res.json({ ok: true, id });
     } catch (err) {

--- a/src/api/admin/knowledge/routes.ts
+++ b/src/api/admin/knowledge/routes.ts
@@ -13,6 +13,7 @@ import { registerFaqCrudRoutes } from "./faqCrudRoutes";
 import { registerBookPdfRoutes } from "./bookPdfRoutes";
 import { encryptText } from "../../../lib/crypto/textEncrypt";
 import { logger } from '../../../lib/logger';
+import { resolveFaqWriteIndex } from "../../../search/langIndex";
 import type { SupabaseJwtUser } from '../../middleware/roleAuth';
 
 
@@ -165,10 +166,11 @@ ${text.slice(0, 4000)}
   return faqs;
 }
 
-/** ESインデックスからドキュメントを削除（best-effort） */
-async function deleteFromEs(esDocId: string): Promise<void> {
+/** ESインデックスからドキュメントを削除（best-effort）
+ * Phase69-2-E: write index を read path と同じ faq_${tenantId} に統一 */
+async function deleteFromEs(tenantId: string, esDocId: string): Promise<void> {
   const esUrl = process.env.ES_URL;
-  const index = process.env.ES_FAQ_INDEX || "faqs";
+  const index = resolveFaqWriteIndex(tenantId);
   if (!esUrl || !esDocId) return;
   const url = `${esUrl.replace(/\/$/, "")}/${index}/_doc/${encodeURIComponent(esDocId)}`;
   await fetch(url, { method: "DELETE" }).catch(() => {});
@@ -408,7 +410,7 @@ export function registerKnowledgeAdminRoutes(app: Express): void {
       );
 
       // ES 削除（best-effort）
-      if (esDocId) await deleteFromEs(esDocId);
+      if (esDocId) await deleteFromEs(recordTenantId, esDocId);
 
       return res.json({ ok: true, id });
     } catch (err) {

--- a/src/search/faqIndexUnify.test.ts
+++ b/src/search/faqIndexUnify.test.ts
@@ -1,0 +1,48 @@
+// src/search/faqIndexUnify.test.ts
+// Phase69-2-E: ES write path / read path の index 名統一の単体 + 統合テスト
+//
+// 背景: Phase33-c 起因で write path (旧: ES_FAQ_INDEX || "faqs") と
+// read path (faq_${tenantId}) の index 名が不整合になり、ES への
+// is_excluded_from_search 同期や upsert が検索 index に届いていなかった。
+// 本テストは write/read/reindex が同一の `faq_${tenantId}` を参照することを保証する。
+
+import { resolveFaqWriteIndex, resolveFallbackIndices } from "./langIndex";
+
+// ---------------------------------------------------------------------------
+// 単体: resolveFaqWriteIndex と read path の整合
+// ---------------------------------------------------------------------------
+describe("resolveFaqWriteIndex (Phase69-2-E)", () => {
+  it("テナント別に faq_${tenantId} を返す", () => {
+    expect(resolveFaqWriteIndex("demo")).toBe("faq_demo");
+    expect(resolveFaqWriteIndex("carnation")).toBe("faq_carnation");
+  });
+
+  it("write index は read path のフォールバック index（旧形式）と一致する", () => {
+    // hybrid.ts / langRouter.ts は resolveFallbackIndices を read path に使う。
+    // その最終フォールバック（旧形式）が write 先と一致していなければ、
+    // ES に書いた doc が検索でヒットしない。
+    const tenantId = "demo";
+    const writeIndex = resolveFaqWriteIndex(tenantId);
+    const readFallbacks = resolveFallbackIndices(tenantId, "ja");
+    expect(readFallbacks).toContain(writeIndex);
+    // 旧形式（言語サフィックスなし）が write index と完全一致
+    expect(readFallbacks[readFallbacks.length - 1]).toBe(writeIndex);
+  });
+
+  it("hybrid.ts の非言語パス index 表現 faq_${tenantId} と一致する", () => {
+    // hybrid.ts は LANG_SEARCH 無効時に `faq_${tenantId ?? "demo"}` を使う。
+    const tenantId = "t1";
+    expect(resolveFaqWriteIndex(tenantId)).toBe(`faq_${tenantId}`);
+  });
+
+  it("環境変数 ES_FAQ_INDEX を参照しない（廃止済み）", () => {
+    const orig = process.env.ES_FAQ_INDEX;
+    process.env.ES_FAQ_INDEX = "should_be_ignored";
+    try {
+      expect(resolveFaqWriteIndex("demo")).toBe("faq_demo");
+    } finally {
+      if (orig !== undefined) process.env.ES_FAQ_INDEX = orig;
+      else delete process.env.ES_FAQ_INDEX;
+    }
+  });
+});

--- a/src/search/langIndex.ts
+++ b/src/search/langIndex.ts
@@ -18,6 +18,21 @@ export function resolveEsIndex(tenantId: string, lang: SupportedLang): string {
 }
 
 /**
+ * FAQ の ES 書き込み先インデックス名を解決する（テナント別）。
+ *
+ * Phase69-2-E: write path と read path の index 名不整合（Phase33-c 起因）を解消するための
+ * 単一の正典関数。read path（hybrid.ts / langRouter.ts の resolveFallbackIndices）も
+ * 同じ `faq_${tenantId}` 命名規則を使うため、upsert/delete/exclude の全 write 経路は
+ * 必ずこの関数で index 名を解決すること。
+ *
+ * 命名規則の正典は SCRIPTS/sync-es.ts（reindex）と一致: `faq_${tenantId}`。
+ * 環境変数 ES_FAQ_INDEX による上書きは廃止（read path がテナント別 index を前提とするため）。
+ */
+export function resolveFaqWriteIndex(tenantId: string): string {
+  return `faq_${tenantId}`;
+}
+
+/**
  * 言語別インデックスが存在しないテナントのためのフォールバックリスト。
  * 先頭から順に試行し、最初にヒットしたものを使う想定。
  */


### PR DESCRIPTION
## 概要 (Phase69-2-E / Asana GID 1214821660260379, Wave1 クリティカルパス)

ES の **write path** と **read path** で index 名が不整合になっていた既存バグ（Phase33-c 起因）を修正。
write path を read/reindex に合わせて `faq_${tenantId}` に統一した。

### 修正前の不整合
| 経路 | index 名 |
|------|----------|
| write (upsert / exclude 同期 / delete) | `ES_FAQ_INDEX \|\| "faqs"`（≒ `faqs`） |
| read (hybrid / langRouter) | `faq_${tenantId}` |
| reindex (`SCRIPTS/sync-es.ts`) | `faq_${tenantId}` |

→ ES への upsert・`is_excluded_from_search` 同期・delete が検索 index に届かず、**ES 経路の除外同期が事実上機能していなかった**（pgvector 経路の除外は index 非依存で機能していたため、PATCH /exclude の DB 側除外は効いていた）。

## 変更ファイル

| ファイル | 内容 |
|---|---|
| `src/search/langIndex.ts` | `resolveFaqWriteIndex(tenantId)` を新設（`faq_${tenantId}` の単一正典） |
| `src/api/admin/knowledge/faqCrudRoutes.ts` | `upsertToEsAsync` / `syncIsExcludedToEsAsync` / `deleteFromEs` を統一。`deleteFromEs(tenantId, esDocId)` にシグネチャ変更 |
| `src/api/admin/knowledge/routes.ts` | `deleteFromEs` を doc の `recordTenantId` ベースに統一（global は `faq_global`） |
| `src/api/admin/knowledge-gaps/routes.ts` | `upsertToEsAsync` を統一 |
| `src/admin/http/faqAdminRoutes.ts` | `updateEsFaqDocument` を `row.tenant_id` ベースに統一 |
| `.env.example` | `ES_FAQ_INDEX` を deprecated 注記（FAQ 検索では不使用） |
| `docs/VPS_OPS_GUIDE.md` | ES index 命名規則を表で明記 |
| `src/search/faqIndexUnify.test.ts` | 単体: write index = read fallback index の一致検証（4 ケース） |
| `src/api/admin/knowledge/faqCrudEsIndex.test.ts` | 統合: POST/PATCH(exclude)/DELETE の ES URL が `faq_${tenantId}` を指すこと（旧 `faqs` でないこと）を検証（4 ケース） |

### 現用 write 経路の特定結果
`src/index.ts` の登録順を実機確認した結果、**3 つの FAQ write 経路が全て現役で登録済み**:
- `registerFaqCrudRoutes`（`faqCrudRoutes.ts`, `/v1/admin/knowledge/faq*`）— Phase30 CRUD 本流
- `registerFaqAdminRoutes`（`faqAdminRoutes.ts`, `/admin/faqs*`）— 旧 admin 経路、登録継続中
- `registerKnowledgeAdminRoutes`（`routes.ts`, `/v1/admin/knowledge/:id` DELETE）+ `registerKnowledgeGapPhase46Routes`（`knowledge-gaps/routes.ts`）

`faqAdminRoutes.ts` は「旧 vs 現用」ではなく**両方とも登録されている**ため、全経路を統一した。

## テスト結果
- 新規 8 テスト全 pass（単体 4 + 統合 4）
- 全体: **146 suites / 1743 tests pass**

## Gate 結果
| Gate | 結果 |
|------|------|
| Gate 1 `pnpm verify`（typecheck + test + admin-ui test） | PASS（1743 backend tests, admin-ui 18 tests） |
| Gate 1.5 `dead-code-check.sh` | PASS（dead export は既存の `flushPostHog` のみ、本変更と無関係。`resolveFaqWriteIndex` は 4 ファイルから参照） |
| Gate 2 `security-scan.sh` | PASS（CRITICAL/HIGH = 0） |
| Gate 2.5 Codex | skip（常時 OFF） |
| Gate 3 `pnpm build && admin-ui build` | PASS |

## scope 外の関連発見（follow-up 推奨）
`src/agent/knowledge/bookStructurizer.ts` / `src/lib/book-pipeline/embedAndStore.ts`（Phase44/47 book-pipeline）も
**同一の faq index に書き込んでおり**（`ES_FAQ_INDEX ?? 'faqs'`、doc は `source: "book"`）、
read path（hybrid）は `faq_${tenantId}` を `book_id`/`source` で読む前提。
つまり book 経路にも同じ index 不整合が残る。本タスク scope（FAQ write path 統一）外のため未変更とした。
別 Asana タスクで book-pipeline の index 統一を検討されたい。

---

## 本番 ES データ移行手順（手動・hkobayashi 専用 — このコード変更だけでは不十分）

このコード変更により**新規の** upsert/exclude/delete は `faq_${tenantId}` を対象にするが、
**既に `faqs` index に書き込まれた既存 doc は移行が必要**。以下を hkobayashi が手動実行する。
（VPS への接続コマンドは CLI lane では deploy_guard でブロックされるため、ここでは概要手順のみ記載。実際のコマンドは `docs/VPS_OPS_GUIDE.md` の re-index 節を参照。）

### 推奨: reindex スクリプトで再構築（最も安全）
`SCRIPTS/sync-es.ts` は faq_docs（DB が source-of-truth）から `faq_${tenantId}` を削除→再作成するため、
`faqs` index の中身を気にせず正しい状態を再構築できる。

1. deploy 後、VPS 上で `pnpm ts-node SCRIPTS/sync-es.ts --all` を実行（全テナントの `faq_<tenantId>` を再構築）。

### 旧 `faqs` index の後始末（reindex 完了・検証後）
1. `GET $ES_URL/faqs/_count` で旧 index の doc 数を確認。
2. （任意）`POST $ES_URL/_reindex`（source: `faqs` → dest: `faqs_backup_<date>`）でバックアップ。
3. `DELETE $ES_URL/faqs` で旧 index を削除。

### 反映検証
1. テストテナントで FAQ 1 件を `PATCH /v1/admin/knowledge/faq/<faqId>/exclude` で除外 ON。
2. `POST /agent.search` で該当 FAQ が結果に出ないことを確認。
3. `GET $ES_URL/faq_<tenantId>/_search`（`term: is_excluded_from_search=true`）で ES 側にもフラグが伝搬したことを直接確認。

> 詳細なコマンド（ES_URL 等の環境変数込み）は `docs/VPS_OPS_GUIDE.md` の「Elasticsearch re-index」節に記載済み。

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
