### PR TITLE
feat(search): default_excluded_ids を DB から読み取り検索時にマージ

### DIFF
--- a/src/agent/http/agentDialogRoute.ts
+++ b/src/agent/http/agentDialogRoute.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import type { DialogTurnInput } from "../dialog/types";
 import { AgentDialogOrchestrator } from "./AgentDialogOrchestrator";
 import { maybeProbeLemonSliceReadiness } from "./presentation/lemonSliceAdapter";
+import { fetchDefaultExcludedIds, mergeExcludedIds } from "../../lib/defaultExcludedIds";
 
 export type AgentDialogDeps = {
   webhookNotifier?: unknown;
@@ -35,6 +36,14 @@ export function createAgentDialogHandler(
     }
 
     const tenantId = (req as Request & { tenantId?: string }).tenantId ?? "demo-tenant";
+
+    // Phase69-2: DB の default_excluded_ids をリクエスト側とマージする
+    const dbDefaultIds = await fetchDefaultExcludedIds(tenantId);
+    if (dbDefaultIds.length > 0) {
+      const merged = mergeExcludedIds(body.options?.excluded_ids, dbDefaultIds);
+      body.options = body.options ?? {};
+      body.options.excluded_ids = merged;
+    }
 
     // PR2b: adapter 状態（presentation-only）
     let adapterMeta: import("../dialog/types").AdapterMeta | undefined = undefined;

--- a/src/agent/http/agentSearchRoute.ts
+++ b/src/agent/http/agentSearchRoute.ts
@@ -4,6 +4,7 @@ import type pino from "pino";
 import { z } from "zod";
 import type { WebhookNotifier } from "../../integration/webhookNotifier";
 import { runSearchAgent } from "../flow/searchAgent";
+import { fetchDefaultExcludedIds, mergeExcludedIds } from "../../lib/defaultExcludedIds";
 
 const AgentSearchSchema = z.object({
   q: z.string().min(1),
@@ -81,13 +82,17 @@ export function createAgentSearchHandler(
         : "demo";
 
     try {
+      // Phase69-2: DB の default_excluded_ids をリクエスト側とマージする
+      const dbDefaultIds = await fetchDefaultExcludedIds(tenantId);
+      const mergedExcludedIds = mergeExcludedIds(excluded_ids, dbDefaultIds);
+
       const result = await runSearchAgent({
         q,
         topK,
         debug,
         useLlmPlanner,
         tenantId,
-        excludedIds: excluded_ids,
+        excludedIds: mergedExcludedIds,
       });
 
       const durationMs = Date.now() - startedAt;

--- a/src/lib/defaultExcludedIds.test.ts
+++ b/src/lib/defaultExcludedIds.test.ts
@@ -1,0 +1,85 @@
+// src/lib/defaultExcludedIds.test.ts
+// Phase69-2: fetchDefaultExcludedIds + mergeExcludedIds の単体テスト
+
+jest.mock('./db', () => ({
+  pool: { query: jest.fn() },
+}));
+
+import { pool } from './db';
+import { fetchDefaultExcludedIds, mergeExcludedIds } from './defaultExcludedIds';
+
+const mockQuery = (pool as unknown as { query: jest.Mock }).query;
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// fetchDefaultExcludedIds
+// ---------------------------------------------------------------------------
+
+describe('fetchDefaultExcludedIds', () => {
+  it('returns ids from DB when column has values', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ default_excluded_ids: ['id1', 'id2'] }],
+    });
+    const result = await fetchDefaultExcludedIds('tenant-a');
+    expect(result).toEqual(['id1', 'id2']);
+  });
+
+  it('returns [] when DB column is NULL', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ default_excluded_ids: null }],
+    });
+    const result = await fetchDefaultExcludedIds('tenant-a');
+    expect(result).toEqual([]);
+  });
+
+  it('returns [] when tenant not found', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    const result = await fetchDefaultExcludedIds('unknown-tenant');
+    expect(result).toEqual([]);
+  });
+
+  it('returns [] on DB error (silent fail)', async () => {
+    mockQuery.mockRejectedValueOnce(new Error('DB down'));
+    const result = await fetchDefaultExcludedIds('tenant-a');
+    expect(result).toEqual([]);
+  });
+
+  it('returns [] when tenantId is empty string', async () => {
+    const result = await fetchDefaultExcludedIds('');
+    expect(result).toEqual([]);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// mergeExcludedIds
+// ---------------------------------------------------------------------------
+
+describe('mergeExcludedIds', () => {
+  it('returns undefined when both inputs are empty', () => {
+    expect(mergeExcludedIds(undefined, [])).toBeUndefined();
+    expect(mergeExcludedIds([], [])).toBeUndefined();
+  });
+
+  it('returns request ids when defaultIds is empty', () => {
+    expect(mergeExcludedIds(['a', 'b'], [])).toEqual(['a', 'b']);
+  });
+
+  it('returns defaultIds when requestIds is undefined', () => {
+    expect(mergeExcludedIds(undefined, ['x', 'y'])).toEqual(['x', 'y']);
+  });
+
+  it('merges both arrays and deduplicates', () => {
+    const result = mergeExcludedIds(['a', 'b'], ['b', 'c']);
+    expect(result).toEqual(expect.arrayContaining(['a', 'b', 'c']));
+    expect(result).toHaveLength(3);
+  });
+
+  it('request ids appear before default ids (request priority)', () => {
+    const result = mergeExcludedIds(['req1'], ['def1']);
+    expect(result).toEqual(['req1', 'def1']);
+  });
+});

--- a/src/lib/defaultExcludedIds.ts
+++ b/src/lib/defaultExcludedIds.ts
@@ -1,0 +1,37 @@
+// src/lib/defaultExcludedIds.ts
+// Phase69-2: tenants.default_excluded_ids を DB から取得し、リクエスト側の excluded_ids とマージする。
+
+import { pool } from './db';
+
+/**
+ * DB の tenants テーブルから default_excluded_ids を取得する。
+ * DB 未接続・テナント不在・カラム NULL の場合は [] を返す（safe default）。
+ */
+export async function fetchDefaultExcludedIds(tenantId: string): Promise<string[]> {
+  if (!tenantId || !pool) return [];
+  try {
+    const result = await pool.query<{ default_excluded_ids: string[] | null }>(
+      'SELECT default_excluded_ids FROM tenants WHERE id = $1 LIMIT 1',
+      [tenantId],
+    );
+    if (result.rows.length === 0) return [];
+    return result.rows[0]!.default_excluded_ids ?? [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * リクエスト側の excluded_ids と DB の default_excluded_ids をマージして返す。
+ * 重複は除去する。どちらも空の場合は undefined を返す。
+ */
+export function mergeExcludedIds(
+  requestIds: string[] | undefined | null,
+  defaultIds: string[],
+): string[] | undefined {
+  const req = requestIds ?? [];
+  if (defaultIds.length === 0 && req.length === 0) return undefined;
+  if (defaultIds.length === 0) return req;
+  const merged = Array.from(new Set([...req, ...defaultIds]));
+  return merged;
+}


### PR DESCRIPTION
## Summary
- `default_excluded_ids` を DB から動的に読み取り、検索クエリ実行時にマージ
- ハードコードされた除外ID一覧を DB 管理に移行することで運用柔軟性向上

## Test plan
- [ ] Gate 1: `pnpm verify` pass
- [ ] 検索結果から除外IDのアイテムが除外されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)