### PR TITLE
feat(analytics): Prometheus メトリクス永続化 + 時系列グラフ (Phase72-D)

### DIFF
--- a/admin-ui/src/pages/admin/analytics/MetricsTimeseriesSection.tsx
+++ b/admin-ui/src/pages/admin/analytics/MetricsTimeseriesSection.tsx
@@ -1,0 +1,213 @@
+/**
+ * Phase72-D: メトリクス時系列グラフ（super_admin 専用）
+ *
+ * - 3タブ: 会話 / アバター / RAG
+ * - period + granularity フィルタ
+ * - authFetch で /v1/admin/analytics/metrics-history を呼ぶ
+ */
+
+import { useState, useEffect } from "react";
+import { Line, Bar } from "react-chartjs-2";
+import { authFetch, API_BASE } from "../../../lib/api";
+import { chartCardStyle } from "./utils";
+
+interface MetricsTimeseriesSectionProps {
+  isSuperAdmin: boolean;
+}
+
+interface SeriesPoint {
+  timestamp: string;
+  value: number;
+  labels: Record<string, string | number>;
+}
+
+interface MetricsHistoryResponse {
+  metric: string;
+  period: string;
+  granularity: string;
+  series: SeriesPoint[];
+}
+
+const TABS = [
+  { id: "conversation", label: "会話" },
+  { id: "avatar", label: "アバター" },
+  { id: "rag", label: "RAG" },
+] as const;
+
+type TabId = typeof TABS[number]["id"];
+
+const TAB_METRICS: Record<TabId, string> = {
+  conversation: "rajiuce_conversation_terminal_total",
+  avatar: "rajiuce_avatar_requests_total",
+  rag: "rajiuce_rag_duration_ms",
+};
+
+const TAB_COLORS: Record<TabId, string> = {
+  conversation: "#60a5fa",
+  avatar: "#a78bfa",
+  rag: "#34d399",
+};
+
+const PERIOD_OPTIONS = [
+  { value: "1d", label: "1日" },
+  { value: "7d", label: "7日" },
+  { value: "30d", label: "30日" },
+];
+
+const GRANULARITY_OPTIONS = [
+  { value: "1h", label: "1時間" },
+  { value: "6h", label: "6時間" },
+  { value: "24h", label: "24時間" },
+];
+
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString("ja-JP", { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+}
+
+export function MetricsTimeseriesSection({ isSuperAdmin }: MetricsTimeseriesSectionProps) {
+  if (!isSuperAdmin) return null;
+
+  const [activeTab, setActiveTab] = useState<TabId>("conversation");
+  const [period, setPeriod] = useState("7d");
+  const [granularity, setGranularity] = useState("1h");
+  const [data, setData] = useState<MetricsHistoryResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const metric = TAB_METRICS[activeTab];
+    const params = new URLSearchParams({ metric, period, granularity });
+
+    setLoading(true);
+    setError(null);
+
+    authFetch(`${API_BASE}/v1/admin/analytics/metrics-history?${params}`)
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json() as Promise<MetricsHistoryResponse>;
+      })
+      .then((json) => setData(json))
+      .catch(() => setError("メトリクスデータの読み込みに失敗しました"))
+      .finally(() => setLoading(false));
+  }, [activeTab, period, granularity]);
+
+  const series = data?.series ?? [];
+
+  const chartData = {
+    labels: series.map((p) => formatTimestamp(p.timestamp)),
+    datasets: [
+      {
+        label: TABS.find((t) => t.id === activeTab)?.label ?? "",
+        data: series.map((p) => p.value),
+        borderColor: TAB_COLORS[activeTab],
+        backgroundColor: `${TAB_COLORS[activeTab]}14`,
+        borderWidth: 2,
+        pointRadius: series.length > 50 ? 0 : 3,
+        tension: 0.3,
+        fill: true,
+      },
+    ],
+  };
+
+  const chartOptions = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: { legend: { display: false } },
+    scales: {
+      x: {
+        ticks: { color: "var(--muted-foreground)", maxTicksLimit: 8, font: { size: 11 } },
+        grid: { color: "rgba(255,255,255,0.05)" },
+      },
+      y: {
+        ticks: { color: "var(--muted-foreground)", font: { size: 11 } },
+        grid: { color: "rgba(255,255,255,0.05)" },
+        beginAtZero: true,
+      },
+    },
+  } as const;
+
+  const isBarChart = activeTab === "rag";
+
+  return (
+    <div style={{ marginBottom: 24 }}>
+      {/* Section header */}
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 12, flexWrap: "wrap", gap: 8 }}>
+        <h2 style={{ fontSize: 16, fontWeight: 700, color: "var(--foreground)", margin: 0 }}>
+          メトリクス時系列
+        </h2>
+        {/* Filters */}
+        <div style={{ display: "flex", gap: 8 }}>
+          <select
+            value={period}
+            onChange={(e) => setPeriod(e.target.value)}
+            style={{ fontSize: 13, padding: "4px 8px", borderRadius: 8, border: "1px solid var(--border)", background: "var(--card)", color: "var(--foreground)" }}
+          >
+            {PERIOD_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+            ))}
+          </select>
+          <select
+            value={granularity}
+            onChange={(e) => setGranularity(e.target.value)}
+            style={{ fontSize: 13, padding: "4px 8px", borderRadius: 8, border: "1px solid var(--border)", background: "var(--card)", color: "var(--foreground)" }}
+          >
+            {GRANULARITY_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {/* Tabs */}
+      <div style={{ display: "flex", gap: 4, marginBottom: 12 }}>
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            onClick={() => setActiveTab(tab.id)}
+            style={{
+              padding: "6px 14px",
+              borderRadius: 8,
+              border: activeTab === tab.id ? `1px solid ${TAB_COLORS[tab.id]}` : "1px solid var(--border)",
+              background: activeTab === tab.id ? `${TAB_COLORS[tab.id]}20` : "transparent",
+              color: activeTab === tab.id ? TAB_COLORS[tab.id] : "var(--muted-foreground)",
+              fontSize: 13,
+              fontWeight: activeTab === tab.id ? 600 : 400,
+              cursor: "pointer",
+              minWidth: 44,
+              minHeight: 36,
+            }}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* Chart card */}
+      <div style={chartCardStyle}>
+        {error && (
+          <div style={{ padding: "10px 14px", borderRadius: 8, background: "rgba(127,29,29,0.35)", color: "#fca5a5", fontSize: 14, marginBottom: 12 }}>
+            {error}
+          </div>
+        )}
+        {loading ? (
+          <div style={{ height: 220, display: "flex", alignItems: "center", justifyContent: "center", color: "var(--muted-foreground)", fontSize: 14 }}>
+            読み込み中...
+          </div>
+        ) : series.length === 0 ? (
+          <div style={{ height: 220, display: "flex", alignItems: "center", justifyContent: "center", color: "var(--muted-foreground)", fontSize: 14 }}>
+            この期間にデータはありません
+          </div>
+        ) : (
+          <div style={{ height: 220 }}>
+            {isBarChart ? (
+              <Bar data={chartData} options={chartOptions} />
+            ) : (
+              <Line data={chartData} options={chartOptions} />
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/admin-ui/src/pages/admin/analytics/index.tsx
+++ b/admin-ui/src/pages/admin/analytics/index.tsx
@@ -30,6 +30,7 @@ import { TrendChartsSection } from "./TrendChartsSection";
 import { QualityChartsRow } from "./QualityChartsRow";
 import { LowScoreSessionsTable } from "./LowScoreSessionsTable";
 import { ConversionSection } from "./ConversionSection";
+import { MetricsTimeseriesSection } from "./MetricsTimeseriesSection";
 
 ChartJS.register(
   CategoryScale,
@@ -399,6 +400,9 @@ export default function AnalyticsDashboardPage() {
               setTechSortAsc={setTechSortAsc}
             />
           )}
+
+          {/* Phase72-D: メトリクス時系列（super_admin のみ表示） */}
+          {isSuperAdmin && <MetricsTimeseriesSection isSuperAdmin={isSuperAdmin} />}
         </>
       )}
     </div>

--- a/src/api/admin/analytics/metricsHistory.test.ts
+++ b/src/api/admin/analytics/metricsHistory.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Phase72-D: GET /v1/admin/analytics/metrics-history テスト
+ *
+ * - 正常系: super_admin + 有効 metric → 200 + series 配列
+ * - 403: isAllowedAdminRole 失敗
+ * - 403: client_admin（isSuperAdmin = false）
+ * - 400: granularity whitelist 外
+ * - 503: pool null
+ */
+
+// pool と logger を先にモック（jest.mock はホイスティングされる）
+jest.mock('../../../lib/db', () => ({
+  pool: null,
+  getPool: () => null,
+}));
+jest.mock('../../../lib/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock('../../../lib/notifications', () => ({
+  createNotification: jest.fn(),
+  notificationExists: jest.fn(),
+}));
+jest.mock('../../../lib/crypto/textEncrypt', () => ({
+  decryptText: (s: string) => s,
+}));
+jest.mock('../../../admin/http/supabaseAuthMiddleware', () => ({
+  supabaseAuthMiddleware: (req: any, _res: any, next: any) => {
+    req.supabaseUser = req._mockUser ?? null;
+    next();
+  },
+}));
+
+import express from 'express';
+import request from 'supertest';
+import { registerAnalyticsRoutes } from './routes';
+
+// ---------------------------------------------------------------------------
+// Mock pool factory
+// ---------------------------------------------------------------------------
+
+function makeMockPool(rows: unknown[] = []) {
+  return {
+    query: jest.fn().mockResolvedValue({ rows }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// App factory
+// ---------------------------------------------------------------------------
+
+function makeApp(appMetadata: Record<string, unknown> | null, poolOverride?: unknown) {
+  const app = express();
+  app.use(express.json());
+
+  // Inject mock user
+  app.use((req: any, _res: any, next: any) => {
+    req._mockUser = appMetadata ? { app_metadata: appMetadata } : null;
+    next();
+  });
+
+  // Override pool via module-level mock after construction
+  registerAnalyticsRoutes(app);
+
+  // Attach pool to app.locals so the route can access it if needed
+  if (poolOverride) {
+    (app as any)._testPool = poolOverride;
+  }
+
+  return app;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+const SUPER_ADMIN_META = { role: 'super_admin', tenant_id: null };
+const CLIENT_ADMIN_META = { role: 'client_admin', tenant_id: 'tenant-A' };
+const VIEWER_META = { role: 'viewer', tenant_id: 'tenant-A' };
+
+describe('GET /v1/admin/analytics/metrics-history', () => {
+  let dbModule: { pool: unknown };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    dbModule = require('../../../lib/db') as { pool: unknown };
+  });
+
+  afterEach(() => {
+    // pool を null に戻す
+    dbModule.pool = null;
+  });
+
+  it('super_admin + 有効 metric → 200 + series 配列', async () => {
+    const mockRows = [
+      { timestamp: new Date('2026-06-14T10:00:00Z'), value: 5, labels: { reason: 'completed' } },
+    ];
+    dbModule.pool = makeMockPool(mockRows);
+
+    const app = makeApp(SUPER_ADMIN_META);
+    const res = await request(app)
+      .get('/v1/admin/analytics/metrics-history')
+      .query({ metric: 'rajiuce_conversation_terminal_total', period: '7d', granularity: '1h' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('metric', 'rajiuce_conversation_terminal_total');
+    expect(res.body).toHaveProperty('period', '7d');
+    expect(res.body).toHaveProperty('granularity', '1h');
+    expect(Array.isArray(res.body.series)).toBe(true);
+    expect(res.body.series).toHaveLength(1);
+    expect(res.body.series[0]).toHaveProperty('value', 5);
+  });
+
+  it('空データの場合 series = []', async () => {
+    dbModule.pool = makeMockPool([]);
+
+    const app = makeApp(SUPER_ADMIN_META);
+    const res = await request(app)
+      .get('/v1/admin/analytics/metrics-history')
+      .query({ metric: 'rajiuce_avatar_requests_total' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.series).toEqual([]);
+  });
+
+  it('viewer ロール → 403', async () => {
+    dbModule.pool = makeMockPool();
+
+    const app = makeApp(VIEWER_META);
+    const res = await request(app)
+      .get('/v1/admin/analytics/metrics-history')
+      .query({ metric: 'rajiuce_loop_detected_total' });
+
+    expect(res.status).toBe(403);
+  });
+
+  it('client_admin（non super_admin）→ 403', async () => {
+    dbModule.pool = makeMockPool();
+
+    const app = makeApp(CLIENT_ADMIN_META);
+    const res = await request(app)
+      .get('/v1/admin/analytics/metrics-history')
+      .query({ metric: 'rajiuce_conversation_terminal_total' });
+
+    expect(res.status).toBe(403);
+    expect(res.body.code).toBe('AUTH_ROLE_INSUFFICIENT');
+  });
+
+  it('granularity が whitelist 外 → 400', async () => {
+    dbModule.pool = makeMockPool();
+
+    const app = makeApp(SUPER_ADMIN_META);
+    const res = await request(app)
+      .get('/v1/admin/analytics/metrics-history')
+      .query({ metric: 'rajiuce_rag_duration_ms', granularity: '2h' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/granularity/);
+  });
+
+  it('metric が未指定 → 400', async () => {
+    dbModule.pool = makeMockPool();
+
+    const app = makeApp(SUPER_ADMIN_META);
+    const res = await request(app)
+      .get('/v1/admin/analytics/metrics-history');
+
+    expect(res.status).toBe(400);
+  });
+
+  it('pool が null → 503', async () => {
+    // dbModule.pool は null のまま
+    const app = makeApp(SUPER_ADMIN_META);
+    const res = await request(app)
+      .get('/v1/admin/analytics/metrics-history')
+      .query({ metric: 'rajiuce_conversation_terminal_total' });
+
+    expect(res.status).toBe(503);
+  });
+});

--- a/src/api/admin/analytics/routes.ts
+++ b/src/api/admin/analytics/routes.ts
@@ -1363,4 +1363,110 @@ export function registerAnalyticsRoutes(app: Express): void {
       }
     },
   );
+
+  // -------------------------------------------------------------------------
+  // GET /v1/admin/analytics/metrics-history  (Phase72-D: super_admin only)
+  // query: metric (required), period (1d|7d|30d, default 7d),
+  //        tenant_id (optional), granularity (1h|6h|24h, default 1h)
+  // -------------------------------------------------------------------------
+  const VALID_METRICS = new Set([
+    "rajiuce_conversation_terminal_total",
+    "rajiuce_loop_detected_total",
+    "rajiuce_avatar_requests_total",
+    "rajiuce_rag_duration_ms",
+  ] as const);
+
+  const VALID_GRANULARITIES: Record<string, string> = {
+    "1h": "hour",
+    "6h": "6 hours",
+    "24h": "day",
+  };
+
+  const PERIOD_INTERVALS: Record<string, string> = {
+    "1d": "1 day",
+    "7d": "7 days",
+    "30d": "30 days",
+  };
+
+  app.get(
+    "/v1/admin/analytics/metrics-history",
+    async (req: Request, res: Response) => {
+      const su = (req as any).supabaseUser as Record<string, any> | undefined;
+      const actorRole = su?.app_metadata?.role;
+      if (!isAllowedAdminRole(actorRole)) {
+        return res.status(403).json({ error: "この操作を実行する権限がありません", code: "AUTH_ROLE_INVALID" });
+      }
+      const isSuperAdmin: boolean = actorRole === "super_admin";
+      if (!isSuperAdmin) {
+        return res.status(403).json({ error: "アクセス権限がありません", code: "AUTH_ROLE_INSUFFICIENT" });
+      }
+      if (!pool) {
+        return res.status(503).json({ error: "データベース接続が利用できません" });
+      }
+
+      const metricRaw = req.query["metric"] as string | undefined;
+      if (!metricRaw || !VALID_METRICS.has(metricRaw as any)) {
+        return res.status(400).json({
+          error: "metric パラメータが必要です。有効な値: rajiuce_conversation_terminal_total, rajiuce_loop_detected_total, rajiuce_avatar_requests_total, rajiuce_rag_duration_ms",
+        });
+      }
+      const metric = metricRaw;
+
+      const periodRaw = (req.query["period"] as string | undefined) ?? "7d";
+      const periodInterval = PERIOD_INTERVALS[periodRaw] ?? "7 days";
+
+      const granularityRaw = (req.query["granularity"] as string | undefined) ?? "1h";
+      const dateTruncUnit = VALID_GRANULARITIES[granularityRaw];
+      if (!dateTruncUnit) {
+        return res.status(400).json({ error: "granularity は 1h, 6h, 24h のいずれかを指定してください" });
+      }
+
+      const tenantIdFilter = req.query["tenant_id"] as string | undefined;
+
+      try {
+        const params: (string | number)[] = [metric, periodInterval];
+        const tenantClause = tenantIdFilter
+          ? `AND tenant_id = $${params.push(tenantIdFilter)}`
+          : "";
+
+        const result = await pool.query(
+          `SELECT
+             DATE_TRUNC($4, snapshot_at) AS timestamp,
+             SUM(value)::float AS value,
+             labels
+           FROM metrics_snapshots
+           WHERE metric_name = $1
+             AND snapshot_at > NOW() - $2::interval
+             ${tenantClause}
+           GROUP BY DATE_TRUNC($4, snapshot_at), labels
+           ORDER BY timestamp ASC`,
+          [...params, dateTruncUnit],
+        );
+
+        type SnapshotRow = {
+          timestamp: Date;
+          value: number;
+          labels: Record<string, string | number>;
+        };
+
+        const series = (result.rows as SnapshotRow[]).map((row) => ({
+          timestamp: row.timestamp instanceof Date
+            ? row.timestamp.toISOString()
+            : String(row.timestamp),
+          value: row.value,
+          labels: row.labels ?? {},
+        }));
+
+        return res.json({
+          metric,
+          period: periodRaw,
+          granularity: granularityRaw,
+          series,
+        });
+      } catch (err) {
+        logger.warn("[GET /v1/admin/analytics/metrics-history]", err);
+        return res.status(500).json({ error: "メトリクス履歴の取得に失敗しました" });
+      }
+    },
+  );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import type { AuthedRequest } from "./agent/http/authMiddleware";
 import { runOcrPipeline } from "./lib/ocrPipeline";
 import { INTERNAL_REQUEST_HEADER } from "./lib/metrics/kpiDefinitions";
 import { metricsRegistry } from "./lib/metrics/promExporter";
+import { initMetricsFlush } from "./lib/metrics/metricsFlush";
 import { createChatHandler } from "./api/chat/route";
 import { healthHandler } from "./lib/health";
 import { businessHealthHandler } from "./lib/healthBusiness";
@@ -674,8 +675,12 @@ async function startServer() {
     logger.info({ port, env: process.env.NODE_ENV }, "server listening");
   });
 
+  // Phase72-D: Prometheus メトリクス → metrics_snapshots DB 永続化（5分周期）
+  const stopMetricsFlush = initMetricsFlush(db, logger);
+
   const onShutdown = (signal: string) => () => {
     logger.info({ signal }, "[shutdown] graceful shutdown initiated");
+    stopMetricsFlush();
     server.close();
     flushPostHog()
       .catch((err) => logger.error({ err }, "[shutdown] flushPostHog failed"))

--- a/src/lib/metrics/metricsFlush.test.ts
+++ b/src/lib/metrics/metricsFlush.test.ts
@@ -76,7 +76,7 @@ describe("flushOnce", () => {
     await flushOnce(pool, logger);
     expect(pool.query).toHaveBeenCalledTimes(1);
 
-    pool.query.mockClear();
+    (pool.query as jest.Mock).mockClear();
     pool._queries.length = 0;
 
     // 2回目: 増分なし → INSERT しない

--- a/src/lib/metrics/metricsFlush.test.ts
+++ b/src/lib/metrics/metricsFlush.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Phase72-D: metricsFlush ユニットテスト
+ *
+ * - Counter delta 計算の確認
+ * - Histogram sum の確認
+ * - pool null 時に noop
+ * - fake timers で clearInterval（stop 関数）の確認
+ */
+
+import { flushOnce, initMetricsFlush } from "./metricsFlush";
+import {
+  conversationTerminalCounter,
+  loopDetectedCounter,
+  ragDurationHistogram,
+} from "./promExporter";
+import pino from "pino";
+
+// prom-client の Counter/Histogram が実際の in-memory 値を保持するため、
+// テスト間でリセットが必要。metricsRegistry は各テストで reset しない
+// （他テストとの干渉回避のため、reset メソッドをスパイする）
+
+// ---------------------------------------------------------------------------
+// Mock pool
+// ---------------------------------------------------------------------------
+
+function makeMockPool() {
+  const queries: Array<{ text: string; values: unknown[] }> = [];
+  const pool = {
+    query: jest.fn().mockImplementation((text: string, values: unknown[]) => {
+      queries.push({ text, values });
+      return Promise.resolve({ rows: [] });
+    }),
+    _queries: queries,
+  };
+  return pool as unknown as import("pg").Pool & { _queries: typeof queries };
+}
+
+const logger = pino({ level: "silent" });
+
+// ---------------------------------------------------------------------------
+// Tests: flushOnce
+// ---------------------------------------------------------------------------
+
+describe("flushOnce", () => {
+  beforeEach(() => {
+    // Counter/Histogram を reset してテスト間の干渉を排除
+    conversationTerminalCounter.reset();
+    loopDetectedCounter.reset();
+    ragDurationHistogram.reset();
+  });
+
+  it("Counter に増分がある場合 INSERT を実行する", async () => {
+    const pool = makeMockPool();
+
+    conversationTerminalCounter.labels({ reason: "completed", tenantId: "tenant-A" }).inc(3);
+
+    await flushOnce(pool, logger);
+
+    expect(pool.query).toHaveBeenCalledTimes(1);
+    const call = pool._queries[0];
+    expect(call.text).toMatch(/INSERT INTO metrics_snapshots/);
+    // value = 3 が含まれる
+    expect(call.values).toContain(3);
+    // metric_name が含まれる
+    expect(call.values).toContain("rajiuce_conversation_terminal_total");
+    // tenant_id = "tenant-A"
+    expect(call.values).toContain("tenant-A");
+  });
+
+  it("Counter 2回 flush で2回目は delta が 0 なので INSERT しない", async () => {
+    const pool = makeMockPool();
+
+    loopDetectedCounter.labels({ tenantId: "tenant-B" }).inc(2);
+
+    // 1回目: delta = 2 → INSERT
+    await flushOnce(pool, logger);
+    expect(pool.query).toHaveBeenCalledTimes(1);
+
+    pool.query.mockClear();
+    pool._queries.length = 0;
+
+    // 2回目: 増分なし → INSERT しない
+    await flushOnce(pool, logger);
+    expect(pool.query).toHaveBeenCalledTimes(0);
+  });
+
+  it("Histogram の sum delta を INSERT する", async () => {
+    const pool = makeMockPool();
+
+    ragDurationHistogram.labels({ phase: "search", tenantId: "tenant-C" }).observe(500);
+
+    await flushOnce(pool, logger);
+
+    expect(pool.query).toHaveBeenCalledTimes(1);
+    const call = pool._queries[0];
+    expect(call.values).toContain("rajiuce_rag_duration_ms");
+    // sum = 500 が含まれる
+    expect(call.values).toContain(500);
+  });
+
+  it("pool が null の場合 noop（INSERT しない）", async () => {
+    // initMetricsFlush に null を渡す → stop 関数が返る
+    const stop = initMetricsFlush(null, logger);
+    // エラーなく呼べる
+    expect(() => stop()).not.toThrow();
+  });
+
+  it("Counter / Histogram に何も記録がない場合 INSERT しない", async () => {
+    const pool = makeMockPool();
+    await flushOnce(pool, logger);
+    expect(pool.query).toHaveBeenCalledTimes(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests: initMetricsFlush (stop 関数 = clearInterval)
+// ---------------------------------------------------------------------------
+
+describe("initMetricsFlush", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    conversationTerminalCounter.reset();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("stop 関数を呼ぶとタイマーが止まりそれ以降 INSERT しない", async () => {
+    const pool = makeMockPool();
+
+    const stop = initMetricsFlush(pool, logger, 1000);
+
+    // 増分を仕込む
+    conversationTerminalCounter.labels({ reason: "completed", tenantId: "t1" }).inc(1);
+
+    // 1000ms 進める → flush 1回
+    await jest.advanceTimersByTimeAsync(1000);
+    const firstCount = (pool.query as jest.Mock).mock.calls.length;
+
+    // stop してから 1000ms 進める → flush しない
+    stop();
+    await jest.advanceTimersByTimeAsync(1000);
+    const secondCount = (pool.query as jest.Mock).mock.calls.length;
+
+    expect(secondCount).toBe(firstCount);
+  });
+});

--- a/src/lib/metrics/metricsFlush.ts
+++ b/src/lib/metrics/metricsFlush.ts
@@ -1,0 +1,156 @@
+/**
+ * Phase72-D: Prometheus メトリクス → metrics_snapshots DB 永続化
+ *
+ * - Counter: 前回値との delta を INSERT（増分のみ保存）
+ * - Histogram: _sum 値を INSERT
+ * - pool falsy (DB未初期化) 時は noop
+ * - setInterval で定期実行し、戻り値 (stop 関数) で onShutdown に clearInterval を差し込む
+ */
+
+import type { Pool } from "pg";
+import type pino from "pino";
+import {
+  conversationTerminalCounter,
+  loopDetectedCounter,
+  avatarRequestsCounter,
+  httpErrorsCounter,
+  ragDurationHistogram,
+} from "./promExporter";
+import { KPI_METRIC_NAMES } from "./kpiDefinitions";
+
+// ---------------------------------------------------------------------------
+// 前回値キャッシュ（Counter delta 計算用）
+// ---------------------------------------------------------------------------
+
+/** key: `metricName:labelHash` → 前回のカウント値 */
+const prevCounterValues = new Map<string, number>();
+
+function labelHash(labels: Record<string, string | number>): string {
+  return Object.entries(labels)
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([k, v]) => `${k}=${v}`)
+    .join(",");
+}
+
+// ---------------------------------------------------------------------------
+// 内部: 1 回分の flush 処理
+// ---------------------------------------------------------------------------
+
+export async function flushOnce(pool: Pool, logger: pino.Logger): Promise<void> {
+  const rows: Array<{
+    metric_name: string;
+    tenant_id: string | null;
+    labels: Record<string, string | number>;
+    value: number;
+  }> = [];
+
+  // --- Counters ---
+  const counterMetrics = [
+    { counter: conversationTerminalCounter, name: KPI_METRIC_NAMES.CONVERSATION_TERMINAL_TOTAL },
+    { counter: loopDetectedCounter, name: KPI_METRIC_NAMES.LOOP_DETECTED_TOTAL },
+    { counter: avatarRequestsCounter, name: KPI_METRIC_NAMES.AVATAR_REQUESTS_TOTAL },
+    { counter: httpErrorsCounter, name: KPI_METRIC_NAMES.HTTP_ERRORS_TOTAL },
+  ] as const;
+
+  for (const { counter, name } of counterMetrics) {
+    const metric = await counter.get();
+    for (const val of metric.values) {
+      const currentValue = val.value;
+      const labels = val.labels as Record<string, string | number>;
+      const hash = labelHash(labels);
+      const cacheKey = `${name}:${hash}`;
+      const prev = prevCounterValues.get(cacheKey) ?? 0;
+      const delta = currentValue - prev;
+      if (delta > 0) {
+        prevCounterValues.set(cacheKey, currentValue);
+        const tenantId = (labels["tenantId"] as string | undefined) ?? null;
+        // tenantId ラベルは labels JSONB から除外（tenant_id 列で保持）
+        const { tenantId: _omit, ...restLabels } = labels as Record<string, string | number> & { tenantId?: string };
+        rows.push({ metric_name: name, tenant_id: tenantId, labels: restLabels, value: delta });
+      }
+    }
+  }
+
+  // --- Histogram: ragDurationHistogram (_sum のみ保存) ---
+  {
+    const metric = await ragDurationHistogram.get();
+    for (const val of metric.values) {
+      if (val.metricName !== `${KPI_METRIC_NAMES.RAG_DURATION_MS}_sum`) continue;
+      const currentSum = val.value;
+      const sharedLabels = (val as any).sharedLabels as Record<string, string | number> | undefined ?? {};
+      const allLabels = { ...sharedLabels, ...val.labels };
+      const hash = labelHash(allLabels);
+      const cacheKey = `${KPI_METRIC_NAMES.RAG_DURATION_MS}_sum:${hash}`;
+      const prev = prevCounterValues.get(cacheKey) ?? 0;
+      const delta = currentSum - prev;
+      if (delta > 0) {
+        prevCounterValues.set(cacheKey, currentSum);
+        const tenantId = (sharedLabels["tenantId"] as string | undefined) ?? null;
+        const { tenantId: _omit, ...restLabels } = sharedLabels as Record<string, string | number> & { tenantId?: string };
+        rows.push({
+          metric_name: KPI_METRIC_NAMES.RAG_DURATION_MS,
+          tenant_id: tenantId,
+          labels: restLabels,
+          value: delta,
+        });
+      }
+    }
+  }
+
+  if (rows.length === 0) return;
+
+  // Bulk INSERT
+  const placeholders = rows
+    .map((_, i) => {
+      const base = i * 4;
+      return `($${base + 1}, $${base + 2}, $${base + 3}::jsonb, $${base + 4})`;
+    })
+    .join(", ");
+
+  const values: (string | number | null | object)[] = [];
+  for (const row of rows) {
+    values.push(row.metric_name, row.tenant_id, JSON.stringify(row.labels), row.value);
+  }
+
+  await pool.query(
+    `INSERT INTO metrics_snapshots (metric_name, tenant_id, labels, value)
+     VALUES ${placeholders}`,
+    values,
+  );
+
+  logger.debug({ count: rows.length }, "[metricsFlush] flushed metrics_snapshots");
+}
+
+// ---------------------------------------------------------------------------
+// Public: initMetricsFlush
+// ---------------------------------------------------------------------------
+
+/**
+ * 定期 flush を開始する。
+ * @returns stop 関数（onShutdown で呼ぶ）
+ */
+export function initMetricsFlush(
+  pool: Pool | null | undefined,
+  logger: pino.Logger,
+  intervalMs = 300_000,
+): () => void {
+  if (!pool) {
+    logger.warn("[metricsFlush] pool not available — skipping metrics flush setup");
+    return () => { /* noop */ };
+  }
+
+  const resolvedPool = pool;
+
+  const timerId = setInterval(() => {
+    flushOnce(resolvedPool, logger).catch((err) => {
+      logger.error({ err }, "[metricsFlush] flush failed");
+    });
+  }, intervalMs);
+
+  logger.info({ intervalMs }, "[metricsFlush] started");
+
+  return () => {
+    clearInterval(timerId);
+    logger.info("[metricsFlush] stopped");
+  };
+}

--- a/src/migrations/phase72d_metrics_snapshots.sql
+++ b/src/migrations/phase72d_metrics_snapshots.sql
@@ -1,0 +1,19 @@
+-- Phase72-D: metrics_snapshots テーブル
+-- 実行は DBA/人間 が行う（コードは適用済みを前提として実装）
+CREATE TABLE IF NOT EXISTS metrics_snapshots (
+  id          BIGSERIAL    PRIMARY KEY,
+  metric_name TEXT         NOT NULL,
+  tenant_id   TEXT,
+  labels      JSONB        NOT NULL DEFAULT '{}',
+  value       NUMERIC      NOT NULL,
+  snapshot_at TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_metrics_snapshots_name_tenant_at
+  ON metrics_snapshots (metric_name, tenant_id, snapshot_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_metrics_snapshots_at
+  ON metrics_snapshots (snapshot_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_metrics_snapshots_name_at
+  ON metrics_snapshots (metric_name, snapshot_at DESC);


### PR DESCRIPTION
## 概要
Prometheus メトリクスを定期的に DB へ永続化し、Super Admin が時系列グラフで推移を確認できるようにする。DB flush + 時系列API + グラフUI。

Asana: Phase72-D（GID 1215691379754028）

## 実装
- `src/migrations/phase72d_metrics_snapshots.sql` — 新規テーブル（**人間がVPSで適用・不可逆**）
- `src/lib/metrics/metricsFlush.ts` — setInterval(5分) で Counter delta / Histogram sum を DB flush。`initMetricsFlush` は stop 関数を返し onShutdown で clearInterval（タイマーリークなし、VPS運用変更なし）。メトリクス名は kpiDefinitions 定数参照。
- `src/index.ts` — 起動時 initMetricsFlush + onShutdown 配線
- `src/api/admin/analytics/routes.ts` — GET /v1/admin/analytics/metrics-history（super_admin only、period/granularity whitelist、DATE_TRUNC バケット集計）
- `admin-ui` — MetricsTimeseriesSection（Line/Bar、会話/アバター/RAG 3タブ）

## Gate
- Gate 1: typecheck 0 / 1941 tests PASS（**テスト hang なし** — fake timers で検証）
- Gate 2: security-scan High/Critical 0
- Gate 3: backend + admin-ui build PASS
- 安全性: granularity は whitelist 検証後に DATE_TRUNC 展開（SQLインジェクション不可）、全クエリパラメータ化、ラベルに PII なし

## ⚠️ マージ前の人間アクション
1. `src/migrations/phase72d_metrics_snapshots.sql` を適用（SSHトンネル経由・不可逆）→ 適用後 merge 推奨
2. Gate 2.5（Codex review）と merge は人間手動
🤖 Generated with [Claude Code](https://claude.com/claude-code)
