### PR TITLE
feat(widget): LiveKit 2.19.2 ノイズキャンセル + publishData エラーハンドリング

### DIFF
--- a/public/widget.js
+++ b/public/widget.js
@@ -1550,7 +1550,11 @@
 
     try {
       var LK = window.LivekitClient;
-      var room = new LK.Room({ adaptiveStream: true, dynacast: true });
+      var room = new LK.Room({
+        adaptiveStream: true,
+        dynacast: true,
+        audioCaptureDefaults: { noiseSuppression: true, echoCancellation: true, autoGainControl: true },
+      });
 
       // ミュートボタンを生成（SVGは createElement で — innerHTML 禁止）
       var avatarMuteBtn = document.createElement('button');
@@ -1759,10 +1763,13 @@
             var encoder = new TextEncoder();
             var localParticipant = room.localParticipant;
             if (localParticipant) {
-              localParticipant.publishData(
+              var sendPromise = localParticipant.publishData(
                 encoder.encode(JSON.stringify({ type: 'widget_connected' })),
                 { reliable: true }
               );
+              if (sendPromise && typeof sendPromise.catch === 'function') {
+                sendPromise.catch(function (e) { console.warn('[FAQ Widget] publishData error:', e); });
+              }
             }
           } catch (_e) {}
         })


### PR DESCRIPTION
## 概要
[P1-B] public/widget.js に livekit-client 2.19.2 の新機能 2 点を追加。

Asana: https://app.asana.com/0/1213607637045514/1215601272360899

## 変更内容
- **変更1: ノイズキャンセレーション** — `new LK.Room({...})` に `audioCaptureDefaults: { noiseSuppression, echoCancellation, autoGainControl }` を追加（widget.js:1553）
- **変更2: publishData エラーハンドリング** — `widget_connected` 送信（widget.js:1762 付近）に Promise catch を追加

## 実施前確認（推測禁止準拠）
- タスク指定の確認 URL `dist/livekit-client.d.ts` は **404**（grep -c = 0 はファイル不存在によるもの）。実際の型定義 `dist/src/options.d.ts:35` に `audioCaptureDefaults?: AudioCaptureOptions` が**実在**することを確認の上で適用
- UMD バンドル内にも `audioCaptureDefaults` 出現を確認
- タスクが対象とした `sendTTSRequest()` 内の publishData は**既に実装済み**（.then/.catch + 同期フォールバック、widget.js:1798-1806）だったため変更せず。未処理だった `widget_connected` 送信側に同パターンを適用

## Gate
- Gate 1 (pnpm verify): PASS / Gate 2 (security-scan): CRITICAL/HIGH 0 / Gate 3 (build + admin-ui build): PASS / node --check: syntax OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)
