### PR TITLE
feat(billing): LemonSlice 月額固定費の按分課金（仕様B・デフォルトOFF）

### DIFF
--- a/src/lib/billing/migration_lemonslice_monthly.sql
+++ b/src/lib/billing/migration_lemonslice_monthly.sql
@@ -1,0 +1,12 @@
+-- LemonSlice 月額固定費の按分課金: 冪等性テーブル
+-- 月1回・テナント単位で按分額を Stripe に上乗せ請求する際の重複防止。
+-- 実行: psql 'postgresql://postgres:...@localhost:5432/commerce_faq' -f migration_lemonslice_monthly.sql
+
+CREATE TABLE IF NOT EXISTS lemonslice_monthly_charges (
+  tenant_id      TEXT        NOT NULL,
+  period_yyyymm  TEXT        NOT NULL,
+  amount_jpy     INTEGER     NOT NULL,
+  tenant_count   INTEGER     NOT NULL,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (tenant_id, period_yyyymm)
+);

--- a/src/lib/billing/stripeSync.test.ts
+++ b/src/lib/billing/stripeSync.test.ts
@@ -1,7 +1,7 @@
 // src/lib/billing/stripeSync.test.ts
 // プラン倍率の課金数量算出ロジック検証（Phase2A: リクエスト課金 × プラン別単価）
 
