### PR TITLE
fix(billing): LemonSlice アバター使用量を課金計上する

### DIFF
--- a/avatar-agent/agent.py
+++ b/avatar-agent/agent.py
@@ -23,6 +23,7 @@ os.environ.setdefault("LIBVA_DRIVER_NAME", "dummy")
 import asyncio
 import json
 import logging
+import math
 import time
 import aiohttp
 from livekit import agents, rtc
@@ -215,6 +216,37 @@ async def _report_tts_usage(tenant_id: str, tts_text_bytes: int) -> None:
         logger.debug(f"[usage] TTS usage reported: tenant={tenant_id} bytes={tts_text_bytes}")
     except Exception as e:
         logger.warning(f"[usage] TTS usage report failed (non-critical): {e}")
+
+
+# LemonSlice は約24.5クレジット/分消費（料金表の割当 1000credit/41min・5400/220・15000/610 から逆算）。
+LEMONSLICE_CREDITS_PER_MINUTE = 24.5
+
+
+async def _report_avatar_usage(tenant_id: str, session_ms: int) -> None:
+    """LemonSlice アバターのセッション課金をRAJIUCE APIへ非同期レポート（fire-and-forget）。
+
+    セッション時間（ms）→ 分 → クレジット換算（約24.5credit/分）で avatarCredits を報告する。
+    本体側 costCalculator が avatarCredits × $0.007/credit で原価計上する。
+    """
+    if session_ms <= 0:
+        return
+    minutes = session_ms / 60000.0
+    credits = math.ceil(minutes * LEMONSLICE_CREDITS_PER_MINUTE)
+    api_url = os.environ.get("RAJIUCE_API_URL", "http://localhost:3100")
+    try:
+        async with aiohttp.ClientSession() as http_session:
+            await http_session.post(
+                f"{api_url}/api/internal/usage",
+                headers={"X-Internal-Request": "1", "Content-Type": "application/json"},
+                json={"tenantId": tenant_id, "avatarCredits": credits, "avatarSessionMs": session_ms},
+                timeout=aiohttp.ClientTimeout(total=5),
+            )
+        logger.info(
+            f"[usage] LemonSlice avatar usage reported: tenant={tenant_id} "
+            f"session_ms={session_ms} credits={credits}"
+        )
+    except Exception as e:
+        logger.warning(f"[usage] avatar usage report failed (non-critical): {e}")
 
 
 class FishAudioTTS(agents_tts.TTS):
@@ -567,6 +599,8 @@ async def entrypoint(ctx: agents.JobContext) -> None:
         # I-4: avatar.start() の戻り値が LemonSlice session_id（plugin avatar.py:132）
         global _lemonslice_session_id
         _lemonslice_session_id = await avatar.start(session, room=ctx.room)
+        # 課金: アバター起動成功時刻を記録（_close_avatar でセッション時間を算出）
+        _avatar_started_at = time.monotonic()
         logger.info("=== LEMONSLICE AVATAR STARTED ===")
         logger.info(f"[lemonslice] session_id={'SET' if _lemonslice_session_id else 'NOT_AVAILABLE'}")
 
@@ -580,6 +614,12 @@ async def entrypoint(ctx: agents.JobContext) -> None:
         # LiveKit 1.5.17: job shutdown 時に aclose してゾンビアバターを防止
         # (wait_for_shutdown は 1.5.17 に存在しないため add_shutdown_callback を使用)
         async def _close_avatar() -> None:
+            # 課金: セッション時間を算出して LemonSlice 使用量をレポート
+            try:
+                session_ms = int((time.monotonic() - _avatar_started_at) * 1000)
+                await _report_avatar_usage(tenant_id, session_ms)
+            except Exception as e:
+                logger.warning(f"[avatar] usage report on close error (non-fatal): {e}")
             try:
                 await avatar.aclose()
                 logger.info("[avatar] aclose completed")


### PR DESCRIPTION
## 問題
LemonSlice アバター（最もコストの高い構成要素）の使用量が**一切課金されていなかった**。`agent.py` は Groq トークンと TTS は `/api/internal/usage` に報告するが、アバターセッションの credits/session を報告していなかった。その結果 `costCalculator` に単価（`LEMONSLICE_COST_PER_CREDIT_USD`）があっても `avatarCredits=0` で常に ¥0 課金だった。

## 修正（agent.py のみ）
- `avatar.start()` 成功時にセッション開始時刻を記録
- `_close_avatar`（shutdown）でセッション時間(ms)を算出
- LemonSlice 料金表の割当から逆算した **≈24.5 credit/分** でクレジット換算し、`/api/internal/usage` に `avatarCredits` を報告
- 既存チェーン（`usageRoutes` → `trackUsage('avatar')` → `costCalculator`）が**原価×5倍マージン**で計上（`'avatar'` は `END_USER_FEATURES`）

## 料金根拠（LemonSlice pricing）
割当: 1,000credit/41min・5,400/220・15,000/610・36,000/1,463 → いずれも **≈24.5 credit/分**。既存単価 $0.007/credit ≈ $0.17/分 で per-minute 表記と整合。

## 注意
credits はセッションの複雑さ/解像度でも変動しうるが、LemonSlice の主要課金は per-minute であり、時間ベース推定で ¥0 課金を解消する。正確な実消費が必要なら将来 LemonSlice API から取得に切替可能。

## 確認
- `python3 -m py_compile avatar-agent/agent.py` OK
- avatar_credits カラムは VPS に存在確認済み
- マージ後 `deploy-vps.sh` で avatar-agent(venv) 反映が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)