### PR TITLE
feat(infra): Mobile MCP統合 — widget.js実機モバイルE2E検証基盤 (Gate 4c)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -110,6 +110,14 @@
         "--mcp-server"
       ],
       "type": "stdio"
+    },
+    "mobile-mcp": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "@mobilenext/mcp@latest"
+      ],
+      "type": "stdio"
     }
   }
 }

--- a/docs/TEST_DEPLOY_GATE.md
+++ b/docs/TEST_DEPLOY_GATE.md
@@ -54,6 +54,11 @@ Gate 4b: Playwright MCP ブラウザテスト（UI変更Phase: 必須）
   │  ★ UI変更がないPhaseではスキップ可
   │
   ▼
+Gate 4c: Mobile MCP widget.js 実機相当テスト（widget変更Phase: 必須）
+  │  M1-M4 共通チェック（390px / Touch 44px / Shadow DOM）
+  │  ★ widget.js 変更がないPhaseではスキップ可
+  │
+  ▼
 デプロイ: bash SCRIPTS/deploy-vps.sh
   │  ★ DBマイグレーション必要な場合は先にVPSでSQL実行
   │
@@ -252,6 +257,49 @@ Playwright MCPを使って https://admin.r2c.biz にアクセスし、B1〜B5の
 ### スキップ条件
 
 API追加のみ・DBマイグレーションのみ・バックグラウンド処理のみなど、Admin UIに変更がないPhaseではスキップ可。
+
+---
+
+## 6b. Gate 4c: Mobile MCP widget.js 実機相当テスト（widget変更Phase: 必須）
+
+git push後、デプロイ前に実施。`public/widget.js` を変更したPhaseで必須。
+
+### Mobile MCP 接続手順
+
+Mobile MCP は **デフォルト未接続**。`.claude/settings.json` に設定済みのため、セッション再起動で自動接続される。
+手動追加が必要な場合:
+
+```bash
+claude mcp add --scope project mobile-mcp npx @mobilenext/mcp@latest
+```
+
+接続確認:
+
+```bash
+claude mcp list | grep mobile-mcp
+# 出力例: mobile-mcp: npx @mobilenext/mcp@latest (connected)
+```
+
+### 実行方法
+
+Mobile MCP を使って widget.js を 390px 相当の viewport で動作確認する。
+mobilenext.ai はクラウド上の実デバイス（iOS/Android）を API 経由で制御するため、実機がなくても実行可能。
+
+```
+Mobile MCPを使ってwidget.jsの基本動作をiOS Safari 390px viewportで確認して:
+M1〜M4の共通チェックを実施
+```
+
+### 共通チェック（M1-M4）
+
+- [ ] M1: widget が 390px viewport で正常に展開される（FABボタン表示 → クリック → チャット展開）
+- [ ] M2: Touch target が ≥44px（FABボタン、送信ボタン、閉じるボタン）
+- [ ] M3: フォントサイズが ≥16px（iOS Safariの自動ズーム防止）
+- [ ] M4: Shadow DOM 内のレイアウト崩れなし（viewport scale / スクロール挙動）
+
+### スキップ条件
+
+`public/widget.js` に変更がない Phase（API追加のみ、Admin UI のみ等）はスキップ可。
 
 ---
 


### PR DESCRIPTION
## Summary

- `.claude/settings.json` に `mobile-mcp` MCP server を追加（Apache 2.0、Playwright互換API）
- `docs/TEST_DEPLOY_GATE.md` に **Gate 4c** を新設（widget.js変更Phaseで必須）

## 背景・目的

CLAUDE.md の Mobile First DoD（Touch ≥44px / Font ≥16px / 390px viewport first）が、  
`@playwright/mcp` のデスクトップエミュレーションのみで担保されていた。  
`public/widget.js` の Shadow DOM は実機で挙動差異が発生しうるため、  
クラウド実デバイス経由の検証基盤を追加する。

## Gate 4c: 共通チェック（widget変更時のみ必須）

| ID | チェック内容 |
|----|------------|
| M1 | 390px viewport で FAB展開→チャット表示が正常動作 |
| M2 | Touch target ≥44px（FAB・送信・閉じるボタン） |
| M3 | フォントサイズ ≥16px（iOS Safari自動ズーム防止） |
| M4 | Shadow DOM内レイアウト崩れなし |

## 依存関係

このPRは #355 (repomix MCP) の `.claude/settings.json` 変更を前提にしています。  
#355 merge後にmainへの rebase が必要です。

## Test plan

- [x] Gate 1 typecheck/lint: PASS（.claude/settings.json + docs のみ変更、TS変更なし）
- [x] Gate 1 test: repomix worktree で 159 suites / 1892 tests 全PASS確認済み
- [x] settings.json の `mcpServers.mobile-mcp` 構文確認
- [x] TEST_DEPLOY_GATE.md の Gate 4c フローダイアグラム + 詳細セクション整合確認