### PR TITLE
feat(openclaw): Phase47-D — heartbeatHandler 実装（flow 統計 30分監視 + Slack アラート）

### DIFF
--- a/src/agent/dialog/flowContextStore.ts
+++ b/src/agent/dialog/flowContextStore.ts
@@ -83,6 +83,11 @@ export function resetFlowSessionMeta(key: FlowSessionKey): void {
   sessionStore.delete(toInternalKey(key));
 }
 
+// Phase47-D: heartbeat 集計用の読み取り専用 snapshot（副作用なし）
+export function snapshotFlowSessionMetas(): FlowSessionMeta[] {
+  return Array.from(sessionStore.values());
+}
+
 /**
  * Clarify の「同一質問繰り返し」検知用シグネチャ。
  * Phase22 では「賢く解消」より「止まる」を優先するため、

--- a/src/agent/openclaw/heartbeatHandler.test.ts
+++ b/src/agent/openclaw/heartbeatHandler.test.ts
@@ -1,0 +1,198 @@
+// src/agent/openclaw/heartbeatHandler.test.ts
+// Phase47-D: heartbeatHandler テスト
+
+import type {
+  FlowSessionMeta,
+  TerminalReason,
+} from "../dialog/flowContextStore";
+import { snapshotFlowSessionMetas } from "../dialog/flowContextStore";
+import { sendSlackAlert } from "../../lib/alerts/slackNotifier";
+import {
+  evaluateHeartbeat,
+  startOpenClawHeartbeat,
+  stopOpenClawHeartbeat,
+} from "./heartbeatHandler";
+
+jest.mock("../dialog/flowContextStore", () => ({
+  snapshotFlowSessionMetas: jest.fn(),
+}));
+
+jest.mock("../../lib/alerts/slackNotifier", () => ({
+  sendSlackAlert: jest.fn(),
+}));
+
+const mockSnapshot = snapshotFlowSessionMetas as jest.MockedFunction<
+  typeof snapshotFlowSessionMetas
+>;
+const mockSendSlackAlert = sendSlackAlert as jest.MockedFunction<
+  typeof sendSlackAlert
+>;
+
+// 必須フィールドを最小で埋めた FlowSessionMeta ダミー
+function makeMeta(terminalReason?: TerminalReason): FlowSessionMeta {
+  return {
+    state: "terminal",
+    turnIndex: 1,
+    sameStateRepeats: 0,
+    clarifyRepeats: 0,
+    confirmRepeats: 0,
+    recentStates: [],
+    terminalReason,
+    lastUpdatedAt: new Date().toISOString(),
+  };
+}
+
+function makeMetas(
+  counts: Partial<Record<TerminalReason, number>>
+): FlowSessionMeta[] {
+  const metas: FlowSessionMeta[] = [];
+  for (const [reason, count] of Object.entries(counts)) {
+    for (let i = 0; i < (count ?? 0); i++) {
+      metas.push(makeMeta(reason as TerminalReason));
+    }
+  }
+  return metas;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockSendSlackAlert.mockResolvedValue(undefined);
+  process.env.OPENCLAW_ENABLED = "true";
+});
+
+afterEach(() => {
+  stopOpenClawHeartbeat(); // interval + cooldown 状態リセット
+  delete process.env.OPENCLAW_ENABLED;
+  jest.useRealTimers();
+});
+
+describe("evaluateHeartbeat", () => {
+  it("stall_rate 0.25 (>0.2) でアラート発火する", async () => {
+    // 4件中 1件 aborted_loop_detected → stall_rate=0.25
+    mockSnapshot.mockReturnValue(
+      makeMetas({ aborted_loop_detected: 1, completed: 3 })
+    );
+
+    await evaluateHeartbeat();
+
+    expect(mockSendSlackAlert).toHaveBeenCalledTimes(1);
+    const message = mockSendSlackAlert.mock.calls[0][0];
+    expect(message.ruleId).toBe("openclaw-heartbeat");
+    // カウントとレートのみ（会話内容・PII を含めない）
+    expect(message.details).toContain("stall_rate=0.250");
+  });
+
+  it("stall_rate 0.15 かつ abort_rate 0.2 では発火しない", async () => {
+    // 20件中 stall 3 (0.15) / abort 4 (0.2)
+    mockSnapshot.mockReturnValue(
+      makeMetas({
+        aborted_loop_detected: 3,
+        aborted_user: 2,
+        aborted_budget: 1,
+        failed_safe_mode: 1,
+        completed: 12,
+        escalated_handoff: 1,
+      })
+    );
+
+    await evaluateHeartbeat();
+
+    expect(mockSendSlackAlert).not.toHaveBeenCalled();
+  });
+
+  it("abort_rate 0.35 (>0.3) でアラート発火する", async () => {
+    // 20件中 abort 7 (aborted_user 3 + aborted_budget 2 + failed_safe_mode 2) → 0.35
+    mockSnapshot.mockReturnValue(
+      makeMetas({
+        aborted_user: 3,
+        aborted_budget: 2,
+        failed_safe_mode: 2,
+        completed: 13,
+      })
+    );
+
+    await evaluateHeartbeat();
+
+    expect(mockSendSlackAlert).toHaveBeenCalledTimes(1);
+    expect(mockSendSlackAlert.mock.calls[0][0].details).toContain(
+      "abort_rate=0.350"
+    );
+  });
+
+  it("terminalReason 付きセッション 0 件なら発火しない", async () => {
+    // terminalReason undefined のみ（進行中セッション）
+    mockSnapshot.mockReturnValue([makeMeta(undefined), makeMeta(undefined)]);
+
+    await evaluateHeartbeat();
+
+    expect(mockSendSlackAlert).not.toHaveBeenCalled();
+  });
+
+  it("escalated_handoff / completed は両 rate から除外される", async () => {
+    // 10件全部 escalated_handoff/completed → stall 0 / abort 0 → 発火しない
+    mockSnapshot.mockReturnValue(
+      makeMetas({ escalated_handoff: 5, completed: 5 })
+    );
+
+    await evaluateHeartbeat();
+
+    expect(mockSendSlackAlert).not.toHaveBeenCalled();
+  });
+
+  it("cooldown: 発火直後の再 evaluate では再発火しない", async () => {
+    mockSnapshot.mockReturnValue(
+      makeMetas({ aborted_loop_detected: 1, completed: 1 })
+    );
+
+    await evaluateHeartbeat();
+    await evaluateHeartbeat();
+
+    expect(mockSendSlackAlert).toHaveBeenCalledTimes(1);
+  });
+
+  it("Slack 送信失敗は throw しない（non-blocking）", async () => {
+    mockSnapshot.mockReturnValue(
+      makeMetas({ aborted_loop_detected: 1, completed: 1 })
+    );
+    mockSendSlackAlert.mockRejectedValue(new Error("webhook down"));
+
+    await expect(evaluateHeartbeat()).resolves.toBeUndefined();
+  });
+});
+
+describe("startOpenClawHeartbeat", () => {
+  it("グローバル Flag OFF なら interval を作らない", () => {
+    jest.useFakeTimers();
+    delete process.env.OPENCLAW_ENABLED;
+    mockSnapshot.mockReturnValue(
+      makeMetas({ aborted_loop_detected: 1, completed: 1 })
+    );
+
+    startOpenClawHeartbeat();
+    jest.advanceTimersByTime(31 * 60 * 1000);
+
+    expect(mockSnapshot).not.toHaveBeenCalled();
+    expect(mockSendSlackAlert).not.toHaveBeenCalled();
+  });
+
+  it("グローバル Flag ON なら 30 分周期で evaluate される", () => {
+    jest.useFakeTimers();
+    mockSnapshot.mockReturnValue([]);
+
+    startOpenClawHeartbeat();
+    jest.advanceTimersByTime(31 * 60 * 1000);
+
+    expect(mockSnapshot).toHaveBeenCalledTimes(1);
+  });
+
+  it("二重起動しても interval は 1 本のみ", () => {
+    jest.useFakeTimers();
+    mockSnapshot.mockReturnValue([]);
+
+    startOpenClawHeartbeat();
+    startOpenClawHeartbeat();
+    jest.advanceTimersByTime(31 * 60 * 1000);
+
+    expect(mockSnapshot).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/agent/openclaw/heartbeatHandler.ts
+++ b/src/agent/openclaw/heartbeatHandler.ts
@@ -1,0 +1,100 @@
+// src/agent/openclaw/heartbeatHandler.ts
+// Phase47-D: OpenClaw Heartbeat — flow セッション統計を 30 分周期で監視し、
+// stall / abort レートが閾値を超えたら Slack へアラートする。
+//
+// 制約:
+//   - アラートにはカウントとレートのみ含める（会話内容・PII・テナント固有情報は禁止）
+//   - Slack 送信失敗は non-blocking（catch して logger.warn、throw しない）
+//   - cooldown: 前回発火から 30 分未満は再発火しない
+
+import pino from "pino";
+import { snapshotFlowSessionMetas } from "../dialog/flowContextStore";
+import { sendSlackAlert } from "../../lib/alerts/slackNotifier";
+
+const logger = pino({ name: "openclaw-heartbeat" });
+
+const HEARTBEAT_INTERVAL_MS = 30 * 60 * 1000; // 30分
+const COOLDOWN_MS = 30 * 60 * 1000; // 30分
+
+const STALL_RATE_THRESHOLD = 0.2;
+const ABORT_RATE_THRESHOLD = 0.3;
+
+let intervalHandle: NodeJS.Timeout | null = null;
+let lastAlertAt: number | null = null;
+
+/**
+ * グローバル Flag 判定（featureFlag.ts のマスタースイッチと同一ロジック）。
+ * heartbeat はテナント横断のため OPENCLAW_TENANTS は見ない。
+ */
+function isGloballyEnabled(): boolean {
+  return process.env.OPENCLAW_ENABLED === "true";
+}
+
+export async function evaluateHeartbeat(): Promise<void> {
+  const terminated = snapshotFlowSessionMetas().filter(
+    (meta) => meta.terminalReason !== undefined
+  );
+  const total = terminated.length;
+  if (total === 0) return; // ゼロ除算・空アラート防止
+
+  const stallCount = terminated.filter(
+    (meta) => meta.terminalReason === "aborted_loop_detected"
+  ).length;
+  const abortCount = terminated.filter(
+    (meta) =>
+      meta.terminalReason === "aborted_user" ||
+      meta.terminalReason === "aborted_budget" ||
+      meta.terminalReason === "failed_safe_mode"
+  ).length;
+
+  const stallRate = stallCount / total;
+  const abortRate = abortCount / total;
+
+  if (stallRate <= STALL_RATE_THRESHOLD && abortRate <= ABORT_RATE_THRESHOLD) {
+    return;
+  }
+
+  const now = Date.now();
+  if (lastAlertAt !== null && now - lastAlertAt < COOLDOWN_MS) {
+    return; // cooldown 中は再発火しない
+  }
+  lastAlertAt = now;
+
+  logger.warn({ stallRate, abortRate, total }, "openclaw.heartbeat.alert");
+
+  try {
+    // カウントとレートのみ（会話内容・PII・テナント固有情報を含めない）
+    await sendSlackAlert({
+      ruleId: "openclaw-heartbeat",
+      name: "OpenClaw Heartbeat — flow stall/abort rate",
+      level: "WARNING",
+      status: "FIRING",
+      details: [
+        `stall_rate=${stallRate.toFixed(3)} (${stallCount}/${total}, threshold ${STALL_RATE_THRESHOLD})`,
+        `abort_rate=${abortRate.toFixed(3)} (${abortCount}/${total}, threshold ${ABORT_RATE_THRESHOLD})`,
+      ].join("\n"),
+    });
+  } catch (err) {
+    logger.warn({ err }, "openclaw.heartbeat.slack_send_failed");
+  }
+}
+
+export function startOpenClawHeartbeat(): void {
+  if (!isGloballyEnabled()) return; // グローバル Flag オフは no-op
+  if (intervalHandle) return; // 二重起動ガード
+
+  intervalHandle = setInterval(() => {
+    evaluateHeartbeat().catch((err) => {
+      logger.warn({ err }, "openclaw.heartbeat.evaluate_failed");
+    });
+  }, HEARTBEAT_INTERVAL_MS);
+  intervalHandle.unref(); // プロセス終了 / jest をブロックしない
+}
+
+export function stopOpenClawHeartbeat(): void {
+  if (intervalHandle) {
+    clearInterval(intervalHandle);
+    intervalHandle = null;
+  }
+  lastAlertAt = null;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import "./config/env";
 
 import { pool as db } from "./lib/db";
 import { alertEngine } from "./lib/alerts/alertEngine";
+import { startOpenClawHeartbeat } from "./agent/openclaw/heartbeatHandler";
 import express from "express";
 import multer from "multer";
 import path from "node:path";
@@ -680,6 +681,10 @@ async function startServer() {
   // Phase23: AlertEngine — 60秒周期で KPI を評価し Slack アラートを送信
   alertEngine.start();
   logger.info("[startup] AlertEngine started");
+
+  // Phase47-D: OpenClaw Heartbeat — flow 統計を30分周期で監視（Flag 判定は handler 内部）
+  startOpenClawHeartbeat();
+  logger.info("[startup] OpenClaw Heartbeat initialized");
 
   // Phase37 Step6: Stripe 日次使用量送信（24時間ごと）
   if (db && process.env.STRIPE_SECRET_KEY) {


### PR DESCRIPTION
## 概要
[Phase47-D] heartbeatHandler.ts 新規実装。OpenClaw Heartbeat（30分ごと）で flowContextStore の TerminalReason 統計を集計し、閾値超過時に Slack アラートを送信する。

Asana: https://app.asana.com/0/1213607637045514/1215592029683800

## 変更内容
- `src/agent/openclaw/heartbeatHandler.ts`（新規） — start/stop/evaluateHeartbeat。30分 interval（`.unref()` でプロセス終了非ブロック）、二重起動ガード、cooldown 30分
- `src/agent/dialog/flowContextStore.ts` — `snapshotFlowSessionMetas()` 追加（read-only、副作用なし。PR #338 の `peekFlowSessionMeta` と名前衝突回避済み）
- `src/index.ts` — alertEngine.start() 直後に配線（Flag 判定は handler 内部）
- テスト 10 ケース（閾値発火/非発火、total=0、Flag OFF、cooldown、Slack 失敗 non-blocking、二重起動）

## 集計仕様（Asana notes の `aborted_stall` は実機に存在しない値のため解釈を明記）
- stall_rate = `aborted_loop_detected` / total（terminalReason 定義済みセッションのみ、total=0 は no-op）
- abort_rate = (`aborted_user` + `aborted_budget` + `failed_safe_mode`) / total
- `escalated_handoff`（意図的ハンドオフ）と `completed` は両 rate から除外
- 発火条件: stall_rate > 0.2 || abort_rate > 0.3
- アラート文面はカウント・レートのみ（PII/会話内容/テナント情報なし）

## 設計判断
- Flag: 既存 `OPENCLAW_ENABLED` のグローバル判定を再利用（テナント横断処理のため tenantId 単位判定は不適用、新 env 追加なし）
- Slack: 既存 `sendSlackAlert`（src/lib/alerts/slackNotifier.ts）を再利用、失敗は catch して non-blocking

## Gate
- Gate 1 (verify): PASS / Gate 1.5: PASS / Gate 2 (security-scan): CRITICAL/HIGH 0 / Gate 3 (build): PASS
- Evaluator: GO（P0/P1 なし）

## DoD（Asana 記載）
- [x] 単体テスト: stall_rate > 0.2 でアラート発火
- [x] 単体テスト: Feature Flag OFF で何もしない
- [x] pnpm typecheck / test pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
