### PR TITLE
feat(admin-ui): 管理画面エージェント型AIアシスタント（チャットで全設定自動実行）

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { BrowserRouter, Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { AppSidebar, MobileHeader, MobileBottomBar } from "./components/AppSidebar";
 import { ThemeProvider } from "./contexts/ThemeContext";
@@ -20,6 +20,8 @@ import ChatHistorySessionPage from "./pages/admin/chat-history/[sessionId]";
 import TuningPage from "./pages/admin/tuning/index";
 import FeedbackPage from "./pages/admin/feedback/index";
 import AdminAIChat from "./components/AdminAIChat";
+import AdminAgentButton from "./components/AdminAgent/AdminAgentButton";
+import AdminAgentPanel from "./components/AdminAgent/AdminAgentPanel";
 import AvatarListPage from "./pages/admin/avatar/index";
 import AvatarStudioPage from "./pages/admin/avatar/studio";
 import AvatarWizardPage from "./pages/admin/avatar/wizard";
@@ -76,7 +78,8 @@ function ConfigErrorScreen() {
 }
 
 function AppInner() {
-  const { isClientAdmin } = useAuth();
+  const { isClientAdmin, isSuperAdmin, user } = useAuth();
+  const [agentOpen, setAgentOpen] = useState(false);
   const location = useLocation();
   const showAIChat = isClientAdmin && location.pathname !== "/admin/chat-test";
   const isAdmin = location.pathname.startsWith("/admin") || location.pathname === "/";
@@ -182,6 +185,21 @@ function AppInner() {
       </Routes>
       {/* 管理AIチャット — Client Admin、chat-testページを除く */}
       {showAIChat && <AdminAIChat />}
+      {/* R2C AIアシスタント — super_admin/client_admin 共通、chat-testページを除く */}
+      {showAIChat && (
+        <>
+          <AdminAgentButton
+            onClick={() => setAgentOpen((v) => !v)}
+            isOpen={agentOpen}
+          />
+          <AdminAgentPanel
+            isOpen={agentOpen}
+            onClose={() => setAgentOpen(false)}
+            tenantId={user?.tenantId ?? null}
+            isSuperAdmin={isSuperAdmin}
+          />
+        </>
+      )}
       </div>
     </div>
   );

--- a/admin-ui/src/components/AdminAgent/AdminAgentButton.tsx
+++ b/admin-ui/src/components/AdminAgent/AdminAgentButton.tsx
@@ -1,0 +1,48 @@
+// admin-ui/src/components/AdminAgent/AdminAgentButton.tsx
+// 既存 AdminAIChat ボタンは right:88px bottom:24px (z-index:900)
+// 本ボタンは right:24px bottom:24px (z-index:902) で衝突しない
+
+interface AdminAgentButtonProps {
+  onClick: () => void;
+  isOpen: boolean;
+}
+
+export default function AdminAgentButton({ onClick, isOpen }: AdminAgentButtonProps) {
+  return (
+    <button
+      onClick={onClick}
+      aria-label={isOpen ? "AIアシスタントを閉じる" : "AIアシスタントを開く"}
+      style={{
+        position: "fixed",
+        bottom: 24,
+        right: 24,
+        width: 48,
+        height: 48,
+        borderRadius: "50%",
+        border: "none",
+        background: "linear-gradient(135deg, #6366f1, #4f46e5)",
+        color: "#fff",
+        fontSize: 20,
+        cursor: "pointer",
+        boxShadow: "0 4px 20px rgba(99,102,241,0.5)",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        zIndex: 902,
+        transition: "transform 0.15s, box-shadow 0.15s",
+      }}
+      onMouseEnter={(e) => {
+        (e.currentTarget as HTMLButtonElement).style.transform = "scale(1.1)";
+        (e.currentTarget as HTMLButtonElement).style.boxShadow =
+          "0 6px 24px rgba(99,102,241,0.7)";
+      }}
+      onMouseLeave={(e) => {
+        (e.currentTarget as HTMLButtonElement).style.transform = "scale(1)";
+        (e.currentTarget as HTMLButtonElement).style.boxShadow =
+          "0 4px 20px rgba(99,102,241,0.5)";
+      }}
+    >
+      {isOpen ? "✕" : "✨"}
+    </button>
+  );
+}

--- a/admin-ui/src/components/AdminAgent/AdminAgentMessage.tsx
+++ b/admin-ui/src/components/AdminAgent/AdminAgentMessage.tsx
@@ -1,0 +1,89 @@
+// admin-ui/src/components/AdminAgent/AdminAgentMessage.tsx
+import type { AgentMessage } from "./useAdminAgent";
+
+const TOOL_LABEL: Record<string, string> = {
+  list_faqs: "FAQ一覧取得",
+  add_faq: "FAQ追加",
+  update_faq: "FAQ更新",
+  delete_faq: "FAQ削除",
+  list_tenants: "テナント一覧取得",
+  get_tenant: "テナント情報取得",
+  update_tenant: "テナント更新",
+  list_knowledge: "ナレッジ一覧取得",
+  add_knowledge: "ナレッジ追加",
+};
+
+function toolLabel(tool: string): string {
+  return TOOL_LABEL[tool] ?? tool;
+}
+
+interface AdminAgentMessageProps {
+  message: AgentMessage;
+}
+
+export default function AdminAgentMessage({ message }: AdminAgentMessageProps) {
+  const isUser = message.role === "user";
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        justifyContent: isUser ? "flex-end" : "flex-start",
+        flexDirection: "column",
+        alignItems: isUser ? "flex-end" : "flex-start",
+        gap: 4,
+      }}
+    >
+      {/* メッセージ本文 */}
+      <div
+        style={{
+          maxWidth: "85%",
+          padding: "9px 13px",
+          borderRadius: isUser ? "12px 12px 4px 12px" : "12px 12px 12px 4px",
+          background: isUser
+            ? "rgba(99,102,241,0.15)"
+            : "var(--card, rgba(30,41,59,0.9))",
+          border: isUser ? "1px solid rgba(99,102,241,0.3)" : "1px solid rgba(255,255,255,0.08)",
+          color: "var(--foreground, #f9fafb)",
+          fontSize: 14,
+          lineHeight: 1.6,
+          whiteSpace: "pre-wrap",
+          wordBreak: "break-word",
+          textAlign: "left",
+        }}
+      >
+        {message.content}
+      </div>
+
+      {/* アクションバブル */}
+      {message.actions && message.actions.length > 0 && (
+        <div
+          style={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 4,
+            maxWidth: "85%",
+          }}
+        >
+          {message.actions.map((action, i) => (
+            <div
+              key={i}
+              style={{
+                padding: "5px 10px",
+                borderRadius: 8,
+                background: "rgba(16,185,129,0.1)",
+                border: "1px solid rgba(16,185,129,0.2)",
+                color: "rgba(209,250,229,0.85)",
+                fontSize: 12,
+                lineHeight: 1.5,
+                wordBreak: "break-word",
+              }}
+            >
+              {"✅"} {toolLabel(action.tool)}: {action.result}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/admin-ui/src/components/AdminAgent/AdminAgentPanel.tsx
+++ b/admin-ui/src/components/AdminAgent/AdminAgentPanel.tsx
@@ -1,0 +1,227 @@
+// admin-ui/src/components/AdminAgent/AdminAgentPanel.tsx
+import { useRef, useEffect, useState, useCallback } from "react";
+import { useAdminAgent } from "./useAdminAgent";
+import AdminAgentMessage from "./AdminAgentMessage";
+
+interface AdminAgentPanelProps {
+  isOpen: boolean;
+  onClose: () => void;
+  tenantId: string | null;
+  isSuperAdmin: boolean;
+}
+
+const INITIAL_MESSAGE = "こんにちは！設定の変更やFAQの追加など、何でもお手伝いします。";
+
+export default function AdminAgentPanel({
+  isOpen,
+  onClose,
+  tenantId,
+  isSuperAdmin,
+}: AdminAgentPanelProps) {
+  const { messages, isLoading, sendMessage } = useAdminAgent();
+  const [input, setInput] = useState("");
+  const [isComposing, setIsComposing] = useState(false);
+  const bottomRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  // 最新メッセージへ自動スクロール
+  useEffect(() => {
+    if (isOpen) bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, isOpen]);
+
+  // パネルが開いたら入力欄にフォーカス
+  useEffect(() => {
+    if (isOpen) {
+      setTimeout(() => inputRef.current?.focus(), 50);
+    }
+  }, [isOpen]);
+
+  const handleSend = useCallback(async () => {
+    const text = input.trim();
+    if (!text || isLoading) return;
+    setInput("");
+    // super_admin のみ targetTenantId を送る
+    const targetTenantId = isSuperAdmin ? (tenantId ?? undefined) : undefined;
+    await sendMessage(text, targetTenantId);
+    setTimeout(() => inputRef.current?.focus(), 50);
+  }, [input, isLoading, isSuperAdmin, tenantId, sendMessage]);
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (
+      e.key === "Enter" &&
+      !e.shiftKey &&
+      !e.nativeEvent.isComposing &&
+      !isComposing &&
+      e.nativeEvent.keyCode !== 229
+    ) {
+      e.preventDefault();
+      void handleSend();
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        bottom: 80,
+        right: 24,
+        width: 380,
+        height: 600,
+        borderRadius: 16,
+        border: "1px solid rgba(255,255,255,0.08)",
+        background: "rgba(15,23,42,0.98)",
+        backdropFilter: "blur(12px)",
+        display: "flex",
+        flexDirection: "column",
+        zIndex: 902,
+        boxShadow: "0 8px 40px rgba(0,0,0,0.5)",
+        overflow: "hidden",
+        // モバイル 390px 対応: 画面幅が狭い場合は width を調整
+        maxWidth: "calc(100vw - 32px)",
+      }}
+    >
+      {/* ヘッダー */}
+      <div
+        style={{
+          padding: "12px 16px",
+          borderBottom: "1px solid rgba(255,255,255,0.08)",
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          flexShrink: 0,
+        }}
+      >
+        <span style={{ fontSize: 18 }}>{"✨"}</span>
+        <div style={{ flex: 1 }}>
+          <div style={{ fontSize: 14, fontWeight: 700, color: "#f9fafb" }}>
+            R2C AIアシスタント
+          </div>
+        </div>
+        <button
+          onClick={onClose}
+          aria-label="閉じる"
+          style={{
+            background: "none",
+            border: "none",
+            color: "#6b7280",
+            fontSize: 18,
+            cursor: "pointer",
+            padding: 4,
+            minHeight: 44,
+            minWidth: 44,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            borderRadius: 8,
+          }}
+        >
+          {"✕"}
+        </button>
+      </div>
+
+      {/* メッセージエリア */}
+      <div
+        style={{
+          flex: 1,
+          overflowY: "auto",
+          padding: "12px 14px",
+          display: "flex",
+          flexDirection: "column",
+          gap: 10,
+        }}
+      >
+        {/* 初期メッセージ */}
+        <AdminAgentMessage
+          message={{ role: "assistant", content: INITIAL_MESSAGE }}
+        />
+
+        {messages.map((msg, i) => (
+          <AdminAgentMessage key={i} message={msg} />
+        ))}
+
+        {isLoading && (
+          <div style={{ display: "flex", justifyContent: "flex-start" }}>
+            <div
+              style={{
+                padding: "9px 13px",
+                borderRadius: "12px 12px 12px 4px",
+                background: "var(--card, rgba(30,41,59,0.9))",
+                border: "1px solid rgba(255,255,255,0.08)",
+                color: "#9ca3af",
+                fontSize: 14,
+              }}
+            >
+              考え中...
+            </div>
+          </div>
+        )}
+        <div ref={bottomRef} />
+      </div>
+
+      {/* 入力エリア */}
+      <div
+        style={{
+          padding: "10px 12px",
+          borderTop: "1px solid rgba(255,255,255,0.08)",
+          display: "flex",
+          gap: 8,
+          alignItems: "flex-end",
+          flexShrink: 0,
+        }}
+      >
+        <textarea
+          ref={inputRef}
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          onCompositionStart={() => setIsComposing(true)}
+          onCompositionEnd={() => setIsComposing(false)}
+          placeholder="質問を入力… (Enterで送信、Shift+Enterで改行)"
+          rows={1}
+          disabled={isLoading}
+          style={{
+            flex: 1,
+            resize: "none",
+            background: "rgba(30,41,59,0.8)",
+            border: "1px solid rgba(255,255,255,0.1)",
+            borderRadius: 10,
+            color: "#f9fafb",
+            fontSize: 14,
+            padding: "10px 12px",
+            outline: "none",
+            fontFamily: "inherit",
+            lineHeight: 1.5,
+            minHeight: 44,
+            maxHeight: 100,
+          }}
+        />
+        <button
+          onClick={() => void handleSend()}
+          disabled={isLoading || !input.trim()}
+          aria-label="送信"
+          style={{
+            minWidth: 44,
+            minHeight: 44,
+            borderRadius: 10,
+            border: "none",
+            background:
+              isLoading || !input.trim()
+                ? "rgba(99,102,241,0.3)"
+                : "linear-gradient(135deg, #6366f1, #4f46e5)",
+            color: "#fff",
+            fontSize: 18,
+            cursor: isLoading || !input.trim() ? "not-allowed" : "pointer",
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            flexShrink: 0,
+          }}
+        >
+          {"↑"}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/admin-ui/src/components/AdminAgent/useAdminAgent.ts
+++ b/admin-ui/src/components/AdminAgent/useAdminAgent.ts
@@ -1,0 +1,96 @@
+// admin-ui/src/components/AdminAgent/useAdminAgent.ts
+import { useState, useCallback } from "react";
+import { authFetch, API_BASE } from "../../lib/api";
+
+export interface AgentMessage {
+  role: "user" | "assistant";
+  content: string;
+  actions?: { tool: string; result: string }[];
+  needsConfirmation?: boolean;
+}
+
+interface UseAdminAgentResult {
+  messages: AgentMessage[];
+  isOpen: boolean;
+  isLoading: boolean;
+  sessionId: string;
+  setIsOpen: (open: boolean) => void;
+  sendMessage: (text: string, targetTenantId?: string) => Promise<void>;
+}
+
+export function useAdminAgent(): UseAdminAgentResult {
+  const [messages, setMessages] = useState<AgentMessage[]>([]);
+  const [isOpen, setIsOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  // セッションIDはコンポーネントのライフタイム中に一度だけ生成
+  const [sessionId] = useState<string>(() => crypto.randomUUID());
+
+  const sendMessage = useCallback(async (text: string, targetTenantId?: string) => {
+    if (!text.trim() || isLoading) return;
+
+    // optimistic にユーザーメッセージを追加
+    setMessages((prev) => [...prev, { role: "user", content: text }]);
+    setIsLoading(true);
+
+    try {
+      const body: { message: string; sessionId: string; targetTenantId?: string } = {
+        message: text,
+        sessionId,
+      };
+      if (targetTenantId) {
+        body.targetTenantId = targetTenantId;
+      }
+
+      const res = await authFetch(`${API_BASE}/v1/admin/agent/chat`, {
+        method: "POST",
+        body: JSON.stringify(body),
+      });
+
+      if (!res.ok) {
+        setMessages((prev) => [
+          ...prev,
+          {
+            role: "assistant",
+            content: "うまく送信できませんでした。少し時間をおいてお試しください。",
+            actions: [],
+          },
+        ]);
+        return;
+      }
+
+      const data = (await res.json()) as {
+        reply: string;
+        actions: { tool: string; result: string }[];
+      };
+
+      setMessages((prev) => [
+        ...prev,
+        {
+          role: "assistant",
+          content: data.reply,
+          actions: data.actions,
+        },
+      ]);
+    } catch {
+      setMessages((prev) => [
+        ...prev,
+        {
+          role: "assistant",
+          content: "うまく送信できませんでした。少し時間をおいてお試しください。",
+          actions: [],
+        },
+      ]);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [isLoading, sessionId]);
+
+  return {
+    messages,
+    isOpen,
+    isLoading,
+    sessionId,
+    setIsOpen,
+    sendMessage,
+  };
+}

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -1,0 +1,358 @@
+// src/api/admin/agent/actionExecutor.ts
+// Phase B-Admin: 10ツールのアクション実行（tenantId は引数固定 — body禁止）
+
+import { Pool, PoolClient } from 'pg';
+import { logger } from '../../../lib/logger';
+import {
+  insertEmbeddingAsync,
+  upsertToEsAsync,
+} from '../knowledge/faqCrudRoutes';
+
+// ---------------------------------------------------------------------------
+// Avatar activate（avatar/routes.ts は無改変、ここで再実装）
+// ---------------------------------------------------------------------------
+
+export async function activateAvatarConfig(
+  client: PoolClient,
+  id: string,
+  tenantId: string
+): Promise<{ ok: boolean; error?: string }> {
+  try {
+    await client.query('BEGIN');
+
+    // 全て deactivate
+    await client.query(
+      'UPDATE avatar_configs SET is_active = false WHERE tenant_id = $1',
+      [tenantId]
+    );
+
+    // 対象を activate
+    const result = await client.query(
+      'UPDATE avatar_configs SET is_active = true WHERE id = $1 AND tenant_id = $2 RETURNING id',
+      [id, tenantId]
+    );
+
+    if (result.rows.length === 0) {
+      await client.query('ROLLBACK');
+      return { ok: false, error: '設定が見つかりません' };
+    }
+
+    // tenants.features.avatar を true に同期
+    await client.query(
+      "UPDATE tenants SET features = jsonb_set(COALESCE(features, '{}'), '{avatar}', 'true') WHERE id = $1",
+      [tenantId]
+    );
+
+    await client.query('COMMIT');
+    return { ok: true };
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw err;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// メインエントリ
+// ---------------------------------------------------------------------------
+
+export async function executeToolCall(
+  toolName: string,
+  args: Record<string, unknown>,
+  tenantId: string,
+  db: Pool
+): Promise<string> {
+  // 結果は500字以内日本語
+  const truncate = (s: string) => s.slice(0, 500);
+
+  switch (toolName) {
+    // -----------------------------------------------------------------------
+    case 'get_tenant_settings': {
+      try {
+        const result = await db.query(
+          'SELECT ga4_measurement_id, posthog_host, widget_theme FROM tenants WHERE id = $1',
+          [tenantId]
+        );
+        if (result.rows.length === 0) {
+          return truncate('テナント設定が見つかりません');
+        }
+        const row = result.rows[0] as {
+          ga4_measurement_id: string | null;
+          posthog_host: string | null;
+          widget_theme: Record<string, unknown> | null;
+        };
+        return truncate(
+          `現在の設定:\n` +
+          `• GA4 Measurement ID: ${row.ga4_measurement_id ?? '未設定'}\n` +
+          `• PostHog ホスト: ${row.posthog_host ?? '未設定'}\n` +
+          `• ウィジェットテーマ: ${JSON.stringify(row.widget_theme ?? {})}`
+        );
+      } catch (err) {
+        logger.warn('[actionExecutor] get_tenant_settings failed', err);
+        return truncate('設定の取得に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    case 'set_ga4_id': {
+      const measurementId = String(args['measurement_id'] ?? '');
+      if (!/^G-[A-Z0-9]+$/.test(measurementId)) {
+        return truncate(`GA4 Measurement ID の形式が不正です。G-XXXX形式で指定してください（例: G-ABC123）`);
+      }
+      try {
+        await db.query(
+          'UPDATE tenants SET ga4_measurement_id = $1 WHERE id = $2',
+          [measurementId, tenantId]
+        );
+        return truncate(`GA4 Measurement ID を ${measurementId} に設定しました`);
+      } catch (err) {
+        logger.warn('[actionExecutor] set_ga4_id failed', err);
+        return truncate('GA4 ID の設定に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    case 'set_posthog': {
+      const host = String(args['host'] ?? '');
+      if (!host.startsWith('http')) {
+        return truncate('PostHog ホスト URL は http:// または https:// で始まる必要があります');
+      }
+      try {
+        await db.query(
+          'UPDATE tenants SET posthog_host = $1 WHERE id = $2',
+          [host, tenantId]
+        );
+        return truncate(`PostHog ホストを ${host} に設定しました`);
+      } catch (err) {
+        logger.warn('[actionExecutor] set_posthog failed', err);
+        return truncate('PostHog ホストの設定に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    case 'get_faq_list': {
+      try {
+        const limit = Math.min(Math.max(Number(args['limit'] ?? 10), 1), 20);
+        const search = typeof args['search'] === 'string' ? args['search'] : undefined;
+
+        const params: unknown[] = [tenantId];
+        let whereClause = 'WHERE tenant_id = $1';
+
+        if (search) {
+          params.push(`%${search}%`);
+          whereClause += ` AND (question ILIKE $${params.length} OR answer ILIKE $${params.length})`;
+        }
+
+        params.push(limit);
+        const result = await db.query(
+          `SELECT id, question, answer FROM faq_docs ${whereClause} ORDER BY created_at DESC LIMIT $${params.length}`,
+          params
+        );
+
+        if (result.rows.length === 0) {
+          return truncate('FAQ が登録されていません');
+        }
+
+        // anti-slop: answer は .slice(0,200) 必須 / console.log で内容出力禁止
+        const lines = (result.rows as { id: number; question: string; answer: string }[])
+          .map((r) => `[${r.id}] ${r.question} — ${r.answer.slice(0, 200)}`);
+        return truncate(`FAQ 一覧（${result.rows.length}件）:\n` + lines.join('\n'));
+      } catch (err) {
+        logger.warn('[actionExecutor] get_faq_list failed', err);
+        return truncate('FAQ 一覧の取得に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    case 'add_faq': {
+      const question = String(args['question'] ?? '').slice(0, 500);
+      const answer = String(args['answer'] ?? '').slice(0, 2000);
+      const category = typeof args['category'] === 'string' ? args['category'] : null;
+
+      if (!question || !answer) {
+        return truncate('question と answer は必須です');
+      }
+
+      try {
+        const result = await db.query(
+          `INSERT INTO faq_docs (tenant_id, question, answer, category, is_published)
+           VALUES ($1, $2, $3, $4, true)
+           RETURNING id, question, answer, is_published`,
+          [tenantId, question, answer, category]
+        );
+        const row = result.rows[0] as { id: number; question: string; answer: string; is_published: boolean };
+
+        // embedding / ES 同期（fire-and-forget）
+        insertEmbeddingAsync(db, tenantId, `${row.question}\n${row.answer}`, row.id, {
+          source: 'admin_agent',
+          faq_id: row.id,
+        });
+        upsertToEsAsync(tenantId, row.id, row.question, row.answer, row.is_published);
+
+        return truncate(`FAQ を追加しました（ID: ${row.id}）: ${row.question}`);
+      } catch (err) {
+        logger.warn('[actionExecutor] add_faq failed', err);
+        return truncate('FAQ の追加に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    case 'update_faq': {
+      const id = Number(args['id']);
+      const question = String(args['question'] ?? '').slice(0, 500);
+      const answer = String(args['answer'] ?? '').slice(0, 2000);
+
+      if (!Number.isFinite(id) || !question || !answer) {
+        return truncate('id・question・answer は必須です');
+      }
+
+      try {
+        // テナント確認
+        const check = await db.query(
+          'SELECT id, tenant_id FROM faq_docs WHERE id = $1',
+          [id]
+        );
+        if (check.rows.length === 0) {
+          return truncate(`FAQ（ID: ${id}）が見つかりません`);
+        }
+        const existing = check.rows[0] as { tenant_id: string };
+        if (existing.tenant_id !== tenantId) {
+          return truncate('この FAQ へのアクセス権限がありません');
+        }
+
+        const updateResult = await db.query(
+          `UPDATE faq_docs SET question = $1, answer = $2, updated_at = NOW()
+           WHERE id = $3 AND tenant_id = $4
+           RETURNING id, question, answer, is_published`,
+          [question, answer, id, tenantId]
+        );
+        const updated = updateResult.rows[0] as {
+          id: number; question: string; answer: string; is_published: boolean;
+        };
+
+        // 古い embedding 削除 → 再挿入（best-effort）
+        db.query(
+          `DELETE FROM faq_embeddings WHERE tenant_id = $1 AND (metadata->>'faq_id')::bigint = $2`,
+          [tenantId, id]
+        ).catch(() => {});
+        insertEmbeddingAsync(db, tenantId, `${updated.question}\n${updated.answer}`, updated.id, {
+          source: 'admin_agent',
+          faq_id: updated.id,
+        });
+        upsertToEsAsync(tenantId, updated.id, updated.question, updated.answer, updated.is_published);
+
+        return truncate(`FAQ（ID: ${id}）を更新しました: ${updated.question}`);
+      } catch (err) {
+        logger.warn('[actionExecutor] update_faq failed', err);
+        return truncate('FAQ の更新に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    case 'delete_faq': {
+      const id = Number(args['id']);
+      const confirmed = Boolean(args['confirmed']);
+
+      if (!confirmed) {
+        return truncate(`FAQ（ID: ${id}）の削除には確認が必要です。confirmed=true を指定して再度実行してください`);
+      }
+
+      if (!Number.isFinite(id)) {
+        return truncate('id が不正です');
+      }
+
+      try {
+        const check = await db.query(
+          'SELECT id, tenant_id, question FROM faq_docs WHERE id = $1',
+          [id]
+        );
+        if (check.rows.length === 0) {
+          return truncate(`FAQ（ID: ${id}）が見つかりません`);
+        }
+        const existing = check.rows[0] as { tenant_id: string; question: string };
+        if (existing.tenant_id !== tenantId) {
+          return truncate('この FAQ へのアクセス権限がありません');
+        }
+
+        await db.query(
+          `DELETE FROM faq_embeddings WHERE tenant_id = $1 AND (metadata->>'faq_id')::bigint = $2`,
+          [tenantId, id]
+        );
+        await db.query('DELETE FROM faq_docs WHERE id = $1 AND tenant_id = $2', [id, tenantId]);
+
+        return truncate(`FAQ（ID: ${id}）を削除しました`);
+      } catch (err) {
+        logger.warn('[actionExecutor] delete_faq failed', err);
+        return truncate('FAQ の削除に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    case 'activate_avatar': {
+      const id = String(args['id'] ?? '');
+      if (!id) {
+        return truncate('id は必須です');
+      }
+
+      const client = await db.connect();
+      try {
+        const res = await activateAvatarConfig(client, id, tenantId);
+        if (!res.ok) {
+          return truncate(`アバターの有効化に失敗しました: ${res.error ?? '不明なエラー'}`);
+        }
+        return truncate(`アバター（ID: ${id}）を有効化しました`);
+      } catch (err) {
+        logger.warn('[actionExecutor] activate_avatar failed', err);
+        return truncate('アバターの有効化に失敗しました');
+      } finally {
+        client.release();
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    case 'get_embed_code': {
+      try {
+        // 平文 API キーは保存されていないため key_prefix のみ返す
+        const result = await db.query(
+          'SELECT key_prefix FROM tenant_api_keys WHERE tenant_id = $1 ORDER BY created_at DESC LIMIT 1',
+          [tenantId]
+        );
+        const keyPrefix: string = result.rows.length > 0
+          ? String((result.rows[0] as { key_prefix: string }).key_prefix)
+          : '（キー未発行）';
+
+        return truncate(
+          `ウィジェット埋め込みコードのひな形:\n\n` +
+          `<script src="https://api.r2c.biz/widget.js" data-api-key="YOUR_API_KEY"></script>\n\n` +
+          `現在のAPIキー先頭: ${keyPrefix}...\n` +
+          `※ 実際のAPIキーは発行時のみ表示されます。再確認が必要な場合は新しいキーを発行してください`
+        );
+      } catch (err) {
+        logger.warn('[actionExecutor] get_embed_code failed', err);
+        return truncate('埋め込みコードの取得に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    case 'set_widget_theme': {
+      const theme = args['theme'];
+      if (typeof theme !== 'object' || theme === null || Array.isArray(theme)) {
+        return truncate('theme はオブジェクト形式で指定してください（例: {"primaryColor": "#3B82F6"}）');
+      }
+
+      try {
+        await db.query(
+          `UPDATE tenants SET widget_theme = COALESCE(widget_theme, '{}') || $1::jsonb WHERE id = $2`,
+          [JSON.stringify(theme), tenantId]
+        );
+        return truncate(`ウィジェットテーマを更新しました: ${JSON.stringify(theme)}`);
+      } catch (err) {
+        logger.warn('[actionExecutor] set_widget_theme failed', err);
+        return truncate('ウィジェットテーマの更新に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    default:
+      return truncate(`不明なツール: ${toolName}`);
+  }
+}

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -1,0 +1,274 @@
+// src/api/admin/agent/agentRoutes.test.ts
+// Phase B-Admin: admin agent chat route テスト
+
+import express from 'express';
+import request from 'supertest';
+
+// ---------------------------------------------------------------------------
+// モック（副作用 no-op — Gate1 OOM 回避）
+// ---------------------------------------------------------------------------
+
+// supabaseAuthMiddleware: JWT 検証をスキップし req.supabaseUser を注入するモックに置換
+jest.mock('../../../admin/http/supabaseAuthMiddleware', () => ({
+  supabaseAuthMiddleware: (req: any, _res: any, next: any) => {
+    // テストごとにオーバーライド可能にするため req.__mockUser を参照
+    req.supabaseUser = req.__mockUser ?? undefined;
+    next();
+  },
+}));
+
+// db（Pool）モック
+const mockQuery = jest.fn();
+const mockConnect = jest.fn();
+const mockDb = {
+  query: mockQuery,
+  connect: mockConnect,
+} as any;
+
+// Groq fetch モック
+const mockFetch = jest.fn();
+global.fetch = mockFetch as any;
+
+// embedding / ES（fire-and-forget）をモック — 副作用 no-op
+jest.mock('../knowledge/faqCrudRoutes', () => ({
+  insertEmbeddingAsync: jest.fn(),
+  upsertToEsAsync: jest.fn(),
+}));
+
+// logger モック
+jest.mock('../../../lib/logger', () => ({
+  logger: { warn: jest.fn(), info: jest.fn(), error: jest.fn() },
+}));
+
+// ---------------------------------------------------------------------------
+// テスト対象を import
+// ---------------------------------------------------------------------------
+
+import { registerAdminAgentRoutes } from './agentRoutes';
+
+// ---------------------------------------------------------------------------
+// ヘルパー
+// ---------------------------------------------------------------------------
+
+function makeApp(mockUser?: Record<string, any> | undefined) {
+  const app = express();
+  app.use(express.json());
+
+  // テスト用: req.__mockUser を注入する前段ミドルウェア
+  app.use((req: any, _res: any, next: any) => {
+    req.__mockUser = mockUser;
+    next();
+  });
+
+  registerAdminAgentRoutes(app, mockDb);
+  return app;
+}
+
+const CLIENT_ADMIN_USER = {
+  app_metadata: { role: 'client_admin', tenant_id: 'tenant-abc' },
+};
+
+const SUPER_ADMIN_USER = {
+  app_metadata: { role: 'super_admin', tenant_id: '' },
+};
+
+function makeGroqResponse(content: string, tool_calls: any[] = []) {
+  return {
+    ok: true,
+    json: async () => ({
+      choices: [
+        {
+          message: {
+            content,
+            tool_calls,
+          },
+        },
+      ],
+    }),
+    text: async () => content,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// テストスイート
+// ---------------------------------------------------------------------------
+
+describe('POST /v1/admin/agent/chat', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.GROQ_API_KEY = 'test-groq-key';
+  });
+
+  // -------------------------------------------------------------------------
+  // 正常系: client_admin → 200 {reply, actions}（Groq fetch モック）
+  // -------------------------------------------------------------------------
+  describe('正常系: client_admin', () => {
+    it('tool_calls なし → reply と空の actions を返す', async () => {
+      mockFetch.mockResolvedValueOnce(makeGroqResponse('設定を確認しました。'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'GA4の設定を教えて', sessionId: 'sess-001' });
+
+      expect(res.status).toBe(200);
+      expect(res.body).toHaveProperty('reply');
+      expect(res.body).toHaveProperty('actions');
+      expect(Array.isArray(res.body.actions)).toBe(true);
+    });
+
+    it('tool_calls あり → executeToolCall の結果を actions に含む', async () => {
+      // 第1回: tool_call を返す
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            choices: [
+              {
+                message: {
+                  content: null,
+                  tool_calls: [
+                    {
+                      id: 'call-001',
+                      type: 'function',
+                      function: {
+                        name: 'get_tenant_settings',
+                        arguments: '{}',
+                      },
+                    },
+                  ],
+                },
+              },
+            ],
+          }),
+          text: async () => '',
+        })
+        // 第2回: final reply
+        .mockResolvedValueOnce(makeGroqResponse('GA4は未設定です。'));
+
+      // get_tenant_settings の DB クエリ結果
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ ga4_measurement_id: null, posthog_host: 'https://app.posthog.com', widget_theme: {} }],
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '設定を確認して', sessionId: 'sess-002' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions.length).toBe(1);
+      expect(res.body.actions[0].tool).toBe('get_tenant_settings');
+      expect(typeof res.body.actions[0].result).toBe('string');
+      expect(res.body).toHaveProperty('reply');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 認証エラー: supabaseUser なし → 403
+  // -------------------------------------------------------------------------
+  describe('認証エラー', () => {
+    it('supabaseUser なし → 403', async () => {
+      const res = await request(makeApp(undefined))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'hello', sessionId: 'sess-003' });
+
+      expect(res.status).toBe(403);
+    });
+
+    it('role が不正（viewer）→ 403', async () => {
+      const res = await request(makeApp({ app_metadata: { role: 'viewer', tenant_id: 'tenant-abc' } }))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'hello', sessionId: 'sess-004' });
+
+      expect(res.status).toBe(403);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // バリデーション: message 空 → 400
+  // -------------------------------------------------------------------------
+  describe('バリデーション', () => {
+    it('message が空文字列 → 400', async () => {
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '', sessionId: 'sess-005' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('invalid_request');
+    });
+
+    it('message が 2001 字 → 400', async () => {
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'a'.repeat(2001), sessionId: 'sess-006' });
+
+      expect(res.status).toBe(400);
+    });
+
+    it('sessionId が欠落 → 400', async () => {
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'hello' });
+
+      expect(res.status).toBe(400);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // tenantId 分離: body に別 tenantId を入れても JWT 由来が使われる
+  // -------------------------------------------------------------------------
+  describe('tenantId 分離', () => {
+    it('client_admin: body の targetTenantId は無視され JWT 由来テナント "tenant-abc" が使われる', async () => {
+      mockFetch.mockResolvedValueOnce(makeGroqResponse('こんにちは'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({
+          message: '設定を確認して',
+          sessionId: 'sess-007',
+          targetTenantId: 'evil-tenant-override', // body に悪意ある tenant_id
+        });
+
+      // 200 は返るが、実際に使われる tenantId は "tenant-abc"（JWT 由来）
+      // Groq に渡る systemPrompt に "tenant-abc" が含まれることを fetch の呼び出し引数で確認
+      expect(res.status).toBe(200);
+      const fetchCallBody = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+      const systemMessage = fetchCallBody.messages.find((m: any) => m.role === 'system');
+      expect(systemMessage?.content).toContain('tenant-abc');
+      expect(systemMessage?.content).not.toContain('evil-tenant-override');
+    });
+
+    it('super_admin: targetTenantId を指定すると effectiveTenantId として使われる', async () => {
+      mockFetch.mockResolvedValueOnce(makeGroqResponse('こんにちは'));
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({
+          message: '設定を確認して',
+          sessionId: 'sess-008',
+          targetTenantId: 'tenant-target',
+        });
+
+      expect(res.status).toBe(200);
+      const fetchCallBody = JSON.parse(mockFetch.mock.calls[0][1].body as string);
+      const systemMessage = fetchCallBody.messages.find((m: any) => m.role === 'system');
+      expect(systemMessage?.content).toContain('tenant-target');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GROQ_API_KEY 未設定 → グレースフルダウングレード
+  // -------------------------------------------------------------------------
+  describe('GROQ_API_KEY 未設定', () => {
+    it('GROQ_API_KEY なし → 200 AIアシスタントは現在利用できません', async () => {
+      delete process.env.GROQ_API_KEY;
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'hello', sessionId: 'sess-009' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.reply).toBe('AIアシスタントは現在利用できません');
+      expect(res.body.actions).toEqual([]);
+    });
+  });
+});

--- a/src/api/admin/agent/agentRoutes.ts
+++ b/src/api/admin/agent/agentRoutes.ts
@@ -1,0 +1,222 @@
+// src/api/admin/agent/agentRoutes.ts
+// Phase B-Admin: POST /v1/admin/agent/chat
+
+import type { Express, Request, Response } from 'express';
+import { Pool } from 'pg';
+import { z } from 'zod';
+import { supabaseAuthMiddleware } from '../../../admin/http/supabaseAuthMiddleware';
+import { logger } from '../../../lib/logger';
+import { ADMIN_AGENT_TOOLS } from './toolDefinitions';
+import { executeToolCall } from './actionExecutor';
+
+// ---------------------------------------------------------------------------
+// Auth helper（options/routes.ts と同パターンのローカル定義）
+// ---------------------------------------------------------------------------
+
+function extractAuth(req: Request) {
+  const su = (req as any).supabaseUser as Record<string, any> | undefined;
+  const role = su?.app_metadata?.role;
+  const tenantId: string = su?.app_metadata?.tenant_id ?? su?.tenant_id ?? '';
+  const isSuperAdmin: boolean = role === 'super_admin';
+  return { su, role, tenantId, isSuperAdmin };
+}
+
+// ---------------------------------------------------------------------------
+// Zod スキーマ
+// ---------------------------------------------------------------------------
+
+const chatSchema = z.object({
+  message: z.string().min(1).max(2000),
+  sessionId: z.string().min(1).max(100),
+  targetTenantId: z.string().optional(),
+});
+
+// ---------------------------------------------------------------------------
+// Groq function calling 呼び出し（tools 付き）
+// ---------------------------------------------------------------------------
+
+interface GroqMessage {
+  role: 'system' | 'user' | 'assistant' | 'tool';
+  content: string | null;
+  tool_calls?: GroqToolCall[];
+  tool_call_id?: string;
+  name?: string;
+}
+
+interface GroqToolCall {
+  id: string;
+  type: 'function';
+  function: {
+    name: string;
+    arguments: string;
+  };
+}
+
+async function callGroqWithTools(
+  messages: GroqMessage[],
+  tools: typeof ADMIN_AGENT_TOOLS
+): Promise<{ content: string | null; tool_calls: GroqToolCall[] }> {
+  const apiKey = process.env.GROQ_API_KEY?.trim();
+  if (!apiKey) throw new Error('GROQ_API_KEY not configured');
+
+  const res = await fetch('https://api.groq.com/openai/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: 'llama-3.3-70b-versatile',
+      messages,
+      tools,
+      tool_choice: 'auto',
+      max_tokens: 1024,
+      temperature: 0.2,
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Groq API error ${res.status}: ${text.slice(0, 200)}`);
+  }
+
+  const data = (await res.json()) as any;
+  const choice = data.choices?.[0];
+  return {
+    content: choice?.message?.content ?? null,
+    tool_calls: choice?.message?.tool_calls ?? [],
+  };
+}
+
+async function callGroqFinal(messages: GroqMessage[]): Promise<string> {
+  const apiKey = process.env.GROQ_API_KEY?.trim();
+  if (!apiKey) throw new Error('GROQ_API_KEY not configured');
+
+  const res = await fetch('https://api.groq.com/openai/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model: 'llama-3.3-70b-versatile',
+      messages,
+      max_tokens: 512,
+      temperature: 0.2,
+    }),
+  });
+
+  if (!res.ok) {
+    const text = await res.text();
+    throw new Error(`Groq API error ${res.status}: ${text.slice(0, 200)}`);
+  }
+
+  const data = (await res.json()) as any;
+  return data.choices?.[0]?.message?.content?.trim() ?? '';
+}
+
+// ---------------------------------------------------------------------------
+// ルート登録
+// ---------------------------------------------------------------------------
+
+export function registerAdminAgentRoutes(app: Express, db: Pool): void {
+  app.use('/v1/admin/agent', supabaseAuthMiddleware);
+
+  app.post('/v1/admin/agent/chat', async (req: Request, res: Response) => {
+    const { role, tenantId, isSuperAdmin } = extractAuth(req);
+
+    // ロールチェック
+    if (role !== 'super_admin' && role !== 'client_admin') {
+      return res.status(403).json({ error: 'この操作を実行する権限がありません' });
+    }
+
+    // バリデーション
+    const parsed = chatSchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      return res.status(400).json({ error: 'invalid_request', details: parsed.error.issues });
+    }
+
+    const { message, sessionId, targetTenantId } = parsed.data;
+
+    // effectiveTenantId: super_admin は targetTenantId を使用可、client_admin は JWT 由来のみ
+    const effectiveTenantId = isSuperAdmin ? (targetTenantId ?? tenantId) : tenantId;
+
+    if (!isSuperAdmin && !effectiveTenantId) {
+      return res.status(403).json({ error: 'テナント情報が取得できません' });
+    }
+
+    // GROQ_API_KEY 未設定の場合はグレースフルダウングレード
+    if (!process.env.GROQ_API_KEY?.trim()) {
+      return res.status(200).json({
+        reply: 'AIアシスタントは現在利用できません',
+        actions: [],
+      });
+    }
+
+    try {
+      const systemPrompt =
+        `あなたはテナント管理AIエージェントです。テナントID "${effectiveTenantId}" の管理者をサポートします。` +
+        `必要に応じてツールを呼び出して設定を確認・変更してください。回答は日本語で簡潔に行ってください。` +
+        `セッションID: ${sessionId}`;
+
+      const messages: GroqMessage[] = [
+        { role: 'system', content: systemPrompt },
+        { role: 'user', content: message },
+      ];
+
+      // 第1回 Groq 呼び出し（tool_calls あり）
+      const firstResponse = await callGroqWithTools(messages, ADMIN_AGENT_TOOLS);
+
+      const actions: Array<{ tool: string; result: string }> = [];
+
+      if (firstResponse.tool_calls.length > 0) {
+        // アシスタントメッセージをコンテキストに追加
+        messages.push({
+          role: 'assistant',
+          content: firstResponse.content,
+          tool_calls: firstResponse.tool_calls,
+        });
+
+        // tool_calls を順次実行
+        for (const toolCall of firstResponse.tool_calls) {
+          let toolArgs: Record<string, unknown> = {};
+          try {
+            toolArgs = JSON.parse(toolCall.function.arguments);
+          } catch {
+            toolArgs = {};
+          }
+
+          const result = await executeToolCall(
+            toolCall.function.name,
+            toolArgs,
+            effectiveTenantId,
+            db
+          );
+
+          actions.push({ tool: toolCall.function.name, result });
+
+          // tool 結果をコンテキストに追加
+          messages.push({
+            role: 'tool',
+            tool_call_id: toolCall.id,
+            name: toolCall.function.name,
+            content: result,
+          });
+        }
+
+        // 第2回 Groq 呼び出し（最終 reply）
+        const finalReply = await callGroqFinal(messages);
+        return res.json({ reply: finalReply, actions });
+      }
+
+      // tool_calls がなかった場合はそのまま返す
+      return res.json({
+        reply: firstResponse.content ?? '回答を生成できませんでした',
+        actions: [],
+      });
+    } catch (err) {
+      logger.warn('[POST /v1/admin/agent/chat]', err);
+      return res.status(500).json({ error: 'AIエージェントの応答生成に失敗しました' });
+    }
+  });
+}

--- a/src/api/admin/agent/migration_admin_agent_columns.sql
+++ b/src/api/admin/agent/migration_admin_agent_columns.sql
@@ -1,0 +1,8 @@
+-- Phase B-Admin: AIエージェントが操作するカラム追加（人間承認・SSHトンネル経由で手動実行）
+ALTER TABLE tenants
+  ADD COLUMN IF NOT EXISTS ga4_measurement_id TEXT,
+  ADD COLUMN IF NOT EXISTS posthog_host        TEXT DEFAULT 'https://app.posthog.com',
+  ADD COLUMN IF NOT EXISTS widget_theme        JSONB DEFAULT '{}'::jsonb;
+COMMENT ON COLUMN tenants.ga4_measurement_id IS 'GA4 Measurement ID (G-XXXX形式)';
+COMMENT ON COLUMN tenants.posthog_host IS 'PostHog ホスト URL';
+COMMENT ON COLUMN tenants.widget_theme IS 'ウィジェットテーマ (JSONB merge)';

--- a/src/api/admin/agent/toolDefinitions.ts
+++ b/src/api/admin/agent/toolDefinitions.ts
@@ -1,0 +1,204 @@
+// src/api/admin/agent/toolDefinitions.ts
+// Phase B-Admin: AIエージェント用ツール定義（Groq function calling 形式）
+
+export interface GroqTool {
+  type: 'function';
+  function: {
+    name: string;
+    description: string;
+    parameters: {
+      type: 'object';
+      properties: Record<string, unknown>;
+      required?: string[];
+    };
+  };
+}
+
+export const ADMIN_AGENT_TOOLS: GroqTool[] = [
+  {
+    type: 'function',
+    function: {
+      name: 'get_tenant_settings',
+      description: 'テナントの現在の設定（GA4 Measurement ID、PostHog ホスト、ウィジェットテーマ）を取得する',
+      parameters: {
+        type: 'object',
+        properties: {},
+        required: [],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'set_ga4_id',
+      description: 'テナントの GA4 Measurement ID を設定する。G- で始まる形式（例: G-ABCD1234）のみ有効',
+      parameters: {
+        type: 'object',
+        properties: {
+          measurement_id: {
+            type: 'string',
+            description: 'GA4 Measurement ID（G-XXXX形式）',
+            pattern: '^G-[A-Z0-9]+$',
+          },
+        },
+        required: ['measurement_id'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'set_posthog',
+      description: 'テナントの PostHog ホスト URL を設定する',
+      parameters: {
+        type: 'object',
+        properties: {
+          host: {
+            type: 'string',
+            description: 'PostHog ホスト URL（例: https://app.posthog.com）',
+          },
+        },
+        required: ['host'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'get_faq_list',
+      description: 'テナントの FAQ 一覧を取得する（最大20件）',
+      parameters: {
+        type: 'object',
+        properties: {
+          limit: {
+            type: 'number',
+            description: '取得件数（1〜20、デフォルト10）',
+          },
+          search: {
+            type: 'string',
+            description: '検索キーワード（任意）',
+          },
+        },
+        required: [],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'add_faq',
+      description: '新しい FAQ を追加する',
+      parameters: {
+        type: 'object',
+        properties: {
+          question: {
+            type: 'string',
+            description: '質問文（500字以内）',
+          },
+          answer: {
+            type: 'string',
+            description: '回答文（2000字以内）',
+          },
+          category: {
+            type: 'string',
+            description: 'カテゴリ（inventory / campaign / coupon / store_info のいずれか、任意）',
+            enum: ['inventory', 'campaign', 'coupon', 'store_info'],
+          },
+        },
+        required: ['question', 'answer'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'update_faq',
+      description: '既存の FAQ を更新する',
+      parameters: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'number',
+            description: '更新対象の FAQ ID',
+          },
+          question: {
+            type: 'string',
+            description: '新しい質問文（500字以内）',
+          },
+          answer: {
+            type: 'string',
+            description: '新しい回答文（2000字以内）',
+          },
+        },
+        required: ['id', 'question', 'answer'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'delete_faq',
+      description: '指定した FAQ を削除する。confirmed=true の場合のみ実行される',
+      parameters: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'number',
+            description: '削除対象の FAQ ID',
+          },
+          confirmed: {
+            type: 'boolean',
+            description: '削除確認フラグ（true でのみ実行）',
+          },
+        },
+        required: ['id', 'confirmed'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'activate_avatar',
+      description: '指定した ID のアバター設定を有効化する（他のアバターは自動的に無効化される）',
+      parameters: {
+        type: 'object',
+        properties: {
+          id: {
+            type: 'string',
+            description: '有効化するアバター設定の ID',
+          },
+        },
+        required: ['id'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'get_embed_code',
+      description: 'ウィジェット埋め込みコードのひな形を取得する（APIキーは発行時のみ表示のため、key_prefix のみ表示）',
+      parameters: {
+        type: 'object',
+        properties: {},
+        required: [],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'set_widget_theme',
+      description: 'ウィジェットのテーマ設定（色・フォント等）を JSONB で更新する',
+      parameters: {
+        type: 'object',
+        properties: {
+          theme: {
+            type: 'object',
+            description: 'テーマ設定オブジェクト（例: {"primaryColor": "#3B82F6", "fontFamily": "sans-serif"}）',
+          },
+        },
+        required: ['theme'],
+      },
+    },
+  },
+];

--- a/src/api/admin/knowledge/faqCrudRoutes.ts
+++ b/src/api/admin/knowledge/faqCrudRoutes.ts
@@ -28,7 +28,7 @@ async function deleteFromEs(tenantId: string, esDocId: string): Promise<void> {
 }
 
 /** embedding を非同期で挿入（fire-and-forget） */
-function insertEmbeddingAsync(
+export function insertEmbeddingAsync(
   db: Pool,
   tenantId: string,
   text: string,
@@ -47,7 +47,7 @@ function insertEmbeddingAsync(
 }
 
 /** ESにドキュメントをupsert（fire-and-forget） */
-function upsertToEsAsync(
+export function upsertToEsAsync(
   tenantId: string,
   faqId: number,
   question: string,

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,7 @@ import { registerAbTestRoutes } from "./api/conversion/abTestRoutes";
 import { registerKnowledgeGapPhase46Routes } from "./api/admin/knowledge-gaps/routes";
 import { registerNotificationRoutes } from "./api/admin/notifications/routes";
 import { registerOptionRoutes } from "./api/admin/options/routes";
+import { registerAdminAgentRoutes } from "./api/admin/agent/agentRoutes";
 import { roleAuthMiddleware, requireRole } from "./api/middleware/roleAuth";
 import { hybridSearch } from "./search/hybrid";
 import {
@@ -584,6 +585,9 @@ if (db) registerAvatarConfigRoutes(app, db);
 
 // Phase41: Avatar Customization Studio — 画像生成・声マッチング・プロンプト生成API
 if (db) registerAvatarGenerationRoutes(app, db);
+
+// Phase B-Admin: AIエージェント管理チャット API
+if (db) registerAdminAgentRoutes(app, db);
 
 // Phase64: fal.ai Flux Pro アバター画像生成API
 registerFalGenerationRoutes(app);

--- a/tests/e2e/helpers/gotoRetry.ts
+++ b/tests/e2e/helpers/gotoRetry.ts
@@ -7,11 +7,12 @@ export async function gotoWithRetry(
   page: Page,
   url: string,
   attempts = 3,
+  timeoutMs = 8_000,
 ): Promise<Response | null> {
   let lastError: unknown;
   for (let i = 0; i < attempts; i++) {
     try {
-      return await page.goto(url, { waitUntil: 'domcontentloaded', timeout: 8_000 });
+      return await page.goto(url, { waitUntil: 'domcontentloaded', timeout: timeoutMs });
     } catch (e) {
       lastError = e;
       if (i < attempts - 1) {

--- a/tests/e2e/phase65-demo.spec.ts
+++ b/tests/e2e/phase65-demo.spec.ts
@@ -85,8 +85,9 @@ test.describe('Phase65 carnation-demo サイト', () => {
 
   // test 4b: 旧URL /carnation-demo.html が 301 で新URLへリダイレクトされること
   test('旧URL /carnation-demo.html が /carnation-demo/index.html へリダイレクトされる', async ({ page }) => {
+    test.setTimeout(90_000); // CI runner ↔ VPS の往復が遅い場合に対応: 3 × 25s + backoffs = 78s max
     // Playwrightはリダイレクトを自動追跡するため、最終URLを確認する
-    await gotoWithRetry(page, 'https://api.r2c.biz/carnation-demo.html');
+    await gotoWithRetry(page, 'https://api.r2c.biz/carnation-demo.html', 3, 25_000);
     expect(page.url()).toContain('/carnation-demo/index.html');
     const title = await page.title();
     expect(title).toContain('BROSS新潟');


### PR DESCRIPTION
## 概要
管理画面（admin.r2c.biz）に「何でも頼めるAIアシスタント」を実装。テナント管理者がチャットで指示するだけで GA4設定・FAQ管理・アバター有効化・ウィジェット設定などが自動実行される。Groq function calling（llama-3.3-70b-versatile）を使い、ツール定義→アクション実行の2層構造。

Asana: Phase B-Admin（GID 1215691588421742）

## 実装内容
**バックエンド** `src/api/admin/agent/`
- `agentRoutes.ts` — POST /v1/admin/agent/chat（supabaseAuthMiddleware + role 403ガード + tenant分離）
- `toolDefinitions.ts` — Groq function calling ツール定義10種
- `actionExecutor.ts` — ツール名→DB/API 実行マッパー（10ケース、各 try/catch で result文字列化）
- `agentRoutes.test.ts` — ユニットテスト10ケース
- `knowledge/faqCrudRoutes.ts` — embedding/ES ヘルパーを export 昇格（add_faq/update_faq 再利用）

**フロントエンド** `admin-ui/src/components/AdminAgent/`
- `AdminAgentButton.tsx` / `AdminAgentPanel.tsx` / `AdminAgentMessage.tsx` / `useAdminAgent.ts`
- `App.tsx` 組み込み（既存 AdminAIChat と位置非衝突）

## 自動パイプライン経由
Planner → Generator(backend) → Generator(frontend) → Evaluator(GO) → Tester(PR-READY) の Agent Team で実装。

## Gate 結果
- Gate 1 (pnpm verify): PASS — typecheck 0 / backend 1938 tests / admin-ui 34 tests 全パス
- Gate 1.5 (dead-code): PASS — 新規 export は全て参照あり
- Gate 2 (security-scan): PASS — High/Critical 0
- Gate 3 (build): PASS — backend + admin-ui 両ビルド成功

## ⚠️ マージ前に必要な人間アクション（2点）

### 1. DBカラム追加（不可逆・人間承認必須）
`src/api/admin/agent/migration_admin_agent_columns.sql` を tenants テーブルに適用する必要がある。追加カラム: `ga4_measurement_id` / `posthog_host` / `widget_theme`。これらに依存する4ツール（get_tenant_settings / set_ga4_id / set_posthog / set_widget_theme）はカラム適用後に動作する。他6ツールは適用前でも動作。

### 2. get_embed_code の仕様調整（要確認）
タスク notes は「tenant_api_keys から平文 api_key を取得」を想定していたが、実機では平文キーは保存されておらず `key_prefix`（マスク）と key_hash のみ。よって get_embed_code は埋め込みコードのひな形 + key_prefix（マスク）+「実キーは発行時のみ表示」の注記を返す実装にした。仕様意図と相違ないか確認をお願いします。

## レビュー注記
- Gate 2.5（Codex review）は未実施 — 人間手動で実行をお願いします
- 実機 runtime 検証は DBトンネル不通のため未実施。403分岐・キー不在分岐・tool_calls ループはユニットテストで網羅

🤖 Generated with [Claude Code](https://claude.com/claude-code)
