### PR TITLE
feat(sales): SalesFlow 商品カード基盤 PR-1 — scrape商品メタ抽出+永続化+dialog配線 (#4635)

### DIFF
--- a/src/agent/dialog/dialogAgent.test.ts
+++ b/src/agent/dialog/dialogAgent.test.ts
@@ -1,0 +1,180 @@
+// src/agent/dialog/dialogAgent.test.ts
+// Phase73: productCard が recommend ステージで設定されること / clarify では設定されないことをテスト
+
+// 外部依存（DB/Groq/ES等）をすべて no-op mock にする
+jest.mock("../../lib/db", () => ({
+  pool: {
+    query: jest.fn(),
+  },
+  getPool: jest.fn(() => ({
+    query: jest.fn(),
+  })),
+}));
+
+jest.mock("../flow/dialogOrchestrator", () => ({
+  runDialogOrchestrator: jest.fn(),
+}));
+
+jest.mock("../flow/multiStepPlanner", () => ({
+  planMultiStepQuery: jest.fn(),
+}));
+
+jest.mock("../flow/llmMultiStepPlannerRuntime", () => ({
+  planMultiStepQueryWithLlmAsync: jest.fn(),
+}));
+
+jest.mock("../orchestrator/sales/runSalesFlowWithLogging", () => ({
+  runSalesFlowWithLogging: jest.fn(),
+}));
+
+jest.mock("../orchestrator/sales/salesIntentDetector", () => ({
+  detectSalesIntents: jest.fn(),
+}));
+
+jest.mock("./contextStore", () => ({
+  getSessionHistory: jest.fn(() => []),
+  appendToSessionHistory: jest.fn(),
+}));
+
+jest.mock("./salesContextStore", () => ({
+  getSalesSessionMeta: jest.fn(() => null),
+  updateSalesSessionMeta: jest.fn(),
+}));
+
+import { runDialogTurn } from "./dialogAgent";
+import { runDialogOrchestrator } from "../flow/dialogOrchestrator";
+import { planMultiStepQuery } from "../flow/multiStepPlanner";
+import { runSalesFlowWithLogging } from "../orchestrator/sales/runSalesFlowWithLogging";
+import { detectSalesIntents } from "../orchestrator/sales/salesIntentDetector";
+import { pool } from "../../lib/db";
+
+const mockOrchestrator = runDialogOrchestrator as jest.MockedFunction<typeof runDialogOrchestrator>;
+const mockPlanner = planMultiStepQuery as jest.MockedFunction<typeof planMultiStepQuery>;
+const mockSalesFlow = runSalesFlowWithLogging as jest.MockedFunction<typeof runSalesFlowWithLogging>;
+const mockDetectIntents = detectSalesIntents as jest.MockedFunction<typeof detectSalesIntents>;
+const mockPool = pool as { query: jest.Mock };
+
+/** ベースとなる planner plan の戻り値 */
+const basePlan = {
+  steps: [],
+  needsClarification: false,
+  confidence: "high" as const,
+};
+
+/** ベースとなる orchestrator の戻り値 */
+const baseOrchestrated = {
+  answer: "テスト回答",
+  steps: [],
+  final: true,
+  needsClarification: false,
+  clarifyingQuestions: undefined,
+  gapSignal: undefined,
+  llmUsage: { prompt_tokens: 0, completion_tokens: 0 },
+  ragSources: undefined,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockPlanner.mockResolvedValue(basePlan);
+  mockDetectIntents.mockReturnValue({
+    proposeIntent: "trial_lesson_offer",
+    recommendIntent: "recommend_course_based_on_level",
+    closeIntent: undefined,
+  });
+  mockOrchestrator.mockResolvedValue(baseOrchestrated);
+});
+
+describe("runDialogTurn — Phase73 productCard", () => {
+  it("recommend ステージで faq_docs に商品メタがある場合 productCard が設定される", async () => {
+    // salesFlow が recommend を返す
+    mockSalesFlow.mockResolvedValue({
+      nextStage: "recommend",
+      prompt: "おすすめの商品はこちらです。",
+      meta: {} as any,
+    });
+
+    // pool.query が商品メタ行を返す
+    mockPool.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: 42,
+          question: "テスト商品の特徴は？",
+          product_image_url: "https://example.com/img.jpg",
+          product_price: "9800",
+          product_cta_url: "https://example.com/product",
+        },
+      ],
+    });
+
+    const result = await runDialogTurn({
+      sessionId: "test-session-1",
+      tenantId: "test-tenant",
+      message: "おすすめを教えて",
+    });
+
+    expect(result.productCard).toBeDefined();
+    expect(result.productCard?.product_id).toBe("42");
+    expect(result.productCard?.price).toBe("9800");
+    expect(result.productCard?.image_url).toBe("https://example.com/img.jpg");
+    expect(result.productCard?.cta_url).toBe("https://example.com/product");
+  });
+
+  it("recommend ステージでも faq_docs に商品メタがない場合 productCard は undefined", async () => {
+    mockSalesFlow.mockResolvedValue({
+      nextStage: "recommend",
+      prompt: "おすすめ商品",
+      meta: {} as any,
+    });
+
+    // pool.query が空行を返す
+    mockPool.query.mockResolvedValueOnce({ rows: [] });
+
+    const result = await runDialogTurn({
+      sessionId: "test-session-2",
+      tenantId: "test-tenant",
+      message: "おすすめを教えて",
+    });
+
+    expect(result.productCard).toBeUndefined();
+  });
+
+  it("clarify ステージでは productCard は設定されない", async () => {
+    // salesFlow が nextStage を返さない（clarify 初回）
+    mockSalesFlow.mockResolvedValue({
+      nextStage: undefined,
+      prompt: undefined,
+      meta: {} as any,
+    });
+
+    const result = await runDialogTurn({
+      sessionId: "test-session-3",
+      tenantId: "test-tenant",
+      message: "価格を教えて",
+    });
+
+    expect(result.productCard).toBeUndefined();
+    // recommend でないため pool.query が呼ばれないことを確認
+    expect(mockPool.query).not.toHaveBeenCalled();
+  });
+
+  it("pool.query が例外を投げても productCard なしで正常応答する", async () => {
+    mockSalesFlow.mockResolvedValue({
+      nextStage: "recommend",
+      prompt: "おすすめ",
+      meta: {} as any,
+    });
+
+    // DB 未適用環境を想定（migration 未実行 = column not found エラー）
+    mockPool.query.mockRejectedValueOnce(new Error('column "product_image_url" does not exist'));
+
+    const result = await runDialogTurn({
+      sessionId: "test-session-4",
+      tenantId: "test-tenant",
+      message: "おすすめを教えて",
+    });
+
+    // エラーは握りつぶされ productCard なしで応答
+    expect(result.productCard).toBeUndefined();
+    expect(result.answer).toBe("おすすめ"); // salesFlow.prompt が適用される
+  });
+});

