### PR TITLE
perf(livekit): bump agents 1.5.17 / client 2.19.2

### DIFF
--- a/avatar-agent/requirements.txt
+++ b/avatar-agent/requirements.txt
@@ -1,7 +1,7 @@
 # Direct dependencies — pinned via `pip freeze` on VPS 2026-04-21
 # To update: pip install -U <package> && pip freeze > /tmp/freeze.txt, then update this file
 # DO NOT use >= constraints — they allow silent version drift that breaks livekit-agents compatibility
-livekit-agents[lemonslice,openai]==1.5.5
+livekit-agents[lemonslice,openai]==1.5.17
 fish-audio-sdk==1.3.0
 groq==1.2.0
 httpx==0.28.1

--- a/public/widget.js
+++ b/public/widget.js
@@ -1028,7 +1028,7 @@
   /* アバター — LiveKit接続                                               */
   /* ------------------------------------------------------------------ */
 
-  var LIVEKIT_SDK_URL = 'https://cdn.jsdelivr.net/npm/livekit-client@2.9.1/dist/livekit-client.umd.min.js';
+  var LIVEKIT_SDK_URL = 'https://cdn.jsdelivr.net/npm/livekit-client@2.19.2/dist/livekit-client.umd.min.js';
 
   function showAvatarPlaceholder(imageUrl) {
     if (!imageUrl || typeof imageUrl !== 'string') return;


### PR DESCRIPTION
## 概要
[P0] LiveKit バージョンバンプ（締切 2026-06-12）。2ファイルのバージョン番号のみ更新。

Asana: https://app.asana.com/0/1213607637045514/1215589650255804

## 変更内容
- `avatar-agent/requirements.txt`: livekit-agents[lemonslice,openai] 1.5.5 → **1.5.17**
- `public/widget.js:1031`: CDN livekit-client 2.9.1 → **2.19.2**

## 実施前確認（タスク指定コマンド、推測禁止準拠）
- [x] PyPI に livekit-agents 1.5.17 が存在
- [x] CDN `livekit-client@2.19.2/dist/livekit-client.umd.min.js` → HTTP/2 200
- [x] CSP: `script-src` は `https://cdn.jsdelivr.net` ドメイン許可（src/index.ts:151）のため変更不要。旧バージョン参照の残置なし（grep 確認）

## Gate
- Gate 1 (pnpm verify): PASS / Gate 2 (security-scan): CRITICAL/HIGH 0 / Gate 3 (pnpm build + admin-ui build): PASS

## ⚠️ merge 後の人間作業（タスク・24h mode 制約により本 PR に含まず）
- VPS 上で avatar-agent venv の依存更新（Asana タスク記載の手順）
- avatar-agent プロセスの再起動

🤖 Generated with [Claude Code](https://claude.com/claude-code)
