### PR TITLE
refactor(admin-ui): Phase2-P1-2 A2 — GapQuestionBanner/GlobalKnowledgeCheckbox 抽出 (GID 1214120401966111)

### DIFF
--- a/admin-ui/src/components/knowledge/GapQuestionBanner.tsx
+++ b/admin-ui/src/components/knowledge/GapQuestionBanner.tsx
@@ -1,0 +1,23 @@
+export default function GapQuestionBanner({ question }: { question: string }) {
+  return (
+    <div
+      style={{
+        padding: "14px 18px",
+        borderRadius: 12,
+        border: "1px solid rgba(234,179,8,0.4)",
+        background: "rgba(120,53,15,0.25)",
+        marginBottom: 4,
+      }}
+    >
+      <p style={{ margin: "0 0 4px", fontSize: 13, fontWeight: 700, color: "#fbbf24" }}>
+        ❓ ユーザーの質問
+      </p>
+      <p style={{ margin: "0 0 6px", fontSize: 15, color: "#f9fafb", fontWeight: 600, lineHeight: 1.5 }}>
+        「{question}」
+      </p>
+      <p style={{ margin: 0, fontSize: 12, color: "#9ca3af", lineHeight: 1.5 }}>
+        この質問に回答できる情報をナレッジに追加してください。登録後、未回答の質問が自動的に解決済みになります。
+      </p>
+    </div>
+  );
+}

