### PR TITLE
fix(billing): chat 過少課金 — 回答経路が実usage常時報告 + planner別レート内包 (Subtask 3)

### DIFF
--- a/src/agent/dialog/dialogAgent.ts
+++ b/src/agent/dialog/dialogAgent.ts
@@ -200,7 +200,11 @@ export async function runDialogTurn(
       clarifyingQuestions:
         orchestrated.clarifyingQuestions ?? multiStepPlan.clarifyingQuestions,
       gapSignal: orchestrated.gapSignal,
+      // synthesis + query埋め込み（searchAgent で合算済み）。CHAT_LLM_MODEL レートで課金。
       llmUsage: orchestrated.llmUsage,
+      // Subtask 3: マルチステップ planner LLM（GPT-OSS 20B/120B）は chat とは
+      // 別モデル単価のため、合算せず各モデルを実レートで別 usage_log として課金する。
+      plannerLlmUsages: multiStepPlan.llmUsages,
       ragSources: orchestrated.ragSources,
     },
   };

--- a/src/agent/dialog/types.ts
+++ b/src/agent/dialog/types.ts
@@ -53,6 +53,13 @@ export interface MultiStepQueryPlan {
   confidence: "low" | "medium" | "high";
   language?: "ja" | "en" | "other";
   raw?: unknown;
+  /**
+   * Subtask 3: LLM プランナー（GPT-OSS 20B/120B）が消費した実トークン数（モデル別）。
+   * Rule-based 経路や LLM 呼び出し失敗時は undefined。
+   * 20B parse 失敗 → 120B フォールバック等で複数モデルが消費した場合は複数要素になり、
+   * chat とは別モデル単価のため各モデルを実レートで別 usage_log として課金する。
+   */
+  llmUsages?: Array<{ model: string; prompt_tokens: number; completion_tokens: number }>;
 }
 
 // --- Moved here to break circular deps (was in dialogOrchestrator / salesPipeline / salesIntentDetector) ---
@@ -114,8 +121,13 @@ export interface DialogTurnMeta {
   orchestrationSteps?: OrchestratorStep[];
   /** ナレッジギャップ検出シグナル */
   gapSignal?: { hitCount: number; topScore: number };
-  /** Phase53: Groq API実トークン数 */
+  /** Phase53: Groq API実トークン数（synthesis + query埋め込み、CHAT_LLM_MODEL レートで課金） */
   llmUsage?: { prompt_tokens: number; completion_tokens: number };
+  /**
+   * Subtask 3: マルチステップ planner LLM（GPT-OSS 20B/120B）のモデル別 usage。
+   * chat とは別モデル単価のため、chat/route.ts が各モデルで別 trackUsage する。
+   */
+  plannerLlmUsages?: Array<{ model: string; prompt_tokens: number; completion_tokens: number }>;
   /** Phase68: 応答生成に使用された RAG チャンク */
   ragSources?: import("../types").RagSource[];
 }

--- a/src/agent/flow/dialogOrchestrator.ts
+++ b/src/agent/flow/dialogOrchestrator.ts
@@ -66,6 +66,10 @@ export async function runDialogOrchestrator(
       needsClarification: true,
       clarifyingQuestions: plan.clarifyingQuestions ?? [],
       final: false,
+      // Subtask 3: chat モデル（synthesis）は走っていないため実トークンは 0。
+      // 課金経路に「chat LLM 未実行」を明示し、char/4 推定の架空課金を防ぐ。
+      // 聞き返し文を LLM planner が生成した場合のコストは plannerLlmUsages 側で計上。
+      llmUsage: { prompt_tokens: 0, completion_tokens: 0 },
     }
   }
 
@@ -83,6 +87,8 @@ export async function runDialogOrchestrator(
       steps: plan.steps,
       needsClarification: false,
       final: true,
+      // Subtask 3: 検索も synthesis も走らない経路。chat LLM 実トークンは 0。
+      llmUsage: { prompt_tokens: 0, completion_tokens: 0 },
     }
   }
 

--- a/src/agent/flow/llmMultiStepPlannerRuntime.ts
+++ b/src/agent/flow/llmMultiStepPlannerRuntime.ts
@@ -6,6 +6,16 @@ import type { DialogMessage, MultiStepQueryPlan } from '../dialog/types'
 import type { MultiStepPlannerOptions } from './multiStepPlanner'
 import { planMultiStepQuery as planMultiStepQueryRuleBased } from './multiStepPlanner'
 
