### PR TITLE
refactor(lint): 真dead宣言7件削除 + baseline 73→66 [Phase B-2] (GID 1215153474115121)

### DIFF
--- a/admin-ui/src/pages/admin/conversion/index.tsx
+++ b/admin-ui/src/pages/admin/conversion/index.tsx
@@ -33,13 +33,6 @@ interface ABExperiment {
   created_at: string;
 }
 
-interface ABVariantResult {
-  total: number;
-  converted: number;
-  conversion_rate: number;
-  avg_judge_score: number | null;
-}
-
 // ------------------------------------------------------------------ //
 // Styles
 // ------------------------------------------------------------------ //

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "typecheck": "tsc --noEmit",
-    "lint": "oxlint src admin-ui/src --max-warnings 73",
+    "lint": "oxlint src admin-ui/src --max-warnings 66",
     "test": "jest --runInBand",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",

--- a/src/agent/flow/loopDetector.ts
+++ b/src/agent/flow/loopDetector.ts
@@ -2,8 +2,6 @@
 
 import type { FlowState } from "../dialog/flowContextStore";
 
-type LoopType = "state_pattern" | "clarify_signature";
-
 export function detectStatePatternLoop(
   recentStates: FlowState[],
   windowTurns: number

--- a/src/agent/http/authMiddleware.ts
+++ b/src/agent/http/authMiddleware.ts
@@ -29,9 +29,6 @@ function timingSafeCompare(a: string, b: string): boolean {
   return crypto.timingSafeEqual(Buffer.from(a), Buffer.from(b));
 }
 
-type TenantConfigResolver = (
-  tenantId: string
-) => TenantConfig | undefined;
 export type ApiKeyTenantResolver = (
   apiKeyHash: string
 ) => TenantConfig | undefined;

--- a/src/api/admin/evaluations/routes.test.ts
+++ b/src/api/admin/evaluations/routes.test.ts
@@ -50,18 +50,6 @@ function makeApp(role: Role = "client_admin", tenantId = "tenant-a") {
   return app;
 }
 
-function makeAppNoAuth() {
-  const app = express();
-  app.use(express.json());
-  // supabaseAuthMiddleware をモック → 401 を返す
-  jest.mock("../../../admin/http/supabaseAuthMiddleware", () => ({
-    supabaseAuthMiddleware: (_req: any, res: any) =>
-      res.status(401).json({ error: "Unauthorized" }),
-  }));
-  registerEvaluationRoutes(app);
-  return app;
-}
-
 const NOW = new Date().toISOString();
 
 const EVAL_ROW = {

--- a/src/api/admin/feedback/feedbackAuthGuard.test.ts
+++ b/src/api/admin/feedback/feedbackAuthGuard.test.ts
@@ -273,7 +273,6 @@ describe('feedback management routes — super_admin-only routes reject client_a
 describe('feedback management routes — stale JWT (user_metadata.role only) → 403', () => {
   MGMT_ALL_ROUTES.forEach(({ method, path }) => {
     it(`${method.toUpperCase()} ${path} — stale JWT → 403`, async () => {
-      const app = makeAppMgmt(null);
       // Inject full user object with user_metadata only (stale JWT)
       const staleApp = express();
       staleApp.use(express.json());

--- a/src/lib/book-pipeline/pipeline.test.ts
+++ b/src/lib/book-pipeline/pipeline.test.ts
@@ -55,10 +55,6 @@ function makePages(text: string, pageNumber = 1): PageText[] {
   return [{ pageNumber, text }];
 }
 
-function makeLongText(chars: number): string {
-  return "あ".repeat(chars);
-}
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function makeDb(overrides: { queryFn?: (sql: string, params?: any[]) => Promise<unknown> } = {}) {
   const rows: unknown[] = [];

--- a/src/search/hybrid.ts
+++ b/src/search/hybrid.ts
@@ -14,7 +14,6 @@ export interface Hit {
   metadata?: Record<string, unknown>;
 }
 type EsHit = { _id: string; _source?: { text?: string; [key: string]: unknown }; _score?: number };
-type EsSearchResult = { hits?: { hits?: EsHit[] } };
 const BUDGET = Number(process.env.HYBRID_TIMEOUT_MS || 600);
 const ALLOW_MOCK = process.env.HYBRID_MOCK_ON_FAILURE === "1";
 // Phase33 C: フィーチャーフラグ（LANG_SEARCH_ENABLED=1 で有効化）


### PR DESCRIPTION
## Summary
oxlint **Phase B-2**（#258 の上に stack）。「declared but never used」37件を並列分析し、**真に安全な dead 7件のみ**削除して baseline を **73→66** に ratchet。

> ⚠️ base は #258 ブランチ。マージ順: #255 → #258 → 本PR。

## 🔑 最重要の発見（このPRの一番の価値）
37件の「未使用宣言」を分類した結果、**過半数は削除してはいけない**:

| 分類 | 件数 | 対応 |
|---|---|---|
| 真dead (型/テスト足場) | **7** | 本PRで削除 |
| **未配線機能** | **16** | **削除禁止** → 「Phase44-46 未配線機能の検知と回収」へ集約 |
| セキュリティ隣接 | 2 | safePath / SAFE_METHODS → 要レビュー |
| 残(borderline等) | 12 | 個別判断 |

**未配線機能16件**（例: `createNotionSalesTemplateProvider` / `createNotionSalesLogSink` / `runAutoTuningCheck` / `CrewAgent` / `ClarifyLogWriter` / `createAuthMiddleware` / avatar `storeAvatarImageEncrypted`/`decryptStoredAvatarImage` / `registerAvatarToLemonslice` / `normalize`/`validateVoiceSettings` 等）は「実装済みだが呼ばれていない＝配線漏れ」。**一律削除すると回収すべき機能を消す**ため本PRでは保全。

## 削除した7件（非export・参照0・実行時/挙動影響なし）
- 型エイリアス: `LoopType` / `EsSearchResult` / `TenantConfigResolver` / `ABVariantResult`(admin-ui)
- テスト足場: `makeAppNoAuth` / `makeLongText` / `app`(staleApp に置換済の死変数)

## Gate
typecheck✓ / lint✓(66でexit0・65でexit1) / 変更3テスト 71/71✓ / skip Gate2.5(dead宣言削除のみ) / **auto-merge は enable しない**

## 後続
- 未配線16件 → Phase44-46 タスクへ（配線 or 正式廃止）
- セキュリティ隣接 + 残(no-new-array 9 / no-useless-escape 5 / param 3) → 個別

🤖 Generated with [Claude Code](https://claude.com/claude-code)