### PR TITLE
fix(loop): aggregator reconcile を全 pr_created 対象化 (非gate PR取りこぼし解消, GID 1215263653870104)

### DIFF
--- a/SCRIPTS/r2c-codex-aggregator.sh
+++ b/SCRIPTS/r2c-codex-aggregator.sh
@@ -2,11 +2,11 @@
 # r2c-codex-aggregator.sh — R2C 24h ループ Codex Gate 2.5 集計
 #
 # 用途:
-#   queue (.claude/queue/r2c-queue.db) から
-#     gate_2_5_required=1 AND state='pr_created'
-#   のタスクを抽出し、`gh pr view` で merged 状態を確認。
-#   既に merged なら state を `merged` に更新、未 merge なら朝の Codex review
-#   待ち件数として集計する。
+#   queue (.claude/queue/r2c-queue.db) から state='pr_created' の全タスクを抽出し、
+#   `gh pr view` で merged 状態を確認 (reconcile)。既に merged なら state を `merged`
+#   に更新する。gate_2_5_required≠1 の CLI 直接 PR も対象 (GID 1215263653870104)。
+#   未 merge かつ gate_2_5_required=1 の OPEN PR のみ朝の Codex review 待ち件数として
+#   集計する (gate_2_5_required≠1 の OPEN PR は人間マージ待ちで Codex 対象外)。
 #   morning-report.sh から --output-block で呼び出され、Slack Block Kit の
 #   1 セクションとして結果を返す。
 #

--- a/SCRIPTS/r2c-codex-aggregator.sh
+++ b/SCRIPTS/r2c-codex-aggregator.sh
@@ -58,10 +58,14 @@ command -v jq >/dev/null 2>&1 || { echo "ERROR: jq required" >&2; exit 1; }
 # ─── Collect rows from queue (graceful when DB absent) ───
 pending_rows=""
 if command -v sqlite3 >/dev/null 2>&1 && [[ -r "$QUEUE_DB" ]]; then
+    # reconcile(merge同期)は全 pr_created を対象にする。gate_2_5_required で絞ると
+    # CLI 直接 PR 化タスク(gate_2_5_required≠1)が merged 後も pr_created に永久残留する
+    # (GID 1215263653870104)。merge 同期と Gate2.5 レビュー集約は別関心事なので分離し、
+    # gate_2_5_required は列として取得して下流の「Codex 待ち」集計だけに使う。
     pending_rows="$(sqlite3 -separator '|' "$QUEUE_DB" \
-        "SELECT id, asana_gid, asana_name, pr_number, pr_url \
+        "SELECT id, asana_gid, asana_name, pr_number, pr_url, COALESCE(gate_2_5_required, 0) \
          FROM tasks \
-         WHERE gate_2_5_required = 1 AND state = 'pr_created' \
+         WHERE state = 'pr_created' \
          ORDER BY pr_number ASC;" 2>/dev/null || true)"
 else
     log "WARN: queue DB not found or sqlite3 missing (db=${QUEUE_DB}) — empty result"
@@ -72,7 +76,7 @@ merged_count=0
 waiting_lines=()
 
 if [[ -n "$pending_rows" ]]; then
-    while IFS='|' read -r task_id _asana_gid asana_name pr_number pr_url; do
+    while IFS='|' read -r task_id _asana_gid asana_name pr_number pr_url gate_2_5_required; do
         [[ -z "${pr_number:-}" ]] && continue
         pr_state="UNKNOWN"
         merged_at="null"
@@ -94,10 +98,17 @@ if [[ -n "$pending_rows" ]]; then
             fi
             log "merged: PR #${pr_number} (task=${task_id})"
         elif [[ "$pr_state" == "OPEN" ]]; then
-            waiting_count=$((waiting_count + 1))
-            short_name="$(printf '%s' "$asana_name" | cut -c1-40)"
-            url="${pr_url:-https://github.com/${REPO_SLUG}/pull/${pr_number}}"
-            waiting_lines+=("• <${url}|PR #${pr_number}> ${short_name}")
+            # 「Codex Gate 2.5 待ち」は gate_2_5_required=1 の OPEN PR のみ計上する。
+            # gate_2_5_required≠1 の OPEN PR は人間マージ待ちであり Codex レビュー対象ではない
+            # (reconcile では拾うが Codex 待ち集計には混ぜない)。
+            if [[ "${gate_2_5_required:-0}" == "1" ]]; then
+                waiting_count=$((waiting_count + 1))
+                short_name="$(printf '%s' "$asana_name" | cut -c1-40)"
+                url="${pr_url:-https://github.com/${REPO_SLUG}/pull/${pr_number}}"
+                waiting_lines+=("• <${url}|PR #${pr_number}> ${short_name}")
+            else
+                log "open (awaiting merge, non-gate): PR #${pr_number} (task=${task_id})"
+            fi
         else
             log "skip: PR #${pr_number} state=${pr_state} (neither merged nor open)"
         fi


### PR DESCRIPTION
## Summary
24h ループの reconcile が **gate_2_5_required=1 縛り**で、CLI 直接 PR 化タスク(gate_2_5_required≠1)を取りこぼし、PR が merged になっても queue が `pr_created` のまま永久残留する穴を修正。**今日作った PR #255/#256 のような CLI 直接 PR がまさにこの穴を踏む**状態だった。

## 根本原因
`r2c-codex-aggregator.sh` の reconcile SELECT が `WHERE gate_2_5_required = 1 AND state='pr_created'`。reconcile(merge同期) と Gate2.5(レビュー集約) は別関心事なのに AND で束ねていた (2026-05-31 id=48/PR#239 が残留→手動SQL同期した実績)。

## 修正
- SELECT を `WHERE state='pr_created'` に拡大 → **全 pr_created を GitHub mergedAt と突合**して merged へ落とす
- `gate_2_5_required` は列取得し「Codex Gate 2.5 待ち」集計(OPEN時)のみに使用。非gateのOPEN PRは人間マージ待ちとして分離(log のみ・Codex待ちに混ぜない)
- state遷移ロジック/手動SQL非正規化方針は従来通り維持

## 検証 (`--dry-run` + 捨てタスクfixture, 実機確認後に削除)
| fixture | 期待 | 結果 |
|---|---|---|
| gate=0 / PR #250 merged | reconcile が merged 検出 (旧は取りこぼし) | ✓ `merged: PR #250` |
| gate=1 / PR #256 open | Codex Gate2.5 待ちに計上 | ✓ `待ち: 1件` |

`bash -n` 構文チェック✓ / DB は dry-run で不変・fixture は削除済み

## Gate
bash -n✓ / dry-run実機✓ / skip Gate2.5(shell script, no src behavior) / **auto-merge は enable しない**

🤖 Generated with [Claude Code](https://claude.com/claude-code)