### PR TITLE
fix(admin): DELETE /admin/faqs/:id に faq_embeddings 連鎖削除を補完 (F1 HIGH, GID 1215263523759633)

### DIFF
--- a/src/admin/http/faqAdminRoutes.test.ts
+++ b/src/admin/http/faqAdminRoutes.test.ts
@@ -1,0 +1,76 @@
+// src/admin/http/faqAdminRoutes.test.ts
+// F1(HIGH): DELETE /admin/faqs/:id が faq_docs と faq_embeddings を連鎖削除することを検証。
+// faq_embeddings は物理FKを持たず metadata->>'faq_id' 参照のため ON DELETE CASCADE が効かず、
+// 旧ルートが embeddings を残して orphan を量産していた回帰を防ぐ。
+
+import express from "express";
+import request from "supertest";
+
+// ---------------------------------------------------------------------------
+// 外部依存モック（DELETE 経路は db.query のみ使用。残りは module ロード用にスタブ）
+// ---------------------------------------------------------------------------
+jest.mock("../../lib/db", () => ({
+  pool: { query: jest.fn() },
+}));
+jest.mock("./supabaseAuthMiddleware", () => ({
+  supabaseAuthMiddleware: (req: any, _res: any, next: any) => {
+    req.supabaseUser = { app_metadata: { tenant_id: "tenant-a", role: "client_admin" } };
+    next();
+  },
+}));
+jest.mock("../../agent/llm/openaiEmbeddingClient", () => ({ embedText: jest.fn() }));
+jest.mock("../../search/langIndex", () => ({
+  resolveFaqWriteIndex: jest.fn(() => "faq_tenant-a"),
+}));
+
+import { pool } from "../../lib/db";
+import { registerFaqAdminRoutes } from "./faqAdminRoutes";
+
+const mockQuery = (pool as unknown as { query: jest.Mock }).query;
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  registerFaqAdminRoutes(app);
+  return app;
+}
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+describe("DELETE /admin/faqs/:id — faq_embeddings 連鎖削除 (F1)", () => {
+  it("正常系: faq_docs 削除に続けて faq_embeddings も同一 tenant/faq_id で削除する", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 5 }] }) // faq_docs 削除
+      .mockResolvedValueOnce({ rowCount: 1, rows: [] }); // faq_embeddings 削除
+
+    const res = await request(makeApp()).delete("/admin/faqs/5");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, id: 5 });
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+
+    // 2 回目の呼び出しが faq_embeddings の連鎖削除であること
+    const [embedSql, embedParams] = mockQuery.mock.calls[1];
+    expect(embedSql).toMatch(/DELETE FROM faq_embeddings/);
+    expect(embedSql).toMatch(/metadata->>'faq_id'/);
+    expect(embedParams).toEqual(["tenant-a", 5]);
+  });
+
+  it("404: FAQ が存在しない場合は faq_embeddings 削除を実行しない", async () => {
+    mockQuery.mockResolvedValueOnce({ rowCount: 0, rows: [] }); // faq_docs 該当なし
+
+    const res = await request(makeApp()).delete("/admin/faqs/999");
+
+    expect(res.status).toBe(404);
+    expect(mockQuery).toHaveBeenCalledTimes(1); // embeddings 削除は呼ばれない
+  });
+
+  it("バリデーション: id が数値でない場合は 400 で DB を触らない", async () => {
+    const res = await request(makeApp()).delete("/admin/faqs/not-a-number");
+
+    expect(res.status).toBe(400);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+});

--- a/src/admin/http/faqAdminRoutes.ts
+++ b/src/admin/http/faqAdminRoutes.ts
@@ -436,7 +436,19 @@ export function registerFaqAdminRoutes(app: Express) {
         return res.status(404).json({ error: "FAQ not found" });
       }
 
-      // embeddings 側を faq_id などで紐付けるようにしたら、ここで一緒に削除
+      // F1(HIGH): faq_docs 削除に連鎖して faq_embeddings も削除する。
+      // faq_embeddings は物理 FK を持たず metadata->>'faq_id' で faq_docs を参照するため
+      // ON DELETE CASCADE が効かない (phase69_2d_faq_embedding_orphan_cleanup.sql 参照)。
+      // PUT /admin/faqs/:id の再 embed 経路と同じ WHERE で連鎖削除し orphan 量産を防ぐ。
+      await db.query(
+        `
+        DELETE FROM faq_embeddings
+        WHERE tenant_id = $1
+          AND metadata->>'faq_id' IS NOT NULL
+          AND (metadata->>'faq_id')::bigint = $2
+        `,
+        [tenantId, id]
+      );
 
       return res.json({ ok: true, id });
     } catch (err) {


### PR DESCRIPTION
## Summary
旧ルート `DELETE /admin/faqs/:id` が `faq_docs` のみ削除し `faq_embeddings` を残す **orphan embedding 量産源** (HIGH) を修正。`faqAdminRoutes.ts:439` の放置 TODO を実装で解消。

## 背景 / なぜ CASCADE で直らないか
`faq_embeddings` は物理 FK 列を持たず `metadata->>'faq_id'` (JSONB) で `faq_docs` を参照するため `ON DELETE CASCADE` が効かない。`src/migrations/phase69_2d_faq_embedding_orphan_cleanup.sql` (#246) が「物理FKは将来。当面は**アプリ層連鎖削除を正とし旧ルートの欠落を補完する**」と明記しており、本PRはその未完follow-up。

## 変更
- 404 ガード後に `faq_embeddings` の連鎖削除を追加
- WHERE は `PUT /admin/faqs/:id` の再embed経路と**完全に同一パターン** (`tenant_id` + `(metadata->>'faq_id')::bigint = id`) → 実証済みで一貫
- 順序: faq_docs 削除(RETURNING id, 404判定) → faq_embeddings 削除 (どちらも await)

## テスト (新規 `faqAdminRoutes.test.ts`, 3件 PASS)
- 正常系: faq_docs 削除に続き faq_embeddings を同一 tenant/faq_id で削除することを assert
- 404: FAQ 不存在時は embeddings 削除を呼ばない
- バリデーション: id 非数値 → 400・DB 不触

## DoD
- [x] orphan 量産源の修正 (正常 DELETE が embeddings も削除)
- [x] テナント分離維持 (tenant_id を WHERE に含む)
- [x] typecheck✓ / test 3/3✓ / oxlint 新規違反0✓
- [x] 変更は admin route + test のみ

## 備考
完全な原子性 (faq_docs と faq_embeddings の単一トランザクション化) は本ファイル全体が非トランザクション方式のため将来改善とする。本PRで「正常削除経路の orphan 発生」は解消。

## Gate
typecheck✓ / test✓ / skip Gate2.5(常時OFF・小規模src+test) / **auto-merge は enable しない**

🤖 Generated with [Claude Code](https://claude.com/claude-code)