### PR TITLE
feat(openclaw): Phase47-C — workspaceAdapter を本番経路に配線（テナント別メモリキャッシュ）

### DIFF
--- a/src/agent/openclaw/workspaceCache.test.ts
+++ b/src/agent/openclaw/workspaceCache.test.ts
@@ -1,0 +1,88 @@
+// src/agent/openclaw/workspaceCache.test.ts
+// Phase47-C: WorkspaceFiles メモリキャッシュのテスト
+
+import { getOrBuildWorkspace, invalidateWorkspaceCache } from "./workspaceCache";
+import { getPool } from "../../lib/db";
+
+jest.mock("../../lib/db", () => ({
+  getPool: jest.fn(),
+}));
+
+const mockQuery = jest.fn();
+(getPool as jest.Mock).mockReturnValue({ query: mockQuery });
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  (getPool as jest.Mock).mockReturnValue({ query: mockQuery });
+  invalidateWorkspaceCache(); // テスト間のキャッシュ漏れ防止
+  process.env.OPENCLAW_ENABLED = "true";
+  process.env.OPENCLAW_TENANTS = "carnation";
+});
+
+afterEach(() => {
+  delete process.env.OPENCLAW_ENABLED;
+  delete process.env.OPENCLAW_TENANTS;
+});
+
+describe("getOrBuildWorkspace", () => {
+  it("Feature Flag オフは null を返し DB query を呼ばない", async () => {
+    process.env.OPENCLAW_ENABLED = "false";
+
+    const result = await getOrBuildWorkspace("carnation");
+
+    expect(result).toBeNull();
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("carnation テナントは tenants から system_prompt を取得し WorkspaceFiles を返す", async () => {
+    mockQuery.mockResolvedValue({
+      rows: [{ system_prompt: "あなたは中古車販売のアシスタントです" }],
+    });
+
+    const result = await getOrBuildWorkspace("carnation");
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    expect(mockQuery).toHaveBeenCalledWith(
+      "SELECT system_prompt FROM tenants WHERE id = $1",
+      ["carnation"],
+    );
+    expect(result).not.toBeNull();
+    expect(result?.soul).toContain("あなたは中古車販売のアシスタントです");
+    expect(result?.identity).toContain("carnation");
+  });
+
+  it("2回目の呼び出しはキャッシュヒット（pool.query は1回のみ）", async () => {
+    mockQuery.mockResolvedValue({ rows: [{ system_prompt: "test prompt" }] });
+
+    const first = await getOrBuildWorkspace("carnation");
+    const second = await getOrBuildWorkspace("carnation");
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first); // 同一オブジェクト参照
+  });
+
+  it("invalidateWorkspaceCache('carnation') 後は再ビルドする（query 2回目発生）", async () => {
+    mockQuery.mockResolvedValue({ rows: [{ system_prompt: "test prompt" }] });
+
+    await getOrBuildWorkspace("carnation");
+    invalidateWorkspaceCache("carnation");
+    await getOrBuildWorkspace("carnation");
+
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it("invalidateWorkspaceCache() 引数なしは全テナントをクリアする", async () => {
+    process.env.OPENCLAW_TENANTS = "carnation,daisy";
+    mockQuery.mockResolvedValue({ rows: [{ system_prompt: "test prompt" }] });
+
+    await getOrBuildWorkspace("carnation");
+    await getOrBuildWorkspace("daisy");
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+
+    invalidateWorkspaceCache();
+
+    await getOrBuildWorkspace("carnation");
+    await getOrBuildWorkspace("daisy");
+    expect(mockQuery).toHaveBeenCalledTimes(4); // 両方とも再ビルド
+  });
+});

--- a/src/agent/openclaw/workspaceCache.ts
+++ b/src/agent/openclaw/workspaceCache.ts
@@ -1,0 +1,45 @@
+// src/agent/openclaw/workspaceCache.ts
+// Phase47-C: テナント単位の WorkspaceFiles メモリキャッシュ
+//
+// system_prompt は tenants テーブルから取得し buildWorkspaceFiles に渡す。
+// 管理画面で system_prompt 更新時は invalidateWorkspaceCache で無効化する。
+
+import pino from "pino";
+
+import { getPool } from "../../lib/db";
+
+import { isOpenClawEnabled } from "./featureFlag";
+import { buildWorkspaceFiles, type WorkspaceFiles } from "./workspaceAdapter";
+
+const logger = pino();
+const workspaceCache = new Map<string, WorkspaceFiles>();
+
+/** テナントの WorkspaceFiles を取得（キャッシュ優先）。Flag オフ時は DB 照会せず null。 */
+export async function getOrBuildWorkspace(
+  tenantId: string,
+): Promise<WorkspaceFiles | null> {
+  if (!isOpenClawEnabled(tenantId)) return null;
+
+  const cached = workspaceCache.get(tenantId);
+  if (cached) return cached;
+
+  const pool = getPool();
+  const result = await pool.query<{ system_prompt: string | null }>(
+    "SELECT system_prompt FROM tenants WHERE id = $1",
+    [tenantId],
+  );
+  const systemPrompt = result.rows[0]?.system_prompt ?? "";
+
+  const ws = buildWorkspaceFiles(tenantId, systemPrompt);
+  if (ws) {
+    workspaceCache.set(tenantId, ws);
+    logger.debug({ tenantId }, "openclaw.workspace.built"); // 内容はログに出さない
+  }
+  return ws;
+}
+
+/** キャッシュ無効化（tenantId 省略時は全件）。system_prompt 更新時に呼ぶ。 */
+export function invalidateWorkspaceCache(tenantId?: string): void {
+  if (tenantId) workspaceCache.delete(tenantId);
+  else workspaceCache.clear();
+}

--- a/src/agent/orchestrator/langGraphOrchestrator.ts
+++ b/src/agent/orchestrator/langGraphOrchestrator.ts
@@ -55,6 +55,16 @@ export async function runDialogGraph(
     'dialog.run.start',
   );
 
+  // Phase47-C: OpenClaw Workspace 初期化 (fire-and-forget)
+  //     Feature Flag ガードは getOrBuildWorkspace 内で行う。
+  setImmediate(() => {
+    import('../openclaw/workspaceCache').then(({ getOrBuildWorkspace }) =>
+      getOrBuildWorkspace(input.tenantId),
+    ).catch((err: unknown) => {
+      logger.warn({ err, tenantId: input.tenantId }, 'openclaw.workspace.failed (non-blocking)');
+    });
+  });
+
   // -------------------------
   // Phase22: Flow Controller
   // -------------------------

--- a/src/api/admin/tenants/routes.ts
+++ b/src/api/admin/tenants/routes.ts
@@ -6,6 +6,7 @@ import { Pool } from "pg";
 import { z } from "zod";
 import jwt from "jsonwebtoken";
 import { registerTenant, updateTenantEnabled } from "../../../lib/tenant-context";
+import { invalidateWorkspaceCache } from "../../../agent/openclaw/workspaceCache";
 import { generateApiKey, hashApiKey, maskApiKeyPrefix } from "./apiKeyUtils";
 import { supabaseAdmin } from "../../../auth/supabaseClient";
 import { DEFAULT_AVATARS } from "../avatar/routes";
@@ -309,6 +310,10 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
       // in-memory store を即時同期 (is_active 変更が次リクエストから有効になる)
       if (fields.is_active !== undefined) {
         updateTenantEnabled(id, fields.is_active);
+      }
+      // Phase47-C: system_prompt 変更時は OpenClaw Workspace キャッシュを無効化
+      if (fields.system_prompt !== undefined) {
+        invalidateWorkspaceCache(id);
       }
       return res.json(result.rows[0]);
     } catch (err) {


### PR DESCRIPTION
## 概要
[Phase47-C] 実装済みの `buildWorkspaceFiles`（workspaceAdapter.ts）を本番経路に配線。OpenClaw Workspace (SOUL.md/IDENTITY.md) をテナント単位でメモリキャッシュし、dialog 起動時に初期化する。

Asana: https://app.asana.com/0/1213607637045514/1215592030194019

## 変更内容
- `src/agent/openclaw/workspaceCache.ts`（新規） — `getOrBuildWorkspace`: Flag ガード（オフ時は DB 照会ゼロ）→ キャッシュ → `tenants.system_prompt` 取得 → buildWorkspaceFiles。`invalidateWorkspaceCache` で無効化
- `src/agent/orchestrator/langGraphOrchestrator.ts` — runDialogGraph 冒頭に setImmediate fire-and-forget 初期化（dialog 応答を非ブロック、judgeEvaluator 6b/6c と同パターン）
- `src/api/admin/tenants/routes.ts` — PATCH で system_prompt 更新成功後にキャッシュ無効化（auth: tenantAuth + requireSuperAdmin の内側）
- テスト: workspaceCache.test.ts 5ケース（flag off で DB 照会なし / DB 取得 / キャッシュヒット / 個別・全件無効化）

## スコープ判断（Asana notes との差分）
- **FS 書き出し（/var/rajiuce/openclaw/）は対象外**: workspaceAdapter.ts に FS コードが元々存在せずメモリ型設計のため、過剰実装禁止ルールに従いメモリキャッシュ + 配線のみ実装
- **VPS 側確認は HUMAN-TASK**: 24h mode 中の VPS 接続禁止のため、deploy 後の carnation テナント実機確認（`openclaw.workspace.built` ログ）は人間作業

## Gate
- Gate 1 (pnpm verify): PASS / Gate 1.5: PASS（新規 dead export なし） / Gate 2 (security-scan): PASS CRITICAL/HIGH 0 / Gate 3 (build): PASS
- Evaluator: GO（P0/P1 なし。soul/identity をログ出力せず、SQL パラメタライズド、tenantId は req.params/DialogInput のみ）

## 既知の P2（別タスク候補）
- キャッシュ TTL なし（DB 直更新時はプロセス再起動まで stale）/ 初回同時呼び出しの query 重複（実害軽微）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
