### PR TITLE
feat(avatar): LemonSlice I-3 — WebRTC Simulcast 有効化

### DIFF
--- a/avatar-agent/agent.py
+++ b/avatar-agent/agent.py
@@ -492,6 +492,9 @@ async def entrypoint(ctx: agents.JobContext) -> None:
                 "agent_idle_prompt": effective_agent_idle_prompt,
                 "width": 1920,
                 "height": 1080,
+                # I-3: LemonSlice API 公式パラメータ。明示 kwarg ではなく **kwargs →
+                # extra_payload 経由で API payload にマージされる (plugin avatar.py:55)
+                "simulcast": True,
             }
         else:
             avatar_kwargs = {
@@ -502,6 +505,7 @@ async def entrypoint(ctx: agents.JobContext) -> None:
                 "agent_idle_prompt": effective_agent_idle_prompt,
                 "width": 1920,
                 "height": 1080,
+                "simulcast": True,  # I-3: 同上
             }
         avatar = lemonslice.AvatarSession(**avatar_kwargs)
         await avatar.start(session, room=ctx.room)


### PR DESCRIPTION
## 概要
[LemonSlice I-3 / PR-A] WebRTC Simulcast 有効化。複数解像度同時配信でモバイル回線の映像劣化・カクツキを改善する。

Asana: 子タスク GID 1215614601084519（親: LemonSlice Upgrade GID 1215583480435865）

## 変更内容（avatar-agent/agent.py のみ、2行 + コメント）
- `avatar_kwargs`（agent_id / agent_image_url 両ブランチ）に `"simulcast": True` を追加

## 実施前確認（提案書 Q2 準拠 + 実機照合）
- AvatarSession に明示 `simulcast` kwarg は**無い**が、`**kwargs` → `_extra_payload` → LemonSlice API payload にマージされる実装を plugin source（avatar.py:55 / api.py:121-122）で確認
- venv (livekit-agents 1.5.17) で `AvatarSession(agent_id=..., simulcast=True)` を実行し **TypeError なし + `_extra_payload={'simulcast': True, ...}`** を実証（提案書が懸念した TypeError → 映像なしフォールバックは発生しない）
- simulcast は LemonSlice API 公式パラメータ（LiveKit 専用、default false）

## Gate
- Gate 1 (pnpm verify): PASS / py_compile: OK
- Gate 2.5: PR-A はスキップ可（タスク規定）

## ⚠️ merge 後の人間作業
- staging でアバター映像の正常動作確認
- Q7: Simulcast の課金影響は公式未記載 → 有効化後の初回請求サイクルで確認（悪化時は本 PR revert で即無効化可能）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
