### PR TITLE
feat(avatar): LemonSlice I-4 — In-Call Dynamic Update（SalesFlow 連動の表情差し替え）

### DIFF
--- a/avatar-agent/agent.py
+++ b/avatar-agent/agent.py
@@ -56,6 +56,50 @@ SYSTEM_PROMPT = (
     "- 特徴: 全車両整備済み・保証付き、ファイナンス相談可能\n"
 )
 
+# --- LemonSlice I-4: In-Call Dynamic Update ---
+# avatar.start() の戻り値（LemonSlice session_id）を保持。Control API 呼び出しに使用。
+_lemonslice_session_id: str | None = None
+
+# フロー状態 → 表情・動作プロンプトのマッピング（Phase22 State Machine + SalesFlow 互換）
+STATE_AGENT_PROMPTS = {
+    "clarify": "attentive and curious, leaning in slightly",
+    "answer": "confident and helpful",
+    "confirm": "enthusiastic and persuasive",
+    "terminal": "warm and appreciative, gentle bow",
+    # SalesFlow 互換（将来値）
+    "propose": "enthusiastic and persuasive",
+    "close": "joyful and celebratory",
+}
+
+
+async def control_lemonslice(event: str, **kwargs) -> bool:
+    """LemonSlice Control API への fire-and-forget ラッパー（失敗は warning のみ・non-fatal）。
+
+    注意: session_id / API キーはログに出さないこと。
+    """
+    if not _lemonslice_session_id:
+        logger.debug("[lemonslice-control] session_id not available, skipping")
+        return False
+    api_key = os.environ.get("LEMONSLICE_API_KEY")
+    if not api_key:
+        logger.warning("[lemonslice-control] LEMONSLICE_API_KEY not set, skipping")
+        return False
+    try:
+        async with aiohttp.ClientSession() as http:
+            async with http.post(
+                f"https://lemonslice.com/api/liveai/sessions/{_lemonslice_session_id}/control",
+                headers={"X-API-Key": api_key, "Content-Type": "application/json"},
+                json={"event": event, **kwargs},
+                timeout=aiohttp.ClientTimeout(total=3),
+            ) as resp:
+                ok = resp.status == 200
+                if not ok:
+                    logger.warning(f"[lemonslice-control] {event} → {resp.status}")
+                return ok
+    except Exception as e:
+        logger.warning(f"[lemonslice-control] {event} error (non-fatal): {e}")
+        return False
+
 
 # --- Groq LLM 直接呼び出し ---
 async def fetch_avatar_config(tenant_id: str, api_url: str, avatar_config_id: str | None = None) -> dict | None:
@@ -460,6 +504,17 @@ async def entrypoint(ctx: agents.JobContext) -> None:
                 if text:
                     logger.info(f"[data_channel] chat received (fallback): {text[:80]}")
                     asyncio.create_task(handle_chat(text))
+            elif msg_type == "state_change":
+                # I-4: フロー状態に応じて表情プロンプトを差し替え（fire-and-forget）
+                state = msg.get("state")
+                prompt = STATE_AGENT_PROMPTS.get(state) if isinstance(state, str) else None
+                if prompt:
+                    logger.info(f"[data_channel] state_change received: state={state}")
+                    asyncio.create_task(
+                        control_lemonslice("update_agent_prompt", agent_prompt=prompt)
+                    )
+                else:
+                    logger.debug(f"[data_channel] state_change with unknown state, skipping: {state!r}")
             elif msg_type == "widget_connected":
                 logger.info("[data_channel] widget_connected received")
                 # 挨拶は AgentSession が自動的に行うため、手動呼び出し不要
@@ -508,8 +563,11 @@ async def entrypoint(ctx: agents.JobContext) -> None:
                 "simulcast": True,  # I-3: 同上
             }
         avatar = lemonslice.AvatarSession(**avatar_kwargs)
-        await avatar.start(session, room=ctx.room)
+        # I-4: avatar.start() の戻り値が LemonSlice session_id（plugin avatar.py:132）
+        global _lemonslice_session_id
+        _lemonslice_session_id = await avatar.start(session, room=ctx.room)
         logger.info("=== LEMONSLICE AVATAR STARTED ===")
+        logger.info(f"[lemonslice] session_id={'SET' if _lemonslice_session_id else 'NOT_AVAILABLE'}")
 
         # LiveKit 1.5.17: アバターの room 参加を待機（失敗しても続行）
         try:

