### PR TITLE
feat(admin-ui): 経営パートナー向けに管理画面の用語を分かりやすくリネーム

### DIFF
--- a/admin-ui/src/components/AppSidebar.tsx
+++ b/admin-ui/src/components/AppSidebar.tsx
@@ -50,22 +50,22 @@ const MAIN_SECTIONS: NavSection[] = [
     title: "会話・ナレッジ",
     items: [
       { label: "会話履歴", path: "/admin/chat-history", icon: MessageSquare },
-      { label: "ナレッジ管理", path: "/admin/knowledge", icon: BookOpen },
+      { label: "AIの知識データ", path: "/admin/knowledge", icon: BookOpen },
     ],
   },
   {
     title: "分析・成果",
     items: [
       { label: "会話分析", path: "/admin/analytics", icon: BarChart2 },
-      { label: "コンバージョン", path: "/admin/conversion", icon: TrendingUp },
-      { label: "声がけ設定", path: "/admin/engagement", icon: Zap },
+      { label: "成約・効果分析", path: "/admin/conversion", icon: TrendingUp },
+      { label: "自動メッセージ設定", path: "/admin/engagement", icon: Zap },
     ],
   },
   {
     title: "設定",
     items: [
       { label: "アバター設定", path: "/admin/avatar", icon: Palette },
-      { label: "チューニングルール", path: "/admin/tuning", icon: SlidersHorizontal },
+      { label: "AIへの指示ルール", path: "/admin/tuning", icon: SlidersHorizontal },
       { label: "テストチャット", path: "/admin/chat-test", icon: FlaskConical },
     ],
   },