--- a/src/agent/dialog/dialogAgent.test.ts
+++ b/src/agent/dialog/dialogAgent.test.ts
@@ -52,7 +52,7 @@ const mockOrchestrator = runDialogOrchestrator as jest.MockedFunction<typeof run
 const mockPlanner = planMultiStepQuery as jest.MockedFunction<typeof planMultiStepQuery>;
 const mockSalesFlow = runSalesFlowWithLogging as jest.MockedFunction<typeof runSalesFlowWithLogging>;
 const mockDetectIntents = detectSalesIntents as jest.MockedFunction<typeof detectSalesIntents>;
-const mockPool = pool as { query: jest.Mock };
+const mockPool = pool as unknown as { query: jest.Mock };
 
 /** ベースとなる planner plan の戻り値 */
 const basePlan = {

--- a/src/agent/dialog/dialogAgent.ts
+++ b/src/agent/dialog/dialogAgent.ts
@@ -15,7 +15,8 @@ import {
   updateSalesSessionMeta,
   type SalesSessionKey,
 } from "./salesContextStore";
-import type { DialogMessage, DialogTurnInput, DialogTurnResult } from "./types";
+import type { DialogMessage, DialogTurnInput, DialogTurnResult, ProductCard } from "./types";
+import { pool } from "../../lib/db";
 
 // ユーザー入力 + 会話履歴からざっくりトークン数を見積もる。
 // （Phase3 v1 では char/4 の雑な近似で十分）
@@ -208,6 +209,43 @@ export async function runDialogTurn(
       ragSources: orchestrated.ragSources,
     },
   };
