### PR TITLE
fix(e2e): 本番直撃 page.goto にバックオフ付きリトライ導入（CI flake 対策）

### DIFF
--- a/tests/e2e/helpers/gotoRetry.ts
+++ b/tests/e2e/helpers/gotoRetry.ts
@@ -1,0 +1,23 @@
+import type { Page, Response } from '@playwright/test';
+
+// 本番 (api.r2c.biz) 直撃の page.goto は CI ランナーからの一時的なネットワーク断
+// (net::ERR_ABORTED / timeout) で flake する (2026-06-11 PR #346/#347/#349 で実証)。
+// テストリトライは障害ウィンドウを跨げないため、goto 単位でバックオフ付き再試行する。
+export async function gotoWithRetry(
+  page: Page,
+  url: string,
+  attempts = 3,
+): Promise<Response | null> {
+  let lastError: unknown;
+  for (let i = 0; i < attempts; i++) {
+    try {
+      return await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 15_000 });
+    } catch (e) {
+      lastError = e;
+      if (i < attempts - 1) {
+        await page.waitForTimeout(3_000 * (i + 1));
+      }
+    }
+  }
+  throw lastError;
+}

--- a/tests/e2e/phase65-demo.spec.ts
+++ b/tests/e2e/phase65-demo.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { gotoWithRetry } from './helpers/gotoRetry';
 
 const E2E_ENABLED = process.env.E2E_ENABLED === '1' || !!process.env.CI;
 const DEMO_BASE = 'https://api.r2c.biz/carnation-demo';
@@ -24,7 +25,7 @@ test.describe('Phase65 carnation-demo サイト', () => {
       const errors: string[] = [];
       page.on('pageerror', (err) => errors.push(err.message));
 
-      const res = await page.goto(`${DEMO_BASE}${path}`);
+      const res = await gotoWithRetry(page, `${DEMO_BASE}${path}`);
       expect(res?.status()).toBe(200);
 
       // widget.js ロードエラーは許容（ネットワーク制約の可能性あり）
@@ -47,7 +48,7 @@ test.describe('Phase65 carnation-demo サイト', () => {
       }
     });
 
-    await page.goto(`${DEMO_BASE}/inquiry-thanks.html`);
+    await gotoWithRetry(page, `${DEMO_BASE}/inquiry-thanks.html`);
     // polling最大5秒 + 余裕1秒
     await page.waitForTimeout(6000);
 
@@ -70,7 +71,7 @@ test.describe('Phase65 carnation-demo サイト', () => {
       }
     });
 
-    await page.goto(`${DEMO_BASE}/purchase-thanks.html?price=3190000`);
+    await gotoWithRetry(page, `${DEMO_BASE}/purchase-thanks.html?price=3190000`);
     await page.waitForTimeout(6000);
 
     // ヘッドレスCI環境ではwidgetが初期化されない場合があるため0件は許容
@@ -85,7 +86,7 @@ test.describe('Phase65 carnation-demo サイト', () => {
   // test 4b: 旧URL /carnation-demo.html が 301 で新URLへリダイレクトされること
   test('旧URL /carnation-demo.html が /carnation-demo/index.html へリダイレクトされる', async ({ page }) => {
     // Playwrightはリダイレクトを自動追跡するため、最終URLを確認する
-    await page.goto('https://api.r2c.biz/carnation-demo.html');
+    await gotoWithRetry(page, 'https://api.r2c.biz/carnation-demo.html');
     expect(page.url()).toContain('/carnation-demo/index.html');
     const title = await page.title();
     expect(title).toContain('BROSS新潟');
@@ -96,7 +97,7 @@ test.describe('Phase65 carnation-demo サイト', () => {
     await page.setViewportSize({ width: 390, height: 844 });
 
     for (const path of ['/index.html', '/stock.html', '/inquiry.html']) {
-      await page.goto(`${DEMO_BASE}${path}`);
+      await gotoWithRetry(page, `${DEMO_BASE}${path}`);
       // 水平スクロールが発生していないこと
       const scrollWidth = await page.evaluate(() => document.body.scrollWidth);
       const clientWidth = await page.evaluate(() => document.body.clientWidth);

--- a/tests/e2e/widget.spec.ts
+++ b/tests/e2e/widget.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { gotoWithRetry } from './helpers/gotoRetry';
 
 const E2E_ENABLED = process.env.E2E_ENABLED === '1' || !!process.env.CI;
 
@@ -9,7 +10,7 @@ test.describe('Chat Widget — Rendering', () => {
     const errors: string[] = [];
     page.on('pageerror', (err) => errors.push(err.message));
 
-    const response = await page.goto('https://api.r2c.biz/carnation-demo/index.html');
+    const response = await gotoWithRetry(page, 'https://api.r2c.biz/carnation-demo/index.html');
 
     // ページ自体は 200 で返る
     expect(response?.status()).toBe(200);
@@ -22,7 +23,7 @@ test.describe('Chat Widget — Rendering', () => {
   });
 
   test('widget.js script tag is present in demo page', async ({ page }) => {
-    await page.goto('https://api.r2c.biz/carnation-demo/index.html');
+    await gotoWithRetry(page, 'https://api.r2c.biz/carnation-demo/index.html');
 
     // widget.js の <script> タグが埋め込まれていること
     const widgetScript = page.locator('script[src*="widget.js"]');
@@ -30,7 +31,7 @@ test.describe('Chat Widget — Rendering', () => {
   });
 
   test('widget container or chat button appears in DOM', async ({ page }) => {
-    await page.goto('https://api.r2c.biz/carnation-demo/index.html');
+    await gotoWithRetry(page, 'https://api.r2c.biz/carnation-demo/index.html');
 
     // Shadow DOM ホスト要素またはウィジェットコンテナが存在すること
     // widget.js が生成する要素を確認（data-api-key 属性付き script の後に挿入される）


### PR DESCRIPTION
## 概要
本番（api.r2c.biz）を直撃する E2E の `page.goto` にバックオフ付きリトライを導入し、CI ランナーの一時的なネットワーク断による flake を解消する。

Asana: https://app.asana.com/0/1213607637045514/1215613990201087

## 背景（本日 3 回再発）
- PR #346 / #347 / #349 の「E2E — Playwright」が `net::ERR_ABORTED; maybe frame was detached` で fail → いずれも rerun で success、本番は毎回 curl で健全（301→200, ~1.3s）を確認済み
- 失敗箇所は全て本番直撃の goto（phase65-demo.spec.ts ×6 / widget.spec.ts ×3）
- Playwright のテストリトライ（retry1）は既に走っているが、障害ウィンドウを跨げず救えていない → goto 単位の再試行が必要

## 変更内容（tests/ のみ）
- `tests/e2e/helpers/gotoRetry.ts`（新規）— `gotoWithRetry(page, url, attempts=3)`: domcontentloaded / 15s timeout、失敗時 3s×n のバックオフで再試行
- phase65-demo.spec.ts / widget.spec.ts の本番直撃 goto 全 9 箇所を置換（assertion・期待値は不変更）

## 検証
- ローカル `E2E_ENABLED=1 npx playwright test`（対象 2 spec）→ **16 passed**
- tsc エラーなし / gitleaks no leaks
- Gate: テストコードのみのため Codex review スキップ（CLAUDE.md 規定）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