+/** Subtask 3: プランナー LLM が消費した実トークン数。 */
+type PlannerUsage = { prompt_tokens: number; completion_tokens: number }
+
+/**
+ * Subtask 3: プランナー LLM の実モデル別トークン消費。
+ * 20B parse 失敗 → 120B フォールバックのように複数モデルが消費した場合に
+ * それぞれ正しい単価で課金するため、モデルごとに分けて記録する。
+ */
+export type PlannerModelUsage = { model: string } & PlannerUsage
+
 export interface LlmMultiStepPlannerOptions extends MultiStepPlannerOptions {
   /**
    * LLM 用ルーティングコンテキスト。
@@ -146,10 +156,10 @@ async function fetchLlmPlan(
   input: string,
   options: LlmMultiStepPlannerOptions,
   history?: DialogMessage[],
-): Promise<{ plan: LlmMultiStepPlan | null; route: '20b' | '120b'; usedModel: string | null }> {
+): Promise<{ plan: LlmMultiStepPlan | null; route: '20b' | '120b'; usedModel: string | null; usages: PlannerModelUsage[] }> {
   const apiKey = process.env.LLM_API_KEY
   if (!apiKey) {
-    return { plan: null, route: '20b', usedModel: null }
+    return { plan: null, route: '20b', usedModel: null, usages: [] }
   }
 
   const baseUrl =
@@ -170,7 +180,13 @@ async function fetchLlmPlan(
 
   const { system, user } = buildPlannerPrompts(input, history)
 
+  // モデルごとの実トークン消費を蓄積する。HTTP 200 ならば JSON parse の成否に
+  // 関わらずトークンは消費済みなので、課金漏れを防ぐため usage を必ず保持する。
+  const usages: PlannerModelUsage[] = []
+
+  // 戻り値: plan は parse 成功時のみ非 null。usage は HTTP 200 + usage 取得時に push 済み。
   async function callModel(model: string): Promise<LlmMultiStepPlan | null> {
+    let usage: PlannerUsage | undefined
     try {
       const res = await fetch(endpoint, {
         method: 'POST',
@@ -192,7 +208,18 @@ async function fetchLlmPlan(
         return null
       }
 
-      const data = await res.json() as { choices?: Array<{ message?: { content?: string } }> }
+      const data = await res.json() as {
+        choices?: Array<{ message?: { content?: string } }>
+        usage?: { prompt_tokens?: number; completion_tokens?: number }
+      }
+      // usage は parse より先に取り出す（後段の JSON.parse が throw しても課金に残す）。
+      if (data.usage) {
+        usage = {
+          prompt_tokens: data.usage.prompt_tokens ?? 0,
+          completion_tokens: data.usage.completion_tokens ?? 0,
+        }
+      }
+
       const content = data?.choices?.[0]?.message?.content
       if (!content || typeof content !== 'string') return null
 
@@ -202,24 +229,27 @@ async function fetchLlmPlan(
       return parsed
     } catch {
       return null
+    } finally {
+      if (usage) usages.push({ model, ...usage })
     }
   }
 
   // まずはルーティング結果に従って呼び出し
   const primaryPlan = await callModel(primaryModel)
   if (primaryPlan) {
-    return { plan: primaryPlan, route: routed, usedModel: primaryModel }
+    return { plan: primaryPlan, route: routed, usedModel: primaryModel, usages }
   }
 
   // 20B の失敗時のみ 120B へ 1 回だけフォールバック
   if (routed === '20b' && model120b && model120b !== primaryModel) {
     const fallbackPlan = await callModel(model120b)
     if (fallbackPlan) {
-      return { plan: fallbackPlan, route: '120b', usedModel: model120b }
+      return { plan: fallbackPlan, route: '120b', usedModel: model120b, usages }
     }
   }
 
-  return { plan: null, route: routed, usedModel: primaryModel }
+  // plan は取れなくても、消費済みトークンは課金に残す（usages は push 済み）。
+  return { plan: null, route: routed, usedModel: primaryModel, usages }
 }
 
 /**
@@ -230,6 +260,7 @@ function mergeLlmPlanIntoMultiStepPlan(
   llmPlan: LlmMultiStepPlan,
   route: '20b' | '120b',
   usedModel: string | null,
+  usages: PlannerModelUsage[],
 ): MultiStepQueryPlan {
   return {
     ...base,
@@ -247,6 +278,7 @@ function mergeLlmPlanIntoMultiStepPlan(
         : base.followupQueries,
     confidence: llmPlan.confidence ?? base.confidence,
     language: llmPlan.language ?? base.language,
+    llmUsages: usages.length > 0 ? usages : undefined,
     raw: {
       ...(base.raw ?? {}),
       llmPlan,
@@ -272,15 +304,16 @@ export async function planMultiStepQueryWithLlmAsync(
 ): Promise<MultiStepQueryPlan> {
   const basePlan = await planMultiStepQueryRuleBased(input, options, history)
 
-  const { plan: llmPlan, route, usedModel } = await fetchLlmPlan(
+  const { plan: llmPlan, route, usedModel, usages } = await fetchLlmPlan(
     input,
     options,
     history,
   )
 
   if (!llmPlan) {
-    return basePlan
+    // LLM プランが取れなくても Rule-based で継続するが、消費済みトークンは課金に残す。
+    return usages.length > 0 ? { ...basePlan, llmUsages: usages } : basePlan
   }
 
-  return mergeLlmPlanIntoMultiStepPlan(basePlan, llmPlan, route, usedModel)
+  return mergeLlmPlanIntoMultiStepPlan(basePlan, llmPlan, route, usedModel, usages)
 }

--- a/src/agent/flow/searchAgent.ts
+++ b/src/agent/flow/searchAgent.ts
@@ -245,12 +245,13 @@ export async function runSearchAgent(
     ragStats,
     ragSources,
     gapSignal: synth.gapSignal,
-    llmUsage: synth.llmUsage
-      ? {
-          prompt_tokens:     (synth.llmUsage.prompt_tokens ?? 0) + embeddingTokens,
-          completion_tokens: synth.llmUsage.completion_tokens ?? 0,
-        }
-      : undefined,
+    // Subtask 3: synthesis が usage を返さない場合（GROQ キー無し / fallback / エラー）でも
+    // 既に消費済みの embedding トークンを課金に残すため、llmUsage は常に返す。
+    // chat LLM が完全に未実行なら {0,0} となり、上位で「chat 実トークン 0」を表す。
+    llmUsage: {
+      prompt_tokens:     (synth.llmUsage?.prompt_tokens ?? 0) + embeddingTokens,
+      completion_tokens: synth.llmUsage?.completion_tokens ?? 0,
+    },
     debug: {
       query: {
         original: q,

--- a/src/api/chat/route.ts
+++ b/src/api/chat/route.ts
@@ -326,12 +326,24 @@ export function createChatHandler(logger: Logger) {
       );
 
       // fire-and-forget: 使用量記録（APIレスポンスをブロックしない）
-      const llmUsage = result.meta?.llmUsage;
-      const historyText = (body.history ?? []).map((m) => m.content).join("\n");
-      const inputTokens = llmUsage?.prompt_tokens
-        ?? Math.max(1, Math.round((body.message.length + historyText.length) / 4));
-      const outputTokens = llmUsage?.completion_tokens
-        ?? Math.max(1, Math.round(content.length / 4));
+      // Subtask 3 構造修正: 回答経路（searchAgent/orchestrator）が chat モデルの実トークンを
+      // 常に報告する（chat LLM 未実行なら {0,0}、embedding 消費分は内包済み）。
+      // よって char/4 ヒューリスティック推定は廃止し、実 usage を唯一のソースにする。
+      const llmUsage = result.meta?.llmUsage ?? { prompt_tokens: 0, completion_tokens: 0 };
+      const inputTokens = llmUsage.prompt_tokens;
+      const outputTokens = llmUsage.completion_tokens;
+
+      // マルチステップ planner LLM（GPT-OSS 20B/120B）は chat 本体（70B）とはモデル単価が
+      // 異なる。usage_logs は「1行=1リクエスト」（Stripe quantity=COUNT(*)）のため別行は作らず、
+      // 本 chat 行の cost に planner 分をモデル別実レートで内包させる。
+      const extraLlmUsages = (result.meta?.plannerLlmUsages ?? [])
+        .filter((pu) => pu.prompt_tokens > 0 || pu.completion_tokens > 0)
+        .map((pu) => ({
+          model: pu.model,
+          inputTokens: pu.prompt_tokens,
+          outputTokens: pu.completion_tokens,
+        }));
+
       trackUsage({
         tenantId,
         requestId,
@@ -339,6 +351,7 @@ export function createChatHandler(logger: Logger) {
         inputTokens,
         outputTokens,
         featureUsed: "chat",
+        ...(extraLlmUsages.length > 0 ? { extraLlmUsages } : {}),
       });
     } catch (err) {
       logger.error(

--- a/src/lib/billing/costCalculator.test.ts
+++ b/src/lib/billing/costCalculator.test.ts
@@ -42,6 +42,18 @@ describe('normalizeModelKey', () => {
     expect(normalizeModelKey('GEMINI-1.5-FLASH')).toBe('gemini-2.5-flash');
   });
 
+  it('gpt-oss 系は 120b/20b を正しく分離する（"120b" は "20b" を部分文字列に含む罠）', () => {
+    expect(normalizeModelKey('openai/gpt-oss-20b')).toBe('gpt-oss-20b');
+    expect(normalizeModelKey('openai/gpt-oss-120b')).toBe('gpt-oss-120b');
+    expect(normalizeModelKey('GPT-OSS-120B')).toBe('gpt-oss-120b');
+  });
+
+  it('gpt-oss は provider prefix / suffix 付き env override でも拾う', () => {
+    expect(normalizeModelKey('groq/gpt-oss-20b')).toBe('gpt-oss-20b');
+    expect(normalizeModelKey('gpt-oss-120b-128k')).toBe('gpt-oss-120b');
+    expect(normalizeModelKey('gpt-oss')).toBe('gpt-oss-20b'); // 120 を含まなければ 20b 扱い
+  });
+
   it('不明モデルは undefined を返す', () => {
     expect(normalizeModelKey('unknown-model-v99')).toBeUndefined();
     expect(normalizeModelKey('')).toBeUndefined();
@@ -135,6 +147,34 @@ describe('calculateLLMCostCents', () => {
     });
   });
 
+  describe('gpt-oss（planner LLM）', () => {
+    it('gpt-oss-20b: 1M input + 1M output のコストが正確', () => {
+      // input:  1_000_000 * 0.075 / 1_000_000 = $0.075 = 7.5 cents
+      // output: 1_000_000 * 0.30  / 1_000_000 = $0.30  = 30 cents
+      // total: 37.5 cents → Math.ceil = 38
+      const result = calculateLLMCostCents({
+        model: 'openai/gpt-oss-20b', inputTokens: 1_000_000, outputTokens: 1_000_000,
+      });
+      expect(result).toBe(38);
+    });
+
+    it('gpt-oss-120b: 1M input + 1M output のコストが正確（20b の2倍単価）', () => {
+      // input:  1_000_000 * 0.15 / 1_000_000 = $0.15 = 15 cents
+      // output: 1_000_000 * 0.60 / 1_000_000 = $0.60 = 60 cents
+      // total: 75 cents → Math.ceil = 75
+      const result = calculateLLMCostCents({
+        model: 'openai/gpt-oss-120b', inputTokens: 1_000_000, outputTokens: 1_000_000,
+      });
+      expect(result).toBe(75);
+    });
+
+    it('120b は 20b より高コスト（誤正規化していれば破綻する）', () => {
+      const cost20b  = calculateLLMCostCents({ model: 'openai/gpt-oss-20b',  inputTokens: 1_000_000, outputTokens: 1_000_000 });
+      const cost120b = calculateLLMCostCents({ model: 'openai/gpt-oss-120b', inputTokens: 1_000_000, outputTokens: 1_000_000 });
+      expect(cost120b).toBeGreaterThan(cost20b);
+    });
+  });
+
   describe('エッジケース', () => {
     it('ゼロトークンは 0 を返す', () => {
       expect(calculateLLMCostCents({ model: 'llama-3.1-70b-versatile', inputTokens: 0, outputTokens: 0 })).toBe(0);
@@ -178,6 +218,43 @@ describe('calculateBillingAmountCents', () => {
     });
     expect(result).toBe(1);
     expect(Number.isInteger(result)).toBe(true);
+  });
+
+  it('extraLlmUsages: planner 分をモデル別実レートで本行に内包する（サーバーコストは二重計上しない）', () => {
+    // chat 本体: 70B 0トークン → server cost のみ。+ planner: gpt-oss-120b 1M/1M。
+    // planner LLM USD = 0.15 + 0.60 = 0.75。server = 0.0001。margin = 5（chat）。
+    // total USD = (0.75 + 0.0001) * 5 = 3.7505 → cents = Math.ceil(375.05) = 376
+    const withExtra = calculateBillingAmountCents({
+      model:        'llama-3.1-70b-versatile',
+      inputTokens:  0,
+      outputTokens: 0,
+      featureUsed:  'chat',
+      extraLlmUsages: [
+        { model: 'openai/gpt-oss-120b', inputTokens: 1_000_000, outputTokens: 1_000_000 },
+      ],
+    });
+    expect(withExtra).toBe(376);
+
+    // サーバーコストは1回のみ（extra を増やしても server 分は増えない）
+    const base = calculateBillingAmountCents({
+      model: 'llama-3.1-70b-versatile', inputTokens: 0, outputTokens: 0, featureUsed: 'chat',
+    });
+    // 差分 = planner LLM USD × margin（server 分は含まれない）
+    expect(withExtra - base).toBe(375); // 0.75 * 5 * 100
+  });
+
+  it('extraLlmUsages: 複数モデル（20B parse失敗→120B）をそれぞれ実レートで合算する', () => {
+    // cost_llm_cents 相当: 20B(1M/1M)=0.375 + 120B(1M/1M)=0.75 = 1.125 USD → ceil(112.5)=113
+    const cents = calculateLLMCostCents({
+      model: 'llama-3.1-70b-versatile',
+      inputTokens: 0,
+      outputTokens: 0,
+      extraLlmUsages: [
+        { model: 'openai/gpt-oss-20b',  inputTokens: 1_000_000, outputTokens: 1_000_000 },
+        { model: 'openai/gpt-oss-120b', inputTokens: 1_000_000, outputTokens: 1_000_000 },
+      ],
+    });
+    expect(cents).toBe(113);
   });
 
   it('groq-8b (1000/500): マージン適用後の金額が正確', () => {

--- a/src/lib/billing/costCalculator.ts
+++ b/src/lib/billing/costCalculator.ts
@@ -1,7 +1,7 @@
 // src/lib/billing/costCalculator.ts
 // Phase32: コスト計算（金額はセント単位の整数で管理）
 
-export type ModelKey = 'groq-8b' | 'groq-70b' | 'openai-embedding' | 'gemini-2.5-flash' | 'perplexity-sonar-pro';
+export type ModelKey = 'groq-8b' | 'groq-70b' | 'openai-embedding' | 'gemini-2.5-flash' | 'perplexity-sonar-pro' | 'gpt-oss-20b' | 'gpt-oss-120b';
 
 export interface ModelCost {
   /** USD per 1M tokens */
@@ -17,6 +17,9 @@ export const LLM_COSTS: Record<ModelKey, ModelCost> = {
   'openai-embedding':  { inputPerMillion: 0.02,  outputPerMillion: 0.0  },
   'gemini-2.5-flash':     { inputPerMillion: 0.075, outputPerMillion: 0.30  },
   'perplexity-sonar-pro': { inputPerMillion: 3.0,   outputPerMillion: 15.0  },
+  // Groq GPT-OSS（マルチステップ planner 用、2026 値下げ後の公式単価）
+  'gpt-oss-20b':          { inputPerMillion: 0.075, outputPerMillion: 0.30  },
+  'gpt-oss-120b':         { inputPerMillion: 0.15,  outputPerMillion: 0.60  },
 };
 
 /** サーバーコスト: $0.0001 / リクエスト（VPS按分） */
@@ -75,6 +78,28 @@ export interface UsageRecord {
   imageCount?: number;
   /** Phase42: Anamセッション時間（秒） */
   anam_session_seconds?: number;
+  /**
+   * Subtask 3: 同一リクエスト内の追加 LLM 呼び出し（マルチステップ planner 等）を
+   * モデル別の実レートで本行のコストに合算する。usage_logs は「1行=1リクエスト」
+   * （Stripe quantity=COUNT(*)）のため別行は作らず、本行の cost に内包する。
+   * 各要素はそれぞれ自分の model 単価で計算され、サーバーコストは加算しない。
+   */
+  extraLlmUsages?: Array<{ model: string; inputTokens: number; outputTokens: number }>;
+}
+
+/** Subtask 3: 追加 LLM 呼び出し（planner 等）の LLM コストを USD 合算する（モデル別実レート）。 */
+function _sumExtraLlmUsd(extras?: UsageRecord['extraLlmUsages']): number {
+  if (!extras || extras.length === 0) return 0;
+  return extras.reduce(
+    (sum, e) =>
+      sum +
+      _calculateLLMCostUSD({
+        model: e.model,
+        inputTokens: e.inputTokens,
+        outputTokens: e.outputTokens,
+      }),
+    0,
+  );
 }
 
 /**
@@ -86,6 +111,11 @@ export function normalizeModelKey(model: string): ModelKey | undefined {
   if (lower.includes('embedding')) return 'openai-embedding';
   if (lower.includes('gemini')) return 'gemini-2.5-flash';
   if (lower.includes('perplexity')) return 'perplexity-sonar-pro';
+  // gpt-oss は 70b/8b の汎用判定より先に評価する（"120b" は "20b" を部分文字列に含むため 120b を先に）。
+  // env override (LLM_MODEL_20B/120B) で provider prefix 等が変わっても拾えるよう gpt-oss 系を広めに判定。
+  if (lower.includes('gpt-oss')) {
+    return lower.includes('120') ? 'gpt-oss-120b' : 'gpt-oss-20b';
+  }
   if (lower.includes('70b') || lower.includes('mixtral')) return 'groq-70b';
   if (
     lower.includes('8b') ||
@@ -123,9 +153,10 @@ export function calculateLLMCostCents(usage: UsageRecord): number {
       `Invalid token counts: input=${usage.inputTokens}, output=${usage.outputTokens}`
     );
   }
-  if (usage.inputTokens === 0 && usage.outputTokens === 0) return 0;
+  const extraUSD = _sumExtraLlmUsd(usage.extraLlmUsages);
+  if (usage.inputTokens === 0 && usage.outputTokens === 0 && extraUSD === 0) return 0;
 
-  return Math.ceil(_calculateLLMCostUSD(usage) * 100);
+  return Math.ceil((_calculateLLMCostUSD(usage) + extraUSD) * 100);
 }
 
 /**
@@ -168,7 +199,8 @@ export function calculateBillingAmountCents(usage: UsageRecord): number {
 
   const isEndUser = usage.featureUsed === undefined || END_USER_FEATURES.has(usage.featureUsed);
   const margin   = usage.marginOverride ?? (isEndUser ? MARGIN_MULTIPLIER : 1);
-  const llmUSD   = _calculateLLMCostUSD(usage);
+  // 本行の LLM コスト + 同一リクエスト内の追加 LLM 呼び出し（planner 等）をモデル別実レートで合算。
+  const llmUSD   = _calculateLLMCostUSD(usage) + _sumExtraLlmUsd(usage.extraLlmUsages);
   const ttsUSD   = (usage.ttsTextBytes  ?? 0) * FISH_AUDIO_COST_PER_BYTE_USD;
   const avtrUSD  = (usage.avatarCredits ?? 0) * LEMONSLICE_COST_PER_CREDIT_USD;
   const imgUSD   = (usage.imageCount    ?? 0) * IMAGE_GENERATION_COST_USD;

--- a/src/lib/billing/usageTracker.test.ts
+++ b/src/lib/billing/usageTracker.test.ts
@@ -93,6 +93,38 @@ describe('usageTracker', () => {
       expect(Number.isInteger(params[7])).toBe(true);
       expect(params[7]).toBeGreaterThanOrEqual(params[6]);
     });
+
+    it('Subtask 3: extraLlmUsages の planner トークンを永続化列にも合算する', async () => {
+      const mockQuery = jest.fn().mockResolvedValue({ rowCount: 1 });
+      const mockLogger = { warn: jest.fn(), error: jest.fn(), debug: jest.fn(), info: jest.fn() } as any;
+      initUsageTracker({ query: mockQuery } as any, mockLogger);
+
+      trackUsage({
+        tenantId:     'test-tenant',
+        requestId:    'req-planner-001',
+        model:        'llama-3.1-70b-versatile',
+        inputTokens:  1000,
+        outputTokens: 500,
+        featureUsed:  'chat',
+        extraLlmUsages: [
+          { model: 'openai/gpt-oss-20b', inputTokens: 300, outputTokens: 60 },
+        ],
+      });
+
+      await flushSetImmediate();
+      await flushSetImmediate();
+
+      const insertCall = mockQuery.mock.calls.find(
+        ([, p]: [string, any[]]) => p?.[1] === 'req-planner-001'
+      );
+      expect(insertCall).toBeDefined();
+      const [, params] = insertCall!;
+      // input/output_tokens 列に planner 分が合算されている（cost との整合）
+      expect(params[3]).toBe(1300); // 1000 + 300
+      expect(params[4]).toBe(560);  // 500 + 60
+      // model 列は chat 本体（代表モデル）のまま
+      expect(params[2]).toBe('llama-3.1-70b-versatile');
+    });
   });
 
   describe('pool 未初期化時', () => {

--- a/src/lib/billing/usageTracker.ts
+++ b/src/lib/billing/usageTracker.ts
@@ -2,7 +2,7 @@
 // Phase32: API使用量の非同期記録（fire-and-forget）
 
 import type pino from 'pino';
-import { calculateLLMCostCents, calculateBillingAmountCents } from './costCalculator';
+import { calculateLLMCostCents, calculateBillingAmountCents, normalizeModelKey } from './costCalculator';
 
 export type FeatureUsed = 'chat' | 'avatar' | 'voice' | 'avatar_config_image' | 'avatar_config_voice' | 'avatar_config_prompt' | 'avatar_config_test' | 'anam_session' | 'option_service' | 'premium_avatar_generation';
 
@@ -25,6 +25,11 @@ export interface TrackUsageParams {
   anam_session_seconds?: number;
   /** Phase53: 生成画像枚数 */
   imageCount?: number;
+  /**
+   * Subtask 3: 同一リクエスト内の追加 LLM 呼び出し（マルチステップ planner 等）を
+   * モデル別の実レートで本行のコストに内包する（別 usage_log を作らず請求リクエスト数を保つ）。
+   */
+  extraLlmUsages?: Array<{ model: string; inputTokens: number; outputTokens: number }>;
 }
 
 let _pool: any | null = null;
