### PR TITLE
fix(avatar): Anam動画の顔アップを全身表示に修正

### DIFF
--- a/public/widget.js
+++ b/public/widget.js
@@ -1409,6 +1409,15 @@
       shadowVideoEl.setAttribute('autoplay', '');
       shadowVideoEl.setAttribute('playsinline', '');
       shadowVideoEl.setAttribute('muted', '');
+      // 全身表示: object-fit coverはcenter topで顔だけ切り抜かれるためcontainに変更
+      shadowVideoEl.style.objectFit = 'contain';
+      shadowVideoEl.style.objectPosition = 'center top';
+      shadowVideoEl.style.position = 'absolute';
+      shadowVideoEl.style.top = '0';
+      shadowVideoEl.style.left = '0';
+      shadowVideoEl.style.width = '100%';
+      shadowVideoEl.style.height = '100%';
+      shadowVideoEl.style.zIndex = '2';
       avatarArea.appendChild(shadowVideoEl);
 
       // outerVideoにストリームが来たらshadowVideoにsrcObjectをミラー


### PR DESCRIPTION
## Summary

- Anam SDKアバター動画が接続後に顔アップになるバグを修正
- `object-fit: cover; object-position: center top` がportrait動画の上部（顔）だけを切り抜いていた
- `shadowVideoEl` に `object-fit: contain` を適用し、動画全体（全身）を表示するよう変更
- `position: absolute; z-index: 2` でプレースホルダー静止画の上に正しく重なるよう配置

## Test plan

- [ ] アバターアイコンをクリック → 全身表示で開くことを確認
- [ ] 数秒後（Anam接続後）も全身表示が維持されることを確認（顔アップにならない）
- [ ] リップシンク動作に影響がないことを確認
- [ ] デプロイ後にウィジェットで動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)