### PR TITLE
refactor(admin-ui): Phase2-P1-2 PR-5 — avatar studio/index を10コンポーネントに分割（機能変更なし）

### DIFF
--- a/admin-ui/src/pages/admin/avatar/AvatarCard.tsx
+++ b/admin-ui/src/pages/admin/avatar/AvatarCard.tsx
@@ -1,0 +1,270 @@
+// admin-ui/src/pages/admin/avatar/AvatarCard.tsx
+// index.tsx から抽出 — アバター設定カード（サムネイル / バッジ / アクション）（機能変更なし）
+
+import { useNavigate } from "react-router-dom";
+import { useLang } from "../../../i18n/LangContext";
+import type { AvatarConfig, WarningTarget } from "./types";
+
+export function AvatarCard({
+  cfg,
+  isSuperAdmin,
+  avatarEnabled,
+  activating,
+  deleting,
+  handleActivate,
+  handleDelete,
+  setWarningTarget,
+  formatDate,
+}: {
+  cfg: AvatarConfig;
+  isSuperAdmin: boolean;
+  avatarEnabled: boolean;
+  activating: string | null;
+  deleting: string | null;
+  handleActivate: (id: string) => Promise<void>;
+  handleDelete: (id: string) => Promise<void>;
+  setWarningTarget: (t: WarningTarget | null) => void;
+  formatDate: (iso: string) => string;
+}) {
+  const navigate = useNavigate();
+  const { lang } = useLang();
+
+  return (
+    <div
+      key={cfg.id}
+      className="av-card"
+      style={{
+        borderRadius: 14,
+        border: cfg.is_active ? "1px solid rgba(34,197,94,0.5)" : "1px solid var(--border)",
+        background: "var(--card)",
+        overflow: "hidden",
+        display: "flex",
+        flexDirection: "column",
+        position: "relative",
+      }}
+    >
+      {/* テナント名 / R2Cデフォルトバッジ（Super Adminのみ） */}
+      {isSuperAdmin && (cfg.tenant_name || cfg.is_default) && (
+        <div style={{
+          position: "absolute",
+          top: 8,
+          left: 8,
+          zIndex: 10,
+          padding: "3px 8px",
+          borderRadius: 6,
+          background: cfg.is_default
+            ? "rgba(99,102,241,0.85)"
+            : "rgba(0,0,0,0.75)",
+          border: cfg.is_default
+            ? "1px solid rgba(165,180,252,0.5)"
+            : "1px solid rgba(255,255,255,0.15)",
+          color: cfg.is_default ? "#e0e7ff" : "#d1d5db",
+          fontSize: 11,
+          fontWeight: 600,
+          maxWidth: 140,
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+        }}>
+          {cfg.is_default ? "R2C デフォルト" : cfg.tenant_name}
+        </div>
+      )}
+
+      {/* サムネイル */}
+      {cfg.image_url ? (
+        <div className="av-img-wrap">
+          <img
+            src={cfg.image_url}
+            alt={cfg.name}
+            loading="lazy"
+            onError={(e) => {
+              (e.currentTarget as HTMLImageElement).style.display = "none";
+            }}
+          />
+          <div className="av-img-overlay" />
+        </div>
+      ) : (
+        <div className="av-img-placeholder">👤</div>
+      )}
+
+      {/* コンテンツ */}
+      <div style={{ padding: "14px 16px", flex: 1, display: "flex", flexDirection: "column", gap: 10 }}>
+        {/* 名前 + バッジ */}
+        <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+          <span className="av-name" style={{ color: cfg.name ? "#f9fafb" : "#6b7280", fontStyle: cfg.name ? "normal" : "italic", flex: 1, minWidth: 0 }}>
+            {cfg.name || (lang === "ja" ? "名前なし" : "Unnamed")}
+          </span>
+          {cfg.is_active && (isSuperAdmin || avatarEnabled) ? (
+            <span style={{
+              padding: "2px 9px",
+              borderRadius: 999,
+              background: "rgba(34,197,94,0.15)",
+              border: "1px solid rgba(34,197,94,0.5)",
+              color: "#4ade80",
+              fontSize: 11,
+              fontWeight: 700,
+              flexShrink: 0,
+            }}>
+              {lang === "ja" ? "アクティブ" : "Active"}
+            </span>
+          ) : cfg.is_active && !avatarEnabled && !isSuperAdmin ? (
+            <span style={{
+              padding: "2px 9px",
+              borderRadius: 999,
+              background: "rgba(107,114,128,0.15)",
+              border: "1px solid rgba(107,114,128,0.4)",
+              color: "var(--muted-foreground)",
+              fontSize: 11,
+              fontWeight: 700,
+              flexShrink: 0,
+            }}>
+              {lang === "ja" ? "無効" : "Inactive"}
+            </span>
+          ) : null}
+          {cfg.is_default && (
+            <span style={{
+              background: '#dbeafe',
+              color: '#1d4ed8',
+              padding: '2px 8px',
+              borderRadius: '9999px',
+              fontSize: '12px',
+              fontWeight: 500,
+              marginLeft: '8px',
+              flexShrink: 0,
+            }}>
+              {lang === "ja" ? "デフォルト" : "Default"}
+            </span>
+          )}
+        </div>
+
+        {/* 作成日 */}
+        <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>
+          {lang === "ja" ? "作成日: " : "Created: "}{formatDate(cfg.created_at)}
+        </span>
+
+        {/* アクションボタン */}
+        <div style={{ display: "flex", gap: 8, marginTop: "auto", flexWrap: "wrap" }}>
+          {!isSuperAdmin && !cfg.is_active && (
+            <button
+              className="av-btn-sm"
+              onClick={() => void handleActivate(cfg.id)}
+              disabled={activating === cfg.id}
+              style={{
+                minHeight: 44,
+                borderRadius: 8,
+                border: "1px solid rgba(34,197,94,0.4)",
+                background: activating === cfg.id ? "rgba(34,197,94,0.05)" : "rgba(34,197,94,0.1)",
+                color: "#4ade80",
+                fontWeight: 600,
+                cursor: activating === cfg.id ? "not-allowed" : "pointer",
+                opacity: activating === cfg.id ? 0.6 : 1,
+              }}
+            >
+              {activating === cfg.id
+                ? (lang === "ja" ? "処理中..." : "Activating...")
+                : (lang === "ja" ? "有効化" : "Activate")}
+            </button>
+          )}
+          {!isSuperAdmin && (
+            <button
+              className="av-btn-sm"
+              onClick={() => navigate(`/admin/avatar/studio/${cfg.id}`)}
+              style={{
+                minHeight: 44,
+                borderRadius: 8,
+                border: "1px solid var(--border)",
+                background: "transparent",
+                color: "var(--muted-foreground)",
+                fontWeight: 600,
+                cursor: "pointer",
+              }}
+            >
+              {lang === "ja" ? "編集" : "Edit"}
+            </button>
+          )}
+          {!isSuperAdmin && !cfg.is_default && avatarEnabled && (
+            <button
+              className="av-btn-sm"
+              onClick={() => navigate(
+                `/admin/chat-test?tenantId=${encodeURIComponent(cfg.tenant_id)}&avatarConfigId=${encodeURIComponent(cfg.id)}`
+              )}
+              title="このアバターでテストチャットを開く"
+              style={{
+                minHeight: 44,
+                borderRadius: 8,
+                border: "none",
+                background: "linear-gradient(135deg, #3b82f6, #6366f1)",
+                color: "#fff",
+                fontWeight: 600,
+                cursor: "pointer",
+              }}
+            >
+              💬 {lang === "ja" ? "テストチャット" : "Test Chat"}
+            </button>
+          )}
+          {!isSuperAdmin && !cfg.is_active && (
+            <button
+              className="av-btn-sm"
+              onClick={() => void handleDelete(cfg.id)}
+              disabled={deleting === cfg.id}
+              style={{
+                minHeight: 44,
+                borderRadius: 8,
+                border: "1px solid rgba(239,68,68,0.3)",
+                background: deleting === cfg.id ? "rgba(239,68,68,0.05)" : "transparent",
+                color: "#f87171",
+                fontWeight: 600,
+                cursor: deleting === cfg.id ? "not-allowed" : "pointer",
+                opacity: deleting === cfg.id ? 0.6 : 1,
+                marginLeft: "auto",
+              }}
+            >
+              {deleting === cfg.id
+                ? (lang === "ja" ? "削除中..." : "Deleting...")
+                : (lang === "ja" ? "削除" : "Delete")}
+            </button>
+          )}
+          {/* Super Admin アクション */}
+          {isSuperAdmin && (
+            <>
+              <button
+                className="av-btn-sm"
+                onClick={() => navigate(`/admin/avatar/studio/${cfg.id}`)}
+                style={{ minHeight: 44, borderRadius: 8, border: "1px solid var(--border)", background: "transparent", color: "var(--muted-foreground)", fontWeight: 600, cursor: "pointer" }}
+              >
+                編集
+              </button>
+              <button
+                className="av-btn-sm"
+                onClick={() => void handleDelete(cfg.id)}
+                disabled={deleting === cfg.id}
+                style={{ minHeight: 44, borderRadius: 8, border: "1px solid rgba(239,68,68,0.3)", background: deleting === cfg.id ? "rgba(239,68,68,0.05)" : "transparent", color: "#f87171", fontWeight: 600, cursor: deleting === cfg.id ? "not-allowed" : "pointer", opacity: deleting === cfg.id ? 0.6 : 1 }}
+              >
+                {deleting === cfg.id ? "削除中..." : "削除"}
+              </button>
+              <button
+                className="av-btn-sm"
+                onClick={() => navigate(
+                  `/admin/chat-test?tenantId=${encodeURIComponent(cfg.tenant_id)}&avatarConfigId=${encodeURIComponent(cfg.id)}`
+                )}
+                title="このアバターでテストチャットを開く"
+                style={{ minHeight: 44, borderRadius: 8, border: "none", background: "linear-gradient(135deg, #3b82f6, #6366f1)", color: "#fff", fontWeight: 600, cursor: "pointer" }}
+              >
+                💬 テスト
+              </button>
+              {!cfg.is_default && (
+                <button
+                  className="av-btn-sm"
+                  onClick={() => setWarningTarget({ id: cfg.id, tenantId: cfg.tenant_id, name: cfg.name })}
+                  style={{ minHeight: 44, borderRadius: 8, border: "1px solid rgba(251,191,36,0.4)", background: "rgba(251,191,36,0.08)", color: "#fbbf24", fontWeight: 600, cursor: "pointer", marginLeft: "auto" }}
+                >
+                  ⚠️ 警告
+                </button>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/admin-ui/src/pages/admin/avatar/AvatarFeatureToggle.tsx
+++ b/admin-ui/src/pages/admin/avatar/AvatarFeatureToggle.tsx
@@ -1,0 +1,78 @@
+// admin-ui/src/pages/admin/avatar/AvatarFeatureToggle.tsx
+// index.tsx から抽出 — アバター機能 ON/OFF トグル（Client Adminのみ）（機能変更なし）
+
+export function AvatarFeatureToggle({
+  avatarEnabled,
+  toggleLoading,
+  tenantFeatures,
+  handleAvatarToggle,
+  toggleToast,
+}: {
+  avatarEnabled: boolean;
+  toggleLoading: boolean;
+  tenantFeatures: { avatar: boolean; voice: boolean; rag: boolean } | null;
+  handleAvatarToggle: () => Promise<void>;
+  toggleToast: string | null;
+}) {
+  return (
+    <div style={{
+      marginBottom: 24,
+      padding: "20px 24px",
+      borderRadius: 14,
+      border: avatarEnabled
+        ? "1px solid rgba(74,222,128,0.35)"
+        : "1px solid rgba(107,114,128,0.3)",
+      background: avatarEnabled
+        ? "rgba(34,197,94,0.07)"
+        : "rgba(255,255,255,0.03)",
+    }}>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 16, flexWrap: "wrap" }}>
+        <div>
+          <h2 style={{ fontSize: 18, fontWeight: 700, margin: 0, color: "var(--foreground)" }}>🤖 AIアバター機能</h2>
+          <p style={{ fontSize: 14, color: "var(--muted-foreground)", margin: "6px 0 0" }}>
+            ONにすると、チャットウィジェットにAIアバターが表示されます
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => { void handleAvatarToggle(); }}
+          disabled={toggleLoading || tenantFeatures === null}
+          style={{
+            padding: "12px 28px",
+            minHeight: 48,
+            minWidth: 120,
+            borderRadius: 10,
+            border: avatarEnabled
+              ? "1px solid rgba(74,222,128,0.5)"
+              : "1px solid rgba(107,114,128,0.4)",
+            background: avatarEnabled
+              ? "rgba(34,197,94,0.22)"
+              : "rgba(107,114,128,0.18)",
+            color: avatarEnabled ? "#4ade80" : "#9ca3af",
+            fontSize: 16,
+            fontWeight: 700,
+            cursor: toggleLoading || tenantFeatures === null ? "not-allowed" : "pointer",
+            opacity: toggleLoading || tenantFeatures === null ? 0.6 : 1,
+            transition: "all 0.15s",
+          }}
+        >
+          {toggleLoading ? "保存中..." : avatarEnabled ? "✅ ON" : "⏸️ OFF"}
+        </button>
+      </div>
+      {toggleToast && (
+        <div style={{
+          marginTop: 12,
+          padding: "10px 14px",
+          borderRadius: 8,
+          background: toggleToast.startsWith("❌")
+            ? "rgba(239,68,68,0.12)"
+            : "rgba(34,197,94,0.12)",
+          color: toggleToast.startsWith("❌") ? "#fca5a5" : "#86efac",
+          fontSize: 14,
+        }}>
+          {toggleToast}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/admin-ui/src/pages/admin/avatar/AvatarFilterPanel.tsx
+++ b/admin-ui/src/pages/admin/avatar/AvatarFilterPanel.tsx
@@ -1,0 +1,123 @@
+// admin-ui/src/pages/admin/avatar/AvatarFilterPanel.tsx
+// index.tsx から抽出 — ソート / フィルタパネル（機能変更なし）
+
+import { useLang } from "../../../i18n/LangContext";
+import type { SortKey, TypeFilter, StatusFilter } from "./types";
+import { toggleBtnStyle } from "./utils";
+
+export function AvatarFilterPanel({
+  isSuperAdmin,
+  sortKey,
+  setSortKey,
+  tenantFilter,
+  setTenantFilter,
+  tenantList,
+  typeFilter,
+  setTypeFilter,
+  statusFilter,
+  setStatusFilter,
+}: {
+  isSuperAdmin: boolean;
+  sortKey: SortKey;
+  setSortKey: (v: SortKey) => void;
+  tenantFilter: string;
+  setTenantFilter: (v: string) => void;
+  tenantList: { id: string; name: string }[];
+  typeFilter: TypeFilter;
+  setTypeFilter: (v: TypeFilter) => void;
+  statusFilter: StatusFilter;
+  setStatusFilter: (v: StatusFilter) => void;
+}) {
+  const { lang } = useLang();
+
+  return (
+    <div className="av-filter-panel" style={{
+      marginBottom: 24,
+      padding: "16px 20px",
+      borderRadius: 14,
+      border: "1px solid rgba(99,102,241,0.3)",
+      background: "var(--card)",
+    }}>
+      {/* ソート */}
+      <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+        <span style={{ fontSize: 13, color: "var(--muted-foreground)", minWidth: 48 }}>
+          {lang === "ja" ? "ソート:" : "Sort:"}
+        </span>
+        <select
+          value={sortKey}
+          onChange={(e) => setSortKey(e.target.value as SortKey)}
+          style={{
+            padding: "8px 12px",
+            minHeight: 44,
+            borderRadius: 8,
+            border: "1px solid var(--border)",
+            background: "var(--input)",
+            color: "var(--foreground)",
+            fontSize: 13,
+            cursor: "pointer",
+          }}
+        >
+          <option value="name_asc">{lang === "ja" ? "アバター名順 (A→Z)" : "Name (A→Z)"}</option>
+          <option value="created_desc">{lang === "ja" ? "作成日 (新しい順)" : "Created (newest)"}</option>
+          <option value="created_asc">{lang === "ja" ? "作成日 (古い順)" : "Created (oldest)"}</option>
+          <option value="active_first">{lang === "ja" ? "アクティブ優先" : "Active first"}</option>
+          <option value="inactive_first">{lang === "ja" ? "無効優先" : "Inactive first"}</option>
+          <option value="default_first">{lang === "ja" ? "デフォルト優先" : "Default first"}</option>
+        </select>
+      </div>
+
+      {/* フィルタ: テナント（Super Adminのみ） */}
+      {isSuperAdmin && (
+        <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
+          <span style={{ fontSize: 13, color: "var(--muted-foreground)", minWidth: 48 }}>
+            {lang === "ja" ? "テナント:" : "Tenant:"}
+          </span>
+          <select
+            value={tenantFilter}
+            onChange={(e) => setTenantFilter(e.target.value)}
+            style={{
+              padding: "8px 12px",
+              minHeight: 44,
+              borderRadius: 8,
+              border: "1px solid var(--border)",
+              background: "var(--input)",
+              color: "var(--foreground)",
+              fontSize: 13,
+              cursor: "pointer",
+              maxWidth: 220,
+            }}
+          >
+            <option value="all">{lang === "ja" ? "全テナント" : "All tenants"}</option>
+            {tenantList.map((t) => (
+              <option key={t.id} value={t.id}>{t.name}</option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {/* フィルタ: タイプ */}
+      <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+        <span style={{ fontSize: 13, color: "var(--muted-foreground)", minWidth: 48 }}>
+          {lang === "ja" ? "タイプ:" : "Type:"}
+        </span>
+        {(["all", "default", "custom"] as TypeFilter[]).map((v) => (
+          <button key={v} onClick={() => setTypeFilter(v)} style={toggleBtnStyle(typeFilter === v)}>
+            {v === "all" ? (lang === "ja" ? "全て" : "All") : v === "default" ? (lang === "ja" ? "デフォルト" : "Default") : (lang === "ja" ? "カスタム" : "Custom")}
+          </button>
+        ))}
+      </div>
+
+      {/* フィルタ: ステータス */}
+      <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+        <span style={{ fontSize: 13, color: "var(--muted-foreground)", minWidth: 48 }}>
+          {lang === "ja" ? "状態:" : "Status:"}
+        </span>
+        {(["all", "active", "inactive"] as StatusFilter[]).map((v) => (
+          <button key={v} onClick={() => setStatusFilter(v)} style={toggleBtnStyle(statusFilter === v)}>
+            {v === "all" ? (lang === "ja" ? "全て" : "All") : v === "active" ? (lang === "ja" ? "アクティブ" : "Active") : (lang === "ja" ? "無効" : "Inactive")}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/admin-ui/src/pages/admin/avatar/AvatarListHeader.tsx
+++ b/admin-ui/src/pages/admin/avatar/AvatarListHeader.tsx
@@ -1,0 +1,83 @@
+// admin-ui/src/pages/admin/avatar/AvatarListHeader.tsx
+// index.tsx から抽出 — ページヘッダー（タイトル / 件数 / 新規作成ボタン）（機能変更なし）
+
+import { useNavigate } from "react-router-dom";
+import { useLang } from "../../../i18n/LangContext";
+import type { AvatarConfig } from "./types";
+
+export function AvatarListHeader({
+  loading,
+  isSuperAdmin,
+  displayedConfigs,
+  total,
+}: {
+  loading: boolean;
+  isSuperAdmin: boolean;
+  displayedConfigs: AvatarConfig[];
+  total: number;
+}) {
+  const navigate = useNavigate();
+  const { lang } = useLang();
+
+  return (
+    <header style={{ marginBottom: 28 }}>
+      <button
+        onClick={() => navigate("/admin")}
+        style={{ background: "none", border: "none", color: "var(--muted-foreground)", fontSize: 14, cursor: "pointer", padding: 0, marginBottom: 10, display: "block" }}
+      >
+        {lang === "ja" ? "← 管理画面に戻る" : "← Back to Admin"}
+      </button>
+      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", flexWrap: "wrap", gap: 12 }}>
+        <div>
+          <h1 style={{ fontSize: 24, fontWeight: 700, margin: 0, color: "var(--foreground)", display: "flex", alignItems: "center", gap: 8 }}>
+            🎭 {lang === "ja" ? "アバター設定" : "Avatar Configs"}
+          </h1>
+          {!loading && (
+            <p style={{ fontSize: 13, color: "var(--muted-foreground)", margin: "4px 0 0" }}>
+              {isSuperAdmin
+                ? (lang === "ja" ? `全テナント: ${displayedConfigs.length}/${total}件` : `All tenants: ${displayedConfigs.length}/${total}`)
+                : (lang === "ja" ? `${total}件の設定` : `${total} config${total !== 1 ? "s" : ""}`)
+              }
+            </p>
+          )}
+        </div>
+        {!isSuperAdmin && (
+          <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+            <button
+              onClick={() => navigate("/admin/avatar/wizard")}
+              style={{
+                padding: "10px 20px",
+                minHeight: 44,
+                borderRadius: 10,
+                border: "1px solid rgba(245,158,11,0.4)",
+                background: "rgba(245,158,11,0.12)",
+                color: "#fcd34d",
+                fontSize: 14,
+                fontWeight: 700,
+                cursor: "pointer",
+              }}
+            >
+              ✨ {lang === "ja" ? "AI生成" : "AI Generate"}
+            </button>
+            <button
+              onClick={() => navigate("/admin/avatar/studio")}
+              style={{
+                padding: "10px 20px",
+                minHeight: 44,
+                borderRadius: 10,
+                border: "none",
+                background: "linear-gradient(135deg, #3b82f6, #6366f1)",
+                color: "#fff",
+                fontSize: 14,
+                fontWeight: 700,
+                cursor: "pointer",
+              }}
+            >
+              {lang === "ja" ? "+ 新規作成" : "+ New Config"}
+            </button>
+          </div>
+        )}
+      </div>
+    </header>
+  );
+}

--- a/admin-ui/src/pages/admin/avatar/AvatarWarningModal.tsx
+++ b/admin-ui/src/pages/admin/avatar/AvatarWarningModal.tsx
@@ -1,0 +1,104 @@
+// admin-ui/src/pages/admin/avatar/AvatarWarningModal.tsx
+// index.tsx から抽出 — テナント警告送信モーダル（機能変更なし）
+
+import React, { useState } from "react";
+import { authFetch, API_BASE } from "../../../lib/api";
+import type { WarningTarget } from "./types";
+
+const WARNING_REASONS = ["利用規約違反の疑い", "不適切なコンテンツ", "システムリソース過剰使用", "その他"];
+const WARNING_DEADLINES = [{ label: "3日以内", days: 3 }, { label: "7日以内", days: 7 }, { label: "14日以内", days: 14 }];
+
+export function AvatarWarningModal({ target, onClose }: { target: WarningTarget; onClose: () => void }) {
+  const [reason, setReason] = useState(WARNING_REASONS[0]);
+  const [deadlineDays, setDeadlineDays] = useState(3);
+  const [memo, setMemo] = useState("");
+  const [sending, setSending] = useState(false);
+  const [sent, setSent] = useState(false);
+  const [sendError, setSendError] = useState<string | null>(null);
+
+  const deadlineDate = new Date(Date.now() + deadlineDays * 86400000)
+    .toLocaleDateString("ja-JP", { year: "numeric", month: "short", day: "numeric" });
+  const previewTitle = `⚠️ アバター警告: ${target.name}`;
+  const previewMessage = `理由: ${reason}\n対応期限: ${deadlineDate}${memo ? `\nメモ: ${memo}` : ""}`;
+
+  const handleSend = async () => {
+    setSending(true);
+    setSendError(null);
+    try {
+      const res = await authFetch(`${API_BASE}/v1/admin/notifications`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          recipient_tenant_id: target.tenantId,
+          type: "avatar_warning",
+          title: previewTitle,
+          message: previewMessage,
+          link: "/admin/avatar",
+          metadata: { avatar_config_id: target.id, reason, deadline_days: deadlineDays },
+        }),
+      });
+      if (!res.ok) { setSendError("送信に失敗しました。もう一度お試しください。"); return; }
+      setSent(true);
+      setTimeout(onClose, 2000);
+    } catch { setSendError("ネットワークエラーが発生しました。"); }
+    finally { setSending(false); }
+  };
+
+  const INPUT_STYLE: React.CSSProperties = { padding: "8px 10px", minHeight: 44, borderRadius: 8, border: "1px solid var(--border)", background: "var(--input)", color: "var(--foreground)", fontSize: 13 };
+
+  return (
+    <div style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.75)", zIndex: 1000, display: "flex", alignItems: "center", justifyContent: "center", padding: 16 }}>
+      <div style={{ width: "min(480px, 100%)", borderRadius: 16, background: "var(--background)", border: "1px solid rgba(239,68,68,0.3)", padding: 24, display: "flex", flexDirection: "column", gap: 16 }}>
+        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
+          <h2 style={{ fontSize: 18, fontWeight: 700, color: "var(--foreground)", margin: 0 }}>⚠️ 警告メッセージを送信</h2>
+          <button onClick={onClose} style={{ background: "none", border: "none", color: "var(--muted-foreground)", fontSize: 20, cursor: "pointer", padding: 4, lineHeight: 1 }}>×</button>
+        </div>
+        <p style={{ margin: 0, fontSize: 13, color: "var(--muted-foreground)" }}>テナントに警告通知を送信します。対象: <strong style={{ color: "var(--foreground)" }}>{target.name}</strong></p>
+
+        {sent ? (
+          <div style={{ textAlign: "center", padding: "20px 0", color: "#4ade80", fontSize: 16, fontWeight: 700 }}>✅ 送信しました</div>
+        ) : (
+          <>
+            <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+              <span style={{ fontSize: 13, color: "var(--muted-foreground)" }}>警告理由</span>
+              <select value={reason} onChange={(e) => setReason(e.target.value)} style={INPUT_STYLE}>
+                {WARNING_REASONS.map((r) => <option key={r} value={r}>{r}</option>)}
+              </select>
+            </label>
+
+            <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+              <span style={{ fontSize: 13, color: "var(--muted-foreground)" }}>対応期限</span>
+              <select value={deadlineDays} onChange={(e) => setDeadlineDays(Number(e.target.value))} style={INPUT_STYLE}>
+                {WARNING_DEADLINES.map((d) => (
+                  <option key={d.days} value={d.days}>
+                    {d.label}（{new Date(Date.now() + d.days * 86400000).toLocaleDateString("ja-JP", { month: "short", day: "numeric" })}）
+                  </option>
+                ))}
+              </select>
+            </label>
+
+            <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+              <span style={{ fontSize: 13, color: "var(--muted-foreground)" }}>メモ（任意）</span>
+              <textarea value={memo} onChange={(e) => setMemo(e.target.value)} rows={3} placeholder="詳細な説明やリンクなど..." style={{ padding: "8px 10px", borderRadius: 8, border: "1px solid var(--border)", background: "var(--input)", color: "var(--foreground)", fontSize: 13, resize: "vertical", fontFamily: "inherit" }} />
+            </label>
+
+            <div style={{ padding: 12, borderRadius: 10, background: "rgba(239,68,68,0.07)", border: "1px solid rgba(239,68,68,0.2)" }}>
+              <p style={{ margin: "0 0 4px", fontSize: 12, color: "var(--muted-foreground)", fontWeight: 600 }}>プレビュー</p>
+              <p style={{ margin: 0, fontSize: 13, color: "#fca5a5", fontWeight: 700 }}>{previewTitle}</p>
+              <p style={{ margin: "4px 0 0", fontSize: 12, color: "var(--muted-foreground)", whiteSpace: "pre-line", lineHeight: 1.7 }}>{previewMessage}</p>
+            </div>
+
+            {sendError && <div style={{ color: "#fca5a5", fontSize: 13 }}>{sendError}</div>}
+
+            <div style={{ display: "flex", gap: 10, justifyContent: "flex-end" }}>
+              <button onClick={onClose} style={{ padding: "10px 18px", minHeight: 44, borderRadius: 8, border: "1px solid var(--border)", background: "transparent", color: "var(--muted-foreground)", fontSize: 13, fontWeight: 600, cursor: "pointer" }}>キャンセル</button>
+              <button onClick={() => void handleSend()} disabled={sending} style={{ padding: "10px 18px", minHeight: 44, borderRadius: 8, border: "none", background: sending ? "#4b5563" : "#dc2626", color: "#fff", fontSize: 13, fontWeight: 700, cursor: sending ? "not-allowed" : "pointer" }}>
+                {sending ? "送信中..." : "⚠️ 警告を送信"}
+              </button>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/admin-ui/src/pages/admin/avatar/StudioBasicSection.tsx
+++ b/admin-ui/src/pages/admin/avatar/StudioBasicSection.tsx
@@ -1,0 +1,42 @@
+// admin-ui/src/pages/admin/avatar/StudioBasicSection.tsx
+// studio.tsx から抽出 — 1. 基本設定セクション（機能変更なし）
+
+import { useLang } from "../../../i18n/LangContext";
+import { SECTION_STYLE, LABEL_STYLE, INPUT_STYLE } from "./types";
+
+export function StudioBasicSection({
+  name,
+  setName,
+  lemonsliceAgentId,
+  setLemonsliceAgentId,
+}: {
+  name: string;
+  setName: (v: string) => void;
+  lemonsliceAgentId: string;
+  setLemonsliceAgentId: (v: string) => void;
+}) {
+  const { lang } = useLang();
+
+  return (
+    <div style={SECTION_STYLE}>
+      <h2 style={{ fontSize: 16, fontWeight: 700, color: "var(--foreground)", margin: "0 0 16px" }}>
+        {lang === "ja" ? "1. 基本設定" : "1. Basic Settings"}
+      </h2>
+      <div style={{ marginBottom: 14 }}>
+        <label style={LABEL_STYLE}>{lang === "ja" ? "アバター名 *" : "Avatar Name *"}</label>
+        <input
+          type="text"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder={lang === "ja" ? "例: サポートアシスタント" : "e.g. Support Assistant"}
+          style={INPUT_STYLE}
+        />
+      </div>
+      <div>
+        <label style={LABEL_STYLE}>Lemonslice Agent ID</label>
+        <input type="text" value={lemonsliceAgentId} onChange={(e) => setLemonsliceAgentId(e.target.value)}
+          placeholder="agent_xxxxxxxxxx" style={INPUT_STYLE} />
+      </div>
+    </div>
+  );
+}

--- a/admin-ui/src/pages/admin/avatar/StudioFooterActions.tsx
+++ b/admin-ui/src/pages/admin/avatar/StudioFooterActions.tsx
@@ -1,0 +1,68 @@
+// admin-ui/src/pages/admin/avatar/StudioFooterActions.tsx
+// studio.tsx から抽出 — 保存 / キャンセル / デフォルトに戻すボタン行（機能変更なし）
+
+import { useNavigate } from "react-router-dom";
+import { useLang } from "../../../i18n/LangContext";
+import { BTN_PRIMARY, BTN_SECONDARY } from "./types";
+
+export function StudioFooterActions({
+  isEdit,
+  isDefault,
+  resetting,
+  handleResetToDefault,
+  saving,
+  name,
+  handleSave,
+}: {
+  isEdit: boolean;
+  isDefault: boolean;
+  resetting: boolean;
+  handleResetToDefault: () => Promise<void>;
+  saving: boolean;
+  name: string;
+  handleSave: () => Promise<void>;
+}) {
+  const navigate = useNavigate();
+  const { lang } = useLang();
+
+  return (
+    <div style={{ display: "flex", gap: 12, justifyContent: "flex-end", marginTop: 8, flexWrap: "wrap" }}>
+      {isEdit && isDefault && (
+        <button
+          onClick={() => void handleResetToDefault()}
+          disabled={resetting}
+          style={{
+            ...BTN_SECONDARY,
+            opacity: resetting ? 0.6 : 1,
+            cursor: resetting ? "not-allowed" : "pointer",
+            marginRight: "auto",
+          }}
+        >
+          {resetting
+            ? (lang === "ja" ? "リセット中..." : "Resetting...")
+            : (lang === "ja" ? "デフォルトに戻す" : "Reset to Default")}
+        </button>
+      )}
+      <button
+        onClick={() => navigate("/admin/avatar")}
+        style={BTN_SECONDARY}
+      >
+        {lang === "ja" ? "キャンセル" : "Cancel"}
+      </button>
+      <button
+        onClick={() => void handleSave()}
+        disabled={saving || !name.trim()}
+        style={{
+          ...BTN_PRIMARY,
+          minWidth: 120,
+          opacity: saving || !name.trim() ? 0.5 : 1,
+          cursor: saving || !name.trim() ? "not-allowed" : "pointer",
+        }}
+      >
+        {saving
+          ? (lang === "ja" ? "保存中..." : "Saving...")
+          : (lang === "ja" ? "保存する" : "Save")}
+      </button>
+    </div>
+  );
+}

--- a/admin-ui/src/pages/admin/avatar/StudioImageSection.tsx
+++ b/admin-ui/src/pages/admin/avatar/StudioImageSection.tsx
@@ -1,0 +1,292 @@
+// admin-ui/src/pages/admin/avatar/StudioImageSection.tsx
+// studio.tsx から抽出 — 2. アバター画像セクション（AI生成 / 写真アップロード）（機能変更なし）
+
+import type { RefObject } from "react";
+import { useLang } from "../../../i18n/LangContext";
+import { SECTION_STYLE, LABEL_STYLE, INPUT_STYLE, TEXTAREA_STYLE, BTN_PRIMARY } from "./types";
+
+export function StudioImageSection({
+  isDefault,
+  imageUrl,
+  setImageUrl,
+  imageTab,
+  setImageTab,
+  imageDesc,
+  setImageDesc,
+  imageDescError,
+  setImageDescError,
+  generatingImage,
+  generatedImages,
+  selectedImageIdx,
+  handleGenerateImage,
+  handleSelectImage,
+  uploadPreview,
+  uploadConfirmed,
+  handleFileUpload,
+  handleConfirmUpload,
+  handleResetUpload,
+  fileInputRef,
+}: {
+  isDefault: boolean;
+  imageUrl: string;
+  setImageUrl: (v: string) => void;
+  imageTab: 'generate' | 'upload';
+  setImageTab: (v: 'generate' | 'upload') => void;
+  imageDesc: string;
+  setImageDesc: (v: string) => void;
+  imageDescError: string | null;
+  setImageDescError: (v: string | null) => void;
+  generatingImage: boolean;
+  generatedImages: string[];
+  selectedImageIdx: number | null;
+  handleGenerateImage: () => Promise<void>;
+  handleSelectImage: (idx: number) => void;
+  uploadPreview: string | null;
+  uploadConfirmed: boolean;
+  handleFileUpload: (file: File) => void;
+  handleConfirmUpload: () => void;
+  handleResetUpload: () => void;
+  fileInputRef: RefObject<HTMLInputElement | null>;
+}) {
+  const { lang } = useLang();
+
+  return (
+    <div style={SECTION_STYLE}>
+      <h2 style={{ fontSize: 16, fontWeight: 700, color: "var(--foreground)", margin: "0 0 16px" }}>
+        {lang === "ja" ? "2. アバター画像" : "2. Avatar Image"}
+      </h2>
+
+      {/* デフォルトアバターは画像変更不可 */}
+      {isDefault ? (
+        <div style={{
+          padding: "14px 16px",
+          borderRadius: 10,
+          background: "rgba(59,130,246,0.08)",
+          border: "1px solid rgba(59,130,246,0.3)",
+          color: "#93c5fd",
+          fontSize: 14,
+          marginBottom: 8,
+        }}>
+          {lang === "ja"
+            ? "デフォルトアバターの画像は変更できません"
+            : "Default avatar images cannot be changed"}
+          {imageUrl && (
+            <div style={{ marginTop: 12, textAlign: "center" }}>
+              <img
+                src={imageUrl}
+                alt="avatar"
+                style={{ maxHeight: 160, borderRadius: 10, display: "block", margin: "0 auto" }}
+                onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = "none"; }}
+              />
+            </div>
+          )}
+        </div>
+      ) : (
+        <>
+      {/* タブ切り替え */}
+      <div style={{ display: "flex", gap: 8, marginBottom: 18 }}>
+        {(['generate', 'upload'] as const).map((tab) => (
+          <button
+            key={tab}
+            type="button"
+            onClick={() => setImageTab(tab)}
+            style={{
+              padding: "8px 18px",
+              minHeight: 44,
+              borderRadius: 10,
+              border: imageTab === tab ? "2px solid #3b82f6" : "1px solid var(--border)",
+              background: imageTab === tab ? "rgba(59,130,246,0.15)" : "transparent",
+              color: imageTab === tab ? "#93c5fd" : "#9ca3af",
+              fontSize: 13,
+              fontWeight: 700,
+              cursor: "pointer",
+            }}
+          >
+            {tab === 'generate'
+              ? (lang === "ja" ? "AIで生成" : "Generate with AI")
+              : (lang === "ja" ? "写真をアップロード" : "Upload Photo")}
+          </button>
+        ))}
+      </div>
+
+      {/* AIで生成タブ */}
+      {imageTab === 'generate' && (
+        <>
+          <div style={{ marginBottom: 12 }}>
+            <label style={LABEL_STYLE}>{lang === "ja" ? "アバターの説明" : "Avatar Description"}</label>
+            <textarea
+              value={imageDesc}
+              onChange={(e) => { setImageDesc(e.target.value); if (imageDescError) setImageDescError(null); }}
+              placeholder={lang === "ja"
+                ? "例: 30代の日本人女性、ショートヘア、紺色のジャケット、笑顔"
+                : "e.g. Japanese woman in 30s, short hair, navy jacket, smiling"}
+              style={TEXTAREA_STYLE}
+            />
+            {imageDescError && (
+              <p style={{ margin: "6px 0 0", fontSize: 12, color: "#f87171" }}>{imageDescError}</p>
+            )}
+          </div>
+          <button
+            onClick={() => void handleGenerateImage()}
+            disabled={generatingImage || !imageDesc.trim()}
+            style={{
+              ...BTN_PRIMARY,
+              opacity: generatingImage || !imageDesc.trim() ? 0.5 : 1,
+              cursor: generatingImage || !imageDesc.trim() ? "not-allowed" : "pointer",
+            }}
+          >
+            {generatingImage
+              ? (lang === "ja" ? "生成中..." : "Generating...")
+              : (lang === "ja" ? "画像を生成する (4枚)" : "Generate Images (4)")}
+          </button>
+
+          {generatedImages.length > 0 && (
+            <div style={{ marginTop: 16 }}>
+              <p style={{ fontSize: 13, color: "var(--muted-foreground)", marginBottom: 10 }}>
+                {lang === "ja" ? "使用する画像を選択してください" : "Select an image to use"}
+              </p>
+              <div style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: 10 }}>
+                {generatedImages.map((url, idx) => (
+                  <div
+                    key={idx}
+                    onClick={() => handleSelectImage(idx)}
+                    style={{
+                      borderRadius: 10,
+                      overflow: "hidden",
+                      border: selectedImageIdx === idx ? "2px solid #3b82f6" : "2px solid transparent",
+                      cursor: "pointer",
+                      aspectRatio: "1",
+                      background: "var(--muted)",
+                    }}
+                  >
+                    <img
+                      src={url}
+                      alt={`Generated ${idx + 1}`}
+                      style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </>
+      )}
+
+      {/* 写真をアップロードタブ */}
+      {imageTab === 'upload' && (
+        <div>
+          <p style={{ color: "var(--muted-foreground)", marginBottom: 12 }}>
+            {lang === "ja" ? "顔がはっきり写った正面の写真が最適です" : "A clear front-facing photo works best"}
+          </p>
+
+          {/* 確定済み: プレビュー + 差し替えリンク */}
+          {uploadConfirmed && uploadPreview ? (
+            <div style={{ textAlign: "center" }}>
+              <img
+                src={uploadPreview}
+                alt="selected"
+                style={{ maxHeight: 300, borderRadius: 10, display: "block", margin: "0 auto 12px" }}
+              />
+              <button
+                type="button"
+                onClick={handleResetUpload}
+                style={{ background: "none", border: "none", color: "var(--muted-foreground)", fontSize: 13, cursor: "pointer", textDecoration: "underline" }}
+              >
+                {lang === "ja" ? "別の画像を選ぶ" : "Choose a different image"}
+              </button>
+            </div>
+          ) : (
+            <>
+              {/* ドラッグ&ドロップエリア */}
+              <div
+                onDragOver={(e) => { e.preventDefault(); e.stopPropagation(); }}
+                onDrop={(e) => {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  const file = e.dataTransfer.files[0];
+                  if (file && file.type.startsWith("image/")) handleFileUpload(file);
+                }}
+                onClick={() => fileInputRef.current?.click()}
+                style={{
+                  border: "2px dashed #4b5563",
+                  borderRadius: 12,
+                  padding: 40,
+                  textAlign: "center",
+                  cursor: "pointer",
+                  minHeight: 200,
+                  display: "flex",
+                  flexDirection: "column",
+                  alignItems: "center",
+                  justifyContent: "center",
+                }}
+              >
+                {uploadPreview ? (
+                  <img src={uploadPreview} alt="preview" style={{ maxHeight: 300, borderRadius: 8 }} />
+                ) : (
+                  <>
+                    <p style={{ fontSize: 18, color: "white", margin: "0 0 8px" }}>
+                      {lang === "ja" ? "ここに画像をドラッグ" : "Drag image here"}
+                    </p>
+                    <p style={{ color: "var(--muted-foreground)", margin: "0 0 8px" }}>
+                      {lang === "ja" ? "または クリックしてファイルを選択" : "or click to select a file"}
+                    </p>
+                    <p style={{ color: "var(--muted-foreground)", fontSize: 14, margin: 0 }}>
+                      JPG, PNG{lang === "ja" ? "（最大5MB）" : " (max 5MB)"}
+                    </p>
+                  </>
+                )}
+              </div>
+
+              {/* 「この画像を使う」確定ボタン */}
+              {uploadPreview && !uploadConfirmed && (
+                <button
+                  type="button"
+                  onClick={handleConfirmUpload}
+                  style={{
+                    marginTop: 16,
+                    padding: "14px 32px",
+                    background: "#4f46e5",
+                    color: "white",
+                    border: "none",
+                    borderRadius: 8,
+                    fontSize: 16,
+                    cursor: "pointer",
+                    width: "100%",
+                  }}
+                >
+                  {lang === "ja" ? "この画像を使う" : "Use this image"}
+                </button>
+              )}
+            </>
+          )}
+
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/jpeg,image/png"
+            style={{ display: "none" }}
+            onChange={(e) => {
+              const file = e.target.files?.[0];
+              if (file) handleFileUpload(file);
+            }}
+          />
+        </div>
+      )}
+
+      {/* 選択中の画像URL（両タブ共通） */}
+      {imageUrl && (
+        <div style={{ marginTop: 14 }}>
+          <label style={LABEL_STYLE}>{lang === "ja" ? "選択中の画像URL" : "Selected Image URL"}</label>
+          <input
+            type="text"
+            value={imageUrl}
+            onChange={(e) => setImageUrl(e.target.value)}
+            style={INPUT_STYLE}
+          />
+        </div>
+      )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/admin-ui/src/pages/admin/avatar/StudioPersonalitySection.tsx
+++ b/admin-ui/src/pages/admin/avatar/StudioPersonalitySection.tsx
@@ -1,0 +1,158 @@
+// admin-ui/src/pages/admin/avatar/StudioPersonalitySection.tsx
+// studio.tsx から抽出 — 4. パーソナリティセクション（機能変更なし）
+
+import { useLang } from "../../../i18n/LangContext";
+import { SECTION_STYLE, LABEL_STYLE, TEXTAREA_STYLE, BTN_PRIMARY } from "./types";
+
+export function StudioPersonalitySection({
+  isDefault,
+  promptRules,
+  setPromptRules,
+  generatingPrompt,
+  handleGeneratePrompt,
+  personalityPrompt,
+  setPersonalityPrompt,
+  agentPrompt,
+  agentIdlePrompt,
+  behaviorDescription,
+  setBehaviorDescription,
+  emotionTags,
+}: {
+  isDefault: boolean;
+  promptRules: string;
+  setPromptRules: (v: string) => void;
+  generatingPrompt: boolean;
+  handleGeneratePrompt: () => Promise<void>;
+  personalityPrompt: string;
+  setPersonalityPrompt: (v: string) => void;
+  agentPrompt: string;
+  agentIdlePrompt: string;
+  behaviorDescription: string;
+  setBehaviorDescription: (v: string) => void;
+  emotionTags: string[];
+}) {
+  const { lang } = useLang();
+
+  return (
+    <div style={SECTION_STYLE}>
+      <h2 style={{ fontSize: 16, fontWeight: 700, color: "var(--foreground)", margin: "0 0 16px" }}>
+        {lang === "ja" ? "4. パーソナリティ" : "4. Personality"}
+      </h2>
+      <div style={{ marginBottom: 12 }}>
+        <label style={LABEL_STYLE}>{lang === "ja" ? "接客ルール・ペルソナ情報" : "Rules & Persona"}</label>
+        <textarea
+          value={promptRules}
+          onChange={(e) => setPromptRules(e.target.value)}
+          placeholder={lang === "ja"
+            ? "例: 丁寧な口調、商品の良い点を積極的にアピール、クレームには共感してから解決策を提示"
+            : "e.g. Polite tone, proactively highlight product benefits, empathize then resolve complaints"}
+          style={{ ...TEXTAREA_STYLE, minHeight: 100 }}
+        />
+      </div>
+      <button
+        onClick={() => void handleGeneratePrompt()}
+        disabled={isDefault || generatingPrompt || !promptRules.trim()}
+        style={{
+          ...BTN_PRIMARY,
+          opacity: isDefault || generatingPrompt || !promptRules.trim() ? 0.5 : 1,
+          cursor: isDefault || generatingPrompt || !promptRules.trim() ? "not-allowed" : "pointer",
+        }}
+      >
+        {generatingPrompt
+          ? (lang === "ja" ? "生成中..." : "Generating...")
+          : (lang === "ja" ? "プロンプトを生成する" : "Generate Prompt")}
+      </button>
+
+      <div style={{ marginTop: 16 }}>
+        <label style={LABEL_STYLE}>
+          {lang === "ja" ? "システムプロンプト" : "System Prompt"}
+        </label>
+        <textarea
+          value={personalityPrompt}
+          onChange={(e) => setPersonalityPrompt(e.target.value)}
+          readOnly={isDefault}
+          placeholder={lang === "ja" ? "AIが生成するか、直接入力してください" : "Auto-generated or enter manually"}
+          style={{
+            ...TEXTAREA_STYLE,
+            minHeight: 120,
+            ...(isDefault ? { background: "var(--card)", color: "var(--muted-foreground)", cursor: "default" } : {}),
+          }}
+        />
+        {isDefault && (
+          <p style={{ fontSize: 11, color: "#4b5563", marginTop: 4, marginBottom: 0 }}>
+            {lang === "ja" ? "デフォルト設定 — 変更不可" : "Default setting — read-only"}
+          </p>
+        )}
+      </div>
+
+      {isDefault && (agentPrompt || agentIdlePrompt) && (
+        <>
+          <div style={{ marginTop: 14 }}>
+            <label style={LABEL_STYLE}>
+              {lang === "ja" ? "動作プロンプト（会話中）" : "Agent Prompt (During Conversation)"}
+            </label>
+            <textarea
+              value={agentPrompt}
+              readOnly
+              style={{ ...TEXTAREA_STYLE, background: "var(--card)", color: "var(--muted-foreground)", cursor: "default", fontStyle: "italic" }}
+            />
+            <p style={{ fontSize: 11, color: "#4b5563", marginTop: 4, marginBottom: 0 }}>
+              {lang === "ja" ? "デフォルト設定 — 変更不可" : "Default setting — read-only"}
+            </p>
+          </div>
+          <div style={{ marginTop: 14 }}>
+            <label style={LABEL_STYLE}>
+              {lang === "ja" ? "動作プロンプト（待機中）" : "Agent Prompt (Idle)"}
+            </label>
+            <textarea
+              value={agentIdlePrompt}
+              readOnly
+              style={{ ...TEXTAREA_STYLE, background: "var(--card)", color: "var(--muted-foreground)", cursor: "default", fontStyle: "italic" }}
+            />
+            <p style={{ fontSize: 11, color: "#4b5563", marginTop: 4, marginBottom: 0 }}>
+              {lang === "ja" ? "デフォルト設定 — 変更不可" : "Default setting — read-only"}
+            </p>
+          </div>
+        </>
+      )}
+
+      <div style={{ marginTop: 14 }}>
+        <label style={LABEL_STYLE}>
+          {lang === "ja" ? "行動説明" : "Behavior Description"}
+        </label>
+        <textarea
+          value={behaviorDescription}
+          onChange={(e) => setBehaviorDescription(e.target.value)}
+          placeholder={lang === "ja" ? "アバターの行動特性を記述します（任意）" : "Describe behavior characteristics (optional)"}
+          style={TEXTAREA_STYLE}
+        />
+      </div>
+
+      {emotionTags.length > 0 && (
+        <div style={{ marginTop: 14 }}>
+          <label style={LABEL_STYLE}>
+            {lang === "ja" ? "感情タグ" : "Emotion Tags"}
+          </label>
+          <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
+            {emotionTags.map((tag) => (
+              <span
+                key={tag}
+                style={{
+                  padding: "3px 10px",
+                  borderRadius: 999,
+                  background: "rgba(99,102,241,0.15)",
+                  border: "1px solid rgba(99,102,241,0.4)",
+                  color: "#a5b4fc",
+                  fontSize: 12,
+                  fontWeight: 600,
+                }}
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/admin-ui/src/pages/admin/avatar/StudioVoiceSection.tsx
+++ b/admin-ui/src/pages/admin/avatar/StudioVoiceSection.tsx
@@ -1,0 +1,122 @@
+// admin-ui/src/pages/admin/avatar/StudioVoiceSection.tsx
+// studio.tsx から抽出 — 3. 声マッチングセクション（機能変更なし）
+
+import { useLang } from "../../../i18n/LangContext";
+import type { VoiceRecommendation } from "./types";
+import { SECTION_STYLE, LABEL_STYLE, INPUT_STYLE, TEXTAREA_STYLE, BTN_PRIMARY } from "./types";
+
+export function StudioVoiceSection({
+  isDefault,
+  voiceDesc,
+  setVoiceDesc,
+  matchingVoice,
+  handleMatchVoice,
+  voiceRecs,
+  selectedVoiceId,
+  handleSelectVoice,
+  voiceId,
+  setVoiceId,
+}: {
+  isDefault: boolean;
+  voiceDesc: string;
+  setVoiceDesc: (v: string) => void;
+  matchingVoice: boolean;
+  handleMatchVoice: () => Promise<void>;
+  voiceRecs: VoiceRecommendation[];
+  selectedVoiceId: string | null;
+  handleSelectVoice: (rec: VoiceRecommendation) => void;
+  voiceId: string;
+  setVoiceId: (v: string) => void;
+}) {
+  const { lang } = useLang();
+
+  return (
+    <div style={SECTION_STYLE}>
+      <h2 style={{ fontSize: 16, fontWeight: 700, color: "var(--foreground)", margin: "0 0 16px" }}>
+        {lang === "ja" ? "3. 声マッチング" : "3. Voice Matching"}
+      </h2>
+      <div style={{ marginBottom: 12 }}>
+        <label style={LABEL_STYLE}>{lang === "ja" ? "声の説明" : "Voice Description"}</label>
+        <textarea
+          value={voiceDesc}
+          onChange={(e) => setVoiceDesc(e.target.value)}
+          placeholder={lang === "ja"
+            ? "例: 若い女性、明るく親しみやすい声、標準的な日本語"
+            : "e.g. Young female, bright and friendly, standard Japanese"}
+          style={TEXTAREA_STYLE}
+        />
+      </div>
+      <button
+        onClick={() => void handleMatchVoice()}
+        disabled={isDefault || matchingVoice || !voiceDesc.trim()}
+        style={{
+          ...BTN_PRIMARY,
+          opacity: isDefault || matchingVoice || !voiceDesc.trim() ? 0.5 : 1,
+          cursor: isDefault || matchingVoice || !voiceDesc.trim() ? "not-allowed" : "pointer",
+        }}
+      >
+        {matchingVoice
+          ? (lang === "ja" ? "マッチング中..." : "Matching...")
+          : (lang === "ja" ? "声を検索する" : "Find Voices")}
+      </button>
+
+      {voiceRecs.length > 0 && (
+        <div style={{ marginTop: 16, display: "flex", flexDirection: "column", gap: 8 }}>
+          <p style={{ fontSize: 13, color: "var(--muted-foreground)", marginBottom: 4 }}>
+            {lang === "ja" ? "使用する声を選択してください" : "Select a voice to use"}
+          </p>
+          {voiceRecs.map((rec) => (
+            <div
+              key={rec.id}
+              onClick={() => handleSelectVoice(rec)}
+              style={{
+                padding: "12px 14px",
+                borderRadius: 10,
+                border: selectedVoiceId === rec.id
+                  ? "1px solid rgba(99,102,241,0.7)"
+                  : "1px solid var(--border)",
+                background: selectedVoiceId === rec.id
+                  ? "rgba(99,102,241,0.1)"
+                  : "rgba(30,41,59,0.6)",
+                cursor: "pointer",
+              }}
+            >
+              <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 4 }}>
+                <span style={{ fontSize: 14, fontWeight: 600, color: "var(--foreground)" }}>{rec.title}</span>
+                <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>
+                  {Math.round(rec.score * 100)}%
+                </span>
+              </div>
+              <p style={{ fontSize: 12, color: "var(--muted-foreground)", margin: 0, lineHeight: 1.5 }}>{rec.description}</p>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {(voiceId || isDefault) && (
+        <div style={{ marginTop: 14 }}>
+          <label style={LABEL_STYLE}>
+            {isDefault
+              ? (lang === "ja" ? "設定済みの声 (Voice ID)" : "Configured Voice (Voice ID)")
+              : "Voice ID"}
+          </label>
+          <input
+            type="text"
+            value={voiceId}
+            onChange={(e) => setVoiceId(e.target.value)}
+            readOnly={isDefault}
+            style={{
+              ...INPUT_STYLE,
+              ...(isDefault ? { background: "var(--card)", color: "var(--muted-foreground)", cursor: "default" } : {}),
+            }}
+          />
+          {isDefault && (
+            <p style={{ fontSize: 11, color: "#4b5563", marginTop: 4, marginBottom: 0 }}>
+              {lang === "ja" ? "デフォルト設定 — 変更不可" : "Default setting — read-only"}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/admin-ui/src/pages/admin/avatar/index.tsx
+++ b/admin-ui/src/pages/admin/avatar/index.tsx
@@ -2,7 +2,6 @@
 // Avatar Customization Studio — config list page
 
 import { useState, useEffect, useCallback, useMemo } from "react";
-import { useNavigate } from "react-router-dom";
 import { useLang } from "../../../i18n/LangContext";
 import { authFetch, API_BASE } from "../../../lib/api";
 import { useAuth } from "../../../auth/useAuth";
@@ -12,9 +11,9 @@ import { AvatarWarningModal } from "./AvatarWarningModal";
 import { AvatarListHeader } from "./AvatarListHeader";
 import { AvatarFilterPanel } from "./AvatarFilterPanel";
 import { AvatarFeatureToggle } from "./AvatarFeatureToggle";
+import { AvatarCard } from "./AvatarCard";
 
 export default function AvatarListPage() {
-  const navigate = useNavigate();
   const { lang } = useLang();
   const locale = lang === "en" ? "en-US" : "ja-JP";
   const { user, isSuperAdmin } = useAuth();
@@ -388,242 +387,18 @@ export default function AvatarListPage() {
       ) : (
         <div className="av-grid">
           {displayedConfigs.map((cfg) => (
-            <div
+            <AvatarCard
               key={cfg.id}
-              className="av-card"
-              style={{
-                borderRadius: 14,
-                border: cfg.is_active ? "1px solid rgba(34,197,94,0.5)" : "1px solid var(--border)",
-                background: "var(--card)",
-                overflow: "hidden",
-                display: "flex",
-                flexDirection: "column",
-                position: "relative",
-              }}
-            >
-              {/* テナント名 / R2Cデフォルトバッジ（Super Adminのみ） */}
-              {isSuperAdmin && (cfg.tenant_name || cfg.is_default) && (
-                <div style={{
-                  position: "absolute",
-                  top: 8,
-                  left: 8,
-                  zIndex: 10,
-                  padding: "3px 8px",
-                  borderRadius: 6,
-                  background: cfg.is_default
-                    ? "rgba(99,102,241,0.85)"
-                    : "rgba(0,0,0,0.75)",
-                  border: cfg.is_default
-                    ? "1px solid rgba(165,180,252,0.5)"
-                    : "1px solid rgba(255,255,255,0.15)",
-                  color: cfg.is_default ? "#e0e7ff" : "#d1d5db",
-                  fontSize: 11,
-                  fontWeight: 600,
-                  maxWidth: 140,
-                  overflow: "hidden",
-                  textOverflow: "ellipsis",
-                  whiteSpace: "nowrap",
-                }}>
-                  {cfg.is_default ? "R2C デフォルト" : cfg.tenant_name}
-                </div>
-              )}
-
-              {/* サムネイル */}
-              {cfg.image_url ? (
-                <div className="av-img-wrap">
-                  <img
-                    src={cfg.image_url}
-                    alt={cfg.name}
-                    loading="lazy"
-                    onError={(e) => {
-                      (e.currentTarget as HTMLImageElement).style.display = "none";
-                    }}
-                  />
-                  <div className="av-img-overlay" />
-                </div>
-              ) : (
-                <div className="av-img-placeholder">👤</div>
-              )}
-
-              {/* コンテンツ */}
-              <div style={{ padding: "14px 16px", flex: 1, display: "flex", flexDirection: "column", gap: 10 }}>
-                {/* 名前 + バッジ */}
-                <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
-                  <span className="av-name" style={{ color: cfg.name ? "#f9fafb" : "#6b7280", fontStyle: cfg.name ? "normal" : "italic", flex: 1, minWidth: 0 }}>
-                    {cfg.name || (lang === "ja" ? "名前なし" : "Unnamed")}
-                  </span>
-                  {cfg.is_active && (isSuperAdmin || avatarEnabled) ? (
-                    <span style={{
-                      padding: "2px 9px",
-                      borderRadius: 999,
-                      background: "rgba(34,197,94,0.15)",
-                      border: "1px solid rgba(34,197,94,0.5)",
-                      color: "#4ade80",
-                      fontSize: 11,
-                      fontWeight: 700,
-                      flexShrink: 0,
-                    }}>
-                      {lang === "ja" ? "アクティブ" : "Active"}
-                    </span>
-                  ) : cfg.is_active && !avatarEnabled && !isSuperAdmin ? (
-                    <span style={{
-                      padding: "2px 9px",
-                      borderRadius: 999,
-                      background: "rgba(107,114,128,0.15)",
-                      border: "1px solid rgba(107,114,128,0.4)",
-                      color: "var(--muted-foreground)",
-                      fontSize: 11,
-                      fontWeight: 700,
-                      flexShrink: 0,
-                    }}>
-                      {lang === "ja" ? "無効" : "Inactive"}
-                    </span>
-                  ) : null}
-                  {cfg.is_default && (
-                    <span style={{
-                      background: '#dbeafe',
-                      color: '#1d4ed8',
-                      padding: '2px 8px',
-                      borderRadius: '9999px',
-                      fontSize: '12px',
-                      fontWeight: 500,
-                      marginLeft: '8px',
-                      flexShrink: 0,
-                    }}>
-                      {lang === "ja" ? "デフォルト" : "Default"}
-                    </span>
-                  )}
-                </div>
-
-                {/* 作成日 */}
-                <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>
-                  {lang === "ja" ? "作成日: " : "Created: "}{formatDate(cfg.created_at)}
-                </span>
-
-                {/* アクションボタン */}
-                <div style={{ display: "flex", gap: 8, marginTop: "auto", flexWrap: "wrap" }}>
-                  {!isSuperAdmin && !cfg.is_active && (
-                    <button
-                      className="av-btn-sm"
-                      onClick={() => void handleActivate(cfg.id)}
-                      disabled={activating === cfg.id}
-                      style={{
-                        minHeight: 44,
-                        borderRadius: 8,
-                        border: "1px solid rgba(34,197,94,0.4)",
-                        background: activating === cfg.id ? "rgba(34,197,94,0.05)" : "rgba(34,197,94,0.1)",
-                        color: "#4ade80",
-                        fontWeight: 600,
-                        cursor: activating === cfg.id ? "not-allowed" : "pointer",
-                        opacity: activating === cfg.id ? 0.6 : 1,
-                      }}
-                    >
-                      {activating === cfg.id
-                        ? (lang === "ja" ? "処理中..." : "Activating...")
-                        : (lang === "ja" ? "有効化" : "Activate")}
-                    </button>
-                  )}
-                  {!isSuperAdmin && (
-                    <button
-                      className="av-btn-sm"
-                      onClick={() => navigate(`/admin/avatar/studio/${cfg.id}`)}
-                      style={{
-                        minHeight: 44,
-                        borderRadius: 8,
-                        border: "1px solid var(--border)",
-                        background: "transparent",
-                        color: "var(--muted-foreground)",
-                        fontWeight: 600,
-                        cursor: "pointer",
-                      }}
-                    >
-                      {lang === "ja" ? "編集" : "Edit"}
-                    </button>
-                  )}
-                  {!isSuperAdmin && !cfg.is_default && avatarEnabled && (
-                    <button
-                      className="av-btn-sm"
-                      onClick={() => navigate(
-                        `/admin/chat-test?tenantId=${encodeURIComponent(cfg.tenant_id)}&avatarConfigId=${encodeURIComponent(cfg.id)}`
-                      )}
-                      title="このアバターでテストチャットを開く"
-                      style={{
-                        minHeight: 44,
-                        borderRadius: 8,
-                        border: "none",
-                        background: "linear-gradient(135deg, #3b82f6, #6366f1)",
-                        color: "#fff",
-                        fontWeight: 600,
-                        cursor: "pointer",
-                      }}
-                    >
-                      💬 {lang === "ja" ? "テストチャット" : "Test Chat"}
-                    </button>
-                  )}
-                  {!isSuperAdmin && !cfg.is_active && (
-                    <button
-                      className="av-btn-sm"
-                      onClick={() => void handleDelete(cfg.id)}
-                      disabled={deleting === cfg.id}
-                      style={{
-                        minHeight: 44,
-                        borderRadius: 8,
-                        border: "1px solid rgba(239,68,68,0.3)",
-                        background: deleting === cfg.id ? "rgba(239,68,68,0.05)" : "transparent",
-                        color: "#f87171",
-                        fontWeight: 600,
-                        cursor: deleting === cfg.id ? "not-allowed" : "pointer",
-                        opacity: deleting === cfg.id ? 0.6 : 1,
-                        marginLeft: "auto",
-                      }}
-                    >
-                      {deleting === cfg.id
-                        ? (lang === "ja" ? "削除中..." : "Deleting...")
-                        : (lang === "ja" ? "削除" : "Delete")}
-                    </button>
-                  )}
-                  {/* Super Admin アクション */}
-                  {isSuperAdmin && (
-                    <>
-                      <button
-                        className="av-btn-sm"
-                        onClick={() => navigate(`/admin/avatar/studio/${cfg.id}`)}
-                        style={{ minHeight: 44, borderRadius: 8, border: "1px solid var(--border)", background: "transparent", color: "var(--muted-foreground)", fontWeight: 600, cursor: "pointer" }}
-                      >
-                        編集
-                      </button>
-                      <button
-                        className="av-btn-sm"
-                        onClick={() => void handleDelete(cfg.id)}
-                        disabled={deleting === cfg.id}
-                        style={{ minHeight: 44, borderRadius: 8, border: "1px solid rgba(239,68,68,0.3)", background: deleting === cfg.id ? "rgba(239,68,68,0.05)" : "transparent", color: "#f87171", fontWeight: 600, cursor: deleting === cfg.id ? "not-allowed" : "pointer", opacity: deleting === cfg.id ? 0.6 : 1 }}
-                      >
-                        {deleting === cfg.id ? "削除中..." : "削除"}
-                      </button>
-                      <button
-                        className="av-btn-sm"
-                        onClick={() => navigate(
-                          `/admin/chat-test?tenantId=${encodeURIComponent(cfg.tenant_id)}&avatarConfigId=${encodeURIComponent(cfg.id)}`
-                        )}
-                        title="このアバターでテストチャットを開く"
-                        style={{ minHeight: 44, borderRadius: 8, border: "none", background: "linear-gradient(135deg, #3b82f6, #6366f1)", color: "#fff", fontWeight: 600, cursor: "pointer" }}
-                      >
-                        💬 テスト
-                      </button>
-                      {!cfg.is_default && (
-                        <button
-                          className="av-btn-sm"
-                          onClick={() => setWarningTarget({ id: cfg.id, tenantId: cfg.tenant_id, name: cfg.name })}
-                          style={{ minHeight: 44, borderRadius: 8, border: "1px solid rgba(251,191,36,0.4)", background: "rgba(251,191,36,0.08)", color: "#fbbf24", fontWeight: 600, cursor: "pointer", marginLeft: "auto" }}
-                        >
-                          ⚠️ 警告
-                        </button>
-                      )}
-                    </>
-                  )}
-                </div>
-              </div>
-            </div>
+              cfg={cfg}
+              isSuperAdmin={isSuperAdmin}
+              avatarEnabled={avatarEnabled}
+              activating={activating}
+              deleting={deleting}
+              handleActivate={handleActivate}
+              handleDelete={handleDelete}
+              setWarningTarget={setWarningTarget}
+              formatDate={formatDate}
+            />
           ))}
         </div>
       )}

--- a/admin-ui/src/pages/admin/avatar/index.tsx
+++ b/admin-ui/src/pages/admin/avatar/index.tsx
@@ -8,9 +8,9 @@ import { authFetch, API_BASE } from "../../../lib/api";
 import { useAuth } from "../../../auth/useAuth";
 import type { AvatarConfig, SortKey, TypeFilter, StatusFilter, WarningTarget } from "./types";
 import { BG } from "./types";
-import { toggleBtnStyle } from "./utils";
 import { AvatarWarningModal } from "./AvatarWarningModal";
 import { AvatarListHeader } from "./AvatarListHeader";
+import { AvatarFilterPanel } from "./AvatarFilterPanel";
 
 export default function AvatarListPage() {
   const navigate = useNavigate();
@@ -323,94 +323,18 @@ export default function AvatarListPage() {
 
       {/* ── ソート / フィルタパネル ─────────────────────────────── */}
       {!loading && (
-        <div className="av-filter-panel" style={{
-          marginBottom: 24,
-          padding: "16px 20px",
-          borderRadius: 14,
-          border: "1px solid rgba(99,102,241,0.3)",
-          background: "var(--card)",
-        }}>
-          {/* ソート */}
-          <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
-            <span style={{ fontSize: 13, color: "var(--muted-foreground)", minWidth: 48 }}>
-              {lang === "ja" ? "ソート:" : "Sort:"}
-            </span>
-            <select
-              value={sortKey}
-              onChange={(e) => setSortKey(e.target.value as SortKey)}
-              style={{
-                padding: "8px 12px",
-                minHeight: 44,
-                borderRadius: 8,
-                border: "1px solid var(--border)",
-                background: "var(--input)",
-                color: "var(--foreground)",
-                fontSize: 13,
-                cursor: "pointer",
-              }}
-            >
-              <option value="name_asc">{lang === "ja" ? "アバター名順 (A→Z)" : "Name (A→Z)"}</option>
-              <option value="created_desc">{lang === "ja" ? "作成日 (新しい順)" : "Created (newest)"}</option>
-              <option value="created_asc">{lang === "ja" ? "作成日 (古い順)" : "Created (oldest)"}</option>
-              <option value="active_first">{lang === "ja" ? "アクティブ優先" : "Active first"}</option>
-              <option value="inactive_first">{lang === "ja" ? "無効優先" : "Inactive first"}</option>
-              <option value="default_first">{lang === "ja" ? "デフォルト優先" : "Default first"}</option>
-            </select>
-          </div>
-
-          {/* フィルタ: テナント（Super Adminのみ） */}
-          {isSuperAdmin && (
-            <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap" }}>
-              <span style={{ fontSize: 13, color: "var(--muted-foreground)", minWidth: 48 }}>
-                {lang === "ja" ? "テナント:" : "Tenant:"}
-              </span>
-              <select
-                value={tenantFilter}
-                onChange={(e) => setTenantFilter(e.target.value)}
-                style={{
-                  padding: "8px 12px",
-                  minHeight: 44,
-                  borderRadius: 8,
-                  border: "1px solid var(--border)",
-                  background: "var(--input)",
-                  color: "var(--foreground)",
-                  fontSize: 13,
-                  cursor: "pointer",
-                  maxWidth: 220,
-                }}
-              >
-                <option value="all">{lang === "ja" ? "全テナント" : "All tenants"}</option>
-                {tenantList.map((t) => (
-                  <option key={t.id} value={t.id}>{t.name}</option>
-                ))}
-              </select>
-            </div>
-          )}
-
-          {/* フィルタ: タイプ */}
-          <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
-            <span style={{ fontSize: 13, color: "var(--muted-foreground)", minWidth: 48 }}>
-              {lang === "ja" ? "タイプ:" : "Type:"}
-            </span>
-            {(["all", "default", "custom"] as TypeFilter[]).map((v) => (
-              <button key={v} onClick={() => setTypeFilter(v)} style={toggleBtnStyle(typeFilter === v)}>
-                {v === "all" ? (lang === "ja" ? "全て" : "All") : v === "default" ? (lang === "ja" ? "デフォルト" : "Default") : (lang === "ja" ? "カスタム" : "Custom")}
-              </button>
-            ))}
-          </div>
-
-          {/* フィルタ: ステータス */}
-          <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
-            <span style={{ fontSize: 13, color: "var(--muted-foreground)", minWidth: 48 }}>
-              {lang === "ja" ? "状態:" : "Status:"}
-            </span>
-            {(["all", "active", "inactive"] as StatusFilter[]).map((v) => (
-              <button key={v} onClick={() => setStatusFilter(v)} style={toggleBtnStyle(statusFilter === v)}>
-                {v === "all" ? (lang === "ja" ? "全て" : "All") : v === "active" ? (lang === "ja" ? "アクティブ" : "Active") : (lang === "ja" ? "無効" : "Inactive")}
-              </button>
-            ))}
-          </div>
-        </div>
+        <AvatarFilterPanel
+          isSuperAdmin={isSuperAdmin}
+          sortKey={sortKey}
+          setSortKey={setSortKey}
+          tenantFilter={tenantFilter}
+          setTenantFilter={setTenantFilter}
+          tenantList={tenantList}
+          typeFilter={typeFilter}
+          setTypeFilter={setTypeFilter}
+          statusFilter={statusFilter}
+          setStatusFilter={setStatusFilter}
+        />
       )}
 
       {/* ── アバター機能 ON/OFF トグル（Client Adminのみ）─────────────────────────────── */}

--- a/admin-ui/src/pages/admin/avatar/index.tsx
+++ b/admin-ui/src/pages/admin/avatar/index.tsx
@@ -10,6 +10,7 @@ import type { AvatarConfig, SortKey, TypeFilter, StatusFilter, WarningTarget } f
 import { BG } from "./types";
 import { toggleBtnStyle } from "./utils";
 import { AvatarWarningModal } from "./AvatarWarningModal";
+import { AvatarListHeader } from "./AvatarListHeader";
 
 export default function AvatarListPage() {
   const navigate = useNavigate();
@@ -313,65 +314,12 @@ export default function AvatarListPage() {
         }
       `}</style>
       {/* ヘッダー */}
-      <header style={{ marginBottom: 28 }}>
-        <button
-          onClick={() => navigate("/admin")}
-          style={{ background: "none", border: "none", color: "var(--muted-foreground)", fontSize: 14, cursor: "pointer", padding: 0, marginBottom: 10, display: "block" }}
-        >
-          {lang === "ja" ? "← 管理画面に戻る" : "← Back to Admin"}
-        </button>
-        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", flexWrap: "wrap", gap: 12 }}>
-          <div>
-            <h1 style={{ fontSize: 24, fontWeight: 700, margin: 0, color: "var(--foreground)", display: "flex", alignItems: "center", gap: 8 }}>
-              🎭 {lang === "ja" ? "アバター設定" : "Avatar Configs"}
-            </h1>
-            {!loading && (
-              <p style={{ fontSize: 13, color: "var(--muted-foreground)", margin: "4px 0 0" }}>
-                {isSuperAdmin
-                  ? (lang === "ja" ? `全テナント: ${displayedConfigs.length}/${total}件` : `All tenants: ${displayedConfigs.length}/${total}`)
-                  : (lang === "ja" ? `${total}件の設定` : `${total} config${total !== 1 ? "s" : ""}`)
-                }
-              </p>
-            )}
-          </div>
-          {!isSuperAdmin && (
-            <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
-              <button
-                onClick={() => navigate("/admin/avatar/wizard")}
-                style={{
-                  padding: "10px 20px",
-                  minHeight: 44,
-                  borderRadius: 10,
-                  border: "1px solid rgba(245,158,11,0.4)",
-                  background: "rgba(245,158,11,0.12)",
-                  color: "#fcd34d",
-                  fontSize: 14,
-                  fontWeight: 700,
-                  cursor: "pointer",
-                }}
-              >
-                ✨ {lang === "ja" ? "AI生成" : "AI Generate"}
-              </button>
-              <button
-                onClick={() => navigate("/admin/avatar/studio")}
-                style={{
-                  padding: "10px 20px",
-                  minHeight: 44,
-                  borderRadius: 10,
-                  border: "none",
-                  background: "linear-gradient(135deg, #3b82f6, #6366f1)",
-                  color: "#fff",
-                  fontSize: 14,
-                  fontWeight: 700,
-                  cursor: "pointer",
-                }}
-              >
-                {lang === "ja" ? "+ 新規作成" : "+ New Config"}
-              </button>
-            </div>
-          )}
-        </div>
-      </header>
+      <AvatarListHeader
+        loading={loading}
+        isSuperAdmin={isSuperAdmin}
+        displayedConfigs={displayedConfigs}
+        total={total}
+      />
 
       {/* ── ソート / フィルタパネル ─────────────────────────────── */}
       {!loading && (

--- a/admin-ui/src/pages/admin/avatar/index.tsx
+++ b/admin-ui/src/pages/admin/avatar/index.tsx
@@ -1,7 +1,7 @@
 // admin-ui/src/pages/admin/avatar/index.tsx
 // Avatar Customization Studio — config list page
 
-import React, { useState, useEffect, useCallback, useMemo } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 import { useLang } from "../../../i18n/LangContext";
 import { authFetch, API_BASE } from "../../../lib/api";
@@ -9,106 +9,7 @@ import { useAuth } from "../../../auth/useAuth";
 import type { AvatarConfig, SortKey, TypeFilter, StatusFilter, WarningTarget } from "./types";
 import { BG } from "./types";
 import { toggleBtnStyle } from "./utils";
-
-// ── AvatarWarningModal ─────────────────────────────────────────────────────
-
-const WARNING_REASONS = ["利用規約違反の疑い", "不適切なコンテンツ", "システムリソース過剰使用", "その他"];
-const WARNING_DEADLINES = [{ label: "3日以内", days: 3 }, { label: "7日以内", days: 7 }, { label: "14日以内", days: 14 }];
-
-function AvatarWarningModal({ target, onClose }: { target: WarningTarget; onClose: () => void }) {
-  const [reason, setReason] = useState(WARNING_REASONS[0]);
-  const [deadlineDays, setDeadlineDays] = useState(3);
-  const [memo, setMemo] = useState("");
-  const [sending, setSending] = useState(false);
-  const [sent, setSent] = useState(false);
-  const [sendError, setSendError] = useState<string | null>(null);
-
-  const deadlineDate = new Date(Date.now() + deadlineDays * 86400000)
-    .toLocaleDateString("ja-JP", { year: "numeric", month: "short", day: "numeric" });
-  const previewTitle = `⚠️ アバター警告: ${target.name}`;
-  const previewMessage = `理由: ${reason}\n対応期限: ${deadlineDate}${memo ? `\nメモ: ${memo}` : ""}`;
-
-  const handleSend = async () => {
-    setSending(true);
-    setSendError(null);
-    try {
-      const res = await authFetch(`${API_BASE}/v1/admin/notifications`, {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          recipient_tenant_id: target.tenantId,
-          type: "avatar_warning",
-          title: previewTitle,
-          message: previewMessage,
-          link: "/admin/avatar",
-          metadata: { avatar_config_id: target.id, reason, deadline_days: deadlineDays },
-        }),
-      });
-      if (!res.ok) { setSendError("送信に失敗しました。もう一度お試しください。"); return; }
-      setSent(true);
-      setTimeout(onClose, 2000);
-    } catch { setSendError("ネットワークエラーが発生しました。"); }
-    finally { setSending(false); }
-  };
-
-  const INPUT_STYLE: React.CSSProperties = { padding: "8px 10px", minHeight: 44, borderRadius: 8, border: "1px solid var(--border)", background: "var(--input)", color: "var(--foreground)", fontSize: 13 };
-
-  return (
-    <div style={{ position: "fixed", inset: 0, background: "rgba(0,0,0,0.75)", zIndex: 1000, display: "flex", alignItems: "center", justifyContent: "center", padding: 16 }}>
-      <div style={{ width: "min(480px, 100%)", borderRadius: 16, background: "var(--background)", border: "1px solid rgba(239,68,68,0.3)", padding: 24, display: "flex", flexDirection: "column", gap: 16 }}>
-        <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center" }}>
-          <h2 style={{ fontSize: 18, fontWeight: 700, color: "var(--foreground)", margin: 0 }}>⚠️ 警告メッセージを送信</h2>
-          <button onClick={onClose} style={{ background: "none", border: "none", color: "var(--muted-foreground)", fontSize: 20, cursor: "pointer", padding: 4, lineHeight: 1 }}>×</button>
-        </div>
-        <p style={{ margin: 0, fontSize: 13, color: "var(--muted-foreground)" }}>テナントに警告通知を送信します。対象: <strong style={{ color: "var(--foreground)" }}>{target.name}</strong></p>
-
-        {sent ? (
-          <div style={{ textAlign: "center", padding: "20px 0", color: "#4ade80", fontSize: 16, fontWeight: 700 }}>✅ 送信しました</div>
-        ) : (
-          <>
-            <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-              <span style={{ fontSize: 13, color: "var(--muted-foreground)" }}>警告理由</span>
-              <select value={reason} onChange={(e) => setReason(e.target.value)} style={INPUT_STYLE}>
-                {WARNING_REASONS.map((r) => <option key={r} value={r}>{r}</option>)}
-              </select>
-            </label>
-
-            <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-              <span style={{ fontSize: 13, color: "var(--muted-foreground)" }}>対応期限</span>
-              <select value={deadlineDays} onChange={(e) => setDeadlineDays(Number(e.target.value))} style={INPUT_STYLE}>
-                {WARNING_DEADLINES.map((d) => (
-                  <option key={d.days} value={d.days}>
-                    {d.label}（{new Date(Date.now() + d.days * 86400000).toLocaleDateString("ja-JP", { month: "short", day: "numeric" })}）
-                  </option>
-                ))}
-              </select>
-            </label>
-
-            <label style={{ display: "flex", flexDirection: "column", gap: 6 }}>
-              <span style={{ fontSize: 13, color: "var(--muted-foreground)" }}>メモ（任意）</span>
-              <textarea value={memo} onChange={(e) => setMemo(e.target.value)} rows={3} placeholder="詳細な説明やリンクなど..." style={{ padding: "8px 10px", borderRadius: 8, border: "1px solid var(--border)", background: "var(--input)", color: "var(--foreground)", fontSize: 13, resize: "vertical", fontFamily: "inherit" }} />
-            </label>
-
-            <div style={{ padding: 12, borderRadius: 10, background: "rgba(239,68,68,0.07)", border: "1px solid rgba(239,68,68,0.2)" }}>
-              <p style={{ margin: "0 0 4px", fontSize: 12, color: "var(--muted-foreground)", fontWeight: 600 }}>プレビュー</p>
-              <p style={{ margin: 0, fontSize: 13, color: "#fca5a5", fontWeight: 700 }}>{previewTitle}</p>
-              <p style={{ margin: "4px 0 0", fontSize: 12, color: "var(--muted-foreground)", whiteSpace: "pre-line", lineHeight: 1.7 }}>{previewMessage}</p>
-            </div>
-
-            {sendError && <div style={{ color: "#fca5a5", fontSize: 13 }}>{sendError}</div>}
-
-            <div style={{ display: "flex", gap: 10, justifyContent: "flex-end" }}>
-              <button onClick={onClose} style={{ padding: "10px 18px", minHeight: 44, borderRadius: 8, border: "1px solid var(--border)", background: "transparent", color: "var(--muted-foreground)", fontSize: 13, fontWeight: 600, cursor: "pointer" }}>キャンセル</button>
-              <button onClick={() => void handleSend()} disabled={sending} style={{ padding: "10px 18px", minHeight: 44, borderRadius: 8, border: "none", background: sending ? "#4b5563" : "#dc2626", color: "#fff", fontSize: 13, fontWeight: 700, cursor: sending ? "not-allowed" : "pointer" }}>
-                {sending ? "送信中..." : "⚠️ 警告を送信"}
-              </button>
-            </div>
-          </>
-        )}
-      </div>
-    </div>
-  );
-}
+import { AvatarWarningModal } from "./AvatarWarningModal";
 
 export default function AvatarListPage() {
   const navigate = useNavigate();

--- a/admin-ui/src/pages/admin/avatar/index.tsx
+++ b/admin-ui/src/pages/admin/avatar/index.tsx
@@ -11,6 +11,7 @@ import { BG } from "./types";
 import { AvatarWarningModal } from "./AvatarWarningModal";
 import { AvatarListHeader } from "./AvatarListHeader";
 import { AvatarFilterPanel } from "./AvatarFilterPanel";
+import { AvatarFeatureToggle } from "./AvatarFeatureToggle";
 
 export default function AvatarListPage() {
   const navigate = useNavigate();
@@ -339,65 +340,13 @@ export default function AvatarListPage() {
 
       {/* ── アバター機能 ON/OFF トグル（Client Adminのみ）─────────────────────────────── */}
       {!isSuperAdmin && user?.tenantId && (
-        <div style={{
-          marginBottom: 24,
-          padding: "20px 24px",
-          borderRadius: 14,
-          border: avatarEnabled
-            ? "1px solid rgba(74,222,128,0.35)"
-            : "1px solid rgba(107,114,128,0.3)",
-          background: avatarEnabled
-            ? "rgba(34,197,94,0.07)"
-            : "rgba(255,255,255,0.03)",
-        }}>
-          <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", gap: 16, flexWrap: "wrap" }}>
-            <div>
-              <h2 style={{ fontSize: 18, fontWeight: 700, margin: 0, color: "var(--foreground)" }}>🤖 AIアバター機能</h2>
-              <p style={{ fontSize: 14, color: "var(--muted-foreground)", margin: "6px 0 0" }}>
-                ONにすると、チャットウィジェットにAIアバターが表示されます
-              </p>
-            </div>
-            <button
-              type="button"
-              onClick={() => { void handleAvatarToggle(); }}
-              disabled={toggleLoading || tenantFeatures === null}
-              style={{
-                padding: "12px 28px",
-                minHeight: 48,
-                minWidth: 120,
-                borderRadius: 10,
-                border: avatarEnabled
-                  ? "1px solid rgba(74,222,128,0.5)"
-                  : "1px solid rgba(107,114,128,0.4)",
-                background: avatarEnabled
-                  ? "rgba(34,197,94,0.22)"
-                  : "rgba(107,114,128,0.18)",
-                color: avatarEnabled ? "#4ade80" : "#9ca3af",
-                fontSize: 16,
-                fontWeight: 700,
-                cursor: toggleLoading || tenantFeatures === null ? "not-allowed" : "pointer",
-                opacity: toggleLoading || tenantFeatures === null ? 0.6 : 1,
-                transition: "all 0.15s",
-              }}
-            >
-              {toggleLoading ? "保存中..." : avatarEnabled ? "✅ ON" : "⏸️ OFF"}
-            </button>
-          </div>
-          {toggleToast && (
-            <div style={{
-              marginTop: 12,
-              padding: "10px 14px",
-              borderRadius: 8,
-              background: toggleToast.startsWith("❌")
-                ? "rgba(239,68,68,0.12)"
-                : "rgba(34,197,94,0.12)",
-              color: toggleToast.startsWith("❌") ? "#fca5a5" : "#86efac",
-              fontSize: 14,
-            }}>
-              {toggleToast}
-            </div>
-          )}
-        </div>
+        <AvatarFeatureToggle
+          avatarEnabled={avatarEnabled}
+          toggleLoading={toggleLoading}
+          tenantFeatures={tenantFeatures}
+          handleAvatarToggle={handleAvatarToggle}
+          toggleToast={toggleToast}
+        />
       )}
 
       {/* エラーメッセージ */}

--- a/admin-ui/src/pages/admin/avatar/index.tsx
+++ b/admin-ui/src/pages/admin/avatar/index.tsx
@@ -6,28 +6,11 @@ import { useNavigate } from "react-router-dom";
 import { useLang } from "../../../i18n/LangContext";
 import { authFetch, API_BASE } from "../../../lib/api";
 import { useAuth } from "../../../auth/useAuth";
-
-interface AvatarConfig {
-  id: string;
-  tenant_id: string;
-  tenant_name?: string;
-  name: string;
-  image_url: string | null;
-  lemonslice_agent_id: string | null;
-  is_active: boolean;
-  is_default: boolean;
-  created_at: string;
-  avatar_provider: string | null;
-}
-
-type SortKey = "name_asc" | "created_desc" | "created_asc" | "active_first" | "inactive_first" | "default_first";
-type TypeFilter = "all" | "default" | "custom";
-type StatusFilter = "all" | "active" | "inactive";
-
-const BG = "var(--background)";
+import type { AvatarConfig, SortKey, TypeFilter, StatusFilter, WarningTarget } from "./types";
+import { BG } from "./types";
+import { toggleBtnStyle } from "./utils";
 
 // ── AvatarWarningModal ─────────────────────────────────────────────────────
-interface WarningTarget { id: string; tenantId: string; name: string }
 
 const WARNING_REASONS = ["利用規約違反の疑い", "不適切なコンテンツ", "システムリソース過剰使用", "その他"];
 const WARNING_DEADLINES = [{ label: "3日以内", days: 3 }, { label: "7日以内", days: 7 }, { label: "14日以内", days: 14 }];
@@ -324,19 +307,6 @@ export default function AvatarListPage() {
 
   const formatDate = (iso: string) =>
     new Date(iso).toLocaleDateString(locale, { year: "numeric", month: "short", day: "numeric" });
-
-  const toggleBtnStyle = (active: boolean) => ({
-    padding: "8px 14px",
-    minHeight: 44,
-    borderRadius: 8,
-    border: active ? "1px solid rgba(99,102,241,0.6)" : "1px solid var(--border)",
-    background: active ? "rgba(99,102,241,0.2)" : "transparent",
-    color: active ? "#a5b4fc" : "#9ca3af",
-    fontSize: 13,
-    fontWeight: 600,
-    cursor: "pointer",
-    whiteSpace: "nowrap" as const,
-  });
 
   return (
     <div style={{ minHeight: "100vh", background: BG, color: "var(--foreground)", padding: "24px 20px", maxWidth: 1200, margin: "0 auto" }}>

--- a/admin-ui/src/pages/admin/avatar/studio.tsx
+++ b/admin-ui/src/pages/admin/avatar/studio.tsx
@@ -6,6 +6,8 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useLang } from "../../../i18n/LangContext";
 import { authFetch, API_BASE } from "../../../lib/api";
 import { containsBannedWord } from "../../../lib/contentGuard";
+import type { VoiceRecommendation } from "./types";
+import { BG, SECTION_STYLE, LABEL_STYLE, INPUT_STYLE, TEXTAREA_STYLE, BTN_PRIMARY, BTN_SECONDARY } from "./types";
 
 interface AvatarConfig {
   id: string;
@@ -24,75 +26,6 @@ interface AvatarConfig {
   agent_prompt: string | null;
   agent_idle_prompt: string | null;
 }
-
-interface VoiceRecommendation {
-  id: string;
-  title: string;
-  description: string;
-  score: number;
-}
-
-const BG = "var(--background)";
-
-const SECTION_STYLE: React.CSSProperties = {
-  borderRadius: 14,
-  border: "1px solid var(--border)",
-  background: "var(--card)",
-  padding: "20px 22px",
-  marginBottom: 20,
-};
-
-const LABEL_STYLE: React.CSSProperties = {
-  display: "block",
-  fontSize: 13,
-  fontWeight: 600,
-  color: "var(--muted-foreground)",
-  marginBottom: 6,
-};
-
-const INPUT_STYLE: React.CSSProperties = {
-  width: "100%",
-  padding: "10px 12px",
-  borderRadius: 8,
-  border: "1px solid var(--border)",
-  background: "rgba(30,41,59,0.8)",
-  color: "var(--foreground)",
-  fontSize: 14,
-  outline: "none",
-  boxSizing: "border-box",
-};
-
-const TEXTAREA_STYLE: React.CSSProperties = {
-  ...INPUT_STYLE,
-  resize: "vertical",
-  minHeight: 90,
-  fontFamily: "inherit",
-  lineHeight: 1.5,
-};
-
-const BTN_PRIMARY: React.CSSProperties = {
-  padding: "10px 20px",
-  minHeight: 44,
-  borderRadius: 10,
-  border: "none",
-  background: "linear-gradient(135deg, #3b82f6, #6366f1)",
-  color: "#fff",
-  fontSize: 14,
-  fontWeight: 700,
-  cursor: "pointer",
-};
-
-const BTN_SECONDARY: React.CSSProperties = {
-  padding: "10px 18px",
-  minHeight: 44,
-  borderRadius: 10,
-  border: "1px solid var(--border)",
-  background: "transparent",
-  color: "var(--muted-foreground)",
-  fontSize: 14,
-  fontWeight: 600,
-  cursor: "pointer",
-};
 
 export default function AvatarStudioPage() {
   const navigate = useNavigate();

--- a/admin-ui/src/pages/admin/avatar/studio.tsx
+++ b/admin-ui/src/pages/admin/avatar/studio.tsx
@@ -7,10 +7,11 @@ import { useLang } from "../../../i18n/LangContext";
 import { authFetch, API_BASE } from "../../../lib/api";
 import { containsBannedWord } from "../../../lib/contentGuard";
 import type { VoiceRecommendation } from "./types";
-import { BG, SECTION_STYLE, LABEL_STYLE, TEXTAREA_STYLE, BTN_PRIMARY, BTN_SECONDARY } from "./types";
+import { BG, BTN_PRIMARY, BTN_SECONDARY } from "./types";
 import { StudioBasicSection } from "./StudioBasicSection";
 import { StudioImageSection } from "./StudioImageSection";
 import { StudioVoiceSection } from "./StudioVoiceSection";
+import { StudioPersonalitySection } from "./StudioPersonalitySection";
 
 interface AvatarConfig {
   id: string;
@@ -452,126 +453,20 @@ export default function AvatarStudioPage() {
       />
 
       {/* 4. パーソナリティ */}
-      <div style={SECTION_STYLE}>
-        <h2 style={{ fontSize: 16, fontWeight: 700, color: "var(--foreground)", margin: "0 0 16px" }}>
-          {lang === "ja" ? "4. パーソナリティ" : "4. Personality"}
-        </h2>
-        <div style={{ marginBottom: 12 }}>
-          <label style={LABEL_STYLE}>{lang === "ja" ? "接客ルール・ペルソナ情報" : "Rules & Persona"}</label>
-          <textarea
-            value={promptRules}
-            onChange={(e) => setPromptRules(e.target.value)}
-            placeholder={lang === "ja"
-              ? "例: 丁寧な口調、商品の良い点を積極的にアピール、クレームには共感してから解決策を提示"
-              : "e.g. Polite tone, proactively highlight product benefits, empathize then resolve complaints"}
-            style={{ ...TEXTAREA_STYLE, minHeight: 100 }}
-          />
-        </div>
-        <button
-          onClick={() => void handleGeneratePrompt()}
-          disabled={isDefault || generatingPrompt || !promptRules.trim()}
-          style={{
-            ...BTN_PRIMARY,
-            opacity: isDefault || generatingPrompt || !promptRules.trim() ? 0.5 : 1,
-            cursor: isDefault || generatingPrompt || !promptRules.trim() ? "not-allowed" : "pointer",
-          }}
-        >
-          {generatingPrompt
-            ? (lang === "ja" ? "生成中..." : "Generating...")
-            : (lang === "ja" ? "プロンプトを生成する" : "Generate Prompt")}
-        </button>
-
-        <div style={{ marginTop: 16 }}>
-          <label style={LABEL_STYLE}>
-            {lang === "ja" ? "システムプロンプト" : "System Prompt"}
-          </label>
-          <textarea
-            value={personalityPrompt}
-            onChange={(e) => setPersonalityPrompt(e.target.value)}
-            readOnly={isDefault}
-            placeholder={lang === "ja" ? "AIが生成するか、直接入力してください" : "Auto-generated or enter manually"}
-            style={{
-              ...TEXTAREA_STYLE,
-              minHeight: 120,
-              ...(isDefault ? { background: "var(--card)", color: "var(--muted-foreground)", cursor: "default" } : {}),
-            }}
-          />
-          {isDefault && (
-            <p style={{ fontSize: 11, color: "#4b5563", marginTop: 4, marginBottom: 0 }}>
-              {lang === "ja" ? "デフォルト設定 — 変更不可" : "Default setting — read-only"}
-            </p>
-          )}
-        </div>
-
-        {isDefault && (agentPrompt || agentIdlePrompt) && (
-          <>
-            <div style={{ marginTop: 14 }}>
-              <label style={LABEL_STYLE}>
-                {lang === "ja" ? "動作プロンプト（会話中）" : "Agent Prompt (During Conversation)"}
-              </label>
-              <textarea
-                value={agentPrompt}
-                readOnly
-                style={{ ...TEXTAREA_STYLE, background: "var(--card)", color: "var(--muted-foreground)", cursor: "default", fontStyle: "italic" }}
-              />
-              <p style={{ fontSize: 11, color: "#4b5563", marginTop: 4, marginBottom: 0 }}>
-                {lang === "ja" ? "デフォルト設定 — 変更不可" : "Default setting — read-only"}
-              </p>
-            </div>
-            <div style={{ marginTop: 14 }}>
-              <label style={LABEL_STYLE}>
-                {lang === "ja" ? "動作プロンプト（待機中）" : "Agent Prompt (Idle)"}
-              </label>
-              <textarea
-                value={agentIdlePrompt}
-                readOnly
-                style={{ ...TEXTAREA_STYLE, background: "var(--card)", color: "var(--muted-foreground)", cursor: "default", fontStyle: "italic" }}
-              />
-              <p style={{ fontSize: 11, color: "#4b5563", marginTop: 4, marginBottom: 0 }}>
-                {lang === "ja" ? "デフォルト設定 — 変更不可" : "Default setting — read-only"}
-              </p>
-            </div>
-          </>
-        )}
-
-        <div style={{ marginTop: 14 }}>
-          <label style={LABEL_STYLE}>
-            {lang === "ja" ? "行動説明" : "Behavior Description"}
-          </label>
-          <textarea
-            value={behaviorDescription}
-            onChange={(e) => setBehaviorDescription(e.target.value)}
-            placeholder={lang === "ja" ? "アバターの行動特性を記述します（任意）" : "Describe behavior characteristics (optional)"}
-            style={TEXTAREA_STYLE}
-          />
-        </div>
-
-        {emotionTags.length > 0 && (
-          <div style={{ marginTop: 14 }}>
-            <label style={LABEL_STYLE}>
-              {lang === "ja" ? "感情タグ" : "Emotion Tags"}
-            </label>
-            <div style={{ display: "flex", flexWrap: "wrap", gap: 6 }}>
-              {emotionTags.map((tag) => (
-                <span
-                  key={tag}
-                  style={{
-                    padding: "3px 10px",
-                    borderRadius: 999,
-                    background: "rgba(99,102,241,0.15)",
-                    border: "1px solid rgba(99,102,241,0.4)",
-                    color: "#a5b4fc",
-                    fontSize: 12,
-                    fontWeight: 600,
-                  }}
-                >
-                  {tag}
-                </span>
-              ))}
-            </div>
-          </div>
-        )}
-      </div>
+      <StudioPersonalitySection
+        isDefault={isDefault}
+        promptRules={promptRules}
+        setPromptRules={setPromptRules}
+        generatingPrompt={generatingPrompt}
+        handleGeneratePrompt={handleGeneratePrompt}
+        personalityPrompt={personalityPrompt}
+        setPersonalityPrompt={setPersonalityPrompt}
+        agentPrompt={agentPrompt}
+        agentIdlePrompt={agentIdlePrompt}
+        behaviorDescription={behaviorDescription}
+        setBehaviorDescription={setBehaviorDescription}
+        emotionTags={emotionTags}
+      />
 
       {/* 保存ボタン */}
       <div style={{ display: "flex", gap: 12, justifyContent: "flex-end", marginTop: 8, flexWrap: "wrap" }}>

--- a/admin-ui/src/pages/admin/avatar/studio.tsx
+++ b/admin-ui/src/pages/admin/avatar/studio.tsx
@@ -9,6 +9,7 @@ import { containsBannedWord } from "../../../lib/contentGuard";
 import type { VoiceRecommendation } from "./types";
 import { BG, SECTION_STYLE, LABEL_STYLE, INPUT_STYLE, TEXTAREA_STYLE, BTN_PRIMARY, BTN_SECONDARY } from "./types";
 import { StudioBasicSection } from "./StudioBasicSection";
+import { StudioImageSection } from "./StudioImageSection";
 
 interface AvatarConfig {
   id: string;
@@ -412,243 +413,28 @@ export default function AvatarStudioPage() {
       />
 
       {/* 2. アバター画像 */}
-      <div style={SECTION_STYLE}>
-        <h2 style={{ fontSize: 16, fontWeight: 700, color: "var(--foreground)", margin: "0 0 16px" }}>
-          {lang === "ja" ? "2. アバター画像" : "2. Avatar Image"}
-        </h2>
-
-        {/* デフォルトアバターは画像変更不可 */}
-        {isDefault ? (
-          <div style={{
-            padding: "14px 16px",
-            borderRadius: 10,
-            background: "rgba(59,130,246,0.08)",
-            border: "1px solid rgba(59,130,246,0.3)",
-            color: "#93c5fd",
-            fontSize: 14,
-            marginBottom: 8,
-          }}>
-            {lang === "ja"
-              ? "デフォルトアバターの画像は変更できません"
-              : "Default avatar images cannot be changed"}
-            {imageUrl && (
-              <div style={{ marginTop: 12, textAlign: "center" }}>
-                <img
-                  src={imageUrl}
-                  alt="avatar"
-                  style={{ maxHeight: 160, borderRadius: 10, display: "block", margin: "0 auto" }}
-                  onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = "none"; }}
-                />
-              </div>
-            )}
-          </div>
-        ) : (
-          <>
-        {/* タブ切り替え */}
-        <div style={{ display: "flex", gap: 8, marginBottom: 18 }}>
-          {(['generate', 'upload'] as const).map((tab) => (
-            <button
-              key={tab}
-              type="button"
-              onClick={() => setImageTab(tab)}
-              style={{
-                padding: "8px 18px",
-                minHeight: 44,
-                borderRadius: 10,
-                border: imageTab === tab ? "2px solid #3b82f6" : "1px solid var(--border)",
-                background: imageTab === tab ? "rgba(59,130,246,0.15)" : "transparent",
-                color: imageTab === tab ? "#93c5fd" : "#9ca3af",
-                fontSize: 13,
-                fontWeight: 700,
-                cursor: "pointer",
-              }}
-            >
-              {tab === 'generate'
-                ? (lang === "ja" ? "AIで生成" : "Generate with AI")
-                : (lang === "ja" ? "写真をアップロード" : "Upload Photo")}
-            </button>
-          ))}
-        </div>
-
-        {/* AIで生成タブ */}
-        {imageTab === 'generate' && (
-          <>
-            <div style={{ marginBottom: 12 }}>
-              <label style={LABEL_STYLE}>{lang === "ja" ? "アバターの説明" : "Avatar Description"}</label>
-              <textarea
-                value={imageDesc}
-                onChange={(e) => { setImageDesc(e.target.value); if (imageDescError) setImageDescError(null); }}
-                placeholder={lang === "ja"
-                  ? "例: 30代の日本人女性、ショートヘア、紺色のジャケット、笑顔"
-                  : "e.g. Japanese woman in 30s, short hair, navy jacket, smiling"}
-                style={TEXTAREA_STYLE}
-              />
-              {imageDescError && (
-                <p style={{ margin: "6px 0 0", fontSize: 12, color: "#f87171" }}>{imageDescError}</p>
-              )}
-            </div>
-            <button
-              onClick={() => void handleGenerateImage()}
-              disabled={generatingImage || !imageDesc.trim()}
-              style={{
-                ...BTN_PRIMARY,
-                opacity: generatingImage || !imageDesc.trim() ? 0.5 : 1,
-                cursor: generatingImage || !imageDesc.trim() ? "not-allowed" : "pointer",
-              }}
-            >
-              {generatingImage
-                ? (lang === "ja" ? "生成中..." : "Generating...")
-                : (lang === "ja" ? "画像を生成する (4枚)" : "Generate Images (4)")}
-            </button>
-
-            {generatedImages.length > 0 && (
-              <div style={{ marginTop: 16 }}>
-                <p style={{ fontSize: 13, color: "var(--muted-foreground)", marginBottom: 10 }}>
-                  {lang === "ja" ? "使用する画像を選択してください" : "Select an image to use"}
-                </p>
-                <div style={{ display: "grid", gridTemplateColumns: "repeat(2, 1fr)", gap: 10 }}>
-                  {generatedImages.map((url, idx) => (
-                    <div
-                      key={idx}
-                      onClick={() => handleSelectImage(idx)}
-                      style={{
-                        borderRadius: 10,
-                        overflow: "hidden",
-                        border: selectedImageIdx === idx ? "2px solid #3b82f6" : "2px solid transparent",
-                        cursor: "pointer",
-                        aspectRatio: "1",
-                        background: "var(--muted)",
-                      }}
-                    >
-                      <img
-                        src={url}
-                        alt={`Generated ${idx + 1}`}
-                        style={{ width: "100%", height: "100%", objectFit: "cover", display: "block" }}
-                      />
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
-          </>
-        )}
-
-        {/* 写真をアップロードタブ */}
-        {imageTab === 'upload' && (
-          <div>
-            <p style={{ color: "var(--muted-foreground)", marginBottom: 12 }}>
-              {lang === "ja" ? "顔がはっきり写った正面の写真が最適です" : "A clear front-facing photo works best"}
-            </p>
-
-            {/* 確定済み: プレビュー + 差し替えリンク */}
-            {uploadConfirmed && uploadPreview ? (
-              <div style={{ textAlign: "center" }}>
-                <img
-                  src={uploadPreview}
-                  alt="selected"
-                  style={{ maxHeight: 300, borderRadius: 10, display: "block", margin: "0 auto 12px" }}
-                />
-                <button
-                  type="button"
-                  onClick={handleResetUpload}
-                  style={{ background: "none", border: "none", color: "var(--muted-foreground)", fontSize: 13, cursor: "pointer", textDecoration: "underline" }}
-                >
-                  {lang === "ja" ? "別の画像を選ぶ" : "Choose a different image"}
-                </button>
-              </div>
-            ) : (
-              <>
-                {/* ドラッグ&ドロップエリア */}
-                <div
-                  onDragOver={(e) => { e.preventDefault(); e.stopPropagation(); }}
-                  onDrop={(e) => {
-                    e.preventDefault();
-                    e.stopPropagation();
-                    const file = e.dataTransfer.files[0];
-                    if (file && file.type.startsWith("image/")) handleFileUpload(file);
-                  }}
-                  onClick={() => fileInputRef.current?.click()}
-                  style={{
-                    border: "2px dashed #4b5563",
-                    borderRadius: 12,
-                    padding: 40,
-                    textAlign: "center",
-                    cursor: "pointer",
-                    minHeight: 200,
-                    display: "flex",
-                    flexDirection: "column",
-                    alignItems: "center",
-                    justifyContent: "center",
-                  }}
-                >
-                  {uploadPreview ? (
-                    <img src={uploadPreview} alt="preview" style={{ maxHeight: 300, borderRadius: 8 }} />
-                  ) : (
-                    <>
-                      <p style={{ fontSize: 18, color: "white", margin: "0 0 8px" }}>
-                        {lang === "ja" ? "ここに画像をドラッグ" : "Drag image here"}
-                      </p>
-                      <p style={{ color: "var(--muted-foreground)", margin: "0 0 8px" }}>
-                        {lang === "ja" ? "または クリックしてファイルを選択" : "or click to select a file"}
-                      </p>
-                      <p style={{ color: "var(--muted-foreground)", fontSize: 14, margin: 0 }}>
-                        JPG, PNG{lang === "ja" ? "（最大5MB）" : " (max 5MB)"}
-                      </p>
-                    </>
-                  )}
-                </div>
-
-                {/* 「この画像を使う」確定ボタン */}
-                {uploadPreview && !uploadConfirmed && (
-                  <button
-                    type="button"
-                    onClick={handleConfirmUpload}
-                    style={{
-                      marginTop: 16,
-                      padding: "14px 32px",
-                      background: "#4f46e5",
-                      color: "white",
-                      border: "none",
-                      borderRadius: 8,
-                      fontSize: 16,
-                      cursor: "pointer",
-                      width: "100%",
-                    }}
-                  >
-                    {lang === "ja" ? "この画像を使う" : "Use this image"}
-                  </button>
-                )}
-              </>
-            )}
-
-            <input
-              ref={fileInputRef}
-              type="file"
-              accept="image/jpeg,image/png"
-              style={{ display: "none" }}
-              onChange={(e) => {
-                const file = e.target.files?.[0];
-                if (file) handleFileUpload(file);
-              }}
-            />
-          </div>
-        )}
-
-        {/* 選択中の画像URL（両タブ共通） */}
-        {imageUrl && (
-          <div style={{ marginTop: 14 }}>
-            <label style={LABEL_STYLE}>{lang === "ja" ? "選択中の画像URL" : "Selected Image URL"}</label>
-            <input
-              type="text"
-              value={imageUrl}
-              onChange={(e) => setImageUrl(e.target.value)}
-              style={INPUT_STYLE}
-            />
-          </div>
-        )}
-          </>
-        )}
-      </div>
+      <StudioImageSection
+        isDefault={isDefault}
+        imageUrl={imageUrl}
+        setImageUrl={setImageUrl}
+        imageTab={imageTab}
+        setImageTab={setImageTab}
+        imageDesc={imageDesc}
+        setImageDesc={setImageDesc}
+        imageDescError={imageDescError}
+        setImageDescError={setImageDescError}
+        generatingImage={generatingImage}
+        generatedImages={generatedImages}
+        selectedImageIdx={selectedImageIdx}
+        handleGenerateImage={handleGenerateImage}
+        handleSelectImage={handleSelectImage}
+        uploadPreview={uploadPreview}
+        uploadConfirmed={uploadConfirmed}
+        handleFileUpload={handleFileUpload}
+        handleConfirmUpload={handleConfirmUpload}
+        handleResetUpload={handleResetUpload}
+        fileInputRef={fileInputRef}
+      />
 
       {/* 3. 声マッチング */}
       <div style={SECTION_STYLE}>

--- a/admin-ui/src/pages/admin/avatar/studio.tsx
+++ b/admin-ui/src/pages/admin/avatar/studio.tsx
@@ -7,9 +7,10 @@ import { useLang } from "../../../i18n/LangContext";
 import { authFetch, API_BASE } from "../../../lib/api";
 import { containsBannedWord } from "../../../lib/contentGuard";
 import type { VoiceRecommendation } from "./types";
-import { BG, SECTION_STYLE, LABEL_STYLE, INPUT_STYLE, TEXTAREA_STYLE, BTN_PRIMARY, BTN_SECONDARY } from "./types";
+import { BG, SECTION_STYLE, LABEL_STYLE, TEXTAREA_STYLE, BTN_PRIMARY, BTN_SECONDARY } from "./types";
 import { StudioBasicSection } from "./StudioBasicSection";
 import { StudioImageSection } from "./StudioImageSection";
+import { StudioVoiceSection } from "./StudioVoiceSection";
 
 interface AvatarConfig {
   id: string;
@@ -437,93 +438,18 @@ export default function AvatarStudioPage() {
       />
 
       {/* 3. 声マッチング */}
-      <div style={SECTION_STYLE}>
-        <h2 style={{ fontSize: 16, fontWeight: 700, color: "var(--foreground)", margin: "0 0 16px" }}>
-          {lang === "ja" ? "3. 声マッチング" : "3. Voice Matching"}
-        </h2>
-        <div style={{ marginBottom: 12 }}>
-          <label style={LABEL_STYLE}>{lang === "ja" ? "声の説明" : "Voice Description"}</label>
-          <textarea
-            value={voiceDesc}
-            onChange={(e) => setVoiceDesc(e.target.value)}
-            placeholder={lang === "ja"
-              ? "例: 若い女性、明るく親しみやすい声、標準的な日本語"
-              : "e.g. Young female, bright and friendly, standard Japanese"}
-            style={TEXTAREA_STYLE}
-          />
-        </div>
-        <button
-          onClick={() => void handleMatchVoice()}
-          disabled={isDefault || matchingVoice || !voiceDesc.trim()}
-          style={{
-            ...BTN_PRIMARY,
-            opacity: isDefault || matchingVoice || !voiceDesc.trim() ? 0.5 : 1,
-            cursor: isDefault || matchingVoice || !voiceDesc.trim() ? "not-allowed" : "pointer",
-          }}
-        >
-          {matchingVoice
-            ? (lang === "ja" ? "マッチング中..." : "Matching...")
-            : (lang === "ja" ? "声を検索する" : "Find Voices")}
-        </button>
-
-        {voiceRecs.length > 0 && (
-          <div style={{ marginTop: 16, display: "flex", flexDirection: "column", gap: 8 }}>
-            <p style={{ fontSize: 13, color: "var(--muted-foreground)", marginBottom: 4 }}>
-              {lang === "ja" ? "使用する声を選択してください" : "Select a voice to use"}
-            </p>
-            {voiceRecs.map((rec) => (
-              <div
-                key={rec.id}
-                onClick={() => handleSelectVoice(rec)}
-                style={{
-                  padding: "12px 14px",
-                  borderRadius: 10,
-                  border: selectedVoiceId === rec.id
-                    ? "1px solid rgba(99,102,241,0.7)"
-                    : "1px solid var(--border)",
-                  background: selectedVoiceId === rec.id
-                    ? "rgba(99,102,241,0.1)"
-                    : "rgba(30,41,59,0.6)",
-                  cursor: "pointer",
-                }}
-              >
-                <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 4 }}>
-                  <span style={{ fontSize: 14, fontWeight: 600, color: "var(--foreground)" }}>{rec.title}</span>
-                  <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>
-                    {Math.round(rec.score * 100)}%
-                  </span>
-                </div>
-                <p style={{ fontSize: 12, color: "var(--muted-foreground)", margin: 0, lineHeight: 1.5 }}>{rec.description}</p>
-              </div>
-            ))}
-          </div>
-        )}
-
-        {(voiceId || isDefault) && (
-          <div style={{ marginTop: 14 }}>
-            <label style={LABEL_STYLE}>
-              {isDefault
-                ? (lang === "ja" ? "設定済みの声 (Voice ID)" : "Configured Voice (Voice ID)")
-                : "Voice ID"}
-            </label>
-            <input
-              type="text"
-              value={voiceId}
-              onChange={(e) => setVoiceId(e.target.value)}
-              readOnly={isDefault}
-              style={{
-                ...INPUT_STYLE,
-                ...(isDefault ? { background: "var(--card)", color: "var(--muted-foreground)", cursor: "default" } : {}),
-              }}
-            />
-            {isDefault && (
-              <p style={{ fontSize: 11, color: "#4b5563", marginTop: 4, marginBottom: 0 }}>
-                {lang === "ja" ? "デフォルト設定 — 変更不可" : "Default setting — read-only"}
-              </p>
-            )}
-          </div>
-        )}
-      </div>
+      <StudioVoiceSection
+        isDefault={isDefault}
+        voiceDesc={voiceDesc}
+        setVoiceDesc={setVoiceDesc}
+        matchingVoice={matchingVoice}
+        handleMatchVoice={handleMatchVoice}
+        voiceRecs={voiceRecs}
+        selectedVoiceId={selectedVoiceId}
+        handleSelectVoice={handleSelectVoice}
+        voiceId={voiceId}
+        setVoiceId={setVoiceId}
+      />
 
       {/* 4. パーソナリティ */}
       <div style={SECTION_STYLE}>

--- a/admin-ui/src/pages/admin/avatar/studio.tsx
+++ b/admin-ui/src/pages/admin/avatar/studio.tsx
@@ -7,11 +7,12 @@ import { useLang } from "../../../i18n/LangContext";
 import { authFetch, API_BASE } from "../../../lib/api";
 import { containsBannedWord } from "../../../lib/contentGuard";
 import type { VoiceRecommendation } from "./types";
-import { BG, BTN_PRIMARY, BTN_SECONDARY } from "./types";
+import { BG } from "./types";
 import { StudioBasicSection } from "./StudioBasicSection";
 import { StudioImageSection } from "./StudioImageSection";
 import { StudioVoiceSection } from "./StudioVoiceSection";
 import { StudioPersonalitySection } from "./StudioPersonalitySection";
+import { StudioFooterActions } from "./StudioFooterActions";
 
 interface AvatarConfig {
   id: string;
@@ -469,44 +470,15 @@ export default function AvatarStudioPage() {
       />
 
       {/* 保存ボタン */}
-      <div style={{ display: "flex", gap: 12, justifyContent: "flex-end", marginTop: 8, flexWrap: "wrap" }}>
-        {isEdit && isDefault && (
-          <button
-            onClick={() => void handleResetToDefault()}
-            disabled={resetting}
-            style={{
-              ...BTN_SECONDARY,
-              opacity: resetting ? 0.6 : 1,
-              cursor: resetting ? "not-allowed" : "pointer",
-              marginRight: "auto",
-            }}
-          >
-            {resetting
-              ? (lang === "ja" ? "リセット中..." : "Resetting...")
-              : (lang === "ja" ? "デフォルトに戻す" : "Reset to Default")}
-          </button>
-        )}
-        <button
-          onClick={() => navigate("/admin/avatar")}
-          style={BTN_SECONDARY}
-        >
-          {lang === "ja" ? "キャンセル" : "Cancel"}
-        </button>
-        <button
-          onClick={() => void handleSave()}
-          disabled={saving || !name.trim()}
-          style={{
-            ...BTN_PRIMARY,
-            minWidth: 120,
-            opacity: saving || !name.trim() ? 0.5 : 1,
-            cursor: saving || !name.trim() ? "not-allowed" : "pointer",
-          }}
-        >
-          {saving
-            ? (lang === "ja" ? "保存中..." : "Saving...")
-            : (lang === "ja" ? "保存する" : "Save")}
-        </button>
-      </div>
+      <StudioFooterActions
+        isEdit={isEdit}
+        isDefault={isDefault}
+        resetting={resetting}
+        handleResetToDefault={handleResetToDefault}
+        saving={saving}
+        name={name}
+        handleSave={handleSave}
+      />
     </div>
   );
 }

--- a/admin-ui/src/pages/admin/avatar/studio.tsx
+++ b/admin-ui/src/pages/admin/avatar/studio.tsx
@@ -8,6 +8,7 @@ import { authFetch, API_BASE } from "../../../lib/api";
 import { containsBannedWord } from "../../../lib/contentGuard";
 import type { VoiceRecommendation } from "./types";
 import { BG, SECTION_STYLE, LABEL_STYLE, INPUT_STYLE, TEXTAREA_STYLE, BTN_PRIMARY, BTN_SECONDARY } from "./types";
+import { StudioBasicSection } from "./StudioBasicSection";
 
 interface AvatarConfig {
   id: string;
@@ -403,26 +404,12 @@ export default function AvatarStudioPage() {
       )}
 
       {/* 1. 基本設定 */}
-      <div style={SECTION_STYLE}>
-        <h2 style={{ fontSize: 16, fontWeight: 700, color: "var(--foreground)", margin: "0 0 16px" }}>
-          {lang === "ja" ? "1. 基本設定" : "1. Basic Settings"}
-        </h2>
-        <div style={{ marginBottom: 14 }}>
-          <label style={LABEL_STYLE}>{lang === "ja" ? "アバター名 *" : "Avatar Name *"}</label>
-          <input
-            type="text"
-            value={name}
-            onChange={(e) => setName(e.target.value)}
-            placeholder={lang === "ja" ? "例: サポートアシスタント" : "e.g. Support Assistant"}
-            style={INPUT_STYLE}
-          />
-        </div>
-        <div>
-          <label style={LABEL_STYLE}>Lemonslice Agent ID</label>
-          <input type="text" value={lemonsliceAgentId} onChange={(e) => setLemonsliceAgentId(e.target.value)}
-            placeholder="agent_xxxxxxxxxx" style={INPUT_STYLE} />
-        </div>
-      </div>
+      <StudioBasicSection
+        name={name}
+        setName={setName}
+        lemonsliceAgentId={lemonsliceAgentId}
+        setLemonsliceAgentId={setLemonsliceAgentId}
+      />
 
       {/* 2. アバター画像 */}
       <div style={SECTION_STYLE}>

--- a/admin-ui/src/pages/admin/avatar/types.ts
+++ b/admin-ui/src/pages/admin/avatar/types.ts
@@ -1,0 +1,74 @@
+import type * as React from "react";
+
+// ─── 型（studio.tsx から移動） ────────────────────────────────────────────────
+
+export interface VoiceRecommendation {
+  id: string;
+  title: string;
+  description: string;
+  score: number;
+}
+
+// ─── スタイル定数（studio.tsx から移動） ──────────────────────────────────────
+
+export const BG = "var(--background)";
+
+export const SECTION_STYLE: React.CSSProperties = {
+  borderRadius: 14,
+  border: "1px solid var(--border)",
+  background: "var(--card)",
+  padding: "20px 22px",
+  marginBottom: 20,
+};
+
+export const LABEL_STYLE: React.CSSProperties = {
+  display: "block",
+  fontSize: 13,
+  fontWeight: 600,
+  color: "var(--muted-foreground)",
+  marginBottom: 6,
+};
+
+export const INPUT_STYLE: React.CSSProperties = {
+  width: "100%",
+  padding: "10px 12px",
+  borderRadius: 8,
+  border: "1px solid var(--border)",
+  background: "rgba(30,41,59,0.8)",
+  color: "var(--foreground)",
+  fontSize: 14,
+  outline: "none",
+  boxSizing: "border-box",
+};
+
+export const TEXTAREA_STYLE: React.CSSProperties = {
+  ...INPUT_STYLE,
+  resize: "vertical",
+  minHeight: 90,
+  fontFamily: "inherit",
+  lineHeight: 1.5,
+};
+
+export const BTN_PRIMARY: React.CSSProperties = {
+  padding: "10px 20px",
+  minHeight: 44,
+  borderRadius: 10,
+  border: "none",
+  background: "linear-gradient(135deg, #3b82f6, #6366f1)",
+  color: "#fff",
+  fontSize: 14,
+  fontWeight: 700,
+  cursor: "pointer",
+};
+
+export const BTN_SECONDARY: React.CSSProperties = {
+  padding: "10px 18px",
+  minHeight: 44,
+  borderRadius: 10,
+  border: "1px solid var(--border)",
+  background: "transparent",
+  color: "var(--muted-foreground)",
+  fontSize: 14,
+  fontWeight: 600,
+  cursor: "pointer",
+};

--- a/admin-ui/src/pages/admin/avatar/types.ts
+++ b/admin-ui/src/pages/admin/avatar/types.ts
@@ -9,6 +9,27 @@ export interface VoiceRecommendation {
   score: number;
 }
 
+// ─── 型（index.tsx から移動） ─────────────────────────────────────────────────
+
+export interface AvatarConfig {
+  id: string;
+  tenant_id: string;
+  tenant_name?: string;
+  name: string;
+  image_url: string | null;
+  lemonslice_agent_id: string | null;
+  is_active: boolean;
+  is_default: boolean;
+  created_at: string;
+  avatar_provider: string | null;
+}
+
+export type SortKey = "name_asc" | "created_desc" | "created_asc" | "active_first" | "inactive_first" | "default_first";
+export type TypeFilter = "all" | "default" | "custom";
+export type StatusFilter = "all" | "active" | "inactive";
+
+export interface WarningTarget { id: string; tenantId: string; name: string }
+
 // ─── スタイル定数（studio.tsx から移動） ──────────────────────────────────────
 
 export const BG = "var(--background)";

--- a/admin-ui/src/pages/admin/avatar/utils.ts
+++ b/admin-ui/src/pages/admin/avatar/utils.ts
@@ -1,0 +1,15 @@
+// admin-ui/src/pages/admin/avatar/utils.ts
+// index.tsx から移動 — pure ヘルパー（機能変更なし）
+
+export const toggleBtnStyle = (active: boolean) => ({
+  padding: "8px 14px",
+  minHeight: 44,
+  borderRadius: 8,
+  border: active ? "1px solid rgba(99,102,241,0.6)" : "1px solid var(--border)",
+  background: active ? "rgba(99,102,241,0.2)" : "transparent",
+  color: active ? "#a5b4fc" : "#9ca3af",
+  fontSize: 13,
+  fontWeight: 600,
+  cursor: "pointer",
+  whiteSpace: "nowrap" as const,
+});


### PR DESCRIPTION
## 概要
[Phase2-P1-2 PR-5] avatar/studio.tsx（985行）+ avatar/index.tsx（947行）のコンポーネント分割。**機能変更なし**の純粋抽出リファクタ（PR #345/#346/#347 と同一レシピ）。

Asana: 親 https://app.asana.com/0/1213607637045514/1214120401966111 / 子タスク GID 1215613421545911

## 変更内容（avatar/ 配下のみ、14 files）
- `studio.tsx`: **985 → 484 行** — StudioBasicSection / StudioImageSection / StudioVoiceSection / StudioPersonalitySection / StudioFooterActions を抽出
- `index.tsx`: **947 → 414 行** — AvatarWarningModal / AvatarListHeader / AvatarFilterPanel / AvatarFeatureToggle / AvatarCard を抽出
- 型・スタイル定数は types.ts / utils.ts へ（同名別シェイプの AvatarConfig は衝突回避のため studio.tsx 残置）

## 等価性検証
- 空白正規化比較で **20 ブロック全て IDENTICAL**（export 付与・dedent のみの差）
- 条件 guard は親側に原文残置 / state・handler・fetch は親残置で同名 props 注入（PR #347 方式）
- `git diff | grep -E "fetch|api/"` 出現ゼロ / oxlint 60→60（detached checkout 実測比較）
- 必然差分: 抽出で未使用化した `useNavigate` と import 行の削除（TS noUnusedLocals 要件）

## Gate
- Gate 1: typecheck 0 errors / vitest 27 pass / lint 警告増ゼロ
- Gate 3: admin-ui build PASS
- Codex review: 機能変更なしリファクタのためスキップ（CLAUDE.md 規定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
