### PR TITLE
fix(avatar): アバターを縦長(9:16)で全身表示・顔アップのクロップ解消

### DIFF
--- a/avatar-agent/agent.py
+++ b/avatar-agent/agent.py
@@ -578,8 +578,8 @@ async def entrypoint(ctx: agents.JobContext) -> None:
                 "idle_timeout": 300,
                 "response_done_timeout": 4.0,  # 0.5→4.0: 複数センテンスTTS間の合成待ち(~1-2s)でアイドル遷移しないよう延長
                 "agent_idle_prompt": effective_agent_idle_prompt,
-                "width": 1920,
-                "height": 1080,
+                "width": 1080,
+                "height": 1920,
                 # I-3: LemonSlice API 公式パラメータ。明示 kwarg ではなく **kwargs →
                 # extra_payload 経由で API payload にマージされる (plugin avatar.py:55)
                 "simulcast": True,
@@ -591,8 +591,8 @@ async def entrypoint(ctx: agents.JobContext) -> None:
                 "idle_timeout": 300,
                 "response_done_timeout": 4.0,  # 0.5→4.0: 同上
                 "agent_idle_prompt": effective_agent_idle_prompt,
-                "width": 1920,
-                "height": 1080,
+                "width": 1080,
+                "height": 1920,
                 "simulcast": True,  # I-3: 同上
             }
         avatar = lemonslice.AvatarSession(**avatar_kwargs)

--- a/public/widget.js
+++ b/public/widget.js
@@ -467,9 +467,9 @@
 
     /* アバターエリア（avatar=true テナントのみ表示） */
     '.avatar-area {',
-    '  width: calc(100% - 16px);',
-    '  height: 300px;',
-    '  margin: 8px;',
+    '  width: min(calc(100% - 16px), 260px);',
+    '  aspect-ratio: 9 / 16;',
+    '  margin: 8px auto;',
     '  border-radius: 12px;',
     '  background: linear-gradient(160deg, #0f0f1a 0%, #1a1a2e 60%, #0d1117 100%);',
     '  overflow: hidden;',
@@ -484,7 +484,7 @@
     '  width: 100%;',
     '  height: 100%;',
     '  object-fit: cover;',
-    '  object-position: center top;',
+    '  object-position: center;',
     '  border-radius: 12px;',
     '}',
 
@@ -523,7 +523,7 @@
     '}',
 
     /* モバイル最適化 */
-    '@media (max-width: 390px) { .avatar-area { height: 240px; } }',
+    '@media (max-width: 390px) { .avatar-area { width: min(calc(100% - 16px), 200px); } }',
 
     /* ───── avatar-active: PC 横並び2パネル / モバイル縦スプリット ───── */
 
@@ -561,7 +561,7 @@
     '  background: #000;',
     '  overflow: hidden;',
     '}',
-    '.panel.avatar-active .avatar-video { border-radius: 0; width: 100%; height: 100%; object-fit: cover; object-position: center top; }',
+    '.panel.avatar-active .avatar-video { border-radius: 0; height: 100%; width: auto; max-width: 100%; aspect-ratio: 9 / 16; object-fit: cover; object-position: center; margin: 0 auto; display: block; }',
 
     /* 閉じるボタン: アバターエリア右上 */
     '.avatar-close-btn {',


### PR DESCRIPTION
## 概要

アバターが「正方形(顔アップ)」にクロップされて全身が表示されない問題を修正。

**原因**: LemonSlice の出力映像は 1920×1080(16:9 横長)固定だが、ウィジェット側は縦長コンテナに `object-fit: cover` で詰めていたため左右が切られ、中央の縦スライス＝顔アップになっていた。

**方針**（ユーザー選択: 縦長で全身を大きく）: 出力とコンテナの縦横比を **9:16 縦長に統一**し、クロップなしで全身が映るようにする。

## 変更

- **avatar-agent/agent.py**: 両 `avatar_kwargs`(agent_image_url 経路 / agent_id 経路)の `width/height` を `1920×1080` → `1080×1920`
- **public/widget.js**:
  - `.avatar-area`: 高さ固定(300px) → `aspect-ratio: 9/16` + 幅上限260px + 中央寄せ
  - `.avatar-video`: `object-position: center top` → `center`
  - `.panel.avatar-active .avatar-video`(大表示): 高さ基準の縦長ボックスで中央配置(`width:auto; aspect-ratio:9/16`)
  - モバイル(≤390px): 高さ固定をやめ幅上限で制御(高さは aspect-ratio 追従)

`.avatar-video` クラスはサムネイル `<img>` と LiveKit `<video>` の両方で共有されているため、静止画・映像とも一貫して縦長表示になる。

## Gate

- Gate 1 `pnpm verify`: typecheck / lint / test(backend 1997 + widget/admin 34) / security-scan すべて PASS（CRITICAL/HIGH 0）
- Gate 3 `pnpm build`: PASS（admin-ui は未変更のためスキップ）

## 反映に必要な操作（マージ後・人間が実施）

- **widget.js のCSS**: main push で Cloudflare Pages / 配信に反映（フロント側）
- **avatar-agent の縦長出力**: avatar-agent の再デプロイが必要（VPS 上のエージェント・人間承認ドメイン）。再デプロイするまで映像は16:9のまま

## 補足（要視覚確認）

縦横比は 9:16(full body)を採用。大表示(横並びモーダル)では縦長映像の左右に背景の余白が出る（ビデオ通話的な見え方）。実機で見て「もっと頭身を詰めたい/余白を減らしたい」等あれば縦横比・カラム幅を微調整します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)