### PR TITLE
feat(infra): repomix MCP統合 — OpenWolf anatomy.md補完用コードスナップショット基盤

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -100,5 +100,16 @@
         ]
       }
     ]
+  },
+  "mcpServers": {
+    "repomix": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "repomix",
+        "--mcp-server"
+      ],
+      "type": "stdio"
+    }
   }
 }

--- a/repomix.config.json
+++ b/repomix.config.json
@@ -1,0 +1,25 @@
+{
+  "output": {
+    "filePath": ".wolf/repomix-snapshot.xml",
+    "style": "xml",
+    "compress": true
+  },
+  "include": [
+    "src/**",
+    "admin-ui/src/**"
+  ],
+  "ignore": {
+    "useGitignore": true,
+    "useDefaultPatterns": true,
+    "customPatterns": [
+      "**/*.test.ts",
+      "**/*.test.tsx",
+      "**/*.spec.ts",
+      "dist/**",
+      "node_modules/**"
+    ]
+  },
+  "security": {
+    "enableSecurityCheck": true
+  }
+}


### PR DESCRIPTION
## Summary

- `.claude/settings.json` に repomix MCP server (stdio) を追加 → Claude Code から `npx repomix --mcp-server` で直接呼び出し可能
- `repomix.config.json` を新規追加（デフォルト対象: `src/**` + `admin-ui/src/**`、テストファイル除外、compress有効）

## 背景・目的

OpenWolf `anatomy.md` はファイルサマリに特化しており、全文コードを AI に渡す用途に不十分。  
repomix で生成したスナップショット (`.wolf/repomix-snapshot.xml`) を補完として利用する。

**計測結果 (R2C codebase)**:
| 対象 | ファイル数 | トークン数 |
|------|----------|----------|
| `src/**` のみ | 400 | 524k |
| `src/**` + `admin-ui/src/**` | 532 | 821k |

## 使い方

```bash
# CLI スナップショット生成 (repomix.config.json が自動適用)
npx repomix

# MCP サーバー経由 (Claude Code セッション内から直接呼び出し)
# → claude mcp list で "repomix" が表示されていれば有効
```

## Test plan

- [x] Gate 1: pnpm verify PASS
- [x] repomix.config.json の include/ignore 設定確認
- [x] .claude/settings.json の mcpServers エントリ構文確認