### PR TITLE
feat(memory): Phase71-A — learned_memory 学習ループ (Judge高スコア会話→蒸留→RAG還元)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -193,3 +193,15 @@ OPENVIKING_ENABLED=false
 OPENVIKING_URL=
 OPENVIKING_TENANTS=
 OPENVIKING_TIMEOUT_MS=3000
+
+# ==== Learned Memory (Phase71-A: メモリベース学習ループ) ====
+# Judge高スコア会話を蒸留し learned_memory に蓄積、RAG検索へ還元する。
+LEARNED_MEMORY_ENABLED=false
+# 対象テナント (カンマ区切り。'*' で全テナント)
+LEARNED_MEMORY_TENANTS=
+# 検索マージを無効化したい場合のみ false (蒸留だけ先行可能)。既定 true
+LEARNED_MEMORY_READ_ENABLED=true
+# 蒸留対象とする Judge overall_score の下限 (0-100)。既定 80
+LEARNED_MEMORY_THRESHOLD=80
+# 学習メモリの score 重み (curated FAQ より優先しない)。0-1。既定 0.9
+LEARNED_MEMORY_WEIGHT=0.9

--- a/src/agent/flow/searchAgent.ts
+++ b/src/agent/flow/searchAgent.ts
@@ -3,6 +3,8 @@
 
 import { searchPgVector, type PgvectorSearchItem } from "../../search/pgvectorSearch";
 import { embedTextOpenAI } from "../llm/openaiEmbeddingClient";
+import { createLearnedMemoryRepository, type LearnedMemoryHit } from "../memory/learnedMemoryRepository";
+import { isLearnedMemoryReadEnabled, getLearnedMemoryWeight } from "../memory/featureFlag";
 import { rerankTool } from "../tools/rerankTool";
 import { searchTool } from "../tools/searchTool";
 import { synthesizeAnswer } from "../tools/synthesisTool";
@@ -55,20 +57,40 @@ export async function runSearchAgent(
   });
 
   // 2) pgvector search (Phase7 A-mode: pgvector → ES)
+  //    Phase71-A: 同じ埋め込みを使い learned_memory も並列取得する。
   let pgVectorItems: PgvectorSearchItem[] = [];
   let pgVectorMs = 0;
   let pgVectorError = false;
+  let learnedItems: LearnedMemoryHit[] = [];
   try {
     const tPg0 = performance.now();
     const embedding = await embedTextOpenAI(plan.searchQuery ?? q);
-    const pgRes = await searchPgVector({
-      tenantId: effectiveTenantId,
-      embedding,
-      topK: plan.topK ?? topK,
-      excludedIds,
-    });
+    const learnedReadEnabled = isLearnedMemoryReadEnabled(effectiveTenantId);
+    const [pgRes, learnedRes] = await Promise.all([
+      searchPgVector({
+        tenantId: effectiveTenantId,
+        embedding,
+        topK: plan.topK ?? topK,
+        excludedIds,
+      }),
+      learnedReadEnabled
+        ? createLearnedMemoryRepository()
+            .searchLearnedMemory({
+              tenantId: effectiveTenantId,
+              embedding,
+              topK: plan.topK ?? topK,
+              weight: getLearnedMemoryWeight(),
+            })
+            .catch((err) => {
+              // 学習メモリ検索の失敗は致命的でないため握りつぶす
+              logger.error("[runSearchAgent] learned_memory search failed", err);
+              return [] as LearnedMemoryHit[];
+            })
+        : Promise.resolve([] as LearnedMemoryHit[]),
+    ]);
     const tPg1 = performance.now();
     pgVectorItems = pgRes.items ?? [];
+    learnedItems = learnedRes ?? [];
     pgVectorMs = pgRes.ms ?? Math.round(tPg1 - tPg0);
   } catch (err) {
     pgVectorError = true;
@@ -85,11 +107,20 @@ export async function runSearchAgent(
   });
   const tSearch1 = performance.now();
 
-  // Aモード: pgvector → ES の順でマージ
+  // Aモード: pgvector → learned_memory → ES の順でマージ
+  // learned_memory は pgvector 経路で取得するため Hit.source は "pg" に揃え、
+  // 学習データである provenance は metadata.source="learned" に保持する。
   const mergedItems = [
     ...pgVectorItems.map((hit) => ({
       ...hit,
       source: "pg" as const,
+    })),
+    ...learnedItems.map((hit) => ({
+      id: hit.id,
+      text: hit.text,
+      score: hit.score,
+      source: "pg" as const,
+      metadata: hit.metadata,
     })),
     ...(baseSearchResult.items || []),
   ];

--- a/src/agent/judge/judgeEvaluator.ts
+++ b/src/agent/judge/judgeEvaluator.ts
@@ -254,6 +254,24 @@ export async function evaluateSession(sessionId: string): Promise<JudgeEvaluatio
       ],
     );
 
