### PR TITLE
feat(avatar): FishAudio Phase B-2 — 音声クローン作成 API（Fish Audio /model 連携）

### DIFF
--- a/src/api/admin/avatar/routes.test.ts
+++ b/src/api/admin/avatar/routes.test.ts
@@ -303,3 +303,237 @@ describe("POST /v1/admin/avatar/configs — emotion_tags validation", () => {
     expect(res.status).not.toBe(400);
   });
 });
+
+// --------------------------------------------------------------------------
+// POST /v1/admin/avatar/configs/:id/voice-clone — FishAudio Phase B-2
+// --------------------------------------------------------------------------
+
+describe("POST /v1/admin/avatar/configs/:id/voice-clone", () => {
+  const AUDIO_BUFFER = Buffer.from("dummy-audio-bytes");
+  let fetchSpy: jest.SpyInstance;
+
+  // makeApp で role なしユーザーを再現するためのバリアント
+  function makeAppNoRole(db: any) {
+    const app = express();
+    app.use(express.json());
+    app.use((req: any, _res: any, next: any) => {
+      req.supabaseUser = { app_metadata: {} };
+      next();
+    });
+    registerAvatarConfigRoutes(app, db);
+    return app;
+  }
+
+  beforeEach(() => {
+    process.env.FISH_AUDIO_API_KEY = "test-fish-key";
+    fetchSpy = jest.spyOn(global, "fetch" as any).mockResolvedValue({
+      ok: true,
+      status: 201,
+      json: async () => ({ _id: "fish-voice-123" }),
+      text: async () => "",
+    } as any);
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    delete process.env.FISH_AUDIO_API_KEY;
+  });
+
+  it("正常系: client_admin + 自テナント config → Fish Audio 呼び出し + voice_id UPDATE + 200", async () => {
+    const dbQuery = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ id: "config-1" }] })   // 所有チェック SELECT
+      .mockResolvedValueOnce({ rows: [{ id: "config-1" }] });  // UPDATE RETURNING id
+
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "client_admin", "tenant-a"))
+      .post("/v1/admin/avatar/configs/config-1/voice-clone")
+      .field("name", "マイボイス")
+      .attach("audio", AUDIO_BUFFER, {
+        filename: "voice.mp3",
+        contentType: "audio/mpeg",
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ voiceId: "fish-voice-123" });
+
+    // Fish Audio へ FormData で POST されている
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("https://api.fish.audio/model");
+    expect(init.method).toBe("POST");
+    expect(init.body).toBeInstanceOf(FormData);
+    const fd = init.body as FormData;
+    expect(fd.get("visibility")).toBe("private");
+    expect(fd.get("type")).toBe("tts");
+    expect(fd.get("title")).toBe("マイボイス");
+    expect(fd.get("voices")).toBeTruthy();
+
+    // 所有チェック + UPDATE の両方が tenant スコープ付き
+    const [checkSql, checkParams] = dbQuery.mock.calls[0] as [string, unknown[]];
+    expect(checkSql).toContain("tenant_id = $2");
+    expect(checkParams).toEqual(["config-1", "tenant-a"]);
+
+    const [updateSql, updateParams] = dbQuery.mock.calls[1] as [string, unknown[]];
+    expect(updateSql).toContain("UPDATE avatar_configs SET voice_id = $1");
+    expect(updateSql).toContain("updated_at = NOW()");
+    expect(updateSql).toContain("tenant_id = $3");
+    expect(updateParams).toEqual(["fish-voice-123", "config-1", "tenant-a"]);
+  });
+
+  it("認証エラー: role なし → 403、DB・fetch に到達しない", async () => {
+    const dbQuery = jest.fn();
+    const db = { query: dbQuery };
+
+    const res = await request(makeAppNoRole(db))
+      .post("/v1/admin/avatar/configs/config-1/voice-clone")
+      .field("name", "マイボイス")
+      .attach("audio", AUDIO_BUFFER, {
+        filename: "voice.mp3",
+        contentType: "audio/mpeg",
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe("AUTHZ_ROLE_DENIED");
+    expect(dbQuery).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("バリデーション: audio ファイルなし → 400、DB・fetch に到達しない", async () => {
+    const dbQuery = jest.fn();
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "client_admin", "tenant-a"))
+      .post("/v1/admin/avatar/configs/config-1/voice-clone")
+      .field("name", "マイボイス");
+
+    expect(res.status).toBe(400);
+    expect(dbQuery).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("バリデーション: name が 101 字 → 400", async () => {
+    const dbQuery = jest.fn();
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "client_admin", "tenant-a"))
+      .post("/v1/admin/avatar/configs/config-1/voice-clone")
+      .field("name", "あ".repeat(101))
+      .attach("audio", AUDIO_BUFFER, {
+        filename: "voice.mp3",
+        contentType: "audio/mpeg",
+      });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe("invalid_request");
+    expect(dbQuery).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("バリデーション: 許可外 MIME タイプ → 400、fetch に到達しない", async () => {
+    const dbQuery = jest.fn();
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "client_admin", "tenant-a"))
+      .post("/v1/admin/avatar/configs/config-1/voice-clone")
+      .field("name", "マイボイス")
+      .attach("audio", AUDIO_BUFFER, {
+        filename: "evil.txt",
+        contentType: "text/plain",
+      });
+
+    expect(res.status).toBe(400);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("テナント越境: 他テナント configId → 404、Fish Audio に到達しない", async () => {
+    const dbQuery = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [] }); // 所有チェック SELECT → 0 件
+
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "client_admin", "tenant-a"))
+      .post("/v1/admin/avatar/configs/other-tenant-config/voice-clone")
+      .field("name", "マイボイス")
+      .attach("audio", AUDIO_BUFFER, {
+        filename: "voice.mp3",
+        contentType: "audio/mpeg",
+      });
+
+    expect(res.status).toBe(404);
+    expect(fetchSpy).not.toHaveBeenCalled();
+    // UPDATE は呼ばれない（SELECT のみ）
+    expect(dbQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("super_admin は他テナント config も操作可（tenant スコープなし — PATCH と同規則）", async () => {
+    const dbQuery = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ id: "config-x" }] })
+      .mockResolvedValueOnce({ rows: [{ id: "config-x" }] });
+
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "super_admin", ""))
+      .post("/v1/admin/avatar/configs/config-x/voice-clone")
+      .field("name", "マイボイス")
+      .attach("audio", AUDIO_BUFFER, {
+        filename: "voice.wav",
+        contentType: "audio/wav",
+      });
+
+    expect(res.status).toBe(200);
+    const [checkSql] = dbQuery.mock.calls[0] as [string, unknown[]];
+    expect(checkSql).not.toContain("tenant_id");
+    const [updateSql] = dbQuery.mock.calls[1] as [string, unknown[]];
+    expect(updateSql).not.toContain("tenant_id");
+  });
+
+  it("Fish Audio エラー: ok=false → 502、DB UPDATE に到達しない・外部エラー本文を返さない", async () => {
+    fetchSpy.mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => "internal fish error detail",
+      json: async () => ({}),
+    } as any);
+
+    const dbQuery = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ id: "config-1" }] }); // 所有チェックは通る
+
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "client_admin", "tenant-a"))
+      .post("/v1/admin/avatar/configs/config-1/voice-clone")
+      .field("name", "マイボイス")
+      .attach("audio", AUDIO_BUFFER, {
+        filename: "voice.mp3",
+        contentType: "audio/mpeg",
+      });
+
+    expect(res.status).toBe(502);
+    expect(JSON.stringify(res.body)).not.toContain("internal fish error detail");
+    // UPDATE は実行されない（SELECT のみ）
+    expect(dbQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("FISH_AUDIO_API_KEY 未設定 → 503、DB・fetch に到達しない", async () => {
+    delete process.env.FISH_AUDIO_API_KEY;
+    const dbQuery = jest.fn();
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "client_admin", "tenant-a"))
+      .post("/v1/admin/avatar/configs/config-1/voice-clone")
+      .field("name", "マイボイス")
+      .attach("audio", AUDIO_BUFFER, {
+        filename: "voice.mp3",
+        contentType: "audio/mpeg",
+      });
+
+    expect(res.status).toBe(503);
+    expect(dbQuery).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/api/admin/avatar/routes.ts
+++ b/src/api/admin/avatar/routes.ts
@@ -132,6 +132,18 @@ const createSchema = z.object({
   avatar_provider: z.enum(['lemonslice', 'anam']).optional(),
 });
 
+// Phase B-2: 音声クローン作成（multipart fields）
+const voiceCloneSchema = z.object({
+  name: z.string().min(1).max(100),
+});
+
+const ALLOWED_VOICE_MIME_TYPES = [
+  "audio/mpeg",
+  "audio/wav",
+  "audio/mp4",
+  "audio/ogg",
+] as const;
+
 const updateSchema = z.object({
   name: z.string().min(1).max(100).optional(),
   image_url: z.string().optional(),
@@ -685,6 +697,129 @@ export function registerAvatarConfigRoutes(app: Express, db: any): void {
       } catch (err) {
         logger.warn('[POST /v1/admin/avatar/configs/:id/reset-to-default]', err);
         return res.status(500).json({ error: 'リセットに失敗しました' });
+      }
+    }
+  );
+
+  // -----------------------------------------------------------------------
+  // POST /v1/admin/avatar/configs/:id/voice-clone — FishAudio Phase B-2
+  // 音声サンプルをアップロードし Fish Audio に永続クローンを作成、
+  // voice_id を avatar_configs に保存する
+  // -----------------------------------------------------------------------
+  const voiceUpload = multer({
+    storage: multer.memoryStorage(),
+    limits: { fileSize: 10 * 1024 * 1024 },
+  });
+
+  app.post(
+    "/v1/admin/avatar/configs/:id/voice-clone",
+    voiceUpload.single("audio"),
+    async (req: Request, res: Response) => {
+      const { su, role, tenantId, isSuperAdmin } = extractAuth(req);
+      if (!isAllowedAvatarRole(role)) {
+        return denyAvatarRole(req, res, su, role);
+      }
+      const id = req.params["id"];
+
+      const parsed = voiceCloneSchema.safeParse(req.body ?? {});
+      if (!parsed.success) {
+        return res
+          .status(400)
+          .json({ error: "invalid_request", details: parsed.error.issues });
+      }
+      const { name } = parsed.data;
+
+      const file = (req as any).file as Express.Multer.File | undefined;
+      if (!file) {
+        return res.status(400).json({ error: "音声ファイルが必要です" });
+      }
+      if (!(ALLOWED_VOICE_MIME_TYPES as readonly string[]).includes(file.mimetype)) {
+        return res.status(400).json({
+          error: "対応していない音声形式です（MP3 / WAV / MP4 / OGG をご利用ください）",
+        });
+      }
+
+      const fishApiKey = process.env.FISH_AUDIO_API_KEY?.trim();
+      if (!fishApiKey) {
+        return res.status(503).json({ error: "音声クローン機能が現在利用できません" });
+      }
+
+      try {
+        // 対象 config の存在 + テナント所有を先に確認
+        // （他テナント config への外部 API 呼び出しを防ぐ。tenant スコープは PATCH と同規則:
+        //   super_admin は全テナント可、client_admin は自テナントのみ）
+        let checkQuery = "SELECT id FROM avatar_configs WHERE id = $1";
+        const checkValues: unknown[] = [id];
+        if (!isSuperAdmin) {
+          checkQuery += " AND tenant_id = $2";
+          checkValues.push(tenantId);
+        }
+        const existing = await db.query(checkQuery, checkValues);
+        if (existing.rows.length === 0) {
+          return res
+            .status(404)
+            .json({ error: "設定が見つからないかアクセス権限がありません" });
+        }
+
+        // Fish Audio POST /model — 永続クローン作成
+        const fd = new FormData();
+        fd.append("visibility", "private");
+        fd.append("type", "tts");
+        fd.append("title", name);
+        fd.append(
+          "voices",
+          new Blob([new Uint8Array(file.buffer)], { type: file.mimetype }),
+          file.originalname || "voice-sample"
+        );
+
+        const fishRes = await fetch("https://api.fish.audio/model", {
+          method: "POST",
+          headers: { Authorization: `Bearer ${fishApiKey}` },
+          body: fd,
+        });
+
+        if (!fishRes.ok) {
+          // 外部エラー本文はログのみ（レスポンスに含めない）
+          const detail = await fishRes.text().catch(() => "");
+          logger.warn({
+            event: "voice_clone_fish_error",
+            status: fishRes.status,
+            detail: detail.slice(0, 300),
+          }, "[POST /v1/admin/avatar/configs/:id/voice-clone] Fish Audio API error");
+          return res.status(502).json({ error: "音声クローンの作成に失敗しました" });
+        }
+
+        const fishData = (await fishRes.json()) as Record<string, unknown>;
+        const voiceId = typeof fishData["_id"] === "string" ? fishData["_id"] : "";
+        if (!voiceId) {
+          logger.warn({
+            event: "voice_clone_fish_error",
+            reason: "missing_id_in_response",
+          }, "[POST /v1/admin/avatar/configs/:id/voice-clone] Fish Audio response has no _id");
+          return res.status(502).json({ error: "音声クローンの作成に失敗しました" });
+        }
+
+        // voice_id 保存（UPDATE にも同じ tenant スコープを適用 — 防御的二重化）
+        const updateValues: unknown[] = [voiceId, id];
+        let updateQuery =
+          "UPDATE avatar_configs SET voice_id = $1, updated_at = NOW() WHERE id = $2";
+        if (!isSuperAdmin) {
+          updateValues.push(tenantId);
+          updateQuery += " AND tenant_id = $3";
+        }
+        updateQuery += " RETURNING id";
+
+        const result = await db.query(updateQuery, updateValues);
+        if (result.rows.length === 0) {
+          return res
+            .status(404)
+            .json({ error: "設定が見つからないかアクセス権限がありません" });
+        }
+
+        return res.json({ voiceId });
+      } catch (err) {
+        logger.warn("[POST /v1/admin/avatar/configs/:id/voice-clone]", err);
+        return res.status(500).json({ error: "音声クローンの作成に失敗しました" });
       }
     }
   );


### PR DESCRIPTION
## 概要
[FishAudio Phase B-2] 音声クローン管理 API。テナント管理者が音声サンプルをアップロード → Fish Audio `POST /model` で永続クローン作成 → `avatar_configs.voice_id` に割り当てる。

Asana: 子タスク https://app.asana.com/0/0/1215613192417303（B-1 = PR #358 / 本 PR = B-2。これで Phase B 完了）

## エンドポイント
`POST /v1/admin/avatar/configs/:id/voice-clone`（multipart: name + audio）

- **認可 3 層**（PR #262 教訓準拠）: supabaseAuthMiddleware（既存 app.use）→ 既存 `extractAuth`/`isAllowedAvatarRole`（super_admin/client_admin、403 形式は既存踏襲）→ tenant スコープ（client_admin は `AND tenant_id = JWT値`、super_admin は全テナント可 — 既存 PATCH ルートと同一規則）
- **Fish Audio 呼び出し前に所有チェック SELECT**（計画外の追加・理由付き）: 越境試行/不存在 config で外部 API に孤児クローンを作らないため。UPDATE 側の tenant WHERE も防御的に二重化
- multer memoryStorage 10MB、MIME ホワイトリスト（mpeg/wav/mp4/ogg）→ 400
- Fish Audio 失敗は 502、外部エラー本文はログのみ（300字 truncate）でレスポンス非含有。音声 buffer・API キーはログ出力なし
- API キー未設定 → 503

## テスト（新規 9 ケース、計 21 pass）
正常系（FormData 内容 + tenant スコープ SQL 検証）/ 403（DB・fetch 不到達）/ audio なし 400 / name 101字 400 / MIME 400 / 越境 404（fetch 不到達）/ super_admin 規則 / Fish 502（UPDATE 不到達 + 本文非漏洩）/ キー未設定 503。fetch は jest.spyOn で mock（実 API 不到達）。

## Gate
- Gate 1 (pnpm verify): PASS / Gate 2 (security-scan): PASS / Gate 3 (build): PASS / lint: 警告増ゼロ
- DB migration なし（voice_id は既存カラム）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
