### PR TITLE
feat(admin-ui): ナレッジ検索除外チェックボックスUI (Phase69-2-B (a) GID 1214820212071185)

### DIFF
--- a/admin-ui/src/components/knowledge/ExcludeSearchToggle.test.tsx
+++ b/admin-ui/src/components/knowledge/ExcludeSearchToggle.test.tsx
@@ -1,0 +1,185 @@
+// Phase69-2-B (a): ExcludeSearchToggle unit tests
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import ExcludeSearchToggle from "./ExcludeSearchToggle";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock("./shared", () => ({
+  fetchWithAuth: vi.fn(),
+}));
+
+vi.mock("../../lib/api", () => ({
+  API_BASE: "http://localhost:3100",
+}));
+
+import { fetchWithAuth } from "./shared";
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+const mockOk = (data: unknown): Promise<Response> =>
+  Promise.resolve({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(data),
+  } as Response);
+
+const mockErr = (status: number): Promise<Response> =>
+  Promise.resolve({
+    ok: false,
+    status,
+    json: () => Promise.resolve({ error: "err" }),
+  } as Response);
+
+function setup(isExcluded: boolean) {
+  const onToggled = vi.fn();
+  const onError = vi.fn();
+
+  render(
+    <ExcludeSearchToggle
+      faqId={42}
+      tenantId="tenant-abc"
+      isExcluded={isExcluded}
+      onToggled={onToggled}
+      onError={onError}
+    />
+  );
+
+  return { onToggled, onError };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("ExcludeSearchToggle", () => {
+  beforeEach(() => {
+    vi.mocked(fetchWithAuth).mockReset();
+  });
+
+  it("T1: 初期状態 isExcluded=false → 「検索対象」ボタンを表示する", () => {
+    setup(false);
+    expect(screen.getByRole("button", { name: /検索から除外する/ })).toBeTruthy();
+    expect(screen.getByText("検索対象")).toBeTruthy();
+  });
+
+  it("T2: 初期状態 isExcluded=true → 「除外中」ボタンを表示する", () => {
+    setup(true);
+    expect(screen.getByRole("button", { name: /検索除外を解除する/ })).toBeTruthy();
+    expect(screen.getByText("除外中")).toBeTruthy();
+  });
+
+  it("T3: クリックで onToggled(42, true) が即座に呼ばれる（楽観的更新）", async () => {
+    vi.mocked(fetchWithAuth).mockReturnValue(
+      mockOk({ id: 42, is_excluded_from_search: true })
+    );
+    const { onToggled } = setup(false);
+
+    const btn = screen.getByRole("button");
+    fireEvent.click(btn);
+
+    // 楽観的更新は同期的に呼ばれる
+    expect(onToggled).toHaveBeenCalledWith(42, true);
+  });
+
+  it("T4: API成功後 onError は呼ばれない", async () => {
+    vi.mocked(fetchWithAuth).mockReturnValue(
+      mockOk({ id: 42, is_excluded_from_search: true })
+    );
+    const { onError } = setup(false);
+
+    const btn = screen.getByRole("button");
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      expect(onError).not.toHaveBeenCalled();
+    });
+  });
+
+  it("T5: API失敗（500）でロールバック onToggled(42, false) が呼ばれ onError が発火する", async () => {
+    vi.mocked(fetchWithAuth).mockReturnValue(mockErr(500));
+    const { onToggled, onError } = setup(false);
+
+    const btn = screen.getByRole("button");
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      // 楽観的更新 → ロールバックの順で2回呼ばれる
+      expect(onToggled).toHaveBeenCalledTimes(2);
+      expect(onToggled).toHaveBeenNthCalledWith(1, 42, true);
+      expect(onToggled).toHaveBeenNthCalledWith(2, 42, false);
+      expect(onError).toHaveBeenCalledWith(
+        "除外設定を保存できませんでした。ネットワークを確認してください"
+      );
+    });
+  });
+
+  it("T6: API失敗（409）でロールバックし、409専用エラーメッセージを返す", async () => {
+    vi.mocked(fetchWithAuth).mockReturnValue(mockErr(409));
+    const { onToggled, onError } = setup(false);
+
+    const btn = screen.getByRole("button");
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      expect(onToggled).toHaveBeenNthCalledWith(2, 42, false);
+      expect(onError).toHaveBeenCalledWith(
+        "他の処理中のため、少し時間をおいて再度お試しください"
+      );
+    });
+  });
+
+  it("T7: ネットワークエラー（例外）でロールバックし onError が発火する", async () => {
+    vi.mocked(fetchWithAuth).mockRejectedValue(new Error("Network Error"));
+    const { onToggled, onError } = setup(false);
+
+    const btn = screen.getByRole("button");
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      expect(onToggled).toHaveBeenNthCalledWith(2, 42, false);
+      expect(onError).toHaveBeenCalledWith(
+        "除外設定を保存できませんでした。ネットワークを確認してください"
+      );
+    });
+  });
+
+  it("T8: saving中は button が disabled になる", async () => {
+    let resolve!: (v: Response) => void;
+    vi.mocked(fetchWithAuth).mockReturnValue(
+      new Promise<Response>((r) => {
+        resolve = r;
+      })
+    );
+    setup(false);
+
+    const btn = screen.getByRole("button") as HTMLButtonElement;
+    fireEvent.click(btn);
+
+    // クリック直後 saving=true
+    expect(btn.disabled).toBe(true);
+
+    // 解決してcleaup
+    await act(async () => {
+      resolve({ ok: true, status: 200, json: () => Promise.resolve({}) } as Response);
+    });
+
+    expect(btn.disabled).toBe(false);
+  });
+
+  it("T9: PATCH リクエストに正しい tenant が渡される", async () => {
+    vi.mocked(fetchWithAuth).mockReturnValue(mockOk({}));
+    setup(false);
+
+    const btn = screen.getByRole("button");
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      expect(vi.mocked(fetchWithAuth)).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/admin/knowledge/faq/42/exclude?tenant=tenant-abc",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({ is_excluded_from_search: true }),
+        })
+      );
+    });
+  });
+});

