### PR TITLE
feat(admin-ui): テナントのプラン変更UI（Phase1: UI+永続化）

### DIFF
--- a/admin-ui/src/pages/admin/tenants/BillingSection.tsx
+++ b/admin-ui/src/pages/admin/tenants/BillingSection.tsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useLang } from "../../../i18n/LangContext";
-import type { TenantDetail } from "./types";
+import type { TenantDetail, TenantPlan } from "./types";
+import { PLAN_OPTIONS } from "./types";
 
 // ─── 課金管理セクション（Super Admin専用） ────────────────────────────────────
 
@@ -15,12 +16,14 @@ export function BillingSection({
     tenantId: string,
     billing_enabled: boolean,
     billing_free_from: string | null,
-    billing_free_until: string | null
+    billing_free_until: string | null,
+    plan?: TenantPlan
   ) => Promise<TenantDetail>;
 }) {
   const { t, lang } = useLang();
   const locale = lang === "en" ? "en-US" : "ja-JP";
   const [billingEnabled, setBillingEnabled] = useState(tenant.billing_enabled);
+  const [plan, setPlan] = useState<TenantPlan>(tenant.plan);
   const [freeFromDate, setFreeFromDate] = useState<string>(
     tenant.billing_free_from ? tenant.billing_free_from.split("T")[0] : ""
   );
@@ -53,7 +56,8 @@ export function BillingSection({
         tenant.id,
         billingEnabled,
         freeFromDate  || null,
-        freeUntilDate || null
+        freeUntilDate || null,
+        plan
       );
       onUpdate(updated);
     } catch {
@@ -103,6 +107,46 @@ export function BillingSection({
           {error}
         </div>
       )}
+
+      {/* プラン選択 */}
+      <div style={{ marginBottom: 20 }}>
+        <p style={{ margin: "0 0 4px", fontWeight: 600, color: "var(--foreground)", fontSize: 15 }}>
+          プラン
+        </p>
+        <p style={{ margin: "0 0 10px", fontSize: 13, color: "var(--muted-foreground)" }}>
+          対話単価にプラン倍率が適用されます（Starter ×1.0 / Growth ×1.5 / Enterprise ×2.5）。
+        </p>
+        <div style={{ display: "flex", flexWrap: "wrap", gap: 10 }}>
+          {PLAN_OPTIONS.map((opt) => {
+            const selected = plan === opt.value;
+            return (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => setPlan(opt.value)}
+                style={{
+                  flex: "1 1 160px",
+                  textAlign: "left",
+                  padding: "12px 14px",
+                  minHeight: 44,
+                  borderRadius: 10,
+                  border: `1px solid ${selected ? "rgba(124,58,237,0.6)" : "var(--border)"}`,
+                  background: selected ? "rgba(124,58,237,0.15)" : "rgba(255,255,255,0.02)",
+                  color: "var(--foreground)",
+                  cursor: "pointer",
+                }}
+              >
+                <span style={{ display: "block", fontWeight: 700, fontSize: 14 }}>
+                  {opt.label} <span style={{ color: "#a78bfa" }}>×{opt.multiplier.toFixed(1)}</span>
+                </span>
+                <span style={{ display: "block", fontSize: 12, color: "var(--muted-foreground)", marginTop: 2 }}>
+                  {opt.desc}
+                </span>
+              </button>
+            );
+          })}
+        </div>
+      </div>
 
       {/* 課金ステータストグル */}
       <div

--- a/admin-ui/src/pages/admin/tenants/[id].tsx
+++ b/admin-ui/src/pages/admin/tenants/[id].tsx
@@ -130,7 +130,8 @@ async function updateBilling(
   tenantId: string,
   billing_enabled: boolean,
   billing_free_from: string | null,
-  billing_free_until: string | null
+  billing_free_until: string | null,
+  plan?: TenantDetail["plan"]
 ): Promise<TenantDetail> {
   const body: Record<string, unknown> = {
     billing_enabled,
@@ -138,6 +139,7 @@ async function updateBilling(
     billing_free_from:  billing_free_from  ? new Date(billing_free_from).toISOString()  : null,
     billing_free_until: billing_free_until ? new Date(billing_free_until).toISOString() : null,
   };
+  if (plan !== undefined) body.plan = plan;
   const res = await authFetch(`${API_BASE}/v1/admin/tenants/${tenantId}`, {
     method: "PATCH",
     body: JSON.stringify(body),

--- a/admin-ui/src/pages/admin/tenants/index.tsx
+++ b/admin-ui/src/pages/admin/tenants/index.tsx
@@ -12,7 +12,7 @@ interface Tenant {
   id: string;
   name: string;
   slug: string;
-  plan: "starter" | "pro";
+  plan: "starter" | "growth" | "enterprise";
   status: "active" | "inactive";
   apiKeyCount: number;
   createdAt: string;

--- a/admin-ui/src/pages/admin/tenants/types.ts
+++ b/admin-ui/src/pages/admin/tenants/types.ts
@@ -1,6 +1,15 @@
 import type * as React from "react";
 import type { CSSProperties } from "react";
 
+// プラン定義（バックエンド planValues と一致: starter/growth/enterprise）
+export type TenantPlan = "starter" | "growth" | "enterprise";
+
+export const PLAN_OPTIONS: { value: TenantPlan; label: string; multiplier: number; desc: string }[] = [
+  { value: "starter",    label: "Starter",    multiplier: 1.0, desc: "小規模サイト向け（〜500対話/月）" },
+  { value: "growth",     label: "Growth",     multiplier: 1.5, desc: "成長期のビジネス向け（〜3,000対話/月）" },
+  { value: "enterprise", label: "Enterprise", multiplier: 2.5, desc: "大規模・高品質要求向け（無制限）" },
+];
+
 export interface TenantFeatures {
   avatar: boolean;
   voice: boolean;
@@ -13,7 +22,7 @@ export interface TenantDetail {
   id: string;
   name: string;
   slug: string;
-  plan: "starter" | "pro";
+  plan: TenantPlan;
   status: "active" | "inactive";
   createdAt: string;
   widgetTitle: string;


### PR DESCRIPTION
## 概要
テナント管理画面に**プラン変更 UI が存在しなかった**問題に対応（Phase1）。LP では Starter/Growth/Enterprise の3プランを売っているが、管理画面では `BillingInfoTab` の読み取り専用表示のみで切替不可だった。

## 変更
- **型修正**: `plan: "starter" | "pro"`（誤り）→ `"starter" | "growth" | "enterprise"`（バックエンド `planValues` と一致）。`PLAN_OPTIONS` 定数を `types.ts` に追加
- **BillingSection**（super_admin 専用）に**プラン選択 UI** を追加（Starter ×1.0 / Growth ×1.5 / Enterprise ×2.5 を明示）
- `updateBilling` に `plan` を追加し、既存 `PATCH /v1/admin/tenants/:id` に配線（バックエンドは `plan` 更新を既に対応済み = `routes.ts:292`）

## スコープ外（Phase2 で別PR）
プラン倍率を**実際の Stripe 請求に反映**する配線（`stripeSync`）。実装方式（quantity 倍率 vs プラン別 Stripe Price）の決定が必要なため分離。本PRは UI + 永続化まで。

## 確認
- admin-ui ビルド成功
- super_admin: BillingSection でプラン選択 → 保存 → PATCH で永続化
- 課金モデルは「リクエスト課金 × プラン別単価」方針（為替不要、原価×5倍は内部監視として維持）で合意済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)