### PR TITLE
feat(avatar): FishAudio Phase A — S2-Pro 指定 + emotion_tags 注入 + reference_id テナント解決

### DIFF
--- a/avatar-agent/agent.py
+++ b/avatar-agent/agent.py
@@ -172,7 +172,13 @@ async def _report_tts_usage(tenant_id: str, tts_text_bytes: int) -> None:
 
 
 class FishAudioTTS(agents_tts.TTS):
-    def __init__(self, api_key: str, reference_id: str | None = None, tenant_id: str | None = None):
+    def __init__(
+        self,
+        api_key: str,
+        reference_id: str | None = None,
+        tenant_id: str | None = None,
+        emotion_tags: list[str] | None = None,
+    ):
         super().__init__(
             capabilities=agents_tts.TTSCapabilities(streaming=False),
             sample_rate=44100,
@@ -181,7 +187,8 @@ class FishAudioTTS(agents_tts.TTS):
         self._api_key = api_key
         self._reference_id = reference_id
         self._tenant_id = tenant_id
-        logger.info(f"[TTS] FishAudioTTS initialized: ref={self._reference_id} tenant={self._tenant_id}")
+        self._emotion_tags = emotion_tags or []
+        logger.info(f"[TTS] FishAudioTTS initialized: ref={self._reference_id} tenant={self._tenant_id} emotion_tags={self._emotion_tags}")
 
     def synthesize(
         self,
@@ -189,9 +196,11 @@ class FishAudioTTS(agents_tts.TTS):
         *,
         conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
     ) -> "FishAudioChunkedStream":
+        # S2-Pro 感情タグ注入: [empathetic][calm] 形式でテキスト先頭に付与（最大3個）
+        prefix = "".join(f"[{t}]" for t in self._emotion_tags[:3]) if self._emotion_tags else ""
         return FishAudioChunkedStream(
             tts=self,
-            input_text=text,
+            input_text=prefix + text,
             conn_options=conn_options,
             api_key=self._api_key,
             reference_id=self._reference_id,
@@ -230,6 +239,7 @@ class FishAudioChunkedStream(agents_tts.ChunkedStream):
         try:
             request_body = {
                 "text": self._input_text,
+                "model": "s2-pro",  # Phase A: S2-Pro 明示指定（デフォルト依存を排除）
                 "format": "mp3",   # Fish Audio デフォルト形式。WAV より確実。
                 "normalize": True,
                 "latency": "balanced",
@@ -345,13 +355,25 @@ async def entrypoint(ctx: agents.JobContext) -> None:
         avatar_config.get("image_url") if avatar_config and avatar_config.get("image_url")
         else None
     )
+    # emotion_tags: DB には JSON 文字列で格納される場合と list で届く場合の両対応
+    effective_emotion_tags = avatar_config.get("emotion_tags") if avatar_config else None
+    if isinstance(effective_emotion_tags, str):
+        try:
+            effective_emotion_tags = json.loads(effective_emotion_tags)
+        except Exception:
+            logger.warning(f"[entrypoint] emotion_tags JSON parse failed: {effective_emotion_tags!r}")
+            effective_emotion_tags = None
+    if not isinstance(effective_emotion_tags, list):
+        effective_emotion_tags = []
+    effective_emotion_tags = [str(t) for t in effective_emotion_tags if t]
 
-    logger.info(f"[entrypoint] effective config: voice_id={effective_reference_id!r}, agent_id={effective_agent_id!r}, image_url={'set' if effective_image_url else 'none'}, custom_prompt={'yes' if avatar_config and avatar_config.get('personality_prompt') else 'no'}")
+    logger.info(f"[entrypoint] effective config: voice_id={effective_reference_id!r}, agent_id={effective_agent_id!r}, image_url={'set' if effective_image_url else 'none'}, custom_prompt={'yes' if avatar_config and avatar_config.get('personality_prompt') else 'no'}, emotion_tags={len(effective_emotion_tags)} {effective_emotion_tags}")
 
     fish_tts = FishAudioTTS(
         api_key=os.environ["FISH_AUDIO_API_KEY"],
         reference_id=effective_reference_id,
         tenant_id=tenant_id,
+        emotion_tags=effective_emotion_tags,
     )
 
     session = AgentSession(

--- a/src/api/avatar/fishTtsRoutes.test.ts
+++ b/src/api/avatar/fishTtsRoutes.test.ts
@@ -1,0 +1,171 @@
+// src/api/avatar/fishTtsRoutes.test.ts
+// POST /api/avatar/tts — FishAudio Phase A の検証
+//
+// 検証内容:
+//   - S2-Pro モデル明示指定 (model: 's2-pro')
+//   - ハードコード reference_id 撤去 → テナント voice_id を DB 解決
+//   - DB に voice_id がない場合は env FISH_AUDIO_REFERENCE_ID へフォールバック
+//   - 両方ない場合は reference_id フィールド自体を省略
+//   - body から voiceId を受けない（テナント越境防止）
+
+import express from "express";
+import request from "supertest";
+import { registerFishTtsRoutes } from "./fishTtsRoutes";
+
+// ── モック ────────────────────────────────────────────────────────────────────
+
+const mockQuery = jest.fn();
+jest.mock("../../lib/db", () => ({
+  getPool: () => ({ query: mockQuery }),
+}));
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+// ── ヘルパー ──────────────────────────────────────────────────────────────────
+
+function makeApp(tenantId: string | null = "tenant-a") {
+  const app = express();
+  app.use(express.json());
+  app.use((req: any, _res: any, next: any) => {
+    if (tenantId) req.tenantId = tenantId;
+    next();
+  });
+  const apiStack: any[] = [];
+  registerFishTtsRoutes(app, apiStack);
+  return app;
+}
+
+function mockFishAudioOk(audio = "mp3-bytes") {
+  const chunks = [Buffer.from(audio)];
+  let i = 0;
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    body: {
+      getReader: () => ({
+        read: jest.fn(async () =>
+          i < chunks.length ? { done: false, value: chunks[i++] } : { done: true, value: undefined },
+        ),
+      }),
+    },
+  });
+}
+
+function sentBody(): Record<string, unknown> {
+  return JSON.parse(mockFetch.mock.calls[0][1].body as string);
+}
+
+// ── テスト ────────────────────────────────────────────────────────────────────
+
+describe("POST /api/avatar/tts", () => {
+  let savedEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    savedEnv = { ...process.env };
+    process.env.FISH_AUDIO_API_KEY = "test-fish-key";
+    delete process.env.FISH_AUDIO_REFERENCE_ID;
+    mockQuery.mockReset();
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    process.env = savedEnv;
+  });
+
+  it("正常系: DB の voice_id を reference_id に使い、model=s2-pro で Fish Audio を呼ぶ", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ voice_id: "db-voice-123" }] });
+    mockFishAudioOk();
+
+    const res = await request(makeApp("tenant-a"))
+      .post("/api/avatar/tts")
+      .send({ text: "こんにちは" });
+
+    expect(res.status).toBe(200);
+    expect(res.headers["content-type"]).toContain("audio/mpeg");
+
+    // DB 解決クエリが tenant_id + is_active + ORDER BY created_at DESC を含む
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toContain("tenant_id = $1");
+    expect(sql).toContain("is_active = true");
+    expect(sql).toContain("ORDER BY created_at DESC");
+    expect(params).toEqual(["tenant-a"]);
+
+    const body = sentBody();
+    expect(body.model).toBe("s2-pro");
+    expect(body.reference_id).toBe("db-voice-123");
+    // ハードコード ID が復活していないこと
+    expect(JSON.stringify(body)).not.toContain("63bc41e652214372b15d9416a30a60b4");
+  });
+
+  it("認証エラー: tenantId なしは 401", async () => {
+    const res = await request(makeApp(null))
+      .post("/api/avatar/tts")
+      .send({ text: "こんにちは" });
+
+    expect(res.status).toBe(401);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("バリデーションエラー: text なしは 400", async () => {
+    const res = await request(makeApp("tenant-a"))
+      .post("/api/avatar/tts")
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("voice 解決: DB に voice_id がない場合は env FISH_AUDIO_REFERENCE_ID にフォールバック", async () => {
+    process.env.FISH_AUDIO_REFERENCE_ID = "env-voice-456";
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    mockFishAudioOk();
+
+    const res = await request(makeApp("tenant-a"))
+      .post("/api/avatar/tts")
+      .send({ text: "こんにちは" });
+
+    expect(res.status).toBe(200);
+    expect(sentBody().reference_id).toBe("env-voice-456");
+  });
+
+  it("voice 解決: DB にも env にもない場合は reference_id フィールド自体を省略", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    mockFishAudioOk();
+
+    const res = await request(makeApp("tenant-a"))
+      .post("/api/avatar/tts")
+      .send({ text: "こんにちは" });
+
+    expect(res.status).toBe(200);
+    const body = sentBody();
+    expect("reference_id" in body).toBe(false);
+    expect(body.model).toBe("s2-pro");
+  });
+
+  it("voice 解決: DB エラー時は env フォールバックで継続（500 にしない）", async () => {
+    process.env.FISH_AUDIO_REFERENCE_ID = "env-voice-456";
+    mockQuery.mockRejectedValueOnce(new Error("db down"));
+    mockFishAudioOk();
+
+    const res = await request(makeApp("tenant-a"))
+      .post("/api/avatar/tts")
+      .send({ text: "こんにちは" });
+
+    expect(res.status).toBe(200);
+    expect(sentBody().reference_id).toBe("env-voice-456");
+  });
+
+  it("テナント越境防止: body の voiceId は無視され DB 解決値が優先される", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ voice_id: "db-voice-123" }] });
+    mockFishAudioOk();
+
+    const res = await request(makeApp("tenant-a"))
+      .post("/api/avatar/tts")
+      .send({ text: "こんにちは", voiceId: "attacker-voice-999" });
+
+    expect(res.status).toBe(200);
+    const body = sentBody();
+    expect(body.reference_id).toBe("db-voice-123");
+    expect(JSON.stringify(body)).not.toContain("attacker-voice-999");
+  });
+});