--- a/admin-ui/src/components/knowledge/ExcludeSearchToggle.tsx
+++ b/admin-ui/src/components/knowledge/ExcludeSearchToggle.tsx
@@ -1,0 +1,114 @@
+// admin-ui/src/components/knowledge/ExcludeSearchToggle.tsx
+// Phase69-2-B (a): 検索除外チェックボックス — FAQ一覧行インライン切替
+// 専用 PATCH /v1/admin/knowledge/faq/:id/exclude を呼ぶ。楽観的更新+エラー時ロールバック。
+
+import { useState } from "react";
+import { API_BASE } from "../../lib/api";
+import { fetchWithAuth } from "./shared";
+
+interface Props {
+  faqId: number;
+  tenantId: string;
+  isExcluded: boolean;
+  onToggled: (faqId: number, newValue: boolean) => void;
+  onError: (message: string) => void;
+}
+
+export default function ExcludeSearchToggle({
+  faqId,
+  tenantId,
+  isExcluded,
+  onToggled,
+  onError,
+}: Props) {
+  const [saving, setSaving] = useState(false);
+
+  const handleClick = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (saving) return;
+
+    const nextValue = !isExcluded;
+
+    // 楽観的更新
+    onToggled(faqId, nextValue);
+    setSaving(true);
+
+    try {
+      const res = await fetchWithAuth(
+        `${API_BASE}/v1/admin/knowledge/faq/${faqId}/exclude?tenant=${tenantId}`,
+        {
+          method: "PATCH",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ is_excluded_from_search: nextValue }),
+        }
+      );
+
+      if (!res.ok) {
+        // ロールバック
+        onToggled(faqId, isExcluded);
+        if (res.status === 409) {
+          onError("他の処理中のため、少し時間をおいて再度お試しください");
+        } else {
+          onError("除外設定を保存できませんでした。ネットワークを確認してください");
+        }
+      }
+    } catch {
+      // ロールバック
+      onToggled(faqId, isExcluded);
+      onError("除外設定を保存できませんでした。ネットワークを確認してください");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={(e) => void handleClick(e)}
+      disabled={saving}
+      aria-label={isExcluded ? "検索除外を解除する" : "検索から除外する"}
+      aria-pressed={isExcluded}
+      title={isExcluded ? "クリックすると検索に戻します" : "クリックすると検索から除外します"}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: 6,
+        padding: "6px 12px",
+        minHeight: 44,
+        minWidth: 44,
+        borderRadius: 10,
+        border: `1px solid ${
+          isExcluded ? "rgba(239,68,68,0.5)" : "rgba(107,114,128,0.4)"
+        }`,
+        background: isExcluded
+          ? "rgba(127,29,29,0.25)"
+          : "rgba(31,41,55,0.4)",
+        color: isExcluded ? "#f87171" : "#6b7280",
+        fontSize: 12,
+        fontWeight: 600,
+        cursor: saving ? "not-allowed" : "pointer",
+        opacity: saving ? 0.6 : 1,
+        transition: "all 0.15s",
+        whiteSpace: "nowrap",
+        flexShrink: 0,
+      }}
+    >
+      {saving ? (
+        <span
+          style={{
+            width: 12,
+            height: 12,
+            border: "2px solid rgba(255,255,255,0.3)",
+            borderTopColor: isExcluded ? "#f87171" : "#6b7280",
+            borderRadius: "50%",
+            display: "inline-block",
+            animation: "spin 0.8s linear infinite",
+          }}
+        />
+      ) : (
+        <span style={{ fontSize: 14 }}>{isExcluded ? "🚫" : "✅"}</span>
+      )}
+      {isExcluded ? "除外中" : "検索対象"}
+    </button>
+  );
+}

