### PR TITLE
feat(analytics): State Machine 遷移ログ + フロー分析 (Phase72-C)

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -28,6 +28,7 @@ import BooksPage from "./pages/admin/knowledge/books";
 import KnowledgeAnalyticsPage from "./pages/admin/knowledge/analytics";
 import AnalyticsDashboardPage from "./pages/admin/analytics/index";
 import CvStatusPage from "./pages/admin/analytics/cv-status";
+import FlowAnalyticsPage from "./pages/admin/analytics/FlowAnalyticsPage";
 import EngagementPage from "./pages/admin/engagement/index";
 import ConversionDashboardPage from "./pages/admin/conversion/index";
 import OptionManagementPage from "./pages/admin/options/index";
@@ -165,6 +166,8 @@ function AppInner() {
         <Route path="/admin/analytics" element={<RequireAuth><AnalyticsDashboardPage /></RequireAuth>} />
         {/* Phase65-3: CV発火状況 — super_admin 専用 */}
         <Route path="/admin/analytics/cv-status" element={<SuperAdminRoute><CvStatusPage /></SuperAdminRoute>} />
+        {/* Phase72-C: フロー遷移分析 — super_admin 専用 */}
+        <Route path="/admin/analytics/flow" element={<SuperAdminRoute><FlowAnalyticsPage /></SuperAdminRoute>} />
         <Route path="/admin/engagement" element={<RequireAuth><EngagementPage /></RequireAuth>} />
 
         {/* Phase58: コンバージョン最適化ダッシュボード */}

--- a/admin-ui/src/components/AppSidebar.tsx
+++ b/admin-ui/src/components/AppSidebar.tsx
@@ -19,6 +19,7 @@ import {
   Monitor,
   BellRing,
   X,
+  GitBranch,
 } from "lucide-react";
 import { useAuth } from "../auth/useAuth";
 import { useTheme } from "../contexts/ThemeContext";
@@ -32,6 +33,7 @@ interface NavItem {
   path: string;
   icon: React.ElementType;
   end?: boolean;
+  superAdminOnly?: boolean;
 }
 
 interface NavSection {
@@ -60,6 +62,7 @@ const MAIN_SECTIONS: NavSection[] = [
       { label: "会話分析", path: "/admin/analytics", icon: BarChart2 },
       { label: "成約・効果分析", path: "/admin/conversion", icon: TrendingUp },
       { label: "自動メッセージ設定", path: "/admin/engagement", icon: Zap },
+      { label: "フロー遷移分析", path: "/admin/analytics/flow", icon: GitBranch, superAdminOnly: true },
     ],
   },
   {

--- a/admin-ui/src/pages/admin/analytics/FlowAnalyticsPage.tsx
+++ b/admin-ui/src/pages/admin/analytics/FlowAnalyticsPage.tsx
@@ -1,0 +1,278 @@
+// admin-ui/src/pages/admin/analytics/FlowAnalyticsPage.tsx
+// Phase72-C: State Machine フロー遷移分析 (Super Admin 専用)
+
+import { useState, useEffect } from "react";
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from "chart.js";
+import { Bar } from "react-chartjs-2";
+import { authFetch, API_BASE } from "../../../lib/api";
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
+
+type AllowedPeriod = "7d" | "30d" | "90d";
+
+interface TransitionRow {
+  from_state: string | null;
+  to_state: string;
+  transition_count: number;
+}
+
+interface FlowTransitionsResponse {
+  period: AllowedPeriod;
+  tenant_id: string | null;
+  total_transitions: number;
+  funnel: {
+    to_answer_count: number;
+    to_confirm_count: number;
+    to_terminal_count: number;
+    completed_count: number;
+    confirm_rate_pct: number;
+    completion_rate_pct: number;
+  };
+  transitions: TransitionRow[];
+}
+
+const PERIOD_LABELS: Record<AllowedPeriod, string> = {
+  "7d": "過去7日",
+  "30d": "過去30日",
+  "90d": "過去90日",
+};
+
+export default function FlowAnalyticsPage() {
+  const [period, setPeriod] = useState<AllowedPeriod>("30d");
+  const [data, setData] = useState<FlowTransitionsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    authFetch(`${API_BASE}/v1/admin/analytics/flow-transitions?period=${period}`)
+      .then((r) => {
+        if (!r.ok) throw new Error(`取得失敗 (status ${r.status})`);
+        return r.json() as Promise<FlowTransitionsResponse>;
+      })
+      .then(setData)
+      .catch(() => setError("フロー遷移データの取得に失敗しました。しばらく待ってから再試行してください。"))
+      .finally(() => setLoading(false));
+  }, [period]);
+
+  const containerStyle: React.CSSProperties = {
+    minHeight: "100vh",
+    background: "var(--background)",
+    color: "var(--foreground)",
+    padding: "24px 20px",
+    maxWidth: 960,
+    margin: "0 auto",
+  };
+
+  const cardStyle: React.CSSProperties = {
+    borderRadius: 14,
+    border: "1px solid var(--border)",
+    background: "var(--card)",
+    padding: "20px 18px",
+    marginBottom: 20,
+    boxShadow: "0 4px 16px rgba(0,0,0,0.15)",
+  };
+
+  const kpiCardStyle: React.CSSProperties = {
+    flex: "1 1 140px",
+    borderRadius: 12,
+    border: "1px solid var(--border)",
+    background: "var(--card)",
+    padding: "16px 14px",
+    display: "flex",
+    flexDirection: "column",
+    gap: 4,
+  };
+
+  const funnel = data?.funnel;
+
+  // Bar chart data: funnel overview
+  const barData = funnel
+    ? {
+        labels: ["answer遷移", "confirm遷移", "terminal遷移", "completed"],
+        datasets: [
+          {
+            label: "遷移数",
+            data: [
+              funnel.to_answer_count,
+              funnel.to_confirm_count,
+              funnel.to_terminal_count,
+              funnel.completed_count,
+            ],
+            backgroundColor: [
+              "rgba(99,102,241,0.7)",
+              "rgba(34,197,94,0.7)",
+              "rgba(249,115,22,0.7)",
+              "rgba(20,184,166,0.7)",
+            ],
+            borderRadius: 6,
+          },
+        ],
+      }
+    : null;
+
+  return (
+    <div style={containerStyle}>
+      {/* Header */}
+      <div style={{ marginBottom: 24 }}>
+        <h1 style={{ fontSize: 22, fontWeight: 700, margin: 0 }}>
+          フロー遷移分析
+        </h1>
+        <p style={{ fontSize: 13, color: "var(--muted-foreground)", marginTop: 6 }}>
+          State Machine の遷移ログから会話ファネルを可視化します
+        </p>
+      </div>
+
+      {/* Period filter */}
+      <div style={{ display: "flex", gap: 8, marginBottom: 20 }}>
+        {(["7d", "30d", "90d"] as AllowedPeriod[]).map((p) => (
+          <button
+            key={p}
+            onClick={() => setPeriod(p)}
+            style={{
+              padding: "6px 14px",
+              borderRadius: 8,
+              border: "1px solid var(--border)",
+              background: period === p ? "var(--primary)" : "var(--card)",
+              color: period === p ? "var(--primary-foreground)" : "var(--foreground)",
+              cursor: "pointer",
+              fontSize: 13,
+              fontWeight: period === p ? 600 : 400,
+              transition: "all 0.15s",
+            }}
+          >
+            {PERIOD_LABELS[p]}
+          </button>
+        ))}
+      </div>
+
+      {loading && (
+        <div style={{ textAlign: "center", padding: "48px 0", color: "var(--muted-foreground)" }}>
+          読み込み中...
+        </div>
+      )}
+
+      {error && (
+        <div
+          style={{
+            background: "rgba(239,68,68,0.1)",
+            border: "1px solid rgba(239,68,68,0.3)",
+            borderRadius: 10,
+            padding: "16px 18px",
+            color: "var(--foreground)",
+            marginBottom: 20,
+          }}
+        >
+          {error}
+        </div>
+      )}
+
+      {!loading && !error && data && (
+        <>
+          {/* KPI cards */}
+          <div style={{ display: "flex", gap: 12, flexWrap: "wrap", marginBottom: 20 }}>
+            <div style={kpiCardStyle}>
+              <span style={{ fontSize: 11, color: "var(--muted-foreground)" }}>総遷移数</span>
+              <span style={{ fontSize: 26, fontWeight: 700 }}>{data.total_transitions.toLocaleString()}</span>
+            </div>
+            <div style={kpiCardStyle}>
+              <span style={{ fontSize: 11, color: "var(--muted-foreground)" }}>confirm到達率</span>
+              <span style={{ fontSize: 26, fontWeight: 700 }}>{funnel?.confirm_rate_pct ?? 0}%</span>
+            </div>
+            <div style={kpiCardStyle}>
+              <span style={{ fontSize: 11, color: "var(--muted-foreground)" }}>完了率（terminal中）</span>
+              <span style={{ fontSize: 26, fontWeight: 700 }}>{funnel?.completion_rate_pct ?? 0}%</span>
+            </div>
+            <div style={kpiCardStyle}>
+              <span style={{ fontSize: 11, color: "var(--muted-foreground)" }}>completed数</span>
+              <span style={{ fontSize: 26, fontWeight: 700 }}>{funnel?.completed_count ?? 0}</span>
+            </div>
+          </div>
+
+          {/* Bar chart */}
+          {barData && (
+            <div style={cardStyle}>
+              <h3 style={{ fontSize: 15, fontWeight: 600, color: "var(--muted-foreground)", margin: "0 0 16px 0" }}>
+                ファネル概要（{PERIOD_LABELS[period]}）
+              </h3>
+              <div style={{ height: 240 }}>
+                <Bar
+                  data={barData}
+                  options={{
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    plugins: {
+                      legend: { display: false },
+                      title: { display: false },
+                    },
+                    scales: {
+                      x: {
+                        ticks: { color: "var(--muted-foreground)", font: { size: 11 } },
+                        grid: { color: "rgba(255,255,255,0.05)" },
+                      },
+                      y: {
+                        ticks: { color: "var(--muted-foreground)", font: { size: 11 } },
+                        grid: { color: "rgba(255,255,255,0.05)" },
+                        beginAtZero: true,
+                      },
+                    },
+                  }}
+                />
+              </div>
+            </div>
+          )}
+
+          {/* Transition table */}
+          <div style={cardStyle}>
+            <h3 style={{ fontSize: 15, fontWeight: 600, color: "var(--muted-foreground)", margin: "0 0 14px 0" }}>
+              遷移詳細テーブル
+            </h3>
+            {data.transitions.length === 0 ? (
+              <p style={{ color: "var(--muted-foreground)", fontSize: 13 }}>
+                この期間の遷移データがありません。
+              </p>
+            ) : (
+              <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13 }}>
+                <thead>
+                  <tr style={{ borderBottom: "1px solid var(--border)" }}>
+                    <th style={{ textAlign: "left", padding: "8px 10px", color: "var(--muted-foreground)", fontWeight: 600 }}>遷移元</th>
+                    <th style={{ textAlign: "left", padding: "8px 10px", color: "var(--muted-foreground)", fontWeight: 600 }}>遷移先</th>
+                    <th style={{ textAlign: "right", padding: "8px 10px", color: "var(--muted-foreground)", fontWeight: 600 }}>件数</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.transitions.map((row, i) => (
+                    <tr
+                      key={i}
+                      style={{
+                        borderBottom: "1px solid var(--border)",
+                        background: i % 2 === 0 ? "transparent" : "rgba(255,255,255,0.02)",
+                      }}
+                    >
+                      <td style={{ padding: "8px 10px" }}>
+                        {row.from_state ?? <span style={{ color: "var(--muted-foreground)" }}>（開始）</span>}
+                      </td>
+                      <td style={{ padding: "8px 10px" }}>{row.to_state}</td>
+                      <td style={{ padding: "8px 10px", textAlign: "right", fontWeight: 600 }}>
+                        {row.transition_count.toLocaleString()}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/agent/orchestrator/flowControl.ts
+++ b/src/agent/orchestrator/flowControl.ts
@@ -13,6 +13,7 @@ import {
 import { detectStatePatternLoop } from '../flow/loopDetector';
 import type { PlannerPlan } from '../dialog/types';
 import type { PlannerRoute, RouteContextV2 } from '../llm/modelRouter';
+import { logFlowTransition } from '../../lib/analytics/flowLogger';
 
 const logger = pino();
 
@@ -308,6 +309,14 @@ export function applyPhase22FlowAfterGeneration(params: {
       lastUpdatedAt: new Date().toISOString(),
     };
     setFlowSessionMeta(flowKey, next);
+    logFlowTransition({
+      tenantId: flowKey.tenantId,
+      sessionId: flowKey.conversationId,
+      fromState: prevFlow.state,
+      toState: 'terminal',
+      turnIndex,
+      metadata: { reason: 'aborted_loop_detected' },
+    });
 
     logger.info(
       {
@@ -377,6 +386,14 @@ export function applyPhase22FlowAfterGeneration(params: {
       lastUpdatedAt: new Date().toISOString(),
     };
     setFlowSessionMeta(flowKey, next);
+    logFlowTransition({
+      tenantId: flowKey.tenantId,
+      sessionId: flowKey.conversationId,
+      fromState: prevFlow.state,
+      toState: 'terminal',
+      turnIndex,
+      metadata: { reason: 'aborted_budget' },
+    });
 
     logger.info(
       { event: 'flow.terminal_reached', meta: { flow: next } },
@@ -433,6 +450,13 @@ export function applyPhase22FlowAfterGeneration(params: {
     lastUpdatedAt: new Date().toISOString(),
   };
   setFlowSessionMeta(flowKey, next);
+  logFlowTransition({
+    tenantId: flowKey.tenantId,
+    sessionId: flowKey.conversationId,
+    fromState: prevFlow.state,
+    toState: nextState,
+    turnIndex,
+  });
 
   // Phase22: Log entry to new state
   if (prevFlow.state !== nextState) {

--- a/src/agent/orchestrator/langGraphOrchestrator.ts
+++ b/src/agent/orchestrator/langGraphOrchestrator.ts
@@ -7,6 +7,7 @@ import {
   getOrInitFlowSessionMeta,
   setFlowSessionMeta,
 } from '../dialog/flowContextStore';
+import { logFlowTransition } from '../../lib/analytics/flowLogger';
 import { detectUserStop, detectYesNo } from '../flow/userSignals';
 import { evaluateAvatarPolicy } from '../avatar/avatarPolicy';
 import { logPhase22Event } from '../observability/phase22EventLogger';
@@ -86,6 +87,14 @@ export async function runDialogGraph(
       lastUpdatedAt: new Date().toISOString(),
     };
     setFlowSessionMeta(flowKey, next);
+    logFlowTransition({
+      tenantId: flowKey.tenantId,
+      sessionId: flowKey.conversationId,
+      fromState: flow.state,
+      toState: 'terminal',
+      turnIndex,
+      metadata: { reason: 'aborted_budget' },
+    });
     logger.info(
       { event: 'flow.terminal_reached', meta: { flow: next } },
       'phase22.flow.terminal_reached',
@@ -134,6 +143,14 @@ export async function runDialogGraph(
         lastUpdatedAt: new Date().toISOString(),
       };
       setFlowSessionMeta(flowKey, next);
+      logFlowTransition({
+        tenantId: flowKey.tenantId,
+        sessionId: flowKey.conversationId,
+        fromState: flow.state,
+        toState: 'terminal',
+        turnIndex,
+        metadata: { reason: 'aborted_user' },
+      });
       logger.info(
         { event: 'flow.terminal_reached', meta: { flow: next } },
         'phase22.flow.terminal_reached',
@@ -165,6 +182,14 @@ export async function runDialogGraph(
         lastUpdatedAt: new Date().toISOString(),
       };
       setFlowSessionMeta(flowKey, next);
+      logFlowTransition({
+        tenantId: flowKey.tenantId,
+        sessionId: flowKey.conversationId,
+        fromState: flow.state,
+        toState: 'terminal',
+        turnIndex,
+        metadata: { reason: 'completed' },
+      });
       logger.info(
         { event: 'flow.terminal_reached', meta: { flow: next } },
         'phase22.flow.terminal_reached',
@@ -197,6 +222,14 @@ export async function runDialogGraph(
         lastUpdatedAt: new Date().toISOString(),
       };
       setFlowSessionMeta(flowKey, next);
+      logFlowTransition({
+        tenantId: flowKey.tenantId,
+        sessionId: flowKey.conversationId,
+        fromState: flow.state,
+        toState: 'terminal',
+        turnIndex,
+        metadata: { reason: 'aborted_user' },
+      });
       logger.info(
         { event: 'flow.terminal_reached', meta: { flow: next } },
         'phase22.flow.terminal_reached',
@@ -230,6 +263,14 @@ export async function runDialogGraph(
         lastUpdatedAt: new Date().toISOString(),
       };
       setFlowSessionMeta(flowKey, next);
+      logFlowTransition({
+        tenantId: flowKey.tenantId,
+        sessionId: flowKey.conversationId,
+        fromState: flow.state,
+        toState: 'terminal',
+        turnIndex,
+        metadata: { reason: 'aborted_budget' },
+      });
       logger.info(
         { event: 'flow.terminal_reached', meta: { flow: next } },
         'phase22.flow.terminal_reached',
@@ -260,6 +301,13 @@ export async function runDialogGraph(
       lastUpdatedAt: new Date().toISOString(),
     };
     setFlowSessionMeta(flowKey, next);
+    logFlowTransition({
+      tenantId: flowKey.tenantId,
+      sessionId: flowKey.conversationId,
+      fromState: flow.state,
+      toState: 'confirm',
+      turnIndex,
+    });
     logger.info(
       { event: 'flow.enter_state', meta: { flow: next } },
       'phase22.flow.enter_state',

--- a/src/api/admin/analytics/flowTransitions.test.ts
+++ b/src/api/admin/analytics/flowTransitions.test.ts
@@ -1,0 +1,159 @@
+// src/api/admin/analytics/flowTransitions.test.ts
+// Phase72-C: GET /v1/admin/analytics/flow-transitions テスト
+
+import express from 'express';
+import request from 'supertest';
+
+// ---------------------------------------------------------------------------
+// DB モック
+// ---------------------------------------------------------------------------
+
+const mockQuery = jest.fn();
+jest.mock('../../../lib/db', () => ({
+  pool: { query: (...args: unknown[]) => mockQuery(...args) },
+  getPool: () => ({ query: (...args: unknown[]) => mockQuery(...args) }),
+}));
+
+jest.mock('../../../lib/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock('../../../lib/notifications', () => ({
+  createNotification: jest.fn(),
+  notificationExists: jest.fn().mockResolvedValue(false),
+}));
+
+jest.mock('../../../lib/crypto/textEncrypt', () => ({
+  decryptText: jest.fn((v: string) => v),
+}));
+
+// supabase auth middleware — x-role / x-tenant-id ヘッダで制御
+jest.mock('../../../admin/http/supabaseAuthMiddleware', () => ({
+  supabaseAuthMiddleware: (req: any, _res: any, next: any) => {
+    req.supabaseUser = {
+      app_metadata: {
+        role: (req.headers['x-role'] as string) ?? 'client_admin',
+        tenant_id: (req.headers['x-tenant-id'] as string) ?? 'tenant-1',
+      },
+    };
+    next();
+  },
+}));
+
+import { registerAnalyticsRoutes } from './routes';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  registerAnalyticsRoutes(app);
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GET /v1/admin/analytics/flow-transitions', () => {
+  beforeEach(() => mockQuery.mockClear());
+
+  it('正常系: super_admin がデータを取得できる', async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [
+          { from_state: 'clarify', to_state: 'answer', transition_count: 120 },
+          { from_state: 'answer', to_state: 'confirm', transition_count: 80 },
+          { from_state: 'confirm', to_state: 'terminal', transition_count: 60 },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [{ cnt: 45 }] }); // completed count
+
+    const app = makeApp();
+    const res = await request(app)
+      .get('/v1/admin/analytics/flow-transitions?period=30d')
+      .set('x-role', 'super_admin');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      period: '30d',
+      total_transitions: 260,
+      funnel: expect.objectContaining({
+        to_confirm_count: 80,
+        to_terminal_count: 60,
+        completed_count: 45,
+      }),
+      transitions: expect.arrayContaining([
+        expect.objectContaining({ from_state: 'clarify', to_state: 'answer', transition_count: 120 }),
+      ]),
+    });
+  });
+
+  it('403: client_admin はアクセス拒否される', async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .get('/v1/admin/analytics/flow-transitions')
+      .set('x-role', 'client_admin');
+
+    expect(res.status).toBe(403);
+    expect(res.body).toHaveProperty('code', 'AUTH_ROLE_INSUFFICIENT');
+  });
+
+  it('403: 無効なロールはアクセス拒否される', async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .get('/v1/admin/analytics/flow-transitions')
+      .set('x-role', 'unknown_role');
+
+    expect(res.status).toBe(403);
+    expect(res.body).toHaveProperty('code', 'AUTH_ROLE_INVALID');
+  });
+
+  it('ゼロ行のとき率は 0% でNaN/nullにならない', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] })          // transitions: no data
+      .mockResolvedValueOnce({ rows: [{ cnt: 0 }] }); // completed: 0
+
+    const app = makeApp();
+    const res = await request(app)
+      .get('/v1/admin/analytics/flow-transitions?period=7d')
+      .set('x-role', 'super_admin');
+
+    expect(res.status).toBe(200);
+    expect(res.body.total_transitions).toBe(0);
+    expect(res.body.funnel.confirm_rate_pct).toBe(0);
+    expect(res.body.funnel.completion_rate_pct).toBe(0);
+    expect(Number.isNaN(res.body.funnel.confirm_rate_pct)).toBe(false);
+    expect(Number.isNaN(res.body.funnel.completion_rate_pct)).toBe(false);
+  });
+
+  it('period が不正値のとき 30d にフォールバックする', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ cnt: 0 }] });
+
+    const app = makeApp();
+    const res = await request(app)
+      .get('/v1/admin/analytics/flow-transitions?period=999d')
+      .set('x-role', 'super_admin');
+
+    expect(res.status).toBe(200);
+    expect(res.body.period).toBe('30d');
+  });
+
+  it('tenant_id クエリで super_admin はテナント絞り込みができる', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ from_state: 'clarify', to_state: 'answer', transition_count: 5 }] })
+      .mockResolvedValueOnce({ rows: [{ cnt: 3 }] });
+
+    const app = makeApp();
+    const res = await request(app)
+      .get('/v1/admin/analytics/flow-transitions?period=30d&tenant_id=tenant-xyz')
+      .set('x-role', 'super_admin');
+
+    expect(res.status).toBe(200);
+    expect(res.body.tenant_id).toBe('tenant-xyz');
+  });
+});

