### PR TITLE
test(avatar): pre-dispatch ON/OFF トグルのテストカバレッジ追加 (#4088)

### DIFF
--- a/src/api/avatar/livekitTokenRoutes.test.ts
+++ b/src/api/avatar/livekitTokenRoutes.test.ts
@@ -327,4 +327,71 @@ describe("POST /api/avatar/room-token", () => {
       expect(createRoomArg.metadata).toBeUndefined();
     });
   });
+
+  describe("pre_dispatch フラグ分岐", () => {
+    it("pre_dispatch=true かつ connect=false → dispatchAgentToRoom が呼ばれ preDispatchEnabled=true", async () => {
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [{ ...TENANT_ROW, features: { avatar: true, pre_dispatch: true } }],
+          rowCount: 1,
+        })
+        .mockResolvedValueOnce({ rows: [] }); // Q3: avatarConfigId 未指定 → fallback
+
+      const app = makeApp("tenant-a");
+      const res = await request(app)
+        .post("/api/avatar/room-token")
+        .send({ connect: false });
+
+      // レスポンス確認
+      expect(res.status).toBe(200);
+      expect(res.body.enabled).toBe(true);
+      expect(res.body.preDispatchEnabled).toBe(true);
+
+      // dispatch が呼ばれていることを確認（fire-and-forget のため Promise 解決を待つ）
+      await new Promise(resolve => setImmediate(resolve));
+      expect(mockCreateDispatch).toHaveBeenCalledTimes(1);
+    });
+
+    it("pre_dispatch=false かつ connect=false → dispatch 呼ばれず preDispatchEnabled=false", async () => {
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [{ ...TENANT_ROW, features: { avatar: true, pre_dispatch: false } }],
+          rowCount: 1,
+        })
+        .mockResolvedValueOnce({ rows: [] }); // Q3 fallback
+
+      const app = makeApp("tenant-a");
+      const res = await request(app)
+        .post("/api/avatar/room-token")
+        .send({ connect: false });
+
+      expect(res.status).toBe(200);
+      expect(res.body.preDispatchEnabled).toBe(false);
+
+      // dispatch が呼ばれていないことを確認
+      await new Promise(resolve => setImmediate(resolve));
+      expect(mockCreateDispatch).toHaveBeenCalledTimes(0);
+    });
+
+    it("features に pre_dispatch キー無し → dispatch スキップ、preDispatchEnabled=false（コスト発生なし）", async () => {
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [{ ...TENANT_ROW, features: { avatar: true } }],
+          rowCount: 1,
+        })
+        .mockResolvedValueOnce({ rows: [] }); // Q3 fallback
+
+      const app = makeApp("tenant-a");
+      const res = await request(app)
+        .post("/api/avatar/room-token")
+        .send({ connect: false });
+
+      expect(res.status).toBe(200);
+      expect(res.body.preDispatchEnabled).toBe(false);
+
+      // pre_dispatch キーが存在しない場合は dispatch を呼ばない（デフォルト安全）
+      await new Promise(resolve => setImmediate(resolve));
+      expect(mockCreateDispatch).toHaveBeenCalledTimes(0);
+    });
+  });
 });


### PR DESCRIPTION
## 概要
アバター事前起動（pre_dispatch）ON/OFF 機能（本体は PR #368 で main マージ済み）の**テストカバレッジを追加**。

Asana: GID 1215687828694088

## 背景
本体実装（tenants.features.pre_dispatch フラグ / livekitTokenRoutes.ts の dispatch 分岐 / AvatarTab トグル / widget.js 遅延接続）は既に main にあるが、pre_dispatch 分岐のテストが未整備だった。

## 追加テスト（src/api/avatar/livekitTokenRoutes.test.ts に3ケース）
1. pre_dispatch=true + connect=false → dispatch 実行・preDispatchEnabled=true
2. pre_dispatch=false + connect=false → dispatch スキップ・preDispatchEnabled=false
3. features に pre_dispatch キー無し → dispatch スキップ・preDispatchEnabled=false（デフォルト安全＝コスト発生なし）

## Gate
- Gate 1 (pnpm verify): PASS — typecheck 0 / 1931 tests
- Gate 3 (build): PASS
- Gate 2 / 2.5: テストコードのみのためスキップ（CLAUDE.md 準拠）

テストコードのみの追加。merge は人間手動。

🤖 Generated with [Claude Code](https://claude.com/claude-code)