### PR TITLE
refactor(admin-ui): 巨大ファイルリファクタ Stage1/3/5 — tuning型+AIReport分割+style抽出 (Phase2-P1-2)

### DIFF
--- a/admin-ui/src/components/tuning/TuningRuleModal.tsx
+++ b/admin-ui/src/components/tuning/TuningRuleModal.tsx
@@ -2,31 +2,15 @@ import { useState, useEffect } from "react";
 import { useLang } from "../../i18n/LangContext";
 import { authFetch, API_BASE } from "../../lib/api";
 
-export interface ApprovedResponse {
-  text: string;
-  style: string;
-  reason?: string;
-  approved_at: string;
-}
+import type {
+  ApprovedResponse,
+  TuningRule,
+  TuningRuleInput,
+  SourceConversation,
+} from "../../types/tuning";
 
-export interface TuningRule {
-  id: number;
-  tenant_id: string;
-  trigger_pattern: string;
-  expected_behavior: string;
-  priority: number;
-  is_active: boolean;
-  created_by: string;
-  created_at: string;
-  approved_responses?: ApprovedResponse[];
-}
-
-export type TuningRuleInput = Omit<TuningRule, "id" | "created_by" | "created_at">;
-
-export interface SourceConversation {
-  userMsg: string;
-  assistantMsg: string;
-}
+// 既存の import パス互換のため re-export（呼び出し側は変更不要）
+export type { ApprovedResponse, TuningRule, TuningRuleInput, SourceConversation };
 
 interface TestResponseItem {
   style: string;

--- a/admin-ui/src/types/tuning.ts
+++ b/admin-ui/src/types/tuning.ts
@@ -1,0 +1,25 @@
+export interface ApprovedResponse {
+  text: string;
+  style: string;
+  reason?: string;
+  approved_at: string;
+}
+
+export interface TuningRule {
+  id: number;
+  tenant_id: string;
+  trigger_pattern: string;
+  expected_behavior: string;
+  priority: number;
+  is_active: boolean;
+  created_by: string;
+  created_at: string;
+  approved_responses?: ApprovedResponse[];
+}
+
+export type TuningRuleInput = Omit<TuningRule, "id" | "created_by" | "created_at">;
+
+export interface SourceConversation {
+  userMsg: string;
+  assistantMsg: string;
+}


### PR DESCRIPTION
## 概要
[Phase2-P1-2] Admin UI 巨大ファイルリファクタ。**機能変更なし（behavior-preserving）**で巨大ファイルから論理単位を抽出。

Asana: GID 1214120401966111（段階的PR）

## 実施したStage
| Stage | 対象 | 内容 | 行数削減 |
|---|---|---|---|
| 1 | TuningRuleModal.tsx | 型定義4種を `types/tuning.ts` に抽出（re-export 互換） | — |
| 3 | AIReportTab.tsx | プレゼンテーショナル7コンポーネント+型+styleを `ai-report/` に分割 | 817→314行（-503） |
| 5 | TuningRuleModal.tsx | スタイル定数を `tuningModalStyles.ts` に分離 | 900→874行 |

## スキップ（対象ファイル不在）
- Stage 2（feedback/index.tsx）/ Stage 4（engagement/index.tsx）: 当該パスが実機に存在しない（計画時のファイル名が実構造と乖離）。実在する feedback は `FeedbackChat.tsx`(299行・単一)で抽出対象なし。後続調査で別途対応。

## behavior-preserving 証明
- admin-ui typecheck: 本変更による**新規エラー0**（AppSidebar.tsx の pre-existing エラー2件のみ残存、本PR無関係・CI非検査）
- admin-ui build (vite): ✓ 成功
- 純粋なコード移動 + import 付け替えのみ。ロジック/JSX/props/hooks/state 不変

merge は人間手動。rollback リスク低（移動のみ）。
🤖 Generated with [Claude Code](https://claude.com/claude-code)
