### PR TITLE
feat(ci): Mergify 非依存の自前 auto-merge (Tier B) — 完全無人 Step 1

### DIFF
--- a/.github/workflows/auto-merge-tier-b.yml
+++ b/.github/workflows/auto-merge-tier-b.yml
@@ -1,0 +1,86 @@
+# Auto-merge Tier B — Mergify 非依存の自前 auto-merge
+#
+# Mergify Free は private repo で rule engine が動かず auto-merge が一度も発火しなかったため、
+# GitHub Actions + SCRIPTS/ci-auto-merge.sh で自前実装する。
+#
+# 安全設計:
+#   - check_suite / schedule トリガーは base リポジトリの trusted context で実行 (PR コードを checkout しない)
+#   - Tier 判定は pr-risk-scorer.sh (テスト済) を正典に再利用 → Tier S (src/ 等) は絶対に merge しない
+#   - high-risk / do-not-merge / needs-review ラベルで人間が即停止可能
+#   - 必須チェック (Gate 1 / security-scan / path-check / Claude PR Review) が全 green のときのみ merge
+#   - GITHUB_TOKEN で merge (branch protection の必須チェックは GitHub 側でも二重に強制される)
+#
+# トリガー:
+#   - check_suite completed: CI 完了時に該当 PR を評価
+#   - schedule (30分毎): イベント取りこぼしの backstop sweep
+#   - workflow_dispatch: 手動実行 (任意で pr 指定)
+
+name: Auto-merge Tier B
+
+on:
+  check_suite:
+    types: [completed]
+  schedule:
+    - cron: "*/30 * * * *"
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: "評価する PR 番号 (空なら open PR を全 sweep)"
+        required: false
+        type: string
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+  statuses: read
+
+concurrency:
+  group: auto-merge-tier-b
+  cancel-in-progress: false
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout (base repo scripts のみ — PR コードは取得しない)
+        uses: actions/checkout@v4
+
+      - name: 候補 PR を評価して Tier B かつ green なら merge
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # 夜間も含め 24/7 で merge (一晩無人で main に届ける)。夜間停止したい場合は "1"。
+          AUTO_MERGE_NIGHT_FREEZE: "0"
+        run: |
+          set -euo pipefail
+
+          # 候補 PR 番号を決める
+          prs=""
+          case "${{ github.event_name }}" in
+            check_suite)
+              prs=$(jq -r '.check_suite.pull_requests[]?.number' "$GITHUB_EVENT_PATH" 2>/dev/null || true)
+              ;;
+            workflow_dispatch)
+              if [ -n "${{ github.event.inputs.pr }}" ]; then
+                prs="${{ github.event.inputs.pr }}"
+              else
+                prs=$(gh pr list --state open --base main --json number -q '.[].number')
+              fi
+              ;;
+            schedule)
+              prs=$(gh pr list --state open --base main --json number -q '.[].number')
+              ;;
+          esac
+
+          if [ -z "$prs" ]; then
+            echo "評価対象の PR なし"
+            exit 0
+          fi
+
+          echo "評価対象 PR: $(echo "$prs" | tr '\n' ' ')"
+          for pr in $prs; do
+            echo "::group::PR #$pr"
+            bash SCRIPTS/ci-auto-merge.sh "$pr" || echo "  (#$pr は merge せず or エラー — 続行)"
+            echo "::endgroup::"
+          done

