### PR TITLE
perf(avatar): FishAudio Phase B-1 — TTS chunk streaming 化で TTFA 短縮

### DIFF
--- a/avatar-agent/agent.py
+++ b/avatar-agent/agent.py
@@ -23,6 +23,7 @@ os.environ.setdefault("LIBVA_DRIVER_NAME", "dummy")
 import asyncio
 import json
 import logging
+import time
 import aiohttp
 from livekit import agents, rtc
 from livekit.agents import Agent, AgentSession
@@ -248,6 +249,8 @@ class FishAudioChunkedStream(agents_tts.ChunkedStream):
                 request_body["reference_id"] = self._reference_id
 
             logger.info(f"[TTS] requesting Fish Audio: text={self._input_text[:60]!r} ref={self._reference_id}")
+            started_at = time.monotonic()
+            total_bytes = 0
             async with aiohttp.ClientSession() as http_session:
                 async with http_session.post(
                     "https://api.fish.audio/v1/tts",
@@ -263,16 +266,26 @@ class FishAudioChunkedStream(agents_tts.ChunkedStream):
                         error_text = await resp.text()
                         logger.error(f"[TTS] Fish Audio error {resp.status}: {error_text[:300]}")
                         return
-                    audio_bytes = await resp.read()
 
-            logger.info(f"[TTS] got {len(audio_bytes)} bytes, first4={audio_bytes[:4]!r}")
-            if len(audio_bytes) < 1000:
-                logger.warning(f"[TTS] Fish Audio returned suspiciously small audio ({len(audio_bytes)} bytes), skipping (will retry)")
-                return
+                    # Phase B-1: chunk 受信ごとに push して TTFA を短縮
+                    # （公式 openai プラグイン ChunkedStream と同パターン。
+                    #   capabilities.streaming は False のまま — True にすると
+                    #   フレームワークが未実装の stream() を直接呼び NotImplementedError になる）
+                    first_chunk_at: float | None = None
+                    async for chunk in resp.content.iter_chunked(4096):
+                        if not chunk:
+                            continue
+                        if first_chunk_at is None:
+                            first_chunk_at = time.monotonic()
+                            logger.info(f"[TTS] TTFA: {(first_chunk_at - started_at) * 1000:.1f}ms")
+                        output_emitter.push(chunk)
+                        total_bytes += len(chunk)
 
-            output_emitter.push(audio_bytes)
+            if total_bytes < 1000:
+                # 旧実装は一括受信後に skip できたが、streaming では既に push 済みのため警告のみ
+                logger.warning(f"[TTS] Fish Audio returned suspiciously small audio ({total_bytes} bytes)")
             output_emitter.flush()
-            logger.info("[TTS] pushed to emitter OK")
+            logger.info(f"[TTS] streamed {total_bytes} bytes to emitter OK")
 
             # 使用量レポート（fire-and-forget）
             if self._tenant_id:


### PR DESCRIPTION
## 概要
[FishAudio Phase B-1] avatar-agent の TTS 受信を一括 `resp.read()` から **chunk streaming（iter_chunked 4096 + 逐次 push）** に変更し、TTFA（Time To First Audio）を短縮する。

Asana: 子タスク https://app.asana.com/0/0/1215613192417303（Phase B は B-1/B-2 の 2 PR に分割。本 PR は B-1）

## 変更内容（avatar-agent/agent.py のみ）
- `FishAudioChunkedStream._run`: HTTP レスポンスを response コンテキスト内で chunk ごとに `output_emitter.push()`（公式 openai プラグイン ChunkedStream と同一パターン、SDK 実コードで裏取り済み）
- TTFA 計測ログ追加（`[TTS] TTFA: XXms` — staging 実測用、目標 ≤200ms）
- 小サイズ音声の扱い: 旧実装の「<1000 bytes なら push せず skip」は streaming では不可能（既に push 済み）のため警告ログのみに変更

## 重要な設計判断（Planner 案の危険箇所を修正）
当初計画の「`TTSCapabilities(streaming=True)` に変更」は**実施していない**。livekit-agents 1.5.17 の `voice/agent.py:499` を実機確認した結果、`capabilities.streaming=False` の場合のみ StreamAdapter で包まれ `synthesize()`（ChunkedStream）経路になる。True にすると未実装の `FishAudioTTS.stream()` が直接呼ばれ **NotImplementedError で TTS が全壊**するため、False を維持し chunk push のみで TTFA を改善する。

## Gate
- Gate 1 (pnpm verify): PASS / py_compile: OK
- `AudioEmitter.push` が複数回呼び出し可能なこと（チャネル送信実装）を SDK ソースで確認済み

## ⚠️ merge 後の人間作業
- VPS デプロイ後、avatar 起動時のログで `[TTS] TTFA:` を実測（目標 ≤200ms、悪化時は本 PR を revert すれば旧挙動に戻る）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