--- a/src/api/admin/analytics/routes.ts
+++ b/src/api/admin/analytics/routes.ts
@@ -1363,4 +1363,130 @@ export function registerAnalyticsRoutes(app: Express): void {
       }
     },
   );
+
+  // -------------------------------------------------------------------------
+  // GET /v1/admin/analytics/flow-transitions  (Phase72-C: super_admin only)
+  // query: period=7d|30d|90d (default 30d), tenant_id (super_admin filter)
+  // -------------------------------------------------------------------------
+  app.get(
+    "/v1/admin/analytics/flow-transitions",
+    supabaseAuthMiddleware,
+    async (req: Request, res: Response) => {
+      const su = (req as any).supabaseUser as Record<string, any> | undefined;
+      const actorRole = su?.app_metadata?.role;
+      if (!isAllowedAdminRole(actorRole)) {
+        logger.warn({
+          event: 'analytics_access_denied',
+          reason: 'invalid_role',
+          actorEmail: su?.email ? String(su.email).slice(0, 3) + '***' : 'unknown',
+          errorCode: 'AUTH_ROLE_INVALID',
+        }, "Flow-transitions access denied: invalid actor role");
+        return res.status(403).json({ error: "この操作を実行する権限がありません", code: 'AUTH_ROLE_INVALID' });
+      }
+      const isSuperAdmin: boolean = actorRole === "super_admin";
+
+      if (!isSuperAdmin) {
+        logger.warn({
+          event: 'analytics_access_denied',
+          reason: 'insufficient_role',
+          actorRole,
+          actorEmail: su?.email ? String(su.email).slice(0, 3) + '***' : 'unknown',
+          errorCode: 'AUTH_ROLE_INSUFFICIENT',
+        }, "Flow-transitions access denied: super_admin required");
+        return res.status(403).json({ error: "アクセス権限がありません", code: 'AUTH_ROLE_INSUFFICIENT' });
+      }
+
+      if (!pool) {
+        return res.status(503).json({ error: "データベース接続が利用できません" });
+      }
+
+      // whitelist period to avoid SQL injection
+      const ALLOWED_PERIODS = ['7d', '30d', '90d'] as const;
+      type AllowedPeriod = typeof ALLOWED_PERIODS[number];
+      const rawPeriod = typeof req.query['period'] === 'string' ? req.query['period'] : '30d';
+      const period: AllowedPeriod = (ALLOWED_PERIODS as readonly string[]).includes(rawPeriod)
+        ? (rawPeriod as AllowedPeriod)
+        : '30d';
+
+      // super_admin can filter by tenant_id via query
+      const tenantFilter = typeof req.query['tenant_id'] === 'string' && req.query['tenant_id'].trim()
+        ? req.query['tenant_id'].trim()
+        : null;
+
+      // Map period to days integer for parameterized query
+      const periodDays = period === '7d' ? 7 : period === '90d' ? 90 : 30;
+
+      try {
+        const result = await pool.query(
+          `SELECT
+             from_state,
+             to_state,
+             COUNT(*)::int AS transition_count
+           FROM conversation_flow_logs
+           WHERE logged_at > NOW() - ($1::int * INTERVAL '1 day')
+             AND ($2::text IS NULL OR tenant_id = $2)
+           GROUP BY from_state, to_state
+           ORDER BY transition_count DESC`,
+          [periodDays, tenantFilter],
+        );
+
+        type TransitionRow = {
+          from_state: string | null;
+          to_state: string;
+          transition_count: number;
+        };
+
+        const transitions = (result.rows as TransitionRow[]).map((row) => ({
+          from_state: row.from_state,
+          to_state: row.to_state,
+          transition_count: row.transition_count,
+        }));
+
+        // Funnel rates: total sessions entering each state
+        const totalRows = transitions.reduce((sum, r) => sum + r.transition_count, 0);
+        const toTerminal = transitions
+          .filter((r) => r.to_state === 'terminal')
+          .reduce((sum, r) => sum + r.transition_count, 0);
+        const toConfirm = transitions
+          .filter((r) => r.to_state === 'confirm')
+          .reduce((sum, r) => sum + r.transition_count, 0);
+        const toAnswer = transitions
+          .filter((r) => r.to_state === 'answer')
+          .reduce((sum, r) => sum + r.transition_count, 0);
+
+        // completed (terminal via 'completed' reason)
+        const completedResult = await pool.query(
+          `SELECT COUNT(*)::int AS cnt
+           FROM conversation_flow_logs
+           WHERE logged_at > NOW() - ($1::int * INTERVAL '1 day')
+             AND ($2::text IS NULL OR tenant_id = $2)
+             AND to_state = 'terminal'
+             AND metadata->>'reason' = 'completed'`,
+          [periodDays, tenantFilter],
+        );
+        const completedCount: number = (completedResult.rows[0] as { cnt: number })?.cnt ?? 0;
+
+        const safeRate = (n: number, d: number): number =>
+          d === 0 ? 0 : Math.round((n / d) * 10000) / 100;
+
+        return res.json({
+          period,
+          tenant_id: tenantFilter,
+          total_transitions: totalRows,
+          funnel: {
+            to_answer_count: toAnswer,
+            to_confirm_count: toConfirm,
+            to_terminal_count: toTerminal,
+            completed_count: completedCount,
+            confirm_rate_pct: safeRate(toConfirm, totalRows),
+            completion_rate_pct: safeRate(completedCount, toTerminal),
+          },
+          transitions,
+        });
+      } catch (err) {
+        logger.warn("[GET /v1/admin/analytics/flow-transitions]", err);
+        return res.status(500).json({ error: "フロー遷移の集計に失敗しました" });
+      }
+    },
+  );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ import { registerAvatarConfigRoutes } from "./api/admin/avatar/routes";
 import { registerBillingAdminRoutes } from "./lib/billing/billingApi";
 import { createStripeWebhookHandler } from "./lib/billing/stripeWebhook";
 import { initUsageTracker } from "./lib/billing/usageTracker";
