### PR TITLE
fix(admin-ui): replace hardcoded dark colors with CSS design tokens

### DIFF
--- a/admin-ui/src/index.css
+++ b/admin-ui/src/index.css
@@ -55,6 +55,9 @@
   --sidebar-primary:        oklch(52% 0.22 240);
   --sidebar-primary-foreground: oklch(99% 0 0);
 
+  --card:                   oklch(99% 0 0);
+  --card-foreground:        oklch(15% 0.01 240);
+
   --sidebar-width: 240px;
   --sidebar-width-icon: 64px;
 }
@@ -73,6 +76,9 @@
   --accent-foreground:      oklch(75% 0.15 240);
   --destructive:            oklch(60% 0.22 27);
   --ring:                   oklch(62% 0.22 240);
+
+  --card:                   oklch(17% 0.015 240);
+  --card-foreground:        oklch(93% 0.005 240);
 
   --sidebar:                oklch(10% 0.012 240);
   --sidebar-foreground:     oklch(88% 0.005 240);

--- a/admin-ui/src/pages/admin/analytics/cv-status.tsx
+++ b/admin-ui/src/pages/admin/analytics/cv-status.tsx
@@ -41,8 +41,8 @@ export default function CvStatusPage() {
   const cardStyle: React.CSSProperties = {
     flex: "1 1 140px",
     borderRadius: 14,
-    border: "1px solid #1f2937",
-    background: "linear-gradient(145deg, rgba(15,23,42,0.95), rgba(15,23,42,0.7))",
+    border: "1px solid var(--border)",
+    background: "linear-gradient(145deg, var(--card), var(--card))",
     padding: "20px 18px",
     display: "flex",
     flexDirection: "column",
@@ -54,8 +54,8 @@ export default function CvStatusPage() {
     <div
       style={{
         minHeight: "100vh",
-        background: "radial-gradient(circle at top, #0f172a 0, #020617 55%, #000 100%)",
-        color: "#e5e7eb",
+        background: "var(--background)",
+        color: "var(--foreground)",
         padding: "24px 20px",
         maxWidth: 960,
         margin: "0 auto",
@@ -67,7 +67,7 @@ export default function CvStatusPage() {
           style={{
             background: "none",
             border: "none",
-            color: "#9ca3af",
+            color: "var(--muted-foreground)",
             fontSize: 14,
             cursor: "pointer",
             padding: 0,
@@ -77,10 +77,10 @@ export default function CvStatusPage() {
         >
           ← 分析ダッシュボードへ戻る
         </button>
-        <h1 style={{ fontSize: 24, fontWeight: 700, margin: 0, color: "#f9fafb" }}>
+        <h1 style={{ fontSize: 24, fontWeight: 700, margin: 0, color: "var(--foreground)" }}>
           📉 CV発火状況一覧
         </h1>
-        <p style={{ fontSize: 13, color: "#9ca3af", marginTop: 4, marginBottom: 0 }}>
+        <p style={{ fontSize: 13, color: "var(--muted-foreground)", marginTop: 4, marginBottom: 0 }}>
           過去30日間のCV記録状況をテナント別に確認できます（Super Admin専用）
         </p>
       </header>
@@ -101,7 +101,7 @@ export default function CvStatusPage() {
       )}
 
       {loading ? (
-        <div style={{ padding: 60, textAlign: "center", color: "#6b7280" }}>
+        <div style={{ padding: 60, textAlign: "center", color: "var(--muted-foreground)" }}>
           <span style={{ display: "block", fontSize: 32, marginBottom: 8 }}>⏳</span>
           読み込み中...
         </div>
@@ -111,17 +111,17 @@ export default function CvStatusPage() {
           <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginBottom: 28 }}>
             <div style={cardStyle}>
               <span style={{ fontSize: 24 }}>🏢</span>
-              <span style={{ fontSize: 28, fontWeight: 700, color: "#f9fafb", lineHeight: 1 }}>
+              <span style={{ fontSize: 28, fontWeight: 700, color: "var(--foreground)", lineHeight: 1 }}>
                 {data.total_tenants}
               </span>
-              <span style={{ fontSize: 13, fontWeight: 600, color: "#d1d5db" }}>総テナント数</span>
+              <span style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)" }}>総テナント数</span>
             </div>
             <div style={cardStyle}>
               <span style={{ fontSize: 24 }}>✅</span>
               <span style={{ fontSize: 28, fontWeight: 700, color: "#34d399", lineHeight: 1 }}>
                 {data.fired_tenants}
               </span>
-              <span style={{ fontSize: 13, fontWeight: 600, color: "#d1d5db" }}>CV発火済み</span>
+              <span style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)" }}>CV発火済み</span>
             </div>
             <div style={cardStyle}>
               <span style={{ fontSize: 24 }}>📉</span>
@@ -135,7 +135,7 @@ export default function CvStatusPage() {
               >
                 {data.not_fired_tenants}
               </span>
-              <span style={{ fontSize: 13, fontWeight: 600, color: "#d1d5db" }}>未発火</span>
+              <span style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)" }}>未発火</span>
             </div>
           </div>
 
@@ -143,27 +143,27 @@ export default function CvStatusPage() {
           <div
             style={{
               borderRadius: 14,
-              border: "1px solid #1f2937",
-              background: "linear-gradient(145deg, rgba(15,23,42,0.95), rgba(15,23,42,0.7))",
+              border: "1px solid var(--border)",
+              background: "linear-gradient(145deg, var(--card), var(--card))",
               overflow: "hidden",
             }}
           >
-            <div style={{ padding: "14px 18px", borderBottom: "1px solid #1f2937" }}>
-              <span style={{ fontSize: 15, fontWeight: 600, color: "#d1d5db" }}>
+            <div style={{ padding: "14px 18px", borderBottom: "1px solid var(--border)" }}>
+              <span style={{ fontSize: 15, fontWeight: 600, color: "var(--muted-foreground)" }}>
                 テナント別CV状況
               </span>
             </div>
             <div style={{ overflowX: "auto" }}>
               <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
                 <thead>
-                  <tr style={{ borderBottom: "1px solid #1f2937" }}>
+                  <tr style={{ borderBottom: "1px solid var(--border)" }}>
                     {["テナント名", "経過日数", "CV件数(30日)", "最終CV日時", "ステータス", ""].map((h) => (
                       <th
                         key={h}
                         style={{
                           padding: "10px 14px",
                           textAlign: "left",
-                          color: "#6b7280",
+                          color: "var(--muted-foreground)",
                           fontWeight: 600,
                           whiteSpace: "nowrap",
                         }}
@@ -179,10 +179,10 @@ export default function CvStatusPage() {
                       key={t.tenant_id}
                       style={{ borderBottom: "1px solid rgba(31,41,55,0.5)" }}
                     >
-                      <td style={{ padding: "12px 14px", fontWeight: 600, color: "#e5e7eb" }}>
+                      <td style={{ padding: "12px 14px", fontWeight: 600, color: "var(--foreground)" }}>
                         {t.tenant_name}
                       </td>
-                      <td style={{ padding: "12px 14px", color: "#9ca3af", textAlign: "center" }}>
+                      <td style={{ padding: "12px 14px", color: "var(--muted-foreground)", textAlign: "center" }}>
                         {t.days_since_effective_start}日
                       </td>
                       <td
@@ -195,7 +195,7 @@ export default function CvStatusPage() {
                       >
                         {t.cv_count_30d}
                       </td>
-                      <td style={{ padding: "12px 14px", color: "#9ca3af", whiteSpace: "nowrap" }}>
+                      <td style={{ padding: "12px 14px", color: "var(--muted-foreground)", whiteSpace: "nowrap" }}>
                         {t.last_cv_at
                           ? new Date(t.last_cv_at).toLocaleDateString("ja-JP", {
                               month: "short",
@@ -233,7 +233,7 @@ export default function CvStatusPage() {
                           style={{
                             padding: "4px 10px",
                             borderRadius: 6,
-                            border: "1px solid #374151",
+                            border: "1px solid var(--border)",
                             background: "transparent",
                             color: "#60a5fa",
                             fontSize: 12,

--- a/admin-ui/src/pages/admin/analytics/index.tsx
+++ b/admin-ui/src/pages/admin/analytics/index.tsx
@@ -289,7 +289,7 @@ export default function AnalyticsDashboardPage() {
           {
             data: evaluations.score_distribution.map((s) => s.count),
             backgroundColor: ["#f87171", "#fb923c", "#fbbf24", "#60a5fa", "#4ade80"],
-            borderColor: "rgba(15,23,42,0.5)",
+            borderColor: "var(--card)",
             borderWidth: 2,
           },
         ],
@@ -358,7 +358,7 @@ export default function AnalyticsDashboardPage() {
               sentimentColors.neutral,
               sentimentColors.negative,
             ],
-            borderColor: "rgba(15,23,42,0.5)",
+            borderColor: "var(--card)",
             borderWidth: 2,
           },
         ],
@@ -398,7 +398,7 @@ export default function AnalyticsDashboardPage() {
               "rgba(248,113,113,0.8)",
               "rgba(167,139,250,0.8)",
             ],
-            borderColor: "rgba(15,23,42,0.5)",
+            borderColor: "var(--card)",
             borderWidth: 2,
           },
         ],
@@ -437,8 +437,8 @@ export default function AnalyticsDashboardPage() {
   const cardStyle: CSSProperties = {
     flex: "1 1 160px",
     borderRadius: 14,
-    border: "1px solid #1f2937",
-    background: "linear-gradient(145deg, rgba(15,23,42,0.95), rgba(15,23,42,0.7))",
+    border: "1px solid var(--border)",
+    background: "linear-gradient(145deg, var(--card), var(--card))",
     padding: "20px 18px",
     display: "flex",
     flexDirection: "column",
@@ -448,8 +448,8 @@ export default function AnalyticsDashboardPage() {
 
   const chartCardStyle: CSSProperties = {
     borderRadius: 14,
-    border: "1px solid #1f2937",
-    background: "linear-gradient(145deg, rgba(15,23,42,0.95), rgba(15,23,42,0.7))",
+    border: "1px solid var(--border)",
+    background: "linear-gradient(145deg, var(--card), var(--card))",
     padding: "20px",
     boxShadow: "0 4px 16px rgba(0,0,0,0.2)",
     marginBottom: 20,
@@ -459,8 +459,8 @@ export default function AnalyticsDashboardPage() {
     <div
       style={{
         minHeight: "100vh",
-        background: "radial-gradient(circle at top, #0f172a 0, #020617 55%, #000 100%)",
-        color: "#e5e7eb",
+        background: "var(--background)",
+        color: "var(--foreground)",
         padding: "24px 20px",
         maxWidth: 960,
         margin: "0 auto",
@@ -483,7 +483,7 @@ export default function AnalyticsDashboardPage() {
             style={{
               background: "none",
               border: "none",
-              color: "#9ca3af",
+              color: "var(--muted-foreground)",
               fontSize: 14,
               cursor: "pointer",
               padding: 0,
@@ -493,15 +493,15 @@ export default function AnalyticsDashboardPage() {
           >
             ← 管理画面へ戻る
           </button>
-          <h1 style={{ fontSize: 24, fontWeight: 700, margin: 0, color: "#f9fafb", display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+          <h1 style={{ fontSize: 24, fontWeight: 700, margin: 0, color: "var(--foreground)", display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
             📈 会話分析ダッシュボード
             {isSuperAdmin && (
-              <span style={{ fontSize: 16, fontWeight: 400, color: "#9ca3af", marginLeft: 10 }}>
+              <span style={{ fontSize: 16, fontWeight: 400, color: "var(--muted-foreground)", marginLeft: 10 }}>
                 — {selectedTenantName}
               </span>
             )}
           </h1>
-          <p style={{ fontSize: 13, color: "#9ca3af", marginTop: 4, marginBottom: 0 }}>
+          <p style={{ fontSize: 13, color: "var(--muted-foreground)", marginTop: 4, marginBottom: 0 }}>
             KPI・トレンド・センチメントを可視化します
           </p>
         </div>
@@ -515,9 +515,9 @@ export default function AnalyticsDashboardPage() {
               style={{
                 padding: "8px 12px",
                 borderRadius: 8,
-                border: "1px solid #374151",
-                background: "rgba(15,23,42,0.8)",
-                color: "#e5e7eb",
+                border: "1px solid var(--border)",
+                background: "var(--card)",
+                color: "var(--foreground)",
                 fontSize: 14,
                 minWidth: 160,
                 minHeight: 44,
@@ -539,9 +539,9 @@ export default function AnalyticsDashboardPage() {
             style={{
               padding: "8px 12px",
               borderRadius: 8,
-              border: "1px solid #374151",
-              background: "rgba(15,23,42,0.8)",
-              color: "#e5e7eb",
+              border: "1px solid var(--border)",
+              background: "var(--card)",
+              color: "var(--foreground)",
               fontSize: 14,
               minHeight: 44,
               cursor: "pointer",
@@ -572,7 +572,7 @@ export default function AnalyticsDashboardPage() {
       )}
 
       {loading ? (
-        <div style={{ padding: 60, textAlign: "center", color: "#6b7280" }}>
+        <div style={{ padding: 60, textAlign: "center", color: "var(--muted-foreground)" }}>
           <span style={{ display: "block", fontSize: 32, marginBottom: 8 }}>⏳</span>
           読み込み中...
         </div>
@@ -583,10 +583,10 @@ export default function AnalyticsDashboardPage() {
             {/* 総会話数 */}
             <div style={cardStyle}>
               <span style={{ fontSize: 24 }}>💬</span>
-              <span style={{ fontSize: 28, fontWeight: 700, color: "#f9fafb", lineHeight: 1 }}>
+              <span style={{ fontSize: 28, fontWeight: 700, color: "var(--foreground)", lineHeight: 1 }}>
                 {summary?.total_sessions ?? "—"}
               </span>
-              <span style={{ fontSize: 13, fontWeight: 600, color: "#d1d5db" }}>総会話数</span>
+              <span style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)" }}>総会話数</span>
               {summary && (
                 <span
                   style={{
@@ -616,18 +616,18 @@ export default function AnalyticsDashboardPage() {
                   ? `${summary.avg_judge_score.toFixed(1)}`
                   : "—"}
               </span>
-              <span style={{ fontSize: 13, fontWeight: 600, color: "#d1d5db" }}>平均Judgeスコア</span>
-              <span style={{ fontSize: 12, color: "#6b7280" }}>/100</span>
+              <span style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)" }}>平均Judgeスコア</span>
+              <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>/100</span>
             </div>
 
             {/* Knowledge Gap件数 */}
             <div style={cardStyle}>
               <span style={{ fontSize: 24 }}>🔍</span>
-              <span style={{ fontSize: 28, fontWeight: 700, color: "#f9fafb", lineHeight: 1 }}>
+              <span style={{ fontSize: 28, fontWeight: 700, color: "var(--foreground)", lineHeight: 1 }}>
                 {summary?.total_knowledge_gaps ?? "—"}
               </span>
-              <span style={{ fontSize: 13, fontWeight: 600, color: "#d1d5db" }}>Knowledge Gap</span>
-              <span style={{ fontSize: 12, color: "#6b7280" }}>件</span>
+              <span style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)" }}>Knowledge Gap</span>
+              <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>件</span>
             </div>
 
             {/* アバター利用率 */}
@@ -638,8 +638,8 @@ export default function AnalyticsDashboardPage() {
                   ? `${(summary.avatar_rate * 100).toFixed(1)}%`
                   : "—"}
               </span>
-              <span style={{ fontSize: 13, fontWeight: 600, color: "#d1d5db" }}>アバター利用率</span>
-              <span style={{ fontSize: 12, color: "#6b7280" }}>
+              <span style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)" }}>アバター利用率</span>
+              <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>
                 {summary?.avatar_session_count ?? 0}件 / 全会話
               </span>
             </div>
@@ -657,8 +657,8 @@ export default function AnalyticsDashboardPage() {
               >
                 {summary?.cv_count_30d ?? "—"}
               </span>
-              <span style={{ fontSize: 13, fontWeight: 600, color: "#d1d5db" }}>CV件数(30日)</span>
-              <span style={{ fontSize: 12, color: "#6b7280" }}>
+              <span style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)" }}>CV件数(30日)</span>
+              <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>
                 ¥{(summary?.cv_total_value_30d ?? 0).toLocaleString("ja-JP")}
               </span>
             </div>
@@ -678,10 +678,10 @@ export default function AnalyticsDashboardPage() {
                   ? `${(knowledgeTop3AvgRate * 100).toFixed(1)}%`
                   : "—"}
               </span>
-              <span style={{ fontSize: 13, fontWeight: 600, color: "#d1d5db" }}>
+              <span style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)" }}>
                 ナレッジ貢献度
               </span>
-              <span style={{ fontSize: 12, color: "#6b7280" }}>
+              <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>
                 Top3 平均CV率
               </span>
             </div>
@@ -709,8 +709,8 @@ export default function AnalyticsDashboardPage() {
                         ? `${(positiveRate * 100).toFixed(1)}%`
                         : "—"}
                     </span>
-                    <span style={{ fontSize: 13, fontWeight: 600, color: "#d1d5db" }}>顧客感情</span>
-                    <span style={{ fontSize: 12, color: "#6b7280" }}>
+                    <span style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)" }}>顧客感情</span>
+                    <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>
                       ポジティブ率
                     </span>
                   </>
@@ -729,11 +729,11 @@ export default function AnalyticsDashboardPage() {
                 marginBottom: 24,
                 padding: "12px 16px",
                 borderRadius: 10,
-                border: "1px solid #1f2937",
-                background: "rgba(15,23,42,0.6)",
+                border: "1px solid var(--border)",
+                background: "var(--card)",
               }}
             >
-              <span style={{ fontSize: 12, color: "#6b7280", alignSelf: "center", marginRight: 4 }}>CV内訳:</span>
+              <span style={{ fontSize: 12, color: "var(--muted-foreground)", alignSelf: "center", marginRight: 4 }}>CV内訳:</span>
               {(
                 [
                   ["purchase", "購入", "#34d399"],
@@ -766,7 +766,7 @@ export default function AnalyticsDashboardPage() {
           {/* Line Chart: 会話数トレンド */}
           {lineData && (
             <div style={chartCardStyle}>
-              <h3 style={{ fontSize: 15, fontWeight: 600, color: "#d1d5db", margin: "0 0 16px 0" }}>
+              <h3 style={{ fontSize: 15, fontWeight: 600, color: "var(--muted-foreground)", margin: "0 0 16px 0" }}>
                 会話数トレンド
               </h3>
               <div style={{ height: 220 }}>
@@ -778,11 +778,11 @@ export default function AnalyticsDashboardPage() {
                     plugins: { legend: { display: false } },
                     scales: {
                       x: {
-                        ticks: { color: "#6b7280", maxTicksLimit: 8, font: { size: 11 } },
+                        ticks: { color: "var(--muted-foreground)", maxTicksLimit: 8, font: { size: 11 } },
                         grid: { color: "rgba(255,255,255,0.05)" },
                       },
                       y: {
-                        ticks: { color: "#6b7280", font: { size: 11 } },
+                        ticks: { color: "var(--muted-foreground)", font: { size: 11 } },
                         grid: { color: "rgba(255,255,255,0.05)" },
                         beginAtZero: true,
                       },
@@ -796,7 +796,7 @@ export default function AnalyticsDashboardPage() {
           {/* Sentiment Stacked Bar Chart */}
           {stackedBarData && (
             <div style={chartCardStyle}>
-              <h3 style={{ fontSize: 15, fontWeight: 600, color: "#d1d5db", margin: "0 0 16px 0" }}>
+              <h3 style={{ fontSize: 15, fontWeight: 600, color: "var(--muted-foreground)", margin: "0 0 16px 0" }}>
                 センチメント推移
               </h3>
               <div style={{ height: 220 }}>
@@ -808,18 +808,18 @@ export default function AnalyticsDashboardPage() {
                     plugins: {
                       legend: {
                         position: "bottom",
-                        labels: { color: "#9ca3af", font: { size: 11 }, padding: 10 },
+                        labels: { color: "var(--muted-foreground)", font: { size: 11 }, padding: 10 },
                       },
                     },
                     scales: {
                       x: {
                         stacked: true,
-                        ticks: { color: "#6b7280", maxTicksLimit: 8, font: { size: 11 } },
+                        ticks: { color: "var(--muted-foreground)", maxTicksLimit: 8, font: { size: 11 } },
                         grid: { color: "rgba(255,255,255,0.05)" },
                       },
                       y: {
                         stacked: true,
-                        ticks: { color: "#6b7280", font: { size: 11 } },
+                        ticks: { color: "var(--muted-foreground)", font: { size: 11 } },
                         grid: { color: "rgba(255,255,255,0.05)" },
                         beginAtZero: true,
                       },
@@ -842,7 +842,7 @@ export default function AnalyticsDashboardPage() {
             {/* Doughnut: スコア分布 */}
             {doughnutData && (
               <div style={{ ...chartCardStyle, flex: "1 1 280px", marginBottom: 0 }}>
-                <h3 style={{ fontSize: 15, fontWeight: 600, color: "#d1d5db", margin: "0 0 16px 0" }}>
+                <h3 style={{ fontSize: 15, fontWeight: 600, color: "var(--muted-foreground)", margin: "0 0 16px 0" }}>
                   Judgeスコア分布
                 </h3>
                 <div style={{ height: 200, display: "flex", justifyContent: "center" }}>
@@ -854,7 +854,7 @@ export default function AnalyticsDashboardPage() {
                       plugins: {
                         legend: {
                           position: "bottom",
-                          labels: { color: "#9ca3af", font: { size: 11 }, padding: 10 },
+                          labels: { color: "var(--muted-foreground)", font: { size: 11 }, padding: 10 },
                         },
                       },
                     }}
@@ -866,7 +866,7 @@ export default function AnalyticsDashboardPage() {
             {/* Radar: 4軸平均 */}
             {radarData && (
               <div style={{ ...chartCardStyle, flex: "1 1 280px", marginBottom: 0 }}>
-                <h3 style={{ fontSize: 15, fontWeight: 600, color: "#d1d5db", margin: "0 0 16px 0" }}>
+                <h3 style={{ fontSize: 15, fontWeight: 600, color: "var(--muted-foreground)", margin: "0 0 16px 0" }}>
                   4軸平均スコア
                 </h3>
                 <div style={{ height: 200 }}>
@@ -879,10 +879,10 @@ export default function AnalyticsDashboardPage() {
                         r: {
                           min: 0,
                           max: 100,
-                          ticks: { color: "#6b7280", font: { size: 10 }, stepSize: 25 },
+                          ticks: { color: "var(--muted-foreground)", font: { size: 10 }, stepSize: 25 },
                           grid: { color: "rgba(255,255,255,0.08)" },
                           angleLines: { color: "rgba(255,255,255,0.08)" },
-                          pointLabels: { color: "#9ca3af", font: { size: 11 } },
+                          pointLabels: { color: "var(--muted-foreground)", font: { size: 11 } },
                         },
                       },
                       plugins: {
@@ -897,7 +897,7 @@ export default function AnalyticsDashboardPage() {
             {/* Pie: センチメント分布 */}
             {sentimentPieData && (
               <div style={{ ...chartCardStyle, flex: "1 1 280px", marginBottom: 0 }}>
-                <h3 style={{ fontSize: 15, fontWeight: 600, color: "#d1d5db", margin: "0 0 16px 0" }}>
+                <h3 style={{ fontSize: 15, fontWeight: 600, color: "var(--muted-foreground)", margin: "0 0 16px 0" }}>
                   センチメント分布
                 </h3>
                 <div style={{ height: 200, display: "flex", justifyContent: "center" }}>
@@ -909,7 +909,7 @@ export default function AnalyticsDashboardPage() {
                       plugins: {
                         legend: {
                           position: "bottom",
-                          labels: { color: "#9ca3af", font: { size: 11 }, padding: 10 },
+                          labels: { color: "var(--muted-foreground)", font: { size: 11 }, padding: 10 },
                         },
                       },
                     }}
@@ -922,20 +922,20 @@ export default function AnalyticsDashboardPage() {
           {/* Low Score Sessions Table */}
           {evaluations && evaluations.low_score_sessions.length > 0 && (
             <div style={chartCardStyle}>
-              <h3 style={{ fontSize: 15, fontWeight: 600, color: "#d1d5db", margin: "0 0 16px 0" }}>
+              <h3 style={{ fontSize: 15, fontWeight: 600, color: "var(--muted-foreground)", margin: "0 0 16px 0" }}>
                 低スコア会話
               </h3>
               <div style={{ overflowX: "auto" }}>
                 <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
                   <thead>
-                    <tr style={{ borderBottom: "1px solid #1f2937" }}>
+                    <tr style={{ borderBottom: "1px solid var(--border)" }}>
                       {["セッションID", "スコア", "評価日時", "メッセージ数", "フィードバック"].map((h) => (
                         <th
                           key={h}
                           style={{
                             padding: "8px 12px",
                             textAlign: "left",
-                            color: "#6b7280",
+                            color: "var(--muted-foreground)",
                             fontWeight: 600,
                             whiteSpace: "nowrap",
                           }}
@@ -973,7 +973,7 @@ export default function AnalyticsDashboardPage() {
                             {s.score}
                           </span>
                         </td>
-                        <td style={{ padding: "10px 12px", color: "#9ca3af", whiteSpace: "nowrap" }}>
+                        <td style={{ padding: "10px 12px", color: "var(--muted-foreground)", whiteSpace: "nowrap" }}>
                           {new Date(s.evaluated_at).toLocaleDateString("ja-JP", {
                             month: "short",
                             day: "numeric",
@@ -981,13 +981,13 @@ export default function AnalyticsDashboardPage() {
                             minute: "2-digit",
                           })}
                         </td>
-                        <td style={{ padding: "10px 12px", color: "#9ca3af", textAlign: "center" }}>
+                        <td style={{ padding: "10px 12px", color: "var(--muted-foreground)", textAlign: "center" }}>
                           {s.message_count}
                         </td>
                         <td
                           style={{
                             padding: "10px 12px",
-                            color: "#d1d5db",
+                            color: "var(--muted-foreground)",
                             maxWidth: 240,
                             overflow: "hidden",
                             textOverflow: "ellipsis",
@@ -1012,10 +1012,10 @@ export default function AnalyticsDashboardPage() {
                 style={{
                   fontSize: 18,
                   fontWeight: 700,
-                  color: "#f9fafb",
+                  color: "var(--foreground)",
                   marginTop: 40,
                   marginBottom: 16,
-                  borderBottom: "1px solid #1f2937",
+                  borderBottom: "1px solid var(--border)",
                   paddingBottom: 10,
                 }}
               >
@@ -1026,17 +1026,17 @@ export default function AnalyticsDashboardPage() {
               <div style={{ display: "flex", flexWrap: "wrap", gap: 12, marginBottom: 24 }}>
                 <div style={cardStyle}>
                   <span style={{ fontSize: 24 }}>📊</span>
-                  <span style={{ fontSize: 28, fontWeight: 700, color: "#f9fafb", lineHeight: 1 }}>
+                  <span style={{ fontSize: 28, fontWeight: 700, color: "var(--foreground)", lineHeight: 1 }}>
                     {conversion.summary.total_sessions}
                   </span>
-                  <span style={{ fontSize: 13, fontWeight: 600, color: "#d1d5db" }}>総セッション数</span>
+                  <span style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)" }}>総セッション数</span>
                 </div>
                 <div style={cardStyle}>
                   <span style={{ fontSize: 24 }}>✅</span>
                   <span style={{ fontSize: 28, fontWeight: 700, color: "#34d399", lineHeight: 1 }}>
                     {conversion.summary.recorded_outcomes}
                   </span>
-                  <span style={{ fontSize: 13, fontWeight: 600, color: "#d1d5db" }}>記録済み成果</span>
+                  <span style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)" }}>記録済み成果</span>
                 </div>
                 <div style={cardStyle}>
                   <span style={{ fontSize: 24 }}>📝</span>
@@ -1055,7 +1055,7 @@ export default function AnalyticsDashboardPage() {
                   >
                     {conversion.summary.recording_rate.toFixed(1)}%
                   </span>
-                  <span style={{ fontSize: 13, fontWeight: 600, color: "#d1d5db" }}>記録率</span>
+                  <span style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)" }}>記録率</span>
                 </div>
                 {/* コンバージョン率: 離脱・不明を除いた割合 */}
                 {(() => {
@@ -1080,8 +1080,8 @@ export default function AnalyticsDashboardPage() {
                       >
                         {convRate.toFixed(1)}%
                       </span>
-                      <span style={{ fontSize: 13, fontWeight: 600, color: "#d1d5db" }}>コンバージョン率</span>
-                      <span style={{ fontSize: 12, color: "#6b7280" }}>離脱・不明を除く</span>
+                      <span style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)" }}>コンバージョン率</span>
+                      <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>離脱・不明を除く</span>
                     </div>
                   );
                 })()}
@@ -1092,7 +1092,7 @@ export default function AnalyticsDashboardPage() {
                 {/* Conversion rate trend */}
                 {convTrendLineData && (
                   <div style={{ ...chartCardStyle, flex: "2 1 320px", marginBottom: 0 }}>
-                    <div style={{ fontWeight: 600, color: "#d1d5db", marginBottom: 12, fontSize: 14 }}>
+                    <div style={{ fontWeight: 600, color: "var(--muted-foreground)", marginBottom: 12, fontSize: 14 }}>
                       コンバージョン率推移
                     </div>
                     <div style={{ height: 200 }}>
@@ -1104,11 +1104,11 @@ export default function AnalyticsDashboardPage() {
                           plugins: { legend: { display: false } },
                           scales: {
                             x: {
-                              ticks: { color: "#6b7280", maxTicksLimit: 7 },
+                              ticks: { color: "var(--muted-foreground)", maxTicksLimit: 7 },
                               grid: { color: "rgba(75,85,99,0.2)" },
                             },
                             y: {
-                              ticks: { color: "#6b7280", callback: (v) => `${v}%` },
+                              ticks: { color: "var(--muted-foreground)", callback: (v) => `${v}%` },
                               grid: { color: "rgba(75,85,99,0.2)" },
                               min: 0,
                             },
@@ -1122,7 +1122,7 @@ export default function AnalyticsDashboardPage() {
                 {/* Outcome pie */}
                 {outcomePieData && (
                   <div style={{ ...chartCardStyle, flex: "1 1 220px", marginBottom: 0 }}>
-                    <div style={{ fontWeight: 600, color: "#d1d5db", marginBottom: 12, fontSize: 14 }}>
+                    <div style={{ fontWeight: 600, color: "var(--muted-foreground)", marginBottom: 12, fontSize: 14 }}>
                       成果内訳
                     </div>
                     <div style={{ height: 200 }}>
@@ -1134,7 +1134,7 @@ export default function AnalyticsDashboardPage() {
                           plugins: {
                             legend: {
                               position: "bottom",
-                              labels: { color: "#9ca3af", font: { size: 11 }, boxWidth: 12 },
+                              labels: { color: "var(--muted-foreground)", font: { size: 11 }, boxWidth: 12 },
                             },
                           },
                         }}
@@ -1155,7 +1155,7 @@ export default function AnalyticsDashboardPage() {
                       marginBottom: 12,
                     }}
                   >
-                    <span style={{ fontWeight: 600, color: "#d1d5db", fontSize: 14 }}>
+                    <span style={{ fontWeight: 600, color: "var(--muted-foreground)", fontSize: 14 }}>
                       テクニック別効果
                     </span>
                   </div>
@@ -1169,7 +1169,7 @@ export default function AnalyticsDashboardPage() {
                               style={{
                                 padding: "8px 12px",
                                 textAlign: "left",
-                                color: "#6b7280",
+                                color: "var(--muted-foreground)",
                                 fontWeight: 600,
                                 whiteSpace: "nowrap",
                               }}
@@ -1181,7 +1181,7 @@ export default function AnalyticsDashboardPage() {
                             style={{
                               padding: "8px 12px",
                               textAlign: "left",
-                              color: "#6b7280",
+                              color: "var(--muted-foreground)",
                               fontWeight: 600,
                               whiteSpace: "nowrap",
                               cursor: "pointer",
@@ -1196,13 +1196,13 @@ export default function AnalyticsDashboardPage() {
                       <tbody>
                         {sortedTechniques.map((t) => (
                           <tr key={t.technique} style={{ borderBottom: "1px solid rgba(31,41,55,0.5)" }}>
-                            <td style={{ padding: "10px 12px", fontWeight: 600, color: "#e5e7eb" }}>
+                            <td style={{ padding: "10px 12px", fontWeight: 600, color: "var(--foreground)" }}>
                               {t.technique}
                             </td>
-                            <td style={{ padding: "10px 12px", color: "#9ca3af", textAlign: "center" }}>
+                            <td style={{ padding: "10px 12px", color: "var(--muted-foreground)", textAlign: "center" }}>
                               {t.sessions_used}
                             </td>
-                            <td style={{ padding: "10px 12px", color: "#9ca3af", textAlign: "center" }}>
+                            <td style={{ padding: "10px 12px", color: "var(--muted-foreground)", textAlign: "center" }}>
                               {t.converted}
                             </td>
                             <td style={{ padding: "10px 12px" }}>
@@ -1231,7 +1231,7 @@ export default function AnalyticsDashboardPage() {
               {/* Stage dropout bar chart */}
               {stageDropoutBarData && (
                 <div style={chartCardStyle}>
-                  <div style={{ fontWeight: 600, color: "#d1d5db", marginBottom: 12, fontSize: 14 }}>
+                  <div style={{ fontWeight: 600, color: "var(--muted-foreground)", marginBottom: 12, fontSize: 14 }}>
                     ステージ別離脱分析
                   </div>
                   <div style={{ height: 180 }}>
@@ -1243,11 +1243,11 @@ export default function AnalyticsDashboardPage() {
                         plugins: { legend: { display: false } },
                         scales: {
                           x: {
-                            ticks: { color: "#9ca3af" },
+                            ticks: { color: "var(--muted-foreground)" },
                             grid: { display: false },
                           },
                           y: {
-                            ticks: { color: "#6b7280" },
+                            ticks: { color: "var(--muted-foreground)" },
                             grid: { color: "rgba(75,85,99,0.2)" },
                           },
                         },

--- a/admin-ui/src/pages/admin/avatar-defaults/index.tsx
+++ b/admin-ui/src/pages/admin/avatar-defaults/index.tsx
@@ -23,12 +23,12 @@ const DEFAULT_TEMPLATES: TemplateSlot[] = [
   { id: 'default_08', name: 'つむぎ' },
 ];
 
-const BG = "radial-gradient(circle at top, #0f172a 0, #020617 55%, #000 100%)";
+const BG = "var(--background)";
 
 const CARD_STYLE: React.CSSProperties = {
   borderRadius: 14,
-  border: "1px solid #1f2937",
-  background: "rgba(15,23,42,0.95)",
+  border: "1px solid var(--border)",
+  background: "var(--card)",
   overflow: "hidden",
   display: "flex",
   flexDirection: "column",
@@ -138,19 +138,19 @@ export default function AvatarDefaultsPage() {
   };
 
   return (
-    <div style={{ minHeight: "100vh", background: BG, color: "#e5e7eb", padding: "24px 20px", maxWidth: 1000, margin: "0 auto" }}>
+    <div style={{ minHeight: "100vh", background: BG, color: "var(--foreground)", padding: "24px 20px", maxWidth: 1000, margin: "0 auto" }}>
       {/* ヘッダー */}
       <header style={{ marginBottom: 28 }}>
         <button
           onClick={() => navigate("/admin")}
-          style={{ background: "none", border: "none", color: "#9ca3af", fontSize: 14, cursor: "pointer", padding: 0, marginBottom: 10, display: "block" }}
+          style={{ background: "none", border: "none", color: "var(--muted-foreground)", fontSize: 14, cursor: "pointer", padding: 0, marginBottom: 10, display: "block" }}
         >
           {lang === "ja" ? "← 管理画面に戻る" : "← Back to Admin"}
         </button>
-        <h1 style={{ fontSize: 26, fontWeight: 700, margin: 0, color: "#f9fafb" }}>
+        <h1 style={{ fontSize: 26, fontWeight: 700, margin: 0, color: "var(--foreground)" }}>
           {lang === "ja" ? "デフォルトアバター管理" : "Default Avatar Management"}
         </h1>
-        <p style={{ fontSize: 13, color: "#6b7280", marginTop: 4, marginBottom: 0 }}>
+        <p style={{ fontSize: 13, color: "var(--muted-foreground)", marginTop: 4, marginBottom: 0 }}>
           {lang === "ja"
             ? "8種類のデフォルトアバターテンプレートの画像を管理します（Super Admin専用）"
             : "Manage images for 8 default avatar templates (Super Admin only)"}
@@ -192,10 +192,10 @@ export default function AvatarDefaultsPage() {
               <div style={{ padding: "14px 16px", display: "flex", flexDirection: "column", gap: 8 }}>
                 {/* テンプレートID + 名前 */}
                 <div>
-                  <span style={{ fontSize: 16, fontWeight: 700, color: "#f9fafb", display: "block" }}>
+                  <span style={{ fontSize: 16, fontWeight: 700, color: "var(--foreground)", display: "block" }}>
                     {tmpl.name}
                   </span>
-                  <span style={{ fontSize: 12, color: "#6b7280" }}>{tmpl.id}</span>
+                  <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>{tmpl.id}</span>
                 </div>
 
                 {/* フィードバック */}
@@ -224,7 +224,7 @@ export default function AvatarDefaultsPage() {
                     padding: "10px 16px",
                     minHeight: 44,
                     borderRadius: 10,
-                    border: "1px solid #374151",
+                    border: "1px solid var(--border)",
                     background: isUploading ? "rgba(30,41,59,0.4)" : "rgba(30,41,59,0.8)",
                     color: isUploading ? "#6b7280" : "#e5e7eb",
                     fontSize: 14,

--- a/admin-ui/src/pages/admin/avatar/index.tsx
+++ b/admin-ui/src/pages/admin/avatar/index.tsx
@@ -30,7 +30,7 @@ type SortKey = "name_asc" | "created_desc" | "created_asc" | "active_first" | "i
 type TypeFilter = "all" | "default" | "custom";
 type StatusFilter = "all" | "active" | "inactive";
 
-const BG = "radial-gradient(circle at top, #0f172a 0, #020617 55%, #000 100%)";
+const BG = "var(--background)";
 
 // ── AvatarWarningModal ─────────────────────────────────────────────────────
 interface WarningTarget { id: string; tenantId: string; name: string }
@@ -74,30 +74,30 @@ function AvatarWarningModal({ target, onClose }: { target: WarningTarget; onClos
     finally { setSending(false); }
   };
 
-  const INPUT_STYLE: React.CSSProperties = { padding: "8px 10px", minHeight: 44, borderRadius: 8, border: "1px solid #374151", background: "#020617", color: "#e5e7eb", fontSize: 13 };
+  const INPUT_STYLE: React.CSSProperties = { padding: "8px 10px", minHeight: 44, borderRadius: 8, border: "1px solid var(--border)", background: "var(--input)", color: "var(--foreground)", fontSize: 13 };
 
   return (
     <div style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.75)", zIndex: 1000, display: "flex", alignItems: "center", justifyContent: "center", padding: 16 }}>
-      <div style={{ width: "min(480px, 100%)", borderRadius: 16, background: "#0f172a", border: "1px solid rgba(239,68,68,0.3)", padding: 24, display: "flex", flexDirection: "column", gap: 16 }}>
+      <div style={{ width: "min(480px, 100%)", borderRadius: 16, background: "var(--background)", border: "1px solid rgba(239,68,68,0.3)", padding: 24, display: "flex", flexDirection: "column", gap: 16 }}>
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-          <h2 style={{ fontSize: 18, fontWeight: 700, color: "#f9fafb", margin: 0 }}>⚠️ 警告メッセージを送信</h2>
-          <button onClick={onClose} style={{ background: "none", border: "none", color: "#9ca3af", fontSize: 20, cursor: "pointer", padding: 4, lineHeight: 1 }}>×</button>
+          <h2 style={{ fontSize: 18, fontWeight: 700, color: "var(--foreground)", margin: 0 }}>⚠️ 警告メッセージを送信</h2>
+          <button onClick={onClose} style={{ background: "none", border: "none", color: "var(--muted-foreground)", fontSize: 20, cursor: "pointer", padding: 4, lineHeight: 1 }}>×</button>
         </div>
-        <p style={{ margin: 0, fontSize: 13, color: "#9ca3af" }}>テナントに警告通知を送信します。対象: <strong style={{ color: "#e5e7eb" }}>{target.name}</strong></p>
+        <p style={{ margin: 0, fontSize: 13, color: "var(--muted-foreground)" }}>テナントに警告通知を送信します。対象: <strong style={{ color: "var(--foreground)" }}>{target.name}</strong></p>
 
         {sent ? (
           <div style={{ textAlign: "center", padding: "20px 0", color: "#4ade80", fontSize: 16, fontWeight: 700 }}>✅ 送信しました</div>
         ) : (
           <>
             <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-              <span style={{ fontSize: 13, color: "#d1d5db" }}>警告理由</span>
+              <span style={{ fontSize: 13, color: "var(--muted-foreground)" }}>警告理由</span>
               <select value={reason} onChange={(e) => setReason(e.target.value)} style={INPUT_STYLE}>
                 {WARNING_REASONS.map((r) => <option key={r} value={r}>{r}</option>)}
               </select>
             </label>
 
             <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-              <span style={{ fontSize: 13, color: "#d1d5db" }}>対応期限</span>
+              <span style={{ fontSize: 13, color: "var(--muted-foreground)" }}>対応期限</span>
               <select value={deadlineDays} onChange={(e) => setDeadlineDays(Number(e.target.value))} style={INPUT_STYLE}>
                 {WARNING_DEADLINES.map((d) => (
                   <option key={d.days} value={d.days}>
@@ -108,20 +108,20 @@ function AvatarWarningModal({ target, onClose }: { target: WarningTarget; onClos
             </label>
 
             <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-              <span style={{ fontSize: 13, color: "#d1d5db" }}>メモ（任意）</span>
-              <textarea value={memo} onChange={(e) => setMemo(e.target.value)} rows={3} placeholder="詳細な説明やリンクなど..." style={{ padding: "8px 10px", borderRadius: 8, border: "1px solid #374151", background: "#020617", color: "#e5e7eb", fontSize: 13, resize: "vertical", fontFamily: "inherit" }} />
+              <span style={{ fontSize: 13, color: "var(--muted-foreground)" }}>メモ（任意）</span>
+              <textarea value={memo} onChange={(e) => setMemo(e.target.value)} rows={3} placeholder="詳細な説明やリンクなど..." style={{ padding: "8px 10px", borderRadius: 8, border: "1px solid var(--border)", background: "var(--input)", color: "var(--foreground)", fontSize: 13, resize: "vertical", fontFamily: "inherit" }} />
             </label>
 
             <div style={{ padding: 12, borderRadius: 10, background: "rgba(239,68,68,0.07)", border: "1px solid rgba(239,68,68,0.2)" }}>
-              <p style={{ margin: "0 0 4px", fontSize: 12, color: "#9ca3af", fontWeight: 600 }}>プレビュー</p>
+              <p style={{ margin: "0 0 4px", fontSize: 12, color: "var(--muted-foreground)", fontWeight: 600 }}>プレビュー</p>
               <p style={{ margin: 0, fontSize: 13, color: "#fca5a5", fontWeight: 700 }}>{previewTitle}</p>
-              <p style={{ margin: "4px 0 0", fontSize: 12, color: "#d1d5db", whiteSpace: "pre-line", lineHeight: 1.7 }}>{previewMessage}</p>
+              <p style={{ margin: "4px 0 0", fontSize: 12, color: "var(--muted-foreground)", whiteSpace: "pre-line", lineHeight: 1.7 }}>{previewMessage}</p>
             </div>
 
             {sendError && <div style={{ color: "#fca5a5", fontSize: 13 }}>{sendError}</div>}
 
             <div style={{ display: "flex", gap: 10, justifyContent: "flex-end" }}>
-              <button onClick={onClose} style={{ padding: "10px 18px", minHeight: 44, borderRadius: 8, border: "1px solid #374151", background: "transparent", color: "#9ca3af", fontSize: 13, fontWeight: 600, cursor: "pointer" }}>キャンセル</button>
+              <button onClick={onClose} style={{ padding: "10px 18px", minHeight: 44, borderRadius: 8, border: "1px solid var(--border)", background: "transparent", color: "var(--muted-foreground)", fontSize: 13, fontWeight: 600, cursor: "pointer" }}>キャンセル</button>
               <button onClick={() => void handleSend()} disabled={sending} style={{ padding: "10px 18px", minHeight: 44, borderRadius: 8, border: "none", background: sending ? "#4b5563" : "#dc2626", color: "#fff", fontSize: 13, fontWeight: 700, cursor: sending ? "not-allowed" : "pointer" }}>
                 {sending ? "送信中..." : "⚠️ 警告を送信"}
               </button>
@@ -335,7 +335,7 @@ export default function AvatarListPage() {
     padding: "8px 14px",
     minHeight: 44,
     borderRadius: 8,
-    border: active ? "1px solid rgba(99,102,241,0.6)" : "1px solid #374151",
+    border: active ? "1px solid rgba(99,102,241,0.6)" : "1px solid var(--border)",
     background: active ? "rgba(99,102,241,0.2)" : "transparent",
     color: active ? "#a5b4fc" : "#9ca3af",
     fontSize: 13,
@@ -345,7 +345,7 @@ export default function AvatarListPage() {
   });
 
   return (
-    <div style={{ minHeight: "100vh", background: BG, color: "#e5e7eb", padding: "24px 20px", maxWidth: 1200, margin: "0 auto" }}>
+    <div style={{ minHeight: "100vh", background: BG, color: "var(--foreground)", padding: "24px 20px", maxWidth: 1200, margin: "0 auto" }}>
       <style>{`
         .av-grid {
           display: grid;
@@ -451,17 +451,17 @@ export default function AvatarListPage() {
       <header style={{ marginBottom: 28 }}>
         <button
           onClick={() => navigate("/admin")}
-          style={{ background: "none", border: "none", color: "#9ca3af", fontSize: 14, cursor: "pointer", padding: 0, marginBottom: 10, display: "block" }}
+          style={{ background: "none", border: "none", color: "var(--muted-foreground)", fontSize: 14, cursor: "pointer", padding: 0, marginBottom: 10, display: "block" }}
         >
           {lang === "ja" ? "← 管理画面に戻る" : "← Back to Admin"}
         </button>
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", flexWrap: "wrap", gap: 12 }}>
           <div>
-            <h1 style={{ fontSize: 24, fontWeight: 700, margin: 0, color: "#f9fafb", display: "flex", alignItems: "center", gap: 8 }}>
+            <h1 style={{ fontSize: 24, fontWeight: 700, margin: 0, color: "var(--foreground)", display: "flex", alignItems: "center", gap: 8 }}>
               🎭 {lang === "ja" ? "アバター設定" : "Avatar Configs"}
             </h1>
             {!loading && (
-              <p style={{ fontSize: 13, color: "#6b7280", margin: "4px 0 0" }}>
+              <p style={{ fontSize: 13, color: "var(--muted-foreground)", margin: "4px 0 0" }}>
                 {isSuperAdmin
                   ? (lang === "ja" ? `全テナント: ${displayedConfigs.length}/${total}件` : `All tenants: ${displayedConfigs.length}/${total}`)
                   : (lang === "ja" ? `${total}件の設定` : `${total} config${total !== 1 ? "s" : ""}`)
@@ -515,11 +515,11 @@ export default function AvatarListPage() {
           padding: "16px 20px",
           borderRadius: 14,
           border: "1px solid rgba(99,102,241,0.3)",
-          background: "rgba(15,23,42,0.8)",
+          background: "var(--card)",
         }}>
           {/* ソート */}
           <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
-            <span style={{ fontSize: 13, color: "#9ca3af", minWidth: 48 }}>
+            <span style={{ fontSize: 13, color: "var(--muted-foreground)", minWidth: 48 }}>
               {lang === "ja" ? "ソート:" : "Sort:"}
             </span>
             <select
@@ -529,9 +529,9 @@ export default function AvatarListPage() {
                 padding: "8px 12px",
                 minHeight: 44,
                 borderRadius: 8,
-                border: "1px solid #374151",
-                background: "#111827",
-                color: "#e5e7eb",
+                border: "1px solid var(--border)",
+                background: "var(--input)",
+                color: "var(--foreground)",
                 fontSize: 13,
                 cursor: "pointer",
               }}
@@ -548,7 +548,7 @@ export default function AvatarListPage() {
           {/* フィルタ: テナント（Super Adminのみ） */}
           {isSuperAdmin && (
             <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
-              <span style={{ fontSize: 13, color: "#9ca3af", minWidth: 48 }}>
+              <span style={{ fontSize: 13, color: "var(--muted-foreground)", minWidth: 48 }}>
                 {lang === "ja" ? "テナント:" : "Tenant:"}
               </span>
               <select
@@ -558,9 +558,9 @@ export default function AvatarListPage() {
                   padding: "8px 12px",
                   minHeight: 44,
                   borderRadius: 8,
-                  border: "1px solid #374151",
-                  background: "#111827",
-                  color: "#e5e7eb",
+                  border: "1px solid var(--border)",
+                  background: "var(--input)",
+                  color: "var(--foreground)",
                   fontSize: 13,
                   cursor: "pointer",
                   maxWidth: 220,
@@ -576,7 +576,7 @@ export default function AvatarListPage() {
 
           {/* フィルタ: タイプ */}
           <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
-            <span style={{ fontSize: 13, color: "#9ca3af", minWidth: 48 }}>
+            <span style={{ fontSize: 13, color: "var(--muted-foreground)", minWidth: 48 }}>
               {lang === "ja" ? "タイプ:" : "Type:"}
             </span>
             {(["all", "default", "custom"] as TypeFilter[]).map((v) => (
@@ -588,7 +588,7 @@ export default function AvatarListPage() {
 
           {/* フィルタ: ステータス */}
           <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
-            <span style={{ fontSize: 13, color: "#9ca3af", minWidth: 48 }}>
+            <span style={{ fontSize: 13, color: "var(--muted-foreground)", minWidth: 48 }}>
               {lang === "ja" ? "状態:" : "Status:"}
             </span>
             {(["all", "active", "inactive"] as StatusFilter[]).map((v) => (
@@ -615,8 +615,8 @@ export default function AvatarListPage() {
         }}>
           <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 16, flexWrap: "wrap" }}>
             <div>
-              <h2 style={{ fontSize: 18, fontWeight: 700, margin: 0, color: "#f9fafb" }}>🤖 AIアバター機能</h2>
-              <p style={{ fontSize: 14, color: "#9ca3af", margin: "6px 0 0" }}>
+              <h2 style={{ fontSize: 18, fontWeight: 700, margin: 0, color: "var(--foreground)" }}>🤖 AIアバター機能</h2>
+              <p style={{ fontSize: 14, color: "var(--muted-foreground)", margin: "6px 0 0" }}>
                 ONにすると、チャットウィジェットにAIアバターが表示されます
               </p>
             </div>
@@ -680,7 +680,7 @@ export default function AvatarListPage() {
 
       {/* ローディング */}
       {loading ? (
-        <div style={{ textAlign: "center", color: "#6b7280", paddingTop: 60, fontSize: 15 }}>
+        <div style={{ textAlign: "center", color: "var(--muted-foreground)", paddingTop: 60, fontSize: 15 }}>
           {lang === "ja" ? "読み込み中..." : "Loading..."}
         </div>
       ) : displayedConfigs.length === 0 ? (
@@ -689,7 +689,7 @@ export default function AvatarListPage() {
           padding: "60px 20px",
           borderRadius: 14,
           border: "1px dashed #374151",
-          color: "#6b7280",
+          color: "var(--muted-foreground)",
           fontSize: 15,
         }}>
           {configs.length === 0
@@ -707,8 +707,8 @@ export default function AvatarListPage() {
               className="av-card"
               style={{
                 borderRadius: 14,
-                border: cfg.is_active ? "1px solid rgba(34,197,94,0.5)" : "1px solid #1f2937",
-                background: "rgba(15,23,42,0.95)",
+                border: cfg.is_active ? "1px solid rgba(34,197,94,0.5)" : "1px solid var(--border)",
+                background: "var(--card)",
                 overflow: "hidden",
                 display: "flex",
                 flexDirection: "column",
@@ -784,7 +784,7 @@ export default function AvatarListPage() {
                       borderRadius: 999,
                       background: "rgba(107,114,128,0.15)",
                       border: "1px solid rgba(107,114,128,0.4)",
-                      color: "#9ca3af",
+                      color: "var(--muted-foreground)",
                       fontSize: 11,
                       fontWeight: 700,
                       flexShrink: 0,
@@ -809,7 +809,7 @@ export default function AvatarListPage() {
                 </div>
 
                 {/* 作成日 */}
-                <span style={{ fontSize: 12, color: "#6b7280" }}>
+                <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>
                   {lang === "ja" ? "作成日: " : "Created: "}{formatDate(cfg.created_at)}
                 </span>
 
@@ -843,9 +843,9 @@ export default function AvatarListPage() {
                       style={{
                         minHeight: 44,
                         borderRadius: 8,
-                        border: "1px solid #374151",
+                        border: "1px solid var(--border)",
                         background: "transparent",
-                        color: "#9ca3af",
+                        color: "var(--muted-foreground)",
                         fontWeight: 600,
                         cursor: "pointer",
                       }}
@@ -901,7 +901,7 @@ export default function AvatarListPage() {
                       <button
                         className="av-btn-sm"
                         onClick={() => navigate(`/admin/avatar/studio/${cfg.id}`)}
-                        style={{ minHeight: 44, borderRadius: 8, border: "1px solid #374151", background: "transparent", color: "#9ca3af", fontWeight: 600, cursor: "pointer" }}
+                        style={{ minHeight: 44, borderRadius: 8, border: "1px solid var(--border)", background: "transparent", color: "var(--muted-foreground)", fontWeight: 600, cursor: "pointer" }}
                       >
                         編集
                       </button>

--- a/admin-ui/src/pages/admin/avatar/studio.tsx
+++ b/admin-ui/src/pages/admin/avatar/studio.tsx
@@ -32,12 +32,12 @@ interface VoiceRecommendation {
   score: number;
 }
 
-const BG = "radial-gradient(circle at top, #0f172a 0, #020617 55%, #000 100%)";
+const BG = "var(--background)";
 
 const SECTION_STYLE: React.CSSProperties = {
   borderRadius: 14,
-  border: "1px solid #1f2937",
-  background: "rgba(15,23,42,0.95)",
+  border: "1px solid var(--border)",
+  background: "var(--card)",
   padding: "20px 22px",
   marginBottom: 20,
 };
@@ -46,7 +46,7 @@ const LABEL_STYLE: React.CSSProperties = {
   display: "block",
   fontSize: 13,
   fontWeight: 600,
-  color: "#9ca3af",
+  color: "var(--muted-foreground)",
   marginBottom: 6,
 };
 
@@ -54,9 +54,9 @@ const INPUT_STYLE: React.CSSProperties = {
   width: "100%",
   padding: "10px 12px",
   borderRadius: 8,
-  border: "1px solid #374151",
+  border: "1px solid var(--border)",
   background: "rgba(30,41,59,0.8)",
-  color: "#f9fafb",
+  color: "var(--foreground)",
   fontSize: 14,
   outline: "none",
   boxSizing: "border-box",
@@ -86,9 +86,9 @@ const BTN_SECONDARY: React.CSSProperties = {
   padding: "10px 18px",
   minHeight: 44,
   borderRadius: 10,
-  border: "1px solid #374151",
+  border: "1px solid var(--border)",
   background: "transparent",
-  color: "#9ca3af",
+  color: "var(--muted-foreground)",
   fontSize: 14,
   fontWeight: 600,
   cursor: "pointer",
@@ -430,28 +430,28 @@ export default function AvatarStudioPage() {
 
   if (loadingEdit) {
     return (
-      <div style={{ minHeight: "100vh", background: BG, color: "#9ca3af", display: "flex", alignItems: "center", justifyContent: "center", fontSize: 15 }}>
+      <div style={{ minHeight: "100vh", background: BG, color: "var(--muted-foreground)", display: "flex", alignItems: "center", justifyContent: "center", fontSize: 15 }}>
         {lang === "ja" ? "読み込み中..." : "Loading..."}
       </div>
     );
   }
 
   return (
-    <div style={{ minHeight: "100vh", background: BG, color: "#e5e7eb", padding: "24px 20px", maxWidth: 800, margin: "0 auto" }}>
+    <div style={{ minHeight: "100vh", background: BG, color: "var(--foreground)", padding: "24px 20px", maxWidth: 800, margin: "0 auto" }}>
       {/* ヘッダー */}
       <header style={{ marginBottom: 28 }}>
         <button
           onClick={() => navigate("/admin/avatar")}
-          style={{ background: "none", border: "none", color: "#9ca3af", fontSize: 14, cursor: "pointer", padding: 0, marginBottom: 10, display: "block" }}
+          style={{ background: "none", border: "none", color: "var(--muted-foreground)", fontSize: 14, cursor: "pointer", padding: 0, marginBottom: 10, display: "block" }}
         >
           {lang === "ja" ? "← アバター一覧に戻る" : "← Back to Avatar List"}
         </button>
-        <h1 style={{ fontSize: 26, fontWeight: 700, margin: 0, color: "#f9fafb" }}>
+        <h1 style={{ fontSize: 26, fontWeight: 700, margin: 0, color: "var(--foreground)" }}>
           {isEdit
             ? (lang === "ja" ? "アバター編集" : "Edit Avatar")
             : (lang === "ja" ? "アバタースタジオ" : "Avatar Studio")}
         </h1>
-        <p style={{ fontSize: 13, color: "#6b7280", marginTop: 4, marginBottom: 0 }}>
+        <p style={{ fontSize: 13, color: "var(--muted-foreground)", marginTop: 4, marginBottom: 0 }}>
           {lang === "ja"
             ? "アバターの外見・声・パーソナリティを設定します"
             : "Configure avatar appearance, voice, and personality"}
@@ -472,7 +472,7 @@ export default function AvatarStudioPage() {
 
       {/* 1. 基本設定 */}
       <div style={SECTION_STYLE}>
-        <h2 style={{ fontSize: 16, fontWeight: 700, color: "#f9fafb", margin: "0 0 16px" }}>
+        <h2 style={{ fontSize: 16, fontWeight: 700, color: "var(--foreground)", margin: "0 0 16px" }}>
           {lang === "ja" ? "1. 基本設定" : "1. Basic Settings"}
         </h2>
         <div style={{ marginBottom: 14 }}>
@@ -494,7 +494,7 @@ export default function AvatarStudioPage() {
 
       {/* 2. アバター画像 */}
       <div style={SECTION_STYLE}>
-        <h2 style={{ fontSize: 16, fontWeight: 700, color: "#f9fafb", margin: "0 0 16px" }}>
+        <h2 style={{ fontSize: 16, fontWeight: 700, color: "var(--foreground)", margin: "0 0 16px" }}>
           {lang === "ja" ? "2. アバター画像" : "2. Avatar Image"}
         </h2>
 
@@ -536,7 +536,7 @@ export default function AvatarStudioPage() {
                 padding: "8px 18px",
                 minHeight: 44,
                 borderRadius: 10,
-                border: imageTab === tab ? "2px solid #3b82f6" : "1px solid #374151",
+                border: imageTab === tab ? "2px solid #3b82f6" : "1px solid var(--border)",
                 background: imageTab === tab ? "rgba(59,130,246,0.15)" : "transparent",
                 color: imageTab === tab ? "#93c5fd" : "#9ca3af",
                 fontSize: 13,
@@ -584,7 +584,7 @@ export default function AvatarStudioPage() {
 
             {generatedImages.length > 0 && (
               <div style={{ marginTop: 16 }}>
-                <p style={{ fontSize: 13, color: "#9ca3af", marginBottom: 10 }}>
+                <p style={{ fontSize: 13, color: "var(--muted-foreground)", marginBottom: 10 }}>
                   {lang === "ja" ? "使用する画像を選択してください" : "Select an image to use"}
                 </p>
                 <div style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: 10 }}>
@@ -598,7 +598,7 @@ export default function AvatarStudioPage() {
                         border: selectedImageIdx === idx ? "2px solid #3b82f6" : "2px solid transparent",
                         cursor: "pointer",
                         aspectRatio: "1",
-                        background: "#111827",
+                        background: "var(--muted)",
                       }}
                     >
                       <img
@@ -617,7 +617,7 @@ export default function AvatarStudioPage() {
         {/* 写真をアップロードタブ */}
         {imageTab === 'upload' && (
           <div>
-            <p style={{ color: "#9ca3af", marginBottom: 12 }}>
+            <p style={{ color: "var(--muted-foreground)", marginBottom: 12 }}>
               {lang === "ja" ? "顔がはっきり写った正面の写真が最適です" : "A clear front-facing photo works best"}
             </p>
 
@@ -632,7 +632,7 @@ export default function AvatarStudioPage() {
                 <button
                   type="button"
                   onClick={handleResetUpload}
-                  style={{ background: "none", border: "none", color: "#6b7280", fontSize: 13, cursor: "pointer", textDecoration: "underline" }}
+                  style={{ background: "none", border: "none", color: "var(--muted-foreground)", fontSize: 13, cursor: "pointer", textDecoration: "underline" }}
                 >
                   {lang === "ja" ? "別の画像を選ぶ" : "Choose a different image"}
                 </button>
@@ -669,10 +669,10 @@ export default function AvatarStudioPage() {
                       <p style={{ fontSize: 18, color: "white", margin: "0 0 8px" }}>
                         {lang === "ja" ? "ここに画像をドラッグ" : "Drag image here"}
                       </p>
-                      <p style={{ color: "#9ca3af", margin: "0 0 8px" }}>
+                      <p style={{ color: "var(--muted-foreground)", margin: "0 0 8px" }}>
                         {lang === "ja" ? "または クリックしてファイルを選択" : "or click to select a file"}
                       </p>
-                      <p style={{ color: "#6b7280", fontSize: 14, margin: 0 }}>
+                      <p style={{ color: "var(--muted-foreground)", fontSize: 14, margin: 0 }}>
                         JPG, PNG{lang === "ja" ? "（最大5MB）" : " (max 5MB)"}
                       </p>
                     </>
@@ -733,7 +733,7 @@ export default function AvatarStudioPage() {
 
       {/* 3. 声マッチング */}
       <div style={SECTION_STYLE}>
-        <h2 style={{ fontSize: 16, fontWeight: 700, color: "#f9fafb", margin: "0 0 16px" }}>
+        <h2 style={{ fontSize: 16, fontWeight: 700, color: "var(--foreground)", margin: "0 0 16px" }}>
           {lang === "ja" ? "3. 声マッチング" : "3. Voice Matching"}
         </h2>
         <div style={{ marginBottom: 12 }}>
@@ -763,7 +763,7 @@ export default function AvatarStudioPage() {
 
         {voiceRecs.length > 0 && (
           <div style={{ marginTop: 16, display: "flex", flexDirection: "column", gap: 8 }}>
-            <p style={{ fontSize: 13, color: "#9ca3af", marginBottom: 4 }}>
+            <p style={{ fontSize: 13, color: "var(--muted-foreground)", marginBottom: 4 }}>
               {lang === "ja" ? "使用する声を選択してください" : "Select a voice to use"}
             </p>
             {voiceRecs.map((rec) => (
@@ -775,7 +775,7 @@ export default function AvatarStudioPage() {
                   borderRadius: 10,
                   border: selectedVoiceId === rec.id
                     ? "1px solid rgba(99,102,241,0.7)"
-                    : "1px solid #374151",
+                    : "1px solid var(--border)",
                   background: selectedVoiceId === rec.id
                     ? "rgba(99,102,241,0.1)"
                     : "rgba(30,41,59,0.6)",
@@ -783,12 +783,12 @@ export default function AvatarStudioPage() {
                 }}
               >
                 <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 4 }}>
-                  <span style={{ fontSize: 14, fontWeight: 600, color: "#f9fafb" }}>{rec.title}</span>
-                  <span style={{ fontSize: 12, color: "#6b7280" }}>
+                  <span style={{ fontSize: 14, fontWeight: 600, color: "var(--foreground)" }}>{rec.title}</span>
+                  <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>
                     {Math.round(rec.score * 100)}%
                   </span>
                 </div>
-                <p style={{ fontSize: 12, color: "#9ca3af", margin: 0, lineHeight: 1.5 }}>{rec.description}</p>
+                <p style={{ fontSize: 12, color: "var(--muted-foreground)", margin: 0, lineHeight: 1.5 }}>{rec.description}</p>
               </div>
             ))}
           </div>
@@ -808,7 +808,7 @@ export default function AvatarStudioPage() {
               readOnly={isDefault}
               style={{
                 ...INPUT_STYLE,
-                ...(isDefault ? { background: "rgba(15,23,42,0.6)", color: "#6b7280", cursor: "default" } : {}),
+                ...(isDefault ? { background: "var(--card)", color: "var(--muted-foreground)", cursor: "default" } : {}),
               }}
             />
             {isDefault && (
@@ -822,7 +822,7 @@ export default function AvatarStudioPage() {
 
       {/* 4. パーソナリティ */}
       <div style={SECTION_STYLE}>
-        <h2 style={{ fontSize: 16, fontWeight: 700, color: "#f9fafb", margin: "0 0 16px" }}>
+        <h2 style={{ fontSize: 16, fontWeight: 700, color: "var(--foreground)", margin: "0 0 16px" }}>
           {lang === "ja" ? "4. パーソナリティ" : "4. Personality"}
         </h2>
         <div style={{ marginBottom: 12 }}>
@@ -862,7 +862,7 @@ export default function AvatarStudioPage() {
             style={{
               ...TEXTAREA_STYLE,
               minHeight: 120,
-              ...(isDefault ? { background: "rgba(15,23,42,0.6)", color: "#9ca3af", cursor: "default" } : {}),
+              ...(isDefault ? { background: "var(--card)", color: "var(--muted-foreground)", cursor: "default" } : {}),
             }}
           />
           {isDefault && (
@@ -881,7 +881,7 @@ export default function AvatarStudioPage() {
               <textarea
                 value={agentPrompt}
                 readOnly
-                style={{ ...TEXTAREA_STYLE, background: "rgba(15,23,42,0.6)", color: "#9ca3af", cursor: "default", fontStyle: "italic" }}
+                style={{ ...TEXTAREA_STYLE, background: "var(--card)", color: "var(--muted-foreground)", cursor: "default", fontStyle: "italic" }}
               />
               <p style={{ fontSize: 11, color: "#4b5563", marginTop: 4, marginBottom: 0 }}>
                 {lang === "ja" ? "デフォルト設定 — 変更不可" : "Default setting — read-only"}
@@ -894,7 +894,7 @@ export default function AvatarStudioPage() {
               <textarea
                 value={agentIdlePrompt}
                 readOnly
-                style={{ ...TEXTAREA_STYLE, background: "rgba(15,23,42,0.6)", color: "#9ca3af", cursor: "default", fontStyle: "italic" }}
+                style={{ ...TEXTAREA_STYLE, background: "var(--card)", color: "var(--muted-foreground)", cursor: "default", fontStyle: "italic" }}
               />
               <p style={{ fontSize: 11, color: "#4b5563", marginTop: 4, marginBottom: 0 }}>
                 {lang === "ja" ? "デフォルト設定 — 変更不可" : "Default setting — read-only"}

--- a/admin-ui/src/pages/admin/billing/index.tsx
+++ b/admin-ui/src/pages/admin/billing/index.tsx
@@ -125,9 +125,9 @@ function exportCsv(data: DailyUsage[], tenantName: string, month: string, header
 // ─── スタイル定数 ─────────────────────────────────────────
 const CARD: React.CSSProperties = {
   borderRadius: 14,
-  border: "1px solid #1f2937",
+  border: "1px solid var(--border)",
   background:
-    "linear-gradient(145deg, rgba(15,23,42,0.95), rgba(15,23,42,0.7))",
+    "linear-gradient(145deg, var(--card), var(--card))",
   padding: "20px 18px",
   boxShadow: "0 4px 16px rgba(0,0,0,0.2)",
 };
@@ -139,9 +139,9 @@ const BTN_LINK: React.CSSProperties = {
   padding: "10px 18px",
   minHeight: 44,
   borderRadius: 10,
-  border: "1px solid #374151",
+  border: "1px solid var(--border)",
   background: "transparent",
-  color: "#e5e7eb",
+  color: "var(--foreground)",
   fontSize: 15,
   fontWeight: 600,
   cursor: "pointer",
@@ -565,7 +565,7 @@ export default function BillingPage() {
       draft: {
         label: t("billing.invoice_draft"),
         bg: "rgba(107,114,128,0.15)",
-        color: "#9ca3af",
+        color: "var(--muted-foreground)",
         border: "rgba(107,114,128,0.3)",
       },
     };
@@ -601,8 +601,8 @@ export default function BillingPage() {
       style={{
         minHeight: "100vh",
         background:
-          "radial-gradient(circle at top, #0f172a 0, #020617 55%, #000 100%)",
-        color: "#e5e7eb",
+          "var(--background)",
+        color: "var(--foreground)",
         padding: "24px 20px",
         maxWidth: 900,
         margin: "0 auto",
@@ -626,15 +626,15 @@ export default function BillingPage() {
               ...BTN_LINK,
               marginBottom: 12,
               fontSize: 14,
-              color: "#9ca3af",
+              color: "var(--muted-foreground)",
             }}
           >
             {t("billing.back")}
           </button>
-          <h1 style={{ fontSize: 24, fontWeight: 700, margin: 0, color: "#f9fafb" }}>
+          <h1 style={{ fontSize: 24, fontWeight: 700, margin: 0, color: "var(--foreground)" }}>
             {t("billing.title")}
           </h1>
-          <p style={{ fontSize: 14, color: "#9ca3af", marginTop: 4, marginBottom: 0 }}>
+          <p style={{ fontSize: 14, color: "var(--muted-foreground)", marginTop: 4, marginBottom: 0 }}>
             {t("billing.subtitle")}
           </p>
         </div>
@@ -666,7 +666,7 @@ export default function BillingPage() {
             <div style={{ flex: "1 1 200px" }}>
               <label
                 htmlFor="tenant-select"
-                style={{ display: "block", fontSize: 13, color: "#9ca3af", fontWeight: 600, marginBottom: 6 }}
+                style={{ display: "block", fontSize: 13, color: "var(--muted-foreground)", fontWeight: 600, marginBottom: 6 }}
               >
                 {t("billing.tenant_select")}
               </label>
@@ -679,9 +679,9 @@ export default function BillingPage() {
                   padding: "12px 14px",
                   minHeight: 44,
                   borderRadius: 10,
-                  border: "1px solid #374151",
+                  border: "1px solid var(--border)",
                   background: "rgba(0,0,0,0.3)",
-                  color: "#e5e7eb",
+                  color: "var(--foreground)",
                   fontSize: 15,
                   cursor: "pointer",
                 }}
@@ -698,7 +698,7 @@ export default function BillingPage() {
           <div style={{ flex: "1 1 160px" }}>
             <label
               htmlFor="month-select"
-              style={{ display: "block", fontSize: 13, color: "#9ca3af", fontWeight: 600, marginBottom: 6 }}
+              style={{ display: "block", fontSize: 13, color: "var(--muted-foreground)", fontWeight: 600, marginBottom: 6 }}
             >
               {t("billing.month_select")}
             </label>
@@ -712,9 +712,9 @@ export default function BillingPage() {
                 padding: "12px 14px",
                 minHeight: 44,
                 borderRadius: 10,
-                border: "1px solid #374151",
+                border: "1px solid var(--border)",
                 background: "rgba(0,0,0,0.3)",
-                color: "#e5e7eb",
+                color: "var(--foreground)",
                 fontSize: 15,
                 boxSizing: "border-box",
               }}
@@ -743,8 +743,8 @@ export default function BillingPage() {
         {isSuperAdmin && selectedTenantId && (() => {
           const st = tenants.find((t) => t.id === selectedTenantId);
           return (
-            <div style={{ display: "flex", gap: 10, marginTop: 16, flexWrap: "wrap", borderTop: "1px solid #1f2937", paddingTop: 16 }}>
-              <span style={{ fontSize: 13, color: "#6b7280", alignSelf: "center", fontWeight: 600 }}>⚙️ 請求管理:</span>
+            <div style={{ display: "flex", gap: 10, marginTop: 16, flexWrap: "wrap", borderTop: "1px solid var(--border)", paddingTop: 16 }}>
+              <span style={{ fontSize: 13, color: "var(--muted-foreground)", alignSelf: "center", fontWeight: 600 }}>⚙️ 請求管理:</span>
               <button
                 onClick={() => { setAdjustAmount(""); setAdjustReason(""); setAdjustType("discount"); setAdjustModalOpen(true); }}
                 style={{ ...BTN_LINK, fontSize: 13, padding: "8px 14px", borderColor: "#a855f7", color: "#d8b4fe" }}
@@ -792,7 +792,7 @@ export default function BillingPage() {
             alignItems: "center",
             justifyContent: "center",
             minHeight: 160,
-            color: "#9ca3af",
+            color: "var(--muted-foreground)",
             fontSize: 15,
           }}
         >
@@ -803,17 +803,17 @@ export default function BillingPage() {
         <>
           {/* 概要カード */}
           <section style={{ marginBottom: 20 }}>
-            <h2 style={{ fontSize: 15, fontWeight: 600, color: "#9ca3af", marginBottom: 12 }}>
+            <h2 style={{ fontSize: 15, fontWeight: 600, color: "var(--muted-foreground)", marginBottom: 12 }}>
               {summaryTitle}
             </h2>
             <div style={{ display: "flex", flexWrap: "wrap", gap: 12 }}>
               {/* リクエスト数 */}
               <div style={{ ...CARD, flex: "1 1 140px" }}>
                 <div style={{ fontSize: 26, marginBottom: 4 }}>📊</div>
-                <div style={{ fontSize: 26, fontWeight: 700, color: "#f9fafb", lineHeight: 1 }}>
+                <div style={{ fontSize: 26, fontWeight: 700, color: "var(--foreground)", lineHeight: 1 }}>
                   {fmtNum(summary.total_requests)}
                 </div>
-                <div style={{ fontSize: 13, fontWeight: 600, color: "#d1d5db", marginTop: 4 }}>
+                <div style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)", marginTop: 4 }}>
                   {t("billing.total_requests")}
                 </div>
               </div>
@@ -824,7 +824,7 @@ export default function BillingPage() {
                   <span style={{ fontSize: 26 }}>🤖</span>
                   <span
                     title="AIが文章を読み書きした量です"
-                    style={{ fontSize: 13, color: "#6b7280", cursor: "help" }}
+                    style={{ fontSize: 13, color: "var(--muted-foreground)", cursor: "help" }}
                   >
                     (?)
                   </span>
@@ -832,10 +832,10 @@ export default function BillingPage() {
                 <div style={{ fontSize: 22, fontWeight: 700, color: "#a78bfa", lineHeight: 1 }}>
                   {fmtNum(summary.total_input_tokens + summary.total_output_tokens)}
                 </div>
-                <div style={{ fontSize: 13, fontWeight: 600, color: "#d1d5db", marginTop: 4 }}>
+                <div style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)", marginTop: 4 }}>
                   AIの処理量
                 </div>
-                <div style={{ fontSize: 12, color: "#6b7280", marginTop: 2 }}>
+                <div style={{ fontSize: 12, color: "var(--muted-foreground)", marginTop: 2 }}>
                   AIが文章を読み書きした量
                 </div>
               </div>
@@ -846,10 +846,10 @@ export default function BillingPage() {
                 <div style={{ fontSize: 26, fontWeight: 700, color: "#60a5fa", lineHeight: 1 }}>
                   {fmtCents(summary.cost_llm_cents)}
                 </div>
-                <div style={{ fontSize: 13, fontWeight: 600, color: "#d1d5db", marginTop: 4 }}>
+                <div style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)", marginTop: 4 }}>
                   {t("billing.ai_cost")}
                 </div>
-                <div style={{ fontSize: 12, color: "#6b7280", marginTop: 2 }}>
+                <div style={{ fontSize: 12, color: "var(--muted-foreground)", marginTop: 2 }}>
                   {t("billing.ai_cost_sub")}
                 </div>
               </div>
@@ -860,10 +860,10 @@ export default function BillingPage() {
                 <div style={{ fontSize: 26, fontWeight: 700, color: "#4ade80", lineHeight: 1 }}>
                   {fmtCents(summary.cost_total_cents)}
                 </div>
-                <div style={{ fontSize: 13, fontWeight: 600, color: "#d1d5db", marginTop: 4 }}>
+                <div style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)", marginTop: 4 }}>
                   {t("billing.total_amount")}
                 </div>
-                <div style={{ fontSize: 12, color: "#6b7280", marginTop: 2 }}>
+                <div style={{ fontSize: 12, color: "var(--muted-foreground)", marginTop: 2 }}>
                   {t("billing.total_amount_sub")}
                 </div>
               </div>
@@ -874,10 +874,10 @@ export default function BillingPage() {
                 <div style={{ marginTop: 4 }}>
                   {statusBadge(summary.billing_status)}
                 </div>
-                <div style={{ fontSize: 13, fontWeight: 600, color: "#d1d5db", marginTop: 8 }}>
+                <div style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)", marginTop: 8 }}>
                   {t("billing.payment_status")}
                 </div>
-                <div style={{ fontSize: 12, color: "#6b7280", marginTop: 2 }}>
+                <div style={{ fontSize: 12, color: "var(--muted-foreground)", marginTop: 2 }}>
                   {t("billing.payment_status_sub")}
                 </div>
               </div>
@@ -888,7 +888,7 @@ export default function BillingPage() {
           {daily.length > 0 && (
             <section style={{ ...CARD, marginBottom: 20 }}>
               <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 16, flexWrap: "wrap", gap: 8 }}>
-                <h2 style={{ fontSize: 15, fontWeight: 600, color: "#9ca3af", margin: 0 }}>
+                <h2 style={{ fontSize: 15, fontWeight: 600, color: "var(--muted-foreground)", margin: 0 }}>
                   {t("billing.chart_title")}
                 </h2>
                 <div style={{ display: "flex", gap: 8 }}>
@@ -933,7 +933,7 @@ export default function BillingPage() {
           {/* コスト内訳 */}
           {costBreakdown && costBreakdown.total_yen > 0 && (
             <section style={{ ...CARD, marginBottom: 20 }}>
-              <h2 style={{ fontSize: 15, fontWeight: 600, color: "#9ca3af", margin: "0 0 16px" }}>
+              <h2 style={{ fontSize: 15, fontWeight: 600, color: "var(--muted-foreground)", margin: "0 0 16px" }}>
                 コスト内訳
               </h2>
               <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
@@ -947,7 +947,7 @@ export default function BillingPage() {
                   return (
                     <div key={feature}>
                       <div style={{ display: "flex", justifyContent: "space-between", marginBottom: 4, fontSize: 13 }}>
-                        <span style={{ color: "#d1d5db", fontWeight: 600 }}>{item.label}</span>
+                        <span style={{ color: "var(--muted-foreground)", fontWeight: 600 }}>{item.label}</span>
                         <span style={{ color }}>¥{item.cost_yen.toLocaleString("ja-JP")} ({item.percentage}%)</span>
                       </div>
                       <div style={{ height: 8, borderRadius: 4, background: "rgba(255,255,255,0.05)", overflow: "hidden" }}>
@@ -972,7 +972,7 @@ export default function BillingPage() {
           {daily.length > 0 && (
             <section style={{ ...CARD, marginBottom: 20 }}>
               <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 16, flexWrap: "wrap", gap: 8 }}>
-                <h2 style={{ fontSize: 15, fontWeight: 600, color: "#9ca3af", margin: 0 }}>
+                <h2 style={{ fontSize: 15, fontWeight: 600, color: "var(--muted-foreground)", margin: 0 }}>
                   {t("billing.daily_title")}
                 </h2>
                 <button
@@ -994,7 +994,7 @@ export default function BillingPage() {
               <div style={{ overflowX: "auto" }}>
                 <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 14, minWidth: 480 }}>
                   <thead>
-                    <tr style={{ borderBottom: "1px solid #1f2937" }}>
+                    <tr style={{ borderBottom: "1px solid var(--border)" }}>
                       {[t("billing.col_date"), t("billing.col_requests"), t("billing.col_cost")].map((h) => (
                         <th
                           key={h}
@@ -1003,7 +1003,7 @@ export default function BillingPage() {
                             textAlign: "left",
                             fontSize: 12,
                             fontWeight: 600,
-                            color: "#6b7280",
+                            color: "var(--muted-foreground)",
                             whiteSpace: "nowrap",
                           }}
                         >
@@ -1018,8 +1018,8 @@ export default function BillingPage() {
                         key={d.date}
                         style={{ borderBottom: "1px solid rgba(31,41,55,0.5)" }}
                       >
-                        <td style={{ padding: "10px 12px", color: "#d1d5db" }}>{fmtDate(d.date)}</td>
-                        <td style={{ padding: "10px 12px", color: "#f9fafb", fontWeight: 600 }}>
+                        <td style={{ padding: "10px 12px", color: "var(--muted-foreground)" }}>{fmtDate(d.date)}</td>
+                        <td style={{ padding: "10px 12px", color: "var(--foreground)", fontWeight: 600 }}>
                           {fmtNum(d.requests)}
                         </td>
                         <td style={{ padding: "10px 12px", color: "#4ade80", fontWeight: 600 }}>
@@ -1029,9 +1029,9 @@ export default function BillingPage() {
                     ))}
                   </tbody>
                   <tfoot>
-                    <tr style={{ borderTop: "1px solid #374151" }}>
-                      <td style={{ padding: "12px", fontWeight: 700, color: "#f9fafb" }}>{t("billing.total")}</td>
-                      <td style={{ padding: "12px", fontWeight: 700, color: "#f9fafb" }}>
+                    <tr style={{ borderTop: "1px solid var(--border)" }}>
+                      <td style={{ padding: "12px", fontWeight: 700, color: "var(--foreground)" }}>{t("billing.total")}</td>
+                      <td style={{ padding: "12px", fontWeight: 700, color: "var(--foreground)" }}>
                         {fmtNum(summary.total_requests)}
                       </td>
                       <td style={{ padding: "12px", fontWeight: 700, color: "#4ade80" }}>
@@ -1048,18 +1048,18 @@ export default function BillingPage() {
           {daily.length === 0 && summary.total_requests === 0 && (
             <section style={{ ...CARD, marginBottom: 20, textAlign: "center", padding: "32px 20px" }}>
               <div style={{ fontSize: 36, marginBottom: 12 }}>📭</div>
-              <div style={{ fontSize: 15, color: "#6b7280" }}>{t("billing.no_data")}</div>
+              <div style={{ fontSize: 15, color: "var(--muted-foreground)" }}>{t("billing.no_data")}</div>
             </section>
           )}
 
           {/* 請求履歴 */}
           <section style={{ ...CARD, marginBottom: 32 }}>
-            <h2 style={{ fontSize: 15, fontWeight: 600, color: "#9ca3af", marginBottom: 16, margin: "0 0 16px" }}>
+            <h2 style={{ fontSize: 15, fontWeight: 600, color: "var(--muted-foreground)", marginBottom: 16, margin: "0 0 16px" }}>
               {t("billing.invoice_title")}
             </h2>
 
             {invoices.length === 0 ? (
-              <div style={{ textAlign: "center", padding: "24px", color: "#6b7280", fontSize: 14 }}>
+              <div style={{ textAlign: "center", padding: "24px", color: "var(--muted-foreground)", fontSize: 14 }}>
                 {t("billing.invoice_empty")}
               </div>
             ) : (
@@ -1076,17 +1076,17 @@ export default function BillingPage() {
                         alignItems: "center",
                         padding: "14px 16px",
                         borderRadius: 10,
-                        border: "1px solid #1f2937",
+                        border: "1px solid var(--border)",
                         background: "rgba(0,0,0,0.2)",
                         flexWrap: "wrap",
                         gap: 12,
                       }}
                     >
                       <div>
-                        <div style={{ fontSize: 15, fontWeight: 600, color: "#f9fafb" }}>
+                        <div style={{ fontSize: 15, fontWeight: 600, color: "var(--foreground)" }}>
                           {t("billing.invoice_month", { month: monthLabel })}
                         </div>
-                        <div style={{ fontSize: 13, color: "#9ca3af", marginTop: 2 }}>
+                        <div style={{ fontSize: 13, color: "var(--muted-foreground)", marginTop: 2 }}>
                           {t("billing.invoice_amount", { amount: fmtCents(inv.amount_cents) })} &nbsp;|&nbsp;{" "}
                           {invoiceStatusBadge(inv.status)}
                         </div>
@@ -1119,7 +1119,7 @@ export default function BillingPage() {
                               fontSize: 13,
                               padding: "8px 14px",
                               borderColor: "#374151",
-                              color: "#9ca3af",
+                              color: "var(--muted-foreground)",
                             }}
                           >
                             📥 PDF
@@ -1152,7 +1152,7 @@ export default function BillingPage() {
           {/* Super Admin: 金額調整履歴 */}
           {isSuperAdmin && adjustments.length > 0 && (
             <section style={{ ...CARD, marginBottom: 20 }}>
-              <h2 style={{ fontSize: 15, fontWeight: 600, color: "#9ca3af", margin: "0 0 16px" }}>
+              <h2 style={{ fontSize: 15, fontWeight: 600, color: "var(--muted-foreground)", margin: "0 0 16px" }}>
                 💰 金額調整履歴
               </h2>
               <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
@@ -1162,7 +1162,7 @@ export default function BillingPage() {
                     style={{
                       display: "flex", justifyContent: "space-between", alignItems: "center",
                       padding: "12px 16px", borderRadius: 10,
-                      border: "1px solid #1f2937", background: "rgba(0,0,0,0.2)",
+                      border: "1px solid var(--border)", background: "rgba(0,0,0,0.2)",
                       flexWrap: "wrap", gap: 8,
                     }}
                   >
@@ -1175,11 +1175,11 @@ export default function BillingPage() {
                           ? `▼ ¥${Math.abs(adj.amount).toLocaleString("ja-JP")} 割引`
                           : `▲ ¥${adj.amount.toLocaleString("ja-JP")} 追加`}
                       </span>
-                      <div style={{ fontSize: 13, color: "#9ca3af", marginTop: 2 }}>{adj.reason}</div>
+                      <div style={{ fontSize: 13, color: "var(--muted-foreground)", marginTop: 2 }}>{adj.reason}</div>
                     </div>
                     <div style={{ textAlign: "right" }}>
-                      <div style={{ fontSize: 12, color: "#6b7280" }}>{adj.adjusted_by}</div>
-                      <div style={{ fontSize: 12, color: "#6b7280" }}>
+                      <div style={{ fontSize: 12, color: "var(--muted-foreground)" }}>{adj.adjusted_by}</div>
+                      <div style={{ fontSize: 12, color: "var(--muted-foreground)" }}>
                         {new Date(adj.created_at).toLocaleDateString("ja-JP")}
                       </div>
                     </div>
@@ -1192,13 +1192,13 @@ export default function BillingPage() {
           {/* Super Admin: テナント横断利用状況 */}
           {isSuperAdmin && crossTenantRows.length > 0 && (
             <section style={{ ...CARD, marginBottom: 32 }}>
-              <h2 style={{ fontSize: 15, fontWeight: 600, color: "#9ca3af", margin: "0 0 16px" }}>
+              <h2 style={{ fontSize: 15, fontWeight: 600, color: "var(--muted-foreground)", margin: "0 0 16px" }}>
                 テナント別利用状況（今月）
               </h2>
               <div style={{ overflowX: "auto" }}>
                 <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 14, minWidth: 400 }}>
                   <thead>
-                    <tr style={{ borderBottom: "1px solid #1f2937" }}>
+                    <tr style={{ borderBottom: "1px solid var(--border)" }}>
                       {["テナントID", "リクエスト数", "今月のご利用額"].map((h) => (
                         <th
                           key={h}
@@ -1207,7 +1207,7 @@ export default function BillingPage() {
                             textAlign: "left",
                             fontSize: 12,
                             fontWeight: 600,
-                            color: "#6b7280",
+                            color: "var(--muted-foreground)",
                           }}
                         >
                           {h}
@@ -1225,7 +1225,7 @@ export default function BillingPage() {
                         <td style={{ padding: "10px 12px", color: "#60a5fa", fontWeight: 600 }}>
                           {row.tenant_id}
                         </td>
-                        <td style={{ padding: "10px 12px", color: "#f9fafb" }}>
+                        <td style={{ padding: "10px 12px", color: "var(--foreground)" }}>
                           {fmtNum(row.total_requests)}
                         </td>
                         <td style={{ padding: "10px 12px", color: "#4ade80", fontWeight: 600 }}>
@@ -1244,7 +1244,7 @@ export default function BillingPage() {
           style={{
             textAlign: "center",
             padding: "48px 20px",
-            color: "#6b7280",
+            color: "var(--muted-foreground)",
             fontSize: 15,
           }}
         >
@@ -1267,7 +1267,7 @@ export default function BillingPage() {
             padding: "28px 24px", width: "100%", maxWidth: 440,
             boxShadow: "0 24px 64px rgba(0,0,0,0.6)",
           }}>
-            <h3 style={{ margin: "0 0 20px", fontSize: 18, fontWeight: 700, color: "#f9fafb" }}>💰 金額調整</h3>
+            <h3 style={{ margin: "0 0 20px", fontSize: 18, fontWeight: 700, color: "var(--foreground)" }}>💰 金額調整</h3>
 
             {/* タイプ切替 */}
             <div style={{ display: "flex", gap: 8, marginBottom: 16 }}>
@@ -1294,7 +1294,7 @@ export default function BillingPage() {
             </div>
 
             {/* 金額 */}
-            <label style={{ display: "block", fontSize: 13, color: "#9ca3af", fontWeight: 600, marginBottom: 6 }}>
+            <label style={{ display: "block", fontSize: 13, color: "var(--muted-foreground)", fontWeight: 600, marginBottom: 6 }}>
               金額（円）
             </label>
             <input
@@ -1305,13 +1305,13 @@ export default function BillingPage() {
               placeholder="例: 1000"
               style={{
                 width: "100%", padding: "12px 14px", minHeight: 44, borderRadius: 10,
-                border: "1px solid #374151", background: "rgba(0,0,0,0.3)",
-                color: "#e5e7eb", fontSize: 15, boxSizing: "border-box", marginBottom: 16,
+                border: "1px solid var(--border)", background: "rgba(0,0,0,0.3)",
+                color: "var(--foreground)", fontSize: 15, boxSizing: "border-box", marginBottom: 16,
               }}
             />
 
             {/* 理由 */}
-            <label style={{ display: "block", fontSize: 13, color: "#9ca3af", fontWeight: 600, marginBottom: 6 }}>
+            <label style={{ display: "block", fontSize: 13, color: "var(--muted-foreground)", fontWeight: 600, marginBottom: 6 }}>
               理由（必須）
             </label>
             <textarea
@@ -1321,8 +1321,8 @@ export default function BillingPage() {
               rows={3}
               style={{
                 width: "100%", padding: "12px 14px", borderRadius: 10,
-                border: "1px solid #374151", background: "rgba(0,0,0,0.3)",
-                color: "#e5e7eb", fontSize: 14, resize: "vertical",
+                border: "1px solid var(--border)", background: "rgba(0,0,0,0.3)",
+                color: "var(--foreground)", fontSize: 14, resize: "vertical",
                 boxSizing: "border-box", marginBottom: 20, fontFamily: "inherit",
               }}
             />
@@ -1346,8 +1346,8 @@ export default function BillingPage() {
                 onClick={() => setAdjustModalOpen(false)}
                 style={{
                   flex: 1, padding: "12px 0", minHeight: 44, borderRadius: 10,
-                  border: "1px solid #374151", background: "transparent",
-                  color: "#9ca3af", fontSize: 15, fontWeight: 600, cursor: "pointer",
+                  border: "1px solid var(--border)", background: "transparent",
+                  color: "var(--muted-foreground)", fontSize: 15, fontWeight: 600, cursor: "pointer",
                 }}
               >キャンセル</button>
               <button
@@ -1382,7 +1382,7 @@ export default function BillingPage() {
             padding: "28px 24px", width: "100%", maxWidth: 400,
             boxShadow: "0 24px 64px rgba(0,0,0,0.6)",
           }}>
-            <h3 style={{ margin: "0 0 20px", fontSize: 18, fontWeight: 700, color: "#f9fafb" }}>🎁 無料期間の設定</h3>
+            <h3 style={{ margin: "0 0 20px", fontSize: 18, fontWeight: 700, color: "var(--foreground)" }}>🎁 無料期間の設定</h3>
 
             {/* 現在の設定 */}
             {(() => {
@@ -1405,7 +1405,7 @@ export default function BillingPage() {
             })()}
 
             {/* 開始日 */}
-            <label style={{ display: "block", fontSize: 13, color: "#9ca3af", fontWeight: 600, marginBottom: 6 }}>
+            <label style={{ display: "block", fontSize: 13, color: "var(--muted-foreground)", fontWeight: 600, marginBottom: 6 }}>
               開始日
             </label>
             <input
@@ -1414,13 +1414,13 @@ export default function BillingPage() {
               onChange={(e) => setFreeFrom(e.target.value)}
               style={{
                 width: "100%", padding: "12px 14px", minHeight: 44, borderRadius: 10,
-                border: "1px solid #374151", background: "rgba(0,0,0,0.3)",
-                color: "#e5e7eb", fontSize: 15, boxSizing: "border-box", marginBottom: 16,
+                border: "1px solid var(--border)", background: "rgba(0,0,0,0.3)",
+                color: "var(--foreground)", fontSize: 15, boxSizing: "border-box", marginBottom: 16,
               }}
             />
 
             {/* 終了日 */}
-            <label style={{ display: "block", fontSize: 13, color: "#9ca3af", fontWeight: 600, marginBottom: 6 }}>
+            <label style={{ display: "block", fontSize: 13, color: "var(--muted-foreground)", fontWeight: 600, marginBottom: 6 }}>
               終了日
             </label>
             <input
@@ -1429,11 +1429,11 @@ export default function BillingPage() {
               onChange={(e) => setFreeUntil(e.target.value)}
               style={{
                 width: "100%", padding: "12px 14px", minHeight: 44, borderRadius: 10,
-                border: "1px solid #374151", background: "rgba(0,0,0,0.3)",
-                color: "#e5e7eb", fontSize: 15, boxSizing: "border-box", marginBottom: 8,
+                border: "1px solid var(--border)", background: "rgba(0,0,0,0.3)",
+                color: "var(--foreground)", fontSize: 15, boxSizing: "border-box", marginBottom: 8,
               }}
             />
-            <p style={{ fontSize: 12, color: "#6b7280", marginBottom: 20 }}>
+            <p style={{ fontSize: 12, color: "var(--muted-foreground)", marginBottom: 20 }}>
               空欄にすると設定を解除します
             </p>
 
@@ -1442,8 +1442,8 @@ export default function BillingPage() {
                 onClick={() => setFreePeriodModalOpen(false)}
                 style={{
                   flex: 1, padding: "12px 0", minHeight: 44, borderRadius: 10,
-                  border: "1px solid #374151", background: "transparent",
-                  color: "#9ca3af", fontSize: 15, fontWeight: 600, cursor: "pointer",
+                  border: "1px solid var(--border)", background: "transparent",
+                  color: "var(--muted-foreground)", fontSize: 15, fontWeight: 600, cursor: "pointer",
                 }}
               >キャンセル</button>
               <button

--- a/admin-ui/src/pages/admin/chat-history/[sessionId].tsx
+++ b/admin-ui/src/pages/admin/chat-history/[sessionId].tsx
@@ -123,7 +123,7 @@ function SuggestedRulesCard({
               gap: 8,
             }}
           >
-            <p style={{ margin: 0, fontSize: 13, color: "#e5e7eb", lineHeight: 1.6 }}>
+            <p style={{ margin: 0, fontSize: 13, color: "var(--foreground)", lineHeight: 1.6 }}>
               {rule.rule_text}
             </p>
             {isApproved ? (
@@ -403,8 +403,8 @@ export default function ChatHistorySessionPage() {
       <div
         style={{
           minHeight: "100vh",
-          background: "radial-gradient(circle at top, #0f172a 0, #020617 55%, #000 100%)",
-          color: "#e5e7eb",
+          background: "var(--background)",
+          color: "var(--foreground)",
           padding: "24px 20px",
           maxWidth: 900,
           margin: "0 auto",
@@ -415,7 +415,7 @@ export default function ChatHistorySessionPage() {
           style={{
             background: "none",
             border: "none",
-            color: "#9ca3af",
+            color: "var(--muted-foreground)",
             fontSize: 14,
             cursor: "pointer",
             padding: 0,
@@ -462,8 +462,8 @@ export default function ChatHistorySessionPage() {
     <div
       style={{
         minHeight: "100vh",
-        background: "radial-gradient(circle at top, #0f172a 0, #020617 55%, #000 100%)",
-        color: "#e5e7eb",
+        background: "var(--background)",
+        color: "var(--foreground)",
         padding: "24px 20px",
         maxWidth: 900,
         margin: "0 auto",
@@ -477,7 +477,7 @@ export default function ChatHistorySessionPage() {
             style={{
               background: "none",
               border: "none",
-              color: "#9ca3af",
+              color: "var(--muted-foreground)",
               fontSize: 14,
               cursor: "pointer",
               padding: 0,
@@ -534,8 +534,8 @@ export default function ChatHistorySessionPage() {
         <div
           style={{
             borderRadius: 14,
-            border: "1px solid #1f2937",
-            background: "linear-gradient(145deg, rgba(15,23,42,0.95), rgba(15,23,42,0.7))",
+            border: "1px solid var(--border)",
+            background: "linear-gradient(145deg, var(--card), var(--card))",
             padding: "18px 20px",
             display: "flex",
             flexWrap: "wrap",
@@ -558,12 +558,12 @@ export default function ChatHistorySessionPage() {
               >
                 {sessionInfo.tenant_id}
               </span>
-              <span style={{ fontSize: 13, color: "#6b7280" }}>
+              <span style={{ fontSize: 13, color: "var(--muted-foreground)" }}>
                 🕐 {formatDateTime(sessionInfo.started_at)}
               </span>
             </>
           )}
-          <span style={{ fontSize: 13, color: "#6b7280" }}>
+          <span style={{ fontSize: 13, color: "var(--muted-foreground)" }}>
             💬{" "}
             {t("chat_history.message_count").replace(
               "{n}",
@@ -588,7 +588,7 @@ export default function ChatHistorySessionPage() {
             transform: "translateX(-50%)",
             padding: "14px 24px",
             borderRadius: 12,
-            background: "rgba(15,23,42,0.98)",
+            background: "var(--card)",
             border: "1px solid #22c55e",
             color: "#4ade80",
             fontSize: 15,
@@ -626,8 +626,8 @@ export default function ChatHistorySessionPage() {
         >
           <div
             style={{
-              background: "#0f172a",
-              border: "1px solid #1f2937",
+              background: "var(--background)",
+              border: "1px solid var(--border)",
               borderRadius: 16,
               padding: "28px 24px",
               maxWidth: 480,
@@ -655,7 +655,7 @@ export default function ChatHistorySessionPage() {
             {/* Step 1: 警告・確認 */}
             {deleteStep === "step1" && (
               <>
-                <h2 style={{ fontSize: 18, fontWeight: 700, color: "#f9fafb", margin: "0 0 16px" }}>
+                <h2 style={{ fontSize: 18, fontWeight: 700, color: "var(--foreground)", margin: "0 0 16px" }}>
                   🗑️ セッションを完全に削除しますか?
                 </h2>
                 <div
@@ -673,7 +673,7 @@ export default function ChatHistorySessionPage() {
                 >
                   ⚠️ この操作は取り消せません。チャット履歴・評価データがすべて完全に削除されます。
                 </div>
-                <p style={{ fontSize: 15, color: "#d1d5db", marginBottom: 24, lineHeight: 1.6 }}>
+                <p style={{ fontSize: 15, color: "var(--muted-foreground)", marginBottom: 24, lineHeight: 1.6 }}>
                   GDPR（忘れられる権利）または個人情報保護法に基づいて削除を行う場合は「次へ」を押してください。
                 </p>
                 <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
@@ -704,9 +704,9 @@ export default function ChatHistorySessionPage() {
                       padding: "14px 24px",
                       minHeight: 48,
                       borderRadius: 12,
-                      border: "1px solid #374151",
+                      border: "1px solid var(--border)",
                       background: "transparent",
-                      color: "#9ca3af",
+                      color: "var(--muted-foreground)",
                       fontSize: 15,
                       fontWeight: 600,
                       cursor: "pointer",
@@ -722,7 +722,7 @@ export default function ChatHistorySessionPage() {
             {/* Step 2: 削除理由入力 + セッションID確認 */}
             {deleteStep === "step2" && (
               <>
-                <h2 style={{ fontSize: 18, fontWeight: 700, color: "#f9fafb", margin: "0 0 16px" }}>
+                <h2 style={{ fontSize: 18, fontWeight: 700, color: "var(--foreground)", margin: "0 0 16px" }}>
                   削除の詳細確認
                 </h2>
 
@@ -730,10 +730,10 @@ export default function ChatHistorySessionPage() {
                 <div style={{ marginBottom: 20 }}>
                   <label
                     htmlFor="delete-reason"
-                    style={{ display: "block", fontSize: 14, fontWeight: 600, color: "#d1d5db", marginBottom: 8 }}
+                    style={{ display: "block", fontSize: 14, fontWeight: 600, color: "var(--muted-foreground)", marginBottom: 8 }}
                   >
                     削除理由 <span style={{ color: "#f87171" }}>*</span>
-                    <span style={{ fontWeight: 400, color: "#6b7280", marginLeft: 4 }}>(5〜500文字)</span>
+                    <span style={{ fontWeight: 400, color: "var(--muted-foreground)", marginLeft: 4 }}>(5〜500文字)</span>
                   </label>
                   <textarea
                     id="delete-reason"
@@ -747,9 +747,9 @@ export default function ChatHistorySessionPage() {
                       width: "100%",
                       padding: "12px 14px",
                       borderRadius: 10,
-                      border: "1px solid #374151",
-                      background: "rgba(15,23,42,0.9)",
-                      color: "#e5e7eb",
+                      border: "1px solid var(--border)",
+                      background: "var(--card)",
+                      color: "var(--foreground)",
                       fontSize: 14,
                       lineHeight: 1.6,
                       resize: "vertical",
@@ -758,7 +758,7 @@ export default function ChatHistorySessionPage() {
                       outline: "none",
                     }}
                   />
-                  <span style={{ fontSize: 12, color: "#6b7280" }}>
+                  <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>
                     {deleteReason.trim().length} / 500文字
                   </span>
                 </div>
@@ -767,7 +767,7 @@ export default function ChatHistorySessionPage() {
                 <div style={{ marginBottom: 24 }}>
                   <label
                     htmlFor="delete-confirm-id"
-                    style={{ display: "block", fontSize: 14, fontWeight: 600, color: "#d1d5db", marginBottom: 8 }}
+                    style={{ display: "block", fontSize: 14, fontWeight: 600, color: "var(--muted-foreground)", marginBottom: 8 }}
                   >
                     確認のため、セッションIDを入力してください <span style={{ color: "#f87171" }}>*</span>
                   </label>
@@ -775,9 +775,9 @@ export default function ChatHistorySessionPage() {
                     style={{
                       fontFamily: "monospace",
                       fontSize: 12,
-                      color: "#9ca3af",
+                      color: "var(--muted-foreground)",
                       background: "rgba(0,0,0,0.4)",
-                      border: "1px solid #1f2937",
+                      border: "1px solid var(--border)",
                       borderRadius: 8,
                       padding: "6px 10px",
                       marginBottom: 8,
@@ -802,9 +802,9 @@ export default function ChatHistorySessionPage() {
                       border:
                         deleteConfirmId && deleteConfirmId !== sessionId
                           ? "1px solid rgba(248,113,113,0.5)"
-                          : "1px solid #374151",
-                      background: "rgba(15,23,42,0.9)",
-                      color: "#e5e7eb",
+                          : "1px solid var(--border)",
+                      background: "var(--card)",
+                      color: "var(--foreground)",
                       fontSize: 14,
                       fontFamily: "monospace",
                       boxSizing: "border-box",
@@ -861,9 +861,9 @@ export default function ChatHistorySessionPage() {
                       padding: "14px 24px",
                       minHeight: 48,
                       borderRadius: 12,
-                      border: "1px solid #374151",
+                      border: "1px solid var(--border)",
                       background: "transparent",
-                      color: "#9ca3af",
+                      color: "var(--muted-foreground)",
                       fontSize: 15,
                       fontWeight: 600,
                       cursor: deleteSubmitting ? "not-allowed" : "pointer",
@@ -881,7 +881,7 @@ export default function ChatHistorySessionPage() {
 
       {/* Loading */}
       {loading ? (
-        <div style={{ padding: 40, textAlign: "center", color: "#6b7280" }}>
+        <div style={{ padding: 40, textAlign: "center", color: "var(--muted-foreground)" }}>
           <span style={{ display: "block", fontSize: 32, marginBottom: 8 }}>⏳</span>
           {t("chat_history.loading")}
         </div>
@@ -901,7 +901,7 @@ export default function ChatHistorySessionPage() {
               <span
                 style={{
                   fontSize: 12,
-                  color: "#6b7280",
+                  color: "var(--muted-foreground)",
                   marginBottom: 4,
                   paddingLeft: msg.role === "user" ? 0 : 4,
                   paddingRight: msg.role === "user" ? 4 : 0,
@@ -935,7 +935,7 @@ export default function ChatHistorySessionPage() {
                     border:
                       msg.role === "user"
                         ? "none"
-                        : "1px solid #374151",
+                        : "1px solid var(--border)",
                     color: msg.role === "user" ? "#fff" : "#e5e7eb",
                     fontSize: 15,
                     lineHeight: 1.6,
@@ -958,7 +958,7 @@ export default function ChatHistorySessionPage() {
                             borderRadius: 999,
                             background: "rgba(55,65,81,0.8)",
                             border: "1px solid #4b5563",
-                            color: "#9ca3af",
+                            color: "var(--muted-foreground)",
                             fontSize: 11,
                             fontFamily: "monospace",
                           }}
@@ -993,9 +993,9 @@ export default function ChatHistorySessionPage() {
                       padding: "6px 10px",
                       minHeight: 44,
                       borderRadius: 10,
-                      border: "1px solid #374151",
-                      background: "rgba(15,23,42,0.8)",
-                      color: "#9ca3af",
+                      border: "1px solid var(--border)",
+                      background: "var(--card)",
+                      color: "var(--muted-foreground)",
                       fontSize: 13,
                       cursor: "pointer",
                       whiteSpace: "nowrap",
@@ -1025,18 +1025,18 @@ export default function ChatHistorySessionPage() {
               marginTop: 8,
               padding: "20px 18px",
               borderRadius: 14,
-              border: "1px solid #1f2937",
-              background: "linear-gradient(145deg, rgba(15,23,42,0.95), rgba(15,23,42,0.7))",
+              border: "1px solid var(--border)",
+              background: "linear-gradient(145deg, var(--card), var(--card))",
             }}
           >
-            <p style={{ margin: "0 0 14px", fontSize: 15, fontWeight: 700, color: "#e5e7eb" }}>
+            <p style={{ margin: "0 0 14px", fontSize: 15, fontWeight: 700, color: "var(--foreground)" }}>
               🤖 AI品質評価 (Judge)
             </p>
             {evaluation == null ? (
               <span style={{
                 display: "inline-flex", alignItems: "center", padding: "4px 12px",
                 borderRadius: 999, fontSize: 12, fontWeight: 700,
-                background: "rgba(107,114,128,0.15)", border: "1px solid rgba(107,114,128,0.3)", color: "#9ca3af",
+                background: "rgba(107,114,128,0.15)", border: "1px solid rgba(107,114,128,0.3)", color: "var(--muted-foreground)",
               }}>未評価</span>
             ) : (() => {
               const overall = evaluation.overall_score ?? evaluation.score;
@@ -1067,7 +1067,7 @@ export default function ChatHistorySessionPage() {
                       return (
                         <span key={key} style={{
                           padding: "3px 10px", borderRadius: 999, fontSize: 12, fontWeight: 600,
-                          background: "rgba(31,41,55,0.8)", border: "1px solid #374151", color: c,
+                          background: "rgba(31,41,55,0.8)", border: "1px solid var(--border)", color: c,
                         }}>
                           {label}: {s}
                         </span>
@@ -1075,7 +1075,7 @@ export default function ChatHistorySessionPage() {
                     })}
                   </div>
                   {evaluation.feedback?.summary && (
-                    <p style={{ margin: 0, fontSize: 13, color: "#d1d5db", lineHeight: 1.6, padding: "10px 12px", borderRadius: 8, background: "rgba(31,41,55,0.6)", border: "1px solid #374151" }}>
+                    <p style={{ margin: 0, fontSize: 13, color: "var(--muted-foreground)", lineHeight: 1.6, padding: "10px 12px", borderRadius: 8, background: "rgba(31,41,55,0.6)", border: "1px solid var(--border)" }}>
                       {evaluation.feedback.summary}
                     </p>
                   )}
@@ -1097,8 +1097,8 @@ export default function ChatHistorySessionPage() {
               marginTop: 8,
               padding: "20px 18px",
               borderRadius: 14,
-              border: "1px solid #1f2937",
-              background: "linear-gradient(145deg, rgba(15,23,42,0.95), rgba(15,23,42,0.7))",
+              border: "1px solid var(--border)",
+              background: "linear-gradient(145deg, var(--card), var(--card))",
             }}
           >
             <p
@@ -1106,7 +1106,7 @@ export default function ChatHistorySessionPage() {
                 margin: "0 0 14px",
                 fontSize: 15,
                 fontWeight: 700,
-                color: "#e5e7eb",
+                color: "var(--foreground)",
               }}
             >
               この会話の営業結果を記録
@@ -1143,7 +1143,7 @@ export default function ChatHistorySessionPage() {
                     border:
                       outcome === value
                         ? "1px solid rgba(74,222,128,0.5)"
-                        : "1px solid #374151",
+                        : "1px solid var(--border)",
                     background:
                       outcome === value
                         ? "rgba(34,197,94,0.2)"

--- a/admin-ui/src/pages/admin/chat-history/index.tsx
+++ b/admin-ui/src/pages/admin/chat-history/index.tsx
@@ -153,8 +153,8 @@ export default function ChatHistoryPage() {
     <div
       style={{
         minHeight: "100vh",
-        background: "radial-gradient(circle at top, #0f172a 0, #020617 55%, #000 100%)",
-        color: "#e5e7eb",
+        background: "var(--background)",
+        color: "var(--foreground)",
         padding: "24px 20px",
         maxWidth: 900,
         margin: "0 auto",
@@ -177,7 +177,7 @@ export default function ChatHistoryPage() {
             style={{
               background: "none",
               border: "none",
-              color: "#9ca3af",
+              color: "var(--muted-foreground)",
               fontSize: 14,
               cursor: "pointer",
               padding: 0,
@@ -187,10 +187,10 @@ export default function ChatHistoryPage() {
           >
             {t("chat_history.back")}
           </button>
-          <h1 style={{ fontSize: 26, fontWeight: 700, margin: 0, color: "#f9fafb" }}>
+          <h1 style={{ fontSize: 26, fontWeight: 700, margin: 0, color: "var(--foreground)" }}>
             {t("chat_history.title")}
           </h1>
-          <p style={{ fontSize: 14, color: "#9ca3af", marginTop: 4, marginBottom: 0 }}>
+          <p style={{ fontSize: 14, color: "var(--muted-foreground)", marginTop: 4, marginBottom: 0 }}>
             {t("chat_history.subtitle")}
           </p>
         </div>
@@ -244,8 +244,8 @@ export default function ChatHistoryPage() {
             onChange={(e) => { setSelectedTenantFilter(e.target.value); setOffset(0); }}
             style={{
               padding: "8px 12px", minHeight: 38, borderRadius: 10,
-              border: "1px solid #374151", background: "rgba(15,23,42,0.8)",
-              color: "#e5e7eb", fontSize: 13, cursor: "pointer",
+              border: "1px solid var(--border)", background: "var(--card)",
+              color: "var(--foreground)", fontSize: 13, cursor: "pointer",
             }}
           >
             <option value="">すべてのテナント</option>
@@ -259,8 +259,8 @@ export default function ChatHistoryPage() {
           onChange={(e) => { setSentiment(e.target.value as SentimentFilter); setOffset(0); }}
           style={{
             padding: "8px 12px", minHeight: 38, borderRadius: 10,
-            border: "1px solid #374151", background: "rgba(15,23,42,0.8)",
-            color: "#e5e7eb", fontSize: 13, cursor: "pointer",
+            border: "1px solid var(--border)", background: "var(--card)",
+            color: "var(--foreground)", fontSize: 13, cursor: "pointer",
           }}
         >
           <option value="">すべての感情</option>
@@ -277,23 +277,23 @@ export default function ChatHistoryPage() {
 
       {/* Sort bar */}
       <div style={{ display: "flex", gap: 12, marginBottom: 12, alignItems: "center", flexWrap: "wrap" }}>
-        <span style={{ fontSize: 12, color: "#6b7280" }}>並び替え:</span>
+        <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>並び替え:</span>
         <SortableHeader label="最終メッセージ" sortKey="last_message_at" currentSortBy={sortBy} currentSortOrder={sortOrder} onSort={handleSort} />
         <SortableHeader label="メッセージ数" sortKey="message_count" currentSortBy={sortBy} currentSortOrder={sortOrder} onSort={handleSort} />
         <SortableHeader label="スコア" sortKey="score" currentSortBy={sortBy} currentSortOrder={sortOrder} onSort={handleSort} />
-        <span style={{ marginLeft: "auto", fontSize: 13, color: "#6b7280" }}>
-          合計 <span style={{ color: "#d1d5db", fontWeight: 700 }}>{total}</span> 件
+        <span style={{ marginLeft: "auto", fontSize: 13, color: "var(--muted-foreground)" }}>
+          合計 <span style={{ color: "var(--muted-foreground)", fontWeight: 700 }}>{total}</span> 件
         </span>
       </div>
 
       {/* Section title */}
-      <h2 style={{ fontSize: 15, fontWeight: 600, color: "#9ca3af", marginBottom: 12 }}>
+      <h2 style={{ fontSize: 15, fontWeight: 600, color: "var(--muted-foreground)", marginBottom: 12 }}>
         {t("chat_history.sessions")}
       </h2>
 
       {/* Loading */}
       {loading ? (
-        <div style={{ padding: 40, textAlign: "center", color: "#6b7280" }}>
+        <div style={{ padding: 40, textAlign: "center", color: "var(--muted-foreground)" }}>
           <span style={{ display: "block", fontSize: 32, marginBottom: 8 }}>⏳</span>
           {t("chat_history.loading")}
         </div>
@@ -302,11 +302,11 @@ export default function ChatHistoryPage() {
           style={{
             padding: "48px 24px",
             textAlign: "center",
-            color: "#6b7280",
+            color: "var(--muted-foreground)",
             fontSize: 15,
             borderRadius: 14,
-            border: "1px solid #1f2937",
-            background: "linear-gradient(145deg, rgba(15,23,42,0.95), rgba(15,23,42,0.7))",
+            border: "1px solid var(--border)",
+            background: "linear-gradient(145deg, var(--card), var(--card))",
           }}
         >
           {t("chat_history.no_sessions")}
@@ -318,8 +318,8 @@ export default function ChatHistoryPage() {
               key={session.id}
               style={{
                 borderRadius: 14,
-                border: "1px solid #1f2937",
-                background: "linear-gradient(145deg, rgba(15,23,42,0.95), rgba(15,23,42,0.7))",
+                border: "1px solid var(--border)",
+                background: "linear-gradient(145deg, var(--card), var(--card))",
                 padding: "18px 20px",
                 display: "flex",
                 alignItems: "center",
@@ -359,7 +359,7 @@ export default function ChatHistoryPage() {
                   <span
                     style={{
                       fontSize: 15,
-                      color: "#e5e7eb",
+                      color: "var(--foreground)",
                       fontWeight: 500,
                       overflow: "hidden",
                       textOverflow: "ellipsis",
@@ -372,10 +372,10 @@ export default function ChatHistoryPage() {
 
                 {/* Date + message count + UUID (auxiliary) */}
                 <div style={{ display: "flex", gap: 16, flexWrap: "wrap", alignItems: "center" }}>
-                  <span style={{ fontSize: 13, color: "#6b7280" }}>
+                  <span style={{ fontSize: 13, color: "var(--muted-foreground)" }}>
                     🕐 {formatDate(session.last_message_at)}
                   </span>
-                  <span style={{ fontSize: 13, color: "#6b7280" }}>
+                  <span style={{ fontSize: 13, color: "var(--muted-foreground)" }}>
                     💬{" "}
                     {t("chat_history.message_count").replace(
                       "{n}",
@@ -395,9 +395,9 @@ export default function ChatHistoryPage() {
                   padding: "10px 18px",
                   minHeight: 44,
                   borderRadius: 10,
-                  border: "1px solid #374151",
-                  background: "rgba(15,23,42,0.8)",
-                  color: "#e5e7eb",
+                  border: "1px solid var(--border)",
+                  background: "var(--card)",
+                  color: "var(--foreground)",
                   fontSize: 14,
                   fontWeight: 600,
                   cursor: "pointer",

--- a/admin-ui/src/pages/admin/chat-test/index.tsx
+++ b/admin-ui/src/pages/admin/chat-test/index.tsx
@@ -381,21 +381,21 @@ export default function ChatTestPage() {
   };
 
   return (
-    <div style={{ minHeight: "100vh", background: "radial-gradient(circle at top, #0f172a 0, #020617 55%, #000 100%)", color: "#e5e7eb", padding: "24px 20px", maxWidth: 900, margin: "0 auto" }}>
+    <div style={{ minHeight: "100vh", background: "var(--background)", color: "var(--foreground)", padding: "24px 20px", maxWidth: 900, margin: "0 auto" }}>
       <header style={{ display: "flex", alignItems: "center", gap: 12, marginBottom: 32, flexWrap: "wrap" }}>
         <button
           onClick={() => navigate("/admin")}
-          style={{ padding: "10px 16px", minHeight: 44, borderRadius: 999, border: "1px solid #374151", background: "transparent", color: "#9ca3af", fontSize: 14, cursor: "pointer", fontWeight: 500 }}
+          style={{ padding: "10px 16px", minHeight: 44, borderRadius: 999, border: "1px solid var(--border)", background: "transparent", color: "var(--muted-foreground)", fontSize: 14, cursor: "pointer", fontWeight: 500 }}
         >
           {t("common.back_to_dashboard")}
         </button>
         <div>
-          <h1 style={{ fontSize: 24, fontWeight: 700, margin: 0, color: "#f9fafb" }}>{t("chat_test.title")}</h1>
-          <p style={{ fontSize: 14, color: "#9ca3af", marginTop: 4, marginBottom: 0 }}>{t("chat_test.description")}</p>
+          <h1 style={{ fontSize: 24, fontWeight: 700, margin: 0, color: "var(--foreground)" }}>{t("chat_test.title")}</h1>
+          <p style={{ fontSize: 14, color: "var(--muted-foreground)", marginTop: 4, marginBottom: 0 }}>{t("chat_test.description")}</p>
         </div>
       </header>
 
-      <section style={{ borderRadius: 16, border: "1px solid #1f2937", background: "linear-gradient(145deg, rgba(15,23,42,0.95), rgba(15,23,42,0.7))", padding: "32px 24px" }}>
+      <section style={{ borderRadius: 16, border: "1px solid var(--border)", background: "linear-gradient(145deg, var(--card), var(--card))", padding: "32px 24px" }}>
         {/* グローバルナレッジバナー */}
         {scopeGlobal && (
           <div style={{ marginBottom: 24, padding: "14px 18px", borderRadius: 12, background: "rgba(34,197,94,0.15)", border: "1px solid rgba(34,197,94,0.4)", color: "#4ade80", fontSize: 14, fontWeight: 600, display: "flex", alignItems: "center", gap: 8 }}>
@@ -406,7 +406,7 @@ export default function ChatTestPage() {
         {/* Super Admin: テナント選択 */}
         {isSuperAdmin && !scopeGlobal && (
           <div style={{ marginBottom: 24 }}>
-            <label style={{ display: "block", fontSize: 13, fontWeight: 600, color: "#9ca3af", marginBottom: 8 }}>{t("chat_test.select_tenant")}</label>
+            <label style={{ display: "block", fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)", marginBottom: 8 }}>{t("chat_test.select_tenant")}</label>
             {tenantFetchError ? (
               <div style={{ color: "#fca5a5", fontSize: 14, padding: "12px 14px", borderRadius: 10, border: "1px solid rgba(248,113,113,0.3)", background: "rgba(127,29,29,0.3)" }}>
                 ⚠️ テナント一覧の取得に失敗しました。ページを再読み込みしてください。
@@ -415,7 +415,7 @@ export default function ChatTestPage() {
               <select
                 value={selectedTenantId}
                 onChange={(e) => handleTenantChange(e.target.value)}
-                style={{ width: "100%", padding: "12px 14px", borderRadius: 10, border: "1px solid #374151", background: "rgba(15,23,42,0.9)", color: "#e5e7eb", fontSize: 15, outline: "none", cursor: "pointer" }}
+                style={{ width: "100%", padding: "12px 14px", borderRadius: 10, border: "1px solid var(--border)", background: "var(--card)", color: "var(--foreground)", fontSize: 15, outline: "none", cursor: "pointer" }}
               >
                 <option value="">— テナントを選択 —</option>
                 {tenants.map((ten) => <option key={ten.id} value={ten.id}>{ten.name}</option>)}
@@ -427,11 +427,11 @@ export default function ChatTestPage() {
         {/* アバター選択ドロップダウン */}
         {effectiveTenantId && !scopeGlobal && (
           <div style={{ marginBottom: 24 }}>
-            <label style={{ display: "block", fontSize: 13, fontWeight: 600, color: "#9ca3af", marginBottom: 8 }}>
+            <label style={{ display: "block", fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)", marginBottom: 8 }}>
               🎭 テストするアバター
             </label>
             {availableAvatars.length === 0 ? (
-              <p style={{ fontSize: 14, color: "#6b7280", padding: "8px 0", margin: 0 }}>
+              <p style={{ fontSize: 14, color: "var(--muted-foreground)", padding: "8px 0", margin: 0 }}>
                 このテナントにはアバターがありません。テキストチャットでテスト可能です。
               </p>
             ) : (
@@ -439,7 +439,7 @@ export default function ChatTestPage() {
                 <select
                   value={selectedAvatarConfigId ?? ""}
                   onChange={(e) => setSelectedAvatarConfigId(e.target.value || null)}
-                  style={{ flex: 1, minWidth: 200, padding: "12px 14px", minHeight: 44, borderRadius: 10, border: "1px solid #374151", background: "rgba(15,23,42,0.9)", color: "#e5e7eb", fontSize: 15, outline: "none", cursor: "pointer" }}
+                  style={{ flex: 1, minWidth: 200, padding: "12px 14px", minHeight: 44, borderRadius: 10, border: "1px solid var(--border)", background: "var(--card)", color: "var(--foreground)", fontSize: 15, outline: "none", cursor: "pointer" }}
                 >
                   <option value="">— アバターなし（テキストのみ）—</option>
                   {availableAvatars.map((av) => (
@@ -461,7 +461,7 @@ export default function ChatTestPage() {
                   );
                 })()}
                 {!selectedAvatarConfigId && (
-                  <span style={{ fontSize: 13, color: "#6b7280" }}>テキストチャットのみ</span>
+                  <span style={{ fontSize: 13, color: "var(--muted-foreground)" }}>テキストチャットのみ</span>
                 )}
               </div>
             )}
@@ -469,17 +469,17 @@ export default function ChatTestPage() {
         )}
 
         {!effectiveTenantId && !scopeGlobal && (
-          <p style={{ textAlign: "center", color: "#6b7280", fontSize: 15, padding: "32px 0" }}>{t("chat_test.select_tenant")}</p>
+          <p style={{ textAlign: "center", color: "var(--muted-foreground)", fontSize: 15, padding: "32px 0" }}>{t("chat_test.select_tenant")}</p>
         )}
 
         {effectiveTenantId && (
           <>
-            <p style={{ fontSize: 14, color: "#6b7280", marginBottom: 20 }}>
-              {t("chat_test.tenant_label")}: <strong style={{ color: "#9ca3af" }}>{displayTenantName}</strong>
+            <p style={{ fontSize: 14, color: "var(--muted-foreground)", marginBottom: 20 }}>
+              {t("chat_test.tenant_label")}: <strong style={{ color: "var(--muted-foreground)" }}>{displayTenantName}</strong>
             </p>
 
             {gettingToken && (
-              <div style={{ textAlign: "center", padding: "32px 0", color: "#6b7280", fontSize: 15 }}>
+              <div style={{ textAlign: "center", padding: "32px 0", color: "var(--muted-foreground)", fontSize: 15 }}>
                 <span style={{ display: "block", fontSize: 32, marginBottom: 8 }}>⏳</span>
                 {t("chat_test.getting_token")}
               </div>
@@ -496,9 +496,9 @@ export default function ChatTestPage() {
 
             {token && !gettingToken && (
               <>
-                <p style={{ textAlign: "center", color: "#9ca3af", fontSize: 15, marginBottom: 16 }}>👇 右下のボタンからチャットを開けます</p>
+                <p style={{ textAlign: "center", color: "var(--muted-foreground)", fontSize: 15, marginBottom: 16 }}>👇 右下のボタンからチャットを開けます</p>
                 <div style={{ textAlign: "center" }}>
-                  <button onClick={handleReload} style={{ padding: "12px 24px", minHeight: 44, borderRadius: 10, border: "1px solid #374151", background: "transparent", color: "#9ca3af", fontSize: 14, cursor: "pointer" }}>
+                  <button onClick={handleReload} style={{ padding: "12px 24px", minHeight: 44, borderRadius: 10, border: "1px solid var(--border)", background: "transparent", color: "var(--muted-foreground)", fontSize: 14, cursor: "pointer" }}>
                     {t("chat_test.reset")}
                   </button>
                 </div>
@@ -510,26 +510,26 @@ export default function ChatTestPage() {
 
       {/* ── Admin Chat Panel ── */}
       {token && effectiveTenantId && (
-        <section style={{ marginTop: 24, borderRadius: 16, border: "1px solid #1f2937", background: "linear-gradient(145deg, rgba(15,23,42,0.95), rgba(15,23,42,0.7))", padding: "20px 24px" }}>
+        <section style={{ marginTop: 24, borderRadius: 16, border: "1px solid var(--border)", background: "linear-gradient(145deg, var(--card), var(--card))", padding: "20px 24px" }}>
           <button
             onClick={() => setAdminChatOpen((v) => !v)}
-            style={{ display: "flex", alignItems: "center", gap: 8, background: "none", border: "none", color: "#9ca3af", fontSize: 15, fontWeight: 600, cursor: "pointer", padding: 0 }}
+            style={{ display: "flex", alignItems: "center", gap: 8, background: "none", border: "none", color: "var(--muted-foreground)", fontSize: 15, fontWeight: 600, cursor: "pointer", padding: 0 }}
           >
             💬 管理者チャット（会話を選択→AIの回答を改善）
-            <span style={{ fontSize: 12, color: "#6b7280" }}>{adminChatOpen ? "▲ 閉じる" : "▼ 開く"}</span>
+            <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>{adminChatOpen ? "▲ 閉じる" : "▼ 開く"}</span>
           </button>
 
           {adminChatOpen && (
             <div style={{ marginTop: 16 }}>
               {/* 使い方ヒント */}
-              <p style={{ fontSize: 12, color: "#6b7280", marginBottom: 10, margin: "0 0 10px" }}>
+              <p style={{ fontSize: 12, color: "var(--muted-foreground)", marginBottom: 10, margin: "0 0 10px" }}>
                 💡 質問の左にあるチェックボックスを選ぶと、その質問とAIの返答がセットで選択されます
               </p>
 
               {/* メッセージ一覧 */}
               <div style={{ minHeight: 100, maxHeight: 360, overflowY: "auto", marginBottom: 12, display: "flex", flexDirection: "column", gap: 8 }}>
                 {adminMessages.length === 0 && (
-                  <p style={{ color: "#6b7280", fontSize: 14, textAlign: "center", padding: "24px 0" }}>メッセージを送信して会話を始めてください</p>
+                  <p style={{ color: "var(--muted-foreground)", fontSize: 14, textAlign: "center", padding: "24px 0" }}>メッセージを送信して会話を始めてください</p>
                 )}
                 {adminMessages.map((msg, idx) => {
                   const autoHighlight = msg.role === "assistant" && isAutoIncluded(idx);
@@ -544,7 +544,7 @@ export default function ChatTestPage() {
                         gap: 10,
                         padding: "10px 12px",
                         borderRadius: 10,
-                        border: highlighted ? "1px solid rgba(59,130,246,0.5)" : "1px solid #1f2937",
+                        border: highlighted ? "1px solid rgba(59,130,246,0.5)" : "1px solid var(--border)",
                         background: highlighted
                           ? "rgba(59,130,246,0.08)"
                           : (msg.role === "user" ? "rgba(37,99,235,0.1)" : "rgba(30,41,59,0.6)"),
@@ -570,14 +570,14 @@ export default function ChatTestPage() {
                         </div>
                       )}
                       <div style={{ flex: 1 }}>
-                        <div style={{ fontSize: 11, color: "#6b7280", marginBottom: 2 }}>{msg.role === "user" ? "あなた" : "AI"}</div>
-                        <div style={{ fontSize: 14, color: "#e5e7eb", whiteSpace: "pre-wrap", wordBreak: "break-word" }}>{msg.content}</div>
+                        <div style={{ fontSize: 11, color: "var(--muted-foreground)", marginBottom: 2 }}>{msg.role === "user" ? "あなた" : "AI"}</div>
+                        <div style={{ fontSize: 14, color: "var(--foreground)", whiteSpace: "pre-wrap", wordBreak: "break-word" }}>{msg.content}</div>
                       </div>
                     </div>
                   );
                 })}
                 {adminSending && (
-                  <div style={{ padding: "10px 12px", borderRadius: 10, border: "1px solid #1f2937", background: "rgba(30,41,59,0.6)", color: "#6b7280", fontSize: 14 }}>AI応答中...</div>
+                  <div style={{ padding: "10px 12px", borderRadius: 10, border: "1px solid var(--border)", background: "rgba(30,41,59,0.6)", color: "var(--muted-foreground)", fontSize: 14 }}>AI応答中...</div>
                 )}
               </div>
 
@@ -592,7 +592,7 @@ export default function ChatTestPage() {
                   onKeyDown={(e) => { if (e.key === "Enter" && !e.shiftKey && !e.nativeEvent.isComposing && !adminIsComposing && e.nativeEvent.keyCode !== 229) { e.preventDefault(); void handleAdminSend(); } }}
                   placeholder="メッセージを入力..."
                   disabled={adminSending}
-                  style={{ flex: 1, padding: "10px 14px", minHeight: 44, borderRadius: 10, border: "1px solid #374151", background: "rgba(15,23,42,0.9)", color: "#e5e7eb", fontSize: 14, outline: "none" }}
+                  style={{ flex: 1, padding: "10px 14px", minHeight: 44, borderRadius: 10, border: "1px solid var(--border)", background: "var(--card)", color: "var(--foreground)", fontSize: 14, outline: "none" }}
                 />
                 <button
                   onClick={() => void handleAdminSend()}
@@ -619,7 +619,7 @@ export default function ChatTestPage() {
           gap: 12,
           padding: "12px 20px",
           borderRadius: 999,
-          background: "rgba(15,23,42,0.95)",
+          background: "var(--card)",
           border: "1px solid rgba(59,130,246,0.5)",
           boxShadow: "0 8px 32px rgba(0,0,0,0.4)",
           zIndex: 1000,
@@ -636,7 +636,7 @@ export default function ChatTestPage() {
           </button>
           <button
             onClick={() => setAdminMessages((prev) => prev.map((m) => ({ ...m, checked: false })))}
-            style={{ padding: "8px 14px", minHeight: 44, borderRadius: 999, border: "1px solid #374151", background: "transparent", color: "#9ca3af", fontSize: 13, cursor: "pointer" }}
+            style={{ padding: "8px 14px", minHeight: 44, borderRadius: 999, border: "1px solid var(--border)", background: "transparent", color: "var(--muted-foreground)", fontSize: 13, cursor: "pointer" }}
           >
             解除
           </button>
@@ -646,9 +646,9 @@ export default function ChatTestPage() {
       {/* ── AIの回答改善モーダル ── */}
       {tuningModalOpen && (
         <div style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.7)", zIndex: 2000, display: "flex", alignItems: "center", justifyContent: "center", padding: 20 }}>
-          <div style={{ width: "100%", maxWidth: 580, borderRadius: 16, background: "#0f172a", border: "1px solid #1f2937", padding: "24px", maxHeight: "85vh", overflowY: "auto" }}>
-            <h2 style={{ fontSize: 18, fontWeight: 700, color: "#f9fafb", margin: "0 0 4px" }}>AIの回答を改善</h2>
-            <p style={{ fontSize: 13, color: "#6b7280", margin: "0 0 16px" }}>選択した会話をもとに、AIの応答ルールを登録します</p>
+          <div style={{ width: "100%", maxWidth: 580, borderRadius: 16, background: "var(--background)", border: "1px solid var(--border)", padding: "24px", maxHeight: "85vh", overflowY: "auto" }}>
+            <h2 style={{ fontSize: 18, fontWeight: 700, color: "var(--foreground)", margin: "0 0 4px" }}>AIの回答を改善</h2>
+            <p style={{ fontSize: 13, color: "var(--muted-foreground)", margin: "0 0 16px" }}>選択した会話をもとに、AIの応答ルールを登録します</p>
 
             {/* 選択ペアのプレビュー */}
             <div style={{ marginBottom: 16, padding: "12px 14px", borderRadius: 10, background: "rgba(59,130,246,0.07)", border: "1px solid rgba(59,130,246,0.2)", fontSize: 13 }}>
@@ -657,12 +657,12 @@ export default function ChatTestPage() {
               </div>
               {checkedPairs.map((pair, i) => (
                 <div key={pair.question.id} style={{ marginBottom: i < checkedPairs.length - 1 ? 10 : 0 }}>
-                  <div style={{ color: "#9ca3af", fontSize: 12, marginBottom: 2 }}>
+                  <div style={{ color: "var(--muted-foreground)", fontSize: 12, marginBottom: 2 }}>
                     <span style={{ background: "rgba(59,130,246,0.2)", borderRadius: 4, padding: "1px 6px", marginRight: 6 }}>Q</span>
                     {pair.question.content.slice(0, 80)}{pair.question.content.length > 80 ? "…" : ""}
                   </div>
                   {pair.answer && (
-                    <div style={{ color: "#6b7280", fontSize: 12, paddingLeft: 8 }}>
+                    <div style={{ color: "var(--muted-foreground)", fontSize: 12, paddingLeft: 8 }}>
                       <span style={{ background: "rgba(34,197,94,0.15)", borderRadius: 4, padding: "1px 6px", marginRight: 6, color: "#4ade80" }}>A</span>
                       {pair.answer.content.slice(0, 80)}{pair.answer.content.length > 80 ? "…" : ""}
                     </div>
@@ -682,7 +682,7 @@ export default function ChatTestPage() {
                       padding: "8px 16px",
                       minHeight: 44,
                       borderRadius: 8,
-                      border: saveMode === mode ? "1px solid rgba(99,102,241,0.6)" : "1px solid #374151",
+                      border: saveMode === mode ? "1px solid rgba(99,102,241,0.6)" : "1px solid var(--border)",
                       background: saveMode === mode ? "rgba(99,102,241,0.15)" : "transparent",
                       color: saveMode === mode ? "#a5b4fc" : "#9ca3af",
                       fontSize: 13,
@@ -700,22 +700,22 @@ export default function ChatTestPage() {
             {saveMode === "combined" && (
               <>
                 <div style={{ marginBottom: 14 }}>
-                  <label style={{ display: "block", fontSize: 13, fontWeight: 600, color: "#9ca3af", marginBottom: 6 }}>ルール名</label>
+                  <label style={{ display: "block", fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)", marginBottom: 6 }}>ルール名</label>
                   <input
                     type="text"
                     value={combinedRuleName}
                     onChange={(e) => setCombinedRuleName(e.target.value)}
-                    style={{ width: "100%", padding: "10px 12px", minHeight: 44, borderRadius: 8, border: "1px solid #374151", background: "rgba(30,41,59,0.8)", color: "#f9fafb", fontSize: 14, outline: "none", boxSizing: "border-box" }}
+                    style={{ width: "100%", padding: "10px 12px", minHeight: 44, borderRadius: 8, border: "1px solid var(--border)", background: "rgba(30,41,59,0.8)", color: "var(--foreground)", fontSize: 14, outline: "none", boxSizing: "border-box" }}
                   />
                 </div>
                 <div style={{ marginBottom: 20 }}>
-                  <label style={{ display: "block", fontSize: 13, fontWeight: 600, color: "#9ca3af", marginBottom: 6 }}>AIへの改善指示</label>
+                  <label style={{ display: "block", fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)", marginBottom: 6 }}>AIへの改善指示</label>
                   <textarea
                     value={combinedBehavior}
                     onChange={(e) => setCombinedBehavior(e.target.value)}
                     rows={4}
                     placeholder="この質問にAIがどう答えるべきか書いてください"
-                    style={{ width: "100%", padding: "10px 12px", borderRadius: 8, border: "1px solid #374151", background: "rgba(30,41,59,0.8)", color: "#f9fafb", fontSize: 14, outline: "none", resize: "vertical", fontFamily: "inherit", lineHeight: 1.5, boxSizing: "border-box" }}
+                    style={{ width: "100%", padding: "10px 12px", borderRadius: 8, border: "1px solid var(--border)", background: "rgba(30,41,59,0.8)", color: "var(--foreground)", fontSize: 14, outline: "none", resize: "vertical", fontFamily: "inherit", lineHeight: 1.5, boxSizing: "border-box" }}
                   />
                 </div>
               </>
@@ -725,12 +725,12 @@ export default function ChatTestPage() {
             {saveMode === "individual" && (
               <div style={{ display: "flex", flexDirection: "column", gap: 16, marginBottom: 20 }}>
                 {checkedPairs.map((pair, i) => (
-                  <div key={pair.question.id} style={{ padding: "14px", borderRadius: 10, border: "1px solid #1f2937", background: "rgba(30,41,59,0.4)" }}>
-                    <div style={{ fontSize: 12, color: "#6b7280", marginBottom: 10 }}>
+                  <div key={pair.question.id} style={{ padding: "14px", borderRadius: 10, border: "1px solid var(--border)", background: "rgba(30,41,59,0.4)" }}>
+                    <div style={{ fontSize: 12, color: "var(--muted-foreground)", marginBottom: 10 }}>
                       ペア {i + 1}: {pair.question.content.slice(0, 40)}{pair.question.content.length > 40 ? "…" : ""}
                     </div>
                     <div style={{ marginBottom: 10 }}>
-                      <label style={{ display: "block", fontSize: 12, fontWeight: 600, color: "#9ca3af", marginBottom: 4 }}>ルール名</label>
+                      <label style={{ display: "block", fontSize: 12, fontWeight: 600, color: "var(--muted-foreground)", marginBottom: 4 }}>ルール名</label>
                       <input
                         type="text"
                         value={pairRules[i]?.ruleName ?? ""}
@@ -738,11 +738,11 @@ export default function ChatTestPage() {
                           const v = e.target.value;
                           setPairRules((prev) => prev.map((r, ri) => ri === i ? { ...r, ruleName: v } : r));
                         }}
-                        style={{ width: "100%", padding: "8px 10px", minHeight: 40, borderRadius: 8, border: "1px solid #374151", background: "rgba(15,23,42,0.9)", color: "#f9fafb", fontSize: 13, outline: "none", boxSizing: "border-box" }}
+                        style={{ width: "100%", padding: "8px 10px", minHeight: 40, borderRadius: 8, border: "1px solid var(--border)", background: "var(--card)", color: "var(--foreground)", fontSize: 13, outline: "none", boxSizing: "border-box" }}
                       />
                     </div>
                     <div>
-                      <label style={{ display: "block", fontSize: 12, fontWeight: 600, color: "#9ca3af", marginBottom: 4 }}>AIへの改善指示</label>
+                      <label style={{ display: "block", fontSize: 12, fontWeight: 600, color: "var(--muted-foreground)", marginBottom: 4 }}>AIへの改善指示</label>
                       <textarea
                         value={pairRules[i]?.behavior ?? ""}
                         onChange={(e) => {
@@ -751,7 +751,7 @@ export default function ChatTestPage() {
                         }}
                         rows={3}
                         placeholder="この質問にAIがどう答えるべきか書いてください"
-                        style={{ width: "100%", padding: "8px 10px", borderRadius: 8, border: "1px solid #374151", background: "rgba(15,23,42,0.9)", color: "#f9fafb", fontSize: 13, outline: "none", resize: "vertical", fontFamily: "inherit", lineHeight: 1.5, boxSizing: "border-box" }}
+                        style={{ width: "100%", padding: "8px 10px", borderRadius: 8, border: "1px solid var(--border)", background: "var(--card)", color: "var(--foreground)", fontSize: 13, outline: "none", resize: "vertical", fontFamily: "inherit", lineHeight: 1.5, boxSizing: "border-box" }}
                       />
                     </div>
                   </div>
@@ -765,7 +765,7 @@ export default function ChatTestPage() {
             <div style={{ display: "flex", gap: 10, justifyContent: "flex-end" }}>
               <button
                 onClick={() => setTuningModalOpen(false)}
-                style={{ padding: "10px 20px", minHeight: 44, borderRadius: 10, border: "1px solid #374151", background: "transparent", color: "#9ca3af", fontSize: 14, cursor: "pointer" }}
+                style={{ padding: "10px 20px", minHeight: 44, borderRadius: 10, border: "1px solid var(--border)", background: "transparent", color: "var(--muted-foreground)", fontSize: 14, cursor: "pointer" }}
               >
                 キャンセル
               </button>

--- a/admin-ui/src/pages/admin/conversion/index.tsx
+++ b/admin-ui/src/pages/admin/conversion/index.tsx
@@ -36,11 +36,11 @@ interface ABExperiment {
 // ------------------------------------------------------------------ //
 // Styles
 // ------------------------------------------------------------------ //
-const PAGE: CSSProperties = { padding: "80px 24px 48px", maxWidth: 960, margin: "0 auto", color: "#f9fafb", fontFamily: "system-ui, sans-serif" };
-const CARD: CSSProperties = { background: "rgba(15,23,42,0.8)", border: "1px solid #1f2937", borderRadius: 12, padding: "20px 24px", marginBottom: 16 };
+const PAGE: CSSProperties = { padding: "80px 24px 48px", maxWidth: 960, margin: "0 auto", color: "var(--foreground)", fontFamily: "system-ui, sans-serif" };
+const CARD: CSSProperties = { background: "var(--card)", border: "1px solid var(--border)", borderRadius: 12, padding: "20px 24px", marginBottom: 16 };
 const GRID4: CSSProperties = { display: "grid", gridTemplateColumns: "repeat(auto-fill, minmax(180px, 1fr))", gap: 14, marginBottom: 24 };
-const KPI: CSSProperties = { background: "rgba(15,23,42,0.8)", border: "1px solid #1f2937", borderRadius: 12, padding: "16px 20px" };
-const SECTION_TITLE: CSSProperties = { fontSize: 15, fontWeight: 700, color: "#f9fafb", marginBottom: 14 };
+const KPI: CSSProperties = { background: "var(--card)", border: "1px solid var(--border)", borderRadius: 12, padding: "16px 20px" };
+const SECTION_TITLE: CSSProperties = { fontSize: 15, fontWeight: 700, color: "var(--foreground)", marginBottom: 14 };
 
 const STATUS_COLORS: Record<string, string> = {
   draft: "#6b7280",
@@ -55,9 +55,9 @@ const STATUS_COLORS: Record<string, string> = {
 function KpiCard({ label, value, sub }: { label: string; value: string | number; sub?: string }) {
   return (
     <div style={KPI}>
-      <div style={{ fontSize: 12, color: "#6b7280", marginBottom: 6 }}>{label}</div>
-      <div style={{ fontSize: 26, fontWeight: 800, color: "#f9fafb", lineHeight: 1 }}>{value}</div>
-      {sub && <div style={{ fontSize: 11, color: "#6b7280", marginTop: 4 }}>{sub}</div>}
+      <div style={{ fontSize: 12, color: "var(--muted-foreground)", marginBottom: 6 }}>{label}</div>
+      <div style={{ fontSize: 26, fontWeight: 800, color: "var(--foreground)", lineHeight: 1 }}>{value}</div>
+      {sub && <div style={{ fontSize: 11, color: "var(--muted-foreground)", marginTop: 4 }}>{sub}</div>}
     </div>
   );
 }
@@ -72,10 +72,10 @@ function BarChart({ items }: { items: { label: string; value: number }[] }) {
     <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
       {items.map((item) => (
         <div key={item.label} style={{ display: "flex", alignItems: "center", gap: 10 }}>
-          <div style={{ width: 120, fontSize: 12, color: "#d1d5db", textAlign: "right", flexShrink: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+          <div style={{ width: 120, fontSize: 12, color: "var(--muted-foreground)", textAlign: "right", flexShrink: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
             {item.label}
           </div>
-          <div style={{ flex: 1, background: "#1e293b", borderRadius: 4, height: 20, overflow: "hidden" }}>
+          <div style={{ flex: 1, background: "var(--muted)", borderRadius: 4, height: 20, overflow: "hidden" }}>
             <div
               style={{
                 width: `${Math.round((item.value / max) * 100)}%`,
@@ -87,7 +87,7 @@ function BarChart({ items }: { items: { label: string; value: number }[] }) {
               }}
             />
           </div>
-          <div style={{ width: 32, fontSize: 12, color: "#9ca3af", textAlign: "right", flexShrink: 0 }}>
+          <div style={{ width: 32, fontSize: 12, color: "var(--muted-foreground)", textAlign: "right", flexShrink: 0 }}>
             {item.value}
           </div>
         </div>
@@ -198,7 +198,7 @@ export default function ConversionDashboardPage() {
               {p === '7d' ? '7日' : p === '30d' ? '30日' : '90日'}
             </button>
           ))}
-          {loading && <span style={{ fontSize: 12, color: "#6b7280" }}>読み込み中...</span>}
+          {loading && <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>読み込み中...</span>}
         </div>
       </div>
 
@@ -214,7 +214,7 @@ export default function ConversionDashboardPage() {
       <div style={CARD}>
         <div style={SECTION_TITLE}>🧠 {t("conversion.effectiveness")}</div>
         {rankings.length === 0 ? (
-          <p style={{ color: "#6b7280", fontSize: 14 }}>{t("conversion.no_data")}</p>
+          <p style={{ color: "var(--muted-foreground)", fontSize: 14 }}>{t("conversion.no_data")}</p>
         ) : (
           <BarChart items={chartData} />
         )}
@@ -232,11 +232,11 @@ export default function ConversionDashboardPage() {
           </button>
         </div>
         {experiments.length === 0 ? (
-          <p style={{ color: "#6b7280", fontSize: 14 }}>{t("conversion.no_data")}</p>
+          <p style={{ color: "var(--muted-foreground)", fontSize: 14 }}>{t("conversion.no_data")}</p>
         ) : (
           <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
             {experiments.slice(0, 5).map((exp) => (
-              <div key={exp.id} style={{ display: "flex", alignItems: "center", gap: 12, padding: "10px 14px", background: "#1e293b", borderRadius: 8 }}>
+              <div key={exp.id} style={{ display: "flex", alignItems: "center", gap: 12, padding: "10px 14px", background: "var(--muted)", borderRadius: 8 }}>
                 <span
                   style={{
                     padding: "3px 8px",
@@ -251,8 +251,8 @@ export default function ConversionDashboardPage() {
                 >
                   {statusLabel(exp.status)}
                 </span>
-                <span style={{ flex: 1, fontSize: 14, color: "#e5e7eb" }}>{exp.name}</span>
-                <span style={{ fontSize: 12, color: "#6b7280" }}>
+                <span style={{ flex: 1, fontSize: 14, color: "var(--foreground)" }}>{exp.name}</span>
+                <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>
                   最小サンプル: {exp.min_sample_size}件
                 </span>
               </div>
@@ -265,7 +265,7 @@ export default function ConversionDashboardPage() {
       <div style={CARD}>
         <div style={SECTION_TITLE}>💡 {t("conversion.suggestions")}</div>
         {suggestions.length === 0 ? (
-          <p style={{ color: "#6b7280", fontSize: 14 }}>{t("conversion.no_suggestions")}</p>
+          <p style={{ color: "var(--muted-foreground)", fontSize: 14 }}>{t("conversion.no_suggestions")}</p>
         ) : (
           <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
             {suggestions.map((s, i) => (
@@ -285,9 +285,9 @@ export default function ConversionDashboardPage() {
                   {s.type === 'judge_repeated' ? '🔁' : s.type === 'ab_winner' ? '🏆' : '⭐'}
                 </span>
                 <div style={{ flex: 1 }}>
-                  <div style={{ fontSize: 14, color: "#e5e7eb", marginBottom: 4 }}>{s.description}</div>
+                  <div style={{ fontSize: 14, color: "var(--foreground)", marginBottom: 4 }}>{s.description}</div>
                   {s.suggestedAction && (
-                    <div style={{ fontSize: 12, color: "#6b7280" }}>提案: {s.suggestedAction}</div>
+                    <div style={{ fontSize: 12, color: "var(--muted-foreground)" }}>提案: {s.suggestedAction}</div>
                   )}
                 </div>
                 <button

--- a/admin-ui/src/pages/admin/engagement/index.tsx
+++ b/admin-ui/src/pages/admin/engagement/index.tsx
@@ -40,13 +40,13 @@ const PAGE: CSSProperties = {
   padding: "80px 24px 48px",
   maxWidth: 900,
   margin: "0 auto",
-  color: "#f9fafb",
+  color: "var(--foreground)",
   fontFamily: "system-ui, sans-serif",
 };
 
 const CARD: CSSProperties = {
-  background: "rgba(15,23,42,0.8)",
-  border: "1px solid #1f2937",
+  background: "var(--card)",
+  border: "1px solid var(--border)",
   borderRadius: 12,
   padding: "20px 24px",
   marginBottom: 16,
@@ -68,9 +68,9 @@ const BTN_GHOST: CSSProperties = {
   padding: "8px 14px",
   minHeight: 44,
   background: "none",
-  border: "1px solid #374151",
+  border: "1px solid var(--border)",
   borderRadius: 8,
-  color: "#9ca3af",
+  color: "var(--muted-foreground)",
   fontSize: 13,
   cursor: "pointer",
 };
@@ -98,8 +98,8 @@ const OVERLAY: CSSProperties = {
 };
 
 const MODAL: CSSProperties = {
-  background: "#0f172a",
-  border: "1px solid #1f2937",
+  background: "var(--background)",
+  border: "1px solid var(--border)",
   borderRadius: 16,
   width: "100%",
   maxWidth: 560,
@@ -175,7 +175,7 @@ function ConfigForm({
     const v = (config["threshold"] as number) ?? 75;
     return (
       <div>
-        <label style={{ fontSize: 13, color: "#9ca3af" }}>スクロール深度のしきい値</label>
+        <label style={{ fontSize: 13, color: "var(--muted-foreground)" }}>スクロール深度のしきい値</label>
         <div style={{ display: "flex", gap: 10, marginTop: 10, flexWrap: "wrap" }}>
           {[25, 50, 75, 100].map((t) => (
             <button
@@ -212,7 +212,7 @@ function ConfigForm({
     ];
     return (
       <div>
-        <label style={{ fontSize: 13, color: "#9ca3af" }}>滞在時間のしきい値</label>
+        <label style={{ fontSize: 13, color: "var(--muted-foreground)" }}>滞在時間のしきい値</label>
         <select
           value={v}
           onChange={(e) => onChange({ seconds: Number(e.target.value) })}
@@ -222,10 +222,10 @@ function ConfigForm({
             width: "100%",
             padding: "12px 14px",
             minHeight: 44,
-            background: "#1e293b",
-            border: "1px solid #374151",
+            background: "var(--muted)",
+            border: "1px solid var(--border)",
             borderRadius: 8,
-            color: "#f9fafb",
+            color: "var(--foreground)",
             fontSize: 14,
           }}
         >
@@ -260,7 +260,7 @@ function ConfigForm({
     const v = (config["pattern"] as string) ?? "";
     return (
       <div>
-        <label style={{ fontSize: 13, color: "#9ca3af" }}>URLパターン（globで指定）</label>
+        <label style={{ fontSize: 13, color: "var(--muted-foreground)" }}>URLパターン（globで指定）</label>
         <input
           type="text"
           value={v}
@@ -272,15 +272,15 @@ function ConfigForm({
             width: "100%",
             padding: "12px 14px",
             minHeight: 44,
-            background: "#1e293b",
-            border: "1px solid #374151",
+            background: "var(--muted)",
+            border: "1px solid var(--border)",
             borderRadius: 8,
-            color: "#f9fafb",
+            color: "var(--foreground)",
             fontSize: 14,
             boxSizing: "border-box",
           }}
         />
-        <p style={{ fontSize: 12, color: "#6b7280", marginTop: 8 }}>
+        <p style={{ fontSize: 12, color: "var(--muted-foreground)", marginTop: 8 }}>
           例: <code>/products/*</code>（商品一覧）、<code>/products/shoes/**</code>（靴カテゴリ以下全て）
         </p>
       </div>
@@ -297,14 +297,14 @@ function WidgetPreview({ message }: { message: string }) {
   return (
     <div
       style={{
-        background: "#0f172a",
-        border: "1px solid #1f2937",
+        background: "var(--background)",
+        border: "1px solid var(--border)",
         borderRadius: 12,
         padding: 16,
         marginTop: 16,
       }}
     >
-      <p style={{ fontSize: 12, color: "#6b7280", marginBottom: 10 }}>お客様への表示イメージ</p>
+      <p style={{ fontSize: 12, color: "var(--muted-foreground)", marginBottom: 10 }}>お客様への表示イメージ</p>
       <div
         style={{
           display: "flex",
@@ -329,12 +329,12 @@ function WidgetPreview({ message }: { message: string }) {
         </div>
         <div
           style={{
-            background: "#1e293b",
-            border: "1px solid #374151",
+            background: "var(--muted)",
+            border: "1px solid var(--border)",
             borderRadius: "4px 12px 12px 12px",
             padding: "10px 14px",
             fontSize: 14,
-            color: "#f9fafb",
+            color: "var(--foreground)",
             maxWidth: 280,
             lineHeight: 1.5,
           }}
@@ -499,10 +499,10 @@ export default function EngagementPage() {
     <div style={PAGE}>
       {/* Header */}
       <div style={{ marginBottom: 28 }}>
-        <h1 style={{ fontSize: 22, fontWeight: 800, margin: 0, color: "#f9fafb" }}>
+        <h1 style={{ fontSize: 22, fontWeight: 800, margin: 0, color: "var(--foreground)" }}>
           💬 {t("engagement.title")}
         </h1>
-        <p style={{ color: "#6b7280", fontSize: 14, marginTop: 6 }}>
+        <p style={{ color: "var(--muted-foreground)", fontSize: 14, marginTop: 6 }}>
           {t("engagement.description")}
         </p>
       </div>
@@ -515,7 +515,7 @@ export default function EngagementPage() {
 
       {/* Rules list */}
       {loading ? (
-        <p style={{ color: "#6b7280" }}>{t("common.loading")}</p>
+        <p style={{ color: "var(--muted-foreground)" }}>{t("common.loading")}</p>
       ) : rules.length === 0 ? (
         <div
           style={{
@@ -525,7 +525,7 @@ export default function EngagementPage() {
           }}
         >
           <div style={{ fontSize: 40, marginBottom: 12 }}>🌟</div>
-          <p style={{ color: "#9ca3af", fontSize: 15, marginBottom: 20 }}>
+          <p style={{ color: "var(--muted-foreground)", fontSize: 15, marginBottom: 20 }}>
             {t("engagement.empty")}
           </p>
           <button style={BTN_PRIMARY} onClick={openCreate}>
@@ -539,10 +539,10 @@ export default function EngagementPage() {
               {/* Icon + trigger info */}
               <span style={{ fontSize: 24 }}>{TRIGGER_META[rule.trigger_type].icon}</span>
               <div style={{ flex: 1, minWidth: 160 }}>
-                <div style={{ fontSize: 14, fontWeight: 600, color: "#f9fafb" }}>
+                <div style={{ fontSize: 14, fontWeight: 600, color: "var(--foreground)" }}>
                   {triggerLabel(rule.trigger_type, t)}
                 </div>
-                <div style={{ fontSize: 12, color: "#6b7280", marginTop: 2 }}>
+                <div style={{ fontSize: 12, color: "var(--muted-foreground)", marginTop: 2 }}>
                   {configSummary(rule)}
                 </div>
               </div>
@@ -553,8 +553,8 @@ export default function EngagementPage() {
                   flex: 2,
                   minWidth: 140,
                   fontSize: 13,
-                  color: "#d1d5db",
-                  background: "#1e293b",
+                  color: "var(--muted-foreground)",
+                  background: "var(--muted)",
                   borderRadius: 8,
                   padding: "8px 12px",
                   maxWidth: 320,
@@ -572,8 +572,8 @@ export default function EngagementPage() {
               <span
                 style={{
                   fontSize: 11,
-                  color: "#9ca3af",
-                  background: "#1e293b",
+                  color: "var(--muted-foreground)",
+                  background: "var(--muted)",
                   padding: "3px 8px",
                   borderRadius: 6,
                   whiteSpace: "nowrap",
@@ -650,7 +650,7 @@ export default function EngagementPage() {
             {/* Step 1: trigger type selection */}
             {modal.step === 1 && (
               <div>
-                <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 16, color: "#f9fafb" }}>
+                <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 16, color: "var(--foreground)" }}>
                   どんな時に声をかけますか？
                 </h2>
                 <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
@@ -671,9 +671,9 @@ export default function EngagementPage() {
                           padding: "18px 14px",
                           minHeight: 90,
                           borderRadius: 12,
-                          border: `2px solid ${selected ? "#3b82f6" : "#374151"}`,
-                          background: selected ? "rgba(59,130,246,0.1)" : "#1e293b",
-                          color: selected ? "#93c5fd" : "#9ca3af",
+                          border: `2px solid ${selected ? "#3b82f6" : "var(--border)"}`,
+                          background: selected ? "rgba(59,130,246,0.1)" : "var(--muted)",
+                          color: selected ? "#93c5fd" : "var(--muted-foreground)",
                           cursor: "pointer",
                           textAlign: "left",
                           display: "flex",
@@ -707,7 +707,7 @@ export default function EngagementPage() {
             {/* Step 2: config */}
             {modal.step === 2 && modal.triggerType && (
               <div>
-                <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 20, color: "#f9fafb" }}>
+                <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 20, color: "var(--foreground)" }}>
                   {TRIGGER_META[modal.triggerType].icon} {t(TRIGGER_META[modal.triggerType].labelKey)}
                 </h2>
                 <ConfigForm
@@ -716,7 +716,7 @@ export default function EngagementPage() {
                   onChange={(cfg) => setModal((m) => ({ ...m, triggerConfig: cfg }))}
                 />
                 <div style={{ marginTop: 16 }}>
-                  <label style={{ fontSize: 13, color: "#9ca3af" }}>優先度（高いほど先にチェック）</label>
+                  <label style={{ fontSize: 13, color: "var(--muted-foreground)" }}>優先度（高いほど先にチェック）</label>
                   <input
                     type="number"
                     min={0}
@@ -729,10 +729,10 @@ export default function EngagementPage() {
                       width: "100px",
                       padding: "10px 12px",
                       minHeight: 44,
-                      background: "#1e293b",
-                      border: "1px solid #374151",
+                      background: "var(--muted)",
+                      border: "1px solid var(--border)",
                       borderRadius: 8,
-                      color: "#f9fafb",
+                      color: "var(--foreground)",
                       fontSize: 14,
                     }}
                   />
@@ -754,7 +754,7 @@ export default function EngagementPage() {
             {/* Step 3: message */}
             {modal.step === 3 && (
               <div>
-                <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 16, color: "#f9fafb" }}>
+                <h2 style={{ fontSize: 16, fontWeight: 700, marginBottom: 16, color: "var(--foreground)" }}>
                   どんなメッセージを送りますか？
                 </h2>
                 <textarea
@@ -765,10 +765,10 @@ export default function EngagementPage() {
                   style={{
                     width: "100%",
                     padding: "12px 14px",
-                    background: "#1e293b",
-                    border: "1px solid #374151",
+                    background: "var(--muted)",
+                    border: "1px solid var(--border)",
                     borderRadius: 8,
-                    color: "#f9fafb",
+                    color: "var(--foreground)",
                     fontSize: 14,
                     resize: "vertical",
                     boxSizing: "border-box",

--- a/admin-ui/src/pages/admin/feedback/index.tsx
+++ b/admin-ui/src/pages/admin/feedback/index.tsx
@@ -32,7 +32,7 @@ interface AdminFeedback {
 
 // ─── Constants ────────────────────────────────────────────────────────────────
 
-const BG = "radial-gradient(circle at top, #0f172a 0, #020617 55%, #000 100%)";
+const BG = "var(--background)";
 
 const STATUS_COLORS: Record<AdminFeedback["status"], { bg: string; border: string; text: string; label_ja: string; label_en: string }> = {
   new: { bg: "rgba(59,130,246,0.15)", border: "rgba(59,130,246,0.45)", text: "#60a5fa", label_ja: "未対応", label_en: "New" },
@@ -104,9 +104,9 @@ const selectStyle: React.CSSProperties = {
   padding: "8px 12px",
   minHeight: 44,
   borderRadius: 8,
-  border: "1px solid #374151",
-  background: "rgba(15,23,42,0.9)",
-  color: "#e5e7eb",
+  border: "1px solid var(--border)",
+  background: "var(--card)",
+  color: "var(--foreground)",
   fontSize: 14,
   cursor: "pointer",
   outline: "none",
@@ -245,8 +245,8 @@ function DetailModal({ item, lang, isSuperAdmin, onClose, onSaved, onDeleted }: 
           maxHeight: "90vh",
           overflowY: "auto",
           borderRadius: 16,
-          border: "1px solid #1f2937",
-          background: "rgba(15,23,42,0.98)",
+          border: "1px solid var(--border)",
+          background: "var(--card)",
           boxShadow: "0 24px 64px rgba(0,0,0,0.6)",
           padding: "24px 24px 20px",
           display: "flex",
@@ -259,7 +259,7 @@ function DetailModal({ item, lang, isSuperAdmin, onClose, onSaved, onDeleted }: 
           <div style={{ display: "flex", flexWrap: "wrap", gap: 8, alignItems: "center" }}>
             <StatusBadge status={status} lang={lang} />
             <PriorityBadge priority={priority} lang={lang} />
-            <span style={{ fontSize: 12, color: "#6b7280" }}>
+            <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>
               {lang === "ja" ? catLabel.ja : catLabel.en}
             </span>
           </div>
@@ -267,9 +267,9 @@ function DetailModal({ item, lang, isSuperAdmin, onClose, onSaved, onDeleted }: 
             onClick={onClose}
             style={{
               background: "none",
-              border: "1px solid #374151",
+              border: "1px solid var(--border)",
               borderRadius: 8,
-              color: "#9ca3af",
+              color: "var(--muted-foreground)",
               fontSize: 18,
               cursor: "pointer",
               padding: "4px 10px",
@@ -283,7 +283,7 @@ function DetailModal({ item, lang, isSuperAdmin, onClose, onSaved, onDeleted }: 
         </div>
 
         {/* Meta */}
-        <div style={{ fontSize: 12, color: "#6b7280", display: "flex", gap: 16, flexWrap: "wrap" }}>
+        <div style={{ fontSize: 12, color: "var(--muted-foreground)", display: "flex", gap: 16, flexWrap: "wrap" }}>
           <span>{new Date(item.created_at).toLocaleString(locale, { year: "numeric", month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}</span>
           {item.user_email && <span>{item.user_email}</span>}
           <span style={{ fontFamily: "monospace", opacity: 0.6 }}>{item.id.slice(0, 8)}…</span>
@@ -291,16 +291,16 @@ function DetailModal({ item, lang, isSuperAdmin, onClose, onSaved, onDeleted }: 
 
         {/* Message */}
         <div>
-          <p style={{ fontSize: 12, fontWeight: 600, color: "#9ca3af", marginBottom: 6 }}>
+          <p style={{ fontSize: 12, fontWeight: 600, color: "var(--muted-foreground)", marginBottom: 6 }}>
             {lang === "ja" ? "メッセージ" : "Message"}
           </p>
           <div style={{
             padding: "12px 14px",
             borderRadius: 10,
-            border: "1px solid #1f2937",
+            border: "1px solid var(--border)",
             background: "rgba(0,0,0,0.25)",
             fontSize: 14,
-            color: "#f9fafb",
+            color: "var(--foreground)",
             lineHeight: 1.7,
             whiteSpace: "pre-wrap",
             wordBreak: "break-word",
@@ -312,7 +312,7 @@ function DetailModal({ item, lang, isSuperAdmin, onClose, onSaved, onDeleted }: 
         {/* AI response */}
         {item.ai_response && (
           <div>
-            <p style={{ fontSize: 12, fontWeight: 600, color: "#9ca3af", marginBottom: 6 }}>
+            <p style={{ fontSize: 12, fontWeight: 600, color: "var(--muted-foreground)", marginBottom: 6 }}>
               {lang === "ja" ? "AI回答" : "AI Response"}
               {item.ai_answered && (
                 <span style={{ marginLeft: 8, color: "#4ade80", fontSize: 11 }}>
@@ -339,7 +339,7 @@ function DetailModal({ item, lang, isSuperAdmin, onClose, onSaved, onDeleted }: 
         {/* Status + Priority editors */}
         <div style={{ display: "flex", gap: 12, flexWrap: "wrap" }}>
           <div style={{ flex: "1 1 180px" }}>
-            <label style={{ fontSize: 12, fontWeight: 600, color: "#9ca3af", display: "block", marginBottom: 6 }}>
+            <label style={{ fontSize: 12, fontWeight: 600, color: "var(--muted-foreground)", display: "block", marginBottom: 6 }}>
               {lang === "ja" ? "ステータス" : "Status"}
             </label>
             <select value={status} onChange={(e) => setStatus(e.target.value as AdminFeedback["status"])} style={{ ...selectStyle, width: "100%" }}>
@@ -350,7 +350,7 @@ function DetailModal({ item, lang, isSuperAdmin, onClose, onSaved, onDeleted }: 
             </select>
           </div>
           <div style={{ flex: "1 1 140px" }}>
-            <label style={{ fontSize: 12, fontWeight: 600, color: "#9ca3af", display: "block", marginBottom: 6 }}>
+            <label style={{ fontSize: 12, fontWeight: 600, color: "var(--muted-foreground)", display: "block", marginBottom: 6 }}>
               {lang === "ja" ? "優先度" : "Priority"}
             </label>
             <select value={priority} onChange={(e) => setPriority(e.target.value as AdminFeedback["priority"])} style={{ ...selectStyle, width: "100%" }}>
@@ -422,7 +422,7 @@ function DetailModal({ item, lang, isSuperAdmin, onClose, onSaved, onDeleted }: 
 
         {/* Admin notes */}
         <div>
-          <label style={{ fontSize: 12, fontWeight: 600, color: "#9ca3af", display: "block", marginBottom: 6 }}>
+          <label style={{ fontSize: 12, fontWeight: 600, color: "var(--muted-foreground)", display: "block", marginBottom: 6 }}>
             {lang === "ja" ? "管理者メモ" : "Admin Notes"}
           </label>
           <textarea
@@ -434,9 +434,9 @@ function DetailModal({ item, lang, isSuperAdmin, onClose, onSaved, onDeleted }: 
               width: "100%",
               padding: "10px 12px",
               borderRadius: 8,
-              border: "1px solid #374151",
+              border: "1px solid var(--border)",
               background: "rgba(0,0,0,0.3)",
-              color: "#e5e7eb",
+              color: "var(--foreground)",
               fontSize: 14,
               fontFamily: "inherit",
               lineHeight: 1.6,
@@ -472,7 +472,7 @@ function DetailModal({ item, lang, isSuperAdmin, onClose, onSaved, onDeleted }: 
                 padding: "10px 16px",
                 minHeight: 44,
                 borderRadius: 8,
-                border: confirmDelete ? "1px solid rgba(239,68,68,0.7)" : "1px solid #374151",
+                border: confirmDelete ? "1px solid rgba(239,68,68,0.7)" : "1px solid var(--border)",
                 background: confirmDelete ? "rgba(239,68,68,0.15)" : "transparent",
                 color: confirmDelete ? "#f87171" : "#6b7280",
                 fontSize: 14,
@@ -492,9 +492,9 @@ function DetailModal({ item, lang, isSuperAdmin, onClose, onSaved, onDeleted }: 
                 padding: "10px 20px",
                 minHeight: 44,
                 borderRadius: 8,
-                border: "1px solid #374151",
+                border: "1px solid var(--border)",
                 background: "transparent",
-                color: "#9ca3af",
+                color: "var(--muted-foreground)",
                 fontSize: 14,
                 fontWeight: 600,
                 cursor: "pointer",
@@ -619,20 +619,20 @@ export default function FeedbackPage() {
     new Date(iso).toLocaleString(locale, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
 
   return (
-    <div style={{ minHeight: "100vh", background: BG, color: "#e5e7eb", padding: "24px 20px", maxWidth: 1100, margin: "0 auto" }}>
+    <div style={{ minHeight: "100vh", background: BG, color: "var(--foreground)", padding: "24px 20px", maxWidth: 1100, margin: "0 auto" }}>
       {/* Header */}
       <header style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 24, flexWrap: "wrap", gap: 12 }}>
         <div>
           <button
             onClick={() => navigate("/admin")}
-            style={{ background: "none", border: "none", color: "#9ca3af", fontSize: 14, cursor: "pointer", padding: 0, marginBottom: 8, display: "block" }}
+            style={{ background: "none", border: "none", color: "var(--muted-foreground)", fontSize: 14, cursor: "pointer", padding: 0, marginBottom: 8, display: "block" }}
           >
             ← {lang === "ja" ? "管理画面に戻る" : "Back to Dashboard"}
           </button>
-          <h1 style={{ fontSize: 24, fontWeight: 700, margin: 0, color: "#f9fafb", display: "flex", alignItems: "center", gap: 8 }}>
+          <h1 style={{ fontSize: 24, fontWeight: 700, margin: 0, color: "var(--foreground)", display: "flex", alignItems: "center", gap: 8 }}>
             📝 {lang === "ja" ? "お客様の声" : "Customer Feedback"}
           </h1>
-          <p style={{ fontSize: 13, color: "#9ca3af", marginTop: 4, marginBottom: 0 }}>
+          <p style={{ fontSize: 13, color: "var(--muted-foreground)", marginTop: 4, marginBottom: 0 }}>
             {lang === "ja" ? "チャット中にお客様が送ったフィードバックを管理します" : "Manage feedback submitted by customers during chat"}
           </p>
         </div>
@@ -682,16 +682,16 @@ export default function FeedbackPage() {
             padding: "6px 14px",
             minHeight: 36,
             borderRadius: 8,
-            border: "1px solid #374151",
+            border: "1px solid var(--border)",
             background: "transparent",
-            color: "#9ca3af",
+            color: "var(--muted-foreground)",
             fontSize: 13,
             cursor: "pointer",
           }}
         >
           ↻ {lang === "ja" ? "更新" : "Refresh"}
         </button>
-        <span style={{ marginLeft: "auto", fontSize: 13, color: "#6b7280" }}>
+        <span style={{ marginLeft: "auto", fontSize: 13, color: "var(--muted-foreground)" }}>
           {!loading && `${filteredItems.length} ${lang === "ja" ? "件" : "items"}`}
         </span>
       </div>
@@ -721,7 +721,7 @@ export default function FeedbackPage() {
 
       {/* List */}
       {loading ? (
-        <div style={{ display: "flex", alignItems: "center", justifyContent: "center", minHeight: 160, color: "#6b7280", fontSize: 15 }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "center", minHeight: 160, color: "var(--muted-foreground)", fontSize: 15 }}>
           <span style={{ marginRight: 8 }}>⏳</span>
           {lang === "ja" ? "読み込み中..." : "Loading..."}
         </div>
@@ -732,7 +732,7 @@ export default function FeedbackPage() {
           alignItems: "center",
           justifyContent: "center",
           minHeight: 200,
-          color: "#6b7280",
+          color: "var(--muted-foreground)",
           fontSize: 15,
           gap: 8,
         }}>
@@ -752,8 +752,8 @@ export default function FeedbackPage() {
                   padding: "14px 16px",
                   minHeight: 44,
                   borderRadius: 12,
-                  border: "1px solid #1f2937",
-                  background: "rgba(15,23,42,0.95)",
+                  border: "1px solid var(--border)",
+                  background: "var(--card)",
                   cursor: "pointer",
                   textAlign: "left",
                   display: "flex",
@@ -763,16 +763,16 @@ export default function FeedbackPage() {
                 }}
                 onMouseEnter={(e) => {
                   (e.currentTarget as HTMLButtonElement).style.borderColor = "#374151";
-                  (e.currentTarget as HTMLButtonElement).style.background = "rgba(15,23,42,1)";
+                  (e.currentTarget as HTMLButtonElement).style.background = "var(--card)";
                 }}
                 onMouseLeave={(e) => {
                   (e.currentTarget as HTMLButtonElement).style.borderColor = "#1f2937";
-                  (e.currentTarget as HTMLButtonElement).style.background = "rgba(15,23,42,0.95)";
+                  (e.currentTarget as HTMLButtonElement).style.background = "var(--card)";
                 }}
               >
                 {/* Date column */}
                 <div style={{ flexShrink: 0, minWidth: 90, paddingTop: 2 }}>
-                  <span style={{ fontSize: 12, color: "#6b7280" }}>{formatDate(item.created_at)}</span>
+                  <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>{formatDate(item.created_at)}</span>
                 </div>
 
                 {/* Badges */}
@@ -783,7 +783,7 @@ export default function FeedbackPage() {
 
                 {/* Category */}
                 <div style={{ flexShrink: 0, paddingTop: 4, minWidth: 80 }}>
-                  <span style={{ fontSize: 12, color: "#9ca3af", fontWeight: 500 }}>
+                  <span style={{ fontSize: 12, color: "var(--muted-foreground)", fontWeight: 500 }}>
                     {lang === "ja" ? catLabel.ja : catLabel.en}
                   </span>
                 </div>
@@ -792,7 +792,7 @@ export default function FeedbackPage() {
                 <div style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column", gap: 4 }}>
                   <span style={{
                     fontSize: 14,
-                    color: "#f9fafb",
+                    color: "var(--foreground)",
                     overflow: "hidden",
                     textOverflow: "ellipsis",
                     whiteSpace: "nowrap",
@@ -801,7 +801,7 @@ export default function FeedbackPage() {
                     {item.message.slice(0, 60)}{item.message.length > 60 ? "…" : ""}
                   </span>
                   {item.user_email && (
-                    <span style={{ fontSize: 12, color: "#6b7280" }}>{item.user_email}</span>
+                    <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>{item.user_email}</span>
                   )}
                 </div>
 

--- a/admin-ui/src/pages/admin/knowledge/BookChunksPanel.tsx
+++ b/admin-ui/src/pages/admin/knowledge/BookChunksPanel.tsx
@@ -96,9 +96,9 @@ const PANEL: CSSProperties = {
   width: "100%",
   maxWidth: 640,
   borderRadius: 16,
-  border: "1px solid #1f2937",
-  background: "linear-gradient(145deg, #0f172a, #020617)",
-  color: "#e5e7eb",
+  border: "1px solid var(--border)",
+  background: "var(--card)",
+  color: "var(--foreground)",
   display: "flex",
   flexDirection: "column",
   maxHeight: "90vh",
@@ -110,9 +110,9 @@ const TEXTAREA_SM: CSSProperties = {
   minHeight: 64,
   padding: "10px 12px",
   borderRadius: 8,
-  border: "1px solid #374151",
-  background: "rgba(15,23,42,0.8)",
-  color: "#e5e7eb",
+  border: "1px solid var(--border)",
+  background: "var(--card)",
+  color: "var(--foreground)",
   fontSize: 14,
   fontFamily: "inherit",
   resize: "vertical",
@@ -305,7 +305,7 @@ export default function BookChunksPanel({
         <div
           style={{
             padding: "20px 20px 16px",
-            borderBottom: "1px solid #1f2937",
+            borderBottom: "1px solid var(--border)",
             display: "flex",
             alignItems: "center",
             gap: 12,
@@ -317,7 +317,7 @@ export default function BookChunksPanel({
               style={{
                 fontSize: 18,
                 fontWeight: 700,
-                color: "#f9fafb",
+                color: "var(--foreground)",
                 wordBreak: "break-word",
               }}
             >
@@ -328,7 +328,7 @@ export default function BookChunksPanel({
                 {STATUS_LABEL[bookStatus] ?? bookStatus}
               </span>
               {!loading && (
-                <span style={{ fontSize: 13, color: "#6b7280" }}>
+                <span style={{ fontSize: 13, color: "var(--muted-foreground)" }}>
                   {chunks.length}件の分割テキスト
                 </span>
               )}
@@ -338,16 +338,16 @@ export default function BookChunksPanel({
                 <div style={{ color: "#60a5fa", marginBottom: 2 }}>
                   📊 コンテンツ種類: {bookDetail.content_type_label}
                   {bookDetail.schema_confidence != null && (
-                    <span style={{ color: "#6b7280", marginLeft: 6 }}>
+                    <span style={{ color: "var(--muted-foreground)", marginLeft: 6 }}>
                       （確信度: {(bookDetail.schema_confidence * 100).toFixed(0)}%）
                     </span>
                   )}
                 </div>
                 {bookDetail.schema_reasoning && (
-                  <div style={{ color: "#9ca3af", marginBottom: 2 }}>💡 {bookDetail.schema_reasoning}</div>
+                  <div style={{ color: "var(--muted-foreground)", marginBottom: 2 }}>💡 {bookDetail.schema_reasoning}</div>
                 )}
                 {activeSchema.length > 0 && (
-                  <div style={{ color: "#9ca3af" }}>
+                  <div style={{ color: "var(--muted-foreground)" }}>
                     📋 構造化フィールド: {activeSchema.map((f) => f.label).join(" / ")}
                   </div>
                 )}
@@ -361,9 +361,9 @@ export default function BookChunksPanel({
               minHeight: 44,
               minWidth: 44,
               borderRadius: 8,
-              border: "1px solid #374151",
+              border: "1px solid var(--border)",
               background: "transparent",
-              color: "#9ca3af",
+              color: "var(--muted-foreground)",
               fontSize: 14,
               cursor: "pointer",
               flexShrink: 0,
@@ -376,7 +376,7 @@ export default function BookChunksPanel({
         {/* チャンク一覧 */}
         <div style={{ flex: 1, overflowY: "auto", padding: "16px 20px 20px" }}>
           {loading ? (
-            <div style={{ padding: 32, textAlign: "center", color: "#6b7280" }}>
+            <div style={{ padding: 32, textAlign: "center", color: "var(--muted-foreground)" }}>
               読み込み中...
             </div>
           ) : error ? (
@@ -399,7 +399,7 @@ export default function BookChunksPanel({
                 textAlign: "center",
                 borderRadius: 12,
                 border: "1px dashed #374151",
-                color: "#6b7280",
+                color: "var(--muted-foreground)",
                 fontSize: 14,
               }}
             >
@@ -497,7 +497,7 @@ function ChunkCard({
         border: `1px solid ${isEditing ? "rgba(74,222,128,0.3)" : "#1f2937"}`,
         background: isEditing
           ? "rgba(5,46,22,0.15)"
-          : "rgba(15,23,42,0.6)",
+          : "var(--card)",
         padding: "14px 16px",
         transition: "border-color 0.15s",
       }}
@@ -517,7 +517,7 @@ function ChunkCard({
             <div
               style={{
                 fontSize: 13,
-                color: "#6b7280",
+                color: "var(--muted-foreground)",
                 lineHeight: 1.6,
                 marginBottom: 8,
                 display: "flex",
@@ -591,9 +591,9 @@ function ChunkCard({
                 padding: "8px 14px",
                 minHeight: 44,
                 borderRadius: 8,
-                border: "1px solid #374151",
+                border: "1px solid var(--border)",
                 background: "transparent",
-                color: "#9ca3af",
+                color: "var(--muted-foreground)",
                 fontSize: 13,
                 fontWeight: 600,
                 cursor: "pointer",
@@ -646,9 +646,9 @@ function ChunkCard({
                 padding: "12px",
                 minHeight: 44,
                 borderRadius: 8,
-                border: "1px solid #374151",
+                border: "1px solid var(--border)",
                 background: "transparent",
-                color: "#9ca3af",
+                color: "var(--muted-foreground)",
                 fontSize: 14,
                 fontWeight: 600,
                 cursor: deleting ? "not-allowed" : "pointer",
@@ -695,7 +695,7 @@ function ChunkCard({
                   style={{
                     display: "block",
                     fontSize: 12,
-                    color: "#9ca3af",
+                    color: "var(--muted-foreground)",
                     marginBottom: 4,
                     fontWeight: 600,
                   }}
@@ -726,9 +726,9 @@ function ChunkCard({
                 padding: "12px",
                 minHeight: 44,
                 borderRadius: 8,
-                border: "1px solid #374151",
+                border: "1px solid var(--border)",
                 background: "transparent",
-                color: "#9ca3af",
+                color: "var(--muted-foreground)",
                 fontSize: 14,
                 fontWeight: 600,
                 cursor: saving ? "not-allowed" : "pointer",

--- a/admin-ui/src/pages/admin/knowledge/[tenantId].tsx
+++ b/admin-ui/src/pages/admin/knowledge/[tenantId].tsx
@@ -99,8 +99,8 @@ export default function TenantKnowledgePage() {
     <div
       style={{
         minHeight: "100vh",
-        background: "radial-gradient(circle at top, #0f172a 0, #020617 55%, #000 100%)",
-        color: "#e5e7eb",
+        background: "var(--background)",
+        color: "var(--foreground)",
         padding: "24px 20px",
         maxWidth: 900,
         margin: "0 auto",
@@ -110,13 +110,13 @@ export default function TenantKnowledgePage() {
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 8, flexWrap: "wrap", gap: 8 }}>
           <button
             onClick={() => navigate("/admin")}
-            style={{ display: "inline-flex", alignItems: "center", gap: 4, padding: "8px 14px", minHeight: 44, borderRadius: 999, border: "1px solid #374151", background: "transparent", color: "#9ca3af", fontSize: 14, cursor: "pointer", fontWeight: 500 }}
+            style={{ display: "inline-flex", alignItems: "center", gap: 4, padding: "8px 14px", minHeight: 44, borderRadius: 999, border: "1px solid var(--border)", background: "transparent", color: "var(--muted-foreground)", fontSize: 14, cursor: "pointer", fontWeight: 500 }}
           >
             {t("nav.back_dashboard")}
           </button>
           <LangSwitcher />
         </div>
-        <h1 style={{ fontSize: 26, fontWeight: 700, margin: 0, color: "#f9fafb" }}>
+        <h1 style={{ fontSize: 26, fontWeight: 700, margin: 0, color: "var(--foreground)" }}>
           {t("knowledge.title")}
         </h1>
         {isSuperAdmin ? (
@@ -126,8 +126,8 @@ export default function TenantKnowledgePage() {
               onChange={(e) => handleTenantChange(e.target.value)}
               style={{
                 flex: 1, padding: "10px 12px", minHeight: 44, borderRadius: 10,
-                border: "1px solid #374151", background: "rgba(15,23,42,0.8)",
-                color: "#e5e7eb", fontSize: 15, cursor: "pointer",
+                border: "1px solid var(--border)", background: "var(--card)",
+                color: "var(--foreground)", fontSize: 15, cursor: "pointer",
               }}
             >
               <option value="global">🌐 グローバルナレッジ</option>
@@ -163,7 +163,7 @@ export default function TenantKnowledgePage() {
       </header>
 
       {/* タブ */}
-      <div style={{ display: "flex", gap: 0, marginBottom: 24, borderBottom: "1px solid #1f2937" }}>
+      <div style={{ display: "flex", gap: 0, marginBottom: 24, borderBottom: "1px solid var(--border)" }}>
         {tabs.map((tab) => (
           <button
             key={tab.id}

--- a/admin-ui/src/pages/admin/monitoring/index.tsx
+++ b/admin-ui/src/pages/admin/monitoring/index.tsx
@@ -176,8 +176,8 @@ export default function MonitoringPage() {
       style={{
         minHeight: "100vh",
         background:
-          "radial-gradient(circle at top, #0f172a 0, #020617 55%, #000 100%)",
-        color: "#e5e7eb",
+          "var(--background)",
+        color: "var(--foreground)",
         padding: "24px 20px",
         maxWidth: 960,
         margin: "0 auto",
@@ -201,10 +201,10 @@ export default function MonitoringPage() {
               gap: 6,
               padding: "3px 10px",
               borderRadius: 999,
-              background: "rgba(15,23,42,0.9)",
-              border: "1px solid #1f2937",
+              background: "var(--card)",
+              border: "1px solid var(--border)",
               fontSize: 12,
-              color: "#9ca3af",
+              color: "var(--muted-foreground)",
               marginBottom: 8,
             }}
           >
@@ -219,10 +219,10 @@ export default function MonitoringPage() {
             />
             {error ? "接続エラー" : "接続中"}
           </div>
-          <h1 style={{ fontSize: 26, fontWeight: 700, margin: 0, color: "#f9fafb" }}>
+          <h1 style={{ fontSize: 26, fontWeight: 700, margin: 0, color: "var(--foreground)" }}>
             KPI 監視ダッシュボード
           </h1>
-          <p style={{ fontSize: 14, color: "#9ca3af", marginTop: 4, marginBottom: 0 }}>
+          <p style={{ fontSize: 14, color: "var(--muted-foreground)", marginTop: 4, marginBottom: 0 }}>
             サービスの品質指標をリアルタイムで確認できます
           </p>
         </div>
@@ -234,9 +234,9 @@ export default function MonitoringPage() {
               padding: "10px 16px",
               minHeight: 44,
               borderRadius: 999,
-              border: "1px solid #374151",
+              border: "1px solid var(--border)",
               background: "transparent",
-              color: "#9ca3af",
+              color: "var(--muted-foreground)",
               fontSize: 14,
               cursor: "pointer",
               fontWeight: 500,
@@ -245,7 +245,7 @@ export default function MonitoringPage() {
             ← 管理画面に戻る
           </button>
           {lastUpdated && (
-            <span style={{ fontSize: 12, color: "#6b7280" }}>
+            <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>
               最終更新: {lastUpdated.toLocaleTimeString("ja-JP")}
             </span>
           )}
@@ -279,7 +279,7 @@ export default function MonitoringPage() {
             alignItems: "center",
             justifyContent: "center",
             minHeight: 240,
-            color: "#9ca3af",
+            color: "var(--muted-foreground)",
             fontSize: 16,
             flexDirection: "column",
             gap: 16,
@@ -306,7 +306,7 @@ export default function MonitoringPage() {
               style={{
                 fontSize: 15,
                 fontWeight: 600,
-                color: "#9ca3af",
+                color: "var(--muted-foreground)",
                 marginBottom: 16,
                 marginTop: 0,
               }}
@@ -326,7 +326,7 @@ export default function MonitoringPage() {
                 style={{
                   fontSize: 15,
                   fontWeight: 600,
-                  color: "#9ca3af",
+                  color: "var(--muted-foreground)",
                   marginBottom: 16,
                   marginTop: 0,
                 }}

--- a/admin-ui/src/pages/admin/options/index.tsx
+++ b/admin-ui/src/pages/admin/options/index.tsx
@@ -116,11 +116,11 @@ export default function OptionManagementPage() {
   const totalPages = Math.max(1, Math.ceil(total / LIMIT));
   const currentPage = Math.floor(offset / LIMIT) + 1;
 
-  const PAGE_BG = "#0f172a";
-  const CARD_BG = "rgba(255,255,255,0.03)";
-  const BORDER = "#1f2937";
-  const TEXT_MAIN = "#f9fafb";
-  const TEXT_SUB = "#9ca3af";
+  const PAGE_BG = "var(--background)";
+  const CARD_BG = "var(--card)";
+  const BORDER = "var(--border)";
+  const TEXT_MAIN = "var(--foreground)";
+  const TEXT_SUB = "var(--muted-foreground)";
 
   const FILTER_TABS: { label: string; value: StatusFilter }[] = [
     { label: "すべて", value: "" },
@@ -363,7 +363,7 @@ function OrderDetailModal({
       onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}
     >
       <div style={{
-        background: "#111827", border: `1px solid ${BORDER}`, borderRadius: 12,
+        background: "var(--card)", border: `1px solid ${BORDER}`, borderRadius: 12,
         width: "100%", maxWidth: 560, maxHeight: "90vh", overflowY: "auto", padding: 24,
       }}>
         {/* ヘッダー */}

--- a/admin-ui/src/pages/admin/tenants/AnalyticsSummaryTab.tsx
+++ b/admin-ui/src/pages/admin/tenants/AnalyticsSummaryTab.tsx
@@ -42,7 +42,7 @@ export default function AnalyticsSummaryTab({ tenantId }: { tenantId: string }) 
     <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
       {/* Period selector */}
       <div style={{ ...CARD_STYLE, display: "flex", gap: 10, alignItems: "center" }}>
-        <span style={{ fontSize: 14, color: "#9ca3af", fontWeight: 600 }}>期間:</span>
+        <span style={{ fontSize: 14, color: "var(--muted-foreground)", fontWeight: 600 }}>期間:</span>
         {(["last_7d", "last_30d", "last_90d"] as const).map((p) => (
           <button
             key={p}
@@ -52,7 +52,7 @@ export default function AnalyticsSummaryTab({ tenantId }: { tenantId: string }) 
               padding: "8px 16px",
               minHeight: 36,
               borderRadius: 8,
-              border: period === p ? "1px solid #4ade80" : "1px solid #374151",
+              border: period === p ? "1px solid #4ade80" : "1px solid var(--border)",
               background: period === p ? "rgba(34,197,94,0.15)" : "rgba(0,0,0,0.3)",
               color: period === p ? "#4ade80" : "#9ca3af",
               fontSize: 13,
@@ -65,22 +65,22 @@ export default function AnalyticsSummaryTab({ tenantId }: { tenantId: string }) 
         ))}
       </div>
 
-      {loading && <div style={{ color: "#6b7280", textAlign: "center", padding: 32 }}>読み込み中...</div>}
+      {loading && <div style={{ color: "var(--muted-foreground)", textAlign: "center", padding: 32 }}>読み込み中...</div>}
       {error && <div style={{ color: "#f87171", padding: 16 }}>{error}</div>}
 
       {data && !loading && (
         <>
           {/* Conversations */}
           <div style={{ ...CARD_STYLE }}>
-            <h3 style={{ fontSize: 15, fontWeight: 700, color: "#d1d5db", margin: "0 0 16px" }}>💬 会話数</h3>
+            <h3 style={{ fontSize: 15, fontWeight: 700, color: "var(--muted-foreground)", margin: "0 0 16px" }}>💬 会話数</h3>
             <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr", gap: 12 }}>
               {[
                 { label: "総会話数", value: data.conversations.total.toLocaleString() },
                 { label: "1日平均", value: `${data.conversations.avg_per_day}件` },
               ].map(({ label, value }) => (
-                <div key={label} style={{ padding: "16px", borderRadius: 10, background: "rgba(255,255,255,0.03)", border: "1px solid #1f2937" }}>
-                  <div style={{ fontSize: 12, color: "#9ca3af", marginBottom: 6 }}>{label}</div>
-                  <div style={{ fontSize: 22, fontWeight: 700, color: "#e5e7eb" }}>{value}</div>
+                <div key={label} style={{ padding: "16px", borderRadius: 10, background: "rgba(255,255,255,0.03)", border: "1px solid var(--border)" }}>
+                  <div style={{ fontSize: 12, color: "var(--muted-foreground)", marginBottom: 6 }}>{label}</div>
+                  <div style={{ fontSize: 22, fontWeight: 700, color: "var(--foreground)" }}>{value}</div>
                 </div>
               ))}
             </div>
@@ -88,7 +88,7 @@ export default function AnalyticsSummaryTab({ tenantId }: { tenantId: string }) 
 
           {/* CV */}
           <div style={{ ...CARD_STYLE }}>
-            <h3 style={{ fontSize: 15, fontWeight: 700, color: "#d1d5db", margin: "0 0 16px" }}>🎯 コンバージョン</h3>
+            <h3 style={{ fontSize: 15, fontWeight: 700, color: "var(--muted-foreground)", margin: "0 0 16px" }}>🎯 コンバージョン</h3>
             <div style={{ display: "grid", gap: 10 }}>
               {[
                 { label: "マクロCV (r2c_db)", value: data.cv.macro.r2c_db },
@@ -98,9 +98,9 @@ export default function AnalyticsSummaryTab({ tenantId }: { tenantId: string }) 
                 { label: "マイクロCV (GA4)", value: data.cv.micro.ga4 },
                 { label: "ランクA (3ソース確認済)", value: data.cv.macro.ranked_a },
               ].map(({ label, value }) => (
-                <div key={label} style={{ display: "flex", justifyContent: "space-between", padding: "10px 14px", borderRadius: 8, background: "rgba(255,255,255,0.02)", border: "1px solid #1f2937", fontSize: 14 }}>
-                  <span style={{ color: "#9ca3af" }}>{label}</span>
-                  <span style={{ color: "#e5e7eb", fontWeight: 600 }}>{value}</span>
+                <div key={label} style={{ display: "flex", justifyContent: "space-between", padding: "10px 14px", borderRadius: 8, background: "rgba(255,255,255,0.02)", border: "1px solid var(--border)", fontSize: 14 }}>
+                  <span style={{ color: "var(--muted-foreground)" }}>{label}</span>
+                  <span style={{ color: "var(--foreground)", fontWeight: 600 }}>{value}</span>
                 </div>
               ))}
             </div>
@@ -109,15 +109,15 @@ export default function AnalyticsSummaryTab({ tenantId }: { tenantId: string }) 
           {/* LLM Usage */}
           {data.llm_usage && (
             <div style={{ ...CARD_STYLE }}>
-              <h3 style={{ fontSize: 15, fontWeight: 700, color: "#d1d5db", margin: "0 0 16px" }}>🤖 LLM使用量（今月）</h3>
+              <h3 style={{ fontSize: 15, fontWeight: 700, color: "var(--muted-foreground)", margin: "0 0 16px" }}>🤖 LLM使用量（今月）</h3>
               <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 10 }}>
                 {[
                   { label: "総トークン", value: data.llm_usage.tokens.toLocaleString() },
                   { label: "推定コスト", value: `¥${data.llm_usage.cost_jpy.toLocaleString()}` },
                   { label: "生成回数", value: data.llm_usage.generations.toLocaleString() },
                 ].map(({ label, value }) => (
-                  <div key={label} style={{ padding: "14px", borderRadius: 10, background: "rgba(255,255,255,0.03)", border: "1px solid #1f2937" }}>
-                    <div style={{ fontSize: 11, color: "#9ca3af", marginBottom: 4 }}>{label}</div>
+                  <div key={label} style={{ padding: "14px", borderRadius: 10, background: "rgba(255,255,255,0.03)", border: "1px solid var(--border)" }}>
+                    <div style={{ fontSize: 11, color: "var(--muted-foreground)", marginBottom: 4 }}>{label}</div>
                     <div style={{ fontSize: 18, fontWeight: 700, color: "#4ade80" }}>{value}</div>
                   </div>
                 ))}

--- a/admin-ui/src/pages/admin/tenants/ApiKeysTab.tsx
+++ b/admin-ui/src/pages/admin/tenants/ApiKeysTab.tsx
@@ -107,7 +107,7 @@ export default function ApiKeysTab({ tenantId }: { tenantId: string }) {
             transform: "translateX(-50%)",
             padding: "14px 24px",
             borderRadius: 12,
-            background: "rgba(15,23,42,0.98)",
+            background: "var(--card)",
             border: "1px solid #22c55e",
             color: "#4ade80",
             fontSize: 15,
@@ -151,7 +151,7 @@ export default function ApiKeysTab({ tenantId }: { tenantId: string }) {
             alignItems: "center",
             justifyContent: "center",
             minHeight: 80,
-            color: "#9ca3af",
+            color: "var(--muted-foreground)",
             fontSize: 15,
           }}
         >
@@ -163,7 +163,7 @@ export default function ApiKeysTab({ tenantId }: { tenantId: string }) {
           style={{
             ...CARD_STYLE,
             textAlign: "center",
-            color: "#6b7280",
+            color: "var(--muted-foreground)",
             fontSize: 15,
             padding: "32px 20px",
           }}
@@ -242,7 +242,7 @@ export default function ApiKeysTab({ tenantId }: { tenantId: string }) {
                     {key.status === "active" ? t("tenant_detail.key_status_active") : t("tenant_detail.key_status_revoked")}
                   </span>
                 </div>
-                <div style={{ fontSize: 12, color: "#6b7280", display: "flex", gap: 16, flexWrap: "wrap" }}>
+                <div style={{ fontSize: 12, color: "var(--muted-foreground)", display: "flex", gap: 16, flexWrap: "wrap" }}>
                   <span>{t("tenant_detail.key_created_at", { date: formatDate(key.createdAt) })}</span>
                   <span>
                     {key.lastUsedAt

--- a/admin-ui/src/pages/admin/tenants/BillingInfoTab.tsx
+++ b/admin-ui/src/pages/admin/tenants/BillingInfoTab.tsx
@@ -4,7 +4,7 @@ import { CARD_STYLE } from "./types";
 export default function BillingInfoTab({ tenant }: { tenant: TenantDetail }) {
   return (
     <div style={{ ...CARD_STYLE, display: "flex", flexDirection: "column", gap: 16 }}>
-      <h3 style={{ fontSize: 15, fontWeight: 700, color: "#d1d5db", margin: 0 }}>💳 請求情報</h3>
+      <h3 style={{ fontSize: 15, fontWeight: 700, color: "var(--muted-foreground)", margin: 0 }}>💳 請求情報</h3>
       <div style={{ display: "grid", gap: 10 }}>
         {[
           { label: "プラン", value: tenant.plan.toUpperCase() },
@@ -12,13 +12,13 @@ export default function BillingInfoTab({ tenant }: { tenant: TenantDetail }) {
           { label: "無料期間（開始）", value: tenant.billing_free_from ? new Date(tenant.billing_free_from).toLocaleDateString("ja-JP") : "—" },
           { label: "無料期間（終了）", value: tenant.billing_free_until ? new Date(tenant.billing_free_until).toLocaleDateString("ja-JP") : "—" },
         ].map(({ label, value }) => (
-          <div key={label} style={{ display: "flex", justifyContent: "space-between", padding: "12px 16px", borderRadius: 8, background: "rgba(255,255,255,0.02)", border: "1px solid #1f2937", fontSize: 14 }}>
-            <span style={{ color: "#9ca3af" }}>{label}</span>
-            <span style={{ color: "#e5e7eb", fontWeight: 600 }}>{value}</span>
+          <div key={label} style={{ display: "flex", justifyContent: "space-between", padding: "12px 16px", borderRadius: 8, background: "rgba(255,255,255,0.02)", border: "1px solid var(--border)", fontSize: 14 }}>
+            <span style={{ color: "var(--muted-foreground)" }}>{label}</span>
+            <span style={{ color: "var(--foreground)", fontWeight: 600 }}>{value}</span>
           </div>
         ))}
       </div>
-      <p style={{ fontSize: 12, color: "#6b7280", margin: 0 }}>
+      <p style={{ fontSize: 12, color: "var(--muted-foreground)", margin: 0 }}>
         詳細な請求設定はSuper Admin専用の設定タブから変更できます。
       </p>
     </div>

--- a/admin-ui/src/pages/admin/tenants/ConversionTypesTab.tsx
+++ b/admin-ui/src/pages/admin/tenants/ConversionTypesTab.tsx
@@ -63,7 +63,7 @@ export default function ConversionTypesTab({
 
   return (
     <div>
-      <p style={{ fontSize: 14, color: "#9ca3af", marginBottom: 20 }}>
+      <p style={{ fontSize: 14, color: "var(--muted-foreground)", marginBottom: 20 }}>
         お客様の行動結果のカテゴリを設定します。会話詳細ページでこのカテゴリを選んで成果を記録できます。
       </p>
       {saveMsg && (
@@ -86,14 +86,14 @@ export default function ConversionTypesTab({
             {t}
             <button
               onClick={() => removeType(t)}
-              style={{ background: "none", border: "none", color: "#6b7280", cursor: "pointer", fontSize: 14, padding: 0, lineHeight: 1 }}
+              style={{ background: "none", border: "none", color: "var(--muted-foreground)", cursor: "pointer", fontSize: 14, padding: 0, lineHeight: 1 }}
               title="削除"
             >
               ×
             </button>
           </span>
         ))}
-        {types.length === 0 && <span style={{ fontSize: 14, color: "#6b7280" }}>タイプが登録されていません</span>}
+        {types.length === 0 && <span style={{ fontSize: 14, color: "var(--muted-foreground)" }}>タイプが登録されていません</span>}
       </div>
       {/* 追加フォーム */}
       <div style={{ display: "flex", gap: 8, marginBottom: 20 }}>
@@ -106,8 +106,8 @@ export default function ConversionTypesTab({
           maxLength={50}
           style={{
             flex: 1, padding: "10px 14px", borderRadius: 8,
-            border: "1px solid #374151", background: "rgba(255,255,255,0.05)",
-            color: "#f9fafb", fontSize: 14,
+            border: "1px solid var(--border)", background: "rgba(255,255,255,0.05)",
+            color: "var(--foreground)", fontSize: 14,
           }}
         />
         <button
@@ -122,7 +122,7 @@ export default function ConversionTypesTab({
           ＋ 追加
         </button>
       </div>
-      <p style={{ fontSize: 12, color: "#6b7280", marginBottom: 20 }}>最大10件、各50文字以内。現在 {types.length}/10 件</p>
+      <p style={{ fontSize: 12, color: "var(--muted-foreground)", marginBottom: 20 }}>最大10件、各50文字以内。現在 {types.length}/10 件</p>
       <button
         onClick={handleSave}
         disabled={saving}

--- a/admin-ui/src/pages/admin/tenants/DeepResearchTab.tsx
+++ b/admin-ui/src/pages/admin/tenants/DeepResearchTab.tsx
@@ -82,15 +82,15 @@ export default function DeepResearchTab({
         >
           <div
             style={{
-              background: "#111827", borderRadius: 14,
-              border: "1px solid #374151",
+              background: "var(--card)", borderRadius: 14,
+              border: "1px solid var(--border)",
               padding: "28px 24px", maxWidth: 400, width: "100%",
             }}
           >
-            <p style={{ color: "#e5e7eb", fontSize: 15, fontWeight: 600, margin: "0 0 12px" }}>
+            <p style={{ color: "var(--foreground)", fontSize: 15, fontWeight: 600, margin: "0 0 12px" }}>
               ディープリサーチをONにしますか？
             </p>
-            <p style={{ color: "#9ca3af", fontSize: 13, margin: "0 0 24px", lineHeight: 1.6 }}>
+            <p style={{ color: "var(--muted-foreground)", fontSize: 13, margin: "0 0 24px", lineHeight: 1.6 }}>
               ディープリサーチをONにすると、追加コスト（月$3〜8程度）が発生します。よろしいですか？
             </p>
             <div style={{ display: "flex", gap: 12, justifyContent: "flex-end" }}>
@@ -99,8 +99,8 @@ export default function DeepResearchTab({
                 onClick={() => setConfirmPending(false)}
                 style={{
                   padding: "10px 18px", borderRadius: 8,
-                  border: "1px solid #374151", background: "transparent",
-                  color: "#9ca3af", fontSize: 14, cursor: "pointer",
+                  border: "1px solid var(--border)", background: "transparent",
+                  color: "var(--muted-foreground)", fontSize: 14, cursor: "pointer",
                 }}
               >
                 キャンセル
@@ -132,10 +132,10 @@ export default function DeepResearchTab({
         }}
       >
         <div style={{ flex: 1, minWidth: 0 }}>
-          <p style={{ margin: "0 0 4px", fontWeight: 600, color: "#e5e7eb", fontSize: 15 }}>
+          <p style={{ margin: "0 0 4px", fontWeight: 600, color: "var(--foreground)", fontSize: 15 }}>
             🔬 ディープリサーチ（AI提案の精度向上）
           </p>
-          <p style={{ margin: 0, fontSize: 13, color: "#9ca3af" }}>
+          <p style={{ margin: 0, fontSize: 13, color: "var(--muted-foreground)" }}>
             AIの改善提案に最新の市場動向・心理学研究を反映します
           </p>
         </div>
@@ -193,10 +193,10 @@ export default function DeepResearchTab({
       <div
         style={{
           borderRadius: 10,
-          border: "1px solid #1f2937",
+          border: "1px solid var(--border)",
           background: "rgba(17,24,39,0.5)",
           padding: "12px 16px",
-          fontSize: 12, color: "#6b7280", lineHeight: 1.6,
+          fontSize: 12, color: "var(--muted-foreground)", lineHeight: 1.6,
         }}
       >
         <p style={{ margin: "0 0 4px" }}>💰 コスト目安：月あたり約 $3〜8 の追加（提案1回あたり約 $0.05〜0.10）</p>

--- a/admin-ui/src/pages/admin/tenants/EmbedCodeTab.tsx
+++ b/admin-ui/src/pages/admin/tenants/EmbedCodeTab.tsx
@@ -55,7 +55,7 @@ export default function EmbedCodeTab({ tenant, apiKeys }: { tenant: TenantDetail
   const CODE_STYLE: React.CSSProperties = {
     fontFamily: "monospace",
     background: "rgba(0,0,0,0.5)",
-    border: "1px solid #374151",
+    border: "1px solid var(--border)",
     borderRadius: 10,
     padding: "16px",
     fontSize: 13,
@@ -100,14 +100,14 @@ export default function EmbedCodeTab({ tenant, apiKeys }: { tenant: TenantDetail
         </div>
       )}
       <div style={CARD_STYLE}>
-        <p style={{ fontSize: 14, color: "#9ca3af", marginBottom: 16, lineHeight: 1.6 }}>
+        <p style={{ fontSize: 14, color: "var(--muted-foreground)", marginBottom: 16, lineHeight: 1.6 }}>
           {t("tenant_detail.embed_desc")}
         </p>
         <pre
           style={{
             fontFamily: "monospace",
             background: "rgba(0,0,0,0.5)",
-            border: "1px solid #374151",
+            border: "1px solid var(--border)",
             borderRadius: 10,
             padding: "16px",
             fontSize: 13,
@@ -157,15 +157,15 @@ export default function EmbedCodeTab({ tenant, apiKeys }: { tenant: TenantDetail
 
       {/* ─── コンバージョン計測タグ ─── */}
       <div style={{ ...CARD_STYLE, marginTop: 16 }}>
-        <p style={{ fontSize: 15, fontWeight: 700, color: "#f9fafb", marginBottom: 8 }}>
+        <p style={{ fontSize: 15, fontWeight: 700, color: "var(--foreground)", marginBottom: 8 }}>
           コンバージョン計測タグ
         </p>
-        <p style={{ fontSize: 13, color: "#9ca3af", marginBottom: 16, lineHeight: 1.6 }}>
+        <p style={{ fontSize: 13, color: "var(--muted-foreground)", marginBottom: 16, lineHeight: 1.6 }}>
           購入完了ページや問い合わせ完了ページに追加すると、チャット経由の成果を自動で計測できます。
           ウィジェット（widget.js）を読み込んだページでのみ動作します。
         </p>
 
-        <p style={{ fontSize: 13, fontWeight: 600, color: "#d1d5db", marginBottom: 6 }}>
+        <p style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)", marginBottom: 6 }}>
           購入完了ページ用
         </p>
         <pre style={CODE_STYLE}>{purchaseTag}</pre>
@@ -173,7 +173,7 @@ export default function EmbedCodeTab({ tenant, apiKeys }: { tenant: TenantDetail
           {copiedPurchase ? "コピーしました ✓" : "コードをコピー"}
         </button>
 
-        <p style={{ fontSize: 13, fontWeight: 600, color: "#d1d5db", marginTop: 16, marginBottom: 6 }}>
+        <p style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)", marginTop: 16, marginBottom: 6 }}>
           問い合わせ完了ページ用
         </p>
         <pre style={CODE_STYLE}>{inquiryTag}</pre>

--- a/admin-ui/src/pages/admin/tenants/Ga4IntegrationTab.tsx
+++ b/admin-ui/src/pages/admin/tenants/Ga4IntegrationTab.tsx
@@ -127,8 +127,8 @@ export default function Ga4IntegrationTab({ tenantId }: { tenantId: string }) {
   const hasPropertyId = (statusData?.ga4_property_id ?? "").length > 0;
 
   const CARD: React.CSSProperties = {
-    background: "rgba(15,23,42,0.7)",
-    border: "1px solid #1f2937",
+    background: "var(--card)",
+    border: "1px solid var(--border)",
     borderRadius: 14,
     padding: "24px 28px",
     marginBottom: 20,
@@ -157,9 +157,9 @@ export default function Ga4IntegrationTab({ tenantId }: { tenantId: string }) {
     padding: "10px 20px",
     minHeight: 44,
     borderRadius: 10,
-    border: "1px solid #374151",
+    border: "1px solid var(--border)",
     background: "transparent",
-    color: "#9ca3af",
+    color: "var(--muted-foreground)",
     fontSize: 14,
     fontWeight: 500,
     cursor: "pointer",
@@ -167,7 +167,7 @@ export default function Ga4IntegrationTab({ tenantId }: { tenantId: string }) {
 
   function StatusBadge({ status }: { status: Ga4Status }) {
     const map: Record<Ga4Status, { label: string; color: string; bg: string }> = {
-      not_configured: { label: "未設定", color: "#9ca3af", bg: "rgba(156,163,175,0.1)" },
+      not_configured: { label: "未設定", color: "var(--muted-foreground)", bg: "rgba(156,163,175,0.1)" },
       pending: { label: "設定中", color: "#fbbf24", bg: "rgba(251,191,36,0.1)" },
       connected: { label: "✅ 連携中", color: "#4ade80", bg: "rgba(74,222,128,0.1)" },
       error: { label: "❌ エラー", color: "#f87171", bg: "rgba(248,113,113,0.1)" },
@@ -203,7 +203,7 @@ export default function Ga4IntegrationTab({ tenantId }: { tenantId: string }) {
 
   if (loading) {
     return (
-      <div style={{ padding: 40, textAlign: "center", color: "#6b7280" }}>
+      <div style={{ padding: 40, textAlign: "center", color: "var(--muted-foreground)" }}>
         ⏳ 読み込み中...
       </div>
     );
@@ -213,7 +213,7 @@ export default function Ga4IntegrationTab({ tenantId }: { tenantId: string }) {
     <div style={{ paddingTop: 4 }}>
       {/* トースト */}
       {toast && (
-        <div style={{ position: "fixed", bottom: 24, left: "50%", transform: "translateX(-50%)", padding: "14px 24px", borderRadius: 12, background: "rgba(15,23,42,0.98)", border: "1px solid #22c55e", color: "#4ade80", fontSize: 15, fontWeight: 600, zIndex: 3000, whiteSpace: "nowrap" }}>
+        <div style={{ position: "fixed", bottom: 24, left: "50%", transform: "translateX(-50%)", padding: "14px 24px", borderRadius: 12, background: "var(--card)", border: "1px solid #22c55e", color: "#4ade80", fontSize: 15, fontWeight: 600, zIndex: 3000, whiteSpace: "nowrap" }}>
           {toast}
         </div>
       )}
@@ -221,10 +221,10 @@ export default function Ga4IntegrationTab({ tenantId }: { tenantId: string }) {
       {/* 確認モーダル */}
       {showDisconnectConfirm && (
         <div style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.7)", zIndex: 2000, display: "flex", alignItems: "center", justifyContent: "center" }}>
-          <div style={{ background: "#0f172a", border: "1px solid #374151", borderRadius: 16, padding: 32, maxWidth: 400, width: "90%", textAlign: "center" }}>
+          <div style={{ background: "var(--background)", border: "1px solid var(--border)", borderRadius: 16, padding: 32, maxWidth: 400, width: "90%", textAlign: "center" }}>
             <div style={{ fontSize: 36, marginBottom: 16 }}>⚠️</div>
             <div style={{ fontSize: 18, fontWeight: 700, color: "#f1f5f9", marginBottom: 8 }}>GA4連携を解除しますか？</div>
-            <div style={{ color: "#9ca3af", fontSize: 14, marginBottom: 28 }}>設定した識別番号と連携情報が削除されます。</div>
+            <div style={{ color: "var(--muted-foreground)", fontSize: 14, marginBottom: 28 }}>設定した識別番号と連携情報が削除されます。</div>
             <div style={{ display: "flex", gap: 12, justifyContent: "center" }}>
               <button style={{ ...BTN_SECONDARY }} onClick={() => setShowDisconnectConfirm(false)}>キャンセル</button>
               <button style={{ ...BTN_PRIMARY, background: "linear-gradient(135deg,#dc2626,#ef4444)" }} onClick={() => void handleDisconnect()}>解除する</button>
@@ -237,7 +237,7 @@ export default function Ga4IntegrationTab({ tenantId }: { tenantId: string }) {
       <div style={{ ...CARD, display: "flex", justifyContent: "space-between", alignItems: "flex-start", flexWrap: "wrap", gap: 12 }}>
         <div>
           <h2 style={{ fontSize: 18, fontWeight: 700, color: "#f1f5f9", margin: "0 0 8px" }}>📊 Google Analytics 4 連携</h2>
-          <div style={{ color: "#9ca3af", fontSize: 14 }}>
+          <div style={{ color: "var(--muted-foreground)", fontSize: 14 }}>
             GA4のデータをR2Cに連携することで、成果（コンバージョン）の計測精度が上がります。
           </div>
         </div>
@@ -246,11 +246,11 @@ export default function Ga4IntegrationTab({ tenantId }: { tenantId: string }) {
 
       {/* ステップ1: サービスアカウント案内 */}
       <div style={CARD}>
-        <h3 style={{ fontSize: 15, fontWeight: 700, color: "#d1d5db", margin: "0 0 16px" }}>
+        <h3 style={{ fontSize: 15, fontWeight: 700, color: "var(--muted-foreground)", margin: "0 0 16px" }}>
           ステップ 1 — R2Cのメールアドレスに閲覧権限を付与する
         </h3>
-        <div style={{ color: "#9ca3af", fontSize: 14, lineHeight: 1.8, marginBottom: 16 }}>
-          GA4の管理画面で、以下のメールアドレスに <strong style={{ color: "#e5e7eb" }}>「閲覧者」</strong> 権限を付与してください。
+        <div style={{ color: "var(--muted-foreground)", fontSize: 14, lineHeight: 1.8, marginBottom: 16 }}>
+          GA4の管理画面で、以下のメールアドレスに <strong style={{ color: "var(--foreground)" }}>「閲覧者」</strong> 権限を付与してください。
         </div>
         {serviceAccountEmail ? (
           <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
@@ -270,7 +270,7 @@ export default function Ga4IntegrationTab({ tenantId }: { tenantId: string }) {
           <summary style={{ cursor: "pointer", color: "#60a5fa", fontSize: 13, userSelect: "none" }}>
             📖 GA4での権限付与手順を見る
           </summary>
-          <ol style={{ color: "#9ca3af", fontSize: 13, lineHeight: 2, marginTop: 10, paddingLeft: 20 }}>
+          <ol style={{ color: "var(--muted-foreground)", fontSize: 13, lineHeight: 2, marginTop: 10, paddingLeft: 20 }}>
             <li>GA4管理画面（analytics.google.com）にログイン</li>
             <li>左下の「管理」→「アカウントのアクセス管理」をクリック</li>
             <li>右上の「＋」ボタン →「ユーザーを追加」</li>
@@ -282,32 +282,32 @@ export default function Ga4IntegrationTab({ tenantId }: { tenantId: string }) {
 
       {/* ステップ2: Property ID入力 */}
       <div style={CARD}>
-        <h3 style={{ fontSize: 15, fontWeight: 700, color: "#d1d5db", margin: "0 0 16px" }}>
+        <h3 style={{ fontSize: 15, fontWeight: 700, color: "var(--muted-foreground)", margin: "0 0 16px" }}>
           ステップ 2 — GA4の識別番号を入力する
         </h3>
-        <div style={{ color: "#9ca3af", fontSize: 14, marginBottom: 16 }}>
+        <div style={{ color: "var(--muted-foreground)", fontSize: 14, marginBottom: 16 }}>
           GA4管理画面の「プロパティ詳細」ページに表示されている数字（例: <code style={{ color: "#a5b4fc" }}>123456789</code>）を入力してください。
         </div>
         <div style={{ display: "flex", gap: 12, flexWrap: "wrap", alignItems: "flex-end" }}>
           <div style={{ flex: 1, minWidth: 220 }}>
-            <label style={{ display: "block", fontSize: 13, color: "#9ca3af", marginBottom: 6 }}>GA4識別番号 (数字のみ)</label>
+            <label style={{ display: "block", fontSize: 13, color: "var(--muted-foreground)", marginBottom: 6 }}>GA4識別番号 (数字のみ)</label>
             <input
               type="text"
               inputMode="numeric"
               placeholder="例: 123456789"
               value={propertyId}
               onChange={(e) => setPropertyId(e.target.value.replace(/\D/g, ""))}
-              style={{ width: "100%", padding: "12px 14px", borderRadius: 8, border: "1px solid #374151", background: "#0f172a", color: "#f1f5f9", fontSize: 15, boxSizing: "border-box" }}
+              style={{ width: "100%", padding: "12px 14px", borderRadius: 8, border: "1px solid var(--border)", background: "var(--background)", color: "#f1f5f9", fontSize: 15, boxSizing: "border-box" }}
             />
           </div>
           <div style={{ flex: 1, minWidth: 220 }}>
-            <label style={{ display: "block", fontSize: 13, color: "#9ca3af", marginBottom: 6 }}>連絡先メールアドレス (任意)</label>
+            <label style={{ display: "block", fontSize: 13, color: "var(--muted-foreground)", marginBottom: 6 }}>連絡先メールアドレス (任意)</label>
             <input
               type="email"
               placeholder="例: partner@example.com"
               value={contactEmail}
               onChange={(e) => setContactEmail(e.target.value)}
-              style={{ width: "100%", padding: "12px 14px", borderRadius: 8, border: "1px solid #374151", background: "#0f172a", color: "#f1f5f9", fontSize: 15, boxSizing: "border-box" }}
+              style={{ width: "100%", padding: "12px 14px", borderRadius: 8, border: "1px solid var(--border)", background: "var(--background)", color: "#f1f5f9", fontSize: 15, boxSizing: "border-box" }}
             />
           </div>
         </div>
@@ -325,10 +325,10 @@ export default function Ga4IntegrationTab({ tenantId }: { tenantId: string }) {
       {/* ステップ3: 接続テスト */}
       {hasPropertyId && (
         <div style={CARD}>
-          <h3 style={{ fontSize: 15, fontWeight: 700, color: "#d1d5db", margin: "0 0 16px" }}>
+          <h3 style={{ fontSize: 15, fontWeight: 700, color: "var(--muted-foreground)", margin: "0 0 16px" }}>
             ステップ 3 — 接続テスト
           </h3>
-          <div style={{ color: "#9ca3af", fontSize: 14, marginBottom: 16 }}>
+          <div style={{ color: "var(--muted-foreground)", fontSize: 14, marginBottom: 16 }}>
             識別番号: <code style={{ color: "#a5b4fc", fontSize: 14 }}>{statusData?.ga4_property_id}</code>
           </div>
           <button
@@ -361,20 +361,20 @@ export default function Ga4IntegrationTab({ tenantId }: { tenantId: string }) {
       {isConnected && (
         <div style={CARD}>
           <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", flexWrap: "wrap", gap: 10 }}>
-            <h3 style={{ fontSize: 15, fontWeight: 700, color: "#d1d5db", margin: 0 }}>🔗 連携情報</h3>
+            <h3 style={{ fontSize: 15, fontWeight: 700, color: "var(--muted-foreground)", margin: 0 }}>🔗 連携情報</h3>
             <button style={{ ...BTN_SECONDARY, color: "#f87171", borderColor: "#f8717133" }} onClick={() => setShowDisconnectConfirm(true)}>
               🔌 連携を解除
             </button>
           </div>
           <div style={{ marginTop: 14, display: "grid", gap: 8 }}>
             {statusData?.ga4_connected_at && (
-              <div style={{ fontSize: 13, color: "#9ca3af" }}>
-                ✅ 接続日時: <span style={{ color: "#d1d5db" }}>{new Date(statusData.ga4_connected_at).toLocaleString("ja-JP")}</span>
+              <div style={{ fontSize: 13, color: "var(--muted-foreground)" }}>
+                ✅ 接続日時: <span style={{ color: "var(--muted-foreground)" }}>{new Date(statusData.ga4_connected_at).toLocaleString("ja-JP")}</span>
               </div>
             )}
             {statusData?.ga4_last_sync_at && (
-              <div style={{ fontSize: 13, color: "#9ca3af" }}>
-                🔄 最終同期: <span style={{ color: "#d1d5db" }}>{new Date(statusData.ga4_last_sync_at).toLocaleString("ja-JP")}</span>
+              <div style={{ fontSize: 13, color: "var(--muted-foreground)" }}>
+                🔄 最終同期: <span style={{ color: "var(--muted-foreground)" }}>{new Date(statusData.ga4_last_sync_at).toLocaleString("ja-JP")}</span>
               </div>
             )}
           </div>
@@ -384,7 +384,7 @@ export default function Ga4IntegrationTab({ tenantId }: { tenantId: string }) {
       {/* エラー時のガイド */}
       {(currentStatus === "error" || currentStatus === "timeout" || currentStatus === "permission_revoked") && (
         <div style={CARD}>
-          <h3 style={{ fontSize: 15, fontWeight: 700, color: "#d1d5db", margin: "0 0 4px" }}>⚠️ 接続エラー</h3>
+          <h3 style={{ fontSize: 15, fontWeight: 700, color: "var(--muted-foreground)", margin: "0 0 4px" }}>⚠️ 接続エラー</h3>
           <ErrorGuide status={currentStatus} message={statusData?.ga4_error_message} />
         </div>
       )}
@@ -392,12 +392,12 @@ export default function Ga4IntegrationTab({ tenantId }: { tenantId: string }) {
       {/* テスト履歴 */}
       {(statusData?.recent_tests ?? []).length > 0 && (
         <div style={CARD}>
-          <h3 style={{ fontSize: 14, fontWeight: 600, color: "#9ca3af", margin: "0 0 12px" }}>接続テスト履歴</h3>
+          <h3 style={{ fontSize: 14, fontWeight: 600, color: "var(--muted-foreground)", margin: "0 0 12px" }}>接続テスト履歴</h3>
           <div style={{ display: "grid", gap: 6 }}>
             {statusData!.recent_tests.map((t, i) => (
-              <div key={i} style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "8px 12px", borderRadius: 8, background: "rgba(255,255,255,0.02)", border: "1px solid #1f2937", fontSize: 13 }}>
+              <div key={i} style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "8px 12px", borderRadius: 8, background: "rgba(255,255,255,0.02)", border: "1px solid var(--border)", fontSize: 13 }}>
                 <span style={{ color: t.success ? "#4ade80" : "#f87171" }}>{t.success ? "✅" : "❌"} {t.success ? "成功" : (t.error_message ?? "失敗")}</span>
-                <span style={{ color: "#6b7280" }}>{new Date(t.tested_at).toLocaleString("ja-JP")}</span>
+                <span style={{ color: "var(--muted-foreground)" }}>{new Date(t.tested_at).toLocaleString("ja-JP")}</span>
               </div>
             ))}
           </div>

--- a/admin-ui/src/pages/admin/tenants/NotificationPreferencesTab.tsx
+++ b/admin-ui/src/pages/admin/tenants/NotificationPreferencesTab.tsx
@@ -58,24 +58,24 @@ export default function NotificationPreferencesTab({ tenantId }: { tenantId: str
     }
   };
 
-  if (loading) return <div style={{ color: "#6b7280", textAlign: "center", padding: 32 }}>読み込み中...</div>;
+  if (loading) return <div style={{ color: "var(--muted-foreground)", textAlign: "center", padding: 32 }}>読み込み中...</div>;
 
   return (
     <div style={{ display: "flex", flexDirection: "column", gap: 20 }}>
       {toast && (
-        <div style={{ padding: "12px 16px", borderRadius: 10, background: "rgba(15,23,42,0.98)", border: "1px solid #22c55e", color: "#4ade80", fontSize: 14, fontWeight: 600 }}>
+        <div style={{ padding: "12px 16px", borderRadius: 10, background: "var(--card)", border: "1px solid #22c55e", color: "#4ade80", fontSize: 14, fontWeight: 600 }}>
           {toast}
         </div>
       )}
       <div style={{ ...CARD_STYLE }}>
-        <h3 style={{ fontSize: 15, fontWeight: 700, color: "#d1d5db", margin: "0 0 16px" }}>🔔 通知設定</h3>
+        <h3 style={{ fontSize: 15, fontWeight: 700, color: "var(--muted-foreground)", margin: "0 0 16px" }}>🔔 通知設定</h3>
         <div style={{ display: "grid", gap: 8 }}>
           {DEFAULT_NOTIFICATION_TYPES.map(({ type, label }) => {
             const pref = prefs[type] ?? { notification_type: type, email_enabled: true, in_app_enabled: true, threshold: null };
             const isSavingThis = saving === type;
             return (
-              <div key={type} style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "12px 16px", borderRadius: 10, background: "rgba(255,255,255,0.02)", border: "1px solid #1f2937" }}>
-                <span style={{ fontSize: 14, color: "#d1d5db", fontWeight: 500 }}>{label}</span>
+              <div key={type} style={{ display: "flex", justifyContent: "space-between", alignItems: "center", padding: "12px 16px", borderRadius: 10, background: "rgba(255,255,255,0.02)", border: "1px solid var(--border)" }}>
+                <span style={{ fontSize: 14, color: "var(--muted-foreground)", fontWeight: 500 }}>{label}</span>
                 <div style={{ display: "flex", gap: 12 }}>
                   {(["email_enabled", "in_app_enabled"] as const).map((field) => (
                     <button
@@ -87,7 +87,7 @@ export default function NotificationPreferencesTab({ tenantId }: { tenantId: str
                         padding: "6px 14px",
                         minHeight: 32,
                         borderRadius: 6,
-                        border: pref[field] ? "1px solid #4ade80" : "1px solid #374151",
+                        border: pref[field] ? "1px solid #4ade80" : "1px solid var(--border)",
                         background: pref[field] ? "rgba(34,197,94,0.15)" : "rgba(0,0,0,0.3)",
                         color: pref[field] ? "#4ade80" : "#6b7280",
                         fontSize: 12,

--- a/admin-ui/src/pages/admin/tenants/PostHogIntegrationTab.tsx
+++ b/admin-ui/src/pages/admin/tenants/PostHogIntegrationTab.tsx
@@ -78,14 +78,14 @@ export default function PostHogIntegrationTab({ tenantId }: { tenantId: string }
   };
 
   const cardStyle: React.CSSProperties = {
-    background: "#1e293b", borderRadius: 8, padding: "20px 24px", marginBottom: 16,
+    background: "var(--muted)", borderRadius: 8, padding: "20px 24px", marginBottom: 16,
   };
   const labelStyle: React.CSSProperties = {
     display: "block", color: "#9ca3af", fontSize: 12, marginBottom: 6,
   };
   const inputStyle: React.CSSProperties = {
-    width: "100%", background: "#0f172a", border: "1px solid #334155",
-    borderRadius: 6, color: "#e2e8f0", fontSize: 14, padding: "8px 12px",
+    width: "100%", background: "var(--input)", border: "1px solid var(--border)",
+    borderRadius: 6, color: "var(--foreground)", fontSize: 14, padding: "8px 12px",
   };
   const btnStyle = (color: string): React.CSSProperties => ({
     background: color, color: "#fff", border: "none", borderRadius: 6,
@@ -199,11 +199,11 @@ export default function PostHogIntegrationTab({ tenantId }: { tenantId: string }
           position: "fixed", inset: 0, background: "rgba(0,0,0,0.7)",
           display: "flex", alignItems: "center", justifyContent: "center", zIndex: 9999,
         }}>
-          <div style={{ background: "#1e293b", borderRadius: 8, padding: 24, maxWidth: 400, width: "90%" }}>
-            <div style={{ color: "#e2e8f0", fontSize: 15, fontWeight: 600, marginBottom: 8 }}>
+          <div style={{ background: "var(--card)", borderRadius: 8, padding: 24, maxWidth: 400, width: "90%" }}>
+            <div style={{ color: "var(--foreground)", fontSize: 15, fontWeight: 600, marginBottom: 8 }}>
               PostHog 連携を解除しますか？
             </div>
-            <div style={{ color: "#9ca3af", fontSize: 13, marginBottom: 16 }}>
+            <div style={{ color: "var(--muted-foreground)", fontSize: 13, marginBottom: 16 }}>
               Project API Key が削除されます。ウィジェットからのイベント送信が停止します。
             </div>
             <button style={btnStyle("#dc2626")} onClick={handleDisconnect} disabled={disconnecting}>

--- a/admin-ui/src/pages/admin/tenants/[id].tsx
+++ b/admin-ui/src/pages/admin/tenants/[id].tsx
@@ -161,9 +161,9 @@ const INPUT_STYLE: React.CSSProperties = {
   width: "100%",
   padding: "14px 16px",
   borderRadius: 10,
-  border: "1px solid #374151",
+  border: "1px solid var(--border)",
   background: "rgba(0,0,0,0.3)",
-  color: "#f9fafb",
+  color: "var(--foreground)",
   fontSize: 16,
   outline: "none",
   boxSizing: "border-box",
@@ -173,7 +173,7 @@ const LABEL_STYLE: React.CSSProperties = {
   display: "block",
   fontSize: 13,
   fontWeight: 600,
-  color: "#9ca3af",
+  color: "var(--muted-foreground)",
   marginBottom: 6,
 };
 
@@ -270,10 +270,10 @@ function AvatarTab({
         }}
       >
         <div>
-          <p style={{ margin: "0 0 4px", fontWeight: 600, color: "#e5e7eb", fontSize: 15 }}>
+          <p style={{ margin: "0 0 4px", fontWeight: 600, color: "var(--foreground)", fontSize: 15 }}>
             AIアバターを有効にする
           </p>
-          <p style={{ margin: 0, fontSize: 13, color: "#9ca3af" }}>
+          <p style={{ margin: 0, fontSize: 13, color: "var(--muted-foreground)" }}>
             {avatarEnabled ? "アバター表示が有効（Widget側で表示されます）" : "現在はテキストチャットのみ"}
           </p>
         </div>
@@ -303,10 +303,10 @@ function AvatarTab({
         }}
       >
         <div>
-          <p style={{ margin: "0 0 4px", fontWeight: 600, color: "#e5e7eb", fontSize: 15 }}>
+          <p style={{ margin: "0 0 4px", fontWeight: 600, color: "var(--foreground)", fontSize: 15 }}>
             音声会話を有効にする
           </p>
-          <p style={{ margin: 0, fontSize: 13, color: "#9ca3af" }}>
+          <p style={{ margin: 0, fontSize: 13, color: "var(--muted-foreground)" }}>
             {!avatarEnabled
               ? "AIアバターを有効にすると使用できます"
               : voiceEnabled
@@ -327,7 +327,7 @@ function AvatarTab({
       {/* Lemonslice Agent ID */}
       <div style={CARD_STYLE}>
         <label style={LABEL_STYLE}>Lemonslice Agent ID</label>
-        <p style={{ fontSize: 12, color: "#6b7280", margin: "0 0 8px", lineHeight: 1.5 }}>
+        <p style={{ fontSize: 12, color: "var(--muted-foreground)", margin: "0 0 8px", lineHeight: 1.5 }}>
           Lemonslice管理画面で発行したエージェントIDを入力してください。空欄の場合はアバターが起動しません。
         </p>
         <input
@@ -421,9 +421,9 @@ function BillingSection({
   const dateInputStyle: React.CSSProperties = {
     padding: "10px 14px",
     borderRadius: 8,
-    border: "1px solid #374151",
+    border: "1px solid var(--border)",
     background: "rgba(0,0,0,0.3)",
-    color: "#f9fafb",
+    color: "var(--foreground)",
     fontSize: 15,
     outline: "none",
     minHeight: 44,
@@ -432,14 +432,14 @@ function BillingSection({
   return (
     <div
       style={{
-        border: "1px solid #374151",
+        border: "1px solid var(--border)",
         borderRadius: 12,
         padding: "20px 18px",
         marginTop: 24,
         background: "rgba(0,0,0,0.2)",
       }}
     >
-      <h3 style={{ fontSize: 17, fontWeight: 700, margin: "0 0 16px", color: "#f9fafb" }}>
+      <h3 style={{ fontSize: 17, fontWeight: 700, margin: "0 0 16px", color: "var(--foreground)" }}>
         {t("billing_mgmt.title")}
       </h3>
 
@@ -471,10 +471,10 @@ function BillingSection({
         }}
       >
         <div>
-          <p style={{ margin: "0 0 4px", fontWeight: 600, color: "#e5e7eb", fontSize: 15 }}>
+          <p style={{ margin: "0 0 4px", fontWeight: 600, color: "var(--foreground)", fontSize: 15 }}>
             {t("billing_mgmt.status")}
           </p>
-          <p style={{ margin: 0, fontSize: 13, color: "#9ca3af" }}>
+          <p style={{ margin: 0, fontSize: 13, color: "var(--muted-foreground)" }}>
             {billingEnabled ? t("billing_mgmt.enabled_desc") : t("billing_mgmt.disabled_desc")}
           </p>
         </div>
@@ -499,15 +499,15 @@ function BillingSection({
 
       {/* 無料期間（開始日〜終了日） */}
       <div>
-        <p style={{ margin: "0 0 4px", fontWeight: 600, color: "#e5e7eb", fontSize: 15 }}>
+        <p style={{ margin: "0 0 4px", fontWeight: 600, color: "var(--foreground)", fontSize: 15 }}>
           {t("billing_mgmt.free_period")}
         </p>
-        <p style={{ margin: "0 0 12px", fontSize: 13, color: "#9ca3af" }}>
+        <p style={{ margin: "0 0 12px", fontSize: 13, color: "var(--muted-foreground)" }}>
           {t("billing_mgmt.free_period_desc")}
         </p>
         <div style={{ display: "flex", gap: 10, alignItems: "flex-end", flexWrap: "wrap" }}>
           <div>
-            <p style={{ margin: "0 0 6px", fontSize: 12, color: "#9ca3af", fontWeight: 600 }}>
+            <p style={{ margin: "0 0 6px", fontSize: 12, color: "var(--muted-foreground)", fontWeight: 600 }}>
               {t("billing_mgmt.free_from_label")}
             </p>
             <input
@@ -517,9 +517,9 @@ function BillingSection({
               style={dateInputStyle}
             />
           </div>
-          <span style={{ color: "#6b7280", fontSize: 18, paddingBottom: 10, fontWeight: 700 }}>〜</span>
+          <span style={{ color: "var(--muted-foreground)", fontSize: 18, paddingBottom: 10, fontWeight: 700 }}>〜</span>
           <div>
-            <p style={{ margin: "0 0 6px", fontSize: 12, color: "#9ca3af", fontWeight: 600 }}>
+            <p style={{ margin: "0 0 6px", fontSize: 12, color: "var(--muted-foreground)", fontWeight: 600 }}>
               {t("billing_mgmt.free_until_label")}
             </p>
             <input
@@ -681,7 +681,7 @@ function SettingsTab({
                   padding: "12px 16px",
                   minHeight: 44,
                   borderRadius: 10,
-                  border: status === s ? `1px solid ${s === "active" ? "#4ade80" : "#9ca3af"}` : "1px solid #374151",
+                  border: status === s ? `1px solid ${s === "active" ? "#4ade80" : "#9ca3af"}` : "1px solid var(--border)",
                   background: status === s
                     ? s === "active" ? "rgba(34,197,94,0.15)" : "rgba(107,114,128,0.15)"
                     : "rgba(0,0,0,0.3)",
@@ -701,7 +701,7 @@ function SettingsTab({
 
         <div>
           <label style={LABEL_STYLE}>{t("tenant_detail.allowed_origins_label")}</label>
-          <p style={{ fontSize: 12, color: "#6b7280", margin: "0 0 8px", lineHeight: 1.5 }}>
+          <p style={{ fontSize: 12, color: "var(--muted-foreground)", margin: "0 0 8px", lineHeight: 1.5 }}>
             {t("tenant_detail.allowed_origins_desc")}
           </p>
           <textarea
@@ -733,14 +733,14 @@ function SettingsTab({
               lineHeight: 1.6,
             }}
           />
-          <p style={{ fontSize: 12, color: "#6b7280", margin: "4px 0 0", textAlign: "right" }}>
+          <p style={{ fontSize: 12, color: "var(--muted-foreground)", margin: "4px 0 0", textAlign: "right" }}>
             {systemPrompt.length} / 5000
           </p>
         </div>
 
         <div>
           <label style={LABEL_STYLE}>担当者メールアドレス</label>
-          <p style={{ fontSize: 12, color: "#6b7280", margin: "0 0 8px", lineHeight: 1.5 }}>
+          <p style={{ fontSize: 12, color: "var(--muted-foreground)", margin: "0 0 8px", lineHeight: 1.5 }}>
             GA4エラー通知・請求通知の送信先
           </p>
           <input
@@ -922,8 +922,8 @@ export default function TenantDetailPage() {
     <div
       style={{
         minHeight: "100vh",
-        background: "radial-gradient(circle at top, #0f172a 0, #020617 55%, #000 100%)",
-        color: "#e5e7eb",
+        background: "var(--background)",
+        color: "var(--foreground)",
         padding: "24px 20px",
         maxWidth: 900,
         margin: "0 auto",
@@ -939,7 +939,7 @@ export default function TenantDetailPage() {
             transform: "translateX(-50%)",
             padding: "14px 24px",
             borderRadius: 12,
-            background: "rgba(15,23,42,0.98)",
+            background: "var(--card)",
             border: "1px solid #22c55e",
             color: "#4ade80",
             fontSize: 15,
@@ -962,9 +962,9 @@ export default function TenantDetailPage() {
               padding: "8px 14px",
               minHeight: 44,
               borderRadius: 999,
-              border: "1px solid #374151",
+              border: "1px solid var(--border)",
               background: "transparent",
-              color: "#9ca3af",
+              color: "var(--muted-foreground)",
               fontSize: 14,
               cursor: "pointer",
               fontWeight: 500,
@@ -1000,11 +1000,11 @@ export default function TenantDetailPage() {
             <LangSwitcher />
           </div>
         </div>
-        <h1 style={{ fontSize: 26, fontWeight: 700, margin: "0 0 4px", color: "#f9fafb" }}>
+        <h1 style={{ fontSize: 26, fontWeight: 700, margin: "0 0 4px", color: "var(--foreground)" }}>
           {loading ? t("tenant_detail.loading") : (tenant?.name ?? t("tenant_detail.not_found"))}
         </h1>
         {tenant && tenant.slug && (
-          <p style={{ fontSize: 14, color: "#9ca3af", margin: 0 }}>
+          <p style={{ fontSize: 14, color: "var(--muted-foreground)", margin: 0 }}>
             slug: <span style={{ fontFamily: "monospace" }}>{tenant.slug}</span>
           </p>
         )}
@@ -1017,7 +1017,7 @@ export default function TenantDetailPage() {
             alignItems: "center",
             justifyContent: "center",
             minHeight: 120,
-            color: "#9ca3af",
+            color: "var(--muted-foreground)",
             fontSize: 15,
           }}
         >
@@ -1031,8 +1031,8 @@ export default function TenantDetailPage() {
             style={{
               overflowX: "auto",
               marginBottom: 24,
-              background: "rgba(15,23,42,0.8)",
-              border: "1px solid #1f2937",
+              background: "var(--card)",
+              border: "1px solid var(--border)",
               borderRadius: 12,
               padding: 4,
               WebkitOverflowScrolling: "touch" as const,
@@ -1133,7 +1133,7 @@ export default function TenantDetailPage() {
           style={{
             padding: "32px 20px",
             borderRadius: 14,
-            border: "1px solid #1f2937",
+            border: "1px solid var(--border)",
             background: "rgba(127,29,29,0.2)",
             color: "#fca5a5",
             textAlign: "center",

--- a/admin-ui/src/pages/admin/tenants/index.tsx
+++ b/admin-ui/src/pages/admin/tenants/index.tsx
@@ -66,8 +66,8 @@ async function createTenant(data: { name: string; slug: string }): Promise<Tenan
 
 const CARD_STYLE: React.CSSProperties = {
   borderRadius: 14,
-  border: "1px solid #1f2937",
-  background: "linear-gradient(145deg, rgba(15,23,42,0.95), rgba(15,23,42,0.7))",
+  border: "1px solid var(--border)",
+  background: "linear-gradient(145deg, var(--card), var(--card))",
   padding: "20px 18px",
 };
 
@@ -111,9 +111,9 @@ function CreateTenantModal({ onClose, onSuccess }: CreateModalProps) {
     width: "100%",
     padding: "14px 16px",
     borderRadius: 10,
-    border: "1px solid #374151",
+    border: "1px solid var(--border)",
     background: "rgba(0,0,0,0.3)",
-    color: "#f9fafb",
+    color: "var(--foreground)",
     fontSize: 16,
     outline: "none",
     boxSizing: "border-box",
@@ -123,7 +123,7 @@ function CreateTenantModal({ onClose, onSuccess }: CreateModalProps) {
     display: "block",
     fontSize: 13,
     fontWeight: 600,
-    color: "#9ca3af",
+    color: "var(--muted-foreground)",
     marginBottom: 6,
   };
 
@@ -143,15 +143,15 @@ function CreateTenantModal({ onClose, onSuccess }: CreateModalProps) {
     >
       <div
         style={{
-          background: "#0f172a",
-          border: "1px solid #1f2937",
+          background: "var(--background)",
+          border: "1px solid var(--border)",
           borderRadius: 16,
           padding: "28px 24px",
           maxWidth: 480,
           width: "100%",
         }}
       >
-        <h2 style={{ fontSize: 20, fontWeight: 700, color: "#f9fafb", margin: "0 0 24px" }}>
+        <h2 style={{ fontSize: 20, fontWeight: 700, color: "var(--foreground)", margin: "0 0 24px" }}>
           {t("tenants.modal_title")}
         </h2>
 
@@ -233,9 +233,9 @@ function CreateTenantModal({ onClose, onSuccess }: CreateModalProps) {
                 padding: "14px 24px",
                 minHeight: 48,
                 borderRadius: 12,
-                border: "1px solid #374151",
+                border: "1px solid var(--border)",
                 background: "transparent",
-                color: "#9ca3af",
+                color: "var(--muted-foreground)",
                 fontSize: 15,
                 fontWeight: 600,
                 cursor: "pointer",
@@ -339,8 +339,8 @@ export default function TenantsPage() {
     <div
       style={{
         minHeight: "100vh",
-        background: "radial-gradient(circle at top, #0f172a 0, #020617 55%, #000 100%)",
-        color: "#e5e7eb",
+        background: "var(--background)",
+        color: "var(--foreground)",
         padding: "24px 20px",
         maxWidth: 900,
         margin: "0 auto",
@@ -356,7 +356,7 @@ export default function TenantsPage() {
             transform: "translateX(-50%)",
             padding: "14px 24px",
             borderRadius: 12,
-            background: "rgba(15,23,42,0.98)",
+            background: "var(--card)",
             border: "1px solid #22c55e",
             color: "#4ade80",
             fontSize: 15,
@@ -379,9 +379,9 @@ export default function TenantsPage() {
               padding: "8px 14px",
               minHeight: 44,
               borderRadius: 999,
-              border: "1px solid #374151",
+              border: "1px solid var(--border)",
               background: "transparent",
-              color: "#9ca3af",
+              color: "var(--muted-foreground)",
               fontSize: 14,
               cursor: "pointer",
               fontWeight: 500,
@@ -394,10 +394,10 @@ export default function TenantsPage() {
           </button>
           <LangSwitcher />
         </div>
-        <h1 style={{ fontSize: 26, fontWeight: 700, margin: "0 0 4px", color: "#f9fafb" }}>
+        <h1 style={{ fontSize: 26, fontWeight: 700, margin: "0 0 4px", color: "var(--foreground)" }}>
           {t("tenants.title")}
         </h1>
-        <p style={{ fontSize: 14, color: "#9ca3af", margin: 0 }}>
+        <p style={{ fontSize: 14, color: "var(--muted-foreground)", margin: 0 }}>
           {t("tenants.subtitle")}
         </p>
       </header>
@@ -412,9 +412,9 @@ export default function TenantsPage() {
           width: "100%",
           padding: "12px 16px",
           borderRadius: 10,
-          border: "1px solid #374151",
-          background: "rgba(15,23,42,0.8)",
-          color: "#e5e7eb",
+          border: "1px solid var(--border)",
+          background: "var(--card)",
+          color: "var(--foreground)",
           fontSize: 14,
           outline: "none",
           boxSizing: "border-box",
@@ -459,8 +459,8 @@ export default function TenantsPage() {
               onClick={() => setStatusFilter(val)}
               style={{
                 padding: "7px 14px", minHeight: 36, borderRadius: 10, cursor: "pointer",
-                border: active ? "1px solid rgba(96,165,250,0.5)" : "1px solid #374151",
-                background: active ? "rgba(96,165,250,0.1)" : "rgba(15,23,42,0.8)",
+                border: active ? "1px solid rgba(96,165,250,0.5)" : "1px solid var(--border)",
+                background: active ? "rgba(96,165,250,0.1)" : "var(--card)",
                 color: active ? "#60a5fa" : "#9ca3af",
                 fontSize: 13, fontWeight: active ? 700 : 400, whiteSpace: "nowrap",
               }}
@@ -470,13 +470,13 @@ export default function TenantsPage() {
           );
         })}
         <div style={{ display: "flex", gap: 8, alignItems: "center", marginLeft: 8 }}>
-          <span style={{ fontSize: 12, color: "#6b7280" }}>並び替え:</span>
+          <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>並び替え:</span>
           <SortableHeader label="名前" sortKey="name" currentSortBy={sortBy} currentSortOrder={sortOrder} onSort={handleSort} />
           <SortableHeader label="作成日" sortKey="createdAt" currentSortBy={sortBy} currentSortOrder={sortOrder} onSort={handleSort} />
         </div>
-        <span style={{ marginLeft: "auto", fontSize: 13, color: "#6b7280", whiteSpace: "nowrap" }}>
+        <span style={{ marginLeft: "auto", fontSize: 13, color: "var(--muted-foreground)", whiteSpace: "nowrap" }}>
           全{tenants.length}件中{" "}
-          <span style={{ color: "#d1d5db", fontWeight: 700 }}>{filteredTenants.length}</span>件表示
+          <span style={{ color: "var(--muted-foreground)", fontWeight: 700 }}>{filteredTenants.length}</span>件表示
         </span>
       </div>
 
@@ -505,7 +505,7 @@ export default function TenantsPage() {
             alignItems: "center",
             justifyContent: "center",
             minHeight: 120,
-            color: "#9ca3af",
+            color: "var(--muted-foreground)",
             fontSize: 15,
           }}
         >
@@ -519,7 +519,7 @@ export default function TenantsPage() {
               style={{
                 ...CARD_STYLE,
                 textAlign: "center",
-                color: "#6b7280",
+                color: "var(--muted-foreground)",
                 fontSize: 15,
                 padding: "40px 20px",
               }}
@@ -541,7 +541,7 @@ export default function TenantsPage() {
                 {/* テナント情報 */}
                 <div style={{ flex: "1 1 200px", minWidth: 0 }}>
                   <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 4 }}>
-                    <span style={{ fontSize: 16, fontWeight: 700, color: "#f9fafb" }}>
+                    <span style={{ fontSize: 16, fontWeight: 700, color: "var(--foreground)" }}>
                       {tenant.name}
                     </span>
                     {/* 状態バッジ */}
@@ -579,14 +579,14 @@ export default function TenantsPage() {
                         );
                       }
                       return (
-                        <span style={{ padding: "2px 8px", borderRadius: 999, fontSize: 11, fontWeight: 700, background: "rgba(107,114,128,0.15)", color: "#6b7280", border: "1px solid rgba(107,114,128,0.3)" }}>
+                        <span style={{ padding: "2px 8px", borderRadius: 999, fontSize: 11, fontWeight: 700, background: "rgba(107,114,128,0.15)", color: "var(--muted-foreground)", border: "1px solid rgba(107,114,128,0.3)" }}>
                           {t("tenants.billing_inactive")}
                         </span>
                       );
                     })()}
                   </div>
-                  <div style={{ fontSize: 13, color: "#6b7280" }}>
-                    slug: <span style={{ fontFamily: "monospace", color: "#9ca3af" }}>{tenant.slug}</span>
+                  <div style={{ fontSize: 13, color: "var(--muted-foreground)" }}>
+                    slug: <span style={{ fontFamily: "monospace", color: "var(--muted-foreground)" }}>{tenant.slug}</span>
                   </div>
                 </div>
 
@@ -597,14 +597,14 @@ export default function TenantsPage() {
                     gap: 20,
                     flexWrap: "wrap",
                     fontSize: 13,
-                    color: "#9ca3af",
+                    color: "var(--muted-foreground)",
                   }}
                 >
                   <div>
-                    <span style={{ color: "#6b7280" }}>{t("tenants.api_keys", { n: tenant.apiKeyCount ?? 0 })}</span>
+                    <span style={{ color: "var(--muted-foreground)" }}>{t("tenants.api_keys", { n: tenant.apiKeyCount ?? 0 })}</span>
                   </div>
                   <div>
-                    <span style={{ color: "#6b7280" }}>
+                    <span style={{ color: "var(--muted-foreground)" }}>
                       {(() => {
                         const d = tenant.createdAt ? new Date(tenant.createdAt) : null;
                         const dateStr = d && !isNaN(d.getTime())
@@ -623,9 +623,9 @@ export default function TenantsPage() {
                     padding: "10px 18px",
                     minHeight: 44,
                     borderRadius: 10,
-                    border: "1px solid #374151",
+                    border: "1px solid var(--border)",
                     background: "rgba(0,0,0,0.3)",
-                    color: "#d1d5db",
+                    color: "var(--muted-foreground)",
                     fontSize: 14,
                     fontWeight: 600,
                     cursor: "pointer",

--- a/admin-ui/src/pages/admin/tenants/types.ts
+++ b/admin-ui/src/pages/admin/tenants/types.ts
@@ -43,7 +43,7 @@ export interface ApiKey {
 
 export const CARD_STYLE: CSSProperties = {
   borderRadius: 14,
-  border: "1px solid #1f2937",
-  background: "linear-gradient(145deg, rgba(15,23,42,0.95), rgba(15,23,42,0.7))",
+  border: "1px solid var(--border)",
+  background: "var(--card)",
   padding: "20px 18px",
 };

--- a/admin-ui/src/pages/admin/tuning/index.tsx
+++ b/admin-ui/src/pages/admin/tuning/index.tsx
@@ -228,8 +228,8 @@ export default function TuningRulesPage() {
       style={{
         minHeight: "100vh",
         background:
-          "radial-gradient(circle at top, #0f172a 0, #020617 55%, #000 100%)",
-        color: "#e5e7eb",
+          "var(--background)",
+        color: "var(--foreground)",
         padding: "24px 20px",
         maxWidth: 900,
         margin: "0 auto",
@@ -252,7 +252,7 @@ export default function TuningRulesPage() {
             style={{
               background: "none",
               border: "none",
-              color: "#9ca3af",
+              color: "var(--muted-foreground)",
               fontSize: 14,
               cursor: "pointer",
               padding: 0,
@@ -263,14 +263,14 @@ export default function TuningRulesPage() {
             {t("tuning.back")}
           </button>
           <h1
-            style={{ fontSize: 26, fontWeight: 700, margin: 0, color: "#f9fafb" }}
+            style={{ fontSize: 26, fontWeight: 700, margin: 0, color: "var(--foreground)" }}
           >
             {t("tuning.title")}
           </h1>
           <p
             style={{
               fontSize: 14,
-              color: "#9ca3af",
+              color: "var(--muted-foreground)",
               marginTop: 4,
               marginBottom: 0,
             }}
@@ -334,7 +334,7 @@ export default function TuningRulesPage() {
           style={{
             fontSize: 15,
             fontWeight: 600,
-            color: "#9ca3af",
+            color: "var(--muted-foreground)",
             marginBottom: 12,
           }}
         >
@@ -345,7 +345,7 @@ export default function TuningRulesPage() {
       {/* List */}
       {loading ? (
         <div
-          style={{ padding: 40, textAlign: "center", color: "#6b7280" }}
+          style={{ padding: 40, textAlign: "center", color: "var(--muted-foreground)" }}
         >
           <span style={{ display: "block", fontSize: 32, marginBottom: 8 }}>
             ⏳
@@ -359,7 +359,7 @@ export default function TuningRulesPage() {
             textAlign: "center",
             borderRadius: 14,
             border: "1px dashed #374151",
-            background: "rgba(15,23,42,0.4)",
+            background: "var(--card)",
           }}
         >
           <span
@@ -371,7 +371,7 @@ export default function TuningRulesPage() {
             style={{
               fontSize: 16,
               fontWeight: 600,
-              color: "#d1d5db",
+              color: "var(--muted-foreground)",
               margin: 0,
             }}
           >
@@ -380,7 +380,7 @@ export default function TuningRulesPage() {
           <p
             style={{
               fontSize: 13,
-              color: "#6b7280",
+              color: "var(--muted-foreground)",
               marginTop: 6,
               marginBottom: 0,
             }}
@@ -397,8 +397,8 @@ export default function TuningRulesPage() {
                 borderRadius: 14,
                 border: `1px solid ${rule.is_active ? "#1f2937" : "#374151"}`,
                 background: rule.is_active
-                  ? "linear-gradient(145deg, rgba(15,23,42,0.95), rgba(15,23,42,0.7))"
-                  : "rgba(15,23,42,0.4)",
+                  ? "linear-gradient(145deg, var(--card), var(--card))"
+                  : "var(--card)",
                 padding: "18px 20px",
                 boxShadow: "0 4px 16px rgba(0,0,0,0.2)",
                 opacity: rule.is_active ? 1 : 0.65,
@@ -433,7 +433,7 @@ export default function TuningRulesPage() {
                 </span>
 
                 <span
-                  style={{ fontSize: 11, color: "#6b7280", marginLeft: "auto" }}
+                  style={{ fontSize: 11, color: "var(--muted-foreground)", marginLeft: "auto" }}
                 >
                   {formatDate(rule.created_at)}
                 </span>
@@ -468,7 +468,7 @@ export default function TuningRulesPage() {
                   style={{
                     fontSize: 12,
                     fontWeight: 600,
-                    color: "#9ca3af",
+                    color: "var(--muted-foreground)",
                     display: "block",
                     marginBottom: 4,
                   }}
@@ -497,7 +497,7 @@ export default function TuningRulesPage() {
                   <span
                     style={{
                       fontSize: 13,
-                      color: "#6b7280",
+                      color: "var(--muted-foreground)",
                       fontStyle: "italic",
                     }}
                   >
@@ -512,7 +512,7 @@ export default function TuningRulesPage() {
                   style={{
                     fontSize: 12,
                     fontWeight: 600,
-                    color: "#9ca3af",
+                    color: "var(--muted-foreground)",
                     display: "block",
                     marginBottom: 4,
                   }}
@@ -522,7 +522,7 @@ export default function TuningRulesPage() {
                 <p
                   style={{
                     fontSize: 14,
-                    color: "#e5e7eb",
+                    color: "var(--foreground)",
                     margin: 0,
                     lineHeight: 1.6,
                   }}
@@ -632,8 +632,8 @@ export default function TuningRulesPage() {
         >
           <div
             style={{
-              background: "#0f172a",
-              border: "1px solid #1f2937",
+              background: "var(--background)",
+              border: "1px solid var(--border)",
               borderRadius: 16,
               padding: "28px 24px",
               maxWidth: 420,
@@ -645,7 +645,7 @@ export default function TuningRulesPage() {
               style={{
                 fontSize: 18,
                 fontWeight: 700,
-                color: "#f9fafb",
+                color: "var(--foreground)",
                 margin: "0 0 12px",
               }}
             >
@@ -654,7 +654,7 @@ export default function TuningRulesPage() {
             <p
               style={{
                 fontSize: 14,
-                color: "#d1d5db",
+                color: "var(--muted-foreground)",
                 margin: "0 0 6px",
               }}
             >
@@ -663,7 +663,7 @@ export default function TuningRulesPage() {
             <p
               style={{
                 fontSize: 13,
-                color: "#9ca3af",
+                color: "var(--muted-foreground)",
                 margin: "0 0 20px",
                 lineHeight: 1.6,
               }}
@@ -693,9 +693,9 @@ export default function TuningRulesPage() {
                   padding: "14px",
                   minHeight: 56,
                   borderRadius: 10,
-                  border: "1px solid #374151",
+                  border: "1px solid var(--border)",
                   background: "transparent",
-                  color: "#e5e7eb",
+                  color: "var(--foreground)",
                   fontSize: 15,
                   fontWeight: 600,
                   cursor: "pointer",


### PR DESCRIPTION
## Summary
- Add `--card` and `--card-foreground` tokens to `:root` (light) and `[data-theme="dark"]` in `index.css`
- Replace ~180 hardcoded dark hex values (`#0f172a`, `#1e293b`, `#020617`, `#111827`, `rgba(15,23,42,...)`) across 30 admin sub-pages with CSS custom properties (`--background`, `--card`, `--muted`, `--input`, `--border`, `--foreground`, `--muted-foreground`)

## Problem
Sub-pages appeared permanently dark in light mode because hardcoded colors ignored the CSS variable theming system.

## Test plan
- [ ] Open `admin.r2c.biz` after merge — all sub-pages should render with light background in ☀️ mode
- [ ] Toggle dark mode — pages should switch correctly
- [ ] Check analytics, avatar, billing, chat-history, knowledge, monitoring, tenants sub-pages
- [ ] DevTools: `getComputedStyle(document.documentElement).getPropertyValue("--card")` should return non-empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)