### PR TITLE
feat(lp): デモウィジェットを lp-demo 専用テナントに切替

### DIFF
--- a/public/lp/demo-frame.html
+++ b/public/lp/demo-frame.html
@@ -26,8 +26,8 @@
 
   <script
     src="/widget.js"
-    data-api-key="rjc_77aaa951edede3a8faa44161a6f505eca44f4c0517e051ec1f8bb6bc9f22b29b"
-    data-tenant="r2c_default"
+    data-api-key="rjc_9c265687daa95378e33a9cf3f9fa41c3a5d90729c7000b52694e471c5a5dd4d6"
+    data-tenant="lp-demo"
     data-accent-color="#7c3aed"
     data-greeting="こんにちは！R2Cについて何でも聞いてください 😊"
   ></script>


### PR DESCRIPTION
## 概要
LP デモウィジェット（`public/lp/demo-frame.html`）を、LP デモ専用に作成したテナント `lp-demo` の API キーに切り替える。

## 背景
これまで `r2c_default` の API キーを流用していたが、LP デモ専用テナント `lp-demo`（アバター有効・Lemonslice `agent_5bdbe2f531f79e51` 設定済み）を新規作成したため、そちらに分離。

- `data-api-key` → lp-demo のキー
- `data-tenant` → `lp-demo`
- `data-scripted-responses`（事前定義Q&A）は維持 → LLM コストゼロのままライブアバターが発話

## 確認
- 静的ファイルのみの変更
- VPS public/ 配信のため、マージ後に `deploy-vps.sh` で反映が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)