### PR TITLE
fix(ops): 24h-mode-on.sh の branch protection を strict:false に恒久化

### DIFF
--- a/SCRIPTS/24h-mode-on.sh
+++ b/SCRIPTS/24h-mode-on.sh
@@ -119,7 +119,7 @@ CHECKS_JSON=$(printf '%s' "$STATUS_CHECKS" | jq -Rcs 'split(",") | map(gsub("^\\
 PROTECTION_PAYLOAD=$(jq -nc \
     --argjson checks "$CHECKS_JSON" \
     '{
-        required_status_checks: { strict: true, checks: $checks },
+        required_status_checks: { strict: false, checks: $checks },
         enforce_admins: false,
         required_pull_request_reviews: {
             dismiss_stale_reviews: true,


### PR DESCRIPTION
## Summary
- `SCRIPTS/24h-mode-on.sh` の `required_status_checks.strict` を `true` → `false` に変更
- auto-merge が BEHIND PR で詰まる根本原因を恒久修正

## 背景
- #274 の自前 auto-merge が `strict: true` により BEHIND PR で詰まっていた
- #276 で `update-branch` 自己解消を追加したが1サイクル遅延が発生
- `strict: false` にすることで update-branch 不要、即時マージ可能に

## 変更内容
```diff
- required_status_checks: { strict: true, checks: $checks },
+ required_status_checks: { strict: false, checks: $checks },
```

## Test plan
- [ ] 24h-mode-on.sh 実行後、branch protection が strict:false になっていることを確認
- [ ] BEHIND 状態の PR が update-branch なしで auto-merge されることを確認

関連: GID 1215435672578337 / #274 #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)