### PR TITLE
feat(avatar): アバター大表示を33秒非アクティブで自動折りたたみ

### DIFF
--- a/public/widget.js
+++ b/public/widget.js
@@ -977,6 +977,8 @@
   var fabMediaContainer = null;  // FABメディアコンテナ（アバター映像/静止画）
   var fabVideoEl = null;         // LiveKitビデオ要素（FAB↔avatarAreaで移動）
   var lastAvatarImageUrl = null; // 最後に確認されたアバター画像URL（closePanel時のフォールバック）
+  var avatarInactivityTimer = null;
+  var AVATAR_INACTIVITY_MS = 33000; // 大表示非アクティブタイムアウト（33秒）
 
   var conversationId = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
     var r = Math.random() * 16 | 0;
@@ -1145,7 +1147,7 @@
           startFabLoading();
           if (isOpen) {
             avatarArea.style.display = 'flex';
-            panel.classList.add('avatar-active');
+            setAvatarActive();
           }
           initAnamAvatar(data.sessionToken);
           return;
@@ -1175,7 +1177,7 @@
             startFabLoading();
             if (isOpen) {
               avatarArea.style.display = 'flex';
-              panel.classList.add('avatar-active');
+              setAvatarActive();
             }
             showAvatarPlaceholder(lkData.imageUrl);
             initLiveKitAvatar();
@@ -1212,7 +1214,7 @@
             startFabLoading();
             if (isOpen) {
               avatarArea.style.display = 'flex';
-              panel.classList.add('avatar-active');
+              setAvatarActive();
             }
             showAvatarPlaceholder(lkData.imageUrl);
             initLiveKitAvatar();
@@ -1477,7 +1479,7 @@
           avatarStatusText.style.display = 'none';
           voiceModeIndicator.style.display = '';
 
-          panel.classList.add('avatar-active');
+          setAvatarActive();
           textarea.setAttribute('placeholder', placeholderText);
 
           // 右上フローティング閉じるボタン
@@ -1779,7 +1781,7 @@
         console.log('[FAQ Widget] LiveKit reconnected');
         if (isOpen) {
           avatarArea.style.display = 'flex';
-          panel.classList.add('avatar-active');
+          setAvatarActive();
         }
       });
 
@@ -1789,7 +1791,7 @@
           voiceModeIndicator.style.display = '';
 
           // フルスクリーンアバターUIへ切り替え
-          panel.classList.add('avatar-active');
+          setAvatarActive();
           textarea.setAttribute('placeholder', placeholderText);
 
           // 右上フローティング閉じるボタンを生成
@@ -2017,7 +2019,7 @@
     // 既存 Room が接続中ならエリアを再表示するだけ（再fetch・再接続しない）
     if (window.__rajiuceRoom && window.__rajiuceRoom.state === 'connected') {
       avatarArea.style.display = 'flex';
-      panel.classList.add('avatar-active');
+      setAvatarActive();
       document.body.style.overflow = 'hidden';
     } else {
       // avatarConfig が事前取得済み、またはセッションキャッシュがあれば即ダークUI適用
@@ -2027,7 +2029,7 @@
       }
       if (shouldDark) {
         avatarArea.style.display = 'flex';
-        panel.classList.add('avatar-active');
+        setAvatarActive();
         document.body.style.overflow = 'hidden';
       }
       fetchAvatarConfig();
@@ -2036,6 +2038,7 @@
 
   function closePanel() {
     isOpen = false;
+    if (avatarInactivityTimer) { clearTimeout(avatarInactivityTimer); avatarInactivityTimer = null; }
     panel.classList.remove('open');
     panel.setAttribute('aria-hidden', 'true');
     fab.setAttribute('aria-label', 'チャットを開く');
@@ -2123,8 +2126,40 @@
     return fallback;
   }
 
+  /* ------------------------------------------------------------------ */
+  /* アバター大表示 非アクティブタイマー                                     */
+  /* ------------------------------------------------------------------ */
+
+  function resetAvatarInactivityTimer() {
+    if (avatarInactivityTimer) { clearTimeout(avatarInactivityTimer); avatarInactivityTimer = null; }
+    if (!panel.classList.contains('avatar-active')) return;
+    avatarInactivityTimer = setTimeout(collapseAvatarLargeView, AVATAR_INACTIVITY_MS);
+  }
+
+  function collapseAvatarLargeView() {
+    avatarInactivityTimer = null;
+    panel.classList.remove('avatar-active');
+    avatarArea.style.display = 'none';
+    document.body.style.overflow = '';
+  }
+
+  function setAvatarActive() {
+    panel.classList.add('avatar-active');
+    resetAvatarInactivityTimer();
+  }
+
   function sendMessage(text) {
     if (!text || !text.trim() || isLoading) return;
+
+    // 非アクティブで大表示が折りたたまれていた場合は再展開（接続維持中のみ）
+    var _roomOk = window.__rajiuceRoom && window.__rajiuceRoom.state === 'connected';
+    var _anamOk = avatarProvider === 'anam' && (anamClient || window.__anamClient);
+    if ((_roomOk || _anamOk) && !panel.classList.contains('avatar-active')) {
+      avatarArea.style.display = 'flex';
+      panel.classList.add('avatar-active');
+      document.body.style.overflow = 'hidden';
+    }
+    resetAvatarInactivityTimer();
 
     hideError();
 
@@ -2333,6 +2368,7 @@
       isRecording = true;
       micBtn.classList.add('recording');
       micBtn.setAttribute('aria-label', '録音中 — タップで停止');
+      resetAvatarInactivityTimer();
 
       var recognition = new SpeechRecognitionAPI();
       recognition.lang = 'ja-JP';


### PR DESCRIPTION
## Summary

- アバター大表示（`avatar-active`）中にチャット/音声操作が **33秒** なければ大表示を自動折りたたみ
- LiveKit / Anam 接続は**維持**（切断しない）
- 次にメッセージを送信すると大表示を**自動再展開**

## 変更内容

- `avatarInactivityTimer` / `AVATAR_INACTIVITY_MS = 33000` を状態変数に追加
- `setAvatarActive()` ヘルパー追加（`panel.classList.add('avatar-active')` + タイマー起動）
- `collapseAvatarLargeView()` 追加（大表示折りたたみ、接続は切らない）
- `resetAvatarInactivityTimer()` 追加（チャット/音声でタイマーリセット）
- `panel.classList.add('avatar-active')` の全 8 箇所を `setAvatarActive()` に統一
- `sendMessage()` 先頭：折りたたみ後の再展開ロジック + タイマーリセット追加
- `micBtn` click（録音 ON）：タイマーリセット追加
- `closePanel()`：タイマークリア追加

## Test plan

- [ ] アバター接続後、33秒何もしないと大表示が通常チャットに戻る
- [ ] チャット送信でタイマーがリセットされ、33秒カウントが再スタートする
- [ ] 音声ボタン（録音開始）でタイマーがリセットされる
- [ ] 折りたたみ後にメッセージ送信すると大表示が再展開する（接続継続中）
- [ ] パネルを閉じるとタイマーが確実にクリアされる

🤖 Generated with [Claude Code](https://claude.com/claude-code)