### PR TITLE
refactor(lint): 不要import7件削除 + baseline 80→73 ratchet [Phase B] (GID 1215153474115121)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "typecheck": "tsc --noEmit",
-    "lint": "oxlint src admin-ui/src --max-warnings 80",
+    "lint": "oxlint src admin-ui/src --max-warnings 73",
     "test": "jest --runInBand",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",

--- a/src/agent/orchestrator/sales/closePromptBuilder.ts
+++ b/src/agent/orchestrator/sales/closePromptBuilder.ts
@@ -1,7 +1,7 @@
 // src/agent/orchestrator/sales/closePromptBuilder.ts
 // Phase14: Close-flow helper — final decision / closing messages.
 
-import { getSalesTemplate, type SalesPhase, type SalesTemplate } from "./salesRules";
+import { getSalesTemplate, type SalesPhase } from "./salesRules";
 import type { BuiltSalesPromptResult } from "./proposePromptBuilder";
 
 /**

--- a/src/agent/orchestrator/sales/recommendPromptBuilder.ts
+++ b/src/agent/orchestrator/sales/recommendPromptBuilder.ts
@@ -1,7 +1,7 @@
 // src/agent/orchestrator/sales/recommendPromptBuilder.ts
 // Phase14: Recommend-flow helper — similar to Propose, but used for course/module recommendations.
 
-import { getSalesTemplate, type SalesPhase, type SalesTemplate } from "./salesRules";
+import { getSalesTemplate, type SalesPhase } from "./salesRules";
 import type { BuiltSalesPromptResult } from "./proposePromptBuilder";
 
 /**

--- a/src/api/admin/avatar/routes.ts
+++ b/src/api/admin/avatar/routes.ts
@@ -5,7 +5,6 @@
 import type { Express, Request, Response } from "express";
 import { z } from "zod";
 import { supabaseAuthMiddleware } from "../../../admin/http/supabaseAuthMiddleware";
-import { Pool } from "pg";
 import { supabaseAdmin } from "../../../auth/supabaseClient";
 import multer from 'multer';
 import { logger } from '../../../lib/logger';

--- a/src/api/admin/evaluations/routes.test.ts
+++ b/src/api/admin/evaluations/routes.test.ts
@@ -22,9 +22,7 @@ jest.mock("./evaluationsRepository", () => ({
 import {
   listEvaluations,
   getDetailedStats,
-  getEvaluationsBySession,
   updateOutcome,
-  getKpiStats,
   approveTuningRule,
   rejectTuningRule,
 } from "./evaluationsRepository";

--- a/src/api/avatar/anamRoutes.ts
+++ b/src/api/avatar/anamRoutes.ts
@@ -9,7 +9,6 @@
 //   'lemonslice' または未設定なら { enabled: false, avatarProvider: 'lemonslice' } を返す。
 
 import type { Express, Request, Response, RequestHandler } from 'express';
-import { Pool } from 'pg';
 import type { AuthedRequest } from '../../agent/http/authMiddleware';
 import { pool as globalPool } from '../../lib/db';
 import { logger } from '../../lib/logger';

--- a/src/lib/billing/usageTracker.ts
+++ b/src/lib/billing/usageTracker.ts
@@ -1,7 +1,6 @@
 // src/lib/billing/usageTracker.ts
 // Phase32: API使用量の非同期記録（fire-and-forget）
 
-import { Pool } from 'pg';
 import type pino from 'pino';
 import { calculateLLMCostCents, calculateBillingAmountCents } from './costCalculator';
 


### PR DESCRIPTION
## Summary
oxlint **Phase B**（#255 Phase A の上に stack）。100%安全な「型のみ/テストのみ」の不要 import を7件削除し `--max-warnings` を **80→73** に ratchet。

> ⚠️ base は `feature/1215153474115121-oxlint-baseline` (#255)。#255 マージ後に base を main へ切替え推奨。

## 削除した7件（実行時・セキュリティ影響なし）
| ファイル | import |
|---|---|
| api/admin/avatar/routes.ts | `Pool` (pg, 型未使用) |
| api/avatar/anamRoutes.ts | `Pool` (実際は lib/db の pool 使用) |
| lib/billing/usageTracker.ts | `Pool` (未使用) |
| sales/closePromptBuilder.ts | `type SalesTemplate` |
| sales/recommendPromptBuilder.ts | `type SalesTemplate` |
| evaluations/routes.test.ts | `getEvaluationsBySession`, `getKpiStats` (テスト未使用) |

## なぜ `oxlint --fix` を使わなかったか（重要）
`--fix` の `unicorn(no-useless-fallback-in-spread)` が `...(x ?? {})` の `?? {}` を除去し、**TS厳格モードで TS2698 を2ファイルで誘発**（agentSearchRoute.ts / llmMultiStepPlannerRuntime.ts）。本コードベースの spread パターンと衝突するため auto-fix は不採用、**手動で型/テストのみ削除**。

## 🚩 削除しなかった「未使用 import」= 潜在バグとして要調査（本PRでは触らない）
oxlint の「未使用」には dead code でなく**配線漏れ**の疑いが混在（memory: dead export 誤検出の教訓）:
- **`setSalesTemplateProvider`** (notionSalesTemplatesProvider.ts): `setSalesTemplateProvider(` の呼び出しが src 全体に皆無 → **Notion 売上テンプレ provider が未登録＝未配線機能の疑い**（「Phase44-46 未配線機能」タスクと重複の可能性）
- **`superAdminMiddleware`** (index.ts): import のみで未適用（knowledge-gaps は自前 import で適用）→ 残骸 or 配線漏れ、**セキュリティ入口なので要レビュー**
- `getSalesSessionMeta` (dialogAgent.ts), `DEFAULT_LANG` (langRouter.ts): 残骸 import 候補

## 後続 (Phase B-2 以降)
declared-but-unused 40件 / no-new-array 9 / no-useless-escape 5 / 上記🚩4件の判定 → 個別 careful 対応。

## Gate
typecheck✓ / lint✓(73でexit0・72でexit1) / evaluations test 8/8✓ / skip Gate2.5(import削除のみ) / **auto-merge は enable しない**

🤖 Generated with [Claude Code](https://claude.com/claude-code)