### PR TITLE
refactor(authz): isAllowedAdminRole を roleAuth.ts に集約 (3ファイル重複解消)

### DIFF
--- a/src/api/admin/analytics/eventAnalyticsRoutes.ts
+++ b/src/api/admin/analytics/eventAnalyticsRoutes.ts
@@ -9,6 +9,7 @@ import type { Express, Request, Response } from 'express';
 import { supabaseAuthMiddleware } from '../../../admin/http/supabaseAuthMiddleware';
 import { pool } from '../../../lib/db';
 import { logger } from '../../../lib/logger';
+import { isAllowedAdminRole } from "../../middleware/roleAuth";
 
 // whitelist: SQL injection防止のため group_by は固定列名のみ許可
 const ALLOWED_GROUP_BY = new Set(['event_type', 'page_url', 'visitor_id']);
@@ -57,12 +58,6 @@ function formatEventAnalytics(
   }));
 }
 
-const ALLOWED_ADMIN_ROLES = ["super_admin", "client_admin"] as const;
-type AllowedAdminRole = typeof ALLOWED_ADMIN_ROLES[number];
-function isAllowedAdminRole(role: unknown): role is AllowedAdminRole {
-  return typeof role === "string" &&
-         (ALLOWED_ADMIN_ROLES as readonly string[]).includes(role);
-}
 
 export function registerEventAnalyticsRoutes(app: Express): void {
   app.use('/v1/admin/analytics/events', supabaseAuthMiddleware);

--- a/src/api/admin/analytics/routes.ts
+++ b/src/api/admin/analytics/routes.ts
@@ -8,6 +8,7 @@ import { pool } from "../../../lib/db";
 import { createNotification, notificationExists } from "../../../lib/notifications";
 import { logger } from '../../../lib/logger';
 import { decryptText } from '../../../lib/crypto/textEncrypt';
+import { isAllowedAdminRole } from "../../middleware/roleAuth";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -114,13 +115,6 @@ function resolveTenantFilter(
     return fromQuery ?? null;
   }
   return jwtTenantId || null;
-}
-
-const ALLOWED_ADMIN_ROLES = ["super_admin", "client_admin"] as const;
-type AllowedAdminRole = typeof ALLOWED_ADMIN_ROLES[number];
-function isAllowedAdminRole(role: unknown): role is AllowedAdminRole {
-  return typeof role === "string" &&
-         (ALLOWED_ADMIN_ROLES as readonly string[]).includes(role);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/api/admin/chat-history/routes.ts
+++ b/src/api/admin/chat-history/routes.ts
@@ -9,6 +9,7 @@ import { getSessions, getMessages } from "./chatHistoryRepository";
 import { deleteSession } from "./deleteSessionRepository";
 import { createNotification } from "../../../lib/notifications";
 import { logger } from '../../../lib/logger';
+import { isAllowedAdminRole } from "../../middleware/roleAuth";
 
 /**
  * テナントIDをリクエストから解決する。
@@ -27,12 +28,6 @@ function resolveTenantFilter(
   return jwtTenantId; // client_admin は自テナント強制
 }
 
-const ALLOWED_ADMIN_ROLES = ["super_admin", "client_admin"] as const;
-type AllowedAdminRole = typeof ALLOWED_ADMIN_ROLES[number];
-function isAllowedAdminRole(role: unknown): role is AllowedAdminRole {
-  return typeof role === "string" &&
-         (ALLOWED_ADMIN_ROLES as readonly string[]).includes(role);
-}
 
 export function registerChatHistoryRoutes(app: Express): void {
   // 認証ミドルウェアを適用

--- a/src/api/middleware/roleAuth.ts
+++ b/src/api/middleware/roleAuth.ts
@@ -4,6 +4,22 @@ import type { NextFunction, Request, Response } from "express";
 
 export type UserRole = "super_admin" | "client_admin" | "anonymous";
 
+// 管理者ロール allowlist（admin 系ルートの認可判定で共有）。
+// 旧来 chat-history / analytics / eventAnalytics に重複定義されていたものを集約。
+export const ALLOWED_ADMIN_ROLES = ["super_admin", "client_admin"] as const;
+export type AllowedAdminRole = (typeof ALLOWED_ADMIN_ROLES)[number];
+/**
+ * actor のロールが admin 系（super_admin / client_admin）か判定する型ガード。
+ * セキュリティ要件: 認可ロールは app_metadata.role のみを信頼すること
+ * （user_metadata はクライアント編集可能なため特権判定に使用してはならない）。
+ */
+export function isAllowedAdminRole(role: unknown): role is AllowedAdminRole {
+  return (
+    typeof role === "string" &&
+    (ALLOWED_ADMIN_ROLES as readonly string[]).includes(role)
+  );
+}
+
 export interface AuthenticatedUser {
   id: string;
   email: string;


### PR DESCRIPTION
## 背景
PR #248 の削除エンドポイント認可監査の副産物。`isAllowedAdminRole` + `ALLOWED_ADMIN_ROLES` が **chat-history / analytics / eventAnalyticsRoutes の3ファイルに完全同一で重複定義**されていた。将来ロール追加時に修正漏れ（=認可の不整合）を生むリスク。

## 変更
- `src/api/middleware/roleAuth.ts`（既存の admin ロール正典）に `ALLOWED_ADMIN_ROLES` / `AllowedAdminRole` / `isAllowedAdminRole` を export 追加
- 3ファイルのローカル定義を削除し import に置換
- 機能変更なし（純粋な集約リファクタ）

## Gate
- Gate 1: typecheck 0 error / 関連 156 tests PASS（analyticsAuthGuard / deleteSession / roleAuth 含む）
- Gate 2: gitleaks clean
- Gate 3: 別途（backend tsc 通過済み、UIは無変更）

## 補足
- 認可ロールは `app_metadata.role` のみ信頼する原則を共通ヘルパーの doc コメントに明記
- merge しない（hk/Claude.ai 判断）