### PR TITLE
fix(avatar): LiveKit接続リーク修正 — widget再注入でRoom残留→429を誘発

### DIFF
--- a/admin-ui/src/pages/admin/chat-test/index.tsx
+++ b/admin-ui/src/pages/admin/chat-test/index.tsx
@@ -52,6 +52,8 @@ const AVATAR_REASON_MESSAGES: Record<string, string> = {
   tenant_not_found: "テナントの情報が見つかりませんでした。設定をご確認ください。",
   migration_required: "アバター用のデータ準備（サーバー側）がまだ完了していません。運営にお問い合わせください。",
   server_error: "アバターの準備中に問題が発生しました。少し待ってから、もう一度お試しください。",
+  livekit_connect_failed: "アバター配信サービスに接続できませんでした。アクセスが混み合っているか、配信の利用上限に達している可能性があります。時間をおいて再度お試しいただくか、配信プランの状況をご確認ください。",
+  livekit_sdk_load_failed: "アバター配信に必要な部品の読み込みに失敗しました。通信環境をご確認のうえ、もう一度お試しください。",
   unknown: "アバターを表示できませんでした。設定をご確認のうえ、もう一度お試しください。",
 };
 
@@ -115,6 +117,12 @@ export default function ChatTestPage() {
       : (previewMode ? (previewTenantName ?? effectiveTenantId) : (user?.tenantName ?? effectiveTenantId));
 
   const cleanupWidget = useCallback(() => {
+    // DOM ホストを消す前に LiveKit Room を明示的に切断する。
+    // widget の Room は window.__rajiuceRoom（ホスト要素の外）に保持されるため、
+    // ホスト削除だけでは切断されず、再注入のたびに接続が残留して increment し、
+    // LiveKit Cloud に /rtc/validate を 429 でレート制限される(=アバターが出ない)。
+    const fw = (window as unknown as { FaqWidget?: { destroy?: () => void } }).FaqWidget;
+    if (fw && typeof fw.destroy === "function") fw.destroy();
     // querySelectorAll で同一IDの重複ホストを全て削除（getElementById は先頭1件のみ）
     document.querySelectorAll("#faq-chat-widget-host").forEach((host) => host.remove());
     if (widgetScriptRef.current) {

--- a/public/widget.js
+++ b/public/widget.js
@@ -1569,6 +1569,7 @@
     script.onerror = function () {
       avatarArea.style.display = 'none';
       console.warn('[FAQ Widget] LiveKit SDK load failed');
+      emitAvatarStatus({ enabled: false, provider: 'lemonslice', reason: 'livekit_sdk_load_failed' });
     };
     document.head.appendChild(script);
   }
@@ -1823,12 +1824,16 @@
         .catch(function (e) {
           avatarArea.style.display = 'none';
           console.warn('[FAQ Widget] LiveKit connect failed:', e && e.message);
+          // 接続自体が確立できなかった（LiveKit Cloud のレート制限/上限超過=429 を含む）。
+          // room-token は enabled:true なので、この層の失敗はテストチャットでしか可視化されない。
+          emitAvatarStatus({ enabled: false, provider: 'lemonslice', reason: 'livekit_connect_failed' });
         });
 
       window.__rajiuceRoom = room;
     } catch (e) {
       avatarArea.style.display = 'none';
       console.warn('[FAQ Widget] LiveKit init failed:', e && e.message);
+      emitAvatarStatus({ enabled: false, provider: 'lemonslice', reason: 'livekit_connect_failed' });
     }
   }
 
@@ -2482,6 +2487,12 @@
     close: closePanel,
     toggle: togglePanel,
     getTenantId: function () { return tenantId; },
+    // 完全破棄: LiveKit Room を切断してから DOM ホストを除去する用。
+    // SPA(管理画面テストチャット)が widget を作り直す前に必ず呼ぶこと。
+    // beforeunload は SPA 再注入では発火しないため、これが無いと Room が
+    // window.__rajiuceRoom に残留し、再接続タイマーが回り続けて接続が増殖する
+    // (LiveKit Cloud が /rtc/validate を 429 でレート制限する原因になる)。
+    destroy: function () { try { cleanupLiveKit(); } catch (_e) {} },
   };
 
   // アバター設定を事前取得（パネルを開く前に完了させ、FABクリック時のフラッシュを防止）


### PR DESCRIPTION
## 症状

テストチャットでアバターが表示されず、Network に LiveKit Cloud の `/rtc/validate` が **429 (Too Many Requests)** を連発（websocket が接続→Finished を反復）。`room-token` は `enabled:true`（=テナント設定は正常）だが、**ブラウザ↔LiveKit Cloud の接続自体がレート制限で確立できていない**。avatar-agent がルームに参加する以前の層の問題。

## 根本原因 — 接続リーク

テストチャットは状態変化（token取得 / アバター選択 / テナント切替 / リセット）のたびに widget を**再注入**するが:

- LiveKit `Room` は `window.__rajiuceRoom`（**ホスト要素の外のグローバル**）に保持される → `#faq-chat-widget-host` を削除しても切断されない
- `closePanel()` は意図的に Room を切断しない（保持仕様）
- 完全切断する `cleanupLiveKit()` は `beforeunload` でしか発火せず、**SPA 再注入では呼ばれない**
- `window.FaqWidget` 公開APIに破棄手段が無かった

→ 古い Room が SDK 再接続タイマーを回し続け、新しい Room（毎回別 room 名）が積み上がる → 同時接続が増殖 → LiveKit Cloud が `/rtc/validate` を 429。**LiveKit 無料枠の急速消費の一因**でもある。

## 変更

- **`widget.js`**: `window.FaqWidget.destroy()` を追加（`cleanupLiveKit()` で Room 切断）。
- **`chat-test/index.tsx`**: `cleanupWidget()` でホスト削除の**前**に `FaqWidget.destroy()` を呼ぶ。
- **`widget.js`**: LiveKit 接続失敗 / SDK 読込失敗時に `r2c-avatar-status` イベントを発火（`reason: livekit_connect_failed` / `livekit_sdk_load_failed`）。`enabled:true` でも接続層で失敗するケースをテストチャットで初めて可視化。
- **`chat-test`**: 上記 reason の優しい日本語メッセージを追加。

## 重要な但し書き（別レイヤー）

今回の 429 の主因は **LiveKit Cloud 無料枠の超過**（"Your project has exceeded its free tier limit"）。これはアカウント側のアップグレード or クォータリセットで解消が必要で、**本PR単体ではアバターは繋がらない**。本PRは接続リークを止め、①超過の再発防止 ②`enabled:true` 以降の失敗を可視化して原因不明化を防ぐ、ことが目的。

## Gate

- typecheck 0 / lint 60 (< 63) / test 23/23 / backend + admin-ui build OK / widget.js syntax OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)