### PR TITLE
feat(dispatch): Tier S 実装自走 + Tier A/B auto-merge 拡張

### DIFF
--- a/SCRIPTS/ci-auto-merge.sh
+++ b/SCRIPTS/ci-auto-merge.sh
@@ -102,7 +102,7 @@ for cmd in gh jq; do command -v "$cmd" >/dev/null 2>&1 || { log "missing: $cmd";
 
 # ─── PR メタ取得 ─────────────────────────────────────────────────────────────
 META="$(gh pr view "$PR_NUMBER" \
-  --json number,state,isDraft,baseRefName,labels,statusCheckRollup,mergeStateStatus,title \
+  --json number,state,isDraft,baseRefName,headRefName,labels,statusCheckRollup,mergeStateStatus,title \
   2>/dev/null)" || { log "PR #$PR_NUMBER 取得失敗"; exit 2; }
 
 STATE="$(jq -r '.state' <<<"$META")"
@@ -112,6 +112,7 @@ LABELS="$(jq -r '[.labels[].name] | join(",")' <<<"$META")"
 ROLLUP="$(jq -c '.statusCheckRollup' <<<"$META")"
 TITLE="$(jq -r '.title' <<<"$META")"
 MERGE_STATE="$(jq -r '.mergeStateStatus' <<<"$META")"
+HEAD_REF="$(jq -r '.headRefName' <<<"$META")"
 
 decline() { log "SKIP #$PR_NUMBER ($1): $TITLE"; exit 0; }
 
@@ -121,9 +122,18 @@ decline() { log "SKIP #$PR_NUMBER ($1): $TITLE"; exit 0; }
 has_block_label "$LABELS"  && decline "block-label ($LABELS)"
 night_frozen               && decline "night-freeze (22:00-07:00 JST)"
 
-# Tier 判定 (正典: pr-risk-scorer)
-ELIGIBLE="$(bash "$SCORER" "$PR_NUMBER" --json-only 2>/dev/null | jq -r '.auto_merge_eligible')" || decline "scorer失敗"
-[[ "$ELIGIBLE" == "true" ]] || decline "Tier S (auto_merge_eligible=$ELIGIBLE)"
+# Tier 判定: ループ生成 PR (auto/tier-N-*) はブランチ名で確定、それ以外は scorer にフォールバック
+# auto/s-* = Tier S → human merge required (merge しない)
+# auto/a-* = Tier A → auto-merge eligible (scorer スキップ)
+# auto/b-* = Tier B → auto-merge eligible (scorer スキップ)
+# それ以外 (手動PR等) → scorer で判定 (従来動作)
+[[ "$HEAD_REF" =~ ^auto/s- ]] && decline "Tier S — human merge required (branch: $HEAD_REF)"
+if [[ "$HEAD_REF" =~ ^auto/[ab]- ]]; then
+    log "Tier A/B loop PR — auto-merge eligible (branch: $HEAD_REF)"
+else
+    ELIGIBLE="$(bash "$SCORER" "$PR_NUMBER" --json-only 2>/dev/null | jq -r '.auto_merge_eligible')" || decline "scorer失敗"
+    [[ "$ELIGIBLE" == "true" ]] || decline "not auto-merge eligible (auto_merge_eligible=$ELIGIBLE)"
+fi
 
 # 必須チェック全 green
 all_required_green "$ROLLUP" "$REQUIRED_CSV" || decline "checks not all green"

--- a/SCRIPTS/r2c-dispatch.sh
+++ b/SCRIPTS/r2c-dispatch.sh
@@ -135,15 +135,11 @@ dispatch_one() {
     local branch_name="auto/${tier,,}-${task_id}-${slug}"
     local log_file="${LOG_DIR}/lane-${task_id}.log"
     local lane_name="auto-${tier,,}-${task_id}"
-    # Tier B は夜間自律実行のため bypassPermissions（acceptEdits だと Bash で
-    # permission prompt が固着し停止する）。.claude/settings.json の deny 層が
-    # force/main push・scp・rm -rf /opt・.env/opt 書込みを最終防衛する前提。
-    # Tier A/S は朝承認・人間判断のため plan のまま。
+    # 全 Tier bypassPermissions で実装まで自走。merge の可否は ci-auto-merge.sh の
+    # ブランチ名判定(auto/s-* は merge skip、auto/a-* と auto/b-* は auto-merge)で制御する。
+    # acceptEdits だと Bash で permission prompt が固着し停止するため bypassPermissions を使う。
+    # .claude/settings.json の deny 層が force/main push・scp・rm -rf /opt・.env 書込みを防衛。
     local perm_mode="bypassPermissions"
-    case "$tier" in
-        A) perm_mode="plan" ;;
-        S) perm_mode="plan" ;;
-    esac
     local resolved_model="${model:-claude-sonnet-4-6}"
 
     if [ "$DRY_RUN" -eq 1 ]; then


### PR DESCRIPTION
## Summary
- **r2c-dispatch.sh**: Tier A/S の permission mode を `plan` → `bypassPermissions` に変更。実装フェーズは全 Tier 自走、merge 可否はブランチ名判定に委譲。
- **ci-auto-merge.sh**: ループ生成 PR をブランチ名で Tier 判定するロジックを追加。`auto/s-*` は merge skip（human merge required）、`auto/a-*` と `auto/b-*` は auto-merge eligible。手動 PR は従来通り pr-risk-scorer.sh にフォールバック。

## Before / After
| | Tier S | Tier A | Tier B |
|---|---|---|---|
| dispatch perm (before) | plan | plan | bypassPermissions |
| dispatch perm (after) | bypassPermissions | bypassPermissions | bypassPermissions |
| auto-merge (before) | × | × | ◎ |
| auto-merge (after) | × (PR止まり) | ◎ | ◎ |

## Test plan
- [ ] `bash SCRIPTS/ci-auto-merge.sh --self-test` → PASS（実施済）
- [ ] `auto/s-*` ブランチの PR が merge されないことを dry-run で確認
- [ ] `auto/a-*` ブランチの PR が CI green なら auto-merge されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)