### PR TITLE
fix(posthog): wire flushPostHog to SIGTERM/SIGINT graceful shutdown

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ import { registerInternalUsageRoutes } from "./api/internal/usageRoutes";
 import { registerInternalAvatarConfigRoutes } from "./api/internal/avatarConfigRoutes";
 import { registerGa4TenantRoutes } from "./api/admin/tenants/ga4Routes";
 import { registerPostHogTenantRoutes } from "./api/admin/tenants/posthogRoutes";
+import { flushPostHog } from "./lib/posthog/posthogClient";
 import { registerAnalyticsSummaryRoutes } from "./api/admin/tenants/analyticsSummaryRoutes";
 import { registerNotificationPreferencesRoutes } from "./api/admin/tenants/notificationPreferencesRoutes";
 import { registerInternalGa4SyncRoutes } from "./api/internal/ga4SyncRoutes";
@@ -658,9 +659,19 @@ async function startServer() {
     fatal: (msg) => logger.fatal(msg),
   });
 
-  app.listen(port, () => {
+  const server = app.listen(port, () => {
     logger.info({ port, env: process.env.NODE_ENV }, "server listening");
   });
+
+  const onShutdown = (signal: string) => () => {
+    logger.info({ signal }, "[shutdown] graceful shutdown initiated");
+    server.close();
+    flushPostHog()
+      .catch((err) => logger.error({ err }, "[shutdown] flushPostHog failed"))
+      .finally(() => process.exit(0));
+  };
+  process.on("SIGTERM", onShutdown("SIGTERM"));
+  process.on("SIGINT", onShutdown("SIGINT"));
 
   // Phase23: AlertEngine — 60秒周期で KPI を評価し Slack アラートを送信
   alertEngine.start();

--- a/src/lib/posthog/posthogClient.ts
+++ b/src/lib/posthog/posthogClient.ts
@@ -17,7 +17,7 @@ export function getPostHogClient(): PostHog | null {
 
 export async function flushPostHog(): Promise<void> {
   if (_client) {
-    await _client.flush();
+    await _client.shutdown();
   }
 }
 


### PR DESCRIPTION
## Summary
- SIGTERM/SIGINT シグナル受信時に PostHog の `flushPostHog()` を呼び出してキューをフラッシュ
- グレースフルシャットダウン時にイベントロストを防止

## Test plan
- [ ] Gate 1: `pnpm verify` pass
- [ ] PM2 再起動時に PostHog イベントがロストしないことを手動確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)