@@ -483,7 +483,7 @@ export function MobileHeader() {
 const BOTTOM_NAV: { path: string; icon: React.ElementType; label: string; end?: boolean }[] = [
   { path: "/admin", icon: LayoutDashboard, label: "ホーム", end: true },
   { path: "/admin/chat-history", icon: MessageSquare, label: "会話" },
-  { path: "/admin/knowledge", icon: BookOpen, label: "知識" },
+  { path: "/admin/knowledge", icon: BookOpen, label: "知識データ" },
   { path: "/admin/analytics", icon: BarChart2, label: "分析" },
   { path: "/admin/tuning", icon: SlidersHorizontal, label: "設定" },
 ];

--- a/admin-ui/src/i18n/ja.ts
+++ b/admin-ui/src/i18n/ja.ts
@@ -12,7 +12,7 @@ const ja = {
 
   // Nav
   "nav.dashboard": "管理ダッシュボード",
-  "nav.knowledge": "ナレッジ管理",
+  "nav.knowledge": "AIの知識データ",
   "nav.tenants": "テナント管理",
   "nav.billing": "請求・使用量",
 
@@ -44,7 +44,7 @@ const ja = {
   "dashboard.error": "少し問題が起きました。もう一度試してみてください 🙏",
 
   // Knowledge page
-  "knowledge.title": "ナレッジ管理",
+  "knowledge.title": "AIの知識データ",
   "knowledge.subtitle": "在庫・キャンペーン・クーポン情報を登録してAIに覚えさせましょう",
   "knowledge.add_faq": "新しいFAQを追加する",
   "knowledge.category_filter": "カテゴリ絞り込み:",
@@ -266,12 +266,12 @@ const ja = {
   "preview.enter": "🔍 クライアントビューで見る",
 
   // Knowledge global
-  "knowledge.global_label": "グローバルナレッジとして登録（全テナント共通）",
+  "knowledge.global_label": "全店舗共通の知識データとして登録（全テナント共通）",
   "tenants.load_error": "テナント一覧の読み込みに失敗しました",
 
   // Knowledge tenant selector
   "knowledge.select_tenant": "管理するテナントを選択してください",
-  "knowledge.global": "📚 グローバルナレッジ（全テナント共通）",
+  "knowledge.global": "📚 全店舗共通の知識データ（グローバル）",
   "knowledge.global_desc": "パートナーの書籍・資料はこちらから登録します",
   "knowledge.tenant_faqs": "{count}件のFAQ",
   "knowledge.search_tenant": "テナント名で検索...",
@@ -370,7 +370,7 @@ const ja = {
 
   // Tuning rules
   "tuning.back": "← ダッシュボードに戻る",
-  "tuning.title": "AIチューニングルール",
+  "tuning.title": "AIへの指示ルール",
   "tuning.subtitle": "AIの回答スタイルや禁止事項をルールで細かく制御できます",
   "tuning.add_rule": "新しいルールを追加する",
   "tuning.load_error": "ルールの読み込みに失敗しました。もう一度お試しください 🙏",
@@ -472,15 +472,15 @@ const ja = {
   "engagement.back": "← 声がけ設定に戻る",
 
   // Conversion (Phase58)
-  "conversion.title": "コンバージョン分析",
+  "conversion.title": "成約・効果分析",
   "conversion.summary": "成果のまとめ",
-  "conversion.effectiveness": "効果が高い心理アプローチ",
+  "conversion.effectiveness": "効果が高い接客アプローチ",
   "conversion.ab_tests": "A/Bテスト",
   "conversion.suggestions": "AIからの改善提案",
   "conversion.apply": "この提案を適用する",
-  "conversion.total": "合計CV数",
-  "conversion.avg_temp": "平均温度感スコア",
-  "conversion.top_principle": "トップ心理原則",
+  "conversion.total": "合計成約数",
+  "conversion.avg_temp": "平均購買意欲スコア",
+  "conversion.top_principle": "トップ接客アプローチ",
   "conversion.no_data": "まだデータがありません",
   "conversion.no_suggestions": "現在、改善提案はありません",
   "conversion.back": "← コンバージョン分析に戻る",

--- a/admin-ui/src/pages/admin/analytics/index.tsx
+++ b/admin-ui/src/pages/admin/analytics/index.tsx
@@ -298,7 +298,7 @@ export default function AnalyticsDashboardPage() {
 
   const radarData = evaluations
     ? {
-        labels: ["心理学適合", "顧客反応", "ステージ進行", "タブー違反"],
+        labels: ["接客スタイルの適合度", "お客様の反応", "会話の進み具合", "禁止事項の遵守率"],
         datasets: [
           {
             label: "平均スコア",
@@ -408,10 +408,10 @@ export default function AnalyticsDashboardPage() {
   const stageDropoutBarData = conversion
     ? {
         labels: ["clarify", "answer", "confirm", "terminal"].map((s) => ({
-          clarify: "クラリファイ",
-          answer: "アンサー",
-          confirm: "コンファーム",
-          terminal: "ターミナル",
+          clarify: "質問確認",
+          answer: "回答",
+          confirm: "クロージング",
+          terminal: "完了",
         }[s] ?? s)),
         datasets: [
           {
@@ -494,7 +494,7 @@ export default function AnalyticsDashboardPage() {
             ← 管理画面へ戻る
           </button>
           <h1 style={{ fontSize: 24, fontWeight: 700, margin: 0, color: "var(--foreground)", display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
-            📈 会話分析ダッシュボード
+            📈 チャット成績レポート
             {isSuperAdmin && (
               <span style={{ fontSize: 16, fontWeight: 400, color: "var(--muted-foreground)", marginLeft: 10 }}>
                 — {selectedTenantName}
@@ -502,7 +502,7 @@ export default function AnalyticsDashboardPage() {
             )}
           </h1>
           <p style={{ fontSize: 13, color: "var(--muted-foreground)", marginTop: 4, marginBottom: 0 }}>
-            KPI・トレンド・センチメントを可視化します
+            会話の件数・品質・お客様の反応を確認できます
           </p>
         </div>
 
@@ -616,7 +616,7 @@ export default function AnalyticsDashboardPage() {
                   ? `${summary.avg_judge_score.toFixed(1)}`
                   : "—"}
               </span>
-              <span style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)" }}>平均Judgeスコア</span>
+              <span style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)" }}>AI応答品質スコア</span>
               <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>/100</span>
             </div>
 
@@ -626,7 +626,7 @@ export default function AnalyticsDashboardPage() {
               <span style={{ fontSize: 28, fontWeight: 700, color: "var(--foreground)", lineHeight: 1 }}>
                 {summary?.total_knowledge_gaps ?? "—"}
               </span>
-              <span style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)" }}>Knowledge Gap</span>
+              <span style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)" }}>AIが答えられなかった質問</span>
               <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>件</span>
             </div>
 
@@ -638,7 +638,7 @@ export default function AnalyticsDashboardPage() {
                   ? `${(summary.avatar_rate * 100).toFixed(1)}%`
                   : "—"}
               </span>
-              <span style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)" }}>アバター利用率</span>
+              <span style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)" }}>動画AI接客の利用割合</span>
               <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>
                 {summary?.avatar_session_count ?? 0}件 / 全会話
               </span>
@@ -657,7 +657,7 @@ export default function AnalyticsDashboardPage() {
               >
                 {summary?.cv_count_30d ?? "—"}
               </span>
-              <span style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)" }}>CV件数(30日)</span>
+              <span style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)" }}>成約件数（30日）</span>
               <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>
                 ¥{(summary?.cv_total_value_30d ?? 0).toLocaleString("ja-JP")}
               </span>
@@ -679,10 +679,10 @@ export default function AnalyticsDashboardPage() {
                   : "—"}
               </span>
               <span style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)" }}>
-                ナレッジ貢献度
+                知識データの成約貢献度
               </span>
               <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>
-                Top3 平均CV率
+                Top3 平均成約率
               </span>
             </div>
 
@@ -709,7 +709,7 @@ export default function AnalyticsDashboardPage() {
                         ? `${(positiveRate * 100).toFixed(1)}%`
                         : "—"}
                     </span>
-                    <span style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)" }}>顧客感情</span>
+                    <span style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)" }}>お客様の反応</span>
                     <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>
                       ポジティブ率
                     </span>
@@ -733,7 +733,7 @@ export default function AnalyticsDashboardPage() {
                 background: "var(--card)",
               }}
             >
-              <span style={{ fontSize: 12, color: "var(--muted-foreground)", alignSelf: "center", marginRight: 4 }}>CV内訳:</span>
+              <span style={{ fontSize: 12, color: "var(--muted-foreground)", alignSelf: "center", marginRight: 4 }}>成約の内訳:</span>
               {(
                 [
                   ["purchase", "購入", "#34d399"],
@@ -767,7 +767,7 @@ export default function AnalyticsDashboardPage() {
           {lineData && (
             <div style={chartCardStyle}>
               <h3 style={{ fontSize: 15, fontWeight: 600, color: "var(--muted-foreground)", margin: "0 0 16px 0" }}>
-                会話数トレンド
+                会話数の変化
               </h3>
               <div style={{ height: 220 }}>
                 <Line
@@ -797,7 +797,7 @@ export default function AnalyticsDashboardPage() {
           {stackedBarData && (
             <div style={chartCardStyle}>
               <h3 style={{ fontSize: 15, fontWeight: 600, color: "var(--muted-foreground)", margin: "0 0 16px 0" }}>
-                センチメント推移
+                お客様の反応の変化
               </h3>
               <div style={{ height: 220 }}>
                 <Bar
@@ -843,7 +843,7 @@ export default function AnalyticsDashboardPage() {
             {doughnutData && (
               <div style={{ ...chartCardStyle, flex: "1 1 280px", marginBottom: 0 }}>
                 <h3 style={{ fontSize: 15, fontWeight: 600, color: "var(--muted-foreground)", margin: "0 0 16px 0" }}>
-                  Judgeスコア分布
+                  AI応答品質スコアの分布
                 </h3>
                 <div style={{ height: 200, display: "flex", justifyContent: "center" }}>
                   <Doughnut
@@ -867,7 +867,7 @@ export default function AnalyticsDashboardPage() {
             {radarData && (
               <div style={{ ...chartCardStyle, flex: "1 1 280px", marginBottom: 0 }}>
                 <h3 style={{ fontSize: 15, fontWeight: 600, color: "var(--muted-foreground)", margin: "0 0 16px 0" }}>
-                  4軸平均スコア
+                  AI対応の4項目評価
                 </h3>
                 <div style={{ height: 200 }}>
                   <Radar
@@ -898,7 +898,7 @@ export default function AnalyticsDashboardPage() {
             {sentimentPieData && (
               <div style={{ ...chartCardStyle, flex: "1 1 280px", marginBottom: 0 }}>
                 <h3 style={{ fontSize: 15, fontWeight: 600, color: "var(--muted-foreground)", margin: "0 0 16px 0" }}>
-                  センチメント分布
+                  お客様の反応の分布
                 </h3>
                 <div style={{ height: 200, display: "flex", justifyContent: "center" }}>
                   <Pie
@@ -923,7 +923,7 @@ export default function AnalyticsDashboardPage() {
           {evaluations && evaluations.low_score_sessions.length > 0 && (
             <div style={chartCardStyle}>
               <h3 style={{ fontSize: 15, fontWeight: 600, color: "var(--muted-foreground)", margin: "0 0 16px 0" }}>
-                低スコア会話
+                AI応答品質が低い会話
               </h3>
               <div style={{ overflowX: "auto" }}>
                 <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
@@ -1036,7 +1036,7 @@ export default function AnalyticsDashboardPage() {
                   <span style={{ fontSize: 28, fontWeight: 700, color: "#34d399", lineHeight: 1 }}>
                     {conversion.summary.recorded_outcomes}
                   </span>
-                  <span style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)" }}>記録済み成果</span>
+                  <span style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)" }}>成果記録数</span>
                 </div>
                 <div style={cardStyle}>
                   <span style={{ fontSize: 24 }}>📝</span>
@@ -1055,7 +1055,7 @@ export default function AnalyticsDashboardPage() {
                   >
                     {conversion.summary.recording_rate.toFixed(1)}%
                   </span>
-                  <span style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)" }}>記録率</span>
+                  <span style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)" }}>成果記録率</span>
                 </div>
                 {/* コンバージョン率: 離脱・不明を除いた割合 */}
                 {(() => {
@@ -1080,7 +1080,7 @@ export default function AnalyticsDashboardPage() {
                       >
                         {convRate.toFixed(1)}%
                       </span>
-                      <span style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)" }}>コンバージョン率</span>
+                      <span style={{ fontSize: 13, fontWeight: 600, color: "var(--muted-foreground)" }}>成約率</span>
                       <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>離脱・不明を除く</span>
                     </div>
                   );
@@ -1093,7 +1093,7 @@ export default function AnalyticsDashboardPage() {
                 {convTrendLineData && (
                   <div style={{ ...chartCardStyle, flex: "2 1 320px", marginBottom: 0 }}>
                     <div style={{ fontWeight: 600, color: "var(--muted-foreground)", marginBottom: 12, fontSize: 14 }}>
-                      コンバージョン率推移
+                      成約率の変化
                     </div>
                     <div style={{ height: 200 }}>
                       <Line
@@ -1156,14 +1156,14 @@ export default function AnalyticsDashboardPage() {
                     }}
                   >
                     <span style={{ fontWeight: 600, color: "var(--muted-foreground)", fontSize: 14 }}>
-                      テクニック別効果
+                      AIテクニック別 成約率
                     </span>
                   </div>
                   <div style={{ overflowX: "auto" }}>
                     <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
                       <thead>
                         <tr>
-                          {["テクニック", "使用セッション", "コンバージョン"].map((h) => (
+                          {["テクニック", "使用会話数", "成約数"].map((h) => (
                             <th
                               key={h}
                               style={{
@@ -1232,7 +1232,7 @@ export default function AnalyticsDashboardPage() {
               {stageDropoutBarData && (
                 <div style={chartCardStyle}>
                   <div style={{ fontWeight: 600, color: "var(--muted-foreground)", marginBottom: 12, fontSize: 14 }}>
-                    ステージ別離脱分析
+                    会話ステージ別の離脱分析
                   </div>
                   <div style={{ height: 180 }}>
                     <Bar

--- a/admin-ui/src/pages/admin/knowledge/[tenantId].tsx
+++ b/admin-ui/src/pages/admin/knowledge/[tenantId].tsx
@@ -80,7 +80,7 @@ export default function TenantKnowledgePage() {
     { id: "text", label: t("knowledge.tab_text"), icon: "✏️" },
     { id: "scrape", label: t("knowledge.tab_scrape"), icon: "🌐" },
     { id: "pdf", label: "PDFアップロード", icon: "📚" },
-    { id: "attribution", label: "CV影響度", icon: "📈" },
+    { id: "attribution", label: "成約への貢献度", icon: "📈" },
   ];
 
   const isGlobalTenant = resolvedTenantId === "global";

--- a/admin-ui/src/pages/admin/monitoring/index.tsx
+++ b/admin-ui/src/pages/admin/monitoring/index.tsx
@@ -125,7 +125,7 @@ export default function MonitoringPage() {
           description: "お客様との会話が正常に完了した割合",
         },
         {
-          name: "ループ検出率",
+          name: "同じ質問の繰り返し率",
           value: data.loopRate.toFixed(1),
           unit: "%",
           threshold: `${sla.loopRateMax}% 以下`,
@@ -133,7 +133,7 @@ export default function MonitoringPage() {
           description: "同じ質問が繰り返された会話の割合",
         },
         {
-          name: "フォールバック率",
+          name: "AIが答えられなかった割合",
           value: data.fallbackRate.toFixed(1),
           unit: "%",
           threshold: `${sla.fallbackRateMax}% 以下`,
@@ -220,10 +220,10 @@ export default function MonitoringPage() {
             {error ? "接続エラー" : "接続中"}
           </div>
           <h1 style={{ fontSize: 26, fontWeight: 700, margin: 0, color: "var(--foreground)" }}>
-            KPI 監視ダッシュボード
+            システム稼働状況
           </h1>
           <p style={{ fontSize: 14, color: "var(--muted-foreground)", marginTop: 4, marginBottom: 0 }}>
-            サービスの品質指標をリアルタイムで確認できます
+            AIサービスの品質指標をリアルタイムで確認できます
           </p>
         </div>
 

--- a/admin-ui/src/pages/admin/options/index.tsx
+++ b/admin-ui/src/pages/admin/options/index.tsx
@@ -133,7 +133,7 @@ export default function OptionManagementPage() {
     <div style={{ minHeight: "100vh", background: PAGE_BG, color: TEXT_MAIN, fontFamily: "system-ui, -apple-system, sans-serif", padding: "24px 16px" }}>
       {/* ヘッダー */}
       <div style={{ maxWidth: 1100, margin: "0 auto" }}>
-        <h1 style={{ fontSize: 20, fontWeight: 700, marginBottom: 4 }}>💼 オプション代行管理</h1>
+        <h1 style={{ fontSize: 20, fontWeight: 700, marginBottom: 4 }}>💼 代行作業の依頼・管理</h1>
         <p style={{ fontSize: 13, color: TEXT_SUB, marginBottom: 20 }}>テナントから依頼された代行作業の管理・金額確定・完了処理を行います</p>
 
         {/* フィルタータブ */}
@@ -164,7 +164,7 @@ export default function OptionManagementPage() {
           <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
             <thead>
               <tr style={{ borderBottom: `1px solid ${BORDER}`, background: "rgba(255,255,255,0.02)" }}>
-                {["テナント", "作業内容", "LLM見積", "確定金額", "ステータス", "発注日時"].map((h) => (
+                {["テナント", "作業内容", "AI処理コスト見積", "確定金額", "ステータス", "発注日時"].map((h) => (
                   <th key={h} style={{ padding: "10px 14px", textAlign: "left", fontSize: 11, fontWeight: 600, color: TEXT_SUB, whiteSpace: "nowrap" }}>{h}</th>
                 ))}
               </tr>


### PR DESCRIPTION
## Summary

- 管理画面内のエンジニア向け技術用語を、経営パートナーが直感的に理解できる日本語に変更
- 変更スコープ: AppSidebar (ナビ)・analytics・monitoring・options・knowledge・i18n (ja.ts)

## 主な変更一覧

| 旧 | 新 |
|---|---|
| ナレッジ管理 | AIの知識データ |
| チューニングルール | AIへの指示ルール |
| 声がけ設定 | 自動メッセージ設定 |
| コンバージョン分析 | 成約・効果分析 |
| Judge スコア | AI応答品質スコア |
| Knowledge Gap | AIが答えられなかった質問 |
| センチメント | お客様の反応 |
| フォールバック率 | AIが答えられなかった割合 |
| ループ検出率 | 同じ質問の繰り返し率 |
| CV件数 / CV影響度 | 成約件数 / 成約への貢献度 |
| 心理アプローチ | 接客アプローチ |
| 平均温度感スコア | 平均購買意欲スコア |
| LLM見積 | AI処理コスト見積 |

## Test plan

- [ ] 管理画面を開き、サイドバーのラベルが新しい用語になっていることを確認
- [ ] analytics ページで全 KPI カード・グラフタイトルが更新済みであることを確認
- [ ] monitoring ページで KPI名称が更新済みであることを確認
- [ ] knowledge ページでタブ「成約への貢献度」が表示されることを確認
- [ ] tuning ページでタイトルが「AIへの指示ルール」になっていることを確認
- [ ] 型チェック: pnpm typecheck → 0 errors ✅

Asana: https://app.asana.com/0/0/1215584181262847

🤖 Generated with [Claude Code](https://claude.com/claude-code)