### PR TITLE
docs(rules): Karpathy 4原則 + Research-First + CL小型化明文化

### DIFF
--- a/.claude/rules/implementation.md
+++ b/.claude/rules/implementation.md
@@ -1,0 +1,25 @@
+---
+name: implementation
+description: R2C 実装規律 — Research-First + Karpathy 4原則（R2C語彙版）
+version: 1.0.0
+---
+
+# Implementation Discipline
+
+## Research-Before-Coding（推測禁止）
+- 実装前に `file / grep / git log` で現状を確認する — 推測で変更しない
+- memory・anatomy.md 記載のファイル名/パス/endpoint は古い可能性あり → 必ず実機照合してから起票・実装
+
+## Simplicity First（過剰実装禁止）
+- タスク要件を超えた実装追加禁止: 未要求のヘルパー・抽象化・設定ファイルを足さない
+- 「将来使うかも」は理由にならない — 3行の重複は早すぎる抽象化より良い
+- error handling・fallback・validation は system boundary（ユーザー入力/外部API）にのみ書く
+
+## Surgical Changes（関係ない行を触らない）
+- 変更はタスクに直接関係する行のみ。orthogonal な修正は別 PR に
+- 既存の dead code は指摘するだけ — 削除は別タスク・別 PR
+- リファクタは明示的に要求されない限り行わない
+
+## Goal-Driven（完了基準で止まる）
+- 実装前に DoD（Gate 通過 / テスト pass）を確認する
+- DoD を満たしたら止まる — 追加改善・周辺整理は別タスク起票

--- a/docs/PR_MERGE_RULES.md
+++ b/docs/PR_MERGE_RULES.md
@@ -37,6 +37,18 @@ gh pr merge <PR番号> --auto --squash --delete-branch
 - **squash and merge** を標準とする（linear history 維持）
 - rebase merge / merge commit は使わない（履歴複雑化回避）
 
+## CL（変更リスト）小型化原則
+
+Codex レビューのラウンド数削減と安全な auto-merge のために、PR は小さく保つ:
+
+- **1 PR = 1 論理変更**。複数フィーチャーを1 PR に混ぜない
+- `src/` 変更 + `SCRIPTS/` 変更は分離を検討（Tier が変わる場合は必須）
+- migration SQL + アプリコードは同一 PR で可（atomic deploy 前提）
+- テスト追加 + 実装は同一 PR に含める（Gate 通過の前提）
+
+大きな PR は Codex ラウンド数が増え、auto-merge の確認コストも上がる。
+スコープが膨らんだと感じたら、その場で分割を検討すること。
+
 ## 関連タスク
 
 - Phase1（本ルール策定）: Asana 1214121039752589


### PR DESCRIPTION
## Summary
- `.claude/rules/implementation.md` 新規追加: Research-Before-Coding / Simplicity First / Surgical Changes / Goal-Driven（R2C語彙版）
- `docs/PR_MERGE_RULES.md` に CL小型化原則セクション追加

## 背景
外部ツール採用ジャッジ（GID 1215122898111435）の実機照合結果:
- Karpathy 4原則相当がCLAUDE.md未明文 → `.claude/rules/` 階層を活用して追記
- Google eng-practices B方針（CL小型化）をR2C実Gate語彙に翻訳

## Test plan
- [x] pnpm verify 不要（docs/rules のみ）
- [x] `.claude/rules/` は project-level instructions として自動ロード済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)