### PR TITLE
fix(security/HIGH): /admin/faqs 5ルートに role guard + テナント分離追加

### DIFF
--- a/src/admin/http/faqAdminRoutes.test.ts
+++ b/src/admin/http/faqAdminRoutes.test.ts
@@ -1,0 +1,233 @@
+// src/admin/http/faqAdminRoutes.test.ts
+// fix(security/HIGH): /admin/faqs 認証・テナント分離テスト
+
+jest.mock("../../lib/db", () => ({
+  pool: { query: jest.fn() },
+}));
+jest.mock("../../agent/llm/openaiEmbeddingClient", () => ({
+  embedText: jest.fn().mockResolvedValue(Array.from({ length: 1536 }, () => 0)),
+}));
+jest.mock("../../search/langIndex", () => ({
+  resolveFaqWriteIndex: jest.fn(() => "faq_tenant-a"),
+}));
+jest.mock("../../lib/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+// supabaseAuthMiddleware: Bearer トークンの中身 (base64 JSON) を req.supabaseUser にセット
+// 無しまたは不正 → 401
+jest.mock("./supabaseAuthMiddleware", () => ({
+  supabaseAuthMiddleware: (req: any, res: any, next: any) => {
+    const auth: string = req.headers.authorization ?? "";
+    if (!auth.startsWith("Bearer ")) {
+      return res.status(401).json({ error: "Missing Bearer token" });
+    }
+    try {
+      req.supabaseUser = JSON.parse(
+        Buffer.from(auth.slice(7), "base64").toString("utf8")
+      );
+      next();
+    } catch {
+      return res.status(401).json({ error: "Invalid token" });
+    }
+  },
+}));
+
+import express from "express";
+import request from "supertest";
+import { pool } from "../../lib/db";
+import { registerFaqAdminRoutes } from "./faqAdminRoutes";
+
+const mockQuery = (pool as unknown as { query: jest.Mock }).query;
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  registerFaqAdminRoutes(app);
+  return app;
+}
+
+function bearerOf(user: object): string {
+  return `Bearer ${Buffer.from(JSON.stringify(user)).toString("base64")}`;
+}
+
+const SUPER_ADMIN = { app_metadata: { role: "super_admin" } };
+const CLIENT_A    = { app_metadata: { role: "client_admin", tenant_id: "tenant-a" } };
+const ANONYMOUS   = { app_metadata: { role: "anonymous",   tenant_id: "tenant-a" } };
+
+const FAQ_ROW = {
+  id: 1, tenant_id: "tenant-a", question: "q", answer: "a",
+  category: null, es_doc_id: null, tags: null, is_published: true,
+  created_at: "", updated_at: "",
+};
+
+beforeEach(() => {
+  mockQuery.mockReset();
+  mockQuery.mockResolvedValue({ rowCount: 1, rows: [FAQ_ROW] });
+});
+
+// ---------------------------------------------------------------------------
+// 認証必須化 — Bearer なし → 401 (5ルート代表で GET/POST/DELETE を検証)
+// ---------------------------------------------------------------------------
+describe("認証 — Bearer トークン未送信 → 401", () => {
+  it("GET /admin/faqs → 401", async () => {
+    const res = await request(makeApp()).get("/admin/faqs");
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /admin/faqs/:id → 401", async () => {
+    const res = await request(makeApp()).get("/admin/faqs/1");
+    expect(res.status).toBe(401);
+  });
+
+  it("POST /admin/faqs → 401", async () => {
+    const res = await request(makeApp())
+      .post("/admin/faqs")
+      .send({ question: "q", answer: "a" });
+    expect(res.status).toBe(401);
+  });
+
+  it("PUT /admin/faqs/:id → 401", async () => {
+    const res = await request(makeApp())
+      .put("/admin/faqs/1")
+      .send({ question: "q2" });
+    expect(res.status).toBe(401);
+  });
+
+  it("DELETE /admin/faqs/:id → 401", async () => {
+    const res = await request(makeApp()).delete("/admin/faqs/1");
+    expect(res.status).toBe(401);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ロールガード — anonymous role の JWT → 403
+// ---------------------------------------------------------------------------
+describe("ロール — anonymous → 403", () => {
+  it("GET /admin/faqs?tenantId=tenant-a (anonymous role) → 403", async () => {
+    const res = await request(makeApp())
+      .get("/admin/faqs?tenantId=tenant-a")
+      .set("Authorization", bearerOf(ANONYMOUS));
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("forbidden");
+  });
+
+  it("DELETE /admin/faqs/1?tenantId=tenant-a (anonymous role) → 403", async () => {
+    const res = await request(makeApp())
+      .delete("/admin/faqs/1?tenantId=tenant-a")
+      .set("Authorization", bearerOf(ANONYMOUS));
+    expect(res.status).toBe(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// テナント越境 — client_admin が他テナント指定 → 403
+// ---------------------------------------------------------------------------
+describe("テナント分離 — client_admin 越境 → 403", () => {
+  it("GET /admin/faqs?tenantId=tenant-b (JWT は tenant-a) → 403", async () => {
+    const res = await request(makeApp())
+      .get("/admin/faqs?tenantId=tenant-b")
+      .set("Authorization", bearerOf(CLIENT_A));
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("forbidden");
+  });
+
+  it("GET /admin/faqs/:id?tenantId=tenant-b → 403", async () => {
+    const res = await request(makeApp())
+      .get("/admin/faqs/1?tenantId=tenant-b")
+      .set("Authorization", bearerOf(CLIENT_A));
+    expect(res.status).toBe(403);
+  });
+
+  it("POST /admin/faqs?tenantId=tenant-b → 403", async () => {
+    const res = await request(makeApp())
+      .post("/admin/faqs?tenantId=tenant-b")
+      .set("Authorization", bearerOf(CLIENT_A))
+      .send({ question: "q", answer: "a" });
+    expect(res.status).toBe(403);
+  });
+
+  it("PUT /admin/faqs/1?tenantId=tenant-b → 403", async () => {
+    const res = await request(makeApp())
+      .put("/admin/faqs/1?tenantId=tenant-b")
+      .set("Authorization", bearerOf(CLIENT_A))
+      .send({ question: "q2" });
+    expect(res.status).toBe(403);
+  });
+
+  it("DELETE /admin/faqs/1?tenantId=tenant-b → 403", async () => {
+    const res = await request(makeApp())
+      .delete("/admin/faqs/1?tenantId=tenant-b")
+      .set("Authorization", bearerOf(CLIENT_A));
+    expect(res.status).toBe(403);
+  });
+
+  it("x-tenant-id ヘッダーによる越境も 403", async () => {
+    const res = await request(makeApp())
+      .get("/admin/faqs")
+      .set("Authorization", bearerOf(CLIENT_A))
+      .set("x-tenant-id", "tenant-b");
+    expect(res.status).toBe(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// super_admin previewMode 回帰 — 他テナント指定 → 通過
+// ---------------------------------------------------------------------------
+describe("super_admin previewMode — 他テナント指定 → 通過", () => {
+  it("GET /admin/faqs?tenantId=tenant-b (super_admin) → 200", async () => {
+    mockQuery.mockResolvedValue({ rowCount: 0, rows: [] });
+    const res = await request(makeApp())
+      .get("/admin/faqs?tenantId=tenant-b")
+      .set("Authorization", bearerOf(SUPER_ADMIN));
+    expect(res.status).toBe(200);
+  });
+
+  it("DELETE /admin/faqs/1?tenantId=tenant-b (super_admin) → 200", async () => {
+    const res = await request(makeApp())
+      .delete("/admin/faqs/1?tenantId=tenant-b")
+      .set("Authorization", bearerOf(SUPER_ADMIN));
+    expect(res.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// client_admin 自テナント — tenantId 未指定 → JWT から補完して通過
+// ---------------------------------------------------------------------------
+describe("client_admin 自テナント — JWT 補完", () => {
+  it("GET /admin/faqs (tenantId 未指定) → JWT の tenant-a で DB クエリ", async () => {
+    mockQuery.mockResolvedValue({ rowCount: 0, rows: [] });
+    const res = await request(makeApp())
+      .get("/admin/faqs")
+      .set("Authorization", bearerOf(CLIENT_A));
+    expect(res.status).toBe(200);
+    expect(mockQuery).toHaveBeenCalled();
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toMatch(/WHERE tenant_id = \$1/);
+    expect(params[0]).toBe("tenant-a");
+  });
+
+  it("GET /admin/faqs?tenantId=tenant-a (自テナント一致) → 200", async () => {
+    mockQuery.mockResolvedValue({ rowCount: 0, rows: [] });
+    const res = await request(makeApp())
+      .get("/admin/faqs?tenantId=tenant-a")
+      .set("Authorization", bearerOf(CLIENT_A));
+    expect(res.status).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveTenantId JWT 優先 (defense-in-depth)
+// client_admin の JWT tenant-a が query より優先されること
+// ---------------------------------------------------------------------------
+describe("resolveTenantId — JWT 優先", () => {
+  it("client_admin: query=tenant-a 指定 → JWT の tenant-a で DB クエリ (一致するため通過)", async () => {
+    mockQuery.mockResolvedValue({ rowCount: 0, rows: [] });
+    const res = await request(makeApp())
+      .get("/admin/faqs?tenantId=tenant-a")
+      .set("Authorization", bearerOf(CLIENT_A));
+    expect(res.status).toBe(200);
+    const [, params] = mockQuery.mock.calls[0];
+    expect(params[0]).toBe("tenant-a");
+  });
+});

--- a/src/admin/http/faqAdminRoutes.ts
+++ b/src/admin/http/faqAdminRoutes.ts
@@ -1,5 +1,5 @@
 // src/admin/http/faqAdminRoutes.ts
-import express, { type Express, type Request, type Response } from "express";
+import express, { type Express, type NextFunction, type Request, type Response } from "express";
 import { embedText } from "../../agent/llm/openaiEmbeddingClient";
 import { pool } from "../../lib/db";
 import { supabaseAuthMiddleware } from "./supabaseAuthMiddleware";
@@ -28,20 +28,54 @@ function requireDb() {
   return pool;
 }
 
+type FaqSupabaseUser = {
+  app_metadata?: { role?: string; tenant_id?: string };
+};
+
 function resolveTenantId(req: Request): string | null {
   // CLAUDE.md: tenantId は body から取得禁止
-  const fromQuery = (req.query.tenantId || req.query.tenant_id) as
-    | string
-    | undefined;
-  const fromHeader =
-    (req.headers["x-tenant-id"] as string | undefined) ?? undefined;
-  // JWT の app_metadata.tenant_id をフォールバックとして使用
-  const supabaseUser = (req as any).supabaseUser as
-    | { app_metadata?: { tenant_id?: string } }
-    | undefined;
-  const fromJwt = supabaseUser?.app_metadata?.tenant_id ?? undefined;
+  // JWT 優先 (defense-in-depth):
+  //   super_admin: fromJwt = undefined → query/header の previewMode 経路が有効
+  //   client_admin: fromJwt = tenant_id → query/header 注入を無効化
+  const su = (req as any).supabaseUser as FaqSupabaseUser | undefined;
+  const fromJwt = su?.app_metadata?.tenant_id ?? undefined;
+  const fromQuery = (req.query.tenantId || req.query.tenant_id) as string | undefined;
+  const fromHeader = (req.headers["x-tenant-id"] as string | undefined) ?? undefined;
+  return fromJwt || fromQuery || fromHeader || null;
+}
 
-  return fromQuery || fromHeader || fromJwt || null;
+// super_admin / client_admin のみ通過。anonymous JWT は 403。
+function requireFaqRole(req: Request, res: Response, next: NextFunction): void {
+  const su = (req as any).supabaseUser as FaqSupabaseUser | undefined;
+  const role = su?.app_metadata?.role ?? "anonymous";
+  if (role !== "super_admin" && role !== "client_admin") {
+    res.status(403).json({ error: "forbidden", message: "この操作を実行する権限がありません" });
+    return;
+  }
+  next();
+}
+
+// super_admin: 全テナント通過（previewMode 経路）
+// client_admin: JWT tenantId と異なるテナント指定 → 403 / 未指定 → JWT で補完
+function requireFaqTenant(req: Request, res: Response, next: NextFunction): void {
+  const su = (req as any).supabaseUser as FaqSupabaseUser | undefined;
+  const role = su?.app_metadata?.role ?? "anonymous";
+  if (role === "super_admin") { next(); return; }
+
+  const requestedTenant =
+    (req.query.tenantId as string | undefined) ||
+    (req.query.tenant_id as string | undefined) ||
+    (req.headers["x-tenant-id"] as string | undefined);
+  const jwtTenantId = su?.app_metadata?.tenant_id;
+
+  if (requestedTenant && jwtTenantId && requestedTenant !== jwtTenantId) {
+    res.status(403).json({ error: "forbidden", message: "他のテナントのデータにはアクセスできません" });
+    return;
+  }
+  if (!requestedTenant && jwtTenantId) {
+    req.query.tenantId = jwtTenantId;
+  }
+  next();
 }
 
 async function updateEsFaqDocument(row: FaqRow) {
@@ -104,11 +138,8 @@ export function registerFaqAdminRoutes(app: Express) {
 
   const db = requireDb();
 
-  // 🔐 Supabase Auth ミドルウェアを /admin/faqs 配下に適用
-  app.use("/admin/faqs", supabaseAuthMiddleware);
-
-  // 🔐 将来的に Supabase Auth ミドルウェアをここに噛ませる想定
-  // 例: app.use("/admin/faqs", supabaseAuthMiddleware);
+  // 認証 + ロール + テナント分離の3層を /admin/faqs 全ルートに適用
+  app.use("/admin/faqs", supabaseAuthMiddleware, requireFaqRole, requireFaqTenant);
 
   /**
    * GET /admin/faqs
@@ -117,10 +148,8 @@ export function registerFaqAdminRoutes(app: Express) {
    */
   app.get("/admin/faqs", async (req: Request, res: Response) => {
     const tenantId = resolveTenantId(req);
-    const supabaseUser = (req as any).supabaseUser as
-      | { app_metadata?: { role?: string } }
-      | undefined;
-    const role = supabaseUser?.app_metadata?.role ?? "anonymous";
+    const su = (req as any).supabaseUser as FaqSupabaseUser | undefined;
+    const role = su?.app_metadata?.role ?? "anonymous";
 
     if (!tenantId && role !== "super_admin") {
       return res.status(400).json({ error: "tenantId is required" });

--- a/src/lib/healthBusiness.test.ts
+++ b/src/lib/healthBusiness.test.ts
@@ -1,14 +1,13 @@
 // src/lib/healthBusiness.test.ts
 
 import type { Request, Response } from "express";
-import { buildWarnings, businessHealthHandler } from "./healthBusiness";
+import { buildWarnings } from "./healthBusiness";
 
 // ---------------------------------------------------------------------------
 // buildWarnings — 各 warning 条件のユニットテスト
 // ---------------------------------------------------------------------------
 
 describe("buildWarnings", () => {
-  const now = new Date().toISOString();
   const recent = new Date(Date.now() - 30 * 60 * 1000).toISOString(); // 30分前
   const old = new Date(Date.now() - 7 * 60 * 60 * 1000).toISOString(); // 7時間前
 

--- a/src/lib/healthBusiness.ts
+++ b/src/lib/healthBusiness.ts
@@ -124,7 +124,7 @@ export async function businessHealthHandler(_req: Request, res: Response): Promi
     };
 
     res.status(200).json(body);
-  } catch (_err) {
+  } catch {
     res.status(500).json({ error: "internal_error", message: "業務KPI取得に失敗しました" });
   }
 }


### PR DESCRIPTION
## 事象

`/admin/faqs` 5ルートは `supabaseAuthMiddleware` は適用済みだったが、**ロール検証・テナント分離が完全に欠落**していた。

- anonymous Supabase JWT 保持者が `?tenantId=<victim>` で任意テナントの FAQ を CRUD 可能
- client_admin が `?tenantId=other` / `x-tenant-id: other` ヘッダーで他テナントへ越境可能
- `resolveTenantId` が `query > header > JWT` 優先で JWT 詐称可能

導入: `0cb8041` (Phase7, 2025-11-25) — 既存バグ。本番で実害到達可能。

## 修正内容

| 追加 | 効果 |
|---|---|
| `requireFaqRole` | super_admin / client_admin のみ通過。anonymous → 403 |
| `requireFaqTenant` | client_admin 越境 → 403 / tenantId 未指定 → JWT で補完 |
| `resolveTenantId` JWT 優先化 | defense-in-depth: client_admin は JWT tenantId が優先 |
| stale TODO コメント除去 | 実装済みのコメントを削除 |

`app.use("/admin/faqs", supabaseAuthMiddleware, requireFaqRole, requireFaqTenant)` の3層チェーン。

super_admin の previewMode 経路（`useAuth.enterPreview` + `?tenantId=`）は維持。

## テスト (新規 faqAdminRoutes.test.ts — 18件)

- [x] 5ルート Bearer 未送信 → 401
- [x] anonymous role → 403
- [x] client_admin 越境 (query / header 両方) → 403 × 6
- [x] super_admin previewMode 他テナント指定 → 200 (回帰)
- [x] client_admin 自テナント JWT 補完 → 200
- [x] resolveTenantId JWT 優先確認

## Gate 1

- typecheck: ✓ 0 errors
- lint: ✓ 63/63 warnings
- test: ✓ 147 suites / 1761 tests

## 関連

- Codex Gate (2.5): 常時OFF — skip (small scope, test-only + security fix)
- **#256 (faq_embeddings cascade delete) はこの PR merge & deploy 後に解凍**
- requireFaqTenant の roleAuth.ts 集約は別 follow-up

🤖 Generated with [Claude Code](https://claude.com/claude-code)