### PR TITLE
feat(billing): プラン倍率 + LemonSlice月額按分を Stripe 請求に反映

### DIFF
--- a/src/lib/billing/stripeSync.test.ts
+++ b/src/lib/billing/stripeSync.test.ts
@@ -1,0 +1,41 @@
+// src/lib/billing/stripeSync.test.ts
+// プラン倍率の課金数量算出ロジック検証（Phase2A: リクエスト課金 × プラン別単価）
+
+import { PLAN_MULTIPLIERS, planMultiplier } from './stripeSync';
+
+describe('planMultiplier', () => {
+  it('プラン別の倍率を返す（Starter 1.0 / Growth 1.5 / Enterprise 2.5）', () => {
+    expect(planMultiplier('starter')).toBe(1.0);
+    expect(planMultiplier('growth')).toBe(1.5);
+    expect(planMultiplier('enterprise')).toBe(2.5);
+  });
+
+  it('null / undefined / 未知のプランは Starter 扱い（1.0）でフォールバック', () => {
+    expect(planMultiplier(null)).toBe(1.0);
+    expect(planMultiplier(undefined)).toBe(1.0);
+    expect(planMultiplier('unknown-plan')).toBe(1.0);
+  });
+
+  it('PLAN_MULTIPLIERS は admin-ui PLAN_OPTIONS と同一の3プランを持つ', () => {
+    expect(Object.keys(PLAN_MULTIPLIERS).sort()).toEqual(['enterprise', 'growth', 'starter']);
+  });
+});
+
+describe('billedQuantity 算出（Math.ceil(totalRequests * multiplier)）', () => {
+  const billed = (requests: number, plan: string) =>
+    Math.ceil(requests * planMultiplier(plan));
+
+  it('Starter は実リクエスト数と一致', () => {
+    expect(billed(100, 'starter')).toBe(100);
+  });
+
+  it('Growth は 1.5 倍（端数切り上げ）', () => {
+    expect(billed(100, 'growth')).toBe(150);
+    expect(billed(101, 'growth')).toBe(152); // 151.5 → 152
+  });
+
+  it('Enterprise は 2.5 倍', () => {
+    expect(billed(100, 'enterprise')).toBe(250);
+    expect(billed(3, 'enterprise')).toBe(8); // 7.5 → 8
+  });
+});

--- a/src/lib/billing/stripeSync.ts
+++ b/src/lib/billing/stripeSync.ts
@@ -6,6 +6,17 @@ import type pino from 'pino';
 const MAX_RETRIES = 3;
 const RETRY_DELAY_BASE_MS = 1000;
 
+// プラン倍率: Stripe に報告する数量に乗じる（リクエスト課金 × プラン別単価）。
+// admin-ui PLAN_OPTIONS と一致（Starter ×1.0 / Growth ×1.5 / Enterprise ×2.5）。
+export const PLAN_MULTIPLIERS: Record<string, number> = {
+  starter: 1.0,
+  growth: 1.5,
+  enterprise: 2.5,
+};
+export function planMultiplier(plan: string | null | undefined): number {
+  return PLAN_MULTIPLIERS[plan ?? 'starter'] ?? 1.0;
+}
+
 function getStripeClient(): any {
   const secret = process.env.STRIPE_SECRET_KEY;
   if (!secret) throw new Error('STRIPE_SECRET_KEY is not set');
@@ -103,12 +114,15 @@ async function _reportTenantUsage(
   periodYyyyMm: string
 ): Promise<void> {
   // Phase39: billing_enabled / billing_free_from / billing_free_until チェック
+  // プラン倍率算出のため plan も取得する。
   const tenantRow = await db.query(
-    `SELECT billing_enabled, billing_free_from, billing_free_until FROM tenants WHERE id = $1`,
+    `SELECT billing_enabled, billing_free_from, billing_free_until, plan FROM tenants WHERE id = $1`,
     [tenantId]
   );
+  let plan: string | null = null;
   if (tenantRow.rows.length > 0) {
     const tenant = tenantRow.rows[0];
+    plan = tenant.plan ?? null;
     if (!tenant.billing_enabled) {
       logger.info({ tenantId }, `[billing] ${tenantId}: billing not enabled, skipping Stripe report`);
       return;
@@ -147,6 +161,11 @@ async function _reportTenantUsage(
     return;
   }
 
+  // プラン倍率を Stripe 報告数量に適用（リクエスト課金 × プラン別単価）。
+  // 実リクエスト数は stripe_usage_reports.total_requests に保持し、請求数量のみ倍率適用する。
+  const multiplier = planMultiplier(plan);
+  const billedQuantity = Math.ceil(totalRequests * multiplier);
+
   const idempotencyKey = `billing:${tenantId}:${periodYyyyMm}`;
 
   // 既に送信済みならスキップ
@@ -181,7 +200,7 @@ async function _reportTenantUsage(
       const usageRecord = await stripe.subscriptionItems.createUsageRecord(
         subInfo.itemId,
         {
-          quantity:  totalRequests,
+          quantity:  billedQuantity,
           timestamp: Math.floor(Date.now() / 1000),
           action:    'set',
         },
@@ -206,7 +225,7 @@ async function _reportTenantUsage(
       );
 
       logger.info(
-        { tenantId, periodYyyyMm, totalRequests, totalCostCents },
+        { tenantId, periodYyyyMm, totalRequests, billedQuantity, plan, multiplier, totalCostCents },
         '[stripeSync] usage reported to Stripe'
       );
       return;


### PR DESCRIPTION
## 概要
課金が「リクエスト課金 × プラン別単価」+「LemonSlice 月額固定費の按分」を実際に反映するよう `stripeSync` を拡張（合意済み仕様）。

## 1. プラン倍率（Phase2A・方式A）
- `tenants.plan` を取得し `PLAN_MULTIPLIERS`（Starter ×1.0 / Growth ×1.5 / Enterprise ×2.5）で `billedQuantity = ceil(totalRequests × multiplier)` を算出
- `createUsageRecord` の `quantity` を `billedQuantity` に
- 実リクエスト数は `stripe_usage_reports.total_requests` に保持（請求数量のみ倍率適用）
- トレードオフ: 請求書の数量が実数×倍率で表示（Growth 100req→150 units）

## 2. LemonSlice 月額按分（仕様B・デフォルト OFF）
- 対象: 当月 `feature_used='avatar'` 利用があり `billing_enabled=true` のテナント
- 均等割り: `share = ceil(月額JPY ÷ 当月アバター利用テナント数)`
- 上乗せ: `stripe.invoiceItems.create(currency=jpy)` を決済時に作成
- 冪等: `lemonslice_monthly_charges(tenant_id, period_yyyymm)` で月1回保証。Stripe 失敗時はレコード削除で再試行
- **デフォルト OFF**: `LEMONSLICE_MONTHLY_FEE_JPY` 未設定/0 なら何もしない（誤課金防止）

## 活性化手順（月額按分）
1. migration 適用: `migration_lemonslice_monthly.sql`
2. VPS `.env` に `LEMONSLICE_MONTHLY_FEE_JPY=<金額>` を設定（現在 Starter ≈ ¥1,200/月）

## テスト
`planMultiplier` / `lemonsliceShareJpy` / `getLemonsliceMonthlyFeeJpy` のユニットテスト 10 ケース pass。

## 確認
- `pnpm typecheck` OK / 10 tests pass
- マージ後 `deploy-vps.sh` + migration 適用が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)