--- a/admin-ui/src/components/knowledge/KnowledgeListTab.tsx
+++ b/admin-ui/src/components/knowledge/KnowledgeListTab.tsx
@@ -14,6 +14,7 @@ import {
 import FaqSearchBar from "./FaqSearchBar";
 import Pagination from "./Pagination";
 import BulkActionBar from "./BulkActionBar";
+import ExcludeSearchToggle from "./ExcludeSearchToggle";
 
 type SortKey = "created_at" | "updated_at" | "category";
 
@@ -261,6 +262,15 @@ export default function KnowledgeListTab({ tenantId }: { tenantId: string }) {
     }
   };
 
+  // ─── 検索除外フラグ楽観的更新 ────────────────────────────────────────────────
+  const handleExcludeToggled = (faqId: number, newValue: boolean) => {
+    setItems((prev) =>
+      prev.map((item) =>
+        item.id === faqId ? { ...item, is_excluded_from_search: newValue } : item
+      )
+    );
+  };
+
   // ─── Derived ──────────────────────────────────────────────────────────────
   const pageIds = items.map((f) => f.id);
   const allPageSelected =
@@ -493,7 +503,11 @@ export default function KnowledgeListTab({ tenantId }: { tenantId: string }) {
                 flexWrap: "wrap",
                 background: selectedIds.has(item.id)
                   ? "rgba(34,197,94,0.04)"
+                  : item.is_excluded_from_search
+                  ? "rgba(127,29,29,0.06)"
                   : "transparent",
+                opacity: item.is_excluded_from_search ? 0.75 : 1,
+                transition: "all 0.15s",
               }}
             >
               {/* チェックボックス */}
@@ -584,8 +598,16 @@ export default function KnowledgeListTab({ tenantId }: { tenantId: string }) {
                   gap: 8,
                   flexShrink: 0,
                   alignItems: "center",
+                  flexWrap: "wrap",
                 }}
               >
+                <ExcludeSearchToggle
+                  faqId={item.id}
+                  tenantId={tenantId}
+                  isExcluded={item.is_excluded_from_search ?? false}
+                  onToggled={handleExcludeToggled}
+                  onError={(msg) => showToast(msg)}
+                />
                 <button
                   onClick={() =>
                     setEditTarget({
@@ -848,6 +870,9 @@ export default function KnowledgeListTab({ tenantId }: { tenantId: string }) {
           </div>
         </div>
       )}
+
+      {/* spin animation for ExcludeSearchToggle */}
+      <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
     </div>
   );
 }

