### PR TITLE
feat(avatar): アバター沈黙ゼロ化 — thinking_start フィラー発話で応答待ちの無音を解消

### DIFF
--- a/avatar-agent/agent.py
+++ b/avatar-agent/agent.py
@@ -491,9 +491,20 @@ async def entrypoint(ctx: agents.JobContext) -> None:
                 exc_info=inner_error,
             )
 
+    # フィラーハンドル保持（dict でクロージャ越しに再代入可能にする）
+    _filler_state: dict = {"handle": None}
+
     async def handle_tts_request(reply_text: str) -> None:
         """本体APIの応答テキストをそのままTTSに渡す（Groq呼び出しなし）。"""
         try:
+            # thinking_start フィラーが再生中なら interrupt して本来の発話に切り替える
+            fh = _filler_state["handle"]
+            if fh is not None:
+                try:
+                    fh.interrupt()
+                except Exception:
+                    pass
+                _filler_state["handle"] = None
             logger.info(f"[tts_request] TTS直渡し ({len(reply_text)} chars): {reply_text[:80]!r}")
             session.say(reply_text)
         except Exception as e:
@@ -525,7 +536,12 @@ async def entrypoint(ctx: agents.JobContext) -> None:
         try:
             msg = json.loads(data_packet.data.decode())
             msg_type = msg.get("type", "")
-            if msg_type == "tts_request":
+            if msg_type == "thinking_start":
+                # フィラー再生: APIレスポンス到着まで沈黙を埋める
+                logger.info("[data_channel] thinking_start — filler started")
+                handle = session.say("少々お待ちください", allow_interruptions=True)
+                _filler_state["handle"] = handle
+            elif msg_type == "tts_request":
                 # Phase6-D: 本体APIの応答テキストをそのままTTSに渡す
                 text = msg.get("text", "").strip()
                 if text:

--- a/public/widget.js
+++ b/public/widget.js
@@ -2246,6 +2246,17 @@
       fetchOptions.signal = currentAbortController.signal;
     }
 
+    // thinking_start: API応答待ち中の沈黙をフィラーで埋める（lemonslice 接続中のみ）
+    try {
+      var _tsRoom = window.__rajiuceRoom;
+      if (avatarProvider === 'lemonslice' && _tsRoom && _tsRoom.localParticipant) {
+        var _tsPayload = new TextEncoder().encode(JSON.stringify({ type: 'thinking_start' }));
+        _tsRoom.localParticipant.publishData(_tsPayload, { reliable: true });
+      }
+    } catch (_tsErr) {
+      // non-fatal: フィラー送信失敗は無視して通常フローを継続
+    }
+
     fetch(apiBase + '/api/chat', fetchOptions)
       .then(function (res) {
         if (!res.ok) {


### PR DESCRIPTION
## 概要

アバターが LLM 応答生成中に無音になる「沈黙」を、つなぎフィラー発話で埋めて体感待ち時間を短縮します（CV 向上）。

Asana: 【CV↑】アバター沈黙ゼロ化（GID 1215698617405067）

## 実装方針（重要）

当初タスク名の `ctx.with_filler()` は **現行 livekit-agents 1.5.17 に存在しない** API（1.6.0 の `RunContext` 専用）であることが実機照合で判明。SDK bump を伴わない代替設計を採用しました（ユーザー承認済み）。

- `public/widget.js`: `/api/chat` 呼び出し直前に `thinking_start` を DataChannel で publish（`avatarProvider === 'lemonslice'` かつ LiveKit 接続時のみ、失敗は non-fatal）
- `avatar-agent/agent.py`: `thinking_start` 受信で `session.say("少々お待ちください")` のフィラーを再生し、本来の `tts_request` 到着時に `interrupt()` して本文発話へ切り替え

requirements.txt（SDK バージョン）・.env・hooks は **一切変更なし**。変更は上記 2 ファイルのみ。

## Gate 結果

- Gate 1 `pnpm verify`: PASS（1997 tests pass / lint 60≤63。変更2ファイルは非TSのため regression 確認が目的）
- Gate 1.5 dead-code-check: PASS（main と同数、本変更による増加なし）
- Gate 2 security-scan: PASS（CRITICAL/HIGH = 0）
- Gate 3 build: PASS（backend。admin-ui は無変更につき対象外）
- 静的検証: `py_compile` / `node --check` OK、`_filler_state` 参照整合 3 箇所一貫

## 人間ゲート（マージ後）

- avatar-agent の変更は VPS 上のプロセス再起動が必要（人間が実施）
- 実機確認: `thinking_start` 送信 → フィラー発話 → 応答受信で中断 → 本文発話への切替を実機で確認
- Gate 2.5 Codex review は人間手動

## 別タスク候補（P2、本PR対象外）

- フィラー文言のハードコード → i18n（多言語テナント）
- `thinking_start` 連打時のキュー管理 / asyncio.Lock
- livekit-agents 1.6.0 bump（ネイティブ filler API 利用）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
