### PR TITLE
fix(lint): main CI red 復旧 — healthBusiness 未使用警告3件除去 (66→63 ratchet)

### DIFF
--- a/src/lib/healthBusiness.test.ts
+++ b/src/lib/healthBusiness.test.ts
@@ -1,14 +1,13 @@
 // src/lib/healthBusiness.test.ts
 
 import type { Request, Response } from "express";
-import { buildWarnings, businessHealthHandler } from "./healthBusiness";
+import { buildWarnings } from "./healthBusiness";
 
 // ---------------------------------------------------------------------------
 // buildWarnings — 各 warning 条件のユニットテスト
 // ---------------------------------------------------------------------------
 
 describe("buildWarnings", () => {
-  const now = new Date().toISOString();
   const recent = new Date(Date.now() - 30 * 60 * 1000).toISOString(); // 30分前
   const old = new Date(Date.now() - 7 * 60 * 60 * 1000).toISOString(); // 7時間前
 

--- a/src/lib/healthBusiness.ts
+++ b/src/lib/healthBusiness.ts
@@ -124,7 +124,7 @@ export async function businessHealthHandler(_req: Request, res: Response): Promi
     };
 
     res.status(200).json(body);
-  } catch (_err) {
+  } catch {
     res.status(500).json({ error: "internal_error", message: "業務KPI取得に失敗しました" });
   }
 }


### PR DESCRIPTION
## 背景 — main が現在 CI red
`#261` が oxlint baseline を **63** に ratchet 確定した**後**に、`#194`(/health/business KPI) が未使用警告3件を伴ってマージされ、main の oxlint が **66 警告** に増加。`--max-warnings 63` を超過し **main の CI/CD が failure（red）= 全 PR がブロック**状態だった。

`gh run list --branch main` 最新 `8d7064a`: CI/CD = **failure** を確認。

## 修正（lint-only / 挙動不変）
| ファイル | 修正 |
|---|---|
| `src/lib/healthBusiness.ts:127` | `catch (_err)` → optional catch binding `catch {}` |
| `src/lib/healthBusiness.test.ts:4` | 未使用 import `businessHealthHandler` 除去 |
| `src/lib/healthBusiness.test.ts:11` | 未使用 `const now` 除去 |

## 検証 (Gate 1)
- oxlint: **66 → 63**（`--max-warnings 63` で exit 0）
- typecheck: 0 errors
- `healthBusiness.test.ts`: 15 tests pass（挙動不変）

## 補足（別タスク化候補）
- `src/index.ts:51` の `superAdminMiddleware` import は #194 が上方に import を追加して行番号がずれた **既存の未使用**（63 baseline 内）。本 PR では触れない。
- 根本対策: `#194`/`#195` が ratchet 後に red のままマージされた = **branch protection の必須 check に lint gate が効いていない疑い**。要調査。

🤖 Generated with [Claude Code](https://claude.com/claude-code)