+
+  // Phase73: recommend ステージ時に faq_docs から商品メタを取得して productCard に設定
+  if (salesResult.nextStage === "recommend" && pool) {
+    try {
+      const row = await pool.query<{
+        id: number;
+        question: string;
+        product_image_url: string | null;
+        product_price: string | null;
+        product_cta_url: string | null;
+      }>(
+        `SELECT id, question, product_image_url, product_price, product_cta_url
+         FROM faq_docs
+         WHERE tenant_id = $1
+           AND product_image_url IS NOT NULL
+         ORDER BY id DESC
+         LIMIT 1`,
+        [effectiveTenantId]
+      );
+      const meta = row.rows[0];
+      if (
+        meta &&
+        (meta.product_image_url || meta.product_price || meta.product_cta_url)
+      ) {
+        const card: ProductCard = {
+          product_id: String(meta.id),
+          name: meta.question.slice(0, 100),
+          price: meta.product_price ?? "",
+          image_url: meta.product_image_url ?? "",
+          cta_url: meta.product_cta_url ?? "",
+        };
+        result.productCard = card;
+      }
+    } catch {
+      // non-fatal: DB 未適用環境（migration 未実行）でも動作を継続する
+    }
+  }
 
   return result;
 }

--- a/src/agent/dialog/types.ts
+++ b/src/agent/dialog/types.ts
@@ -132,6 +132,15 @@ export interface DialogTurnMeta {
   ragSources?: import("../types").RagSource[];
 }
 
+/** Phase73: recommend ステージで乗せる商品カード情報 */
+export interface ProductCard {
+  product_id: string;
+  name: string;
+  price: string;
+  image_url: string;
+  cta_url: string;
+}
+
 export interface DialogTurnResult {
   sessionId: string;
   answer: string | null;
@@ -143,6 +152,8 @@ export interface DialogTurnResult {
   steps: (AgentStep | OrchestratorStep)[];
   final: boolean;
   meta?: DialogTurnMeta;
+  /** Phase73: SalesFlow recommend ステージ時に設定される商品カード情報 */
+  productCard?: ProductCard;
 }
 
 // --- Phase8: Sales-oriented Planner types ---

--- a/src/api/admin/knowledge/knowledgeRoutesAuthGuard.test.ts
+++ b/src/api/admin/knowledge/knowledgeRoutesAuthGuard.test.ts
@@ -103,3 +103,75 @@ describe('knowledge — requireKnowledgeRole guard', () => {
     expect(res.status).not.toBe(403);
   });
 });
