### PR TITLE
feat(billing): Fish TTS / Anam / voice clone / Perplexity に trackUsage 追加 (Subtask 4)

### DIFF
--- a/src/agent/gap/gapRecommender.ts
+++ b/src/agent/gap/gapRecommender.ts
@@ -63,7 +63,11 @@ export async function generateRecommendations(
     searchKnowledgeForSuggestion(tenantId, representativeQuery).catch(() => ({ results: [] })),
     getCrossTenantContext().catch(() => ({ avgScores: null, topPsychologyPrinciples: [], commonGapPatterns: [], effectiveRulePatterns: [], totalTenants: 0, dataAsOf: new Date().toISOString() })),
     deepResearchEnabled
-      ? (getResearchProvider()?.search(buildResearchQuery({ userMessage: representativeQuery }), 'ja') ?? Promise.resolve(null)).catch(() => null)
+      ? (getResearchProvider()?.search(
+          buildResearchQuery({ userMessage: representativeQuery }),
+          'ja',
+          { tenantId, requestId: `gap-rec-${tenantId}-${Date.now()}` },
+        ) ?? Promise.resolve(null)).catch(() => null)
       : Promise.resolve(null),
   ]);
   const faqSummary = formatKnowledgeContext(knowledgeCtx) || '（既存ナレッジなし）';

--- a/src/api/admin/ai-assist/routes.ts
+++ b/src/api/admin/ai-assist/routes.ts
@@ -178,7 +178,11 @@ async function buildBusinessFaqAnswer(
       searchKnowledgeForSuggestion(tenantId, message),
       getCrossTenantContext().catch(() => ({ avgScores: null, topPsychologyPrinciples: [], commonGapPatterns: [], effectiveRulePatterns: [], totalTenants: 0, dataAsOf: new Date().toISOString() })),
       deepResearchEnabled
-        ? (getResearchProvider()?.search(buildResearchQuery({ userMessage: message }), 'ja') ?? Promise.resolve(null)).catch(() => null)
+        ? (getResearchProvider()?.search(
+            buildResearchQuery({ userMessage: message }),
+            'ja',
+            { tenantId, requestId: `ai-assist-${tenantId}-${Date.now()}` },
+          ) ?? Promise.resolve(null)).catch(() => null)
         : Promise.resolve(null),
     ]);
     const crossTenantSection = formatCrossTenantContext(crossTenantCtx);

--- a/src/api/admin/avatar/routes.ts
+++ b/src/api/admin/avatar/routes.ts
@@ -8,6 +8,7 @@ import { supabaseAuthMiddleware } from "../../../admin/http/supabaseAuthMiddlewa
 import { supabaseAdmin } from "../../../auth/supabaseClient";
 import multer from 'multer';
 import { logger } from '../../../lib/logger';
+import { trackUsage } from '../../../lib/billing/usageTracker';
 
 // ---------------------------------------------------------------------------
 // Supabase Storage: base64 data URL → 公開 HTTP URL
@@ -842,6 +843,16 @@ export function registerAvatarConfigRoutes(app: Express, db: any): void {
             .status(404)
             .json({ error: "設定が見つからないかアクセス権限がありません" });
         }
+
+        trackUsage({
+          tenantId: tenantId ?? 'unknown',
+          requestId: (req as any).requestId ?? `vc-${id}-${Date.now()}`,
+          model: 'fish-audio-s2-pro',
+          inputTokens: 0,
+          outputTokens: 0,
+          featureUsed: 'avatar_config_voice',
+          marginOverride: 1,
+        });
 
         return res.json({ voiceId });
       } catch (err) {

--- a/src/api/avatar/anamRoutes.ts
+++ b/src/api/avatar/anamRoutes.ts
@@ -12,6 +12,7 @@ import type { Express, Request, Response, RequestHandler } from 'express';
 import type { AuthedRequest } from '../../agent/http/authMiddleware';
 import { pool as globalPool } from '../../lib/db';
 import { logger } from '../../lib/logger';
+import { trackUsage } from '../../lib/billing/usageTracker';
 
 const ANAM_API_BASE = 'https://api.anam.ai';
 
@@ -134,5 +135,33 @@ export function registerAnamRoutes(app: Express, apiStack: RequestHandler[]): vo
       logger.error('[POST /api/avatar/anam-session]', err);
       return res.json({ enabled: false, avatarProvider: 'lemonslice' });
     }