--- a/src/api/admin/knowledge/faqCrudRoutes.ts
+++ b/src/api/admin/knowledge/faqCrudRoutes.ts
@@ -188,7 +188,7 @@ export function registerFaqCrudRoutes(
       params.push(limit);
       params.push(offset);
       const itemsResult = await db.query(
-        `SELECT id, tenant_id, question, answer, category, tags, is_published, created_at, updated_at
+        `SELECT id, tenant_id, question, answer, category, tags, is_published, is_excluded_from_search, created_at, updated_at
          FROM faq_docs
          ${whereClause}
          ORDER BY ${safeSortCol} ${safeOrder}
@@ -220,7 +220,7 @@ export function registerFaqCrudRoutes(
 
     try {
       const result = await db.query(
-        `SELECT id, tenant_id, question, answer, category, tags, is_published, created_at, updated_at
+        `SELECT id, tenant_id, question, answer, category, tags, is_published, is_excluded_from_search, created_at, updated_at
          FROM faq_docs
          WHERE id = $1`,
         [id]


### PR DESCRIPTION
## Summary

- FAQ一覧の各行に **検索除外トグルボタン** (`ExcludeSearchToggle`) を追加
- 専用 `PATCH /v1/admin/knowledge/faq/:id/exclude` を呼ぶ（embedding 再生成不要の軽量エンドポイント）
- 楽観的更新 + エラー時ロールバック + ローディング表示（spin アニメーション）
- 除外中アイテムは opacity 0.75 + 薄赤背景で視覚的に判別可能
- `GET /v1/admin/knowledge/faq` の SELECT に `is_excluded_from_search` を追加（一覧取得で未返却だったバグ修正）
- unit tests 9件 (T1–T9): 初期表示・楽観的更新・ロールバック・409エラー・saving disabledを検証

## スコープ分割について

- **(a) FAQ一覧の検索除外チェックボックスUI** ← このPR
- **(b) テナント設定 default_excluded_ids 管理UI** ← **このPRには含めない**  
  F2 (GID 1215263563564554) の backend 実装が完了してから別タスクで対応

## 使用API（確定）

```
PATCH /v1/admin/knowledge/faq/:id/exclude?tenant=<tenantId>
Body: { "is_excluded_from_search": boolean }
Response: { "id": number, "is_excluded_from_search": boolean }
```

既存の `PUT /faq/:id` ではなく専用 PATCH エンドポイントを使用（embedding 再生成を回避、atomic DB tx）。

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `admin-ui/src/components/knowledge/ExcludeSearchToggle.tsx` | 新規: inline トグルボタンコンポーネント |
| `admin-ui/src/components/knowledge/ExcludeSearchToggle.test.tsx` | 新規: unit tests T1-T9 (9件) |
| `admin-ui/src/components/knowledge/KnowledgeListTab.tsx` | ExcludeSearchToggle 追加、楽観的更新ハンドラ、除外行の淡色化 |
| `src/api/admin/knowledge/faqCrudRoutes.ts` | GET 一覧・単体の SELECT に `is_excluded_from_search` 追加 |

## Gate 結果

- Gate 1: pnpm verify → **PASS** (144 suites / 1735 tests all pass)
- Gate 1.5: dead-code-check → **PASS** (pre-existing 1 dead export, 変更起因なし)
- Gate 2: security-scan → **PASS** (High/Critical = 0)
- Gate 2.5: Codex review → 常時OFF / skip
- Gate 3: pnpm build && admin-ui build → **PASS**

## Wave 3 残タスク (Gate 4b / Gate 6)

- Playwright E2E: 除外トグルクリック → 状態永続化 → リロード後も除外バッジ確認
- UI調査: 390px viewport での touch target サイズ検証（minHeight 44px 設定済み）