+
+// Phase73 — safeHttpUrl スキーム検証: POST /v1/admin/knowledge/scrape
+describe('scrape — product URL scheme guard (safeHttpUrl)', () => {
+  const SCRAPE_PATH = '/v1/admin/knowledge/scrape?tenant=t1';
+  const adminDecoded = { app_metadata: { role: 'super_admin', tenant_id: 't1' }, email: 't@t.com' };
+
+  function makeScrapeApp(html: string) {
+    const app = makeApp(adminDecoded);
+    // global fetch を mock: 指定 HTML を返す
+    global.fetch = jest.fn().mockResolvedValue({
+      text: () => Promise.resolve(html),
+      ok: true,
+    } as unknown as Response);
+    return app;
+  }
+
+  afterEach(() => {
+    // global.fetch を元に戻す
+    delete (global as Record<string, unknown>)['fetch'];
+  });
+
+  // body テキストは HTML タグ除去後に 50 文字以上必要（routes.ts の text.length < 50 チェック回避）
+  const BODY_PADDING = 'この商品の詳細説明文です。商品情報をここに記載しています。テキストを十分な長さにするためのパディング文章。';
+
+  it('javascript: スキームの og:url → product_cta_url が null', async () => {
+    const html = `<html><head>
+      <meta property="og:url" content="javascript:alert(1)" />
+      <meta property="og:image" content="javascript:xss()" />
+    </head><body>${BODY_PADDING}</body></html>`;
+    const app = makeScrapeApp(html);
+    const res = await request(app)
+      .post(SCRAPE_PATH)
+      .set('Authorization', 'Bearer fake')
+      .send({ urls: ['https://example.com/p/danger'] });
+    expect(res.status).toBe(200);
+    const preview = res.body.preview as Array<{ productMeta?: { product_cta_url: string | null; product_image_url: string | null } }>;
+    expect(preview[0]?.productMeta?.product_cta_url).toBeNull();
+    expect(preview[0]?.productMeta?.product_image_url).toBeNull();
+  });
+
+  it('https: スキームの og:url → product_cta_url にそのまま採用される', async () => {
+    const html = `<html><head>
+      <meta property="og:url" content="https://example.com/p/1" />
+      <meta property="og:image" content="https://cdn.example.com/img.jpg" />
+    </head><body>${BODY_PADDING}</body></html>`;
+    const app = makeScrapeApp(html);
+    const res = await request(app)
+      .post(SCRAPE_PATH)
+      .set('Authorization', 'Bearer fake')
+      .send({ urls: ['https://example.com/p/1'] });
+    expect(res.status).toBe(200);
+    const preview = res.body.preview as Array<{ productMeta?: { product_cta_url: string | null; product_image_url: string | null } }>;
+    expect(preview[0]?.productMeta?.product_cta_url).toBe('https://example.com/p/1');
+    expect(preview[0]?.productMeta?.product_image_url).toBe('https://cdn.example.com/img.jpg');
+  });
+
+  it('data: スキームの og:image → product_image_url が null、pageUrl フォールバックの cta_url は http(s) なら保持', async () => {
+    const html = `<html><head>
+      <meta property="og:image" content="data:image/png;base64,abc" />
+    </head><body>${BODY_PADDING}</body></html>`;
+    const app = makeScrapeApp(html);
+    const res = await request(app)
+      .post(SCRAPE_PATH)
+      .set('Authorization', 'Bearer fake')
+      .send({ urls: ['https://example.com/p/safe'] });
+    expect(res.status).toBe(200);
+    const preview = res.body.preview as Array<{ productMeta?: { product_cta_url: string | null; product_image_url: string | null } }>;
+    expect(preview[0]?.productMeta?.product_image_url).toBeNull();
+    // og:url なし → pageUrl('https://example.com/p/safe') にフォールバック → http(s) なので保持
+    expect(preview[0]?.productMeta?.product_cta_url).toBe('https://example.com/p/safe');
+  });
+});

--- a/src/api/admin/knowledge/routes.ts
+++ b/src/api/admin/knowledge/routes.ts
@@ -39,6 +39,90 @@ interface FaqEntryWithDuplicate extends FaqEntry {
   } | null;
 }
 