+import { initFlowLogger } from "./lib/analytics/flowLogger";
 import { reportUsageToStripe } from "./lib/billing/stripeSync";
 import { pipelineQueue } from "./lib/book-pipeline/pipelineQueue";
 import { supabaseAuthMiddleware } from "./admin/http/supabaseAuthMiddleware";
@@ -519,6 +520,9 @@ if (db) registerNotificationPreferencesRoutes(app, db);
 
 // Phase32: 課金管理API
 if (db) initUsageTracker(db, logger);
+
+// Phase72-C: State Machine 遷移ログ
+if (db) initFlowLogger(db, logger);
 
 // Stripe Webhook（raw body 必須 — express.json より前にマッチさせること）
 app.post(

--- a/src/lib/analytics/flowLogger.test.ts
+++ b/src/lib/analytics/flowLogger.test.ts
@@ -1,0 +1,158 @@
+// src/lib/analytics/flowLogger.test.ts
+// Phase72-C: flowLogger ユニットテスト
+
+import { logFlowTransition, initFlowLogger } from './flowLogger';
+
+// 各テスト前に pool を null にリセット
+beforeEach(() => {
+  initFlowLogger(null as any, {
+    warn: jest.fn(), error: jest.fn(), debug: jest.fn(), info: jest.fn(),
+  } as any);
+});
+
+function flushSetImmediate(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
+
+describe('flowLogger', () => {
+  describe('logFlowTransition: fire-and-forget', () => {
+    it('pool 未初期化時は warn を出してスキップする', async () => {
+      const mockLogger = {
+        warn: jest.fn(), error: jest.fn(), debug: jest.fn(), info: jest.fn(),
+      } as any;
+      // pool を null のまま使う
+      initFlowLogger(null as any, mockLogger);
+
+      logFlowTransition({
+        tenantId: 'tenant-1',
+        sessionId: 'session-abc',
+        fromState: 'clarify',
+        toState: 'answer',
+        turnIndex: 1,
+      });
+
+      await flushSetImmediate();
+      await flushSetImmediate();
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ sessionId: 'session-abc' }),
+        expect.stringContaining('pool not initialized'),
+      );
+    });
+
+    it('INSERT を非同期で発行する（setImmediate 後）', async () => {
+      const mockQuery = jest.fn().mockResolvedValue({ rowCount: 1 });
+      const mockPool = { query: mockQuery };
+      const mockLogger = {
+        warn: jest.fn(), error: jest.fn(), debug: jest.fn(), info: jest.fn(),
+      } as any;
+
+      initFlowLogger(mockPool as any, mockLogger);
+
+      logFlowTransition({
+        tenantId: 'tenant-1',
+        sessionId: 'session-abc',
+        fromState: 'clarify',
+        toState: 'answer',
+        turnIndex: 2,
+      });
+
+      // setImmediate 前は未実行
+      expect(mockQuery).not.toHaveBeenCalled();
+
+      await flushSetImmediate();
+      await flushSetImmediate();
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+      expect(sql).toContain('INSERT INTO conversation_flow_logs');
+      expect(params[0]).toBe('tenant-1');  // tenantId
+      expect(params[1]).toBe('session-abc'); // sessionId
+      expect(params[2]).toBe('clarify');   // from_state
+      expect(params[3]).toBe('answer');    // to_state
+      expect(params[4]).toBe(2);           // turn_index
+    });
+
+    it('terminal 遷移時に metadata.reason が保存される', async () => {
+      const mockQuery = jest.fn().mockResolvedValue({ rowCount: 1 });
+      const mockPool = { query: mockQuery };
+      const mockLogger = {
+        warn: jest.fn(), error: jest.fn(), debug: jest.fn(), info: jest.fn(),
+      } as any;
+
+      initFlowLogger(mockPool as any, mockLogger);
+
+      logFlowTransition({
+        tenantId: 'tenant-1',
+        sessionId: 'session-xyz',
+        fromState: 'confirm',
+        toState: 'terminal',
+        turnIndex: 5,
+        metadata: { reason: 'completed' },
+      });
+
+      await flushSetImmediate();
+      await flushSetImmediate();
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+      const metadataStr = params[5] as string;
+      const metadata = JSON.parse(metadataStr);
+      expect(metadata).toEqual({ reason: 'completed' });
+    });
+
+    it('fromState が null でも正常に INSERT される', async () => {
+      const mockQuery = jest.fn().mockResolvedValue({ rowCount: 1 });
+      const mockPool = { query: mockQuery };
+      const mockLogger = {
+        warn: jest.fn(), error: jest.fn(), debug: jest.fn(), info: jest.fn(),
+      } as any;
+
+      initFlowLogger(mockPool as any, mockLogger);
+
+      logFlowTransition({
+        tenantId: 'tenant-1',
+        sessionId: 'session-new',
+        fromState: null,
+        toState: 'clarify',
+        turnIndex: 1,
+      });
+
+      await flushSetImmediate();
+      await flushSetImmediate();
+
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+      expect(params[2]).toBeNull(); // from_state
+    });
+
+    it('DB エラーは API を止めずにエラーログのみ出す', async () => {
+      const mockQuery = jest.fn().mockRejectedValue(new Error('DB connection failed'));
+      const mockPool = { query: mockQuery };
+      const mockLogger = {
+        warn: jest.fn(), error: jest.fn(), debug: jest.fn(), info: jest.fn(),
+      } as any;
+
+      initFlowLogger(mockPool as any, mockLogger);
+
+      // エラーでも例外を投げない（fire-and-forget）
+      expect(() =>
+        logFlowTransition({
+          tenantId: 'tenant-err',
+          sessionId: 'session-err',
+          fromState: 'clarify',
+          toState: 'terminal',
+          turnIndex: 3,
+        })
+      ).not.toThrow();
+
+      await flushSetImmediate();
+      await flushSetImmediate();
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        expect.objectContaining({ tenantId: 'tenant-err' }),
+        expect.stringContaining('db insert failed'),
+      );
+    });
+  });
+});

