### PR TITLE
feat(judge): Phase47-B — rewardBridge を judgeEvaluator に配線（OpenClaw-RL reward signal）

### DIFF
--- a/src/agent/dialog/flowContextStore.ts
+++ b/src/agent/dialog/flowContextStore.ts
@@ -71,6 +71,13 @@ export function getOrInitFlowSessionMeta(key: FlowSessionKey): FlowSessionMeta {
   return init;
 }
 
+// Phase47-B: 副作用なしの読み取り専用 getter（reward signal 用）
+export function peekFlowSessionMeta(
+  key: FlowSessionKey
+): FlowSessionMeta | undefined {
+  return sessionStore.get(toInternalKey(key));
+}
+
 export function setFlowSessionMeta(
   key: FlowSessionKey,
   meta: FlowSessionMeta

--- a/src/agent/judge/judgeEvaluator.test.ts
+++ b/src/agent/judge/judgeEvaluator.test.ts
@@ -34,14 +34,32 @@ jest.mock('../../lib/crossTenantContext', () => ({
   formatCrossTenantContext: jest.fn().mockReturnValue(''),
 }));
 
+// Phase47-B: rewardBridge を no-op モック（fetch が走ると OOM/flaky の原因）
+jest.mock('../openclaw/rewardBridge', () => ({
+  sendRewardSignal: jest.fn().mockResolvedValue(undefined),
+}));
+
 import { callGeminiJudge } from '../../lib/gemini/client';
 import { getPool } from '../../lib/db';
 import { readFile } from 'fs/promises';
 import { evaluateSession } from './judgeEvaluator';
+import { sendRewardSignal } from '../openclaw/rewardBridge';
+import {
+  getOrInitFlowSessionMeta,
+  setFlowSessionMeta,
+  resetFlowSessionMeta,
+} from '../dialog/flowContextStore';
 
 const mockCallGroq = callGeminiJudge as jest.MockedFunction<typeof callGeminiJudge>;
 const mockGetPool = getPool as jest.MockedFunction<typeof getPool>;
 const mockReadFile = readFile as jest.MockedFunction<typeof readFile>;
+const mockSendRewardSignal = sendRewardSignal as jest.MockedFunction<typeof sendRewardSignal>;
+
+// Phase47-B: fire-and-forget (setImmediate + dynamic import) を消化する
+async function flushFireAndForget(): Promise<void> {
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+}
 
 const PROMPT_TEMPLATE =
   'Judge prompt template\n{{CONVERSATION_LOG}}\nOutput JSON only.';
@@ -86,7 +104,9 @@ function makeMockPool(queryImpl?: jest.Mock): jest.Mocked<{ query: jest.Mock }> 
 }
 
 describe('evaluateSession', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
+    // Phase47-B: 前テストの fire-and-forget (setImmediate) を消化してから mock をリセット
+    await flushFireAndForget();
     jest.clearAllMocks();
     // Default: prompt file loads successfully
     mockReadFile.mockResolvedValue(PROMPT_TEMPLATE as never);
@@ -98,7 +118,7 @@ describe('evaluateSession', () => {
 
     // chat_sessions query
     mockPool.query
-      .mockResolvedValueOnce({ rows: [{ id: 'internal-uuid-123', tenant_id: 'tenant-abc' }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'internal-uuid-123', tenant_id: 'tenant-abc', prompt_variant_id: 'v-test-1' }] })
       // chat_messages query
       .mockResolvedValueOnce({
         rows: [
@@ -145,7 +165,7 @@ describe('evaluateSession', () => {
     mockGetPool.mockReturnValue(mockPool as any);
 
     mockPool.query
-      .mockResolvedValueOnce({ rows: [{ id: 'internal-uuid-low', tenant_id: 'tenant-low' }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'internal-uuid-low', tenant_id: 'tenant-low', prompt_variant_id: null }] })
       .mockResolvedValueOnce({
         rows: [
           { role: 'user', content: '商品が欲しい', created_at: new Date() },
@@ -183,7 +203,7 @@ describe('evaluateSession', () => {
     mockGetPool.mockReturnValue(mockPool as any);
 
     mockPool.query
-      .mockResolvedValueOnce({ rows: [{ id: 'internal-uuid-high', tenant_id: 'tenant-high' }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'internal-uuid-high', tenant_id: 'tenant-high', prompt_variant_id: null }] })
       .mockResolvedValueOnce({
         rows: [
           { role: 'user', content: '予算200万で家族4人', created_at: new Date() },
@@ -221,7 +241,7 @@ describe('evaluateSession', () => {
     mockGetPool.mockReturnValue(mockPool as any);
 
     mockPool.query
-      .mockResolvedValueOnce({ rows: [{ id: 'internal-uuid-fail', tenant_id: 'tenant-fail' }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'internal-uuid-fail', tenant_id: 'tenant-fail', prompt_variant_id: null }] })
       .mockResolvedValueOnce({
         rows: [
           { role: 'user', content: 'hi', created_at: new Date() },
@@ -256,7 +276,7 @@ describe('evaluateSession', () => {
     const longContent = 'あ'.repeat(300);
 
     mockPool.query
-      .mockResolvedValueOnce({ rows: [{ id: 'internal-uuid-trunc', tenant_id: 'tenant-trunc' }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'internal-uuid-trunc', tenant_id: 'tenant-trunc', prompt_variant_id: null }] })
       .mockResolvedValueOnce({
         rows: [
           { role: 'user', content: longContent, created_at: new Date() },
@@ -281,5 +301,83 @@ describe('evaluateSession', () => {
     expect(promptArg).toContain('あ'.repeat(200));
     // 201st char should not be present (300 chars would be present if not truncated)
     expect(promptArg).not.toContain('あ'.repeat(201));
+  });
+
+  // Phase47-B: 評価完了後の OpenClaw-RL reward signal 配線
+  it('7. Phase47-B: 評価成功時に sendRewardSignal が正しい payload で呼ばれる', async () => {
+    const mockPool = makeMockPool();
+    mockGetPool.mockReturnValue(mockPool as any);
+
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [{ id: 'internal-uuid-reward', tenant_id: 'tenant-reward', prompt_variant_id: 'v-test-1' }] })
+      .mockResolvedValueOnce({
+        rows: [
+          { role: 'user', content: '納期はいつですか？', created_at: new Date() },
+          { role: 'assistant', content: '最短で3日です。', created_at: new Date() },
+        ],
+      })
+      // Phase60-A: tuning_rules SELECT
+      .mockResolvedValueOnce({ rows: [] })
+      // INSERT conversation_evaluations
+      .mockResolvedValueOnce({ rows: [] });
+
+    mockCallGroq.mockResolvedValueOnce(makeGroqResponse({ overall_score: 75 }));
+
+    // flowContextStore に terminalReason=completed を仕込む（key = tenantId::sessionId）
+    const flowKey = { tenantId: 'tenant-reward', conversationId: 'session-reward' };
+    const meta = getOrInitFlowSessionMeta(flowKey);
+    setFlowSessionMeta(flowKey, { ...meta, terminalReason: 'completed' });
+
+    try {
+      const result = await evaluateSession('session-reward');
+      expect(result).not.toBeNull();
+
+      await flushFireAndForget();
+
+      expect(mockSendRewardSignal).toHaveBeenCalledTimes(1);
+      expect(mockSendRewardSignal).toHaveBeenCalledWith({
+        tenantId: 'tenant-reward',
+        sessionId: 'session-reward',
+        variantId: 'v-test-1',
+        score: 75,
+        outcome: 'replied', // terminalReason=completed → replied
+      });
+    } finally {
+      resetFlowSessionMeta(flowKey);
+    }
+  });
+
+  it('8. Phase47-B: prompt_variant_id が null / flow メタ未存在なら variantId: null, outcome: unknown', async () => {
+    const mockPool = makeMockPool();
+    mockGetPool.mockReturnValue(mockPool as any);
+
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [{ id: 'internal-uuid-novariant', tenant_id: 'tenant-novariant', prompt_variant_id: null }] })
+      .mockResolvedValueOnce({
+        rows: [
+          { role: 'user', content: '在庫はありますか？', created_at: new Date() },
+          { role: 'assistant', content: 'ございます。', created_at: new Date() },
+        ],
+      })
+      // Phase60-A: tuning_rules SELECT
+      .mockResolvedValueOnce({ rows: [] })
+      // INSERT conversation_evaluations
+      .mockResolvedValueOnce({ rows: [] });
+
+    mockCallGroq.mockResolvedValueOnce(makeGroqResponse({ overall_score: 80 }));
+
+    const result = await evaluateSession('session-novariant');
+    expect(result).not.toBeNull();
+
+    await flushFireAndForget();
+
+    expect(mockSendRewardSignal).toHaveBeenCalledTimes(1);
+    expect(mockSendRewardSignal).toHaveBeenCalledWith({
+      tenantId: 'tenant-novariant',
+      sessionId: 'session-novariant',
+      variantId: null,
+      score: 80,
+      outcome: 'unknown', // flow メタ未存在（プロセス再起動後・手動評価）は中立
+    });
   });
 });

--- a/src/agent/judge/judgeEvaluator.ts
+++ b/src/agent/judge/judgeEvaluator.ts
@@ -60,6 +60,7 @@ interface ChatMessageRow {
 interface ChatSessionRow {
   id: string;
   tenant_id: string;
+  prompt_variant_id: string | null;
 }
 
 function clamp(v: number): number {
@@ -135,7 +136,7 @@ export async function evaluateSession(sessionId: string): Promise<JudgeEvaluatio
 
     // 1. Fetch internal id + tenant_id from chat_sessions (session_id is the public text key)
     const sessionResult = await pool.query<ChatSessionRow>(
-      'SELECT id, tenant_id FROM chat_sessions WHERE session_id = $1 LIMIT 1',
+      'SELECT id, tenant_id, prompt_variant_id FROM chat_sessions WHERE session_id = $1 LIMIT 1',
       [sessionId],
     );
     if (sessionResult.rows.length === 0) {
@@ -144,6 +145,7 @@ export async function evaluateSession(sessionId: string): Promise<JudgeEvaluatio
     }
     const internalId: string = sessionResult.rows[0]!.id;
     const tenantId: string = sessionResult.rows[0]!.tenant_id;
+    const variantId: string | null = sessionResult.rows[0]!.prompt_variant_id ?? null;
 
     // 2. Fetch all messages using internal UUID (chat_messages.session_id → chat_sessions.id)
     const msgResult = await pool.query<ChatMessageRow>(
@@ -269,6 +271,31 @@ export async function evaluateSession(sessionId: string): Promise<JudgeEvaluatio
         }),
       ).catch((err: unknown) => {
         logger.warn({ err, sessionId }, 'learnedMemory.distill.failed (non-blocking)');
+      });
+    });
+
+    // 6c. Phase47-B: Judge評価完了後に OpenClaw-RL へ reward signal 送信 (fire-and-forget)
+    //     Feature Flag (isOpenClawEnabled) のガードは sendRewardSignal 内で行う。
+    setImmediate(() => {
+      Promise.all([
+        import('../openclaw/rewardBridge'),
+        import('../dialog/flowContextStore'),
+      ]).then(([{ sendRewardSignal }, { peekFlowSessionMeta }]) => {
+        const terminalReason = peekFlowSessionMeta({ tenantId, conversationId: sessionId })?.terminalReason;
+        const outcome =
+          terminalReason === 'completed' ? 'replied' :
+          terminalReason === 'aborted_user' || terminalReason === 'aborted_budget' ||
+          terminalReason === 'aborted_loop_detected' || terminalReason === 'failed_safe_mode' ? 'lost' :
+          'unknown'; // escalated_handoff / メタ未存在（プロセス再起動後・手動評価）は中立
+        return sendRewardSignal({
+          tenantId,
+          sessionId,
+          variantId,
+          score: result.overall_score,
+          outcome,
+        });
+      }).catch((err: unknown) => {
+        logger.warn({ err, sessionId }, 'openclaw.reward.failed (non-blocking)');
       });
     });
 

--- a/src/agent/openclaw/rewardBridge.test.ts
+++ b/src/agent/openclaw/rewardBridge.test.ts
@@ -21,6 +21,18 @@ afterEach(() => {
 });
 
 describe("sendRewardSignal", () => {
+  it("OPENCLAW_ENABLED=false は許可テナントでも何もしない", async () => {
+    process.env.OPENCLAW_ENABLED = "false";
+    await sendRewardSignal({
+      tenantId: "carnation",
+      sessionId: "sess-000",
+      variantId: "v1",
+      score: 80,
+      outcome: "replied",
+    });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
   it("Feature Flag オフのテナントは何もしない", async () => {
     await sendRewardSignal({
       tenantId: "other-tenant",


### PR DESCRIPTION
## 概要
[Phase47-B] 実装済みの `sendRewardSignal`（rewardBridge.ts）を judgeEvaluator から配線。Judge 評価完了後に OpenClaw-RL へ reward signal を fire-and-forget 送信する。

Asana: https://app.asana.com/0/1213607637045514/1215601290179080

## 変更内容
- `src/agent/dialog/flowContextStore.ts` — `peekFlowSessionMeta` 追加（副作用なし read-only getter。`getOrInitFlowSessionMeta` は missing 時にエントリ生成の副作用があるため）
- `src/agent/judge/judgeEvaluator.ts` — SELECT 句に `prompt_variant_id` 追加 / ChatSessionRow 拡張 / 「6b」直後に「6c」reward signal ブロック（distillAndPromote と同一の setImmediate + dynamic import + catch パターン）
- outcome マッピング: `completed`→`replied` / `aborted_*`・`failed_safe_mode`→`lost` / `escalated_handoff`・メタ未存在→`unknown`
- テスト: judgeEvaluator 2ケース追加（payload 検証 + variantId null/メタ未存在）、rewardBridge に `OPENCLAW_ENABLED=false` 明示ケース追加

## Gate
- Gate 1 (typecheck + test): PASS — 1870 tests
- Gate 1.5 (dead-code-check): PASS — 新規 dead export なし
- Gate 2 (security-scan): PASS — CRITICAL/HIGH 0
- Gate 3 (pnpm build): PASS（admin-ui 変更なしのため admin-ui build 対象外）
- Evaluator レビュー: GO（P0/P1 なし。reward payload に会話内容・PII 含まず、tenantId は DB 取得値のみ）

## DoD（Asana 記載）
- [x] pnpm typecheck 0 errors
- [x] pnpm test pass
- [x] OPENCLAW_ENABLED=false 時に rewardBridge が呼ばれない（rewardBridge.test.ts に明示ケース追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
