### PR TITLE
refactor(lint): 置換済み重複3件RETIRE + baseline 66→63 [Phase B-3] (GID 1215153474115121)

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "typecheck": "tsc --noEmit",
-    "lint": "oxlint src admin-ui/src --max-warnings 66",
+    "lint": "oxlint src admin-ui/src --max-warnings 63",
     "test": "jest --runInBand",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",

--- a/src/agent/crew/CrewAgent.ts
+++ b/src/agent/crew/CrewAgent.ts
@@ -14,22 +14,5 @@ export type CrewAgentOutput = {
   meta?: DialogAgentMeta;
 };
 
-class CrewAgent {
-  name: string;
-  description: string;
-  private executor: (input: CrewAgentInput) => Promise<CrewAgentOutput>;
-
-  constructor(opts: {
-    name: string;
-    description: string;
-    executor: (input: CrewAgentInput) => Promise<CrewAgentOutput>;
-  }) {
-    this.name = opts.name;
-    this.description = opts.description;
-    this.executor = opts.executor;
-  }
-
-  async run(input: CrewAgentInput): Promise<CrewAgentOutput> {
-    return this.executor(input);
-  }
-}
+// NOTE: CrewAgent クラス本体は CrewGraph (LangGraph 統一) に置換済みのため削除。
+// CrewAgentInput / CrewAgentOutput 型は CrewOrchestrator 等が参照するため保持する。

--- a/src/agent/tools/synthesisTool.ts
+++ b/src/agent/tools/synthesisTool.ts
@@ -16,20 +16,6 @@ import type { SimilarPattern } from '../../api/events/similarUserMatcher';
 import { getPool } from '../../lib/db';
 import { buildSentimentHint } from '../../lib/sentiment/hint';
 
-async function getTenantsSystemPrompt(tenantId: string): Promise<string | null> {
-  try {
-    const pool = getPool();
-    const result = await pool.query<{ system_prompt: string | null }>(
-      'SELECT system_prompt FROM tenants WHERE id = $1',
-      [tenantId],
-    );
-    const val = result.rows[0]?.system_prompt;
-    return val && val.trim() ? val.trim() : null;
-  } catch {
-    return null;
-  }
-}
-
 async function getTenantsPromptWithVariant(tenantId: string): Promise<{
   prompt: string | null;
   variantId: string | null;

--- a/src/api/admin/tuning/tuningRulesRepository.ts
+++ b/src/api/admin/tuning/tuningRulesRepository.ts
@@ -214,28 +214,6 @@ export async function deleteRule(
 // テナント固有システムプロンプト取得
 // ---------------------------------------------------------------------------
 
-/**
- * tenants.system_prompt を取得する。
- * カラムが存在しない / 空の場合は null を返す。
- * テーブルまたはカラムが存在しない場合は null を返す（migration未実行環境でも安全）。
- */
-async function getTenantSystemPrompt(
-  tenantId: string,
-): Promise<string | null> {
-  const pool = getPool();
-  try {
-    const result = await pool.query<{ system_prompt: string | null }>(
-      `SELECT system_prompt FROM tenants WHERE id = $1`,
-      [tenantId],
-    );
-    const raw = result.rows[0]?.system_prompt;
-    return raw && raw.trim() ? raw.trim() : null;
-  } catch {
-    // カラム未追加など（migration前のデプロイ）は null を返す
-    return null;
-  }
-}
-
 // ---------------------------------------------------------------------------
 // プロンプト注入用ユーティリティ
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
未配線16件の triage 結果、「過去の cleanup で意図的に de-export 済み・**機能損失ゼロ**」の高確度 RETIRE 3件を削除。baseline **66→63**。（#259 の上に stack）

> ⚠️ base は #259。マージ順: #255 → #258 → #259 → 本PR。

## 削除（すべて置換済み重複・機能損失なし）
| シンボル | 根拠 |
|---|---|
| `getTenantsSystemPrompt` (synthesisTool) | 上位互換 `getTenantsPromptWithVariant`(A/B variant, Phase46) が稼働中・完全重複 |
| `getTenantSystemPrompt` (tuningRulesRepository) | private・呼出元0・同一SQLの重複 |
| `class CrewAgent` (型は保持) | commit 575385a「ts-prune確認済み」で class export 除去済・CrewGraph(LangGraph)へ統合済 |

## triage 全体像（残りは本PR対象外）
16件を WIRE/RETIRE/KEEP に分類（実コード+git履歴ベース）。**多くは過去cleanupの de-export 残骸**:
- **WIRE候補(要product判断)**: `buildClarifyPrompt`(export漏れ) / `getDefaultAvatarImageUrl` / `runAutoTuningCheck`(完成済・cron未配線)
- **RETIRE(要検証/サインオフ)**: `createAuthMiddleware`(@deprecated・security) / avatar `storeAvatarImageEncrypted`・`decryptStoredAvatarImage`(PII・Supabase Storageに置換済) / `normalize`・`validateVoiceSettings`(検証ロジック)
- **KEEP**: `createNotionSalesTemplateProvider`(fallback) / `registerAvatarToLemonslice`(課金連携・要audit) / `isOpenVikingEnabled`(Phase47 pending) / `metricsCollector`(設計上non-export)

→ 全件 Phase44-46 タスク(GID 1215114203188918)へ集約済(コメント投稿)。

## Gate
typecheck✓ / lint✓(63でexit0・62でexit1) / crew・tuning test 32✓ / skip Gate2.5(重複削除) / **auto-merge は enable しない**

🤖 Generated with [Claude Code](https://claude.com/claude-code)