+    // 6b. Phase71-A: 高スコア会話を learned_memory に蒸留 (fire-and-forget)
+    //     書込み Feature Flag + スコア閾値のガードは distillAndPromote 内で行う。
+    setImmediate(() => {
+      import('../memory/memoryDistiller').then(({ distillAndPromote }) =>
+        distillAndPromote({
+          tenantId,
+          sessionId,
+          judgeScore: result.overall_score,
+          messages: messages.map((m: ChatMessageRow) => ({
+            role: m.role,
+            content: m.content,
+          })),
+        }),
+      ).catch((err: unknown) => {
+        logger.warn({ err, sessionId }, 'learnedMemory.distill.failed (non-blocking)');
+      });
+    });
+
     // 7. If score below threshold, seed tuning_rules
     const threshold = parseInt(process.env['JUDGE_SCORE_THRESHOLD'] ?? '60', 10);
     if (result.overall_score < threshold && result.suggested_rules.length > 0) {

--- a/src/agent/memory/featureFlag.test.ts
+++ b/src/agent/memory/featureFlag.test.ts
@@ -1,0 +1,93 @@
+// src/agent/memory/featureFlag.test.ts
+// Phase71-A: Learned Memory Feature Flag テスト
+
+import {
+  isLearnedMemoryWriteEnabled,
+  isLearnedMemoryReadEnabled,
+  getLearnedMemoryThreshold,
+  getLearnedMemoryWeight,
+} from "./featureFlag";
+
+const ENV_KEYS = [
+  "LEARNED_MEMORY_ENABLED",
+  "LEARNED_MEMORY_TENANTS",
+  "LEARNED_MEMORY_READ_ENABLED",
+  "LEARNED_MEMORY_THRESHOLD",
+  "LEARNED_MEMORY_WEIGHT",
+] as const;
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) delete process.env[k];
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) delete process.env[k];
+});
+
+describe("isLearnedMemoryWriteEnabled", () => {
+  it("マスタースイッチ未設定なら false", () => {
+    process.env.LEARNED_MEMORY_TENANTS = "carnation";
+    expect(isLearnedMemoryWriteEnabled("carnation")).toBe(false);
+  });
+
+  it("対象テナントのみ true", () => {
+    process.env.LEARNED_MEMORY_ENABLED = "true";
+    process.env.LEARNED_MEMORY_TENANTS = "carnation";
+    expect(isLearnedMemoryWriteEnabled("carnation")).toBe(true);
+    expect(isLearnedMemoryWriteEnabled("other")).toBe(false);
+  });
+
+  it("'*' で全テナント true", () => {
+    process.env.LEARNED_MEMORY_ENABLED = "true";
+    process.env.LEARNED_MEMORY_TENANTS = "*";
+    expect(isLearnedMemoryWriteEnabled("anyone")).toBe(true);
+  });
+});
+
+describe("isLearnedMemoryReadEnabled", () => {
+  it("マスタースイッチ ON + 対象テナントで true", () => {
+    process.env.LEARNED_MEMORY_ENABLED = "true";
+    process.env.LEARNED_MEMORY_TENANTS = "carnation";
+    expect(isLearnedMemoryReadEnabled("carnation")).toBe(true);
+  });
+
+  it("READ 明示 OFF なら false (write だけ先行可能)", () => {
+    process.env.LEARNED_MEMORY_ENABLED = "true";
+    process.env.LEARNED_MEMORY_TENANTS = "carnation";
+    process.env.LEARNED_MEMORY_READ_ENABLED = "false";
+    expect(isLearnedMemoryReadEnabled("carnation")).toBe(false);
+    // write 側は引き続き有効
+    expect(isLearnedMemoryWriteEnabled("carnation")).toBe(true);
+  });
+});
+
+describe("getLearnedMemoryThreshold", () => {
+  it("既定 80", () => {
+    expect(getLearnedMemoryThreshold()).toBe(80);
+  });
+
+  it("env で上書き、0-100 にクランプ", () => {
+    process.env.LEARNED_MEMORY_THRESHOLD = "70";
+    expect(getLearnedMemoryThreshold()).toBe(70);
+    process.env.LEARNED_MEMORY_THRESHOLD = "150";
+    expect(getLearnedMemoryThreshold()).toBe(100);
+  });
+
+  it("不正値は既定 80", () => {
+    process.env.LEARNED_MEMORY_THRESHOLD = "abc";
+    expect(getLearnedMemoryThreshold()).toBe(80);
+  });
+});
+
+describe("getLearnedMemoryWeight", () => {
+  it("既定 0.9", () => {
+    expect(getLearnedMemoryWeight()).toBe(0.9);
+  });
+
+  it("env で上書き、0-1 にクランプ", () => {
+    process.env.LEARNED_MEMORY_WEIGHT = "0.5";
+    expect(getLearnedMemoryWeight()).toBe(0.5);
+    process.env.LEARNED_MEMORY_WEIGHT = "2";
+    expect(getLearnedMemoryWeight()).toBe(1);
+  });
+});