--- a/src/api/avatar/fishTtsRoutes.ts
+++ b/src/api/avatar/fishTtsRoutes.ts
@@ -7,6 +7,7 @@
 
 import type { Express, Request, Response, RequestHandler } from 'express';
 import type { AuthedRequest } from '../../agent/http/authMiddleware';
+import { getPool } from '../../lib/db';
 import { logger } from '../../lib/logger';
 
 const FISH_AUDIO_API = 'https://api.fish.audio/v1/tts';
@@ -26,9 +27,21 @@ export function registerFishTtsRoutes(app: Express, apiStack: RequestHandler[]):
     }
 
     const fishApiKey = process.env.FISH_AUDIO_API_KEY?.trim();
-    const referenceId = process.env.FISH_AUDIO_REFERENCE_ID?.trim();
     if (!fishApiKey) {
       return res.status(500).json({ error: 'TTS not configured' });
+    }
+
+    // テナントのアクティブアバター voice_id を解決（avatarConfigRoutes と同一クエリ）
+    // body から voiceId は受けない（テナント越境防止）
+    let referenceId = process.env.FISH_AUDIO_REFERENCE_ID?.trim() || undefined;
+    try {
+      const result = await getPool().query<{ voice_id: string | null }>(
+        `SELECT voice_id FROM avatar_configs WHERE tenant_id = $1 AND is_active = true ORDER BY created_at DESC LIMIT 1`,
+        [tenantId],
+      );
+      if (result.rows[0]?.voice_id) referenceId = result.rows[0].voice_id;
+    } catch (err) {
+      logger.warn({ err, tenantId }, '[fishTts] voice_id resolve failed — env fallback');
     }
 
     try {
@@ -40,7 +53,8 @@ export function registerFishTtsRoutes(app: Express, apiStack: RequestHandler[]):
         },
         body: JSON.stringify({
           text: text,
-          reference_id: referenceId || '63bc41e652214372b15d9416a30a60b4',
+          model: 's2-pro',
+          ...(referenceId ? { reference_id: referenceId } : {}),
           format: 'mp3',
           latency: 'balanced',
         }),