--- a/avatar-agent/agent.py
+++ b/avatar-agent/agent.py
@@ -66,8 +66,9 @@ STATE_AGENT_PROMPTS = {
     "answer": "confident and helpful",
     "confirm": "enthusiastic and persuasive",
     "terminal": "warm and appreciative, gentle bow",
-    # SalesFlow 互換（将来値）
+    # SalesFlow（/api/chat パスの salesContextStore currentStage 由来）
     "propose": "enthusiastic and persuasive",
+    "recommend": "confident and persuasive, presenting options",
     "close": "joyful and celebratory",
 }
 

--- a/public/widget.js
+++ b/public/widget.js
@@ -2156,6 +2156,19 @@
         console.log('[FAQ Widget] sendMessage after API: avatarProvider=' + avatarProvider + ' roomState=' + (lkRoom ? lkRoom.state : 'null') + ' hasParticipant=' + !!(lkRoom && lkRoom.localParticipant));
         if (avatarProvider === 'lemonslice' && lkRoom && lkRoom.localParticipant) {
           sendTTSRequest(assistantContent);
+          // I-4: フロー状態をアバターエージェントへ通知（表情プロンプト差し替え用）
+          if (json.data && typeof json.data.flowState === 'string') {
+            try {
+              var stateEncoder = new TextEncoder();
+              var statePayload = stateEncoder.encode(JSON.stringify({ type: 'state_change', state: json.data.flowState }));
+              var statePromise = lkRoom.localParticipant.publishData(statePayload, { reliable: true });
+              if (statePromise && typeof statePromise.catch === 'function') {
+                statePromise.catch(function (err) { console.warn('[FAQ Widget] state_change publishData rejected:', err && (err.message || err)); });
+              }
+            } catch (e) {
+              console.warn('[FAQ Widget] state_change send error:', e && (e.message || e));
+            }
+          }
         }
 
         emitToHost('assistant:message', { messageLength: assistantContent.length });

--- a/src/api/chat/route.ts
+++ b/src/api/chat/route.ts
@@ -5,6 +5,7 @@ import { z } from "zod";
 import { randomUUID } from "crypto";
 import { runDialogTurn } from "../../agent/dialog/dialogAgent";
 import { peekFlowSessionMeta } from "../../agent/dialog/flowContextStore";
+import { getSalesSessionMeta } from "../../agent/dialog/salesContextStore";
 import { trackUsage } from "../../lib/billing/usageTracker";
 import type { ApiResponse, ChatAction, ChatMessage } from "../../types/contracts";
 import { t } from "../i18n/messages";
@@ -251,8 +252,14 @@ export function createChatHandler(logger: Logger) {
         });
       }
 
-      // LemonSlice I-4: フロー状態を応答に含める（アバター表情連動用、read-only peek）
-      const flowState = peekFlowSessionMeta({ tenantId, conversationId: sessionId })?.state;
+      // LemonSlice I-4: フロー状態を応答に含める（アバター表情連動用、副作用なし getter）
+      // /api/chat パス（runDialogTurn）は salesContextStore を更新するためこちらが実ソース、
+      // langGraph パスでは flowContextStore をフォールバックとして参照する。
+      // "ended" は表情マッピング対象外のため flow store へフォールバック。
+      const salesStage = getSalesSessionMeta({ tenantId, sessionId })?.currentStage;
+      const flowState =
+        (salesStage !== "ended" ? salesStage : undefined) ??
+        peekFlowSessionMeta({ tenantId, conversationId: sessionId })?.state;
 
       const chatMessage: ChatMessage = {
         id: requestId,

--- a/src/api/chat/route.ts
+++ b/src/api/chat/route.ts
@@ -4,6 +4,7 @@ import type { Logger } from "pino";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { runDialogTurn } from "../../agent/dialog/dialogAgent";
+import { peekFlowSessionMeta } from "../../agent/dialog/flowContextStore";
 import { trackUsage } from "../../lib/billing/usageTracker";
 import type { ApiResponse, ChatAction, ChatMessage } from "../../types/contracts";
 import { t } from "../i18n/messages";
@@ -250,6 +251,9 @@ export function createChatHandler(logger: Logger) {
         });
       }
 
