### PR TITLE
perf(avatar): アバター一覧の高速化 — リストAPIをスリム化 + /configs/:id 追加

### DIFF
--- a/admin-ui/src/pages/admin/avatar/index.tsx
+++ b/admin-ui/src/pages/admin/avatar/index.tsx
@@ -13,12 +13,6 @@ interface AvatarConfig {
   tenant_name?: string;
   name: string;
   image_url: string | null;
-  image_prompt: string | null;
-  voice_id: string | null;
-  voice_description: string | null;
-  personality_prompt: string | null;
-  behavior_description: string | null;
-  emotion_tags: string[];
   lemonslice_agent_id: string | null;
   is_active: boolean;
   is_default: boolean;
@@ -748,6 +742,7 @@ export default function AvatarListPage() {
                   <img
                     src={cfg.image_url}
                     alt={cfg.name}
+                    loading="lazy"
                     onError={(e) => {
                       (e.currentTarget as HTMLImageElement).style.display = "none";
                     }}

--- a/admin-ui/src/pages/admin/avatar/studio.tsx
+++ b/admin-ui/src/pages/admin/avatar/studio.tsx
@@ -164,10 +164,9 @@ export default function AvatarStudioPage() {
     if (!id) return;
     setLoadingEdit(true);
     try {
-      const res = await authFetch(`${API_BASE}/v1/admin/avatar/configs`);
+      const res = await authFetch(`${API_BASE}/v1/admin/avatar/configs/${id}`);
       if (!res.ok) return;
-      const data = await res.json() as { configs: AvatarConfig[] };
-      const found = data.configs.find((c) => c.id === id);
+      const found = await res.json() as AvatarConfig;
       if (found) {
         setName(found.name);
         setLemonsliceAgentId(found.lemonslice_agent_id ?? "");

--- a/src/api/admin/avatar/routes.ts
+++ b/src/api/admin/avatar/routes.ts
@@ -269,7 +269,9 @@ export function registerAvatarConfigRoutes(app: Express, db: any): void {
     }
     try {
       const result = await db.query(
-        `SELECT ac.*, COALESCE(t.name, ac.tenant_id) AS tenant_name
+        `SELECT ac.id, ac.tenant_id, ac.name, ac.image_url, ac.is_active, ac.is_default,
+                ac.created_at, ac.avatar_provider, ac.lemonslice_agent_id,
+                COALESCE(t.name, ac.tenant_id) AS tenant_name
          FROM avatar_configs ac
          LEFT JOIN tenants t ON t.id = ac.tenant_id
          ORDER BY t.name ASC, ac.created_at DESC`
@@ -277,6 +279,32 @@ export function registerAvatarConfigRoutes(app: Express, db: any): void {
       return res.json({ configs: result.rows, total: result.rows.length });
     } catch (err) {
       logger.warn("[GET /v1/admin/avatar/configs/all]", err);
+      return res.status(500).json({ error: "アバター設定の取得に失敗しました" });
+    }
+  });
+
+  // -----------------------------------------------------------------------
+  // GET /v1/admin/avatar/configs/:id — 単体フル取得 (edit用)
+  // -----------------------------------------------------------------------
+  app.get("/v1/admin/avatar/configs/:id", async (req: Request, res: Response) => {
+    const { su, role, tenantId, isSuperAdmin } = extractAuth(req);
+    if (!isAllowedAvatarRole(role)) {
+      return denyAvatarRole(req, res, su, role);
+    }
+    const { id } = req.params;
+    try {
+      const result = isSuperAdmin
+        ? await db.query("SELECT * FROM avatar_configs WHERE id = $1", [id])
+        : await db.query(
+            "SELECT * FROM avatar_configs WHERE id = $1 AND (tenant_id = $2 OR tenant_id = 'r2c_default')",
+            [id, tenantId]
+          );
+      if (result.rows.length === 0) {
+        return res.status(404).json({ error: "設定が見つかりません" });
+      }
+      return res.json(result.rows[0]);
+    } catch (err) {
+      logger.warn("[GET /v1/admin/avatar/configs/:id]", err);
       return res.status(500).json({ error: "アバター設定の取得に失敗しました" });
     }
   });
@@ -303,16 +331,17 @@ export function registerAvatarConfigRoutes(app: Express, db: any): void {
 
     try {
       let result;
+      const listCols = "id, tenant_id, name, image_url, is_active, is_default, created_at, avatar_provider, lemonslice_agent_id";
       if (filterTenantId) {
         result = await db.query(
-          `SELECT * FROM avatar_configs
+          `SELECT ${listCols} FROM avatar_configs
            WHERE (tenant_id = $1 OR tenant_id = 'r2c_default')
            ORDER BY is_default ASC, created_at DESC`,
           [filterTenantId]
         );
       } else {
         result = await db.query(
-          "SELECT * FROM avatar_configs ORDER BY created_at DESC"
+          `SELECT ${listCols} FROM avatar_configs ORDER BY created_at DESC`
         );
       }
       return res.json({ configs: result.rows, total: result.rows.length });


### PR DESCRIPTION
## 問題
アバター設定画面の一覧表示に 30秒以上かかっていた。

**原因**: `GET /configs` / `GET /configs/all` が `SELECT *` で全カラムを返しており、
`personality_prompt`・`behavior_description`・`agent_prompt`・`agent_idle_prompt` 等の大テキストフィールドを含んでいた。
テナント数 × 18 デフォルトテンプレートで数百 KB のレスポンスになっていた。

## 変更内容
- **リストエンドポイントをスリム化**: 一覧表示に必要な列のみ SELECT (`id`, `tenant_id`, `name`, `image_url`, `is_active`, `is_default`, `created_at`, `avatar_provider`, `lemonslice_agent_id`)
- **`GET /v1/admin/avatar/configs/:id` 追加**: 編集画面用の単体フル取得エンドポイント
- **`studio.tsx` 修正**: 全件取得→フィルタ から 1件取得 `/configs/:id` に変更
- **`loading="lazy"` 追加**: アバターサムネイルの遅延読み込み
- **`AvatarConfig` インターフェース**: 一覧で使わないフィールドを削除

## テスト
- [ ] アバター一覧が 2〜3秒以内に表示されることを確認
- [ ] アバター編集（studio）が正常に動作することを確認（全フィールドが読み込まれる）
- [ ] Gate 1 / Gate 3 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)