--- a/SCRIPTS/ci-auto-merge.sh
+++ b/SCRIPTS/ci-auto-merge.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# ci-auto-merge.sh — Tier B PR を CI green かつ非 Tier S のとき自動マージする (Mergify 非依存・自前)
+#
+# 背景: Mergify Free は private repo で rule engine が動かず (config-lint のみ)、
+#       auto-merge が一度も発火しなかった。本スクリプト + GitHub Actions workflow で
+#       自前の auto-merge を実現する。Tier 判定は既存・テスト済の pr-risk-scorer.sh を正典として再利用。
+#
+# 判定 (全て満たすと merge):
+#   1. PR が OPEN / 非 draft / base=main
+#   2. high-risk / do-not-merge / needs-review ラベルが付いていない
+#   3. pr-risk-scorer.sh の auto_merge_eligible == true (= Tier B)
+#   4. 必須チェックが全て SUCCESS (REQUIRED_CHECKS)
+#   5. (任意) 夜間フリーズ: AUTO_MERGE_NIGHT_FREEZE=1 のとき 22:00-07:00 JST は merge しない
+#
+# 使い方:
+#   bash SCRIPTS/ci-auto-merge.sh <PR番号>             # 条件を満たせば squash merge
+#   bash SCRIPTS/ci-auto-merge.sh <PR番号> --dry-run   # 判定のみ (merge しない)
+#   bash SCRIPTS/ci-auto-merge.sh --self-test          # ラベル/チェック判定ロジックの単体確認
+#
+# 環境変数:
+#   REQUIRED_CHECKS           必須チェック名 CSV (default: 下記4つ)
+#   AUTO_MERGE_NIGHT_FREEZE   1 で夜間 (22:00-07:00 JST) を停止 (default: 0 = 24/7 merge)
+#   GH_TOKEN / GITHUB_TOKEN   gh CLI 認証 (CI では自動)
+#
+# 依存: gh, jq
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SCORER="${SCRIPT_DIR}/pr-risk-scorer.sh"
+
+DEFAULT_REQUIRED='Gate 1 — typecheck + lint + test,security-scan,path-check,Claude PR Review'
+BLOCK_LABELS=("high-risk" "do-not-merge" "needs-review")
+
+log() { printf '[ci-auto-merge] %s\n' "$*" >&2; }
+
+# ─── 純粋判定ヘルパー (self-test 対象) ───────────────────────────────────────
+
+# 引数: ラベル(改行区切り) を stdin。BLOCK_LABELS のいずれかがあれば 1(blocked)。
+has_block_label() {
+  local labels_csv="$1"
+  local l
+  for l in "${BLOCK_LABELS[@]}"; do
+    if printf '%s' "$labels_csv" | tr ',' '\n' | grep -qx "$l"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+# 必須チェックが全て SUCCESS か。引数1: statusCheckRollup JSON, 引数2: REQUIRED CSV。
+# 0=all green, 1=未達。未達の理由を stderr に出す。
+all_required_green() {
+  local rollup="$1" required_csv="$2"
+  local ok=0 name concl
+  while IFS= read -r name; do
+    [[ -z "$name" ]] && continue
+    concl="$(printf '%s' "$rollup" | jq -r --arg n "$name" \
+      '[.[] | select((.name // .context) == $n)] | last | (.conclusion // .state // "MISSING")')"
+    if [[ "$concl" != "SUCCESS" && "$concl" != "success" ]]; then
+      log "  check not green: '${name}' = ${concl}"
+      ok=1
+    fi
+  done < <(printf '%s' "$required_csv" | tr ',' '\n')
+  return "$ok"
+}
+
+# 夜間フリーズ判定。0=merge可, 1=夜間で停止。
+night_frozen() {
+  [[ "${AUTO_MERGE_NIGHT_FREEZE:-0}" == "1" ]] || return 1
+  # JST hour
+  local h
+  h="$(TZ=Asia/Tokyo date +%H)"
+  h=$((10#$h))
+  if (( h >= 22 || h < 7 )); then return 0; fi
+  return 1
+}
+
+# ─── self-test ───────────────────────────────────────────────────────────────
+if [[ "${1:-}" == "--self-test" ]]; then
+  fail=0
+  has_block_label "high-risk,foo" && echo "PASS block: high-risk 検出" || { echo "FAIL block high-risk"; fail=1; }
+  has_block_label "needs-review" && echo "PASS block: needs-review 検出" || { echo "FAIL block needs-review"; fail=1; }
+  if has_block_label "tier-b,docs"; then echo "FAIL: 無害ラベルを blocked 判定"; fail=1; else echo "PASS block: 無害ラベルは通す"; fi
+  ROLLUP_GREEN='[{"name":"Gate 1 — typecheck + lint + test","conclusion":"SUCCESS"},{"name":"security-scan","conclusion":"SUCCESS"},{"name":"path-check","conclusion":"SUCCESS"},{"name":"Claude PR Review","conclusion":"SUCCESS"}]'
+  ROLLUP_RED='[{"name":"Gate 1 — typecheck + lint + test","conclusion":"FAILURE"},{"name":"security-scan","conclusion":"SUCCESS"},{"name":"path-check","conclusion":"SUCCESS"},{"name":"Claude PR Review","conclusion":"SUCCESS"}]'
+  ROLLUP_MISSING='[{"name":"security-scan","conclusion":"SUCCESS"}]'
+  if all_required_green "$ROLLUP_GREEN" "$DEFAULT_REQUIRED" 2>/dev/null; then echo "PASS green: 全 green 検出"; else echo "FAIL green all"; fail=1; fi
+  if all_required_green "$ROLLUP_RED" "$DEFAULT_REQUIRED" 2>/dev/null; then echo "FAIL: red を green 判定"; fail=1; else echo "PASS green: red を検出"; fi
+  if all_required_green "$ROLLUP_MISSING" "$DEFAULT_REQUIRED" 2>/dev/null; then echo "FAIL: 欠落 check を green 判定"; fail=1; else echo "PASS green: 欠落 check を検出"; fi
+  echo "---"; [[ "$fail" == 0 ]] && { echo "✅ self-test PASS"; exit 0; } || { echo "❌ self-test FAIL"; exit 1; }
+fi
+
+# ─── 引数 ────────────────────────────────────────────────────────────────────
+PR_NUMBER="${1:-}"
+DRY_RUN=0
+[[ "${2:-}" == "--dry-run" ]] && DRY_RUN=1
+[[ -z "$PR_NUMBER" ]] && { log "PR番号を指定してください"; exit 2; }
+REQUIRED_CSV="${REQUIRED_CHECKS:-$DEFAULT_REQUIRED}"
+
+for cmd in gh jq; do command -v "$cmd" >/dev/null 2>&1 || { log "missing: $cmd"; exit 2; }; done
+
+# ─── PR メタ取得 ─────────────────────────────────────────────────────────────
+META="$(gh pr view "$PR_NUMBER" \
+  --json number,state,isDraft,baseRefName,labels,statusCheckRollup,mergeStateStatus,title \
+  2>/dev/null)" || { log "PR #$PR_NUMBER 取得失敗"; exit 2; }
+
+STATE="$(jq -r '.state' <<<"$META")"
+DRAFT="$(jq -r '.isDraft' <<<"$META")"
+BASE="$(jq -r '.baseRefName' <<<"$META")"
+LABELS="$(jq -r '[.labels[].name] | join(",")' <<<"$META")"
+ROLLUP="$(jq -c '.statusCheckRollup' <<<"$META")"
+TITLE="$(jq -r '.title' <<<"$META")"
+
+decline() { log "SKIP #$PR_NUMBER ($1): $TITLE"; exit 0; }
+
+[[ "$STATE" == "OPEN" ]]   || decline "state=$STATE"
+[[ "$DRAFT" == "false" ]]  || decline "draft"
+[[ "$BASE" == "main" ]]    || decline "base=$BASE"
+has_block_label "$LABELS"  && decline "block-label ($LABELS)"
+night_frozen               && decline "night-freeze (22:00-07:00 JST)"
+
+# Tier 判定 (正典: pr-risk-scorer)
+ELIGIBLE="$(bash "$SCORER" "$PR_NUMBER" --json-only 2>/dev/null | jq -r '.auto_merge_eligible')" || decline "scorer失敗"
+[[ "$ELIGIBLE" == "true" ]] || decline "Tier S (auto_merge_eligible=$ELIGIBLE)"
+
+# 必須チェック全 green
+all_required_green "$ROLLUP" "$REQUIRED_CSV" || decline "checks not all green"
+
+# ─── merge ───────────────────────────────────────────────────────────────────
+if [[ "$DRY_RUN" == "1" ]]; then
+  log "DRY-RUN: #$PR_NUMBER は全条件クリア → merge 対象 (Tier B / 全 green / 非ブロック)"
+  exit 0
+fi
+log "MERGE: #$PR_NUMBER (Tier B / 全 green) を squash merge します"
+gh pr merge "$PR_NUMBER" --squash --delete-branch 2>&1 | sed 's/^/[ci-auto-merge]   /' >&2
+log "✅ #$PR_NUMBER merged"


### PR DESCRIPTION
Asana 関連: 24h 自律ループ導入 (GID 1214893855764119) / 本丸「狭くても完全無人を即実証」Step 1

## なぜこれが必要か（重要な発見）
\`.mergify.yml\`(#267) は valid だったが **Mergify の rule engine はこの private repo で一度も動いていなかった**:
- mergify[bot] のマージ: **0件**
- high-risk ラベル付与: **0件**（Rule1 が多数の src PR に対して一度も発火せず）
- Mergify Summary check: **無し**

→ config-lint（「invalid config」コメント・\`Configuration changed\` check・#271 生成）は動くが、**automation engine は動かない** = Mergify Free × private repo の制約。**Mergify では auto-merge は永遠に鳴らない。**

## 解決：自前 auto-merge（subscription 非依存・完全制御）
| ファイル | 役割 |
|---|---|
| \`SCRIPTS/ci-auto-merge.sh\` | 1 PR を評価し条件を満たせば squash merge。**Tier 判定は既存・テスト済の \`pr-risk-scorer.sh\` を正典に再利用** |
| \`.github/workflows/auto-merge-tier-b.yml\` | check_suite 完了 / 30分 sweep / 手動 で起動し上記を実行 |

### マージ条件（全て満たすときのみ）
1. OPEN / 非 draft / base=main
2. \`high-risk\` / \`do-not-merge\` / \`needs-review\` ラベルが無い（**人間の即時停止スイッチ**）
3. \`pr-risk-scorer\` が **auto_merge_eligible=true**（= Tier B。src/ 等 Tier S は弾く）
4. 必須チェック全 green（Gate 1 / security-scan / path-check / Claude PR Review）

### 安全設計
- check_suite/schedule は **base リポの trusted context** で実行。**PR コードを checkout しない**（pull_request_target の典型脆弱性を回避）。
- Tier S（src/security/deploy/hooks/.github 等）は pr-risk-scorer が弾くため **絶対に自動マージしない**。本 PR 自身も \`.github/\` 変更 = Tier S なので **auto-merge 対象外**（あなたが手動マージ）。
- \`AUTO_MERGE_NIGHT_FREEZE=0\`（既定 24/7）。夜間停止したいなら workflow env を \`1\` に。

## 検証
- \`bash SCRIPTS/ci-auto-merge.sh --self-test\` → ラベル/チェック green 判定 **6 ケース pass**。
- \`bash SCRIPTS/ci-auto-merge.sh 273 --dry-run\` → **正しく Tier S 判定で SKIP**（#273 は src を含むため。誤って src を merge しない実証）。
- bash 構文・YAML 検証 OK。

## このPRをマージすると
Tier B（docs / tests / SCRIPTS / tooling）の PR が **CI green で無人マージ**される。
= 本丸「完全無人」の最初の動く部品。**初の実走検証**は次の clean な Tier B PR（detect-unwired ツール）で行える。

## 既知
- ワークフローは default ブランチから動くため、**main にマージされて初めて有効化**（それまで未稼働）。
- GITHUB_TOKEN での merge は branch protection（path-check + Gate1 green / 0 review）を満たせば成功する想定。最初の Tier B PR で実地確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)