### PR TITLE
feat(api): エラーメッセージの「グローバルナレッジ」を「全店舗共通の知識データ」にリネーム

### DIFF
--- a/src/api/admin/knowledge/routes.ts
+++ b/src/api/admin/knowledge/routes.ts
@@ -388,7 +388,7 @@ export function registerKnowledgeAdminRoutes(app: Express): void {
       if (recordTenantId === "global") {
         const user = (req as KnowledgeReq).user;
         if (user?.role !== "super_admin") {
-          return res.status(403).json({ error: "グローバルナレッジはSuper Adminのみ削除可能です" });
+          return res.status(403).json({ error: "全店舗共通の知識データはSuper Adminのみ削除可能です" });
         }
       }
 
@@ -517,7 +517,7 @@ export function registerKnowledgeAdminRoutes(app: Express): void {
 
     // "global" は super_admin のみ許可
     if (target === "global" && (req as KnowledgeReq).user?.role !== "super_admin") {
-      return res.status(403).json({ error: "グローバルナレッジはSuper Adminのみ登録可能です" });
+      return res.status(403).json({ error: "全店舗共通の知識データはSuper Adminのみ登録可能です" });
     }
 
     // コミット時の重複スキップ: バイグラム類似度が閾値以上の既存FAQはスキップ
@@ -680,7 +680,7 @@ export function registerKnowledgeAdminRoutes(app: Express): void {
 
     // "global" は super_admin のみ許可
     if (target === "global" && (req as KnowledgeReq).user?.role !== "super_admin") {
-      return res.status(403).json({ error: "グローバルナレッジはSuper Adminのみ登録可能です" });
+      return res.status(403).json({ error: "全店舗共通の知識データはSuper Adminのみ登録可能です" });
     }
 
     // コミット時の重複スキップ: バイグラム類似度が閾値以上の既存FAQはスキップ

--- a/src/index.ts
+++ b/src/index.ts
@@ -426,7 +426,7 @@ app.post(
 
     // "global" は super_admin のみ許可
     if (target === "global" && (req as any).user?.role !== "super_admin") {
-      res.status(403).json({ error: "グローバルナレッジはSuper Adminのみ登録可能です" });
+      res.status(403).json({ error: "全店舗共通の知識データはSuper Adminのみ登録可能です" });
       return;
     }
 

--- a/tests/phase35/globalRag.test.ts
+++ b/tests/phase35/globalRag.test.ts
@@ -65,13 +65,13 @@ describe("global guard — knowledge routes source", () => {
   });
 
   it("global ガードのエラーメッセージが含まれる", () => {
-    const globalGuardCount = (source.match(/グローバルナレッジはSuper Adminのみ/g) || []).length;
+    const globalGuardCount = (source.match(/全店舗共通の知識データはSuper Adminのみ/g) || []).length;
     // PDF route + text/commit + scrape/commit = 少なくとも3箇所
     expect(globalGuardCount).toBeGreaterThanOrEqual(3);
   });
 
   it("DELETE guard で global の super_admin チェックがある", () => {
-    expect(source).toContain("グローバルナレッジはSuper Adminのみ削除可能です");
+    expect(source).toContain("全店舗共通の知識データはSuper Adminのみ削除可能です");
   });
 
   it("DELETE で recordTenantId を使って削除する", () => {


### PR DESCRIPTION
## 概要
backend のユーザー向けエラーメッセージに残っていた「グローバルナレッジ」を、admin-ui（PR #336/#343）と同じ「全店舗共通の知識データ」に統一。

Asana: https://app.asana.com/0/1213607637045514/1215613312408622

## 変更内容
- `src/index.ts:429` / `src/api/admin/knowledge/routes.ts:391,520,683` — 403 エラーメッセージ 4 箇所
- `tests/phase35/globalRag.test.ts` — 文言 assert 2 箇所を追随（ガード件数チェックのロジックは不変）
- `tests/search/langRouterGlobal.test.ts:84` はテスト入力クエリ（ラベルでない）ため対象外

## Gate
- Gate 1 (pnpm verify): PASS（globalRag 11/11 含む） / Gate 2: 文言のみ・gitleaks 対象差分なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)
