### PR TITLE
fix(admin-ui): AI学習・貢献分析を super_admin 専用に制限

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -154,8 +154,8 @@ function AppInner() {
         {/* 書籍管理 */}
         <Route path="/admin/knowledge/books" element={<RequireAuth><BooksPage /></RequireAuth>} />
 
-        {/* AI学習・貢献分析 */}
-        <Route path="/admin/knowledge-analytics" element={<RequireAuth><KnowledgeAnalyticsPage /></RequireAuth>} />
+        {/* AI学習・貢献分析 — super_admin 専用（OpenClaw 横断分析） */}
+        <Route path="/admin/knowledge-analytics" element={<SuperAdminRoute><KnowledgeAnalyticsPage /></SuperAdminRoute>} />
 
         {/* Phase45: AI評価 — 廃止: /admin/chat-history にリダイレクト */}
         <Route path="/admin/evaluations" element={<Navigate to="/admin/chat-history" replace />} />

--- a/admin-ui/src/components/AppSidebar.tsx
+++ b/admin-ui/src/components/AppSidebar.tsx
@@ -51,7 +51,7 @@ const MAIN_SECTIONS: NavSection[] = [
     items: [
       { label: "会話履歴", path: "/admin/chat-history", icon: MessageSquare },
       { label: "AIの知識データ", path: "/admin/knowledge", icon: BookOpen },
-      { label: "AI学習・貢献分析", path: "/admin/knowledge-analytics", icon: BarChart2 },
+      { label: "AI学習・貢献分析", path: "/admin/knowledge-analytics", icon: BarChart2, superAdminOnly: true },
     ],
   },
   {
@@ -202,9 +202,11 @@ function SidebarContent({ onClose }: SidebarContentProps) {
   // Override knowledge path in nav items
   const patchedSections = MAIN_SECTIONS.map((section) => ({
     ...section,
-    items: section.items.map((item) =>
-      item.path === "/admin/knowledge" ? { ...item, path: knowledgePath } : item
-    ),
+    items: section.items
+      .filter((item) => isSuperAdmin || !item.superAdminOnly)
+      .map((item) =>
+        item.path === "/admin/knowledge" ? { ...item, path: knowledgePath } : item
+      ),
   }));
 
   const allSections = isSuperAdmin


### PR DESCRIPTION
## 問題
「AI学習・貢献分析」(OpenClaw 横断分析、`/admin/knowledge-analytics`) は各テナント横断の貢献を確認する super_admin 向けページだが、client_admin にもサイドバー表示・ルートアクセスできていた。

## 修正（フロントのみ）
- **ルート** (`App.tsx`): `<RequireAuth>` → `<SuperAdminRoute>`
- **サイドバー** (`AppSidebar.tsx`): 項目に `superAdminOnly: true` を付与 + item 単位フィルタを実装（フラグは定義済みだが未使用だった）

## バックエンドを変更しない理由
`/v1/admin/analytics/knowledge-attribution` は `KnowledgeAttributionTab` と会話分析ダッシュボード（`analytics/index.tsx`）でも client_admin が**自テナントスコープ**で正規利用している。エンドポイント自体は既に非 super_admin のとき JWT の tenant_id を強制しており安全。super_admin 限定にロックすると client_admin の正規機能が壊れるため変更しない。

## 確認
- admin-ui ビルド成功
- client_admin: サイドバー非表示 + ルート直叩きも SuperAdminRoute でブロック
- super_admin: 従来通り表示・アクセス可

🤖 Generated with [Claude Code](https://claude.com/claude-code)