--- a/admin-ui/src/components/knowledge/GlobalKnowledgeCheckbox.tsx
+++ b/admin-ui/src/components/knowledge/GlobalKnowledgeCheckbox.tsx
@@ -3,9 +3,11 @@ import { useLang } from "../../i18n/LangContext";
 export default function GlobalKnowledgeCheckbox({
   isGlobal,
   onChange,
+  disabled = false,
 }: {
   isGlobal: boolean;
   onChange: (v: boolean) => void;
+  disabled?: boolean;
 }) {
   const { t } = useLang();
   return (
@@ -14,7 +16,7 @@ export default function GlobalKnowledgeCheckbox({
         display: "flex",
         alignItems: "center",
         gap: 10,
-        cursor: "pointer",
+        cursor: disabled ? "default" : "pointer",
         padding: "12px 14px",
         borderRadius: 10,
         border: `1px solid ${isGlobal ? "rgba(234,179,8,0.4)" : "#374151"}`,
@@ -25,13 +27,15 @@ export default function GlobalKnowledgeCheckbox({
         fontWeight: isGlobal ? 600 : 400,
         transition: "all 0.15s",
         userSelect: "none",
+        opacity: disabled ? 0.85 : 1,
       }}
     >
       <input
         type="checkbox"
         checked={isGlobal}
         onChange={(e) => onChange(e.target.checked)}
-        style={{ width: 18, height: 18, accentColor: "#fbbf24", cursor: "pointer" }}
+        disabled={disabled}
+        style={{ width: 18, height: 18, accentColor: "#fbbf24", cursor: disabled ? "default" : "pointer" }}
       />
       📚 {t("knowledge.global_label")}
     </label>

--- a/admin-ui/src/pages/admin/knowledge/[tenantId].tsx
+++ b/admin-ui/src/pages/admin/knowledge/[tenantId].tsx
@@ -7,6 +7,8 @@ import LangSwitcher from "../../../components/LangSwitcher";
 import { useAuth } from "../../../auth/useAuth";
 import BookChunksPanel from "./BookChunksPanel";
 import KnowledgeAttributionTab from "../../../components/knowledge/KnowledgeAttributionTab";
+import GapQuestionBanner from "../../../components/knowledge/GapQuestionBanner";
+import GlobalKnowledgeCheckbox from "../../../components/knowledge/GlobalKnowledgeCheckbox";
 import {
   getAccessToken,
   fetchWithAuth,
@@ -72,76 +74,6 @@ interface ScrapePreviewItem {
 type Tab = "list" | "text" | "scrape" | "pdf" | "attribution";
 type DeleteState = "idle" | "confirming" | "deleting" | "success" | "error";
 type Category = string;
-
-// ─── ナレッジギャップバナー ────────────────────────────────────────────────────
-
-function GapQuestionBanner({ question }: { question: string }) {
-  return (
-    <div
-      style={{
-        padding: "14px 18px",
-        borderRadius: 12,
-        border: "1px solid rgba(234,179,8,0.4)",
-        background: "rgba(120,53,15,0.25)",
-        marginBottom: 4,
-      }}
-    >
-      <p style={{ margin: "0 0 4px", fontSize: 13, fontWeight: 700, color: "#fbbf24" }}>
-        ❓ ユーザーの質問
-      </p>
-      <p style={{ margin: "0 0 6px", fontSize: 15, color: "#f9fafb", fontWeight: 600, lineHeight: 1.5 }}>
-        「{question}」
-      </p>
-      <p style={{ margin: 0, fontSize: 12, color: "#9ca3af", lineHeight: 1.5 }}>
-        この質問に回答できる情報をナレッジに追加してください。登録後、未回答の質問が自動的に解決済みになります。
-      </p>
-    </div>
-  );
-}
-
-// ─── グローバルナレッジチェックボックス（Super Admin専用） ────────────────────
-
-function GlobalKnowledgeCheckbox({
-  isGlobal,
-  onChange,
-  disabled = false,
-}: {
-  isGlobal: boolean;
-  onChange: (v: boolean) => void;
-  disabled?: boolean;
-}) {
-  const { t } = useLang();
-  return (
-    <label
-      style={{
-        display: "flex",
-        alignItems: "center",
-        gap: 10,
-        cursor: disabled ? "default" : "pointer",
-        padding: "12px 14px",
-        borderRadius: 10,
-        border: `1px solid ${isGlobal ? "rgba(234,179,8,0.4)" : "#374151"}`,
-        background: isGlobal ? "rgba(234,179,8,0.08)" : "rgba(0,0,0,0.2)",
-        marginBottom: 16,
-        fontSize: 14,
-        color: isGlobal ? "#fbbf24" : "#9ca3af",
-        fontWeight: isGlobal ? 600 : 400,
-        transition: "all 0.15s",
-        userSelect: "none",
-        opacity: disabled ? 0.85 : 1,
-      }}
-    >
-      <input
-        type="checkbox"
-        checked={isGlobal}
-        onChange={(e) => onChange(e.target.checked)}
-        disabled={disabled}
-        style={{ width: 18, height: 18, accentColor: "#fbbf24", cursor: disabled ? "default" : "pointer" }}
-      />
-      📚 {t("knowledge.global_label")}
-    </label>
-  );
-}
 
 // ─── タブ1: ナレッジ一覧 ────────────────────────────────────────────────────
 


### PR DESCRIPTION
## 変更内容 (計画 A2)
`[tenantId].tsx` のローカル定義 `GapQuestionBanner` / `GlobalKnowledgeCheckbox` を `components/knowledge/` へ抽出。

- 新規: `components/knowledge/GapQuestionBanner.tsx` (ローカル版をそのまま)
- 上書き: `components/knowledge/GlobalKnowledgeCheckbox.tsx` — **デッドだった既存版は `disabled` prop を欠いており分岐していた**ため、ライブのローカル版 (disabled 付き) で上書きして統一
- ページ: ローカル定義削除 + import 追加 (−72 行)

## 機能変更なしの根拠 (A1 結果反映)
- A1 で確定: ページのローカル版が本番描画される実装。デッド component は import 元ゼロ。
- 抽出元は**ライブのローカル版**。GlobalKnowledgeCheckbox は `disabled` を含む完全版を採用 (ページ呼び出し `disabled={tenantId === "global"}` を維持)。
- typecheck: 変更ファイル 0 errors / `pnpm build`(vite) 成功 / gitleaks clean。

## 関連
- 計画/A1: PR #314 / #316 / A0: #315
- Asana: https://app.asana.com/0/1213607637045514/1214120401966111

> リファクタのため機能等価性の最終判断は人間 merge 推奨。