### PR TITLE
feat(avatar): LiveKit 1.5.17 新API活用（wait_for_join / aclose cleanup）

### DIFF
--- a/admin-ui/src/pages/admin/chat-history/[sessionId].tsx
+++ b/admin-ui/src/pages/admin/chat-history/[sessionId].tsx
@@ -4,37 +4,11 @@ import { useLang } from "../../../i18n/LangContext";
 import LangSwitcher from "../../../components/LangSwitcher";
 import { authFetch, API_BASE } from "../../../lib/api";
 import { useAuth } from "../../../auth/useAuth";
+import type { SuggestedRule, Evaluation, Message, DeleteStep } from "./types";
 
 const DEFAULT_CONVERSION_TYPES = ["購入完了", "予約完了", "問い合わせ送信", "離脱", "不明"];
 
-// ─── 型定義 ───────────────────────────────────────────────────────────────────
-
-interface SuggestedRule {
-  rule_text: string;
-  status?: string;
-  tuning_rule_id?: number;
-}
-
-interface Evaluation {
-  id: number;
-  overall_score?: number;
-  score: number;
-  psychology_fit_score?: number;
-  customer_reaction_score?: number;
-  stage_progress_score?: number;
-  taboo_violation_score?: number;
-  feedback?: { summary?: string };
-  evaluated_at: string;
-  suggested_rules?: SuggestedRule[];
-}
-
-interface Message {
-  id: number;
-  role: "user" | "assistant";
-  content: string;
-  created_at: string;
-  metadata: Record<string, unknown>;
-}
+// ─── 型定義 (SuggestedRule, Evaluation, Message, DeleteStep は ./types に移動) ─
 
 interface SessionInfo {
   id: string;
@@ -201,7 +175,6 @@ export default function ChatHistorySessionPage() {
   const [outcomeToast, setOutcomeToast] = useState<string | null>(null);
 
   // ─── セッション完全削除（GDPR Art.17 / 個情法30条） ────────────────────────
-  type DeleteStep = "idle" | "step1" | "step2";
   const [deleteStep, setDeleteStep] = useState<DeleteStep>("idle");
   const [deleteReason, setDeleteReason] = useState("");
   const [deleteConfirmId, setDeleteConfirmId] = useState("");

--- a/admin-ui/src/pages/admin/chat-history/types.ts
+++ b/admin-ui/src/pages/admin/chat-history/types.ts
@@ -1,0 +1,30 @@
+// ─── 型定義 ───────────────────────────────────────────────────────────────────
+
+export interface SuggestedRule {
+  rule_text: string;
+  status?: string;
+  tuning_rule_id?: number;
+}
+
+export interface Evaluation {
+  id: number;
+  overall_score?: number;
+  score: number;
+  psychology_fit_score?: number;
+  customer_reaction_score?: number;
+  stage_progress_score?: number;
+  taboo_violation_score?: number;
+  feedback?: { summary?: string };
+  evaluated_at: string;
+  suggested_rules?: SuggestedRule[];
+}
+
+export interface Message {
+  id: number;
+  role: "user" | "assistant";
+  content: string;
+  created_at: string;
+  metadata: Record<string, unknown>;
+}
+
+export type DeleteStep = "idle" | "step1" | "step2";

--- a/avatar-agent/agent.py
+++ b/avatar-agent/agent.py
@@ -493,6 +493,24 @@ async def entrypoint(ctx: agents.JobContext) -> None:
         avatar = lemonslice.AvatarSession(**avatar_kwargs)
         await avatar.start(session, room=ctx.room)
         logger.info("=== LEMONSLICE AVATAR STARTED ===")
+
+        # LiveKit 1.5.17: アバターの room 参加を待機（失敗しても続行）
+        try:
+            await avatar.wait_for_join(timeout=10.0)
+            logger.info("=== AVATAR PARTICIPANT JOINED ROOM ===")
+        except Exception as e:
+            logger.warning(f"[avatar] wait_for_join timeout (continuing): {e}")
+
+        # LiveKit 1.5.17: job shutdown 時に aclose してゾンビアバターを防止
+        # (wait_for_shutdown は 1.5.17 に存在しないため add_shutdown_callback を使用)
+        async def _close_avatar() -> None:
+            try:
+                await avatar.aclose()
+                logger.info("[avatar] aclose completed")
+            except Exception as e:
+                logger.warning(f"[avatar] aclose error: {e}")
+
+        ctx.add_shutdown_callback(_close_avatar)
     except Exception as e:
         logger.warning(f"Lemonslice avatar failed (text-only fallback): {e}")
 


### PR DESCRIPTION
## 概要
[P1-A] avatar-agent/agent.py に livekit-agents 1.5.17 の新 API を追加。タスク規定の「実機で API 存在確認後に実施（確認失敗=スキップ）」に従い、ローカル venv に 1.5.17 を実インストールして全 API を照合した。

Asana: https://app.asana.com/0/1213607637045514/1215601272301006

## 実機照合結果と適用判断（3点）

| 変更 | 照合結果 | 判断 |
|---|---|---|
| 変更1 `avatar.wait_for_join` | `dir(lemonslice.AvatarSession)` に **実在** | タスク通り適用（avatar.start 直後、timeout=10s、失敗時 warning で続行） |
| 変更2 `session.wait_for_shutdown` | **存在しない**（あるのは `shutdown(drain=True)` = トリガー関数）。`avatar.aclose` は実在 | 同目的（ゾンビアバター防止）を実在 API で実装: `ctx.add_shutdown_callback` に `avatar.aclose()` を登録（signature 照合済み: async callable 受理） |
| 変更3 `AgentSession(audio_config=AudioConfig(fade_in/out))` | `AudioConfig` は `livekit.agents.voice.background_audio` の BGM 音量用クラス。`AgentSession.__init__` に audio_config パラメータ**無し**（全31パラメータ列挙で確認） | **スキップ**（タスク規定: 確認失敗=スキップ。TTS フェードは 1.5.17 に該当 API なし） |

## Gate
- Gate 1 (pnpm verify): PASS / Gate 3 (pnpm build): PASS / py_compile: OK
- avatar-agent に pytest 基盤なし（既存慣行どおり Python テストなし）

## ⚠️ merge 後の人間作業
- VPS の avatar-agent venv は 1.5.5 のまま（P0 #342 の依存更新が前提）。依存更新 + プロセス再起動後に wait_for_join / aclose のログ実機確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)