--- a/src/lib/analytics/flowLogger.ts
+++ b/src/lib/analytics/flowLogger.ts
@@ -1,0 +1,57 @@
+// src/lib/analytics/flowLogger.ts
+// Phase72-C: State Machine 遷移ログ（fire-and-forget）
+
+import type pino from 'pino';
+
+let _pool: any | null = null;
+let _logger: pino.Logger | null = null;
+
+export function initFlowLogger(pool: any, logger: pino.Logger): void {
+  _pool = pool;
+  _logger = logger;
+}
+
+export interface LogFlowTransitionParams {
+  tenantId: string;
+  sessionId: string;
+  fromState: string | null;
+  toState: string;
+  turnIndex: number;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * State Machine 遷移をDBに非同期で記録する（fire-and-forget）。
+ * setImmediate で遅延実行するため API レスポンス速度に影響しない。
+ * pool 未初期化時は warn を出してスキップする。
+ */
+export function logFlowTransition(params: LogFlowTransitionParams): void {
+  setImmediate(() => {
+    void _insertFlowLog(params);
+  });
+}
+
+async function _insertFlowLog(params: LogFlowTransitionParams): Promise<void> {
+  if (!_pool) {
+    _logger?.warn({ sessionId: params.sessionId }, '[flowLogger] pool not initialized, skipping');
+    return;
+  }
+
+  const { tenantId, sessionId, fromState, toState, turnIndex, metadata } = params;
+
+  try {
+    await _pool.query(
+      `INSERT INTO conversation_flow_logs
+         (tenant_id, session_id, from_state, to_state, turn_index, metadata)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [tenantId, sessionId, fromState ?? null, toState, turnIndex, JSON.stringify(metadata ?? {})],
+    );
+    _logger?.debug(
+      { tenantId, sessionId, fromState, toState, turnIndex },
+      '[flowLogger] logged',
+    );
+  } catch (err) {
+    // DB エラーはログするが API レスポンスには影響させない
+    _logger?.error({ err, tenantId, sessionId }, '[flowLogger] db insert failed');
+  }
+}

--- a/src/migrations/phase72c_conversation_flow_logs.sql
+++ b/src/migrations/phase72c_conversation_flow_logs.sql
@@ -1,0 +1,18 @@
+-- Phase72-C: State Machine 遷移ログテーブル
+-- 実行: psql $DATABASE_URL -f src/migrations/phase72c_conversation_flow_logs.sql
+-- 注意: このファイルは人間が手動で実行する（自動適用禁止）
+
+CREATE TABLE IF NOT EXISTS conversation_flow_logs (
+  id BIGSERIAL PRIMARY KEY,
+  tenant_id TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  from_state TEXT,
+  to_state TEXT NOT NULL,
+  turn_index INT NOT NULL DEFAULT 0,
+  metadata JSONB NOT NULL DEFAULT '{}',
+  logged_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_cfl_tenant_session ON conversation_flow_logs(tenant_id, session_id);
+CREATE INDEX IF NOT EXISTS idx_cfl_tenant_logged ON conversation_flow_logs(tenant_id, logged_at DESC);
+CREATE INDEX IF NOT EXISTS idx_cfl_to_state ON conversation_flow_logs(to_state);


### PR DESCRIPTION
## 概要
Phase22 State Machine（clarify→answer→confirm→terminal）の状態遷移を DB に記録し、Super Admin がフロー（ファネル）を分析できるようにする。遷移ログ + 分析API + 可視化UI。

Asana: Phase72-C（GID 1215691379753932）

## 実装
- `src/migrations/phase72c_conversation_flow_logs.sql` — 新規テーブル（**人間がVPSで適用・不可逆**）
- `src/lib/analytics/flowLogger.ts` — fire-and-forget logger（usageTracker パターン、setImmediate、未init時 warn skip）
- `src/agent/orchestrator/flowControl.ts` / `langGraphOrchestrator.ts` — 各 setFlowSessionMeta 直後にログ呼び出しを**追加のみ**（遷移ロジック不変）
- `src/api/admin/analytics/routes.ts` — GET /v1/admin/analytics/flow-transitions（super_admin only、funnel 集計、ゼロ行ガード）
- `admin-ui` — FlowAnalyticsPage + ルート + サイドバー（NavItem 型に superAdminOnly 追加で pre-existing 型エラーも解消）

## Gate
- Gate 1: typecheck 0 / 1939 tests PASS（**orchestrator 既存テスト回帰なし**）
- Gate 2: security-scan High/Critical 0
- Gate 3: backend + admin-ui build PASS
- 安全性: ログは fire-and-forget で await/throw を遷移に伝播しない

## ⚠️ マージ前の人間アクション
1. `src/migrations/phase72c_conversation_flow_logs.sql` を適用（SSHトンネル経由・不可逆）→ 適用後 merge 推奨
2. Gate 2.5（Codex review）と merge は人間手動

## 注記
- 遷移先 to_state は FlowState 4値、terminal 理由は metadata.reason に格納（notes の loop_abort 等は実機型と不一致のため正規化）
🤖 Generated with [Claude Code](https://claude.com/claude-code)
