### PR TITLE
refactor(lint): Phase B net-cleanup — import7+dead7+dup3削除 + baseline 80→63 ratchet (GID 1215153474115121)

### DIFF
--- a/admin-ui/src/pages/admin/conversion/index.tsx
+++ b/admin-ui/src/pages/admin/conversion/index.tsx
@@ -33,13 +33,6 @@ interface ABExperiment {
   created_at: string;
 }
 
-interface ABVariantResult {
-  total: number;
-  converted: number;
-  conversion_rate: number;
-  avg_judge_score: number | null;
-}
-
 // ------------------------------------------------------------------ //
 // Styles
 // ------------------------------------------------------------------ //

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "typecheck": "tsc --noEmit",
-    "lint": "oxlint src admin-ui/src --max-warnings 73",
+    "lint": "oxlint src admin-ui/src --max-warnings 66",
     "test": "jest --runInBand",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "typecheck": "tsc --noEmit",
-    "lint": "oxlint src admin-ui/src --max-warnings 66",
+    "lint": "oxlint src admin-ui/src --max-warnings 63",
     "test": "jest --runInBand",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
     "typecheck": "tsc --noEmit",
-    "lint": "oxlint src admin-ui/src --max-warnings 80",
+    "lint": "oxlint src admin-ui/src --max-warnings 73",
     "test": "jest --runInBand",
     "test:e2e": "playwright test",
     "test:e2e:ui": "playwright test --ui",

--- a/src/agent/crew/CrewAgent.ts
+++ b/src/agent/crew/CrewAgent.ts
@@ -14,22 +14,5 @@ export type CrewAgentOutput = {
   meta?: DialogAgentMeta;
 };
 
-class CrewAgent {
-  name: string;
-  description: string;
-  private executor: (input: CrewAgentInput) => Promise<CrewAgentOutput>;
-
-  constructor(opts: {
-    name: string;
-    description: string;
-    executor: (input: CrewAgentInput) => Promise<CrewAgentOutput>;
-  }) {
-    this.name = opts.name;
-    this.description = opts.description;
-    this.executor = opts.executor;
-  }
-
-  async run(input: CrewAgentInput): Promise<CrewAgentOutput> {
-    return this.executor(input);
-  }
-}
+// NOTE: CrewAgent クラス本体は CrewGraph (LangGraph 統一) に置換済みのため削除。
+// CrewAgentInput / CrewAgentOutput 型は CrewOrchestrator 等が参照するため保持する。

--- a/src/agent/flow/loopDetector.ts
+++ b/src/agent/flow/loopDetector.ts
@@ -2,8 +2,6 @@
 
 import type { FlowState } from "../dialog/flowContextStore";
 
