### PR TITLE
feat(groq): Groq 404/model_not_found 自動フォールバック機構

### DIFF
--- a/src/agent/llm/groqClient.fallback.test.ts
+++ b/src/agent/llm/groqClient.fallback.test.ts
@@ -1,0 +1,233 @@
+// src/agent/llm/groqClient.fallback.test.ts
+// Groq 404/model_not_found フォールバック機構のユニットテスト
+
+import * as groqClientModule from './groqClient';
+import {
+  GroqModelNotFoundError,
+  GroqBadRequestError,
+  GroqServerError,
+  GroqRateLimitError,
+  isModelNotFoundBody,
+  callGroqWithModelFallback,
+  GroqCallParams,
+  groqClient,
+} from './groqClient';
+import { GROQ_VERSATILE_70B, GROQ_INSTANT_8B, GPT_OSS_120B, GPT_OSS_20B, GROQ_VERSATILE_70B as VERSATILE } from '../../config/groqModels';
+
+function makeParams(model: string): GroqCallParams {
+  return {
+    model,
+    messages: [{ role: 'user', content: 'hello' }],
+  };
+}
+
+const warnMock = jest.fn();
+const infoMock = jest.fn();
+const logger = { warn: warnMock, info: infoMock };
+
+let callSpy: jest.SpyInstance;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  callSpy = jest.spyOn(groqClient, 'call');
+});
+
+afterEach(() => {
+  callSpy.mockRestore();
+});
+
+// ---------------------------------------------------------------------------
+// isModelNotFoundBody
+// ---------------------------------------------------------------------------
+describe('isModelNotFoundBody', () => {
+  it('model_not_found を含む文字列で true を返す', () => {
+    expect(isModelNotFoundBody('{"error":{"code":"model_not_found"}}')).toBe(true);
+  });
+
+  it('model not found (空白区切り) を含む文字列で true を返す', () => {
+    expect(isModelNotFoundBody('The model not found on this deployment')).toBe(true);
+  });
+
+  it('大文字混じりでも true を返す', () => {
+    expect(isModelNotFoundBody('Model_Not_Found')).toBe(true);
+  });
+
+  it('関係ない文字列で false を返す', () => {
+    expect(isModelNotFoundBody('{"error":"rate_limit_exceeded"}')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GroqModelNotFoundError クラス
+// ---------------------------------------------------------------------------
+describe('GroqModelNotFoundError', () => {
+  it('正しいプロパティを持つ', () => {
+    const err = new GroqModelNotFoundError(404, 'model_not_found body', 'some-model-id');
+    expect(err.name).toBe('GroqModelNotFoundError');
+    expect(err.status).toBe(404);
+    expect(err.modelId).toBe('some-model-id');
+    expect(err.message).toContain('some-model-id');
+  });
+
+  it('GroqBadRequestError と同じ基底クラス (GroqApiError) を持つ', () => {
+    const err = new GroqModelNotFoundError(404, '', 'x');
+    // GroqApiError の status プロパティが存在することを確認
+    expect(typeof err.status).toBe('number');
+    expect(typeof err.bodySnippet).toBe('string');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// callGroqWithModelFallback — 正常系
+// ---------------------------------------------------------------------------
+describe('callGroqWithModelFallback — 正常系', () => {
+  it('最初の呼び出しが成功した場合はそのまま返す', async () => {
+    callSpy.mockResolvedValueOnce('ok-response');
+
+    const result = await callGroqWithModelFallback(makeParams(GROQ_VERSATILE_70B), { logger });
+
+    expect(result).toBe('ok-response');
+    expect(callSpy).toHaveBeenCalledTimes(1);
+    expect(callSpy).toHaveBeenCalledWith(expect.objectContaining({ model: GROQ_VERSATILE_70B }));
+    // 最初の試行が成功した場合は warn を出さない
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it('1 回 model_not_found → フォールバック先で成功', async () => {
+    const notFoundError = new GroqModelNotFoundError(404, '{"error":"model_not_found"}', GROQ_VERSATILE_70B);
+    callSpy
+      .mockRejectedValueOnce(notFoundError)
+      .mockResolvedValueOnce('fallback-response');
+
+    const result = await callGroqWithModelFallback(makeParams(GROQ_VERSATILE_70B), { logger });
+
+    expect(result).toBe('fallback-response');
+    expect(callSpy).toHaveBeenCalledTimes(2);
+    // 2 回目はフォールバック先モデルで呼ばれること
+    expect(callSpy).toHaveBeenNthCalledWith(2, expect.objectContaining({ model: GROQ_INSTANT_8B }));
+  });
+
+  it('フォールバック発生時に warn ログが出力される（無言フォールバック禁止）', async () => {
+    const notFoundError = new GroqModelNotFoundError(404, '{"error":"model_not_found"}', GROQ_VERSATILE_70B);
+    callSpy
+      .mockRejectedValueOnce(notFoundError)
+      .mockResolvedValueOnce('ok');
+
+    await callGroqWithModelFallback(makeParams(GROQ_VERSATILE_70B), { logger });
+
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    expect(warnMock.mock.calls[0][0]).toMatchObject({
+      originalModel: GROQ_VERSATILE_70B,
+      failedModel: GROQ_VERSATILE_70B,
+      fallbackModel: GROQ_INSTANT_8B,
+    });
+    expect(warnMock.mock.calls[0][1]).toMatch(/groq-fallback/);
+  });
+
+  it('フォールバック成功後に info ログが出力される', async () => {
+    const notFoundError = new GroqModelNotFoundError(404, '{"error":"model_not_found"}', GROQ_VERSATILE_70B);
+    callSpy
+      .mockRejectedValueOnce(notFoundError)
+      .mockResolvedValueOnce('ok');
+
+    await callGroqWithModelFallback(makeParams(GROQ_VERSATILE_70B), { logger });
+
+    expect(infoMock).toHaveBeenCalledTimes(1);
+    expect(infoMock.mock.calls[0][0]).toMatchObject({
+      originalModel: GROQ_VERSATILE_70B,
+      resolvedModel: GROQ_INSTANT_8B,
+    });
+  });
+
+  it('GPT_OSS_120B → GPT_OSS_20B のチェーンが動作する', async () => {
+    const notFoundError = new GroqModelNotFoundError(404, '{"error":"model_not_found"}', GPT_OSS_120B);
+    callSpy
+      .mockRejectedValueOnce(notFoundError)
+      .mockResolvedValueOnce('oss-20b-response');
+
+    const result = await callGroqWithModelFallback(makeParams(GPT_OSS_120B), { logger });
+
+    expect(result).toBe('oss-20b-response');
+    expect(callSpy).toHaveBeenNthCalledWith(2, expect.objectContaining({ model: GPT_OSS_20B }));
+  });
+
+  it('onFallback コールバックが呼ばれる', async () => {
+    const notFoundError = new GroqModelNotFoundError(404, '{"error":"model_not_found"}', GROQ_VERSATILE_70B);
+    callSpy
+      .mockRejectedValueOnce(notFoundError)
+      .mockResolvedValueOnce('ok');
+
+    const onFallback = jest.fn();
+    await callGroqWithModelFallback(makeParams(GROQ_VERSATILE_70B), { logger, onFallback });
+
+    expect(onFallback).toHaveBeenCalledWith(GROQ_VERSATILE_70B, GROQ_INSTANT_8B);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// callGroqWithModelFallback — エラー系
+// ---------------------------------------------------------------------------
+describe('callGroqWithModelFallback — エラー系', () => {
+  it('model_not_found 以外のエラーはそのまま再スローする', async () => {
+    const serverError = new GroqServerError(500, 'internal error');
+    callSpy.mockRejectedValueOnce(serverError);
+
+    await expect(callGroqWithModelFallback(makeParams(GROQ_VERSATILE_70B), { logger }))
+      .rejects.toBeInstanceOf(GroqServerError);
+
+    expect(callSpy).toHaveBeenCalledTimes(1);
+    expect(warnMock).not.toHaveBeenCalled();
+  });
+
+  it('429 エラーはフォールバックせずそのまま投げる', async () => {
+    const rateLimitError = new GroqRateLimitError(429, 'rate limit exceeded');
+    callSpy.mockRejectedValueOnce(rateLimitError);
+
+    await expect(callGroqWithModelFallback(makeParams(GROQ_VERSATILE_70B), { logger }))
+      .rejects.toBeInstanceOf(GroqRateLimitError);
+
+    expect(callSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('GroqBadRequestError (非 model_not_found) はフォールバックしない', async () => {
+    const badRequestError = new GroqBadRequestError(400, 'bad request');
+    callSpy.mockRejectedValueOnce(badRequestError);
+
+    await expect(callGroqWithModelFallback(makeParams(GROQ_VERSATILE_70B), { logger }))
+      .rejects.toBeInstanceOf(GroqBadRequestError);
+
+    expect(callSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('チェーン終端（GROQ_INSTANT_8B）はフォールバック先なしでエラーを投げる', async () => {
+    const notFoundError = new GroqModelNotFoundError(404, '{"error":"model_not_found"}', GROQ_INSTANT_8B);
+    callSpy.mockRejectedValue(notFoundError);
+
+    await expect(callGroqWithModelFallback(makeParams(GROQ_INSTANT_8B), { logger }))
+      .rejects.toBeInstanceOf(GroqModelNotFoundError);
+
+    // フォールバック試行なし（チェーン終端なので 1 回のみ）
+    expect(callSpy).toHaveBeenCalledTimes(1);
+    // warn ログが出力されること（チェーン終端の場合も無言は禁止）
+    expect(warnMock).toHaveBeenCalledTimes(1);
+    expect(warnMock.mock.calls[0][1]).toMatch(/no fallback available/);
+  });
+
+  it('フォールバック先でも model_not_found になった場合にチェーンを辿る', async () => {
+    // GPT_OSS_120B → GPT_OSS_20B → GROQ_VERSATILE_70B と辿る
+    const notFoundFor120b = new GroqModelNotFoundError(404, '{"error":"model_not_found"}', GPT_OSS_120B);
+    const notFoundFor20b = new GroqModelNotFoundError(404, '{"error":"model_not_found"}', GPT_OSS_20B);
+    callSpy
+      .mockRejectedValueOnce(notFoundFor120b)
+      .mockRejectedValueOnce(notFoundFor20b)
+      .mockResolvedValueOnce('final-fallback');
+
+    const result = await callGroqWithModelFallback(makeParams(GPT_OSS_120B), { logger });
+
+    expect(result).toBe('final-fallback');
+    expect(callSpy).toHaveBeenCalledTimes(3);
+    expect(callSpy).toHaveBeenNthCalledWith(3, expect.objectContaining({ model: GROQ_VERSATILE_70B }));
+    // warn は 2 回（各フォールバック発生時）
+    expect(warnMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/agent/llm/groqClient.ts
+++ b/src/agent/llm/groqClient.ts
@@ -1,5 +1,7 @@
 // src/agent/llm/groqClient.ts
 
+import { getFallbackGroqModel } from '../../config/groqModels';
+
 export type GroqRole = 'system' | 'user' | 'assistant'
 
 export interface GroqMessage {
@@ -71,6 +73,32 @@ export class GroqBadRequestError extends GroqApiError {
     super('Groq bad request error', status, bodySnippet);
     this.name = 'GroqBadRequestError';
   }
+}
+
+/**
+ * Groq が 404 / `model_not_found` を返したときに投げるエラー。
+ *
+ * 判定条件: HTTP 404、かつレスポンスボディに "model_not_found" または "model not found"
+ * (大文字小文字問わず) が含まれる場合。単純な 404 は GroqBadRequestError のまま。
+ */
+export class GroqModelNotFoundError extends GroqApiError {
+  /** 存在しないとして扱われたモデル ID */
+  readonly modelId: string;
+
+  constructor(status: number, bodySnippet: string, modelId: string) {
+    super(`Groq model not found: "${modelId}"`, status, bodySnippet);
+    this.name = 'GroqModelNotFoundError';
+    this.modelId = modelId;
+  }
+}
+
+/**
+ * HTTP 404 レスポンスが「モデル不在」由来かを判定するヘルパー。
+ * エラー識別を groqClient 内に閉じ込めるための内部ユーティリティ。
+ */
+export function isModelNotFoundBody(bodySnippet: string): boolean {
+  const lower = bodySnippet.toLowerCase();
+  return lower.includes('model_not_found') || lower.includes('model not found');
 }
 
 /** Groq API の usage フィールド */
@@ -149,6 +177,10 @@ export const groqClient: GroqClient = {
         throw new GroqRateLimitError(response.status, bodySnippet, retryAfterMs);
       }
 
+      if (response.status === 404 && isModelNotFoundBody(bodySnippet)) {
+        throw new GroqModelNotFoundError(response.status, bodySnippet, model);
+      }
+
       if (response.status >= 500) {
         throw new GroqServerError(response.status, bodySnippet);
       }
@@ -198,6 +230,9 @@ export const groqClient: GroqClient = {
         }
       }
       if (response.status === 429) throw new GroqRateLimitError(response.status, bodySnippet, retryAfterMs);
+      if (response.status === 404 && isModelNotFoundBody(bodySnippet)) {
+        throw new GroqModelNotFoundError(response.status, bodySnippet, model);
+      }
       if (response.status >= 500) throw new GroqServerError(response.status, bodySnippet);
       throw new GroqBadRequestError(response.status, bodySnippet);
     }
@@ -333,6 +368,125 @@ export async function callGroqWith429Retry(
       await new Promise((resolve) => setTimeout(resolve, retryAfterMs));
       attempt += 1;
       // ループして再試行
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Model-not-found フォールバック機構
+// ---------------------------------------------------------------------------
+
+export interface GroqFallbackOptions {
+  /**
+   * 呼び出し用途タグ（ログ集計用）。省略可。
+   */
+  tag?: string;
+  /**
+   * ログ出力先。省略した場合はログなし。
+   * 注意: フォールバック発生は必ずログに残すこと（無言フォールバック禁止）。
+   * Slack 通知が不要な場合でも warn レベルのログは必須。
+   */
+  logger?: {
+    warn: (obj: unknown, msg: string) => void;
+    info?: (obj: unknown, msg: string) => void;
+  };
+  /**
+   * Slack 通知コールバック。省略可。
+   * フォールバック発生時に呼び出されるので、Slack 通知が必要なら渡すこと。
+   */
+  onFallback?: (originalModel: string, fallbackModel: string) => void;
+}
+
+/**
+ * Groq 呼び出しに 404 / model_not_found が返った場合、カタログ定義のフォールバック先へ
+ * 自動退避するラッパー。
+ *
+ * - フォールバックチェーンは `src/config/groqModels.ts` の `GROQ_FALLBACK_CHAIN` を参照。
+ * - フォールバック発生時は必ず warn ログを出力する（無言フォールバック禁止）。
+ * - チェーン終端（退避先なし）または非 model_not_found エラーはそのまま上位へ投げる。
+ * - 最大フォールバック回数は GROQ_FALLBACK_CHAIN の深さ（現在 2 段）に依存する。
+ *
+ * @param params   Groq 呼び出しパラメータ（model はフォールバックで上書きされる）
+ * @param options  ログ・Slack 通知オプション
+ * @returns        最初に成功したモデルの応答テキスト
+ */
+export async function callGroqWithModelFallback(
+  params: GroqCallParams,
+  options: GroqFallbackOptions = {},
+): Promise<string> {
+  const { logger, onFallback } = options;
+  let currentModel = params.model;
+  // フォールバック済みモデルを追跡（循環ループ防止）
+  const visited = new Set<string>([currentModel]);
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    try {
+      const result = await groqClient.call({ ...params, model: currentModel });
+      if (currentModel !== params.model) {
+        // 最終的にフォールバック先で成功した場合は info ログ
+        logger?.info?.(
+          { originalModel: params.model, resolvedModel: currentModel, tag: params.tag },
+          '[groq-fallback] call succeeded on fallback model',
+        );
+      }
+      return result;
+    } catch (err) {
+      if (!(err instanceof GroqModelNotFoundError)) {
+        // model_not_found 以外のエラーはそのまま上位へ
+        throw err;
+      }
+
+      const fallbackModel = getFallbackGroqModel(currentModel);
+
+      if (fallbackModel === null) {
+        // フォールバックチェーン終端: これ以上退避できない
+        logger?.warn?.(
+          {
+            originalModel: params.model,
+            failedModel: currentModel,
+            tag: params.tag,
+            status: err.status,
+          },
+          '[groq-fallback] model_not_found and no fallback available, giving up',
+        );
+        throw err;
+      }
+
+      if (visited.has(fallbackModel)) {
+        // 循環ループ検知（カタログ設定ミスへの防衛）
+        logger?.warn?.(
+          {
+            originalModel: params.model,
+            failedModel: currentModel,
+            fallbackModel,
+            visited: [...visited],
+            tag: params.tag,
+          },
+          '[groq-fallback] fallback cycle detected, giving up',
+        );
+        throw err;
+      }
+
+      // フォールバック発生を必ずログに残す（無言フォールバック禁止）
+      logger?.warn?.(
+        {
+          originalModel: params.model,
+          failedModel: currentModel,
+          fallbackModel,
+          tag: params.tag,
+          status: err.status,
+          bodySnippet: err.bodySnippet,
+        },
+        '[groq-fallback] model_not_found, falling back to alternative model',
+      );
+
+      // Slack 通知コールバックが設定されていれば呼ぶ
+      onFallback?.(currentModel, fallbackModel);
+
+      visited.add(fallbackModel);
+      currentModel = fallbackModel;
+      // ループして代替モデルで再試行
     }
   }
 }

--- a/src/config/groqModels.ts
+++ b/src/config/groqModels.ts
@@ -81,3 +81,36 @@ export function assertActiveGroqModel(model: string): void {
     );
   }
 }
+
+/**
+ * モデルが 404 / model_not_found エラーを返した際のフォールバックチェーン。
+ *
+ * キー: 優先モデルの ID
+ * 値: 退避先モデルの ID（カタログの ACTIVE_GROQ_MODELS 内のみ許可）
+ *
+ * 設計方針:
+ *   - 高性能モデルから汎用モデルへ段階的に下げる。
+ *   - 最後は必ず llama-3.1-8b-instant（最小/最安）。
+ *   - 120B 系は compound に退避（ANTI-SLOP: 120B は複雑クエリ/safety のみ使用）。
+ *   - チェーンは最大 2 段。無限ループ防止のため resolve 時に検証する。
+ */
+export const GROQ_FALLBACK_CHAIN: Readonly<Record<string, string>> = {
+  // gpt-oss 系: EOL 通知前の緊急退避
+  [GPT_OSS_120B]: GPT_OSS_20B,
+  [GPT_OSS_20B]: GROQ_VERSATILE_70B,
+  // compound 系
+  [GROQ_COMPOUND]: GROQ_COMPOUND_MINI,
+  [GROQ_COMPOUND_MINI]: GROQ_VERSATILE_70B,
+  // versatile → instant
+  [GROQ_VERSATILE_70B]: GROQ_INSTANT_8B,
+  // instant: これ以上退避先なし（チェーン終端）
+};
+
+/**
+ * 指定モデルのフォールバック先を返す。
+ *
+ * @returns フォールバック先モデル ID。チェーン終端の場合は null。
+ */
+export function getFallbackGroqModel(model: string): string | null {
+  return GROQ_FALLBACK_CHAIN[model] ?? null;
+}


### PR DESCRIPTION
## Summary

- `GroqModelNotFoundError` クラスを新設（`GroqApiError` サブクラス）
- `isModelNotFoundBody()` ヘルパーで HTTP 404 + body 判定を分離
- `GROQ_FALLBACK_CHAIN` を `src/config/groqModels.ts` に定義（カタログ一元管理）
- `callGroqWithModelFallback()` 関数を `src/agent/llm/groqClient.ts` に追加
  - フォールバック発生時は必ず warn ログ出力（無言退避禁止）
  - `onFallback` コールバックで Slack 通知を任意追加可能
  - 循環ループ検知付き（カタログ設定ミス防衛）
- 17 ユニットテスト追加

## フォールバックチェーン

```
GPT_OSS_120B → GPT_OSS_20B → GROQ_VERSATILE_70B → GROQ_INSTANT_8B (終端)
GROQ_COMPOUND → GROQ_COMPOUND_MINI → GROQ_VERSATILE_70B → GROQ_INSTANT_8B (終端)
```

## Test plan

- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 63 warnings (閾値 80 以内)
- [x] `pnpm test` — 1840 tests all pass (新規 17 tests 含む)
- [ ] Gate 2: security-scan (CI 自動実行)

Asana GID: 1215114051952421

🤖 Generated with [Claude Code](https://claude.com/claude-code)