--- a/src/agent/memory/featureFlag.ts
+++ b/src/agent/memory/featureFlag.ts
@@ -1,0 +1,60 @@
+// src/agent/memory/featureFlag.ts
+// Phase71-A: Learned Memory Feature Flag
+//
+// 書込み (蒸留→保存) と 読込み (検索マージ) を独立に制御する。
+// 段階導入のため、特定テナントだけで先行有効化できるようにする。
+//
+//   LEARNED_MEMORY_ENABLED=true       マスタースイッチ (write + read 両方の前提)
+//   LEARNED_MEMORY_TENANTS=carnation  対象テナント (カンマ区切り。'*' で全テナント)
+//   LEARNED_MEMORY_READ_ENABLED=true  検索マージを有効化 (既定 true。蒸留だけ先行したい場合 false)
+
+function parseTenants(raw: string | undefined): string[] {
+  return (raw ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+function isTenantAllowed(tenantId: string): boolean {
+  const allowed = parseTenants(process.env.LEARNED_MEMORY_TENANTS);
+  if (allowed.includes("*")) return true;
+  return allowed.includes(tenantId);
+}
+
+/**
+ * 学習メモリの書込み (高スコア会話の蒸留→保存) が有効か。
+ */
+export function isLearnedMemoryWriteEnabled(tenantId: string): boolean {
+  if (process.env.LEARNED_MEMORY_ENABLED !== "true") return false;
+  return isTenantAllowed(tenantId);
+}
+
+/**
+ * 学習メモリの読込み (RAG検索へのマージ) が有効か。
+ * マスタースイッチ ON かつ READ 明示 OFF でない場合に有効。
+ */
+export function isLearnedMemoryReadEnabled(tenantId: string): boolean {
+  if (process.env.LEARNED_MEMORY_ENABLED !== "true") return false;
+  if (process.env.LEARNED_MEMORY_READ_ENABLED === "false") return false;
+  return isTenantAllowed(tenantId);
+}
+
+/**
+ * 蒸留対象とする Judge overall_score の下限閾値。
+ * 既定 80 (高品質会話のみ学習に取り込む)。
+ */
+export function getLearnedMemoryThreshold(): number {
+  const raw = parseInt(process.env.LEARNED_MEMORY_THRESHOLD ?? "80", 10);
+  if (Number.isNaN(raw)) return 80;
+  return Math.max(0, Math.min(100, raw));
+}
+
+/**
+ * 学習メモリのスコアに掛ける重み (キュレーション済みFAQより優先させない)。
+ * 既定 0.9。同点時は curated FAQ を優先させる意図。
+ */
+export function getLearnedMemoryWeight(): number {
+  const raw = parseFloat(process.env.LEARNED_MEMORY_WEIGHT ?? "0.9");
+  if (Number.isNaN(raw)) return 0.9;
+  return Math.max(0, Math.min(1, raw));
+}

--- a/src/agent/memory/learnedMemoryRepository.test.ts
+++ b/src/agent/memory/learnedMemoryRepository.test.ts
@@ -1,0 +1,133 @@
+// src/agent/memory/learnedMemoryRepository.test.ts
+// Phase71-A: learnedMemoryRepository テスト (fake pool 注入)
+
+import { createLearnedMemoryRepository } from "./learnedMemoryRepository";
+
+type QueryMock = jest.Mock<Promise<{ rows: unknown[] }>, [string, unknown[]?]>;
+
+function makePool(queryMock: QueryMock) {
+  // createLearnedMemoryRepository は pg.Pool を期待するが、テストでは query だけ使う
+  return { query: queryMock } as unknown as Parameters<
+    typeof createLearnedMemoryRepository
+  >[0];
+}
+
+describe("saveLearnedMemory", () => {
+  it("INSERT を発行し、挿入されたら true", async () => {
+    const query: QueryMock = jest.fn().mockResolvedValue({ rows: [{ id: 1 }] });
+    const repo = createLearnedMemoryRepository(makePool(query));
+
+    const inserted = await repo.saveLearnedMemory({
+      tenantId: "carnation",
+      question: "保証はありますか",
+      answer: "全車3ヶ月保証付きです",
+      embedding: [0.1, 0.2, 0.3],
+      sourceSessionId: "sess-1",
+      judgeScore: 88,
+    });
+
+    expect(inserted).toBe(true);
+    expect(query).toHaveBeenCalledTimes(1);
+    const [sql, args] = query.mock.calls[0]!;
+    expect(sql).toContain("INSERT INTO learned_memory");
+    expect(sql).toContain("ON CONFLICT (tenant_id, source_session_id) DO NOTHING");
+    // embedding は pgvector リテラル形式
+    expect(args![3]).toBe("[0.1,0.2,0.3]");
+    expect(args![0]).toBe("carnation");
+    expect(args![5]).toBe(88);
+  });
+
+  it("ON CONFLICT で行が返らなければ false (重複スキップ)", async () => {
+    const query: QueryMock = jest.fn().mockResolvedValue({ rows: [] });
+    const repo = createLearnedMemoryRepository(makePool(query));
+
+    const inserted = await repo.saveLearnedMemory({
+      tenantId: "carnation",
+      question: "q",
+      answer: "a",
+      embedding: [0.1],
+      sourceSessionId: "sess-dup",
+      judgeScore: 90,
+    });
+
+    expect(inserted).toBe(false);
+  });
+});
+
+describe("searchLearnedMemory", () => {
+  it("空 embedding は DB を叩かず空配列", async () => {
+    const query: QueryMock = jest.fn();
+    const repo = createLearnedMemoryRepository(makePool(query));
+
+    const hits = await repo.searchLearnedMemory({
+      tenantId: "carnation",
+      embedding: [],
+    });
+
+    expect(hits).toEqual([]);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it("tenant_id 単独フィルタ + is_active で検索し、weight を score に掛ける", async () => {
+    const query: QueryMock = jest.fn().mockResolvedValue({
+      rows: [
+        {
+          id: "10",
+          question: "保証はありますか",
+          answer: "全車3ヶ月保証付きです",
+          judge_score: 88,
+          source_session_id: "sess-1",
+          score: 0.8,
+        },
+      ],
+    });
+    const repo = createLearnedMemoryRepository(makePool(query));
+
+    const hits = await repo.searchLearnedMemory({
+      tenantId: "carnation",
+      embedding: [0.1, 0.2],
+      topK: 3,
+      weight: 0.9,
+    });
+
+    const [sql, args] = query.mock.calls[0]!;
+    // テナント横断しない (global を含めない)
+    expect(sql).toContain("tenant_id = $2");
+    expect(sql).not.toContain("'global'");
+    expect(sql).toContain("is_active = true");
+    expect(args).toEqual(["[0.1,0.2]", "carnation", 3]);
+
+    expect(hits).toHaveLength(1);
+    expect(hits[0]!.id).toBe("learned:10");
+    expect(hits[0]!.text).toBe("全車3ヶ月保証付きです"); // answer を本文に
+    expect(hits[0]!.source).toBe("learned");
+    expect(hits[0]!.score).toBeCloseTo(0.72, 5); // 0.8 * 0.9
+    expect(hits[0]!.metadata.source).toBe("learned");
+    expect(hits[0]!.metadata.question).toBe("保証はありますか");
+    expect(hits[0]!.metadata.judge_score).toBe(88);
+  });
+
+  it("score は 0-1 にクランプしてから weight を掛ける", async () => {
+    const query: QueryMock = jest.fn().mockResolvedValue({
+      rows: [
+        {
+          id: "11",
+          question: "q",
+          answer: "a",
+          judge_score: 95,
+          source_session_id: "s",
+          score: 1.5, // 異常値
+        },
+      ],
+    });
+    const repo = createLearnedMemoryRepository(makePool(query));
+
+    const hits = await repo.searchLearnedMemory({
+      tenantId: "carnation",
+      embedding: [0.1],
+      weight: 1,
+    });
+
+    expect(hits[0]!.score).toBe(1); // clamp(1.5)=1 * 1
+  });
+});

--- a/src/agent/memory/learnedMemoryRepository.ts
+++ b/src/agent/memory/learnedMemoryRepository.ts
@@ -1,0 +1,133 @@
+// src/agent/memory/learnedMemoryRepository.ts
+// Phase71-A: learned_memory テーブルのリポジトリ (save / search)
+//
+// evaluationRepository.ts のファクトリ + 遅延 pool 解決パターンを踏襲。
+// text / answer は faq_embeddings と同様に AES-256-GCM で暗号化して保存する。
+
+import { Pool } from "pg";
+import { getPool as _getDefaultPool } from "../../lib/db";
+import { encryptText, decryptText } from "../../lib/crypto/textEncrypt";
+
+export interface LearnedMemoryEntry {
+  id?: number;
+  tenantId: string;
+  question: string;
+  answer: string;
+  embedding: number[];
+  sourceSessionId: string;
+  judgeScore: number;
+  metadata?: Record<string, unknown>;
+  createdAt?: Date;
+}
+
+/** 検索結果。searchAgent のマージに合わせた形 (id/text/score/metadata)。 */
+export interface LearnedMemoryHit {
+  id: string;
+  /** RAG コンテキストに注入する本文 (= 蒸留された応答)。 */
+  text: string;
+  score: number;
+  source: "learned";
+  metadata: Record<string, unknown>;
+}
+
+export interface LearnedMemorySearchParams {
+  tenantId: string;
+  embedding: number[];
+  topK?: number;
+  /** スコアに掛ける重み (curated FAQ より優先させないため)。 */
+  weight?: number;
+}
+
+export function createLearnedMemoryRepository(pool?: InstanceType<typeof Pool>) {
+  // pool 解決は実 DB 呼び出し時まで遅延 (DATABASE_URL 無しのテスト環境を許容)
+  function getPool(): InstanceType<typeof Pool> {
+    return pool ?? _getDefaultPool();
+  }
+
+  return {
+    /**
+     * 蒸留した Q&A を learned_memory に保存する。
+     * (tenant_id, source_session_id) が既存なら何もしない (ON CONFLICT DO NOTHING)。
+     * @returns 挿入されたら true、重複でスキップされたら false
+     */
+    async saveLearnedMemory(entry: LearnedMemoryEntry): Promise<boolean> {
+      const embeddingLiteral = `[${entry.embedding.join(",")}]`;
+      const result = await getPool().query(
+        `INSERT INTO learned_memory
+           (tenant_id, question, answer, embedding, source_session_id, judge_score, metadata)
+         VALUES ($1, $2, $3, $4::vector, $5, $6, $7::jsonb)
+         ON CONFLICT (tenant_id, source_session_id) DO NOTHING
+         RETURNING id`,
+        [
+          entry.tenantId,
+          encryptText(entry.question),
+          encryptText(entry.answer),
+          embeddingLiteral,
+          entry.sourceSessionId,
+          entry.judgeScore,
+          JSON.stringify(entry.metadata ?? {}),
+        ],
+      );
+      return result.rows.length > 0;
+    },
+
+    /**
+     * クエリ埋め込みに近い learned_memory を取得する。
+     *
+     * - テナント分離: tenant_id = $1 のみ (verbatim 内容は横断共有しない)。
+     * - is_active = true のみ。
+     * - スコアは faq_embeddings (pgvectorSearch) と同じ正規化式に揃え、
+     *   weight を掛けて curated FAQ より優先しないようにする。
+     */
+    async searchLearnedMemory(
+      params: LearnedMemorySearchParams,
+    ): Promise<LearnedMemoryHit[]> {
+      const { tenantId, embedding, topK = 5, weight = 1 } = params;
+      if (!embedding || embedding.length === 0) return [];
+
+      const embeddingLiteral = `[${embedding.join(",")}]`;
+      const result = await getPool().query(
+        `SELECT
+           id::text,
+           question,
+           answer,
+           judge_score,
+           source_session_id,
+           1 - (embedding <-> $1::vector) / 2 AS score
+         FROM learned_memory
+         WHERE tenant_id = $2
+           AND is_active = true
+         ORDER BY embedding <-> $1::vector
+         LIMIT $3`,
+        [embeddingLiteral, tenantId, topK],
+      );
+
+      type Row = {
+        id: string;
+        question: string | null;
+        answer: string | null;
+        judge_score: number;
+        source_session_id: string;
+        score: number;
+      };
+
+      return (result.rows as Row[]).map((row) => {
+        const rawScore =
+          typeof row.score === "number" ? row.score : Number(row.score) || 0;
+        const clamped = Math.max(0, Math.min(1, rawScore));
+        return {
+          id: `learned:${row.id}`,
+          text: decryptText(row.answer ?? ""),
+          score: clamped * weight,
+          source: "learned" as const,
+          metadata: {
+            source: "learned",
+            question: decryptText(row.question ?? ""),
+            judge_score: row.judge_score,
+            source_session_id: row.source_session_id,
+          },
+        };
+      });
+    },
+  };
+}

--- a/src/agent/memory/memoryDistiller.test.ts
+++ b/src/agent/memory/memoryDistiller.test.ts
@@ -1,0 +1,137 @@
+// src/agent/memory/memoryDistiller.test.ts
+// Phase71-A: memoryDistiller テスト
+
+import { distillAndPromote } from "./memoryDistiller";
+import { groqClient } from "../llm/groqClient";
+import { createLearnedMemoryRepository } from "./learnedMemoryRepository";
+
+jest.mock("../llm/groqClient", () => ({
+  groqClient: { call: jest.fn() },
+}));
+
+jest.mock("./learnedMemoryRepository", () => ({
+  createLearnedMemoryRepository: jest.fn(),
+}));
+
+const mockCall = groqClient.call as jest.Mock;
+const mockCreateRepo = createLearnedMemoryRepository as jest.Mock;
+const mockSave = jest.fn();
+
+const ENV_KEYS = [
+  "LEARNED_MEMORY_ENABLED",
+  "LEARNED_MEMORY_TENANTS",
+  "LEARNED_MEMORY_THRESHOLD",
+] as const;
+
+const MESSAGES = [
+  { role: "user", content: "保証はありますか" },
+  { role: "assistant", content: "全車3ヶ月保証付きです。延長保証もご用意しています。" },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  process.env.NODE_ENV = "test"; // embedText がダミーベクトルを返す
+  mockCreateRepo.mockReturnValue({ saveLearnedMemory: mockSave });
+  mockSave.mockResolvedValue(true);
+  for (const k of ENV_KEYS) delete process.env[k];
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) delete process.env[k];
+});
+
+function enable(tenant = "carnation") {
+  process.env.LEARNED_MEMORY_ENABLED = "true";
+  process.env.LEARNED_MEMORY_TENANTS = tenant;
+}
+
+describe("distillAndPromote", () => {
+  it("Feature Flag (write) オフなら蒸留せず false", async () => {
+    const ok = await distillAndPromote({
+      tenantId: "carnation",
+      sessionId: "s1",
+      judgeScore: 95,
+      messages: MESSAGES,
+    });
+    expect(ok).toBe(false);
+    expect(mockCall).not.toHaveBeenCalled();
+  });
+
+  it("スコアが閾値未満なら蒸留しない", async () => {
+    enable();
+    process.env.LEARNED_MEMORY_THRESHOLD = "80";
+    const ok = await distillAndPromote({
+      tenantId: "carnation",
+      sessionId: "s1",
+      judgeScore: 70,
+      messages: MESSAGES,
+    });
+    expect(ok).toBe(false);
+    expect(mockCall).not.toHaveBeenCalled();
+  });
+
+  it("高スコアなら蒸留→保存し true", async () => {
+    enable();
+    mockCall.mockResolvedValue(
+      '{"question":"保証はありますか","answer":"全車3ヶ月保証付きです"}',
+    );
+
+    const ok = await distillAndPromote({
+      tenantId: "carnation",
+      sessionId: "s1",
+      judgeScore: 90,
+      messages: MESSAGES,
+    });
+
+    expect(ok).toBe(true);
+    expect(mockCall).toHaveBeenCalledTimes(1);
+    expect(mockSave).toHaveBeenCalledTimes(1);
+    const saved = mockSave.mock.calls[0]![0];
+    expect(saved.tenantId).toBe("carnation");
+    expect(saved.question).toBe("保証はありますか");
+    expect(saved.answer).toBe("全車3ヶ月保証付きです");
+    expect(saved.judgeScore).toBe(90);
+    expect(saved.embedding).toHaveLength(1536); // ダミー埋め込み
+  });
+
+  it("蒸留が空Q&Aを返したら保存しない", async () => {
+    enable();
+    mockCall.mockResolvedValue('{"question":"","answer":""}');
+
+    const ok = await distillAndPromote({
+      tenantId: "carnation",
+      sessionId: "s1",
+      judgeScore: 90,
+      messages: MESSAGES,
+    });
+
+    expect(ok).toBe(false);
+    expect(mockSave).not.toHaveBeenCalled();
+  });
+
+  it("メッセージが2未満なら蒸留しない", async () => {
+    enable();
+    const ok = await distillAndPromote({
+      tenantId: "carnation",
+      sessionId: "s1",
+      judgeScore: 90,
+      messages: [{ role: "user", content: "hi" }],
+    });
+    expect(ok).toBe(false);
+    expect(mockCall).not.toHaveBeenCalled();
+  });
+
+  it("Groq が例外でも伝播させず false", async () => {
+    enable();
+    mockCall.mockRejectedValue(new Error("groq down"));
+
+    await expect(
+      distillAndPromote({
+        tenantId: "carnation",
+        sessionId: "s1",
+        judgeScore: 90,
+        messages: MESSAGES,
+      }),
+    ).resolves.toBe(false);
+  });
+});

--- a/src/agent/memory/memoryDistiller.ts
+++ b/src/agent/memory/memoryDistiller.ts
@@ -1,0 +1,151 @@
+// src/agent/memory/memoryDistiller.ts
+// Phase71-A: 高スコア会話 → 正規 Q&A 蒸留 → 埋め込み → learned_memory 保存
+//
+// Judge 評価 (evaluateSession) の fire-and-forget フックから呼ばれる。
+// 失敗しても本番フローに伝播させない (呼び出し側で setImmediate + catch)。
+
+import pino from "pino";
+
+import { groqClient } from "../llm/groqClient";
+import { GROQ_VERSATILE_70B } from "../../config/groqModels";
+import { embedText } from "../llm/openaiEmbeddingClient";
+import {
+  isLearnedMemoryWriteEnabled,
+  getLearnedMemoryThreshold,
+} from "./featureFlag";
+import {
+  createLearnedMemoryRepository,
+  type LearnedMemoryEntry,
+} from "./learnedMemoryRepository";
+
+const logger = pino();
+
+export interface DistillSourceMessage {
+  role: string;
+  content: string;
+}
+
+export interface DistillParams {
+  tenantId: string;
+  sessionId: string;
+  judgeScore: number;
+  messages: DistillSourceMessage[];
+}
+
+interface DistilledQa {
+  question: string;
+  answer: string;
+}
+
+const DISTILL_SYSTEM_PROMPT = `あなたは営業チャットの会話ログから「再利用可能な正規Q&A」を1つだけ抽出する専門家です。
+顧客の中心的な質問・関心を1つの簡潔な質問にまとめ、AIの応答のうち最も効果的だった部分を簡潔な模範回答にまとめてください。
+個人情報・固有名詞・一回限りの文脈は除き、他の顧客にも再利用できる汎用的な形にしてください。
+JSONのみで回答してください: {"question":"...","answer":"..."}
+有用なQ&Aが抽出できない場合は {"question":"","answer":""} を返してください。`;
+
+/**
+ * Groq で会話ログを正規 Q&A に蒸留する。抽出不能なら null。
+ */
+async function distillConversation(
+  messages: DistillSourceMessage[],
+): Promise<DistilledQa | null> {
+  // Anti-Slop: 各発話 200 文字に制限 (judgeEvaluator と同方針)
+  const conversationLog = messages
+    .map((m) => `${m.role}: ${m.content.slice(0, 200)}`)
+    .join("\n");
+
+  const raw = await groqClient.call({
+    model: GROQ_VERSATILE_70B,
+    messages: [
+      { role: "system", content: DISTILL_SYSTEM_PROMPT },
+      { role: "user", content: conversationLog },
+    ],
+    temperature: 0.2,
+    maxTokens: 500,
+  });
+
+  const jsonMatch = raw.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) return null;
+
+  let parsed: Record<string, unknown>;
+  try {
+    parsed = JSON.parse(jsonMatch[0]) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+
+  const question =
+    typeof parsed["question"] === "string" ? parsed["question"].trim() : "";
+  const answer =
+    typeof parsed["answer"] === "string" ? parsed["answer"].trim() : "";
+
+  if (!question || !answer) return null;
+  return { question, answer };
+}
+
+/**
+ * 高スコア会話を蒸留して learned_memory に保存する。
+ *
+ * ガード:
+ *   - Feature Flag (write) オフ → 何もしない
+ *   - judgeScore < 閾値 → 何もしない
+ *   - メッセージ 2 未満 → 何もしない
+ *   - 蒸留失敗 → 何もしない
+ *
+ * @returns 保存されたら true
+ */
+export async function distillAndPromote(
+  params: DistillParams,
+): Promise<boolean> {
+  const { tenantId, sessionId, judgeScore, messages } = params;
+
+  if (!isLearnedMemoryWriteEnabled(tenantId)) return false;
+
+  const threshold = getLearnedMemoryThreshold();
+  if (judgeScore < threshold) {
+    logger.debug(
+      { tenantId, sessionId, judgeScore, threshold },
+      "[learnedMemory] score below threshold, skip",
+    );
+    return false;
+  }
+
+  if (messages.length < 2) return false;
+
+  try {
+    const qa = await distillConversation(messages);
+    if (!qa) {
+      logger.debug({ tenantId, sessionId }, "[learnedMemory] distill yielded no Q&A");
+      return false;
+    }
+
+    const embedding = await embedText(qa.question);
+
+    const entry: LearnedMemoryEntry = {
+      tenantId,
+      question: qa.question,
+      answer: qa.answer,
+      embedding,
+      sourceSessionId: sessionId,
+      judgeScore,
+      metadata: { distilled_by: GROQ_VERSATILE_70B },
+    };
+
+    const repo = createLearnedMemoryRepository();
+    const inserted = await repo.saveLearnedMemory(entry);
+
+    logger.info(
+      { tenantId, sessionId, judgeScore, inserted },
+      inserted
+        ? "[learnedMemory] promoted high-score conversation"
+        : "[learnedMemory] already promoted (dedup)",
+    );
+    return inserted;
+  } catch (err) {
+    logger.warn(
+      { err, tenantId, sessionId },
+      "[learnedMemory] distillAndPromote failed (non-blocking)",
+    );
+    return false;
+  }
+}

--- a/src/migrations/phase71_learned_memory.sql
+++ b/src/migrations/phase71_learned_memory.sql
@@ -1,0 +1,69 @@
+-- Phase71-A: learned_memory（学習ループの semantic memory tier）
+-- 実行日: VPS で手動実行
+-- 対象: VPS PostgreSQL (65.108.159.161) — pgvector 拡張が有効であること
+--
+-- 設計意図:
+--   Judge が高スコア (>= LEARNED_MEMORY_THRESHOLD) と評価した会話を
+--   正規 Q&A ペアに蒸留し、テナント分離された semantic memory として蓄積する。
+--   検索時に faq_embeddings (キュレーション済みFAQ) と並列取得してマージし、
+--   「過去に上手くいった応答」を次回以降の RAG に還元する = メモリベースの学習。
+--
+--   GoClaw の 3層メモリ (working/episodic/semantic) のうち semantic tier に相当。
+--   faq_embeddings に相乗りせず別テーブルにする理由:
+--     - 既存検索は faq_docs JOIN で孤児を弾く設計 → 学習データが弾かれてしまう
+--     - キュレーション済み FAQ を汚さない / 学習データだけ重み・ガバナンスを分離
+--     - 将来 decay / 失効ポリシーを learned 専用に持たせやすい
+--
+-- テナント分離方針 (重要):
+--   verbatim な Q&A 内容はテナント横断で共有しない (tenant_id = $1 のみ)。
+--   横断学習は既存 crossTenantContext の「集計統計のみ共有」方式を踏襲する。
+
+-- ============================================================
+-- 1. learned_memory テーブル本体
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS learned_memory (
+  id                BIGSERIAL PRIMARY KEY,
+  tenant_id         TEXT NOT NULL,
+  question          TEXT NOT NULL,            -- 蒸留した正規質問 (AES-256-GCM 暗号化)
+  answer            TEXT NOT NULL,            -- 蒸留した正規応答 (AES-256-GCM 暗号化)
+  embedding         VECTOR(1536) NOT NULL,    -- question の埋め込み (text-embedding-3-small)
+  source_session_id TEXT NOT NULL,            -- 蒸留元の chat_sessions.session_id
+  judge_score       INTEGER NOT NULL,         -- 蒸留時の overall_score (0-100)
+  metadata          JSONB DEFAULT '{}'::jsonb,
+  is_active         BOOLEAN DEFAULT TRUE,     -- 失効/手動無効化フラグ
+  created_at        TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- ============================================================
+-- 2. インデックス
+-- ============================================================
+
+-- テナント分離フィルター用
+CREATE INDEX IF NOT EXISTS idx_learned_memory_tenant
+  ON learned_memory (tenant_id);
+
+-- ANN 検索用 (cosine)。faq_embeddings と同じ ivfflat 方式。
+CREATE INDEX IF NOT EXISTS idx_learned_memory_embedding
+  ON learned_memory
+  USING ivfflat (embedding vector_cosine_ops)
+  WITH (lists = 100);
+
+-- 有効エントリのみ検索する部分インデックス
+CREATE INDEX IF NOT EXISTS idx_learned_memory_active
+  ON learned_memory (tenant_id, is_active)
+  WHERE is_active = true;
+
+-- 1セッションにつき1学習エントリ (蒸留の重複防止 / ON CONFLICT DO NOTHING のキー)
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_learned_memory_session
+  ON learned_memory (tenant_id, source_session_id);
+
+COMMENT ON TABLE learned_memory IS 'Phase71-A: Judge高スコア会話を蒸留した semantic memory。RAG検索時に faq_embeddings と並列取得・マージされる。';
+COMMENT ON COLUMN learned_memory.judge_score IS 'Phase71-A: 蒸留時の Judge overall_score (0-100)。検索時の重み付けに利用可能。';
+
+-- ============================================================
+-- 確認クエリ (実行後に手動確認)
+-- ============================================================
+-- SELECT column_name, data_type FROM information_schema.columns
+-- WHERE table_name = 'learned_memory' ORDER BY ordinal_position;
+-- SELECT indexname FROM pg_indexes WHERE tablename = 'learned_memory';


### PR DESCRIPTION
## 概要

メモリ/RAGベースの**学習ループ**を実装。Judge が高スコア（≥ 閾値）と評価した会話を正規 Q&A に蒸留し、テナント分離された semantic memory（`learned_memory`）として蓄積。RAG 検索時に `faq_embeddings` と並列取得・マージし、**過去に上手くいった応答を次回以降に還元**する。

GoClaw の semantic tier 設計を借用しつつ、既存 Node/TS + pgvector 上に自前実装（**新サービス・GPU不要、Groq継続**）。

```
会話 → Judge評価(報酬) → 高スコア(≥80)なら蒸留 → learned_memory蓄積
                                                    ↓
        次回の検索が faq_embeddings + learned_memory 両方から取得 → 賢くなる
```

## 背景

`src/agent/openclaw/`（Phase47）は本番フローに未配線の死蔵コードで、学習ループが閉じていなかった。本PRは Judge スコアを報酬シグナルとして扱い、**モデル重み更新ではなくメモリ昇格**で「学習」を実現する（OpenClaw-RL の good/bad/neutral 評価のメモリ版）。

## 変更点

| ファイル | 役割 |
|---|---|
| `src/migrations/phase71_learned_memory.sql` | semantic memory テーブル（vector(1536), ivfflat, テナント分離, セッション単位UNIQUE） |
| `src/agent/memory/featureFlag.ts` | write/read 独立トグル + テナントゲート + 閾値/重み |
| `src/agent/memory/learnedMemoryRepository.ts` | save（ON CONFLICT 重複防止）/ search（テナント単独・weight適用） |
| `src/agent/memory/memoryDistiller.ts` | Groq 70B で会話→正規Q&A蒸留→embed→保存（全ガード内蔵） |
| `src/agent/judge/judgeEvaluator.ts` | 評価後に fire-and-forget で蒸留フック（既存 gap 検知と同方式） |
| `src/agent/flow/searchAgent.ts` | 同一 embedding で learned_memory を並列取得しマージ（provenance=metadata.source） |
| `.env.example` | LEARNED_MEMORY_* 設定を追記 |

## 安全設計

- **全機能 Feature Flag 既定 OFF**（`LEARNED_MEMORY_ENABLED=false`）。マージ後も挙動不変。
- verbatim な Q&A は**テナント横断共有しない**（tenant_id 単独フィルタ）。横断学習は既存 `crossTenantContext` の「集計統計のみ共有」方針を踏襲。
- 蒸留・検索の失敗は本番フローに伝播しない（fire-and-forget + catch）。
- learned_memory は curated FAQ より低重み（既定 0.9）で、同点時は FAQ 優先。

## 品質ゲート

- `tsc --noEmit`: **0 error**
- `oxlint`: **clean**
- 新規テスト **21 件 PASS**（featureFlag / repository / distiller）
- 既存 judge テスト **回帰なし**

## デプロイ状況

- [x] VPS に `learned_memory` テーブル作成済み（CREATE TABLE IF NOT EXISTS、追加のみ／本番挙動変化なし）
- [ ] `.env` 有効化（**本PRレビュー承認後**に 1 テナント先行で実施予定）

## レビュー観点（Codex Gate 2.5）

- テナント分離: `searchLearnedMemory` が `tenant_id = $1` 単独で global を含めないこと
- 暗号化: question/answer が `encryptText` 経由で保存されること（faq_embeddings と同方針）
- fire-and-forget の例外が本番フローに漏れないこと

## 残作業（別PR）

- Phase B: エピソードメモリ永続化（セッション要約の保存・再開時ロード）
- Phase C: BM25+vector 重み付きハイブリッド、負例回避

🤖 Generated with [Claude Code](https://claude.com/claude-code)