### PR TITLE
feat(admin-ui): 用語ブラッシュアップ残差 — PR #336 未カバー分のリネーム

### DIFF
--- a/admin-ui/src/components/knowledge/PdfUploadTab.tsx
+++ b/admin-ui/src/components/knowledge/PdfUploadTab.tsx
@@ -24,7 +24,7 @@ const STATUS_LABEL: Record<string, string> = {
   uploaded: "アップロード済",
   processing: "処理中",
   chunked: "分割完了",
-  embedded: "埋め込み完了",
+  embedded: "登録完了",
   failed: "失敗",
 };
 const STATUS_COLOR: Record<string, string> = {
@@ -175,7 +175,7 @@ export function BookUploadsSection({ tenantId }: { tenantId: string }) {
                 )}
                 {book.status === "embedded" && (
                   <div style={{ fontSize: 12, color: "#4ade80", marginTop: 4 }}>
-                    ✅ {book.chunk_count ?? 0}件の分割テキスト埋め込み完了
+                    ✅ {book.chunk_count ?? 0}件の分割テキスト登録完了
                   </div>
                 )}
               </div>

--- a/admin-ui/src/pages/admin/chat-history/[sessionId].tsx
+++ b/admin-ui/src/pages/admin/chat-history/[sessionId].tsx
@@ -1047,7 +1047,7 @@ export default function ChatHistorySessionPage() {
                 { key: "psychology_fit_score" as const, label: "心理対応力" },
                 { key: "customer_reaction_score" as const, label: "顧客対応力" },
                 { key: "stage_progress_score" as const, label: "商談進行力" },
-                { key: "taboo_violation_score" as const, label: "NG行為" },
+                { key: "taboo_violation_score" as const, label: "禁止事項の遵守率" },
               ];
               return (
                 <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>

--- a/admin-ui/src/pages/admin/chat-test/index.tsx
+++ b/admin-ui/src/pages/admin/chat-test/index.tsx
@@ -87,7 +87,7 @@ export default function ChatTestPage() {
       ? selectedTenantId
       : (user?.tenantId ?? (previewMode ? (previewTenantId ?? "") : ""));
   const displayTenantName = scopeGlobal
-    ? "グローバルナレッジ"
+    ? "全店舗共通の知識データ"
     : isSuperAdmin
       ? (tenants.find((ten) => ten.id === selectedTenantId)?.name ?? selectedTenantId)
       : (previewMode ? (previewTenantName ?? effectiveTenantId) : (user?.tenantName ?? effectiveTenantId));
@@ -399,7 +399,7 @@ export default function ChatTestPage() {
         {/* グローバルナレッジバナー */}
         {scopeGlobal && (
           <div style={{ marginBottom: 24, padding: "14px 18px", borderRadius: 12, background: "rgba(34,197,94,0.15)", border: "1px solid rgba(34,197,94,0.4)", color: "#4ade80", fontSize: 14, fontWeight: 600, display: "flex", alignItems: "center", gap: 8 }}>
-            <span>🌐</span><span>グローバルナレッジでテスト中</span>
+            <span>🌐</span><span>全店舗共通の知識データでテスト中</span>
           </div>
         )}
 

--- a/admin-ui/src/pages/admin/knowledge/BookChunksPanel.tsx
+++ b/admin-ui/src/pages/admin/knowledge/BookChunksPanel.tsx
@@ -66,7 +66,7 @@ const STATUS_LABEL: Record<string, string> = {
   uploaded: "アップロード済",
   processing: "処理中",
   chunked: "分割完了",
-  embedded: "埋め込み完了",
+  embedded: "登録完了",
   failed: "失敗",
 };
 

--- a/admin-ui/src/pages/admin/knowledge/[tenantId].tsx
+++ b/admin-ui/src/pages/admin/knowledge/[tenantId].tsx
@@ -130,7 +130,7 @@ export default function TenantKnowledgePage() {
                 color: "var(--foreground)", fontSize: 15, cursor: "pointer",
               }}
             >
-              <option value="global">🌐 グローバルナレッジ</option>
+              <option value="global">🌐 全店舗共通の知識データ</option>
               {tenants.map((tn) => (
                 <option key={tn.id} value={tn.id}>{tn.name}</option>
               ))}


### PR DESCRIPTION
## 概要
管理画面用語ブラッシュアップの残差対応。PR #336 で未カバーだった画面表示文字列をリネーム。

Asana: https://app.asana.com/0/1213607637045514/1215584181262847

## 変更内容（表示文字列のみ、キー・変数名は不変更）
- 埋め込み完了 → **登録完了**（PdfUploadTab / BookChunksPanel の STATUS_LABEL + 完了メッセージ）
- グローバルナレッジ → **全店舗共通の知識データ**（knowledge セレクタ / chat-test 表示名・バナー）
- NG行為 → **禁止事項の遵守率**（chat-history セッション詳細の taboo_violation_score ラベル）

## 「NG行為」修正の根拠
`taboo_violation_score` は judgeEvaluator でデフォルト 100・overall_score に正方向加重（高い=遵守できている）。PR #336 が同スコアを analytics では「禁止事項の遵守率」、セッション詳細では「NG行為」とリネームしており、後者は「NG行為: 95」（高スコア=緑）と意味が反転して読める誤表示だったため、analytics と同一ラベルに統一。

## 残差調査の結果（変更不要と判断した分）
- タブー違反 / 温度感スコア / 心理学適合 / クラリファイ / アンサー / コンファーム / ターミナル: admin-ui/src の表示文字列に出現なし（PR #336 で解消済み）
- KPI監視ダッシュボード / アバター利用率 / 4軸平均: コメント内のみ残存、近傍の表示文字列は新用語化済み
- 📌 backend の API エラーメッセージに「グローバルナレッジ」残存（src/index.ts:428 ほか3箇所、tests/phase35 が assert）→ 別タスク候補

## Gate
- Gate 1: typecheck 0 errors / vitest 27 pass / lint exit 0（警告増なし）
- Gate 2 (security-scan): CRITICAL/HIGH 0
- Gate 3: admin-ui build PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
