### PR TITLE
feat(admin-ui): AI提案ルール承認済み後の再編集機能

### DIFF
--- a/admin-ui/src/pages/admin/chat-history/[sessionId].tsx
+++ b/admin-ui/src/pages/admin/chat-history/[sessionId].tsx
@@ -12,6 +12,7 @@ const DEFAULT_CONVERSION_TYPES = ["購入完了", "予約完了", "問い合わ�
 interface SuggestedRule {
   rule_text: string;
   status?: string;
+  tuning_rule_id?: number;
 }
 
 interface Evaluation {
@@ -69,10 +70,12 @@ function SuggestedRulesCard({
   rules: SuggestedRule[];
   onUpdate: (updated: SuggestedRule[]) => void;
 }) {
+  const navigate = useNavigate();
   const [processing, setProcessing] = useState<number | null>(null);
 
   const pending = rules.filter((r) => !r.status || r.status === "pending");
-  if (pending.length === 0) return null;
+  const approved = rules.filter((r) => r.status === "approved");
+  if (pending.length === 0 && approved.length === 0) return null;
 
   const handleAction = async (ruleIndex: number, action: "approve" | "reject") => {
     setProcessing(ruleIndex);
@@ -82,8 +85,11 @@ function SuggestedRulesCard({
         { method: "PATCH", headers: { "Content-Type": "application/json" }, body: JSON.stringify({ action }) },
       );
       if (res.ok) {
+        const json = await res.json() as { tuning_rule_id?: number };
         const updated = rules.map((r, i) =>
-          i === ruleIndex ? { ...r, status: action === "approve" ? "approved" : "rejected" } : r,
+          i === ruleIndex
+            ? { ...r, status: action === "approve" ? "approved" : "rejected", tuning_rule_id: json.tuning_rule_id }
+            : r,
         );
         onUpdate(updated);
       }
@@ -92,13 +98,17 @@ function SuggestedRulesCard({
     }
   };
 
+  const totalShown = pending.length + approved.length;
+
   return (
     <div style={{ marginTop: 12, display: "flex", flexDirection: "column", gap: 10 }}>
       <p style={{ margin: 0, fontSize: 13, fontWeight: 700, color: "#c4b5fd" }}>
-        💡 AI提案ルール ({pending.length}件)
+        💡 AI提案ルール ({totalShown}件)
       </p>
       {rules.map((rule, idx) => {
-        if (rule.status && rule.status !== "pending") return null;
+        const isApproved = rule.status === "approved";
+        const isPending = !rule.status || rule.status === "pending";
+        if (!isPending && !isApproved) return null;
         const busy = processing === idx;
         return (
           <div
@@ -106,8 +116,8 @@ function SuggestedRulesCard({
             style={{
               padding: "12px 14px",
               borderRadius: 10,
-              background: "rgba(124,58,237,0.08)",
-              border: "1px solid rgba(196,181,253,0.2)",
+              background: isApproved ? "rgba(34,197,94,0.06)" : "rgba(124,58,237,0.08)",
+              border: `1px solid ${isApproved ? "rgba(74,222,128,0.2)" : "rgba(196,181,253,0.2)"}`,
               display: "flex",
               flexDirection: "column",
               gap: 8,
@@ -116,32 +126,52 @@ function SuggestedRulesCard({
             <p style={{ margin: 0, fontSize: 13, color: "#e5e7eb", lineHeight: 1.6 }}>
               {rule.rule_text}
             </p>
-            <div style={{ display: "flex", gap: 8 }}>
-              <button
-                onClick={() => void handleAction(idx, "approve")}
-                disabled={busy}
-                style={{
-                  flex: 1, padding: "10px 12px", minHeight: 44, borderRadius: 8,
-                  border: "1px solid rgba(74,222,128,0.4)", background: "rgba(34,197,94,0.15)",
-                  color: "#4ade80", fontSize: 14, fontWeight: 700,
-                  cursor: busy ? "not-allowed" : "pointer", opacity: busy ? 0.6 : 1,
-                }}
-              >
-                ✅ 承認してルールに追加
-              </button>
-              <button
-                onClick={() => void handleAction(idx, "reject")}
-                disabled={busy}
-                style={{
-                  padding: "10px 16px", minHeight: 44, borderRadius: 8,
-                  border: "1px solid rgba(248,113,113,0.4)", background: "rgba(239,68,68,0.15)",
-                  color: "#f87171", fontSize: 14, fontWeight: 700,
-                  cursor: busy ? "not-allowed" : "pointer", opacity: busy ? 0.6 : 1,
-                }}
-              >
-                ❌ 却下
-              </button>
-            </div>
+            {isApproved ? (
+              <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                <span style={{ fontSize: 13, color: "#4ade80", fontWeight: 600 }}>✅ 承認済み</span>
+                <button
+                  onClick={() => {
+                    const params = new URLSearchParams();
+                    if (rule.tuning_rule_id) params.set("editId", String(rule.tuning_rule_id));
+                    navigate(`/admin/tuning?${params.toString()}`);
+                  }}
+                  style={{
+                    padding: "6px 12px", minHeight: 32, borderRadius: 6,
+                    border: "1px solid rgba(148,163,184,0.3)", background: "rgba(148,163,184,0.1)",
+                    color: "#94a3b8", fontSize: 12, fontWeight: 600, cursor: "pointer",
+                  }}
+                >
+                  ✏️ 編集
+                </button>
+              </div>
+            ) : (
+              <div style={{ display: "flex", gap: 8 }}>
+                <button
+                  onClick={() => void handleAction(idx, "approve")}
+                  disabled={busy}
+                  style={{
+                    flex: 1, padding: "10px 12px", minHeight: 44, borderRadius: 8,
+                    border: "1px solid rgba(74,222,128,0.4)", background: "rgba(34,197,94,0.15)",
+                    color: "#4ade80", fontSize: 14, fontWeight: 700,
+                    cursor: busy ? "not-allowed" : "pointer", opacity: busy ? 0.6 : 1,
+                  }}
+                >
+                  ✅ 承認してルールに追加
+                </button>
+                <button
+                  onClick={() => void handleAction(idx, "reject")}
+                  disabled={busy}
+                  style={{
+                    padding: "10px 16px", minHeight: 44, borderRadius: 8,
+                    border: "1px solid rgba(248,113,113,0.4)", background: "rgba(239,68,68,0.15)",
+                    color: "#f87171", fontSize: 14, fontWeight: 700,
+                    cursor: busy ? "not-allowed" : "pointer", opacity: busy ? 0.6 : 1,
+                  }}
+                >
+                  ❌ 却下
+                </button>
+              </div>
+            )}
           </div>
         );
       })}

--- a/admin-ui/src/pages/admin/tuning/index.tsx
+++ b/admin-ui/src/pages/admin/tuning/index.tsx
@@ -162,6 +162,21 @@ export default function TuningRulesPage() {
     }
   }, [searchParams]);
 
+  // ─── Auto-open edit modal from URL params (from AI evaluation detail) ────────
+  useEffect(() => {
+    const editIdStr = searchParams.get("editId");
+    if (!editIdStr) return;
+    const editId = Number(editIdStr);
+    if (!Number.isFinite(editId) || editId <= 0) return;
+    // Wait until rules are loaded, then open the edit modal for the matching rule
+    if (loading) return;
+    const target = rules.find((r) => r.id === editId);
+    if (target) {
+      setEditTarget(target);
+      window.history.replaceState({}, "", "/admin/tuning");
+    }
+  }, [searchParams, rules, loading]);
+
   // ─── Modal success ──────────────────────────────────────────────────────────
   // モーダルが保存API を自身で呼び出してTuningRuleを返す。
   // ここではリスト更新とトーストのみ行い、モーダルは閉じない（テスト返答フェーズへ遷移）。

--- a/src/api/admin/evaluations/evaluationsAuthGuard.test.ts
+++ b/src/api/admin/evaluations/evaluationsAuthGuard.test.ts
@@ -21,7 +21,7 @@ jest.mock('./evaluationsRepository', () => ({
   getEvaluationById: jest.fn().mockResolvedValue(null),
   checkAlreadyEvaluated: jest.fn().mockResolvedValue(false),
   updateSuggestedRuleStatus: jest.fn().mockResolvedValue({ id: 1 }),
-  insertTuningRuleFromSuggestion: jest.fn().mockResolvedValue(undefined),
+  insertTuningRuleFromSuggestion: jest.fn().mockResolvedValue(1),
 }));
 
 import express from 'express';

--- a/src/api/admin/evaluations/evaluationsRepository.ts
+++ b/src/api/admin/evaluations/evaluationsRepository.ts
@@ -641,7 +641,7 @@ export async function insertTuningRuleFromSuggestion(
   tenantId: string,
   ruleText: string,
   options?: { editedText?: string; editedBy?: string },
-): Promise<void> {
+): Promise<number | null> {
   const pool = getPool();
   const finalText = options?.editedText ?? ruleText;
   const originalText = options?.editedText ? ruleText : null;
@@ -649,21 +649,23 @@ export async function insertTuningRuleFromSuggestion(
   const editedAt = options?.editedText ? "NOW()" : null;
 
   if (editedAt) {
-    await pool.query(
+    const result = await pool.query<{ id: number }>(
       `INSERT INTO tuning_rules
          (tenant_id, trigger_pattern, expected_behavior, priority, is_active,
           original_text, edited_by, edited_at)
        VALUES ($1, $2, $2, 0, true, $3, $4, NOW())
-       ON CONFLICT DO NOTHING`,
+       ON CONFLICT DO NOTHING RETURNING id`,
       [tenantId, finalText, originalText, editedBy],
     );
+    return result.rows[0]?.id ?? null;
   } else {
-    await pool.query(
+    const result = await pool.query<{ id: number }>(
       `INSERT INTO tuning_rules
          (tenant_id, trigger_pattern, expected_behavior, priority, is_active)
        VALUES ($1, $2, $2, 0, true)
-       ON CONFLICT DO NOTHING`,
+       ON CONFLICT DO NOTHING RETURNING id`,
       [tenantId, finalText],
     );
+    return result.rows[0]?.id ?? null;
   }
 }

--- a/src/api/admin/evaluations/routes.ts
+++ b/src/api/admin/evaluations/routes.ts
@@ -273,6 +273,7 @@ export function registerEvaluationRoutes(app: Express): void {
       const tenantId = isSuperAdmin ? undefined : jwtTenantId || undefined;
 
       try {
+        let tuningRuleId: number | null = null;
         if (action === "approve") {
           // Fetch the evaluation to get the rule text
           const data = await getEvaluationById(id, tenantId);
@@ -286,7 +287,7 @@ export function registerEvaluationRoutes(app: Express): void {
           }
           const ruleText = rule.rule_text ?? "";
           if (ruleText) {
-            await insertTuningRuleFromSuggestion(data.evaluation.tenant_id, ruleText, {
+            tuningRuleId = await insertTuningRuleFromSuggestion(data.evaluation.tenant_id, ruleText, {
               editedText: typeof edited_text === "string" ? edited_text : undefined,
               editedBy: email || undefined,
             });
@@ -302,7 +303,7 @@ export function registerEvaluationRoutes(app: Express): void {
         if (!updated) {
           return res.status(404).json({ error: "評価データが見つかりません" });
         }
-        return res.json({ ok: true, evaluation: updated });
+        return res.json({ ok: true, evaluation: updated, ...(tuningRuleId !== null ? { tuning_rule_id: tuningRuleId } : {}) });
       } catch (err: unknown) {
         if (err instanceof RangeError) {
           return res.status(400).json({ error: err.message });


### PR DESCRIPTION
## Summary
- 承認済みAI提案ルールに「✏️ 編集」ボタンを追加（`[sessionId].tsx` の `SuggestedRulesCard`）
- `insertTuningRuleFromSuggestion` が `RETURNING id` で新規ルールIDを返すよう変更
- PATCH `/evaluations/:id/rules/:ruleIndex` のレスポンスに `tuning_rule_id` を追加
- チューニングページが `?editId=<id>` で対象ルールの編集モーダルを自動オープン

## Test plan
- [ ] AI評価詳細ページでPendingルールを承認 → 「✅ 承認済み ✏️ 編集」に変わることを確認
- [ ] 「✏️ 編集」クリック → `/admin/tuning?editId=<id>` に遷移し編集モーダルが開くことを確認
- [ ] 却下したルールは表示されないことを確認（approved/pendingのみ表示）
- [ ] Gate 1: pnpm verify ✅

Closes GID 1213921646775637

🤖 Generated with [Claude Code](https://claude.com/claude-code)