### PR TITLE
fix(admin-ui): テナント作成が常に失敗するバグを修正

### DIFF
--- a/admin-ui/src/pages/admin/tenants/index.tsx
+++ b/admin-ui/src/pages/admin/tenants/index.tsx
@@ -55,7 +55,7 @@ async function fetchTenants(): Promise<Tenant[]> {
 async function createTenant(data: { name: string; slug: string }): Promise<Tenant> {
   const res = await authFetch(`${API_BASE}/v1/admin/tenants`, {
     method: "POST",
-    body: JSON.stringify({ ...data, plan: "starter" }),
+    body: JSON.stringify({ id: data.slug, name: data.name, plan: "starter" }),
   });
   if (!res.ok) throw new Error(`HTTP ${res.status}`);
   const json = (await res.json()) as { tenant?: Tenant } | Tenant;


### PR DESCRIPTION
## 概要
管理画面からのテナント作成が**常に失敗**するバグを修正。

## 原因
`createTenant` が body に `slug` を送っていたが、サーバーの `createTenantSchema`（`src/api/admin/tenants/routes.ts:17`）は `id` フィールドを必須としていた。`id` が無いため zod バリデーションで弾かれ、400 が返り、全テナント作成が失敗していた。

サーバーはバリデーション失敗時にログを出さないため、症状はトースト「テナントの作成に失敗しました」のみで、API ログにも痕跡が残らず原因特定が困難だった。

## 修正
`{ ...data, plan }`（`slug` を含む）→ `{ id: data.slug, name: data.name, plan }` にマッピング。

## 確認
- admin-ui ビルド成功
- スラッグ・テナント名は既存のクライアント側バリデーション（`^[a-z0-9-]+$`、3文字以上はサーバー側）を踏襲

🤖 Generated with [Claude Code](https://claude.com/claude-code)