### PR TITLE
feat(admin-ui): ナレッジ管理テナント選択ページ廃止・ドロップダウン統合

### DIFF
--- a/admin-ui/src/pages/admin/knowledge/[tenantId].tsx
+++ b/admin-ui/src/pages/admin/knowledge/[tenantId].tsx
@@ -8,8 +8,15 @@ import LangSwitcher from "../../../components/LangSwitcher";
 import { useAuth } from "../../../auth/useAuth";
 import BookChunksPanel from "./BookChunksPanel";
 import KnowledgeAttributionTab from "../../../components/knowledge/KnowledgeAttributionTab";
+import { KNOWLEDGE_TENANT_STORAGE_KEY } from "./index";
 
 // ─── 型定義 ──────────────────────────────────────────────────────────────────
+
+interface Tenant {
+  id: string;
+  name: string;
+  slug: string;
+}
 
 interface KnowledgeItem {
   id: number;
@@ -2185,11 +2192,28 @@ export default function TenantKnowledgePage() {
       : "list"
   );
 
+  // テナント一覧（Super Admin のみ使用）
+  const [tenants, setTenants] = useState<Tenant[]>([]);
+  useEffect(() => {
+    if (!isSuperAdmin) return;
+    fetchWithAuth(`${API_BASE}/v1/admin/tenants`)
+      .then((res) => res.json() as Promise<{ tenants?: Tenant[]; items?: Tenant[] }>)
+      .then((data) => setTenants(data.tenants ?? data.items ?? []))
+      .catch(() => {/* best-effort */});
+  }, [isSuperAdmin]);
+
   // tenantId の解決: URL params → pathnameの末尾 → JWTのtenantId
   // /admin/knowledge/global のように固定パスの場合 useParams では undefined になるため
   // pathname から取得するフォールバックを追加
   const pathTenantId = tenantId ?? location.pathname.split("/").pop() ?? "";
   const resolvedTenantId = pathTenantId || user?.tenantId || "";
+
+  // テナント切り替え時に localStorage に保存
+  useEffect(() => {
+    if (isSuperAdmin && resolvedTenantId) {
+      localStorage.setItem(KNOWLEDGE_TENANT_STORAGE_KEY, resolvedTenantId);
+    }
+  }, [isSuperAdmin, resolvedTenantId]);
 
   useEffect(() => {
     void (async () => {
@@ -2208,6 +2232,16 @@ export default function TenantKnowledgePage() {
 
   const isGlobalTenant = resolvedTenantId === "global";
 
+  const handleTenantChange = (newTenantId: string) => {
+    localStorage.setItem(KNOWLEDGE_TENANT_STORAGE_KEY, newTenantId);
+    const tabSuffix = activeTab !== "list" ? `?tab=${activeTab}` : "";
+    navigate(`/admin/knowledge/${newTenantId}${tabSuffix}`);
+  };
+
+  const testUrl = isGlobalTenant
+    ? "/admin/chat-test?scope=global"
+    : `/admin/chat-test?tenantId=${encodeURIComponent(resolvedTenantId)}`;
+
   return (
     <div
       style={{
@@ -2222,26 +2256,57 @@ export default function TenantKnowledgePage() {
       <header style={{ marginBottom: 28 }}>
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8, flexWrap: "wrap", gap: 8 }}>
           <button
-            onClick={() => navigate(isSuperAdmin ? "/admin/knowledge" : "/admin")}
+            onClick={() => navigate("/admin")}
             style={{ display: "inline-flex", alignItems: "center", gap: 4, padding: "8px 14px", minHeight: 44, borderRadius: 999, border: "1px solid #374151", background: "transparent", color: "#9ca3af", fontSize: 14, cursor: "pointer", fontWeight: 500 }}
           >
-            {isSuperAdmin ? t("nav.back_knowledge") : t("nav.back_dashboard")}
+            {t("nav.back_dashboard")}
           </button>
           <LangSwitcher />
         </div>
         <h1 style={{ fontSize: 26, fontWeight: 700, margin: 0, color: "#f9fafb" }}>
           {t("knowledge.title")}
         </h1>
-        <p style={{ fontSize: 14, color: "#9ca3af", marginTop: 4, marginBottom: 0 }}>
-          {isGlobalTenant
-            ? t("knowledge.global_desc")
-            : t("knowledge.subtitle")}
-          {resolvedTenantId && !isGlobalTenant && (
-            <span style={{ marginLeft: 8, fontFamily: "monospace", color: "#6b7280", fontSize: 12 }}>
-              ({resolvedTenantId})
-            </span>
-          )}
-        </p>
+        {isSuperAdmin ? (
+          <div style={{ display: "flex", gap: 8, alignItems: "center", marginTop: 10 }}>
+            <select
+              value={resolvedTenantId}
+              onChange={(e) => handleTenantChange(e.target.value)}
+              style={{
+                flex: 1, padding: "10px 12px", minHeight: 44, borderRadius: 10,
+                border: "1px solid #374151", background: "rgba(15,23,42,0.8)",
+                color: "#e5e7eb", fontSize: 15, cursor: "pointer",
+              }}
+            >
+              <option value="global">🌐 グローバルナレッジ</option>
+              {tenants.map((tn) => (
+                <option key={tn.id} value={tn.id}>{tn.name}</option>
+              ))}
+            </select>
+            <button
+              onClick={() => navigate(testUrl)}
+              style={{
+                padding: "10px 16px", minHeight: 44, borderRadius: 10,
+                border: "1px solid rgba(59,130,246,0.3)", background: "rgba(59,130,246,0.08)",
+                color: "#93c5fd", fontSize: 14, fontWeight: 600, cursor: "pointer", whiteSpace: "nowrap",
+              }}
+            >
+              💬 テスト
+            </button>
+          </div>
+        ) : (
+          <div style={{ display: "flex", justifyContent: "flex-end", marginTop: 8 }}>
+            <button
+              onClick={() => navigate(testUrl)}
+              style={{
+                padding: "10px 16px", minHeight: 44, borderRadius: 10,
+                border: "1px solid rgba(59,130,246,0.3)", background: "rgba(59,130,246,0.08)",
+                color: "#93c5fd", fontSize: 14, fontWeight: 600, cursor: "pointer",
+              }}
+            >
+              💬 テスト
+            </button>
+          </div>
+        )}
       </header>
 
       {/* タブ */}

--- a/admin-ui/src/pages/admin/knowledge/index.tsx
+++ b/admin-ui/src/pages/admin/knowledge/index.tsx
@@ -1,206 +1,24 @@
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { useNavigate } from "react-router-dom";
-import { useLang } from "../../../i18n/LangContext";
-import LangSwitcher from "../../../components/LangSwitcher";
 import { useAuth } from "../../../auth/useAuth";
-import { API_BASE } from "../../../lib/api";
-import { fetchWithAuth } from "../../../components/knowledge/shared";
 
-interface Tenant {
-  id: string;
-  name: string;
-  slug: string;
-  plan: "starter" | "pro";
-  status: "active" | "inactive";
-}
+export const KNOWLEDGE_TENANT_STORAGE_KEY = "knowledge_last_tenant";
 
 export default function KnowledgePage() {
   const navigate = useNavigate();
-  const { t } = useLang();
   const { user, isSuperAdmin, isLoading } = useAuth();
-  const [tenants, setTenants] = useState<Tenant[]>([]);
-  const [loadingTenants, setLoadingTenants] = useState(false);
-  const [error, setError] = useState<string | null>(null);
 
-  // client_admin → 自テナントにリダイレクト
   useEffect(() => {
     if (isLoading) return;
     if (!isSuperAdmin && user?.tenantId) {
       navigate(`/admin/knowledge/${user.tenantId}`, { replace: true });
+      return;
+    }
+    if (isSuperAdmin) {
+      const last = localStorage.getItem(KNOWLEDGE_TENANT_STORAGE_KEY) ?? "global";
+      navigate(`/admin/knowledge/${last}`, { replace: true });
     }
   }, [isLoading, isSuperAdmin, user, navigate]);
 
-  // super_admin → テナント一覧を取得
-  useEffect(() => {
-    if (!isSuperAdmin) return;
-    setLoadingTenants(true);
-    fetchWithAuth(`${API_BASE}/v1/admin/tenants`)
-      .then((res) => res.json() as Promise<{ tenants?: Tenant[]; items?: Tenant[] }>)
-      .then((data) => setTenants(data.tenants ?? data.items ?? []))
-      .catch(() => setError(t("knowledge.load_error")))
-      .finally(() => setLoadingTenants(false));
-  }, [isSuperAdmin, t]);
-
-  // リダイレクト中は何も表示しない
-  if (isLoading || (!isSuperAdmin && user?.tenantId)) {
-    return null;
-  }
-
-  return (
-    <div
-      style={{
-        minHeight: "100vh",
-        background: "radial-gradient(circle at top, #0f172a 0, #020617 55%, #000 100%)",
-        color: "#e5e7eb",
-        padding: "24px 20px",
-        maxWidth: 900,
-        margin: "0 auto",
-      }}
-    >
-      <header style={{ marginBottom: 28 }}>
-        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8, flexWrap: "wrap", gap: 8 }}>
-          <button
-            onClick={() => navigate("/admin")}
-            style={{ display: "inline-flex", alignItems: "center", gap: 4, padding: "4px 0", border: "none", background: "none", color: "#9ca3af", fontSize: 13, cursor: "pointer" }}
-          >
-            {t("common.back_to_dashboard")}
-          </button>
-          <LangSwitcher />
-        </div>
-        <h1 style={{ fontSize: 26, fontWeight: 700, margin: 0, color: "#f9fafb" }}>
-          {t("knowledge.title")}
-        </h1>
-        <p style={{ fontSize: 14, color: "#9ca3af", marginTop: 4, marginBottom: 0 }}>
-          {t("knowledge.subtitle")}
-        </p>
-      </header>
-
-
-      {/* グローバルナレッジカード（super_admin のみ） */}
-      <div style={{ display: "flex", gap: 8, alignItems: "stretch", marginBottom: 12 }}>
-        <button
-          onClick={() => navigate("/admin/knowledge/global")}
-          style={{
-            flex: 1,
-            padding: "20px 18px",
-            borderRadius: 14,
-            border: "1px solid rgba(234,179,8,0.3)",
-            background: "linear-gradient(145deg, rgba(120,53,15,0.3), rgba(15,23,42,0.7))",
-            color: "#fbbf24",
-            fontSize: 16,
-            fontWeight: 700,
-            cursor: "pointer",
-            textAlign: "left",
-            display: "flex",
-            alignItems: "center",
-            gap: 12,
-          }}
-        >
-          <span style={{ fontSize: 24 }}>🌐</span>
-          <div>
-            <div>グローバルナレッジ</div>
-            <div style={{ fontSize: 13, fontWeight: 400, color: "#d97706", marginTop: 2 }}>
-              全テナント共通のナレッジを管理
-            </div>
-          </div>
-          <span style={{ marginLeft: "auto", fontSize: 18, color: "#d97706" }}>›</span>
-        </button>
-        <button
-          onClick={() => navigate("/admin/chat-test?scope=global")}
-          style={{
-            padding: "12px 16px",
-            minHeight: 44,
-            borderRadius: 14,
-            border: "1px solid rgba(59,130,246,0.3)",
-            background: "rgba(59,130,246,0.08)",
-            color: "#93c5fd",
-            fontSize: 13,
-            fontWeight: 600,
-            cursor: "pointer",
-            whiteSpace: "nowrap",
-            flexShrink: 0,
-          }}
-          title="グローバルナレッジのテストチャットを開く"
-        >
-          💬 テスト
-        </button>
-      </div>
-
-      {/* テナント一覧 */}
-      {error && (
-        <div style={{ padding: "14px 18px", borderRadius: 12, background: "rgba(127,29,29,0.4)", border: "1px solid rgba(248,113,113,0.3)", color: "#fca5a5", fontSize: 15, marginBottom: 12 }}>
-          {error}
-        </div>
-      )}
-
-      {loadingTenants ? (
-        <div style={{ padding: 40, textAlign: "center", color: "#6b7280" }}>
-          <span style={{ display: "block", fontSize: 32, marginBottom: 8 }}>⏳</span>
-          {t("knowledge.loading")}
-        </div>
-      ) : (
-        <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
-          {tenants.map((tenant) => (
-            <div key={tenant.id} style={{ display: "flex", gap: 8, alignItems: "stretch" }}>
-              <button
-                onClick={() => navigate(`/admin/knowledge/${tenant.id}`)}
-                style={{
-                  flex: 1,
-                  padding: "18px 20px",
-                  borderRadius: 14,
-                  border: "1px solid #1f2937",
-                  background: "linear-gradient(145deg, rgba(15,23,42,0.95), rgba(15,23,42,0.7))",
-                  color: "#e5e7eb",
-                  fontSize: 15,
-                  fontWeight: 600,
-                  cursor: "pointer",
-                  textAlign: "left",
-                  display: "flex",
-                  alignItems: "center",
-                  gap: 12,
-                  transition: "border-color 0.15s",
-                }}
-              >
-                <span style={{ fontSize: 22 }}>🏢</span>
-                <div style={{ flex: 1 }}>
-                  <div style={{ color: "#f9fafb" }}>{tenant.name}</div>
-                  <div style={{ fontSize: 12, color: "#6b7280", marginTop: 2 }}>
-                    {tenant.slug ? `${tenant.slug} · ` : ""}{tenant.plan === "pro" ? "プロ" : "スターター"} · {tenant.status === "active" ? "✅ 有効" : "⏸ 停止中"}
-                  </div>
-                </div>
-                <span style={{ fontSize: 18, color: "#6b7280" }}>›</span>
-              </button>
-              <button
-                onClick={() => navigate(`/admin/chat-test?tenantId=${encodeURIComponent(tenant.id)}`)}
-                style={{
-                  padding: "12px 16px",
-                  minHeight: 44,
-                  borderRadius: 14,
-                  border: "1px solid rgba(59,130,246,0.3)",
-                  background: "rgba(59,130,246,0.08)",
-                  color: "#93c5fd",
-                  fontSize: 13,
-                  fontWeight: 600,
-                  cursor: "pointer",
-                  whiteSpace: "nowrap",
-                  flexShrink: 0,
-                }}
-                title={`${tenant.name} のテストチャットを開く`}
-              >
-                💬 テスト
-              </button>
-            </div>
-          ))}
-          {tenants.length === 0 && !loadingTenants && (
-            <div style={{ padding: 40, textAlign: "center", borderRadius: 14, border: "1px dashed #374151", background: "rgba(15,23,42,0.4)" }}>
-              <span style={{ display: "block", fontSize: 40, marginBottom: 12 }}>📭</span>
-              <p style={{ fontSize: 16, fontWeight: 600, color: "#d1d5db", margin: 0 }}>
-                {t("knowledge.empty_title")}
-              </p>
-            </div>
-          )}
-        </div>
-      )}
-    </div>
-  );
+  return null;
 }

--- a/src/agent/avatar/piiRouteDetector.ts
+++ b/src/agent/avatar/piiRouteDetector.ts
@@ -89,7 +89,7 @@ export function detectPiiRoute(payload: {
   // IDっぽいトークン（ざっくり）: 連続数字が長い、英数ハイフンが長い等
   // ※厳密にPII抽出しない。あくまで「導線」判定。
   const longDigit = /\b\d{10,}\b/;
-  const longToken = /\b[a-z0-9\-]{16,}\b/;
+  const longToken = /\b[a-z0-9-]{16,}\b/;
   if (longDigit.test(text) || longToken.test(text)) {
     reasons.push("id_like_token");
   }

--- a/src/agent/http/agentSearchRoute.ts
+++ b/src/agent/http/agentSearchRoute.ts
@@ -113,7 +113,7 @@ export function createAgentSearchHandler(
       const responseBody: Record<string, unknown> & { meta?: Record<string, unknown> } = {
         ...anyResult,
         meta: {
-          ...(anyResult.meta ?? {}),
+          ...anyResult.meta,
           tenant_id: tenantId,
           duration_ms: durationMs,
           ...(camelRagStats
@@ -128,7 +128,7 @@ export function createAgentSearchHandler(
       // Compat: optionally keep top-level ragStats.
       if (camelRagStats) {
         responseBody.meta = {
-          ...(responseBody.meta ?? {}),
+          ...responseBody.meta,
           deprecated: {
             ...(responseBody.meta?.deprecated ?? {}),
             ...(keepTopLevelRagStats

--- a/src/lib/book-pipeline/pipeline.ts
+++ b/src/lib/book-pipeline/pipeline.ts
@@ -149,7 +149,7 @@ export async function runBookPipeline(
 
     // 6. Groq 8b 構造化
     const structuredChunks = await structurizeChunks(chunks, {
-      ...(deps.structurizer ?? {}),
+      ...deps.structurizer,
       schema: contentSchema,
     });
 


### PR DESCRIPTION
## Summary
- `knowledge/index.tsx` をリダイレクト専用ページに変換（テナント選択UIを廃止）
  - Super Admin: `localStorage` の最終選択テナントへ自動リダイレクト（デフォルト: global）
  - Client Admin: 自テナントに直接リダイレクト（従来通り）
- `knowledge/[tenantId].tsx` ヘッダーにテナントセレクター + テストボタンを追加
  - Super Admin: 「🌐 グローバルナレッジ」+テナントドロップダウン + 「💬 テスト」ボタン
  - Client Admin: 「💬 テスト」ボタンのみ
  - テナント切り替え時に localStorage に保存、現在タブを維持
- 「← ナレッジ管理に戻る」を「← ダッシュボードに戻る」に統一

## Test plan
- [ ] Super Admin でダッシュボード → ナレッジ管理 → テナントセレクターが表示されることを確認
- [ ] テナント切り替え → ナレッジ一覧・書籍一覧が即座に切り替わることを確認
- [ ] ブラウザリロード後に最後に選択したテナントが維持されることを確認
- [ ] Client Admin では ドロップダウンが非表示で💬テストボタンのみ表示されることを確認
- [ ] Gate 1: pnpm verify ✅

Closes GID 1214046277704259

🤖 Generated with [Claude Code](https://claude.com/claude-code)