-import { PLAN_MULTIPLIERS, planMultiplier } from './stripeSync';
+import { PLAN_MULTIPLIERS, planMultiplier, lemonsliceShareJpy, getLemonsliceMonthlyFeeJpy } from './stripeSync';
 
 describe('planMultiplier', () => {
   it('プラン別の倍率を返す（Starter 1.0 / Growth 1.5 / Enterprise 2.5）', () => {
@@ -37,5 +37,36 @@ describe('billedQuantity 算出（Math.ceil(totalRequests * multiplier)）', () 
   it('Enterprise は 2.5 倍', () => {
     expect(billed(100, 'enterprise')).toBe(250);
     expect(billed(3, 'enterprise')).toBe(8); // 7.5 → 8
+  });
+});
+
+describe('lemonsliceShareJpy（月額固定費の均等割り・切り上げ）', () => {
+  it('テナント数で均等割り（切り上げ）', () => {
+    expect(lemonsliceShareJpy(1200, 1)).toBe(1200);
+    expect(lemonsliceShareJpy(1200, 3)).toBe(400);
+    expect(lemonsliceShareJpy(1000, 3)).toBe(334); // 333.3 → 334
+  });
+
+  it('fee=0 または テナント数=0 は 0（無効）', () => {
+    expect(lemonsliceShareJpy(0, 5)).toBe(0);
+    expect(lemonsliceShareJpy(1200, 0)).toBe(0);
+  });
+});
+
+describe('getLemonsliceMonthlyFeeJpy（デフォルト OFF）', () => {
+  const saved = process.env.LEMONSLICE_MONTHLY_FEE_JPY;
+  afterEach(() => {
+    if (saved === undefined) delete process.env.LEMONSLICE_MONTHLY_FEE_JPY;
+    else process.env.LEMONSLICE_MONTHLY_FEE_JPY = saved;
+  });
+
+  it('未設定なら 0（按分課金は無効）', () => {
+    delete process.env.LEMONSLICE_MONTHLY_FEE_JPY;
+    expect(getLemonsliceMonthlyFeeJpy()).toBe(0);
+  });
+
+  it('数値を設定すると反映', () => {
+    process.env.LEMONSLICE_MONTHLY_FEE_JPY = '1200';
+    expect(getLemonsliceMonthlyFeeJpy()).toBe(1200);
   });
 });

--- a/src/lib/billing/stripeSync.ts
+++ b/src/lib/billing/stripeSync.ts
@@ -17,6 +17,97 @@ export function planMultiplier(plan: string | null | undefined): number {
   return PLAN_MULTIPLIERS[plan ?? 'starter'] ?? 1.0;
 }
 
+/** 環境変数から LemonSlice 月額固定費(JPY)を取得。未設定/0 なら按分課金は無効。 */
+export function getLemonsliceMonthlyFeeJpy(): number {
+  return Number(process.env.LEMONSLICE_MONTHLY_FEE_JPY ?? '0') || 0;
+}
+
+/** 月額固定費を当月アバター利用テナント数で均等割りした1テナント分(JPY、切り上げ)。 */
+export function lemonsliceShareJpy(monthlyFeeJpy: number, tenantCount: number): number {
+  if (monthlyFeeJpy <= 0 || tenantCount <= 0) return 0;
+  return Math.ceil(monthlyFeeJpy / tenantCount);
+}
+
+/**
+ * LemonSlice 月額固定費を、当月アバターを利用したテナント間で均等割りして
+ * Stripe 請求に上乗せする（テナント単位・月1回・冪等）。
+ * - 対象: 当月 feature_used='avatar' の利用があり billing_enabled=true のテナント（仕様B）
+ * - 無効化: LEMONSLICE_MONTHLY_FEE_JPY 未設定/0 のとき何もしない（デフォルト OFF）
+ */
+async function _chargeLemonsliceMonthlyShare(
+  db: any,
+  stripe: any,
+  logger: pino.Logger,
+  tenantId: string,
+  periodYyyyMm: string,
+  startDate: string,
+  endDate: string,
+  customerId: string | null
+): Promise<void> {
+  const monthlyFeeJpy = getLemonsliceMonthlyFeeJpy();
+  if (monthlyFeeJpy <= 0) return; // デフォルト OFF
+  if (!customerId) {
+    logger.warn({ tenantId }, '[stripeSync] lemonslice monthly: no customerId, skipping');
+    return;
+  }
+
+  // このテナントが当月アバターを利用したか（仕様B）
+  const used = await db.query(
+    `SELECT 1 FROM usage_logs
+      WHERE tenant_id = $1 AND feature_used = 'avatar'
+        AND created_at >= $2 AND created_at < $3 LIMIT 1`,
+    [tenantId, startDate, endDate]
+  );
+  if (used.rows.length === 0) return;
+
+  // 当月アバターを利用した課金対象テナント数（按分の分母）
+  const cntRes = await db.query(
+    `SELECT COUNT(DISTINCT u.tenant_id)::integer AS cnt
+       FROM usage_logs u
+       JOIN tenants t ON t.id = u.tenant_id
+      WHERE u.feature_used = 'avatar'
+        AND u.created_at >= $1 AND u.created_at < $2
+        AND t.billing_enabled = true`,
+    [startDate, endDate]
+  );
+  const tenantCount: number = Math.max(1, cntRes.rows[0]?.cnt ?? 1);
+  const share = lemonsliceShareJpy(monthlyFeeJpy, tenantCount);
+  if (share <= 0) return;
+
+  // 冪等: テナント×月で1回だけ。INSERT 成功時のみ Stripe 請求を作成する。
+  const ins = await db.query(
+    `INSERT INTO lemonslice_monthly_charges (tenant_id, period_yyyymm, amount_jpy, tenant_count)
+     VALUES ($1, $2, $3, $4)
+     ON CONFLICT (tenant_id, period_yyyymm) DO NOTHING
+     RETURNING tenant_id`,
+    [tenantId, periodYyyyMm, share, tenantCount]
+  );
+  if (ins.rows.length === 0) return; // 既に請求済み
+
+  try {
+    await stripe.invoiceItems.create(
+      {
+        customer:    customerId,
+        amount:      share, // JPY は最小単位=1円
+        currency:    'jpy',
+        description: `LemonSlice 月額按分 ${periodYyyyMm} (1/${tenantCount})`,
+      },
+      { idempotencyKey: `lemonslice-monthly:${tenantId}:${periodYyyyMm}` }
+    );
+    logger.info(
+      { tenantId, periodYyyyMm, share, tenantCount, monthlyFeeJpy },
+      '[stripeSync] lemonslice monthly share charged'
+    );
+  } catch (err) {
+    // Stripe 失敗時は冪等レコードを取り消して次回再試行できるようにする
+    await db.query(
+      `DELETE FROM lemonslice_monthly_charges WHERE tenant_id = $1 AND period_yyyymm = $2`,
+      [tenantId, periodYyyyMm]
+    );
+    logger.error({ err, tenantId, periodYyyyMm }, '[stripeSync] lemonslice monthly charge failed, rolled back');
+  }
+}
+
 function getStripeClient(): any {
   const secret = process.env.STRIPE_SECRET_KEY;
   if (!secret) throw new Error('STRIPE_SECRET_KEY is not set');
@@ -48,7 +139,7 @@ async function getSubscriptionItemId(
   tenantId: string,
   stripe: any,
   logger: pino.Logger
-): Promise<{ subscriptionId: string; itemId: string } | null> {
+): Promise<{ subscriptionId: string; itemId: string; customerId: string | null } | null> {
   const result = await db.query(
     `SELECT stripe_subscription_id
      FROM stripe_subscriptions
@@ -69,7 +160,10 @@ async function getSubscriptionItemId(
       logger.warn({ tenantId, subscriptionId }, '[stripeSync] subscription has no items');
       return null;
     }
-    return { subscriptionId, itemId: item.id };
+    const customerId = typeof subscription.customer === 'string'
+      ? subscription.customer
+      : (subscription.customer?.id ?? null);
+    return { subscriptionId, itemId: item.id, customerId };
   } catch (err) {
     logger.error({ err, tenantId, subscriptionId }, '[stripeSync] failed to retrieve subscription');
     return null;
@@ -227,6 +321,11 @@ async function _reportTenantUsage(
       logger.info(
         { tenantId, periodYyyyMm, totalRequests, billedQuantity, plan, multiplier, totalCostCents },
         '[stripeSync] usage reported to Stripe'
+      );
+
+      // LemonSlice 月額固定費の按分を上乗せ（デフォルト OFF・冪等・仕様B）
+      await _chargeLemonsliceMonthlyShare(
+        db, stripe, logger, tenantId, periodYyyyMm, startDate, endDate, subInfo.customerId
       );
       return;
     } catch (err) {


### PR DESCRIPTION
## 概要
LemonSlice の月額固定費を、当月アバターを利用したテナント間で均等割りして Stripe 請求に上乗せする（合意済み仕様B）。

※ 当初 PR #380 に含めたが、ブランチ削除タイミングでマージから漏れたため再起票（cherry-pick）。プラン倍率（#380）は main 反映済み。

## 内容
- 対象: 当月 `feature_used='avatar'` 利用があり `billing_enabled=true` のテナント（仕様B）
- 均等割り: `share = ceil(月額JPY ÷ 当月アバター利用テナント数)`
- 上乗せ: `stripe.invoiceItems.create(currency=jpy)` を決済時に作成
- 冪等: `lemonslice_monthly_charges(tenant_id, period_yyyymm)` で月1回保証。Stripe 失敗時はレコード削除で再試行
- **デフォルト OFF**: `LEMONSLICE_MONTHLY_FEE_JPY` 未設定/0 なら何もしない（誤課金防止）
- `getSubscriptionItemId` が customerId も返すよう拡張

## 活性化手順
1. migration 適用: `src/lib/billing/migration_lemonslice_monthly.sql`
2. VPS `.env` に `LEMONSLICE_MONTHLY_FEE_JPY=<金額>`（現在 Starter ≈ ¥1,200/月）

## テスト
`lemonsliceShareJpy` / `getLemonsliceMonthlyFeeJpy` 含む 10 ケース pass、typecheck OK。

🤖 Generated with [Claude Code](https://claude.com/claude-code)