### PR TITLE
fix(avatar): 音声クローン検証 — .m4a MIME 不整合を修正（コアは検証済み・正常）

### DIFF
--- a/admin-ui/src/pages/admin/avatar/StudioVoiceCloneSection.tsx
+++ b/admin-ui/src/pages/admin/avatar/StudioVoiceCloneSection.tsx
@@ -16,6 +16,8 @@ const ALLOWED_VOICE_MIME_TYPES = [
   "audio/mpeg",
   "audio/wav",
   "audio/mp4",
+  "audio/x-m4a",
+  "audio/m4a",
   "audio/ogg",
 ];
 

--- a/src/api/admin/avatar/routes.test.ts
+++ b/src/api/admin/avatar/routes.test.ts
@@ -447,6 +447,25 @@ describe("POST /v1/admin/avatar/configs/:id/voice-clone", () => {
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
+  it("回帰: audio/x-m4a (.m4a macOS Chrome) → Fish Audio 呼び出し + 200", async () => {
+    const dbQuery = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ id: "config-1" }] })
+      .mockResolvedValueOnce({ rows: [{ id: "config-1" }] });
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "client_admin", "tenant-a"))
+      .post("/v1/admin/avatar/configs/config-1/voice-clone")
+      .field("name", "m4aボイス")
+      .attach("audio", AUDIO_BUFFER, {
+        filename: "voice.m4a",
+        contentType: "audio/x-m4a",
+      });
+
+    expect(res.status).toBe(200);
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
   it("テナント越境: 他テナント configId → 404、Fish Audio に到達しない", async () => {
     const dbQuery = jest
       .fn()

--- a/src/api/admin/avatar/routes.ts
+++ b/src/api/admin/avatar/routes.ts
@@ -164,6 +164,8 @@ const ALLOWED_VOICE_MIME_TYPES = [
   "audio/mpeg",
   "audio/wav",
   "audio/mp4",
+  "audio/x-m4a",
+  "audio/m4a",
   "audio/ogg",
 ] as const;
 


### PR DESCRIPTION
## 概要

テナント音声クローン機能の「検証・修正」タスク。実機照合の結果、**コア機能は正しく実装済み**であることを確認し、唯一見つかった具体的な不整合（`.m4a` の MIME 不一致）を修正します。

Asana: 【差別化↑】Fish Audio Voice Cloning（検証・修正）（GID 1215698756176637）

## 検証結果（コアは正常 — 修正不要）

- サブタスク (B) の懸念「TTS 呼び出し時に reference_id が渡っていなければ修正」→ **既に正しく配線済み**。`src/api/avatar/fishTtsRoutes.ts` がテナントの `avatar_configs.voice_id` を解決し（L39-43）、Fish TTS リクエストに `reference_id` を付与（L58）、body 由来の voiceId は受けない（テナント越境防止, L36）。→ クローン音声は発話時に実際に使われている。
- クローン作成 API（#359）/ Admin UI（#365）/ billing（#369）/ 各テスト — 全て実装済み・PASS。

## 修正内容（唯一の defect）

ファイルピッカーの `accept` 属性は `.m4a` を許可しているのに、frontend/backend 両方の MIME 許可リストに `audio/x-m4a` が無く、macOS の `.m4a` アップロードが弾かれていた。

- `src/api/admin/avatar/routes.ts`: 許可リストに `audio/x-m4a` / `audio/m4a` を追加
- `admin-ui/src/pages/admin/avatar/StudioVoiceCloneSection.tsx`: 同期して追加
- `src/api/admin/avatar/routes.test.ts`: `audio/x-m4a` → 200 の回帰テストを追加

## Gate 結果

- Gate 1 `pnpm verify`: PASS（1998 tests。bookPdfRoutes の flaky は既存・本変更無関係、単独 PASS）
- Gate 1.5 dead-code: PASS（増加なし）
- Gate 2 security-scan: PASS（CRITICAL/HIGH=0）
- Gate 3 build: PASS（backend + admin-ui）

## 人間ゲート / 残作業（このタスクはまだ完了にしない）

- (C) Admin UI のブラウザ目視確認、(D) テナント A/B で異なる声・フォールバックの実機テスト（VPS redeploy 後）
- Gate 2.5 Codex review（Tier A、人間手動）

## 別タスク候補（本PR対象外）

- `emotion_tags` の TTS 注入（admin で保存済みだが TTS 呼び出し時に未注入）
- クローン再作成時の Fish Audio 旧モデル削除（ガベージ蓄積対策）
- `bookPdfRoutes.test.ts` の並列実行 flaky

🤖 Generated with [Claude Code](https://claude.com/claude-code)