+/** Phase73: スクレイプで抽出した商品メタ（OG/JSON-LD） */
+interface ProductMeta {
+  product_image_url: string | null;
+  product_price: string | null;
+  product_cta_url: string | null;
+}
+
+/**
+ * Phase73: HTML から OG/JSON-LD を regex で抽出して商品メタを返す。
+ * 依存追加禁止 — cheerio/jsdom 不使用、regex のみ。
+ * JSON-LD parse 失敗は non-fatal（握りつぶし）。
+ */
+function extractProductMeta(html: string, pageUrl: string): ProductMeta {
+  // og:image
+  const ogImageMatch = html.match(/<meta[^>]+property=["']og:image["'][^>]+content=["']([^"']+)["']/i)
+    ?? html.match(/<meta[^>]+content=["']([^"']+)["'][^>]+property=["']og:image["']/i);
+  const ogImage = ogImageMatch?.[1] ?? null;
+
+  // 価格: og:price:amount → product:price:amount → JSON-LD
+  const ogPriceMatch = html.match(/<meta[^>]+property=["']og:price:amount["'][^>]+content=["']([^"']+)["']/i)
+    ?? html.match(/<meta[^>]+content=["']([^"']+)["'][^>]+property=["']og:price:amount["']/i)
+    ?? html.match(/<meta[^>]+property=["']product:price:amount["'][^>]+content=["']([^"']+)["']/i)
+    ?? html.match(/<meta[^>]+content=["']([^"']+)["'][^>]+property=["']product:price:amount["']/i);
+  let ogPrice = ogPriceMatch?.[1] ?? null;
+
+  // cta_url: og:url → fallback to pageUrl
+  const ogUrlMatch = html.match(/<meta[^>]+property=["']og:url["'][^>]+content=["']([^"']+)["']/i)
+    ?? html.match(/<meta[^>]+content=["']([^"']+)["'][^>]+property=["']og:url["']/i);
+  let ctaUrl = ogUrlMatch?.[1] ?? pageUrl;
+
+  // JSON-LD 優先採用（@type=Product の場合）
+  const ldJsonMatch = html.match(/<script[^>]+type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi);
+  if (ldJsonMatch) {
+    for (const block of ldJsonMatch) {
+      const inner = block.replace(/<script[^>]*>/i, '').replace(/<\/script>/i, '').trim();
+      try {
+        const data = JSON.parse(inner) as Record<string, unknown>;
+        const objs = Array.isArray(data) ? data : [data];
+        for (const obj of objs) {
+          if (typeof obj !== 'object' || obj === null) continue;
+          const typed = obj as Record<string, unknown>;
+          if (typed['@type'] !== 'Product') continue;
+          // image 優先採用
+          let resolvedImage: string | null = ogImage;
+          if (typed['image']) {
+            const img = typed['image'];
+            if (typeof img === 'string') {
+              resolvedImage = img;
+            } else if (Array.isArray(img) && typeof img[0] === 'string') {
+              resolvedImage = img[0];
+            } else if (typeof img === 'object' && img !== null && typeof (img as Record<string, unknown>)['url'] === 'string') {
+              resolvedImage = (img as Record<string, unknown>)['url'] as string;
+            }
+          }
+          return {
+            product_image_url: resolvedImage,
+            product_price: extractJsonLdPrice(typed) ?? ogPrice,
+            product_cta_url: typeof typed['url'] === 'string' ? typed['url'] : ctaUrl,
+          };
+        }
+      } catch {
+        // non-fatal: JSON.parse 失敗は握りつぶす
+      }
+    }
+  }
+
+  return {
+    product_image_url: ogImage,
+    product_price: ogPrice,
+    product_cta_url: ctaUrl,
+  };
+}
+
+/** JSON-LD Product オブジェクトから offers.price を文字列として取得 */
+function extractJsonLdPrice(product: Record<string, unknown>): string | null {
+  const offers = product['offers'];
+  if (!offers || typeof offers !== 'object') return null;
+  const o = (Array.isArray(offers) ? offers[0] : offers) as Record<string, unknown>;
+  if (!o) return null;
+  const price = o['price'];
+  if (price === undefined || price === null) return null;
+  return String(price);
+}
+
 /** query/header からテナントIDを解決（bodyから取得禁止 — CLAUDE.md） */
 function resolveTenantId(req: Request): string | null {
   const fromQuery = (req.query.tenant || req.query.tenant_id) as string | undefined;
@@ -584,7 +668,7 @@ export function registerKnowledgeAdminRoutes(app: Express): void {
     }
 
     const { urls, category } = parsed.data;
-    const results: { url: string; faqs: FaqEntryWithDuplicate[]; error?: string }[] = [];
+    const results: { url: string; faqs: FaqEntryWithDuplicate[]; productMeta?: ProductMeta; error?: string }[] = [];
 
     // 既存FAQ質問を一度だけ取得（重複防止のためプロンプトに渡す）
     let existingRows: { question: string; answer: string }[] = [];
@@ -605,6 +689,9 @@ export function registerKnowledgeAdminRoutes(app: Express): void {
           headers: { "User-Agent": "Mozilla/5.0 (compatible; R2C/1.0)" },
           signal: AbortSignal.timeout(10_000),
         }).then((r) => r.text());
+
+        // Phase73: OG/JSON-LD から商品メタを抽出（script/style 除去前の生 HTML を使う）
+        const productMeta = extractProductMeta(html, url);
 
         const text = html
           .replace(/<script[\s\S]*?<\/script>/gi, "")
@@ -635,7 +722,7 @@ export function registerKnowledgeAdminRoutes(app: Express): void {
                 : null,
           };
         });
-        results.push({ url, faqs: faqsWithDuplicate });
+        results.push({ url, faqs: faqsWithDuplicate, productMeta });
       } catch (err) {
         results.push({ url, faqs: [], error: String(err).slice(0, 200) });
       }
@@ -663,6 +750,12 @@ export function registerKnowledgeAdminRoutes(app: Express): void {
               .array(z.object({ question: z.string(), answer: z.string(), category: z.string().optional() }))
               .min(1)
               .max(20),
+            // Phase73: preview から引き継いだ商品メタ（省略可）
+            productMeta: z.object({
+              product_image_url: z.string().nullable().optional(),
+              product_price: z.string().nullable().optional(),
+              product_cta_url: z.string().nullable().optional(),
+            }).optional(),
           })
         )
         .min(1)
@@ -703,10 +796,12 @@ export function registerKnowledgeAdminRoutes(app: Express): void {
           continue;
         }
         const faqCategory = categoryOverride || faq.category || "general";
+        // Phase73: preview から引き継いだ商品メタを適用（各 item 単位）
+        const pm = item.productMeta;
         try {
           const r = await db.query(
-            `INSERT INTO faq_docs (tenant_id, question, answer, category, tags, is_published)
-             VALUES ($1, $2, $3, $4, $5, true)
+            `INSERT INTO faq_docs (tenant_id, question, answer, category, tags, is_published, product_image_url, product_price, product_cta_url)
+             VALUES ($1, $2, $3, $4, $5, true, $6, $7, $8)
              RETURNING id`,
             [
               target,
@@ -714,6 +809,9 @@ export function registerKnowledgeAdminRoutes(app: Express): void {
               faq.answer.slice(0, 2000),
               faqCategory,
               [item.url],
+              pm?.product_image_url ?? null,
+              pm?.product_price ?? null,
+              pm?.product_cta_url ?? null,
             ]
           );
           const faqId = r.rows[0].id as number;

--- a/src/api/admin/knowledge/routes.ts
+++ b/src/api/admin/knowledge/routes.ts
@@ -47,6 +47,13 @@ interface ProductMeta {
 }
 
 /**
+ * http(s) スキームのみを許可するガード。javascript:/data:/相対パス等は null に落とす。
+ * system boundary (外部 HTML からの抽出値) にのみ適用。
+ */
+const safeHttpUrl = (u: unknown): string | null =>
+  typeof u === 'string' && /^https?:\/\//i.test(u.trim()) ? u.trim() : null;
+
+/**
  * Phase73: HTML から OG/JSON-LD を regex で抽出して商品メタを返す。
  * 依存追加禁止 — cheerio/jsdom 不使用、regex のみ。
  * JSON-LD parse 失敗は non-fatal（握りつぶし）。
@@ -94,9 +101,9 @@ function extractProductMeta(html: string, pageUrl: string): ProductMeta {
             }
           }
           return {
-            product_image_url: resolvedImage,
+            product_image_url: safeHttpUrl(resolvedImage),
             product_price: extractJsonLdPrice(typed) ?? ogPrice,
-            product_cta_url: typeof typed['url'] === 'string' ? typed['url'] : ctaUrl,
+            product_cta_url: safeHttpUrl(typeof typed['url'] === 'string' ? typed['url'] : ctaUrl),
           };
         }
       } catch {
@@ -106,9 +113,9 @@ function extractProductMeta(html: string, pageUrl: string): ProductMeta {
   }
 
   return {
-    product_image_url: ogImage,
+    product_image_url: safeHttpUrl(ogImage),
     product_price: ogPrice,
-    product_cta_url: ctaUrl,
+    product_cta_url: safeHttpUrl(ctaUrl),
   };
 }
 

--- a/src/api/chat/route.ts
+++ b/src/api/chat/route.ts
@@ -269,6 +269,8 @@ export function createChatHandler(logger: Logger) {
         timestamp: Date.now(),
         tenantId,
         flowState,
+        // Phase73: recommend ステージで productCard が設定されていれば転送
+        ...(result.productCard ? { productCard: result.productCard } : {}),
       };
 
       logger.info(

--- a/src/migrations/phase73_product_meta_in_faq_docs.sql
+++ b/src/migrations/phase73_product_meta_in_faq_docs.sql
@@ -1,0 +1,7 @@
+-- Phase73: SalesFlow 商品カード同期 — faq_docs に商品メタカラムを追加
+-- Asana タスク #4635 (salesflow-product-card-backend)
+-- 実行は DBA/人間 が行う（コードは適用済みを前提として実装）
+ALTER TABLE faq_docs
+  ADD COLUMN IF NOT EXISTS product_image_url TEXT DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS product_price     TEXT DEFAULT NULL,
+  ADD COLUMN IF NOT EXISTS product_cta_url   TEXT DEFAULT NULL;

--- a/src/types/contracts.ts
+++ b/src/types/contracts.ts
@@ -37,6 +37,14 @@ export interface ChatMessage {
     | "propose"
     | "recommend"
     | "close";
+  /** Phase73: recommend ステージ時に設定される商品カード情報 */
+  productCard?: {
+    product_id: string;
+    name: string;
+    price: string;
+    image_url: string;
+    cta_url: string;
+  };
 }
 
 export interface ChatAction {


### PR DESCRIPTION
## 概要

SalesFlow の `recommend` ステージで、スクレイプ済みの商品メタ（画像/価格/CTA）を会話レスポンスに `productCard` として載せる**バックエンド基盤**（PR-1/2）。ウィジェット側の ProductCard 描画は PR-2 で実装します。

Asana: 【CV↑】SalesFlow × 商品カード（GID 1215698617354635）

## このPRの範囲（PR-1: バックエンド + 永続化）

- **DB migration（人間実行ゲート）**: `src/migrations/phase73_product_meta_in_faq_docs.sql` — `faq_docs` に `product_image_url` / `product_price` / `product_cta_url` を追加（`IF NOT EXISTS`、冪等）
- **スクレイプ拡張**: `src/api/admin/knowledge/routes.ts` の scrape endpoint に `extractProductMeta`（OG / JSON-LD を正規表現抽出、cheerio 不使用＝Simplicity First）を追加し、INSERT を product_* カラムに拡張
- **書き込み境界の URL サニタイズ**: `extractProductMeta` の `cta_url` / `image_url` に `http(s)` スキームガード（`safeHttpUrl`）を適用。`javascript:` 等は `null` 化して DB に汚染 URL を残さない
- **dialog 配線**: `recommend` ステージで product メタを持つ行を取得し `DialogTurnResult.productCard` に載せる（未 migration DB でも落ちないよう try/catch 保護）
- **contract**: `src/types/contracts.ts` / `src/api/chat/route.ts` の Chat レスポンスに `productCard?` を追加

## Gate 結果

- Gate 1 `pnpm verify`: PASS
- Gate 1.5 dead-code-check: PASS（増加なし）
- Gate 2 security-scan: PASS（CRITICAL/HIGH=0）
- Gate 3 build: PASS（backend。admin-ui は本PR無変更）

## 人間ゲート（このPRはまだ Asana 完了にしない）

1. **migration を人間が実行**: `psql ... -f src/migrations/phase73_product_meta_in_faq_docs.sql`（不可逆ではないが DB 変更のため人間承認）
2. main merge は人間手動（Branch Rule）
3. Gate 2.5 Codex review（Tier A、人間手動）

## PR-2 への申し送り（必須キャリーオーバー）

1. **ウィジェット側 URL ガード**: `widget.js` で href/src 描画前にも http(s) スキーム検証（DB 値を信用しない多層防御）
2. **商品マッチ精度**: 現状は `ORDER BY id DESC LIMIT 1`（暫定）。PR-2 で会話コンテキスト（category/tags/semantic）でマッチし、該当なしは `undefined` を返す
3. **デプロイ順序**: PR-2 のデプロイは PR-1 の migration 適用後でないと product メタが空になる

🤖 Generated with [Claude Code](https://claude.com/claude-code)