@@ -54,21 +59,42 @@ async function _insertUsageLog(params: TrackUsageParams): Promise<void> {
   const {
     tenantId, requestId, model, inputTokens, outputTokens,
     featureUsed, marginOverride, ttsTextBytes, avatarCredits, avatarSessionMs, imageCount,
-    anam_session_seconds,
+    anam_session_seconds, extraLlmUsages,
   } = params;
+
+  // Subtask 3: 追加 LLM（planner 等）に価格表に無いモデルが来た場合、コストは 0 計上になる。
+  // env override 等で発生しうるため、サイレント未課金を避けるべく可視化ログを出す。
+  if (extraLlmUsages) {
+    for (const e of extraLlmUsages) {
+      if ((e.inputTokens > 0 || e.outputTokens > 0) && !normalizeModelKey(e.model)) {
+        _logger?.warn(
+          { requestId, model: e.model },
+          '[usageTracker] extra LLM model has no price entry — cost recorded as 0 (add to LLM_COSTS)',
+        );
+      }
+    }
+  }
 
   let costLlmCents = 0;
   let costTotalCents = 0;
   try {
-    costLlmCents   = calculateLLMCostCents({ model, inputTokens, outputTokens });
+    costLlmCents   = calculateLLMCostCents({ model, inputTokens, outputTokens, extraLlmUsages });
     costTotalCents = calculateBillingAmountCents({
       model, inputTokens, outputTokens, marginOverride,
       ttsTextBytes, avatarCredits, avatarSessionMs,
-      featureUsed, imageCount, anam_session_seconds,
+      featureUsed, imageCount, anam_session_seconds, extraLlmUsages,
     });
   } catch (err) {
     _logger?.warn({ err, requestId }, '[usageTracker] cost calculation error, defaulting to 0');
   }
+
+  // Subtask 3: cost に planner 分（extraLlmUsages）を内包したので、永続化する
+  // input_tokens / output_tokens にも planner トークンを合算し、コストとトークンの
+  // 整合性を保つ（トークンあたりコスト分析が破綻しないようにする）。
+  const totalInputTokens =
+    inputTokens + (extraLlmUsages?.reduce((s, e) => s + e.inputTokens, 0) ?? 0);
+  const totalOutputTokens =
+    outputTokens + (extraLlmUsages?.reduce((s, e) => s + e.outputTokens, 0) ?? 0);
 
   try {
     await _pool.query(
@@ -78,7 +104,7 @@ async function _insertUsageLog(params: TrackUsageParams): Promise<void> {
           tts_text_bytes, avatar_credits, avatar_session_ms, anam_session_seconds)
        VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
        ON CONFLICT (request_id) DO NOTHING`,
-      [tenantId, requestId, model, inputTokens, outputTokens,
+      [tenantId, requestId, model, totalInputTokens, totalOutputTokens,
        featureUsed, costLlmCents, costTotalCents,
        ttsTextBytes ?? null, avatarCredits ?? null, avatarSessionMs ?? null,
        anam_session_seconds ?? null]


### PR DESCRIPTION
## 背景
`chat/route.ts` が拾う `result.meta.llmUsage` は synthesis 1回分のみで、マルチステップ planner LLM（GPT-OSS 20B/120B）のトークンが課金から漏れていた（過少課金）。加えて応答 usage 不在時の char/4 ヒューリスティック推定が「chat LLM 未実行ターン」に架空課金を発生させていた。

## 設計（Codex Gate 2.5 を複数周反映、構造修正方針は owner 承認）
**不変条件**: `usage_logs` は「1行=1リクエスト」。Stripe は `quantity: COUNT(*)`（行数）で課金するため、内部 LLM 呼び出しごとに別行を作ると顧客への過大請求になる。

→ **回答経路（searchAgent/orchestrator）を chat モデル実トークンの唯一のソース**にし、char/4 推定を全廃。planner は別行を作らず本 chat 行の cost に**各モデル実レート**で内包する。

## 変更
- **dialogOrchestrator**: clarification / no-search の早期 return で `llmUsage={0,0}` を明示（chat LLM 未実行を表す）
- **searchAgent**: synthesis が usage を返さない場合（GROQキー無し/fallback/エラー）でも embedding トークンを落とさず `llmUsage` を常時返す
- **chat/route**: char/4 推定を廃止し `result.meta.llmUsage` を直接使用。planner は `extraLlmUsages` として本行 cost に内包
- **costCalculator**: `gpt-oss-20b($0.075/$0.30)`・`gpt-oss-120b($0.15/$0.60)` 追加（公式 Groq 単価、env override 吸収）。`extraLlmUsages` をモデル別実レートで cost 両系統に合算（サーバーコストは1回のみ）
- **usageTracker**: 内包した planner トークンを `input_tokens/output_tokens` 列にも合算しコストと整合。価格表に無い追加モデルは可視化 warn
- **llmMultiStepPlannerRuntime**: usage を JSON parse より先に取得し、HTTP 200 なら parse 失敗でもモデル別 `usages[]` に保持。20B→120B フォールバックは両モデル記録

## 実機照合
- `principleDetector(Groq 8B)` はテスト以外から未呼び出しで実チャット経路にいない（synthesis の原則注入は `principleSearch` のセマンティック検索）→ デッドコード配線せず
- planner LLM は `useLlmPlanner=true` のリクエストのみ作動（デフォルト production は OFF）

## Gate
- Gate 1: typecheck / lint(60<80) / test **1918 pass**（serial、並列時の supertest port flake を除外確認）
- Gate 2: security-scan **PASS**（CRITICAL/HIGH 0）
- Gate 3: src + admin-ui build **PASS**
- **Gate 2.5（Codex）**: round 1–6 を実施し全 P1/P2 を解消。round 7 確認は **Codex 利用上限到達で実行不可**（~1ヶ月後リセット）。直近完了の round 6 指摘（char/4 過大課金 / token列不整合）は本構造修正で解消済み。**課金本体のため最終 merge 判断は owner に委ねる**

## Codex 解消履歴（round 1–6）
1. planner を 70B レートで混合課金 → モデル別実レートへ
2. 別 usage_log でサーバーコスト二重計上 → `extraLlmUsages` で本行内包
3. parse 失敗時 usage 破棄 → parse 前に取得し保持
4. 別行で Stripe リクエスト数水増し → 行を分けず cost 内包
5. clarification 二重課金 / fallback 過少 → 回答経路が `{0,0}`/実usage を常時報告（char/4 全廃）
6. token列がcostと不整合 → planner トークンを列にも合算

🤖 Generated with [Claude Code](https://claude.com/claude-code)