### PR TITLE
fix(health): Gate 8 誤検知防止 — ゼロトラフィック時の CRITICAL 警告を抑制 (ci-27003681990)

### DIFF
--- a/src/lib/healthBusiness.test.ts
+++ b/src/lib/healthBusiness.test.ts
@@ -59,16 +59,29 @@ describe("buildWarnings", () => {
     expect(warnings.some((w) => w.includes("7-day average"))).toBe(false);
   });
 
-  it("warns when last_chat_message_at is null", () => {
+  it("warns when last_chat_message_at is null and there was 7-day traffic", () => {
     const warnings = buildWarnings({
       last_chat_message_at: null,
       chat_messages_24h: 0,
-      chat_messages_7d: 0,
+      chat_messages_7d: 100, // had traffic recently, now silent
       cv_events_24h: 0,
       rag_searches_24h: 10,
       tenants_active_24h: [],
     });
     expect(warnings.some((w) => w.includes("last_chat_message_at is null"))).toBe(true);
+  });
+
+  it("does NOT warn when last_chat_message_at is null with no 7-day traffic (new/idle system)", () => {
+    const warnings = buildWarnings({
+      last_chat_message_at: null,
+      chat_messages_24h: 0,
+      chat_messages_7d: 0,
+      cv_events_24h: 0,
+      rag_searches_24h: 0,
+      tenants_active_24h: [],
+    });
+    expect(warnings.some((w) => w.includes("last_chat_message_at is null"))).toBe(false);
+    expect(warnings.some((w) => w.includes("CRITICAL"))).toBe(false);
   });
 
   it("warns when last_chat_message_at is older than 6 hours", () => {

--- a/src/lib/healthBusiness.ts
+++ b/src/lib/healthBusiness.ts
@@ -92,17 +92,19 @@ export function buildWarnings(metrics: BusinessMetrics): string[] {
   }
 
   // last_chat_message_at が 6 時間以上前
-  if (metrics.last_chat_message_at === null) {
+  // 7日間に実績がある場合のみ警告 (ゼロトラフィック環境での誤報を防ぐ)
+  if (metrics.chat_messages_7d > 0 && metrics.last_chat_message_at === null) {
     warnings.push("last_chat_message_at is null: no messages recorded");
-  } else {
+  } else if (metrics.last_chat_message_at !== null) {
     const lastAt = new Date(metrics.last_chat_message_at).getTime();
     if (Date.now() - lastAt > SIX_HOURS_MS) {
       warnings.push("last_chat_message_at is older than 6 hours");
     }
   }
 
-  // rag_searches_24h が 0
-  if (metrics.rag_searches_24h === 0) {
+  // rag_searches_24h が 0 — トラフィックがある場合のみ警告
+  // chat_messages_24h=0 の場合は RAG が呼ばれないのは当然なので除外
+  if (metrics.rag_searches_24h === 0 && metrics.chat_messages_24h > 0) {
     warnings.push("CRITICAL: rag_searches_24h is 0 — RAG pipeline may be down");
   }
 


### PR DESCRIPTION
## Summary

- `rag_searches_24h=0` の CRITICAL 警告を `chat_messages_24h > 0` の場合のみ発火するよう変更
- `last_chat_message_at=null` 警告を `chat_messages_7d > 0`（7日間実績あり）の場合のみ発火するよう変更
- 新システムや無トラフィック環境で Gate 8 が毎 commit 失敗する誤検知を根絶

## Root Cause

Gate 8 は commit 8a881a7, b2b55f7, 5fd6f98, 71e99a6 で連続失敗していた (`run 27003681990`)。  
失敗内容: `/health/business → warnings=2: last_chat_message_at is null; CRITICAL: rag_searches_24h is 0`  

これはコード回帰ではなく、production トラフィックが 24h ゼロの場合に両警告が常に発火する誤報設計が原因。  
RAG pipeline は「chat があるのに RAG が 0」の場合に壊れていると判断すべきであり、そもそも traffic がない場合は判断不能。

## Gate Status

- Gate 1: typecheck N/A → 0 errors ✅ / lint N/A → 0 warnings ✅ / test 1841/1841 pass ✅
- Gate 1.5: N/A (no dead exports added)
- Gate 2: N/A (no code secret changes)
- Gate 3: N/A (build check on CI)
- Gate 2.5: skip (bug fix — straightforward logic guard)

## DoD

- [x] `git diff --name-only main...HEAD` → src/lib/ のみ (Tier A)
- [x] 16/16 healthBusiness unit tests pass
- [x] 1841/1841 全テスト pass
- [x] Asana GID: ci-27003681990