### PR TITLE
fix(events): conversion_attributions event_id NOT NULL 違反を修正 (GID 1215465911474503)

### DIFF
--- a/src/api/conversion/conversionRoutes.ts
+++ b/src/api/conversion/conversionRoutes.ts
@@ -57,8 +57,8 @@ export function registerConversionRoutes(
         `INSERT INTO conversion_attributions
            (tenant_id, session_id, psychology_principle_used, trigger_type, trigger_rule_id,
             temp_score_at_conversion, conversion_type, conversion_value,
-            sales_stage_at_conversion, message_count, session_duration_sec)
-         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
+            sales_stage_at_conversion, message_count, session_duration_sec, event_id)
+         VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11, gen_random_uuid())`,
         [
           tenantId,
           d.session_id ?? null,

--- a/src/api/events/eventRoutes.conversionBridge.test.ts
+++ b/src/api/events/eventRoutes.conversionBridge.test.ts
@@ -54,6 +54,7 @@ describe('bridgeConversionEvents', () => {
     expect(mockQuery).toHaveBeenCalledTimes(1);
     const [sql, params] = mockQuery.mock.calls[0];
     expect(sql).toContain('INSERT INTO conversion_attributions');
+    expect(sql).toContain('event_id');
     expect(params[0]).toBe('tenant-1');
     expect(params[2]).toBe('inquiry');
     expect(params[3]).toBe(0);

--- a/src/api/events/eventRoutes.ts
+++ b/src/api/events/eventRoutes.ts
@@ -128,8 +128,8 @@ export async function bridgeConversionEvents(
     try {
       await db.query(
         `INSERT INTO conversion_attributions
-           (tenant_id, session_id, conversion_type, conversion_value, created_at)
-         VALUES ($1, $2::uuid, $3, $4, now())`,
+           (tenant_id, session_id, conversion_type, conversion_value, event_id, created_at)
+         VALUES ($1, $2::uuid, $3, $4, gen_random_uuid(), now())`,
         [
           tenantId,
           sessionIdForAttribution,


### PR DESCRIPTION
## Summary
- `migration_phase_a.sql` が `event_id UUID NOT NULL UNIQUE` を `conversion_attributions` に追加後、2 箇所の INSERT に `event_id` が含まれず NOT NULL 制約違反で失敗していた
- `bridgeConversionEvents()` (eventRoutes.ts) と `registerConversionRoutes()` (conversionRoutes.ts) の INSERT に `gen_random_uuid()` を追加して修正
- パラメータインデックス変更なし → 既存テストへの影響ゼロ
- テストに regression guard (`expect(sql).toContain('event_id')`) を追加

## 変更ファイル
- `src/api/events/eventRoutes.ts` — `bridgeConversionEvents()` の INSERT に `event_id, gen_random_uuid()` 追加
- `src/api/conversion/conversionRoutes.ts` — attribution INSERT に `event_id, gen_random_uuid()` 追加
- `src/api/events/eventRoutes.conversionBridge.test.ts` — regression guard 追加

## DoD チェック
- [x] 変更が src/ のみ (`git diff --name-only` 確認済み)
- [x] `pnpm typecheck` → 0 errors
- [x] 8/8 テスト全パス
- [x] `event_id` NOT NULL 違反の根本原因を修正
- [x] commit メッセージに `fix(events):` プレフィックス + Asana GID 明記

## Asana
GID: 1215465911474503

(skip Gate 2.5: src fix, no schema/migration change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)