+  });
+
+  // POST /api/avatar/anam-session-end
+  // クライアントがAnamセッション終了時に実際のセッション秒数を報告する（課金記録用）
+  app.post('/api/avatar/anam-session-end', ...apiStack, async (req: Request, res: Response) => {
+    const tenantId = (req as AuthedRequest).tenantId;
+    if (!tenantId) {
+      return res.status(401).json({ error: 'unauthorized' });
+    }
+
+    const sessionSeconds = typeof req.body?.sessionSeconds === 'number'
+      ? req.body.sessionSeconds
+      : 0;
+    if (sessionSeconds < 0) {
+      return res.status(400).json({ error: 'sessionSeconds must be >= 0' });
+    }
+
+    trackUsage({
+      tenantId,
+      requestId: (req as any).requestId ?? `anam-end-${Date.now()}`,
+      model: 'anam-ai',
+      inputTokens: 0,
+      outputTokens: 0,
+      featureUsed: 'anam_session',
+      anam_session_seconds: sessionSeconds,
+    });
+
+    return res.json({ ok: true });
   });
 }

--- a/src/api/avatar/fishTtsRoutes.ts
+++ b/src/api/avatar/fishTtsRoutes.ts
@@ -9,6 +9,7 @@ import type { Express, Request, Response, RequestHandler } from 'express';
 import type { AuthedRequest } from '../../agent/http/authMiddleware';
 import { getPool } from '../../lib/db';
 import { logger } from '../../lib/logger';
+import { trackUsage } from '../../lib/billing/usageTracker';
 
 const FISH_AUDIO_API = 'https://api.fish.audio/v1/tts';
 
@@ -81,6 +82,16 @@ export function registerFishTtsRoutes(app: Express, apiStack: RequestHandler[]):
         res.write(value);
       }
       res.end();
