### PR TITLE
feat(metrics): Prometheus メトリクス永続化 + 時系列分析 (Phase72-D)

### DIFF
--- a/admin-ui/src/pages/admin/analytics/MetricsHistorySection.tsx
+++ b/admin-ui/src/pages/admin/analytics/MetricsHistorySection.tsx
@@ -1,0 +1,414 @@
+// admin-ui/src/pages/admin/analytics/MetricsHistorySection.tsx
+// Phase72-D: Prometheus メトリクス時系列グラフ (super_admin only)
+
+import { useState, useEffect } from "react";
+import { Line, Bar } from "react-chartjs-2";
+import { authFetch, API_BASE } from "../../../lib/api";
+import { chartCardStyle } from "./utils";
+
+// ---------------------------------------------------------------------------
+// 型
+// ---------------------------------------------------------------------------
+
+interface MetricsSeriesItem {
+  timestamp: string;
+  value: number;
+  labels: Record<string, string>;
+}
+
+interface MetricsHistoryResponse {
+  metric: string;
+  period: string;
+  granularity: string;
+  series: MetricsSeriesItem[];
+}
+
+// ---------------------------------------------------------------------------
+// ヘルパー
+// ---------------------------------------------------------------------------
+
+const PERIOD_OPTIONS = [
+  { value: "1d", label: "1日" },
+  { value: "7d", label: "7日" },
+  { value: "30d", label: "30日" },
+];
+
+const GRANULARITY_OPTIONS = [
+  { value: "1h", label: "1時間" },
+  { value: "6h", label: "6時間" },
+  { value: "24h", label: "1日" },
+];
+
+const TABS = [
+  { id: "conversation", label: "会話・ループ" },
+  { id: "avatar", label: "アバターリクエスト" },
+  { id: "rag", label: "RAG 処理時間" },
+] as const;
+
+type TabId = typeof TABS[number]["id"];
+
+function formatTimestamp(iso: string): string {
+  const d = new Date(iso);
+  return d.toLocaleDateString("ja-JP", { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+}
+
+function groupByLabel(series: MetricsSeriesItem[]): Map<string, MetricsSeriesItem[]> {
+  const map = new Map<string, MetricsSeriesItem[]>();
+  for (const item of series) {
+    const key = JSON.stringify(item.labels);
+    if (!map.has(key)) map.set(key, []);
+    map.get(key)!.push(item);
+  }
+  return map;
+}
+
+function labelDisplay(labels: Record<string, string>): string {
+  return Object.entries(labels)
+    .map(([k, v]) => `${k}=${v}`)
+    .join(", ") || "全体";
+}
+
+// ---------------------------------------------------------------------------
+// useMetrics フック
+// ---------------------------------------------------------------------------
+
+function useMetrics(metric: string, period: string, granularity: string) {
+  const [data, setData] = useState<MetricsHistoryResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setLoading(true);
+    setError(null);
+    const params = new URLSearchParams({ metric, period, granularity });
+    authFetch(`${API_BASE}/v1/admin/analytics/metrics-history?${params}`)
+      .then((res) => {
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+        return res.json() as Promise<MetricsHistoryResponse>;
+      })
+      .then(setData)
+      .catch(() => setError("データの取得に失敗しました"))
+      .finally(() => setLoading(false));
+  }, [metric, period, granularity]);
+
+  return { data, loading, error };
+}
+
+// ---------------------------------------------------------------------------
+// 会話終了 vs ループ検出 グラフ（Line 2 系列）
+// ---------------------------------------------------------------------------
+
+function ConversationChart({ period, granularity }: { period: string; granularity: string }) {
+  const terminal = useMetrics("rajiuce_conversation_terminal_total", period, granularity);
+  const loop = useMetrics("rajiuce_loop_detected_total", period, granularity);
+
+  const loading = terminal.loading || loop.loading;
+  const error = terminal.error ?? loop.error;
+
+  if (loading) return <div style={{ padding: 40, textAlign: "center", color: "var(--muted-foreground)" }}>読み込み中...</div>;
+  if (error) return <div style={{ padding: 16, color: "#fca5a5" }}>データの取得に失敗しました</div>;
+
+  const terminalSeries = terminal.data?.series ?? [];
+  const loopSeries = loop.data?.series ?? [];
+
+  // タイムスタンプ軸を統合
+  const allTimestamps = Array.from(
+    new Set([...terminalSeries.map((s) => s.timestamp), ...loopSeries.map((s) => s.timestamp)])
+  ).sort();
+
+  if (allTimestamps.length === 0) {
+    return <div style={{ padding: 16, color: "var(--muted-foreground)", textAlign: "center" }}>データがありません</div>;
+  }
+
+  const terminalMap = new Map(terminalSeries.map((s) => [s.timestamp, s.value]));
+  const loopMap = new Map(loopSeries.map((s) => [s.timestamp, s.value]));
+
+  const chartData = {
+    labels: allTimestamps.map(formatTimestamp),
+    datasets: [
+      {
+        label: "会話終了（delta）",
+        data: allTimestamps.map((t) => terminalMap.get(t) ?? 0),
+        borderColor: "#60a5fa",
+        backgroundColor: "rgba(96,165,250,0.08)",
+        borderWidth: 2,
+        pointRadius: 2,
+        tension: 0.3,
+        fill: true,
+      },
+      {
+        label: "ループ検出（delta）",
+        data: allTimestamps.map((t) => loopMap.get(t) ?? 0),
+        borderColor: "#f87171",
+        backgroundColor: "rgba(248,113,113,0.08)",
+        borderWidth: 2,
+        pointRadius: 2,
+        tension: 0.3,
+        fill: false,
+      },
+    ],
+  };
+
+  return (
+    <div style={chartCardStyle}>
+      <h3 style={{ fontSize: 15, fontWeight: 600, color: "var(--muted-foreground)", margin: "0 0 16px 0" }}>
+        会話終了数 vs ループ検出数
+      </h3>
+      <div style={{ height: 220 }}>
+        <Line
+          data={chartData}
+          options={{
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+              legend: {
+                position: "bottom",
+                labels: { color: "var(--muted-foreground)", font: { size: 11 }, padding: 10 },
+              },
+            },
+            scales: {
+              x: {
+                ticks: { color: "var(--muted-foreground)", maxTicksLimit: 8, font: { size: 10 } },
+                grid: { color: "rgba(255,255,255,0.05)" },
+              },
+              y: {
+                beginAtZero: true,
+                ticks: { color: "var(--muted-foreground)", font: { size: 11 } },
+                grid: { color: "rgba(255,255,255,0.05)" },
+              },
+            },
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// アバターリクエスト グラフ（Bar stacked by result）
+// ---------------------------------------------------------------------------
+
+function AvatarRequestChart({ period, granularity }: { period: string; granularity: string }) {
+  const { data, loading, error } = useMetrics("rajiuce_avatar_requests_total", period, granularity);
+
+  if (loading) return <div style={{ padding: 40, textAlign: "center", color: "var(--muted-foreground)" }}>読み込み中...</div>;
+  if (error) return <div style={{ padding: 16, color: "#fca5a5" }}>データの取得に失敗しました</div>;
+
+  const series = data?.series ?? [];
+  if (series.length === 0) {
+    return <div style={{ padding: 16, color: "var(--muted-foreground)", textAlign: "center" }}>データがありません</div>;
+  }
+
+  // ラベル（result/status）別にグループ化
+  const grouped = groupByLabel(series);
+  const allTimestamps = Array.from(
+    new Set(series.map((s) => s.timestamp))
+  ).sort();
+
+  const COLORS = ["rgba(52,211,153,0.75)", "rgba(248,113,113,0.75)", "rgba(251,191,36,0.75)", "rgba(167,139,250,0.75)"];
+  const datasets = Array.from(grouped.entries()).map(([key, items], idx) => {
+    const labels = JSON.parse(key) as Record<string, string>;
+    const valueMap = new Map(items.map((s) => [s.timestamp, s.value]));
+    return {
+      label: labelDisplay(labels),
+      data: allTimestamps.map((t) => valueMap.get(t) ?? 0),
+      backgroundColor: COLORS[idx % COLORS.length],
+      stack: "avatar",
+    };
+  });
+
+  const chartData = {
+    labels: allTimestamps.map(formatTimestamp),
+    datasets,
+  };
+
+  return (
+    <div style={chartCardStyle}>
+      <h3 style={{ fontSize: 15, fontWeight: 600, color: "var(--muted-foreground)", margin: "0 0 16px 0" }}>
+        アバターリクエスト数（ラベル別）
+      </h3>
+      <div style={{ height: 220 }}>
+        <Bar
+          data={chartData}
+          options={{
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+              legend: {
+                position: "bottom",
+                labels: { color: "var(--muted-foreground)", font: { size: 11 }, padding: 10 },
+              },
+            },
+            scales: {
+              x: {
+                stacked: true,
+                ticks: { color: "var(--muted-foreground)", maxTicksLimit: 8, font: { size: 10 } },
+                grid: { color: "rgba(255,255,255,0.05)" },
+              },
+              y: {
+                stacked: true,
+                beginAtZero: true,
+                ticks: { color: "var(--muted-foreground)", font: { size: 11 } },
+                grid: { color: "rgba(255,255,255,0.05)" },
+              },
+            },
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// RAG 処理時間 グラフ（Line）
+// ---------------------------------------------------------------------------
+
+function RagDurationChart({ period, granularity }: { period: string; granularity: string }) {
+  const { data, loading, error } = useMetrics("rajiuce_rag_duration_ms", period, granularity);
+
+  if (loading) return <div style={{ padding: 40, textAlign: "center", color: "var(--muted-foreground)" }}>読み込み中...</div>;
+  if (error) return <div style={{ padding: 16, color: "#fca5a5" }}>データの取得に失敗しました</div>;
+
+  const series = data?.series ?? [];
+  if (series.length === 0) {
+    return <div style={{ padding: 16, color: "var(--muted-foreground)", textAlign: "center" }}>データがありません</div>;
+  }
+
+  // phase ラベル別にグループ化
+  const grouped = groupByLabel(series);
+  const allTimestamps = Array.from(new Set(series.map((s) => s.timestamp))).sort();
+
+  const COLORS = ["#a78bfa", "#60a5fa", "#34d399", "#fbbf24"];
+  const datasets = Array.from(grouped.entries()).map(([key, items], idx) => {
+    const labels = JSON.parse(key) as Record<string, string>;
+    const valueMap = new Map(items.map((s) => [s.timestamp, s.value]));
+    return {
+      label: labelDisplay(labels),
+      data: allTimestamps.map((t) => valueMap.get(t) ?? 0),
+      borderColor: COLORS[idx % COLORS.length],
+      backgroundColor: "transparent",
+      borderWidth: 2,
+      pointRadius: 2,
+      tension: 0.3,
+    };
+  });
+
+  const chartData = {
+    labels: allTimestamps.map(formatTimestamp),
+    datasets,
+  };
+
+  return (
+    <div style={chartCardStyle}>
+      <h3 style={{ fontSize: 15, fontWeight: 600, color: "var(--muted-foreground)", margin: "0 0 16px 0" }}>
+        RAG 処理時間（平均 ms / フェーズ別）
+      </h3>
+      <div style={{ height: 220 }}>
+        <Line
+          data={chartData}
+          options={{
+            responsive: true,
+            maintainAspectRatio: false,
+            plugins: {
+              legend: {
+                position: "bottom",
+                labels: { color: "var(--muted-foreground)", font: { size: 11 }, padding: 10 },
+              },
+            },
+            scales: {
+              x: {
+                ticks: { color: "var(--muted-foreground)", maxTicksLimit: 8, font: { size: 10 } },
+                grid: { color: "rgba(255,255,255,0.05)" },
+              },
+              y: {
+                beginAtZero: true,
+                ticks: {
+                  color: "var(--muted-foreground)",
+                  font: { size: 11 },
+                  callback: (v) => `${v}ms`,
+                },
+                grid: { color: "rgba(255,255,255,0.05)" },
+              },
+            },
+          }}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// メインコンポーネント
+// ---------------------------------------------------------------------------
+
+export function MetricsHistorySection() {
+  const [activeTab, setActiveTab] = useState<TabId>("conversation");
+  const [period, setPeriod] = useState("7d");
+  const [granularity, setGranularity] = useState("1h");
+
+  const selectStyle = {
+    padding: "4px 8px",
+    borderRadius: 6,
+    border: "1px solid var(--border)",
+    background: "var(--card)",
+    color: "var(--foreground)",
+    fontSize: 13,
+  };
+
+  const tabStyle = (active: boolean) => ({
+    padding: "6px 14px",
+    borderRadius: 8,
+    border: "none",
+    cursor: "pointer" as const,
+    fontSize: 13,
+    fontWeight: active ? 600 : 400,
+    background: active ? "rgba(96,165,250,0.2)" : "transparent",
+    color: active ? "#60a5fa" : "var(--muted-foreground)",
+  });
+
+  return (
+    <section>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 16, flexWrap: "wrap", gap: 8 }}>
+        <h2 style={{ fontSize: 17, fontWeight: 700, color: "var(--foreground)", margin: 0 }}>
+          Prometheus メトリクス履歴
+        </h2>
+        <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap" }}>
+          <select style={selectStyle} value={period} onChange={(e) => setPeriod(e.target.value)}>
+            {PERIOD_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+            ))}
+          </select>
+          <select style={selectStyle} value={granularity} onChange={(e) => setGranularity(e.target.value)}>
+            {GRANULARITY_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+            ))}
+          </select>
+        </div>
+      </div>
+
+      {/* タブ */}
+      <div style={{ display: "flex", gap: 4, marginBottom: 16, borderBottom: "1px solid var(--border)", paddingBottom: 4 }}>
+        {TABS.map((tab) => (
+          <button
+            key={tab.id}
+            style={tabStyle(activeTab === tab.id)}
+            onClick={() => setActiveTab(tab.id)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* グラフ */}
+      {activeTab === "conversation" && (
+        <ConversationChart period={period} granularity={granularity} />
+      )}
+      {activeTab === "avatar" && (
+        <AvatarRequestChart period={period} granularity={granularity} />
+      )}
+      {activeTab === "rag" && (
+        <RagDurationChart period={period} granularity={granularity} />
+      )}
+    </section>
+  );
+}

--- a/admin-ui/src/pages/admin/analytics/index.tsx
+++ b/admin-ui/src/pages/admin/analytics/index.tsx
@@ -32,6 +32,7 @@ import { LowScoreSessionsTable } from "./LowScoreSessionsTable";
 import { ConversionSection } from "./ConversionSection";
 import { AvatarSettingsSection } from "./AvatarSettingsSection";
 import { FlowFunnelSection } from "./FlowFunnelSection";
+import { MetricsHistorySection } from "./MetricsHistorySection";
 
 ChartJS.register(
   CategoryScale,
@@ -413,6 +414,10 @@ export default function AnalyticsDashboardPage() {
             tenantId={tenantId}
             isSuperAdmin={isSuperAdmin}
           />
+          {/* ============================================================ */}
+          {/* Phase72-D: Prometheus メトリクス時系列グラフ (super_admin only) */}
+          {/* ============================================================ */}
+          {isSuperAdmin && <MetricsHistorySection />}
         </>
       )}
     </div>

--- a/src/api/admin/analytics/analyticsAuthGuard.test.ts
+++ b/src/api/admin/analytics/analyticsAuthGuard.test.ts
@@ -51,11 +51,12 @@ const TENANT_SCOPED_ROUTES = [
   '/v1/admin/analytics/flow-transitions',
 ];
 
-// All routes including super_admin-only endpoints (cv-status, avatar-settings-summary)
+// All routes including super_admin-only endpoints (cv-status, avatar-settings-summary, metrics-history)
 const ALL_ROUTES = [
   ...TENANT_SCOPED_ROUTES,
   '/v1/admin/analytics/cv-status',
   '/v1/admin/analytics/avatar-settings-summary',
+  '/v1/admin/analytics/metrics-history',
 ];
 
 beforeEach(() => {

--- a/src/api/admin/analytics/metricsHistory.test.ts
+++ b/src/api/admin/analytics/metricsHistory.test.ts
@@ -190,4 +190,43 @@ describe("GET /v1/admin/analytics/metrics-history — 正常系", () => {
     expect(res.body.period).toBe("7d");
     expect(res.body.granularity).toBe("1h");
   });
+
+  // granularity 別の SQL バケット式検証（P1-1 regression guard）
+  it("granularity=1h のとき DATE_TRUNC('hour', ...) が SQL に使われる", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+    const app = makeApp();
+    await request(app)
+      .get(`${ROUTE}?metric=rajiuce_conversation_terminal_total&granularity=1h`)
+      .set("x-role", "super_admin");
+
+    const [sql] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toMatch(/DATE_TRUNC\('hour'/i);
+    expect(sql).not.toMatch(/DATE_BIN/i);
+  });
+
+  it("granularity=6h のとき DATE_BIN('6 hours', ...) が SQL に使われる（PG16対応）", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+    const app = makeApp();
+    await request(app)
+      .get(`${ROUTE}?metric=rajiuce_conversation_terminal_total&granularity=6h`)
+      .set("x-role", "super_admin");
+
+    const [sql] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toMatch(/DATE_BIN/i);
+    expect(sql).toMatch(/6 hours/i);
+    // DATE_TRUNC の不正な使い方になっていないこと
+    expect(sql).not.toMatch(/DATE_TRUNC\('6 hours'/i);
+  });
+
+  it("granularity=24h のとき DATE_TRUNC('day', ...) が SQL に使われる", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+    const app = makeApp();
+    await request(app)
+      .get(`${ROUTE}?metric=rajiuce_conversation_terminal_total&granularity=24h`)
+      .set("x-role", "super_admin");
+
+    const [sql] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toMatch(/DATE_TRUNC\('day'/i);
+    expect(sql).not.toMatch(/DATE_BIN/i);
+  });
 });

--- a/src/api/admin/analytics/metricsHistory.test.ts
+++ b/src/api/admin/analytics/metricsHistory.test.ts
@@ -1,0 +1,193 @@
+// src/api/admin/analytics/metricsHistory.test.ts
+// Phase72-D: GET /v1/admin/analytics/metrics-history テスト
+// flowTransitions.test.ts の mock パターンを踏襲
+
+import express from "express";
+import request from "supertest";
+
+// ---------------------------------------------------------------------------
+// モック
+// ---------------------------------------------------------------------------
+
+const mockQuery = jest.fn();
+jest.mock("../../../lib/db", () => ({
+  pool: { query: (...args: unknown[]) => mockQuery(...args) },
+  getPool: () => ({ query: (...args: unknown[]) => mockQuery(...args) }),
+}));
+
+jest.mock("../../../lib/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock("../../../lib/notifications", () => ({
+  createNotification: jest.fn(),
+  notificationExists: jest.fn().mockResolvedValue(false),
+}));
+
+// supabase auth middleware — x-role ヘッダで制御
+jest.mock("../../../admin/http/supabaseAuthMiddleware", () => ({
+  supabaseAuthMiddleware: (req: any, _res: any, next: any) => {
+    const role = (req.headers["x-role"] as string) ?? "super_admin";
+    const tenantId = req.headers["x-tenant-id"] as string | undefined;
+    req.supabaseUser = {
+      app_metadata: {
+        role,
+        ...(tenantId ? { tenant_id: tenantId } : {}),
+      },
+    };
+    next();
+  },
+}));
+
+import { registerAnalyticsRoutes } from "./routes";
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  registerAnalyticsRoutes(app);
+  return app;
+}
+
+const ROUTE = "/v1/admin/analytics/metrics-history";
+
+beforeEach(() => {
+  mockQuery.mockClear();
+});
+
+// ---------------------------------------------------------------------------
+// 認証ガード
+// ---------------------------------------------------------------------------
+
+describe("GET /v1/admin/analytics/metrics-history — 認証ガード", () => {
+  it("viewer ロール → 403 AUTH_ROLE_INVALID", async () => {
+    const app = makeApp();
+    const res = await request(app).get(`${ROUTE}?metric=rajiuce_conversation_terminal_total`).set("x-role", "viewer");
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({ code: "AUTH_ROLE_INVALID" });
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("client_admin → 403 AUTH_ROLE_INSUFFICIENT（super_admin 専用）", async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .get(`${ROUTE}?metric=rajiuce_conversation_terminal_total`)
+      .set("x-role", "client_admin")
+      .set("x-tenant-id", "tenant-a");
+    expect(res.status).toBe(403);
+    expect(res.body).toMatchObject({ code: "AUTH_ROLE_INSUFFICIENT" });
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// バリデーション
+// ---------------------------------------------------------------------------
+
+describe("GET /v1/admin/analytics/metrics-history — バリデーション", () => {
+  it("metric 未指定 → 400", async () => {
+    const app = makeApp();
+    const res = await request(app).get(ROUTE).set("x-role", "super_admin");
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/metric/);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("不正な period → 400", async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .get(`${ROUTE}?metric=rajiuce_conversation_terminal_total&period=999d`)
+      .set("x-role", "super_admin");
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/period/);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("不正な granularity → 400", async () => {
+    const app = makeApp();
+    const res = await request(app)
+      .get(`${ROUTE}?metric=rajiuce_conversation_terminal_total&granularity=3h`)
+      .set("x-role", "super_admin");
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/granularity/);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 正常系
+// ---------------------------------------------------------------------------
+
+describe("GET /v1/admin/analytics/metrics-history — 正常系", () => {
+  it("DATE_TRUNC バケット集計: series が返る", async () => {
+    mockQuery.mockResolvedValue({
+      rows: [
+        {
+          bucket: new Date("2026-06-14T10:00:00Z"),
+          value: 5.0,
+          labels: { reason: "completed", tenantId: "t1" },
+        },
+        {
+          bucket: new Date("2026-06-14T11:00:00Z"),
+          value: 3.0,
+          labels: { reason: "completed", tenantId: "t1" },
+        },
+      ],
+    });
+
+    const app = makeApp();
+    const res = await request(app)
+      .get(`${ROUTE}?metric=rajiuce_conversation_terminal_total&period=7d&granularity=1h`)
+      .set("x-role", "super_admin");
+
+    expect(res.status).toBe(200);
+    expect(res.body).toMatchObject({
+      metric: "rajiuce_conversation_terminal_total",
+      period: "7d",
+      granularity: "1h",
+    });
+    expect(Array.isArray(res.body.series)).toBe(true);
+    expect(res.body.series).toHaveLength(2);
+    expect(res.body.series[0]).toMatchObject({ value: 5, labels: { reason: "completed" } });
+    expect(typeof res.body.series[0].timestamp).toBe("string");
+  });
+
+  it("DB が空のとき series:[] を返す（null 禁止）", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    const app = makeApp();
+    const res = await request(app)
+      .get(`${ROUTE}?metric=rajiuce_loop_detected_total&period=1d`)
+      .set("x-role", "super_admin");
+
+    expect(res.status).toBe(200);
+    expect(res.body.series).toEqual([]);
+    // series が null でないことを確認
+    expect(res.body.series).not.toBeNull();
+  });
+
+  it("tenant_id クエリを渡すと DB クエリに含まれる", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    const app = makeApp();
+    await request(app)
+      .get(`${ROUTE}?metric=rajiuce_avatar_requests_total&tenant_id=tenant-x`)
+      .set("x-role", "super_admin");
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const callArgs = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(callArgs[1]).toContain("tenant-x");
+  });
+
+  it("デフォルト period=7d / granularity=1h が適用される", async () => {
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    const app = makeApp();
+    const res = await request(app)
+      .get(`${ROUTE}?metric=rajiuce_rag_duration_ms`)
+      .set("x-role", "super_admin");
+
+    expect(res.status).toBe(200);
+    expect(res.body.period).toBe("7d");
+    expect(res.body.granularity).toBe("1h");
+  });
+});

--- a/src/api/admin/analytics/routes.ts
+++ b/src/api/admin/analytics/routes.ts
@@ -1674,17 +1674,25 @@ export function registerAnalyticsRoutes(app: Express): void {
       }
       const period = periodRaw as ValidPeriod;
 
-      // granularity 検証（DATE_TRUNC に渡す値 — allow-list で SQL インジェクション防止）
+      // granularity 検証（allow-list で SQL インジェクション防止）
+      // 1h/24h は DATE_TRUNC('hour'/'day', …) で対応。
+      // 6h は DATE_TRUNC が 'hour' 単位しか受け付けないため
+      // DATE_BIN('6 hours', …, TIMESTAMPTZ '2000-01-01') を使用（PG14+/本番PG16対応）。
       const granularityRaw = (req.query["granularity"] as string | undefined) ?? "1h";
-      const GRANULARITY_MAP: Record<string, string> = {
-        "1h": "hour",
-        "6h": "6 hours",
-        "24h": "day",
-      };
-      if (!(granularityRaw in GRANULARITY_MAP)) {
+      type GranularityKey = "1h" | "6h" | "24h";
+      const VALID_GRANULARITIES: ReadonlyArray<string> = ["1h", "6h", "24h"];
+      if (!VALID_GRANULARITIES.includes(granularityRaw)) {
         return res.status(400).json({ error: "granularity は 1h | 6h | 24h のいずれかを指定してください" });
       }
-      const truncUnit = GRANULARITY_MAP[granularityRaw]!;
+      const granularity = granularityRaw as GranularityKey;
+
+      // バケット式を granularity 別に組み立て（固定値 allow-list のみ使用）
+      const BUCKET_EXPR: Record<GranularityKey, string> = {
+        "1h":  "DATE_TRUNC('hour', snapshot_at)",
+        "6h":  "DATE_BIN('6 hours', snapshot_at, TIMESTAMPTZ '2000-01-01')",
+        "24h": "DATE_TRUNC('day', snapshot_at)",
+      };
+      const bucketExpr = BUCKET_EXPR[granularity];
 
       const tenantIdFilter = (req.query["tenant_id"] as string | undefined)?.trim() || null;
 
@@ -1711,16 +1719,15 @@ export function registerAnalyticsRoutes(app: Express): void {
 
         const result = await pool.query(
           `SELECT
-             DATE_TRUNC($truncUnit_literal, snapshot_at) AS bucket,
+             ${bucketExpr} AS bucket,
              SUM(value)::float AS value,
              labels
            FROM metrics_snapshots
            WHERE metric_name = $1
              AND snapshot_at >= NOW() - $2::interval
              ${tenantClause}
-           GROUP BY DATE_TRUNC($truncUnit_literal, snapshot_at), labels
-           ORDER BY bucket ASC`
-            .replace(/\$truncUnit_literal/g, `'${truncUnit}'`),
+           GROUP BY ${bucketExpr}, labels
+           ORDER BY bucket ASC`,
           params,
         );
 
@@ -1741,7 +1748,7 @@ export function registerAnalyticsRoutes(app: Express): void {
         return res.json({
           metric,
           period,
-          granularity: granularityRaw,
+          granularity,
           series,
         });
       } catch (err) {

--- a/src/api/admin/analytics/routes.ts
+++ b/src/api/admin/analytics/routes.ts
@@ -1624,4 +1624,130 @@ export function registerAnalyticsRoutes(app: Express): void {
       }
     },
   );
+
+  // -------------------------------------------------------------------------
+  // GET /v1/admin/analytics/metrics-history  (Phase72-D: super_admin only)
+  // Prometheus スナップショットの時系列集計
+  //   - metric: rajiuce_ prefix メトリクス名（必須）
+  //   - period: 1d | 7d | 30d（デフォルト 7d）
+  //   - tenant_id: テナント絞り込み（任意）
+  //   - granularity: 1h | 6h | 24h（デフォルト 1h）
+  // -------------------------------------------------------------------------
+  app.get(
+    "/v1/admin/analytics/metrics-history",
+    async (req: Request, res: Response) => {
+      const su = (req as any).supabaseUser as Record<string, any> | undefined;
+      const actorRole = su?.app_metadata?.role;
+      if (!isAllowedAdminRole(actorRole)) {
+        logger.warn({
+          event: 'analytics_access_denied',
+          reason: 'invalid_role',
+          actorEmail: su?.email ? String(su.email).slice(0, 3) + '***' : 'unknown',
+          errorCode: 'AUTH_ROLE_INVALID',
+        }, "Admin analytics access denied: invalid actor role");
+        return res.status(403).json({ error: "この操作を実行する権限がありません", code: 'AUTH_ROLE_INVALID' });
+      }
+      const isSuperAdmin: boolean = actorRole === "super_admin";
+      if (!isSuperAdmin) {
+        logger.warn({
+          event: 'analytics_access_denied',
+          reason: 'insufficient_role',
+          actorRole,
+          actorEmail: su?.email ? String(su.email).slice(0, 3) + '***' : 'unknown',
+          errorCode: 'AUTH_ROLE_INSUFFICIENT',
+        }, "Admin analytics access denied: super_admin required");
+        return res.status(403).json({ error: "アクセス権限がありません", code: 'AUTH_ROLE_INSUFFICIENT' });
+      }
+
+      // バリデーション: metric 必須
+      const metric = (req.query["metric"] as string | undefined)?.trim();
+      if (!metric) {
+        return res.status(400).json({ error: "metric パラメータは必須です" });
+      }
+
+      // period 検証
+      const periodRaw = (req.query["period"] as string | undefined) ?? "7d";
+      const VALID_PERIODS = ["1d", "7d", "30d"] as const;
+      type ValidPeriod = typeof VALID_PERIODS[number];
+      if (!VALID_PERIODS.includes(periodRaw as ValidPeriod)) {
+        return res.status(400).json({ error: "period は 1d | 7d | 30d のいずれかを指定してください" });
+      }
+      const period = periodRaw as ValidPeriod;
+
+      // granularity 検証（DATE_TRUNC に渡す値 — allow-list で SQL インジェクション防止）
+      const granularityRaw = (req.query["granularity"] as string | undefined) ?? "1h";
+      const GRANULARITY_MAP: Record<string, string> = {
+        "1h": "hour",
+        "6h": "6 hours",
+        "24h": "day",
+      };
+      if (!(granularityRaw in GRANULARITY_MAP)) {
+        return res.status(400).json({ error: "granularity は 1h | 6h | 24h のいずれかを指定してください" });
+      }
+      const truncUnit = GRANULARITY_MAP[granularityRaw]!;
+
+      const tenantIdFilter = (req.query["tenant_id"] as string | undefined)?.trim() || null;
+
+      const periodIntervalMap: Record<ValidPeriod, string> = {
+        "1d": "1 day",
+        "7d": "7 days",
+        "30d": "30 days",
+      };
+      const interval = periodIntervalMap[period];
+
+      if (!pool) {
+        return res.status(503).json({ error: "データベース接続が利用できません" });
+      }
+
+      try {
+        const params: (string | null)[] = [metric, interval];
+        let tenantClause: string;
+        if (tenantIdFilter) {
+          params.push(tenantIdFilter);
+          tenantClause = "AND tenant_id = $3";
+        } else {
+          tenantClause = "";
+        }
+
+        const result = await pool.query(
+          `SELECT
+             DATE_TRUNC($truncUnit_literal, snapshot_at) AS bucket,
+             SUM(value)::float AS value,
+             labels
+           FROM metrics_snapshots
+           WHERE metric_name = $1
+             AND snapshot_at >= NOW() - $2::interval
+             ${tenantClause}
+           GROUP BY DATE_TRUNC($truncUnit_literal, snapshot_at), labels
+           ORDER BY bucket ASC`
+            .replace(/\$truncUnit_literal/g, `'${truncUnit}'`),
+          params,
+        );
+
+        type SnapshotRow = {
+          bucket: Date | string;
+          value: number;
+          labels: Record<string, string>;
+        };
+
+        const series = (result.rows as SnapshotRow[]).map((row) => ({
+          timestamp: row.bucket instanceof Date
+            ? row.bucket.toISOString()
+            : String(row.bucket),
+          value: row.value ?? 0,
+          labels: row.labels ?? {},
+        }));
+
+        return res.json({
+          metric,
+          period,
+          granularity: granularityRaw,
+          series,
+        });
+      } catch (err) {
+        logger.warn("[GET /v1/admin/analytics/metrics-history]", err);
+        return res.status(500).json({ error: "メトリクス履歴の取得に失敗しました" });
+      }
+    },
+  );
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -47,6 +47,7 @@ import { registerBillingAdminRoutes } from "./lib/billing/billingApi";
 import { createStripeWebhookHandler } from "./lib/billing/stripeWebhook";
 import { initUsageTracker } from "./lib/billing/usageTracker";
 import { initFlowLogger } from "./lib/analytics/flowLogger";
+import { initMetricsFlush } from "./lib/metrics/metricsFlush";
 import { reportUsageToStripe } from "./lib/billing/stripeSync";
 import { pipelineQueue } from "./lib/book-pipeline/pipelineQueue";
 import { supabaseAuthMiddleware } from "./admin/http/supabaseAuthMiddleware";
@@ -516,6 +517,8 @@ if (db) registerNotificationPreferencesRoutes(app, db);
 if (db) initUsageTracker(db, logger);
 // Phase72-C: フロー遷移ログ
 if (db) initFlowLogger(db, logger);
+// Phase72-D: Prometheus メトリクス DB フラッシュ
+const cleanupMetricsFlush = initMetricsFlush(db, logger);
 
 // Stripe Webhook（raw body 必須 — express.json より前にマッチさせること）
 app.post(
@@ -673,6 +676,7 @@ async function startServer() {
 
   const onShutdown = (signal: string) => () => {
     logger.info({ signal }, "[shutdown] graceful shutdown initiated");
+    cleanupMetricsFlush();
     server.close();
     flushPostHog()
       .catch((err) => logger.error({ err }, "[shutdown] flushPostHog failed"))

--- a/src/lib/metrics/metricsFlush.test.ts
+++ b/src/lib/metrics/metricsFlush.test.ts
@@ -30,6 +30,12 @@ const mockLogger = { warn: mockWarn, info: mockInfo };
 import { initMetricsFlush } from "./metricsFlush";
 import { KPI_METRIC_NAMES } from "./kpiDefinitions";
 
+/** マイクロタスクキューを全て処理してから進む（void Promise の解決待ち用） */
+async function flushMicrotasks(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
 beforeEach(() => {
   jest.clearAllMocks();
   jest.useFakeTimers();
@@ -49,9 +55,69 @@ describe("initMetricsFlush — pool 未初期化", () => {
     expect(mockWarn).toHaveBeenCalledWith(
       "[metricsFlush] pool not initialized, flush disabled",
     );
-    // タイマーが仕掛けられていないことを確認（setInterval 呼ばれない）
     expect(typeof cleanup).toBe("function");
     cleanup(); // エラーにならないこと
+  });
+});
+
+// ---------------------------------------------------------------------------
+// warm-up: 初回 flush は Counter を INSERT しない（P1-2 regression guard）
+// ---------------------------------------------------------------------------
+
+describe("initMetricsFlush — warm-up dry-run", () => {
+  it("initMetricsFlush 直後（タイマー tick 前）は Counter を INSERT しない", async () => {
+    // warm-up dryRun の getMetricsAsJSON 呼び出し用
+    mockGetMetricsAsJSON.mockResolvedValue([
+      {
+        name: KPI_METRIC_NAMES.CONVERSATION_TERMINAL_TOTAL,
+        type: "counter",
+        values: [{ labels: { reason: "completed", tenantId: "t1" }, value: 999 }],
+      },
+    ]);
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    const cleanup = initMetricsFlush(mockPool as any, mockLogger as any, 5000);
+
+    // warm-up の void Promise を解決させる
+    await flushMicrotasks();
+
+    // dryRun なので INSERT は呼ばれないこと
+    expect(mockQuery).not.toHaveBeenCalled();
+
+    cleanup();
+  });
+
+  it("warm-up 後の最初の tick では累積値ではなく warm-up 以降の delta だけ INSERT する", async () => {
+    // warm-up: value=500（大きな累積値）
+    mockGetMetricsAsJSON.mockResolvedValueOnce([
+      {
+        name: KPI_METRIC_NAMES.CONVERSATION_TERMINAL_TOTAL,
+        type: "counter",
+        values: [{ labels: { reason: "completed", tenantId: "t1" }, value: 500 }],
+      },
+    ]);
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    const cleanup = initMetricsFlush(mockPool as any, mockLogger as any, 5000);
+    await flushMicrotasks(); // warm-up dryRun 完了
+
+    // 1st tick: value=503 → delta = 503 - 500 = 3（500 はスパイクしない）
+    mockGetMetricsAsJSON.mockResolvedValueOnce([
+      {
+        name: KPI_METRIC_NAMES.CONVERSATION_TERMINAL_TOTAL,
+        type: "counter",
+        values: [{ labels: { reason: "completed", tenantId: "t1" }, value: 503 }],
+      },
+    ]);
+    await jest.advanceTimersByTimeAsync(5000);
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const call = mockQuery.mock.calls[0];
+    // INSERT params に delta=3 が含まれ、累積値 500 は含まれない
+    expect(call[1]).toContain(3);
+    expect(call[1]).not.toContain(500);
+
+    cleanup();
   });
 });
 
@@ -61,28 +127,37 @@ describe("initMetricsFlush — pool 未初期化", () => {
 
 describe("initMetricsFlush — Counter delta", () => {
   it("Counter の delta（前回値との差分）を INSERT する", async () => {
-    // 1 回目の flush で value=10
-    mockGetMetricsAsJSON.mockResolvedValue([
+    // warm-up: value=0（新規プロセス相当）
+    mockGetMetricsAsJSON.mockResolvedValueOnce([
+      {
+        name: KPI_METRIC_NAMES.CONVERSATION_TERMINAL_TOTAL,
+        type: "counter",
+        values: [{ labels: { reason: "completed", tenantId: "t1" }, value: 0 }],
+      },
+    ]);
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    const cleanup = initMetricsFlush(mockPool as any, mockLogger as any, 5000);
+    await flushMicrotasks(); // warm-up
+
+    // 1 回目の tick: value=10 → delta=10
+    mockGetMetricsAsJSON.mockResolvedValueOnce([
       {
         name: KPI_METRIC_NAMES.CONVERSATION_TERMINAL_TOTAL,
         type: "counter",
         values: [{ labels: { reason: "completed", tenantId: "t1" }, value: 10 }],
       },
     ]);
-    mockQuery.mockResolvedValue({ rows: [] });
-
-    const cleanup = initMetricsFlush(mockPool as any, mockLogger as any, 5000);
-
-    // 最初の tick（5000ms 後）
     await jest.advanceTimersByTimeAsync(5000);
     expect(mockQuery).toHaveBeenCalledTimes(1);
-    // delta = 10 - 0 = 10
     const firstCall = mockQuery.mock.calls[0];
+    // INSERT params: metric_name, tenant_id, labels, value, snapshot_at
     expect(firstCall[1]).toContain(KPI_METRIC_NAMES.CONVERSATION_TERMINAL_TOTAL);
-    expect(firstCall[1]).toContain(10); // value = delta
+    expect(firstCall[1]).toContain("t1");   // tenant_id カラムに格納
+    expect(firstCall[1]).toContain(10);     // delta
 
     // 2 回目: value=15 → delta=5
-    mockGetMetricsAsJSON.mockResolvedValue([
+    mockGetMetricsAsJSON.mockResolvedValueOnce([
       {
         name: KPI_METRIC_NAMES.CONVERSATION_TERMINAL_TOTAL,
         type: "counter",
@@ -97,8 +172,49 @@ describe("initMetricsFlush — Counter delta", () => {
     cleanup();
   });
 
-  it("delta が 0 以下（デクリメント）のときは INSERT しない", async () => {
-    // 1 回目: value=20 → prev=0, delta=20 → INSERT
+  it("tenantId が labels JSONB から除去され tenant_id カラムに分離される（PII anti-slop）", async () => {
+    // warm-up
+    mockGetMetricsAsJSON.mockResolvedValueOnce([
+      {
+        name: KPI_METRIC_NAMES.AVATAR_REQUESTS_TOTAL,
+        type: "counter",
+        values: [{ labels: { status: "success", tenantId: "tenant-abc" }, value: 0 }],
+      },
+    ]);
+    mockQuery.mockResolvedValue({ rows: [] });
+    const cleanup = initMetricsFlush(mockPool as any, mockLogger as any, 5000);
+    await flushMicrotasks();
+
+    // tick: value=7 → delta=7
+    mockGetMetricsAsJSON.mockResolvedValueOnce([
+      {
+        name: KPI_METRIC_NAMES.AVATAR_REQUESTS_TOTAL,
+        type: "counter",
+        values: [{ labels: { status: "success", tenantId: "tenant-abc" }, value: 7 }],
+      },
+    ]);
+    await jest.advanceTimersByTimeAsync(5000);
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+
+    // tenant_id がカラムとして INSERT される
+    expect(sql).toContain("tenant_id");
+    expect(params).toContain("tenant-abc");
+
+    // labels JSONB に tenantId が含まれていないこと
+    const labelsArg = params.find(
+      (p) => typeof p === "object" && p !== null && !Array.isArray(p) && "status" in (p as object),
+    ) as Record<string, unknown> | undefined;
+    expect(labelsArg).toBeDefined();
+    expect(labelsArg).not.toHaveProperty("tenantId");
+    expect(labelsArg).toHaveProperty("status", "success");
+
+    cleanup();
+  });
+
+  it("delta が 0 以下（変化なし）のときは INSERT しない", async () => {
+    // warm-up: value=20
     mockGetMetricsAsJSON.mockResolvedValueOnce([
       {
         name: KPI_METRIC_NAMES.LOOP_DETECTED_TOTAL,
@@ -108,20 +224,29 @@ describe("initMetricsFlush — Counter delta", () => {
     ]);
     mockQuery.mockResolvedValue({ rows: [] });
     const cleanup = initMetricsFlush(mockPool as any, mockLogger as any, 5000);
-    await jest.advanceTimersByTimeAsync(5000);
-    expect(mockQuery).toHaveBeenCalledTimes(1);
+    await flushMicrotasks();
 
-    // 2 回目: value=20（変化なし）→ delta=0 → INSERT しない
+    // 1st tick: value=25 → delta=5 → INSERT
     mockGetMetricsAsJSON.mockResolvedValueOnce([
       {
         name: KPI_METRIC_NAMES.LOOP_DETECTED_TOTAL,
         type: "counter",
-        values: [{ labels: { tenantId: "t1" }, value: 20 }],
+        values: [{ labels: { tenantId: "t1" }, value: 25 }],
       },
     ]);
     await jest.advanceTimersByTimeAsync(5000);
-    // delta=0 なので INSERT 呼ばれない（前と同じ 1 回のまま）
     expect(mockQuery).toHaveBeenCalledTimes(1);
+
+    // 2nd tick: value=25（変化なし）→ delta=0 → INSERT しない
+    mockGetMetricsAsJSON.mockResolvedValueOnce([
+      {
+        name: KPI_METRIC_NAMES.LOOP_DETECTED_TOTAL,
+        type: "counter",
+        values: [{ labels: { tenantId: "t1" }, value: 25 }],
+      },
+    ]);
+    await jest.advanceTimersByTimeAsync(5000);
+    expect(mockQuery).toHaveBeenCalledTimes(1); // 増えない
 
     cleanup();
   });
@@ -133,14 +258,13 @@ describe("initMetricsFlush — Counter delta", () => {
 
 describe("initMetricsFlush — Histogram", () => {
   it("count=0 の Histogram バケットは INSERT しない（divide-by-zero ガード）", async () => {
-    mockGetMetricsAsJSON.mockResolvedValue([
+    // warm-up
+    mockGetMetricsAsJSON.mockResolvedValueOnce([
       {
         name: KPI_METRIC_NAMES.RAG_DURATION_MS,
         type: "histogram",
         values: [
-          // le バケット（count=0）: +Inf value=0
           { labels: { phase: "embed", tenantId: "t1", le: "+Inf" }, value: 0 },
-          // sum エントリ（le なし）: value=0
           { labels: { phase: "embed", tenantId: "t1" }, value: 0 },
         ],
       },
@@ -148,6 +272,19 @@ describe("initMetricsFlush — Histogram", () => {
     mockQuery.mockResolvedValue({ rows: [] });
 
     const cleanup = initMetricsFlush(mockPool as any, mockLogger as any, 5000);
+    await flushMicrotasks();
+
+    // tick: count=0 のまま
+    mockGetMetricsAsJSON.mockResolvedValueOnce([
+      {
+        name: KPI_METRIC_NAMES.RAG_DURATION_MS,
+        type: "histogram",
+        values: [
+          { labels: { phase: "embed", tenantId: "t1", le: "+Inf" }, value: 0 },
+          { labels: { phase: "embed", tenantId: "t1" }, value: 0 },
+        ],
+      },
+    ]);
     await jest.advanceTimersByTimeAsync(5000);
 
     // count=0 なので INSERT されない
@@ -155,27 +292,51 @@ describe("initMetricsFlush — Histogram", () => {
     cleanup();
   });
 
-  it("count>0 の Histogram は sum/count = avg を INSERT する", async () => {
-    // sum=3000ms, count=3 → avg=1000ms
-    mockGetMetricsAsJSON.mockResolvedValue([
+  it("count>0 の Histogram は sum/count = avg を INSERT し tenantId を tenant_id カラムに分離する", async () => {
+    // warm-up
+    mockGetMetricsAsJSON.mockResolvedValueOnce([
       {
         name: KPI_METRIC_NAMES.RAG_DURATION_MS,
         type: "histogram",
         values: [
-          { labels: { phase: "search", tenantId: "t2", le: "+Inf" }, value: 3 }, // count=3
-          { labels: { phase: "search", tenantId: "t2" }, value: 3000 },          // sum=3000
+          { labels: { phase: "search", tenantId: "t2", le: "+Inf" }, value: 3 },
+          { labels: { phase: "search", tenantId: "t2" }, value: 3000 },
         ],
       },
     ]);
     mockQuery.mockResolvedValue({ rows: [] });
 
     const cleanup = initMetricsFlush(mockPool as any, mockLogger as any, 5000);
+    await flushMicrotasks();
+
+    // tick: sum=3000ms, count=3 → avg=1000ms
+    mockGetMetricsAsJSON.mockResolvedValueOnce([
+      {
+        name: KPI_METRIC_NAMES.RAG_DURATION_MS,
+        type: "histogram",
+        values: [
+          { labels: { phase: "search", tenantId: "t2", le: "+Inf" }, value: 3 },
+          { labels: { phase: "search", tenantId: "t2" }, value: 3000 },
+        ],
+      },
+    ]);
     await jest.advanceTimersByTimeAsync(5000);
 
     expect(mockQuery).toHaveBeenCalledTimes(1);
-    const call = mockQuery.mock.calls[0];
-    // value = 3000/3 = 1000
-    expect(call[1]).toContain(1000);
+    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(params).toContain(1000);     // avg = 3000/3
+    expect(params).toContain("t2");     // tenant_id カラム
+
+    // labels JSONB に tenantId が含まれないこと
+    const labelsArg = params.find(
+      (p) => typeof p === "object" && p !== null && !Array.isArray(p) && "phase" in (p as object),
+    ) as Record<string, unknown> | undefined;
+    expect(labelsArg).toBeDefined();
+    expect(labelsArg).not.toHaveProperty("tenantId");
+    expect(labelsArg).toHaveProperty("phase", "search");
+
+    void sql; // 参照のみ
+
     cleanup();
   });
 });
@@ -188,14 +349,13 @@ describe("initMetricsFlush — cleanup", () => {
   it("cleanup() を呼ぶとタイマーが停止し、その後 flush が発生しない", async () => {
     mockGetMetricsAsJSON.mockResolvedValue([]);
     const cleanup = initMetricsFlush(mockPool as any, mockLogger as any, 5000);
+    await flushMicrotasks();
 
-    // 1 tick
     await jest.advanceTimersByTimeAsync(5000);
     const callsBefore = mockQuery.mock.calls.length;
 
     cleanup();
 
-    // cleanup 後は追加呼び出しなし
     await jest.advanceTimersByTimeAsync(15000);
     expect(mockQuery.mock.calls.length).toBe(callsBefore);
   });

--- a/src/lib/metrics/metricsFlush.test.ts
+++ b/src/lib/metrics/metricsFlush.test.ts
@@ -1,0 +1,202 @@
+// src/lib/metrics/metricsFlush.test.ts
+// Phase72-D: metricsFlush ユニットテスト
+
+// ---------------------------------------------------------------------------
+// prom-client モック（metricsRegistry.getMetricsAsJSON を制御）
+// ---------------------------------------------------------------------------
+
+const mockGetMetricsAsJSON = jest.fn();
+jest.mock("./promExporter", () => ({
+  metricsRegistry: {
+    getMetricsAsJSON: (...args: unknown[]) => mockGetMetricsAsJSON(...args),
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Pool モック
+// ---------------------------------------------------------------------------
+
+const mockQuery = jest.fn();
+const mockPool = { query: (...args: unknown[]) => mockQuery(...args) };
+
+// ---------------------------------------------------------------------------
+// Logger モック
+// ---------------------------------------------------------------------------
+
+const mockWarn = jest.fn();
+const mockInfo = jest.fn();
+const mockLogger = { warn: mockWarn, info: mockInfo };
+
+import { initMetricsFlush } from "./metricsFlush";
+import { KPI_METRIC_NAMES } from "./kpiDefinitions";
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  jest.useFakeTimers();
+});
+
+afterEach(() => {
+  jest.useRealTimers();
+});
+
+// ---------------------------------------------------------------------------
+// pool 未初期化
+// ---------------------------------------------------------------------------
+
+describe("initMetricsFlush — pool 未初期化", () => {
+  it("pool=null のとき warn を出して cleanup 関数を返す（タイマーなし）", () => {
+    const cleanup = initMetricsFlush(null, mockLogger as any, 1000);
+    expect(mockWarn).toHaveBeenCalledWith(
+      "[metricsFlush] pool not initialized, flush disabled",
+    );
+    // タイマーが仕掛けられていないことを確認（setInterval 呼ばれない）
+    expect(typeof cleanup).toBe("function");
+    cleanup(); // エラーにならないこと
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Counter delta 正計算
+// ---------------------------------------------------------------------------
+
+describe("initMetricsFlush — Counter delta", () => {
+  it("Counter の delta（前回値との差分）を INSERT する", async () => {
+    // 1 回目の flush で value=10
+    mockGetMetricsAsJSON.mockResolvedValue([
+      {
+        name: KPI_METRIC_NAMES.CONVERSATION_TERMINAL_TOTAL,
+        type: "counter",
+        values: [{ labels: { reason: "completed", tenantId: "t1" }, value: 10 }],
+      },
+    ]);
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    const cleanup = initMetricsFlush(mockPool as any, mockLogger as any, 5000);
+
+    // 最初の tick（5000ms 後）
+    await jest.advanceTimersByTimeAsync(5000);
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    // delta = 10 - 0 = 10
+    const firstCall = mockQuery.mock.calls[0];
+    expect(firstCall[1]).toContain(KPI_METRIC_NAMES.CONVERSATION_TERMINAL_TOTAL);
+    expect(firstCall[1]).toContain(10); // value = delta
+
+    // 2 回目: value=15 → delta=5
+    mockGetMetricsAsJSON.mockResolvedValue([
+      {
+        name: KPI_METRIC_NAMES.CONVERSATION_TERMINAL_TOTAL,
+        type: "counter",
+        values: [{ labels: { reason: "completed", tenantId: "t1" }, value: 15 }],
+      },
+    ]);
+    await jest.advanceTimersByTimeAsync(5000);
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+    const secondCall = mockQuery.mock.calls[1];
+    expect(secondCall[1]).toContain(5); // delta = 15 - 10 = 5
+
+    cleanup();
+  });
+
+  it("delta が 0 以下（デクリメント）のときは INSERT しない", async () => {
+    // 1 回目: value=20 → prev=0, delta=20 → INSERT
+    mockGetMetricsAsJSON.mockResolvedValueOnce([
+      {
+        name: KPI_METRIC_NAMES.LOOP_DETECTED_TOTAL,
+        type: "counter",
+        values: [{ labels: { tenantId: "t1" }, value: 20 }],
+      },
+    ]);
+    mockQuery.mockResolvedValue({ rows: [] });
+    const cleanup = initMetricsFlush(mockPool as any, mockLogger as any, 5000);
+    await jest.advanceTimersByTimeAsync(5000);
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+
+    // 2 回目: value=20（変化なし）→ delta=0 → INSERT しない
+    mockGetMetricsAsJSON.mockResolvedValueOnce([
+      {
+        name: KPI_METRIC_NAMES.LOOP_DETECTED_TOTAL,
+        type: "counter",
+        values: [{ labels: { tenantId: "t1" }, value: 20 }],
+      },
+    ]);
+    await jest.advanceTimersByTimeAsync(5000);
+    // delta=0 なので INSERT 呼ばれない（前と同じ 1 回のまま）
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+
+    cleanup();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Histogram count=0 の divide-by-zero なし
+// ---------------------------------------------------------------------------
+
+describe("initMetricsFlush — Histogram", () => {
+  it("count=0 の Histogram バケットは INSERT しない（divide-by-zero ガード）", async () => {
+    mockGetMetricsAsJSON.mockResolvedValue([
+      {
+        name: KPI_METRIC_NAMES.RAG_DURATION_MS,
+        type: "histogram",
+        values: [
+          // le バケット（count=0）: +Inf value=0
+          { labels: { phase: "embed", tenantId: "t1", le: "+Inf" }, value: 0 },
+          // sum エントリ（le なし）: value=0
+          { labels: { phase: "embed", tenantId: "t1" }, value: 0 },
+        ],
+      },
+    ]);
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    const cleanup = initMetricsFlush(mockPool as any, mockLogger as any, 5000);
+    await jest.advanceTimersByTimeAsync(5000);
+
+    // count=0 なので INSERT されない
+    expect(mockQuery).not.toHaveBeenCalled();
+    cleanup();
+  });
+
+  it("count>0 の Histogram は sum/count = avg を INSERT する", async () => {
+    // sum=3000ms, count=3 → avg=1000ms
+    mockGetMetricsAsJSON.mockResolvedValue([
+      {
+        name: KPI_METRIC_NAMES.RAG_DURATION_MS,
+        type: "histogram",
+        values: [
+          { labels: { phase: "search", tenantId: "t2", le: "+Inf" }, value: 3 }, // count=3
+          { labels: { phase: "search", tenantId: "t2" }, value: 3000 },          // sum=3000
+        ],
+      },
+    ]);
+    mockQuery.mockResolvedValue({ rows: [] });
+
+    const cleanup = initMetricsFlush(mockPool as any, mockLogger as any, 5000);
+    await jest.advanceTimersByTimeAsync(5000);
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const call = mockQuery.mock.calls[0];
+    // value = 3000/3 = 1000
+    expect(call[1]).toContain(1000);
+    cleanup();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleanup 関数
+// ---------------------------------------------------------------------------
+
+describe("initMetricsFlush — cleanup", () => {
+  it("cleanup() を呼ぶとタイマーが停止し、その後 flush が発生しない", async () => {
+    mockGetMetricsAsJSON.mockResolvedValue([]);
+    const cleanup = initMetricsFlush(mockPool as any, mockLogger as any, 5000);
+
+    // 1 tick
+    await jest.advanceTimersByTimeAsync(5000);
+    const callsBefore = mockQuery.mock.calls.length;
+
+    cleanup();
+
+    // cleanup 後は追加呼び出しなし
+    await jest.advanceTimersByTimeAsync(15000);
+    expect(mockQuery.mock.calls.length).toBe(callsBefore);
+  });
+});

--- a/src/lib/metrics/metricsFlush.ts
+++ b/src/lib/metrics/metricsFlush.ts
@@ -35,10 +35,31 @@ function cacheKey(metricName: string, labels: Record<string, string>): string {
 }
 
 // ---------------------------------------------------------------------------
-// flush 実行関数（1 回分）
+// tenantId ラベル抽出（PII anti-slop: tenantId を JSONB labels に含めない）
 // ---------------------------------------------------------------------------
 
-async function flushOnce(pool: Pool, logger: Logger): Promise<void> {
+/**
+ * Prometheus labels から tenantId を抜き出し、残りを返す。
+ * prom-client の labelNames は camelCase "tenantId" を使用しているため
+ * "tenantId" キーを対象とする。
+ */
+function extractTenantId(labels: Record<string, string>): {
+  tenantId: string | null;
+  labelsWithoutTenant: Record<string, string>;
+} {
+  const { tenantId, ...rest } = labels;
+  return {
+    tenantId: tenantId ?? null,
+    labelsWithoutTenant: rest,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// flush 実行関数（1 回分）
+// dryRun=true のときは prevCounterValues だけ充填して INSERT しない（warm-up 用）
+// ---------------------------------------------------------------------------
+
+async function flushOnce(pool: Pool, logger: Logger, dryRun = false): Promise<void> {
   let metrics: Awaited<ReturnType<typeof metricsRegistry.getMetricsAsJSON>>;
   try {
     metrics = await metricsRegistry.getMetricsAsJSON();
@@ -50,6 +71,7 @@ async function flushOnce(pool: Pool, logger: Logger): Promise<void> {
   const now = new Date();
   const rows: Array<{
     metric_name: string;
+    tenant_id: string | null;
     labels: Record<string, string>;
     value: number;
   }> = [];
@@ -60,36 +82,29 @@ async function flushOnce(pool: Pool, logger: Logger): Promise<void> {
     if (COUNTER_METRIC_NAMES.includes(name)) {
       // Counter: 各ラベルセットの delta を計算
       for (const value of metric.values ?? []) {
-        const labels = value.labels as Record<string, string>;
+        const rawLabels = value.labels as Record<string, string>;
         const currentVal = value.value as number;
-        const key = cacheKey(name, labels);
+        const key = cacheKey(name, rawLabels);
         const prev = prevCounterValues.get(key) ?? 0;
         const delta = currentVal - prev;
-        if (delta > 0) {
-          rows.push({ metric_name: name, labels, value: delta });
+        // dryRun でなく delta > 0 の場合のみ INSERT キューに積む
+        if (!dryRun && delta > 0) {
+          const { tenantId, labelsWithoutTenant } = extractTenantId(rawLabels);
+          rows.push({ metric_name: name, tenant_id: tenantId, labels: labelsWithoutTenant, value: delta });
         }
         prevCounterValues.set(key, currentVal);
       }
     } else if (HISTOGRAM_METRIC_NAMES.includes(name)) {
       // Histogram: sum と count から平均を計算
-      // prom-client は _sum / _count suffix サフィックスで別 metric として返す場合があるが
-      // getMetricsAsJSON は bucket 形式で返す。sum/count を label なしで集約する。
-      // 各 bucket エントリの value.value はバケット累積値。
-      // sum エントリは metricName_sum、count は metricName_count で提供される。
-      // ただし getMetricsAsJSON では values[].labels に le が付く bucket のほか、
-      // {count, sum} フィールドが values 配列に含まれない場合がある。
-      // → 同じ Registry から collect() → getMetricsAsJSON() の実体を使う。
-      //
-      // 実際の構造: { name, help, type: 'histogram', values: [{labels:{le:'50',...}, value: N}, ..., {labels:{}, value: sum}] }
-      // sum ラベル: le が無く、metricName_sum という名前 OR labels = {} で最後のエントリ。
-      //
-      // 安全な方法: labels.le が undefined のエントリで sum/count を取る。
-      // prom-client v15 では {labels:{}, value: N} が _sum と _count に対応する
-      // 2 エントリが末尾に現れる（順番は sum→count）。
-      //
-      // ここではラベル別に sum と count を集計し、count>0 の場合のみ INSERT する。
+      // prom-client v15 の getMetricsAsJSON 構造:
+      //   { name, type: 'histogram', values: [
+      //     {labels:{le:'50', phase:'embed', tenantId:'t1'}, value: N},  // bucket
+      //     ...
+      //     {labels:{le:'+Inf', phase:'embed', tenantId:'t1'}, value: C}, // count
+      //     {labels:{phase:'embed', tenantId:'t1'}, value: S},            // sum (le なし)
+      //   ]}
+      // le を除いたラベルセットごとに sum/count を集計し、count>0 の場合のみ INSERT。
 
-      // ラベル（le 除く）ごとに sum/count を集計するための Map
       const histAgg = new Map<string, { sum: number; count: number }>();
 
       for (const v of metric.values ?? []) {
@@ -106,41 +121,44 @@ async function flushOnce(pool: Pool, logger: Logger): Promise<void> {
           // +Inf バケットの累積値 = count
           entry.count = v.value as number;
         } else if (le === undefined) {
-          // le がない = _sum エントリ（prom-client が返す構造に依存）
+          // le がない = _sum エントリ
           entry.sum = v.value as number;
         }
         // 他バケット（le = 数値）はスキップ
       }
 
-      for (const [key, { sum, count }] of histAgg) {
-        if (count <= 0) continue; // divide-by-zero ガード
-        const avg = sum / count;
-        // key から labels を復元（cacheKey は name|JSON）
-        const labelsJson = key.slice(name.length + 1);
-        let parsedLabels: Record<string, string> = {};
-        try {
-          parsedLabels = JSON.parse(labelsJson) as Record<string, string>;
-        } catch {
-          // JSON 解析失敗は空ラベルで続行
+      if (!dryRun) {
+        for (const [key, { sum, count }] of histAgg) {
+          if (count <= 0) continue; // divide-by-zero ガード
+          const avg = sum / count;
+          // key から labels を復元（cacheKey は name|JSON）
+          const labelsJson = key.slice(name.length + 1);
+          let parsedLabels: Record<string, string> = {};
+          try {
+            parsedLabels = JSON.parse(labelsJson) as Record<string, string>;
+          } catch {
+            // JSON 解析失敗は空ラベルで続行
+          }
+          const { tenantId, labelsWithoutTenant } = extractTenantId(parsedLabels);
+          rows.push({ metric_name: name, tenant_id: tenantId, labels: labelsWithoutTenant, value: avg });
         }
-        rows.push({ metric_name: name, labels: parsedLabels, value: avg });
       }
     }
   }
 
-  if (rows.length === 0) return;
+  if (dryRun || rows.length === 0) return;
 
   try {
-    // バルク INSERT
+    // バルク INSERT（5カラム: metric_name, tenant_id, labels, value, snapshot_at）
     const valuesClause = rows
-      .map((_, i) => `($${i * 4 + 1}, $${i * 4 + 2}, $${i * 4 + 3}, $${i * 4 + 4})`)
+      .map((_, i) => `($${i * 5 + 1}, $${i * 5 + 2}, $${i * 5 + 3}, $${i * 5 + 4}, $${i * 5 + 5})`)
       .join(", ");
-    const params: (string | number | object)[] = [];
+    const params: (string | number | object | null)[] = [];
     for (const row of rows) {
-      params.push(row.metric_name, row.labels, row.value, now.toISOString());
+      params.push(row.metric_name, row.tenant_id, row.labels, row.value, now.toISOString());
     }
     await pool.query(
-      `INSERT INTO metrics_snapshots (metric_name, labels, value, snapshot_at)
+      `INSERT INTO metrics_snapshots (metric_name, tenant_id, labels, value, snapshot_at)
        VALUES ${valuesClause}`,
       params,
     );
@@ -167,6 +185,10 @@ export function initMetricsFlush(
     logger.warn("[metricsFlush] pool not initialized, flush disabled");
     return () => {};
   }
+
+  // warm-up: 初回 flush 前に prevCounterValues を現在値で充填する。
+  // これにより再起動直後の初回 tick で Counter 累積値全量が delta として INSERT されるスパイクを防ぐ。
+  void flushOnce(pool, logger, /*dryRun=*/true);
 
   const timer = setInterval(() => {
     void flushOnce(pool, logger);

--- a/src/lib/metrics/metricsFlush.ts
+++ b/src/lib/metrics/metricsFlush.ts
@@ -1,0 +1,181 @@
+// src/lib/metrics/metricsFlush.ts
+// Phase72-D: Prometheus メトリクスを PostgreSQL に 5 分周期でスナップショット
+
+import type { Pool } from "pg";
+import type { Logger } from "pino";
+import { metricsRegistry } from "./promExporter";
+import { KPI_METRIC_NAMES } from "./kpiDefinitions";
+
+// ---------------------------------------------------------------------------
+// 対象メトリクス（Counter: delta / Histogram: avg）
+// ---------------------------------------------------------------------------
+
+const COUNTER_METRIC_NAMES: ReadonlyArray<string> = [
+  KPI_METRIC_NAMES.CONVERSATION_TERMINAL_TOTAL,
+  KPI_METRIC_NAMES.AVATAR_REQUESTS_TOTAL,
+  KPI_METRIC_NAMES.LOOP_DETECTED_TOTAL,
+];
+
+const HISTOGRAM_METRIC_NAMES: ReadonlyArray<string> = [
+  KPI_METRIC_NAMES.RAG_DURATION_MS,
+];
+
+// ---------------------------------------------------------------------------
+// Counter 前回値キャッシュ（key = `metricName|serializedLabels`）
+// ---------------------------------------------------------------------------
+
+const prevCounterValues = new Map<string, number>();
+
+// ---------------------------------------------------------------------------
+// 内部ユーティリティ
+// ---------------------------------------------------------------------------
+
+function cacheKey(metricName: string, labels: Record<string, string>): string {
+  return `${metricName}|${JSON.stringify(labels, Object.keys(labels).sort())}`;
+}
+
+// ---------------------------------------------------------------------------
+// flush 実行関数（1 回分）
+// ---------------------------------------------------------------------------
+
+async function flushOnce(pool: Pool, logger: Logger): Promise<void> {
+  let metrics: Awaited<ReturnType<typeof metricsRegistry.getMetricsAsJSON>>;
+  try {
+    metrics = await metricsRegistry.getMetricsAsJSON();
+  } catch (err) {
+    logger.warn({ err }, "[metricsFlush] getMetricsAsJSON failed");
+    return;
+  }
+
+  const now = new Date();
+  const rows: Array<{
+    metric_name: string;
+    labels: Record<string, string>;
+    value: number;
+  }> = [];
+
+  for (const metric of metrics) {
+    const name = metric.name;
+
+    if (COUNTER_METRIC_NAMES.includes(name)) {
+      // Counter: 各ラベルセットの delta を計算
+      for (const value of metric.values ?? []) {
+        const labels = value.labels as Record<string, string>;
+        const currentVal = value.value as number;
+        const key = cacheKey(name, labels);
+        const prev = prevCounterValues.get(key) ?? 0;
+        const delta = currentVal - prev;
+        if (delta > 0) {
+          rows.push({ metric_name: name, labels, value: delta });
+        }
+        prevCounterValues.set(key, currentVal);
+      }
+    } else if (HISTOGRAM_METRIC_NAMES.includes(name)) {
+      // Histogram: sum と count から平均を計算
+      // prom-client は _sum / _count suffix サフィックスで別 metric として返す場合があるが
+      // getMetricsAsJSON は bucket 形式で返す。sum/count を label なしで集約する。
+      // 各 bucket エントリの value.value はバケット累積値。
+      // sum エントリは metricName_sum、count は metricName_count で提供される。
+      // ただし getMetricsAsJSON では values[].labels に le が付く bucket のほか、
+      // {count, sum} フィールドが values 配列に含まれない場合がある。
+      // → 同じ Registry から collect() → getMetricsAsJSON() の実体を使う。
+      //
+      // 実際の構造: { name, help, type: 'histogram', values: [{labels:{le:'50',...}, value: N}, ..., {labels:{}, value: sum}] }
+      // sum ラベル: le が無く、metricName_sum という名前 OR labels = {} で最後のエントリ。
+      //
+      // 安全な方法: labels.le が undefined のエントリで sum/count を取る。
+      // prom-client v15 では {labels:{}, value: N} が _sum と _count に対応する
+      // 2 エントリが末尾に現れる（順番は sum→count）。
+      //
+      // ここではラベル別に sum と count を集計し、count>0 の場合のみ INSERT する。
+
+      // ラベル（le 除く）ごとに sum/count を集計するための Map
+      const histAgg = new Map<string, { sum: number; count: number }>();
+
+      for (const v of metric.values ?? []) {
+        const labels = v.labels as Record<string, string>;
+        const { le, ...labelWithoutLe } = labels;
+        const key = cacheKey(name, labelWithoutLe);
+
+        if (!histAgg.has(key)) {
+          histAgg.set(key, { sum: 0, count: 0 });
+        }
+        const entry = histAgg.get(key)!;
+
+        if (le === "+Inf") {
+          // +Inf バケットの累積値 = count
+          entry.count = v.value as number;
+        } else if (le === undefined) {
+          // le がない = _sum エントリ（prom-client が返す構造に依存）
+          entry.sum = v.value as number;
+        }
+        // 他バケット（le = 数値）はスキップ
+      }
+
+      for (const [key, { sum, count }] of histAgg) {
+        if (count <= 0) continue; // divide-by-zero ガード
+        const avg = sum / count;
+        // key から labels を復元（cacheKey は name|JSON）
+        const labelsJson = key.slice(name.length + 1);
+        let parsedLabels: Record<string, string> = {};
+        try {
+          parsedLabels = JSON.parse(labelsJson) as Record<string, string>;
+        } catch {
+          // JSON 解析失敗は空ラベルで続行
+        }
+        rows.push({ metric_name: name, labels: parsedLabels, value: avg });
+      }
+    }
+  }
+
+  if (rows.length === 0) return;
+
+  try {
+    // バルク INSERT
+    const valuesClause = rows
+      .map((_, i) => `($${i * 4 + 1}, $${i * 4 + 2}, $${i * 4 + 3}, $${i * 4 + 4})`)
+      .join(", ");
+    const params: (string | number | object)[] = [];
+    for (const row of rows) {
+      params.push(row.metric_name, row.labels, row.value, now.toISOString());
+    }
+    await pool.query(
+      `INSERT INTO metrics_snapshots (metric_name, labels, value, snapshot_at)
+       VALUES ${valuesClause}`,
+      params,
+    );
+    logger.info({ count: rows.length }, "[metricsFlush] snapshot flushed");
+  } catch (err) {
+    logger.warn({ err }, "[metricsFlush] INSERT failed");
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public: initMetricsFlush
+// ---------------------------------------------------------------------------
+
+/**
+ * Prometheus メトリクスを PostgreSQL に定期 flush する。
+ * @returns cleanup 関数（SIGTERM/SIGINT ハンドラ内で呼ぶ）
+ */
+export function initMetricsFlush(
+  pool: Pool | null,
+  logger: Logger,
+  intervalMs = 5 * 60 * 1000,
+): () => void {
+  if (!pool) {
+    logger.warn("[metricsFlush] pool not initialized, flush disabled");
+    return () => {};
+  }
+
+  const timer = setInterval(() => {
+    void flushOnce(pool, logger);
+  }, intervalMs);
+
+  logger.info({ intervalMs }, "[metricsFlush] initialized");
+
+  return () => {
+    clearInterval(timer);
+    logger.info("[metricsFlush] timer cleared");
+  };
+}

--- a/src/migrations/phase72d_metrics_snapshots.sql
+++ b/src/migrations/phase72d_metrics_snapshots.sql
@@ -1,0 +1,53 @@
+-- Phase72-D: metrics_snapshots（Prometheus メトリクス時系列スナップショット）
+-- 実行日: VPS で手動実行
+-- 対象: VPS PostgreSQL (65.108.159.161)
+--
+-- 設計意図:
+--   Prometheus の Counter/Histogram メトリクスを 5 分周期で PostgreSQL に保存し、
+--   管理 UI で時系列グラフ表示できる永続ストレージを提供する。
+--   Counter は前回値との差分（delta）をスナップショット。
+--   Histogram は sum/count から平均を計算して record する。
+--
+--   フック先: src/lib/metrics/metricsFlush.ts（initMetricsFlush）
+--   エンドポイント: GET /v1/admin/analytics/metrics-history（super_admin 限定）
+
+-- ============================================================
+-- 1. metrics_snapshots テーブル本体
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS metrics_snapshots (
+  id          BIGSERIAL PRIMARY KEY,
+  metric_name TEXT NOT NULL,
+  tenant_id   TEXT,                              -- NULL = 全テナント集計
+  labels      JSONB NOT NULL DEFAULT '{}',        -- Prometheus ラベルセット
+  value       NUMERIC NOT NULL,                  -- Counter: delta / Histogram: avg_ms
+  snapshot_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- ============================================================
+-- 2. インデックス
+-- ============================================================
+
+-- メトリクス名 + テナント + 時系列（主要クエリ: DATE_TRUNC バケット集計）
+CREATE INDEX IF NOT EXISTS idx_metrics_snapshots_name_tenant_at
+  ON metrics_snapshots (metric_name, tenant_id, snapshot_at DESC);
+
+-- 時系列全体（全メトリクス横断参照）
+CREATE INDEX IF NOT EXISTS idx_metrics_snapshots_at
+  ON metrics_snapshots (snapshot_at DESC);
+
+-- メトリクス名 + 時系列（テナントフィルタなし集計）
+CREATE INDEX IF NOT EXISTS idx_metrics_snapshots_name_at
+  ON metrics_snapshots (metric_name, snapshot_at DESC);
+
+COMMENT ON TABLE metrics_snapshots IS 'Phase72-D: Prometheus KPI メトリクスの時系列スナップショット。5 分周期で INSERT。Counter は delta 値、Histogram は avg 値を格納。';
+COMMENT ON COLUMN metrics_snapshots.metric_name IS 'Phase72-D: rajiuce_ prefix 付きメトリクス名（KPI_METRIC_NAMES 定数と対応）。';
+COMMENT ON COLUMN metrics_snapshots.labels IS 'Phase72-D: Prometheus ラベルセットを JSONB で保存。PII・書籍内容を含めないこと。';
+COMMENT ON COLUMN metrics_snapshots.value IS 'Phase72-D: Counter は前回値との差分（負値はスキップ）、Histogram は sum/count の平均（count=0 の場合はスキップ）。';
+
+-- ============================================================
+-- 確認クエリ (実行後に手動確認)
+-- ============================================================
+-- SELECT column_name, data_type FROM information_schema.columns
+-- WHERE table_name = 'metrics_snapshots' ORDER BY ordinal_position;
+-- SELECT indexname FROM pg_indexes WHERE tablename = 'metrics_snapshots';


### PR DESCRIPTION
## 概要
Prometheus メトリクスを5分毎に DB へ flush し、プロセス再起動を跨いだ時系列分析を可能にする。Asana GID 1215691379754028。

⚠️ **このPRは #392 (72-C) に stack**。マージ順: **#386 → #392 → 本PR**。

## 変更内容（72-D 分・9ファイル純追加）
- **DB migration**: `src/migrations/phase72d_metrics_snapshots.sql` — `metrics_snapshots` + 3インデックス。⚠️ 本番適用は hkobayashi が手動実行
- **metricsFlush**: `src/lib/metrics/metricsFlush.ts` — metricsRegistry から4メトリクス(KPI_METRIC_NAMES)を5分毎 flush。Counter は delta、Histogram は sum/count。**warm-up dry-run** で再起動直後のスパイクを防止。**tenantId は labels から分離し tenant_id カラムへ**（PII をラベルに残さない）。`src/index.ts` で初期化、onShutdown で clearInterval
- **API**: GET `/v1/admin/analytics/metrics-history`（super_admin限定）。period/granularity バケット集計。**6h は DATE_BIN、1h/24h は DATE_TRUNC**（PG16 で 6h が DATE_TRUNC 無効になる問題を修正）
- **UI**: MetricsHistorySection（react-chartjs-2 Line/Bar 時系列3種 + 期間/粒度フィルタ）

## Gate 結果（Planner→Generator→Evaluator→Tester、差し戻し1回）
- Evaluator NO-GO で本番バグ2件を捕捉→修正: ①granularity=6h の無効SQL（DATE_BIN化）②再起動時 Counter スパイク（warm-up）。加えて tenantId ラベルの PII 分離も実施
- Gate1: typecheck 0 / oxlint 62(≤63,新規0) / 全1977 tests pass / admin-ui build OK
- Gate1.5/2/3: dead-code新規なし / security High-Critical 0 / 両build OK

## 人間対応
1. レビュー + Gate2.5 Codex
2. #386→#392→本PR の順でマージ
3. マージ後 VPS で migration SQL を手動適用（72-A/C/D の3つ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)