### PR TITLE
fix(admin-ui): 全テナントアバター表示でデフォルトの重複を集約

### DIFF
--- a/admin-ui/src/pages/admin/avatar/index.tsx
+++ b/admin-ui/src/pages/admin/avatar/index.tsx
@@ -127,6 +127,19 @@ export default function AvatarListPage() {
     // テナントフィルタ（strict tenant_id 一致のみ）
     if (tenantFilter !== "all") {
       result = result.filter((c) => (c.tenant_id ?? "") === tenantFilter);
+    } else {
+      // 全テナント表示時: デフォルトアバターはテナント分コピーされ重複するため、
+      // 名前単位で1枚に集約する（カスタムアバターはテナントごとに全件表示）。
+      // r2c_default のコピーを優先的に代表として残す。
+      const seenDefaults = new Set<string>();
+      result = [...result]
+        .sort((a, b) => (a.tenant_id === "r2c_default" ? -1 : 0) - (b.tenant_id === "r2c_default" ? -1 : 0))
+        .filter((c) => {
+          if (!c.is_default) return true;
+          if (seenDefaults.has(c.name)) return false;
+          seenDefaults.add(c.name);
+          return true;
+        });
     }
     // タイプフィルタ
     if (typeFilter === "default") result = result.filter((c) => c.is_default);


### PR DESCRIPTION
## 問題
新規テナント作成時にデフォルトアバター18体がテナント分コピーされる（Phase44/50 仕様）ため、super_admin の「全テナント」アバター表示で同一デフォルトがテナント数×18枚並ぶ。37テナントで最大666枚の重複カードとなり UX が破綻していた。

## 修正
`displayedConfigs`（`admin-ui/src/pages/admin/avatar/index.tsx`）で、テナントフィルタが「全テナント」のときのみ `is_default` アバターを `name` 単位で1枚に集約。代表は r2c_default のコピーを優先。

- カスタムアバター（`is_default=false`）はテナントごとに全件表示（変更なし）
- 特定テナント選択時は従来通り全件表示（変更なし）

## 確認
- admin-ui ビルド成功
- フロントのみの変更・DB / API 無変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)