+
+      trackUsage({
+        tenantId,
+        requestId: (req as any).requestId ?? `tts-${Date.now()}`,
+        model: 'fish-audio-s2-pro',
+        inputTokens: 0,
+        outputTokens: 0,
+        featureUsed: 'voice',
+        ttsTextBytes: Buffer.byteLength(text, 'utf8'),
+      });
 
     } catch (err) {
       logger.error('[fishTts] Error:', err);

--- a/src/lib/billing/costCalculator.ts
+++ b/src/lib/billing/costCalculator.ts
@@ -1,7 +1,7 @@
 // src/lib/billing/costCalculator.ts
 // Phase32: コスト計算（金額はセント単位の整数で管理）
 
-export type ModelKey = 'groq-8b' | 'groq-70b' | 'openai-embedding' | 'gemini-2.5-flash';
+export type ModelKey = 'groq-8b' | 'groq-70b' | 'openai-embedding' | 'gemini-2.5-flash' | 'perplexity-sonar-pro';
 
 export interface ModelCost {
   /** USD per 1M tokens */
@@ -15,7 +15,8 @@ export const LLM_COSTS: Record<ModelKey, ModelCost> = {
   'groq-8b':           { inputPerMillion: 0.05,  outputPerMillion: 0.08 },
   'groq-70b':          { inputPerMillion: 0.59,  outputPerMillion: 0.79 },
   'openai-embedding':  { inputPerMillion: 0.02,  outputPerMillion: 0.0  },
-  'gemini-2.5-flash':  { inputPerMillion: 0.075, outputPerMillion: 0.30 },
+  'gemini-2.5-flash':     { inputPerMillion: 0.075, outputPerMillion: 0.30  },
+  'perplexity-sonar-pro': { inputPerMillion: 3.0,   outputPerMillion: 15.0  },
 };
 
 /** サーバーコスト: $0.0001 / リクエスト（VPS按分） */
@@ -72,6 +73,8 @@ export interface UsageRecord {
   featureUsed?: string;
   /** Phase53: 生成画像枚数（DALL-E / Leonardo 等）。原価のみ。 */
   imageCount?: number;
+  /** Phase42: Anamセッション時間（秒） */
+  anam_session_seconds?: number;
 }
 
 /**
@@ -82,6 +85,7 @@ export function normalizeModelKey(model: string): ModelKey | undefined {
   const lower = model.toLowerCase();
   if (lower.includes('embedding')) return 'openai-embedding';
   if (lower.includes('gemini')) return 'gemini-2.5-flash';
+  if (lower.includes('perplexity')) return 'perplexity-sonar-pro';
   if (lower.includes('70b') || lower.includes('mixtral')) return 'groq-70b';
   if (
     lower.includes('8b') ||
@@ -168,6 +172,9 @@ export function calculateBillingAmountCents(usage: UsageRecord): number {
   const ttsUSD   = (usage.ttsTextBytes  ?? 0) * FISH_AUDIO_COST_PER_BYTE_USD;
   const avtrUSD  = (usage.avatarCredits ?? 0) * LEMONSLICE_COST_PER_CREDIT_USD;
   const imgUSD   = (usage.imageCount    ?? 0) * IMAGE_GENERATION_COST_USD;
-  const totalUSD = llmUSD + SERVER_COST_PER_REQUEST_USD + ttsUSD + avtrUSD + imgUSD;
+  const anamUSD  = (usage.anam_session_seconds ?? 0) > 0
+    ? calculateAnamSessionCostCents(usage.anam_session_seconds!) / 100
+    : 0;
+  const totalUSD = llmUSD + SERVER_COST_PER_REQUEST_USD + ttsUSD + avtrUSD + imgUSD + anamUSD;
   return Math.ceil(totalUSD * margin * 100);
 }

--- a/src/lib/billing/migration.sql
+++ b/src/lib/billing/migration.sql
@@ -51,7 +51,8 @@ CREATE TABLE IF NOT EXISTS stripe_usage_reports (
 ALTER TABLE usage_logs
   ADD COLUMN IF NOT EXISTS tts_text_bytes  INTEGER,
   ADD COLUMN IF NOT EXISTS avatar_credits  INTEGER,
-  ADD COLUMN IF NOT EXISTS avatar_session_ms INTEGER;
+  ADD COLUMN IF NOT EXISTS avatar_session_ms INTEGER,
+  ADD COLUMN IF NOT EXISTS anam_session_seconds INTEGER;
 
 CREATE INDEX IF NOT EXISTS idx_usage_logs_tenant_id ON usage_logs(tenant_id);
 CREATE INDEX IF NOT EXISTS idx_usage_logs_created_at ON usage_logs(created_at);

--- a/src/lib/billing/usageTracker.ts
+++ b/src/lib/billing/usageTracker.ts
@@ -54,6 +54,7 @@ async function _insertUsageLog(params: TrackUsageParams): Promise<void> {
   const {
     tenantId, requestId, model, inputTokens, outputTokens,
     featureUsed, marginOverride, ttsTextBytes, avatarCredits, avatarSessionMs, imageCount,
+    anam_session_seconds,
   } = params;
 
   let costLlmCents = 0;
@@ -63,7 +64,7 @@ async function _insertUsageLog(params: TrackUsageParams): Promise<void> {
     costTotalCents = calculateBillingAmountCents({
       model, inputTokens, outputTokens, marginOverride,
       ttsTextBytes, avatarCredits, avatarSessionMs,
-      featureUsed, imageCount,
+      featureUsed, imageCount, anam_session_seconds,
     });
   } catch (err) {
     _logger?.warn({ err, requestId }, '[usageTracker] cost calculation error, defaulting to 0');
@@ -74,12 +75,13 @@ async function _insertUsageLog(params: TrackUsageParams): Promise<void> {
       `INSERT INTO usage_logs
          (tenant_id, request_id, model, input_tokens, output_tokens,
           feature_used, cost_llm_cents, cost_total_cents,
-          tts_text_bytes, avatar_credits, avatar_session_ms)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+          tts_text_bytes, avatar_credits, avatar_session_ms, anam_session_seconds)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
        ON CONFLICT (request_id) DO NOTHING`,
       [tenantId, requestId, model, inputTokens, outputTokens,
        featureUsed, costLlmCents, costTotalCents,
-       ttsTextBytes ?? null, avatarCredits ?? null, avatarSessionMs ?? null]
+       ttsTextBytes ?? null, avatarCredits ?? null, avatarSessionMs ?? null,
+       anam_session_seconds ?? null]
     );
     _logger?.debug(
       { tenantId, requestId, costLlmCents, costTotalCents },

--- a/src/lib/research/perplexityProvider.ts
+++ b/src/lib/research/perplexityProvider.ts
@@ -2,7 +2,8 @@
 // Phase60-C: Perplexity sonar-pro クライアント（24時間TTLキャッシュ付き）
 
 import { logger } from '../logger';
-import type { ExternalResearchProvider, ResearchResult } from './types';
+import { trackUsage } from '../billing/usageTracker';
+import type { ExternalResearchProvider, ResearchBillingContext, ResearchResult } from './types';
 
 // ─── キャッシュ ───────────────────────────────────────────────────────────────
 
@@ -26,7 +27,7 @@ export class PerplexityProvider implements ExternalResearchProvider {
   readonly name = 'perplexity';
   readonly costPerQuery = 0.005; // $0.005 / query (sonar-pro)
 
-  async search(query: string, locale: string): Promise<ResearchResult | null> {
+  async search(query: string, locale: string, billingContext?: ResearchBillingContext): Promise<ResearchResult | null> {
     const apiKey = process.env['PERPLEXITY_API_KEY']?.trim();
     if (!apiKey) {
       logger.warn('[perplexityProvider] PERPLEXITY_API_KEY is not set');
@@ -74,6 +75,19 @@ export class PerplexityProvider implements ExternalResearchProvider {
       const choices = data['choices'] as Array<Record<string, unknown>> | undefined;
       const rawSummary: string = (choices?.[0]?.['message'] as Record<string, unknown>)?.['content'] as string ?? '';
       const rawCitations = (data['citations'] as string[] | undefined) ?? [];
+      const usage = data['usage'] as { prompt_tokens?: number; completion_tokens?: number } | undefined;
+
+      if (billingContext) {
+        trackUsage({
+          tenantId: billingContext.tenantId,
+          requestId: billingContext.requestId,
+          model: 'perplexity-sonar-pro',
+          inputTokens: usage?.prompt_tokens ?? 0,
+          outputTokens: usage?.completion_tokens ?? 0,
+          featureUsed: 'option_service',
+          marginOverride: 1,
+        });
+      }
 
       const result: ResearchResult = {
         summary: rawSummary.slice(0, 500),

--- a/src/lib/research/types.ts
+++ b/src/lib/research/types.ts
@@ -9,8 +9,13 @@ export interface ResearchResult {
   cachedAt?: string;     // キャッシュ日時（ISO）
 }
 
+export interface ResearchBillingContext {
+  tenantId: string;
+  requestId: string;
+}
+
 export interface ExternalResearchProvider {
-  search(query: string, locale: string): Promise<ResearchResult | null>;
+  search(query: string, locale: string, billingContext?: ResearchBillingContext): Promise<ResearchResult | null>;
   name: string;
   costPerQuery: number; // USD概算
 }


### PR DESCRIPTION
## Summary
- **Fish TTS**: TTS成功後に `ttsTextBytes` で `voice` 課金記録
- **Anam**: `POST /api/avatar/anam-session-end` エンドポイント追加（クライアントがセッション終了時に秒数を報告）
- **Voice clone**: Fish Audio クローン作成成功後に `avatar_config_voice` 課金記録
- **Perplexity**: `billingContext` オプションを追加し、実際のトークン数でコスト記録

## 基盤変更
- `costCalculator.ts`: `perplexity-sonar-pro` モデル追加（$3/$15/M tokens）+ Anam コストを `calculateBillingAmountCents` に配線
- `migration.sql`: `anam_session_seconds INTEGER` カラム追加（`ADD COLUMN IF NOT EXISTS`）
- `usageTracker.ts`: `anam_session_seconds` を INSERT に追加

## Test plan
- [ ] `pnpm test -- --testPathPatterns="costCalculator|usageTracker"` で既存テスト全pass確認
- [ ] `pnpm typecheck` 0 errors
- [ ] Gate 1–3 通過

🤖 Generated with [Claude Code](https://claude.ai/claude-code)