+      // LemonSlice I-4: フロー状態を応答に含める（アバター表情連動用、read-only peek）
+      const flowState = peekFlowSessionMeta({ tenantId, conversationId: sessionId })?.state;
+
       const chatMessage: ChatMessage = {
         id: requestId,
         role: "assistant",
@@ -257,6 +261,7 @@ export function createChatHandler(logger: Logger) {
         actions: actions.length > 0 ? actions : undefined,
         timestamp: Date.now(),
         tenantId,
+        flowState,
       };
 
       logger.info(

--- a/src/types/contracts.ts
+++ b/src/types/contracts.ts
@@ -28,8 +28,15 @@ export interface ChatMessage {
   modelUsed?: GroqModel;
   timestamp: number;
   tenantId: string;
-  /** LemonSlice I-4: 会話フロー状態（アバター表情連動用） */
-  flowState?: "clarify" | "answer" | "confirm" | "terminal";
+  /** LemonSlice I-4: 会話フロー状態（アバター表情連動用、Phase22 + SalesFlow） */
+  flowState?:
+    | "clarify"
+    | "answer"
+    | "confirm"
+    | "terminal"
+    | "propose"
+    | "recommend"
+    | "close";
 }
 
 export interface ChatAction {

--- a/src/types/contracts.ts
+++ b/src/types/contracts.ts
@@ -28,6 +28,8 @@ export interface ChatMessage {
   modelUsed?: GroqModel;
   timestamp: number;
   tenantId: string;
+  /** LemonSlice I-4: 会話フロー状態（アバター表情連動用） */
+  flowState?: "clarify" | "answer" | "confirm" | "terminal";
 }
 
 export interface ChatAction {

--- a/tests/integration/wiring-check.test.ts
+++ b/tests/integration/wiring-check.test.ts
@@ -113,6 +113,10 @@ import { searchPgVector } from "../../src/search/pgvector";
 
 import { createChatHandler } from "../../src/api/chat/route";
 import { runDialogTurn } from "../../src/agent/dialog/dialogAgent";
+import {
+  setFlowSessionMeta,
+  resetFlowSessionMeta,
+} from "../../src/agent/dialog/flowContextStore";
 import { searchTool } from "../../src/agent/tools/searchTool";
 import { synthesizeAnswer } from "../../src/agent/tools/synthesisTool";
 import { getActiveRulesForTenant } from "../../src/api/admin/tuning/tuningRulesRepository";
@@ -223,6 +227,46 @@ describe("Flow 1: Widget → Chat → RAG → LLM", () => {
         tenantId: "test-tenant",
       })
     );
+  });
+
+  it("POST /api/chat returns flowState from flowContextStore (LemonSlice I-4)", async () => {
+    const SESSION_ID = "session-flowstate-i4-test";
+    const FLOW_KEY = { tenantId: "test-tenant", conversationId: SESSION_ID };
+
+    jest.spyOn(
+      require("../../src/agent/dialog/dialogAgent"),
+      "runDialogTurn"
+    ).mockResolvedValue({
+      answer: "確認です。来店予約を進めてよろしいですか？",
+      needsClarification: false,
+      clarifyingQuestions: [],
+      detectedIntents: {},
+      meta: { gapSignal: { hitCount: 1, topScore: 0.9 } },
+    });
+
+    // flowContextStore に confirm 状態をセット（langGraph パスが書き込む想定の状態を再現）
+    setFlowSessionMeta(FLOW_KEY, {
+      state: "confirm",
+      turnIndex: 2,
+      sameStateRepeats: 0,
+      clarifyRepeats: 0,
+      confirmRepeats: 1,
+      recentStates: ["answer", "confirm"],
+      lastUpdatedAt: new Date().toISOString(),
+    });
+
+    try {
+      const app = buildChatApp();
+      const res = await request(app)
+        .post("/api/chat")
+        .set("x-api-key", "test-api-key")
+        .send({ message: "予約をお願いします", sessionId: SESSION_ID });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.flowState).toBe("confirm");
+    } finally {
+      resetFlowSessionMeta(FLOW_KEY);
+    }
   });
 
   it("chat handler returns 400 for an empty message", async () => {

--- a/tests/integration/wiring-check.test.ts
+++ b/tests/integration/wiring-check.test.ts
@@ -117,6 +117,10 @@ import {
   setFlowSessionMeta,
   resetFlowSessionMeta,
 } from "../../src/agent/dialog/flowContextStore";
+import {
+  setSalesSessionMeta,
+  clearSalesSessionMeta,
+} from "../../src/agent/dialog/salesContextStore";
 import { searchTool } from "../../src/agent/tools/searchTool";
 import { synthesizeAnswer } from "../../src/agent/tools/synthesisTool";
 import { getActiveRulesForTenant } from "../../src/api/admin/tuning/tuningRulesRepository";
@@ -265,6 +269,49 @@ describe("Flow 1: Widget → Chat → RAG → LLM", () => {
       expect(res.status).toBe(200);
       expect(res.body.data.flowState).toBe("confirm");
     } finally {
+      resetFlowSessionMeta(FLOW_KEY);
+    }
+  });
+
+  it("POST /api/chat prefers salesContextStore currentStage over flowContextStore (LemonSlice I-4)", async () => {
+    const SESSION_ID = "session-flowstate-i4-sales-test";
+    const SALES_KEY = { tenantId: "test-tenant", sessionId: SESSION_ID };
+    const FLOW_KEY = { tenantId: "test-tenant", conversationId: SESSION_ID };
+
+    jest.spyOn(
+      require("../../src/agent/dialog/dialogAgent"),
+      "runDialogTurn"
+    ).mockResolvedValue({
+      answer: "体験レッスンはいかがですか？",
+      needsClarification: false,
+      clarifyingQuestions: [],
+      detectedIntents: {},
+      meta: { gapSignal: { hitCount: 1, topScore: 0.9 } },
+    });
+
+    // sales store に propose、flow store に confirm を投入 → sales が優先されること
+    setSalesSessionMeta(SALES_KEY, { currentStage: "propose" });
+    setFlowSessionMeta(FLOW_KEY, {
+      state: "confirm",
+      turnIndex: 2,
+      sameStateRepeats: 0,
+      clarifyRepeats: 0,
+      confirmRepeats: 1,
+      recentStates: ["answer", "confirm"],
+      lastUpdatedAt: new Date().toISOString(),
+    });
+
+    try {
+      const app = buildChatApp();
+      const res = await request(app)
+        .post("/api/chat")
+        .set("x-api-key", "test-api-key")
+        .send({ message: "レッスンに興味があります", sessionId: SESSION_ID });
+
+      expect(res.status).toBe(200);
+      expect(res.body.data.flowState).toBe("propose");
+    } finally {
+      clearSalesSessionMeta(SALES_KEY);
       resetFlowSessionMeta(FLOW_KEY);
     }
   });


### PR DESCRIPTION
## 概要
[LemonSlice I-4 / PR-D] In-Call Dynamic Update — SalesFlow ステート連動でアバターの表情プロンプトをセッション中に動的差し替えする。

Asana: 子タスク GID 1215614600861778（親: LemonSlice Upgrade GID 1215583480435865）

## 配線（3 層、5 commits）
1. **src/api/chat/route.ts** — `/api/chat` 応答に `flowState` を追加。解決順: `salesContextStore.currentStage`（runDialogTurn が実更新する一次ソース。`ended` は対象外）→ fallback `peekFlowSessionMeta().state`（langGraph パス用）
2. **public/widget.js** — 応答受信後、avatar 接続中なら `{type:'state_change', state}` を DataChannel 送信（既存 publishData エラーハンドリングパターン踏襲）
3. **avatar-agent/agent.py** — `control_lemonslice()` ヘルパー（LemonSlice Control API `POST /sessions/{id}/control`、timeout 3s、non-fatal）+ `_lemonslice_session_id` を **`avatar.start()` の戻り値**から捕捉（plugin avatar.py:132 で照合済み、getattr 探索不要）+ `state_change` 受信で `STATE_AGENT_PROMPTS`（clarify/answer/confirm/terminal/propose/recommend/close）から `update_agent_prompt` 発火

## 実機照合に基づく設計判断
- 当初計画の flowContextStore 単独ソースは **`/api/chat` の実行パス（runDialogTurn）が書き込まないため死に配線**になると判明 → タスク名どおり SalesFlow（salesContextStore）を一次ソースに変更
- session_id / API キーはログ非出力。control 失敗は warning のみで会話を阻害しない

## テスト
- wiring-check.test.ts +2 件（25/25 pass）: flow store 由来の flowState / **sales=propose と flow=confirm 同時投入で sales 優先**を実 store 経由で検証
- py_compile / node --check: OK

## Gate
- Gate 1 (verify): PASS / Gate 2 (security-scan): PASS / Gate 3 (build): PASS
- **Gate 2.5（タスク規定で PR-D は必須）: 人間実行をお願いします** — `/codex:review --base main --background`

## ⚠️ merge 後の人間作業
- VPS 実機で state_change → Control API 200 のログ観測（`avatar.start()` 戻り値が実環境でも session_id を返すかの最終確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
