### PR TITLE
feat(avatar): emotion_tags に文字種バリデーション追加（[tag] TTS構文の保護）

### DIFF
--- a/src/api/admin/avatar/routes.test.ts
+++ b/src/api/admin/avatar/routes.test.ts
@@ -271,3 +271,35 @@ describe("DELETE /v1/admin/avatar/configs/:id", () => {
     expect(res.status).toBe(403);
   });
 });
+
+// --------------------------------------------------------------------------
+// POST /v1/admin/avatar/configs — emotion_tags バリデーション（Phase47-A 構文保護）
+// --------------------------------------------------------------------------
+
+describe("POST /v1/admin/avatar/configs — emotion_tags validation", () => {
+  it("emotion_tags に [ ] を含むタグがあると 400 を返す", async () => {
+    const db = { query: jest.fn() };
+    const app = makeApp(db, "client_admin");
+
+    const res = await request(app)
+      .post("/v1/admin/avatar/configs")
+      .send({ name: "テスト", emotion_tags: ["happy", "[injection]"] });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_request");
+    expect(db.query).not.toHaveBeenCalled();
+  });
+
+  it("emotion_tags が通常の英単語/日本語タグなら schema を通過する", async () => {
+    const db = {
+      query: jest.fn().mockResolvedValue({ rows: [{ ...CONFIG_ROW, is_active: false }] }),
+    };
+    const app = makeApp(db, "client_admin");
+
+    const res = await request(app)
+      .post("/v1/admin/avatar/configs")
+      .send({ name: "テスト", emotion_tags: ["happy", "落ち着き"] });
+
+    expect(res.status).not.toBe(400);
+  });
+});

--- a/src/api/admin/avatar/routes.ts
+++ b/src/api/admin/avatar/routes.ts
@@ -107,6 +107,14 @@ async function uploadBase64ToStorage(
 // Zod スキーマ
 // ---------------------------------------------------------------------------
 
+// Phase47-A: emotion_tags は TTS テキスト先頭に [tag] 形式で注入されるため、
+// 構文を壊す角括弧・改行を拒否する（既存の英単語/日本語タグは許容）
+const emotionTagSchema = z
+  .string()
+  .min(1)
+  .max(30)
+  .regex(/^[^[\]\r\n]+$/, "emotion_tags に [ ] や改行は使用できません");
+
 const createSchema = z.object({
   name: z.string().min(1).max(100),
   image_url: z.string().optional(),
@@ -115,7 +123,7 @@ const createSchema = z.object({
   voice_description: z.string().optional(),
   personality_prompt: z.string().optional(),
   behavior_description: z.string().optional(),
-  emotion_tags: z.array(z.string()).optional(),
+  emotion_tags: z.array(emotionTagSchema).optional(),
   lemonslice_agent_id: z.string().optional(),
   anam_avatar_id: z.string().optional(),
   anam_voice_id: z.string().optional(),
@@ -132,7 +140,7 @@ const updateSchema = z.object({
   voice_description: z.string().optional(),
   personality_prompt: z.string().optional(),
   behavior_description: z.string().optional(),
-  emotion_tags: z.array(z.string()).optional(),
+  emotion_tags: z.array(emotionTagSchema).optional(),
   lemonslice_agent_id: z.string().optional(),
   anam_avatar_id: z.string().optional(),
   anam_voice_id: z.string().optional(),


### PR DESCRIPTION
## 概要
emotion_tags に文字種バリデーションを追加。PR #344（FishAudio Phase A）の Evaluator P2 指摘対応。

Asana: https://app.asana.com/0/1213607637045514/1215613311977860

## 変更内容
- `src/api/admin/avatar/routes.ts` — `emotionTagSchema`（min 1 / max 30 / 角括弧・改行を拒否する deny-list regex）を新設し、create/update 両スキーマの `emotion_tags` に適用
- deny-list 方式の理由: タグは LLM 生成の英単語（"happy" 等）に加え日本語タグの可能性もあるため、whitelist では既存データの更新を壊すリスク。TTS の `[tag]` 構文を壊すのは `[` `]` 改行のみ
- テスト 2 ケース追加: `[injection]` 入り → 400 + DB 未到達 / 英単語・日本語タグ → schema 通過

## Gate
- Gate 1 (pnpm verify): PASS — 1894 tests（初回実行は jest "Force exiting" の一時 flake、再実行 exit=0）
- Gate 3: build PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)