-type LoopType = "state_pattern" | "clarify_signature";
-
 export function detectStatePatternLoop(
   recentStates: FlowState[],
   windowTurns: number

--- a/src/agent/http/authMiddleware.ts
+++ b/src/agent/http/authMiddleware.ts
@@ -29,9 +29,6 @@ function timingSafeCompare(a: string, b: string): boolean {
   return crypto.timingSafeEqual(Buffer.from(a), Buffer.from(b));
 }
 
-type TenantConfigResolver = (
-  tenantId: string
-) => TenantConfig | undefined;
 export type ApiKeyTenantResolver = (
   apiKeyHash: string
 ) => TenantConfig | undefined;

--- a/src/agent/orchestrator/sales/closePromptBuilder.ts
+++ b/src/agent/orchestrator/sales/closePromptBuilder.ts
@@ -1,7 +1,7 @@
 // src/agent/orchestrator/sales/closePromptBuilder.ts
 // Phase14: Close-flow helper — final decision / closing messages.
 
-import { getSalesTemplate, type SalesPhase, type SalesTemplate } from "./salesRules";
+import { getSalesTemplate, type SalesPhase } from "./salesRules";
 import type { BuiltSalesPromptResult } from "./proposePromptBuilder";
 
 /**

--- a/src/agent/orchestrator/sales/recommendPromptBuilder.ts
+++ b/src/agent/orchestrator/sales/recommendPromptBuilder.ts
@@ -1,7 +1,7 @@
 // src/agent/orchestrator/sales/recommendPromptBuilder.ts
 // Phase14: Recommend-flow helper — similar to Propose, but used for course/module recommendations.
 
-import { getSalesTemplate, type SalesPhase, type SalesTemplate } from "./salesRules";
+import { getSalesTemplate, type SalesPhase } from "./salesRules";
 import type { BuiltSalesPromptResult } from "./proposePromptBuilder";
 
 /**

--- a/src/agent/tools/synthesisTool.ts
+++ b/src/agent/tools/synthesisTool.ts
@@ -16,20 +16,6 @@ import type { SimilarPattern } from '../../api/events/similarUserMatcher';
 import { getPool } from '../../lib/db';
 import { buildSentimentHint } from '../../lib/sentiment/hint';
 
-async function getTenantsSystemPrompt(tenantId: string): Promise<string | null> {
-  try {
-    const pool = getPool();
-    const result = await pool.query<{ system_prompt: string | null }>(
-      'SELECT system_prompt FROM tenants WHERE id = $1',
-      [tenantId],
-    );
-    const val = result.rows[0]?.system_prompt;
-    return val && val.trim() ? val.trim() : null;
-  } catch {
-    return null;
-  }
-}
-
 async function getTenantsPromptWithVariant(tenantId: string): Promise<{
   prompt: string | null;
   variantId: string | null;

--- a/src/api/admin/avatar/routes.ts
+++ b/src/api/admin/avatar/routes.ts
@@ -5,7 +5,6 @@
 import type { Express, Request, Response } from "express";
 import { z } from "zod";
 import { supabaseAuthMiddleware } from "../../../admin/http/supabaseAuthMiddleware";
-import { Pool } from "pg";
 import { supabaseAdmin } from "../../../auth/supabaseClient";
 import multer from 'multer';
 import { logger } from '../../../lib/logger';

--- a/src/api/admin/evaluations/routes.test.ts
+++ b/src/api/admin/evaluations/routes.test.ts
@@ -22,9 +22,7 @@ jest.mock("./evaluationsRepository", () => ({
 import {
   listEvaluations,
   getDetailedStats,
-  getEvaluationsBySession,
   updateOutcome,
-  getKpiStats,
   approveTuningRule,
   rejectTuningRule,
 } from "./evaluationsRepository";

--- a/src/api/admin/evaluations/routes.test.ts
+++ b/src/api/admin/evaluations/routes.test.ts
@@ -50,18 +50,6 @@ function makeApp(role: Role = "client_admin", tenantId = "tenant-a") {
   return app;
 }
 
-function makeAppNoAuth() {
-  const app = express();
-  app.use(express.json());
-  // supabaseAuthMiddleware をモック → 401 を返す
-  jest.mock("../../../admin/http/supabaseAuthMiddleware", () => ({
-    supabaseAuthMiddleware: (_req: any, res: any) =>
-      res.status(401).json({ error: "Unauthorized" }),
-  }));
-  registerEvaluationRoutes(app);
-  return app;
-}
-
 const NOW = new Date().toISOString();
 
 const EVAL_ROW = {

--- a/src/api/admin/feedback/feedbackAuthGuard.test.ts
+++ b/src/api/admin/feedback/feedbackAuthGuard.test.ts
@@ -273,7 +273,6 @@ describe('feedback management routes — super_admin-only routes reject client_a
 describe('feedback management routes — stale JWT (user_metadata.role only) → 403', () => {
   MGMT_ALL_ROUTES.forEach(({ method, path }) => {
     it(`${method.toUpperCase()} ${path} — stale JWT → 403`, async () => {
-      const app = makeAppMgmt(null);
       // Inject full user object with user_metadata only (stale JWT)
       const staleApp = express();
       staleApp.use(express.json());

--- a/src/api/admin/tuning/tuningRulesRepository.ts
+++ b/src/api/admin/tuning/tuningRulesRepository.ts
@@ -214,28 +214,6 @@ export async function deleteRule(
 // テナント固有システムプロンプト取得
 // ---------------------------------------------------------------------------
 
-/**
- * tenants.system_prompt を取得する。
- * カラムが存在しない / 空の場合は null を返す。
- * テーブルまたはカラムが存在しない場合は null を返す（migration未実行環境でも安全）。
- */
-async function getTenantSystemPrompt(
-  tenantId: string,
-): Promise<string | null> {
-  const pool = getPool();
-  try {
-    const result = await pool.query<{ system_prompt: string | null }>(
-      `SELECT system_prompt FROM tenants WHERE id = $1`,
-      [tenantId],
-    );
-    const raw = result.rows[0]?.system_prompt;
-    return raw && raw.trim() ? raw.trim() : null;
-  } catch {
-    // カラム未追加など（migration前のデプロイ）は null を返す
-    return null;
-  }
-}
-
 // ---------------------------------------------------------------------------
 // プロンプト注入用ユーティリティ
 // ---------------------------------------------------------------------------

--- a/src/api/avatar/anamRoutes.ts
+++ b/src/api/avatar/anamRoutes.ts
@@ -9,7 +9,6 @@
 //   'lemonslice' または未設定なら { enabled: false, avatarProvider: 'lemonslice' } を返す。
 
 import type { Express, Request, Response, RequestHandler } from 'express';
-import { Pool } from 'pg';
 import type { AuthedRequest } from '../../agent/http/authMiddleware';
 import { pool as globalPool } from '../../lib/db';
 import { logger } from '../../lib/logger';

--- a/src/lib/billing/usageTracker.ts
+++ b/src/lib/billing/usageTracker.ts
@@ -1,7 +1,6 @@
 // src/lib/billing/usageTracker.ts
 // Phase32: API使用量の非同期記録（fire-and-forget）
 
-import { Pool } from 'pg';
 import type pino from 'pino';
 import { calculateLLMCostCents, calculateBillingAmountCents } from './costCalculator';
 

--- a/src/lib/book-pipeline/pipeline.test.ts
+++ b/src/lib/book-pipeline/pipeline.test.ts
@@ -55,10 +55,6 @@ function makePages(text: string, pageNumber = 1): PageText[] {
   return [{ pageNumber, text }];
 }
 
-function makeLongText(chars: number): string {
-  return "あ".repeat(chars);
-}
-
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function makeDb(overrides: { queryFn?: (sql: string, params?: any[]) => Promise<unknown> } = {}) {
   const rows: unknown[] = [];

--- a/src/search/hybrid.ts
+++ b/src/search/hybrid.ts
@@ -14,7 +14,6 @@ export interface Hit {
   metadata?: Record<string, unknown>;
 }
 type EsHit = { _id: string; _source?: { text?: string; [key: string]: unknown }; _score?: number };
-type EsSearchResult = { hits?: { hits?: EsHit[] } };
 const BUDGET = Number(process.env.HYBRID_TIMEOUT_MS || 600);
 const ALLOW_MOCK = process.env.HYBRID_MOCK_ON_FAILURE === "1";
 // Phase33 C: フィーチャーフラグ（LANG_SEARCH_ENABLED=1 で有効化）


### PR DESCRIPTION
## Summary

- PR #258/#259/#260 (stacked on closed feature branches) の net 削除差分を現 main (Phase A: `.oxlintrc.json` 追加済み) へ再適用
- 不要 import 7件 / 真 dead 宣言 7件 / 置換済み重複 3件 = 計 17シンボル削除
- `--max-warnings 80 → 63` ratchet (実測 63警告)

## Changes
| PR | 内容 | 削減 |
|---|---|---|
| #258 (cherry-pick) | 不要 import 7件削除 | 80→73 |
| #259 (cherry-pick) | 真 dead 宣言 7件削除 | 73→66 |
| #260 (cherry-pick) | 置換済み重複 3件 RETIRE | 66→63 |

## Test plan
- [x] `pnpm typecheck` → 0 errors
- [x] `pnpm lint` → 63 warnings (exit 0, max-warnings 63)
- [x] `pnpm test` → 146 suites, 1743 tests passed
- [x] `bash SCRIPTS/security-scan.sh` → CRITICAL/HIGH: 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)