### PR TITLE
perf(avatar): アバター起動を高速化 — dispatch fire-and-forget + LiveKit SDK 先読み込み

### DIFF
--- a/public/widget.js
+++ b/public/widget.js
@@ -1103,6 +1103,13 @@
     if (avatarConfigFetched || !apiKey) return;
     avatarConfigFetched = true;
 
+    // LiveKit SDK を API 応答待ちと並行して先読み込み（CDN ロードを API 待ちに重ねる）
+    if (!window.LivekitClient && !document.querySelector('script[src="' + LIVEKIT_SDK_URL + '"]')) {
+      var _preloadScript = document.createElement('script');
+      _preloadScript.src = LIVEKIT_SDK_URL;
+      document.head.appendChild(_preloadScript);
+    }
+
     // まず Anam セッションを試みる
     fetch(apiBase + '/api/avatar/anam-session', {
       method: 'POST',
@@ -1499,8 +1506,12 @@
       return;
     }
 
-    // スクリプトタグが既に DOM にある（ロード中）なら追加しない
-    if (document.querySelector('script[src="' + LIVEKIT_SDK_URL + '"]')) {
+    // スクリプトタグが既に DOM にある（先読み込み or ロード中）
+    var existingScript = document.querySelector('script[src="' + LIVEKIT_SDK_URL + '"]');
+    if (existingScript) {
+      // 先読み込みスクリプトが load 済みかもしれない — イベント登録後に再チェック（race 対策）
+      existingScript.addEventListener('load', function () { connectLiveKit(); });
+      if (window.LivekitClient) { connectLiveKit(); }
       return;
     }
 

--- a/src/api/avatar/livekitTokenRoutes.ts
+++ b/src/api/avatar/livekitTokenRoutes.ts
@@ -195,12 +195,12 @@ export function registerLiveKitTokenRoutes(
         }
       }
 
-      // Room 作成 + Agent Dispatch（SDK 経由 — await して結果をログ、失敗してもトークンは返す）
-      try {
-        await dispatchAgentToRoom(livekitUrl, apiKey, apiSecret, roomName, verifiedAvatarConfigId ?? undefined);
-      } catch (err) {
-        logger.error("[livekitTokenRoutes] dispatchAgentToRoom error:", err);
-      }
+      // Room 作成 + Agent Dispatch — fire-and-forget（await しない）
+      // クライアントへのトークン返却を先に行い、LiveKit Cloud API 待ちを排除する。
+      // LiveKit SDK CDN ロード（~500ms-2s）の間に dispatch が完了するため、
+      // agent は room.connect() 前後に到達する。
+      dispatchAgentToRoom(livekitUrl, apiKey, apiSecret, roomName, verifiedAvatarConfigId ?? undefined)
+        .catch(err => logger.error("[livekitTokenRoutes] dispatchAgentToRoom error:", err));
 
       return res.json({
         enabled: true,


### PR DESCRIPTION
## Summary

- **`livekitTokenRoutes.ts`**: `dispatchAgentToRoom()` を fire-and-forget に変更。LiveKit Cloud API（room 作成 + agent dispatch）の完了を待たずにトークンを即返却。CDN SDK ロード中にバックグラウンドで dispatch が完了するため、WebRTC 接続時には agent が到達済みになる。
- **`widget.js`**: `fetchAvatarConfig()` 冒頭で LiveKit SDK CDN を先読み込み開始。anam-session / room-token の API 待ち時間と CDN ロードが並列化される。
- `initLiveKitAvatar()` の先読み済みスクリプト処理を修正：ロード中スクリプトへ `addEventListener('load')` を追加 + race condition guard。

**効果（推定）**
| 前 | 後 |
|---|---|
| anam-session (~100ms) → room-token (100ms + LiveKit Cloud dispatch ~2-5s) → SDK CDN load (~1s) → connect | anam-session / room-token は SDK と並行。room-token は即返却。dispatch はバックグラウンド |
| 合計 4-7 秒 | 合計 1-2 秒 |

## Test plan

- [ ] テストチャットでアバターを切り替え → 右下アバターが表示されるまでの時間が短縮されることを確認
- [ ] クライアントサイト埋め込みウィジェットで同様に確認
- [ ] アバター映像が正常に表示されること（agent が disconnect されていないこと）
- [ ] `pnpm verify` 通過確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)