### PR DESCRIPTION
## 概要
[FishAudio Phase A] S2-Pro モデル指定 + emotion_tags の TTS 注入 + reference_id ハードコード撤去。

Asana: https://app.asana.com/0/0/1215612929976868（親: Fish Audio S2-Pro 全機能統合 GID 1215583479062436）

## 変更内容
- `avatar-agent/agent.py`
  - `FishAudioTTS` に emotion_tags パラメータ追加、`synthesize()` でテキスト先頭に `[tag]` 形式で注入（最大3個、提案書記載構文）
  - `request_body` に `"model": "s2-pro"` 追加（従来は S1 デフォルト）
  - entrypoint で avatar_config.emotion_tags を JSON 文字列 / list 両対応でパース
- `src/api/avatar/fishTtsRoutes.ts`
  - `"model": "s2-pro"` 追加
  - ハードコード reference_id `63bc41e6...` を撤去 → **テナントの avatar_configs.voice_id を DB 解決**（パラメタライズド + tenant_id WHERE）。env fallback、どちらも無ければフィールド省略
  - body から voiceId は受けない（テナント越境防止）
- `src/api/avatar/fishTtsRoutes.test.ts`（新規 7 ケース）: 正常系 / 認証 / バリデーション / voice 解決優先順位 / DB エラー時 env fallback / body voiceId 無視

## Gate
- Gate 1 (verify): PASS — 1874 tests / Gate 1.5: PASS / Gate 2 (security-scan): PASS / Gate 3 (build): PASS / py_compile: OK
- Evaluator: GO（P0/P1 なし）

## ⚠️ merge 後の人間作業（24h mode 制約により本 PR に含まず）
- Fish Audio API で S2-Pro モデル名の有効性を curl 確認（無効ならフォールバック検討）
- VPS で avatar-agent 再起動 + carnation で実音声確認

## 📌 別タスク候補（P2）
- emotion_tags の admin バリデーションに文字種制限なし（`]` を含むタグが `[tag]` 構文を壊す）→ `z.string().regex(/^[a-z0-9_\-]+$/i)` 追加を follow-up 推奨
- 提案書 FISH_AUDIO_UPGRADE_PROPOSAL.md が worktree にのみ存在し main 未収録 → docs PR 候補

🤖 Generated with [Claude Code](https://claude.com/claude-code)
