### PR TITLE
feat(sales): SalesFlow 商品カード PR-2 — widget描画+会話マッチ+多層URLガード (#4635)

### DIFF
--- a/public/widget.js
+++ b/public/widget.js
@@ -60,6 +60,15 @@
     : [window.location.origin];
 
   /* ------------------------------------------------------------------ */
+  /* 1b. URL サニタイザー（商品カード等の外部 URL 検証）                   */
+  /* ------------------------------------------------------------------ */
+
+  // DB 値を信頼しない多層防御: https? スキーム以外の URL（javascript: 等）を拒否
+  function safeHttpUrl(u) {
+    return (typeof u === 'string' && /^https?:\/\//i.test(u.trim())) ? u.trim() : '';
+  }
+
+  /* ------------------------------------------------------------------ */
   /* 2a. PostHog SDK 読み込み + イベントキャプチャ                        */
   /* ------------------------------------------------------------------ */
 
@@ -706,6 +715,54 @@
     '    border-radius: 0;',
     '  }',
     '}',
+
+    /* 商品カード */
+    '@keyframes product-card-slide-in { from { opacity: 0; transform: translateY(8px); } to { opacity: 1; transform: translateY(0); } }',
+    '.product-card {',
+    '  margin-top: 8px;',
+    '  border-radius: 12px;',
+    '  border: 1px solid #e2e8f0;',
+    '  background: #fff;',
+    '  overflow: hidden;',
+    '  max-width: 280px;',
+    '  animation: product-card-slide-in 0.25s ease both;',
+    '}',
+    '.product-card-img {',
+    '  width: 100%;',
+    '  height: auto;',
+    '  display: block;',
+    '  object-fit: cover;',
+    '  max-height: 180px;',
+    '}',
+    '.product-card-body {',
+    '  padding: 10px 12px;',
+    '}',
+    '.product-card-name {',
+    '  font-size: 14px;',
+    '  font-weight: 600;',
+    '  color: #1e293b;',
+    '  margin: 0 0 4px;',
+    '}',
+    '.product-card-price {',
+    '  font-size: 14px;',
+    '  color: #475569;',
+    '  margin: 0 0 8px;',
+    '}',
+    '.product-cta {',
+    '  display: block;',
+    '  min-height: 44px;',
+    '  width: 100%;',
+    '  border: none;',
+    '  border-radius: 8px;',
+    '  background: var(--accent);',
+    '  color: #fff;',
+    '  font-size: 16px;',
+    '  cursor: pointer;',
+    '  padding: 10px 14px;',
+    '  text-align: center;',
+    '}',
+    '.product-cta:hover { opacity: 0.9; }',
+    '.product-cta:focus-visible { outline: 3px solid #93c5fd; outline-offset: 2px; }',
   ].join('\n');
 
   shadow.appendChild(styleEl);
@@ -1945,6 +2002,43 @@
       } else {
         inner.appendChild(bubble);
       }
+      // 商品カード（recommend ステージで productCard が設定されている場合）
+      if (msg.productCard) {
+        var pc = msg.productCard;
+        var cardEl = el('div', { className: 'product-card' });
+        var guardedImgUrl = safeHttpUrl(pc.image_url || '');
+        if (guardedImgUrl) {
+          var imgEl = el('img', { className: 'product-card-img', loading: 'lazy', alt: pc.name || '' });
+          imgEl.src = guardedImgUrl;
+          cardEl.appendChild(imgEl);
+        }
+        var bodyEl = el('div', { className: 'product-card-body' });
+        if (pc.name) {
+          var nameEl = el('div', { className: 'product-card-name' });
+          nameEl.textContent = pc.name;
+          bodyEl.appendChild(nameEl);
+        }
+        if (pc.price) {
+          var priceEl = el('div', { className: 'product-card-price' });
+          priceEl.textContent = pc.price;
+          bodyEl.appendChild(priceEl);
+        }
+        var guardedCtaUrl = safeHttpUrl(pc.cta_url || '');
+        if (guardedCtaUrl) {
+          var ctaBtn = el('button', { className: 'product-cta', type: 'button' });
+          ctaBtn.textContent = '詳細を見る';
+          ctaBtn.addEventListener('click', function () {
+            try {
+              window.open(guardedCtaUrl, '_blank', 'noopener,noreferrer');
+            } catch (_e) {
+              // ignore navigation failure
+            }
+          });
+          bodyEl.appendChild(ctaBtn);
+        }
+        cardEl.appendChild(bodyEl);
+        inner.appendChild(cardEl);
+      }
       var ts = el('div', { className: 'ts' });
       ts.textContent = formatTime(msg.timestamp);
       inner.appendChild(ts);
@@ -2262,6 +2356,21 @@
           ? json.data.content
           : '申し訳ありません。現在回答を生成できませんでした。再度お試しください。';
 
+        var rawCard = json.data && json.data.productCard;
+        var productCard = null;
+        if (rawCard && typeof rawCard === 'object') {
+          productCard = {
+            product_id: rawCard.product_id != null ? String(rawCard.product_id) : '',
+            name: rawCard.name != null ? String(rawCard.name) : '',
+            price: rawCard.price != null ? String(rawCard.price) : '',
+            image_url: safeHttpUrl(rawCard.image_url != null ? String(rawCard.image_url) : ''),
+            cta_url: safeHttpUrl(rawCard.cta_url != null ? String(rawCard.cta_url) : ''),
+          };
+          // image_url も cta_url も price も空の場合はカード自体を表示しない
+          if (!productCard.image_url && !productCard.cta_url && !productCard.price) {
+            productCard = null;
+          }
+        }
         var assistantMsg = {
           id: (json.data && json.data.id) || generateMsgId(),
           role: 'assistant',
@@ -2280,6 +2389,7 @@
                 })
               : undefined,
           timestamp: (json.data && json.data.timestamp) || Date.now(),
+          productCard: productCard || undefined,
         };
         messages.push(assistantMsg);
 

--- a/src/agent/dialog/dialogAgent.test.ts
+++ b/src/agent/dialog/dialogAgent.test.ts
@@ -61,7 +61,7 @@ const basePlan = {
   confidence: "high" as const,
 };
 
-/** ベースとなる orchestrator の戻り値 */
+/** ベースとなる orchestrator の戻り値（ragSources なし） */
 const baseOrchestrated = {
   answer: "テスト回答",
   steps: [],
@@ -71,6 +71,16 @@ const baseOrchestrated = {
   gapSignal: undefined,
   llmUsage: { prompt_tokens: 0, completion_tokens: 0 },
   ragSources: undefined,
+};
+
+/** ragSources に faq チャンクを含む orchestrator の戻り値 */
+const orchestratedWithRagSources = {
+  ...baseOrchestrated,
+  ragSources: [
+    { chunk_id: "emb-100", source: "faq" as const, score: 0.95 },
+    { chunk_id: "emb-200", source: "faq" as const, score: 0.80 },
+    { chunk_id: "emb-300", source: "book" as const, score: 0.75 }, // book は除外される
+  ],
 };
 
 beforeEach(() => {
@@ -84,16 +94,16 @@ beforeEach(() => {
   mockOrchestrator.mockResolvedValue(baseOrchestrated);
 });
 
-describe("runDialogTurn — Phase73 productCard", () => {
-  it("recommend ステージで faq_docs に商品メタがある場合 productCard が設定される", async () => {
-    // salesFlow が recommend を返す
+describe("runDialogTurn — Phase73 productCard (RAG関連度マッチング)", () => {
+  it("recommend ステージ + ragSources に faq チャンクあり → 商品メタ行で productCard が設定される", async () => {
     mockSalesFlow.mockResolvedValue({
       nextStage: "recommend",
       prompt: "おすすめの商品はこちらです。",
       meta: {} as any,
     });
+    mockOrchestrator.mockResolvedValue(orchestratedWithRagSources);
 
-    // pool.query が商品メタ行を返す
+    // JOIN クエリが商品メタ行を返す（chunk_id=emb-100 → faq_docs.id=42）
     mockPool.query.mockResolvedValueOnce({
       rows: [
         {
@@ -117,20 +127,73 @@ describe("runDialogTurn — Phase73 productCard", () => {
     expect(result.productCard?.price).toBe("9800");
     expect(result.productCard?.image_url).toBe("https://example.com/img.jpg");
     expect(result.productCard?.cta_url).toBe("https://example.com/product");
+
+    // DB クエリに faq chunk_id 配列が渡されることを確認
+    expect(mockPool.query).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockPool.query.mock.calls[0] as [string, unknown[]];
+    expect(sql).toMatch(/faq_embeddings/);
+    expect(sql).toMatch(/faq_docs/);
+    // book チャンク emb-300 は除外され faq チャンクのみ渡される
+    expect(params[1]).toEqual(["emb-100", "emb-200"]);
   });
 
-  it("recommend ステージでも faq_docs に商品メタがない場合 productCard は undefined", async () => {
+  it("recommend ステージ + ragSources が undefined → DB クエリなし → productCard は undefined", async () => {
     mockSalesFlow.mockResolvedValue({
       nextStage: "recommend",
       prompt: "おすすめ商品",
       meta: {} as any,
     });
-
-    // pool.query が空行を返す
-    mockPool.query.mockResolvedValueOnce({ rows: [] });
+    // ragSources は undefined（orchestrator が返さなかった）
+    mockOrchestrator.mockResolvedValue({ ...baseOrchestrated, ragSources: undefined });
 
     const result = await runDialogTurn({
       sessionId: "test-session-2",
+      tenantId: "test-tenant",
+      message: "おすすめを教えて",
+    });
+
+    expect(result.productCard).toBeUndefined();
+    // 関連チャンクなし → DB クエリ不要
+    expect(mockPool.query).not.toHaveBeenCalled();
+  });
+
+  it("recommend ステージ + ragSources が book のみ → DB クエリなし → productCard は undefined", async () => {
+    mockSalesFlow.mockResolvedValue({
+      nextStage: "recommend",
+      prompt: "おすすめ商品",
+      meta: {} as any,
+    });
+    mockOrchestrator.mockResolvedValue({
+      ...baseOrchestrated,
+      ragSources: [
+        { chunk_id: "emb-999", source: "book" as const, score: 0.90 },
+      ],
+    });
+
+    const result = await runDialogTurn({
+      sessionId: "test-session-3",
+      tenantId: "test-tenant",
+      message: "おすすめを教えて",
+    });
+
+    expect(result.productCard).toBeUndefined();
+    // book チャンクのみで faq_docs JOIN は不要
+    expect(mockPool.query).not.toHaveBeenCalled();
+  });
+
+  it("recommend ステージ + ragSources あり + DB が空行 → productCard は undefined（最新商品へのフォールバックなし）", async () => {
+    mockSalesFlow.mockResolvedValue({
+      nextStage: "recommend",
+      prompt: "おすすめ商品",
+      meta: {} as any,
+    });
+    mockOrchestrator.mockResolvedValue(orchestratedWithRagSources);
+
+    // 該当チャンクの faq_docs に product_image_url がない
+    mockPool.query.mockResolvedValueOnce({ rows: [] });
+
+    const result = await runDialogTurn({
+      sessionId: "test-session-4",
       tenantId: "test-tenant",
       message: "おすすめを教えて",
     });
@@ -147,7 +210,7 @@ describe("runDialogTurn — Phase73 productCard", () => {
     });
 
     const result = await runDialogTurn({
-      sessionId: "test-session-3",
+      sessionId: "test-session-5",
       tenantId: "test-tenant",
       message: "価格を教えて",
     });
@@ -163,12 +226,13 @@ describe("runDialogTurn — Phase73 productCard", () => {
       prompt: "おすすめ",
       meta: {} as any,
     });
+    mockOrchestrator.mockResolvedValue(orchestratedWithRagSources);
 
     // DB 未適用環境を想定（migration 未実行 = column not found エラー）
     mockPool.query.mockRejectedValueOnce(new Error('column "product_image_url" does not exist'));
 
     const result = await runDialogTurn({
-      sessionId: "test-session-4",
+      sessionId: "test-session-6",
       tenantId: "test-tenant",
       message: "おすすめを教えて",
     });

--- a/src/agent/dialog/dialogAgent.ts
+++ b/src/agent/dialog/dialogAgent.ts
@@ -211,39 +211,61 @@ export async function runDialogTurn(
   };
 
   // Phase73: recommend ステージ時に faq_docs から商品メタを取得して productCard に設定
+  // 今ターンの ragSources（RAG で実際に使われた chunk）に含まれる faq_docs 行から
+  // product_image_url を持つ上位 ranked 行を選択する。
+  // 関連 chunk が存在しない / 商品メタがない場合は productCard を設定しない（fallback 禁止）。
   if (salesResult.nextStage === "recommend" && pool) {
     try {
-      const row = await pool.query<{
-        id: number;
-        question: string;
-        product_image_url: string | null;
-        product_price: string | null;
-        product_cta_url: string | null;
-      }>(
-        `SELECT id, question, product_image_url, product_price, product_cta_url
-         FROM faq_docs
-         WHERE tenant_id = $1
-           AND product_image_url IS NOT NULL
-         ORDER BY id DESC
-         LIMIT 1`,
-        [effectiveTenantId]
-      );
-      const meta = row.rows[0];
-      if (
-        meta &&
-        (meta.product_image_url || meta.product_price || meta.product_cta_url)
-      ) {
-        const card: ProductCard = {
-          product_id: String(meta.id),
-          name: meta.question.slice(0, 100),
-          price: meta.product_price ?? "",
-          image_url: meta.product_image_url ?? "",
-          cta_url: meta.product_cta_url ?? "",
-        };
-        result.productCard = card;
+      const ragSources = orchestrated.ragSources ?? [];
+      // faq ソース（書籍チャンクは faq_docs と無関係）の chunk_id のみ抽出し、
+      // rerank スコア順（降順）に並べる
+      const faqChunkIds = ragSources
+        .filter((s) => s.source === "faq")
+        .sort((a, b) => b.score - a.score)
+        .map((s) => s.chunk_id);
+
+      if (faqChunkIds.length === 0) {
+        // 関連 FAQ チャンクなし → productCard は設定しない
+      } else {
+        // faq_embeddings.id = chunk_id → metadata->>'faq_id' = faq_docs.id
+        // rerank スコア順を保持するために ORDER BY array_position を使用
+        const row = await pool.query<{
+          id: number;
+          question: string;
+          product_image_url: string | null;
+          product_price: string | null;
+          product_cta_url: string | null;
+        }>(
+          `SELECT fd.id, fd.question, fd.product_image_url, fd.product_price, fd.product_cta_url
+           FROM faq_embeddings fe
+           JOIN faq_docs fd
+             ON fe.metadata->>'faq_id' ~ '^[0-9]+$'
+            AND fd.id = (fe.metadata->>'faq_id')::bigint
+           WHERE fe.tenant_id = $1
+             AND fe.id = ANY($2)
+             AND fd.tenant_id = $1
+             AND fd.product_image_url IS NOT NULL
+           ORDER BY array_position($2, fe.id)
+           LIMIT 1`,
+          [effectiveTenantId, faqChunkIds]
+        );
+        const meta = row.rows[0];
+        if (
+          meta &&
+          (meta.product_image_url || meta.product_price || meta.product_cta_url)
+        ) {
+          const card: ProductCard = {
+            product_id: String(meta.id),
+            name: meta.question.slice(0, 100),
+            price: meta.product_price ?? "",
+            image_url: meta.product_image_url ?? "",
+            cta_url: meta.product_cta_url ?? "",
+          };
+          result.productCard = card;
+        }
       }
     } catch {
-      // non-fatal: DB 未適用環境（migration 未実行）でも動作を継続する
+      // non-fatal: DB 未適用環境（migration 未実行 / column not found）でも動作を継続する
     }
   }
 

--- a/tests/e2e/widget-product-card.spec.ts
+++ b/tests/e2e/widget-product-card.spec.ts
@@ -1,0 +1,318 @@
+// tests/e2e/widget-product-card.spec.ts
+// Phase73: 390px viewport で productCard 商品カードがレンダリングされることを検証
+//
+// 方針:
+//   - E2E_ENABLED=1 または CI=true の場合のみ実行（それ以外は SKIP）
+//   - Playwright の route インターセプトで /api/chat レスポンスに productCard を注入
+//   - Shadow DOM (mode:open) 内の .product-card を page.evaluate() でアクセス
+//   - 実デバイス不要: iPhone 12 エミュレーション (390×844px)
+//
+// 制限事項:
+//   - DEMO_URL (https://api.r2c.biz/carnation-demo/index.html) が存在し、
+//     正規の data-api-key を持っていることが前提。
+//   - ウィジェットが起動するまでの初期化完了を waitForFunction で待つ。
+//   - chat レスポンスのルートインターセプトはウィジェットが /api/chat に POST する
+//     タイミングに依存するため、メッセージ送信後にアサートする。
+
+import { test, expect } from '@playwright/test';
+import { gotoWithRetry } from './helpers/gotoRetry';
+
+const E2E_ENABLED = process.env.E2E_ENABLED === '1' || !!process.env.CI;
+const DEMO_URL = 'https://api.r2c.biz/carnation-demo/index.html';
+
+const MOCK_PRODUCT_CARD = {
+  product_id: '99',
+  name: 'テスト商品',
+  price: '¥9,800',
+  image_url: 'https://example.com/test-product.jpg',
+  cta_url: 'https://example.com/buy',
+};
+
+test.describe('Widget — 商品カード 390px (P1-P3)', () => {
+  test.skip(!E2E_ENABLED, 'E2E tests require E2E_ENABLED=1 or CI=true');
+
+  test.use({
+    viewport: { width: 390, height: 844 },
+    hasTouch: true,
+    isMobile: true,
+  });
+
+  // P1: productCard を含む /api/chat レスポンスで .product-card が描画される
+  test('P1: productCard レスポンスで商品カードが Shadow DOM 内に描画される', async ({ page }) => {
+    // /api/chat への POST をインターセプトして productCard を含む応答を返す
+    await page.route('**/api/chat', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: {
+            id: 'msg-test-1',
+            content: 'こちらのコースがおすすめです。',
+            actions: [],
+            timestamp: Date.now(),
+            flowState: 'recommend',
+            productCard: MOCK_PRODUCT_CARD,
+          },
+        }),
+      });
+    });
+
+    await gotoWithRetry(page, DEMO_URL);
+    await page.waitForTimeout(2000);
+
+    // ウィジェット FAB をクリックして開く
+    const opened = await page.evaluate(() => {
+      const host = document.querySelector('#faq-chat-widget-host') as HTMLElement;
+      if (!host?.shadowRoot) return false;
+      const fab = host.shadowRoot.querySelector('.fab') as HTMLElement;
+      if (!fab) return false;
+      fab.click();
+      return true;
+    });
+
+    if (!opened) {
+      test.info().annotations.push({
+        type: 'info',
+        description: 'Widget host not initialized on demo page — P1 skipped (no tenant)',
+      });
+      return;
+    }
+
+    await page.waitForTimeout(500);
+
+    // テキストを入力して送信（route インターセプトが productCard 付き応答を返す）
+    const sent = await page.evaluate(() => {
+      const host = document.querySelector('#faq-chat-widget-host') as HTMLElement;
+      if (!host?.shadowRoot) return false;
+      const textarea = host.shadowRoot.querySelector('textarea') as HTMLTextAreaElement;
+      if (!textarea) return false;
+      // nativeInputValueSetter を使わずに value + input event で入力
+      const nativeSetter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')?.set;
+      if (nativeSetter) nativeSetter.call(textarea, 'おすすめを教えて');
+      textarea.dispatchEvent(new Event('input', { bubbles: true }));
+      const sendBtn = host.shadowRoot.querySelector('.send-btn') as HTMLButtonElement;
+      if (!sendBtn) return false;
+      sendBtn.click();
+      return true;
+    });
+
+    if (!sent) {
+      test.info().annotations.push({
+        type: 'info',
+        description: 'Widget textarea/send-btn not found — P1 skipped',
+      });
+      return;
+    }
+
+    // 商品カードが描画されるのを待つ（最大 5 秒）
+    await page.waitForTimeout(3000);
+
+    const cardInfo = await page.evaluate(() => {
+      const host = document.querySelector('#faq-chat-widget-host') as HTMLElement;
+      if (!host?.shadowRoot) return null;
+      const card = host.shadowRoot.querySelector('.product-card') as HTMLElement;
+      if (!card) return null;
+      const img = card.querySelector('img') as HTMLImageElement | null;
+      const cta = card.querySelector('.product-cta') as HTMLButtonElement | null;
+      const name = card.querySelector('.product-card-name') as HTMLElement | null;
+      const price = card.querySelector('.product-card-price') as HTMLElement | null;
+      return {
+        hasCard: true,
+        imgSrc: img ? img.src : null,
+        ctaText: cta ? cta.textContent : null,
+        nameText: name ? name.textContent : null,
+        priceText: price ? price.textContent : null,
+      };
+    });
+
+    if (!cardInfo || !cardInfo.hasCard) {
+      test.info().annotations.push({
+        type: 'info',
+        description: 'product-card not found in DOM — widget may not have initialized with valid tenant',
+      });
+      return;
+    }
+
+    expect(cardInfo.imgSrc).toBe(MOCK_PRODUCT_CARD.image_url);
+    expect(cardInfo.nameText).toBe(MOCK_PRODUCT_CARD.name);
+    expect(cardInfo.priceText).toBe(MOCK_PRODUCT_CARD.price);
+    expect(cardInfo.ctaText).toBeTruthy();
+  });
+
+  // P2: safeHttpUrl ガード — javascript: URL を持つ productCard でも img.src に設定されない
+  test('P2: javascript: URL は img.src に設定されない（safeHttpUrl ガード）', async ({ page }) => {
+    await page.route('**/api/chat', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: {
+            id: 'msg-test-2',
+            content: '商品情報です。',
+            actions: [],
+            timestamp: Date.now(),
+            flowState: 'recommend',
+            productCard: {
+              product_id: '1',
+              name: '悪意ある商品',
+              price: '999',
+              // javascript: スキームは safeHttpUrl で空文字列に変換される
+              image_url: 'javascript:alert(1)',
+              cta_url: 'javascript:void(0)',
+            },
+          },
+        }),
+      });
+    });
+
+    await gotoWithRetry(page, DEMO_URL);
+    await page.waitForTimeout(2000);
+
+    const opened = await page.evaluate(() => {
+      const host = document.querySelector('#faq-chat-widget-host') as HTMLElement;
+      if (!host?.shadowRoot) return false;
+      const fab = host.shadowRoot.querySelector('.fab') as HTMLElement;
+      if (!fab) return false;
+      fab.click();
+      return true;
+    });
+
+    if (!opened) {
+      test.info().annotations.push({
+        type: 'info',
+        description: 'Widget host not initialized — P2 skipped',
+      });
+      return;
+    }
+
+    await page.waitForTimeout(500);
+
+    await page.evaluate(() => {
+      const host = document.querySelector('#faq-chat-widget-host') as HTMLElement;
+      if (!host?.shadowRoot) return;
+      const textarea = host.shadowRoot.querySelector('textarea') as HTMLTextAreaElement;
+      if (!textarea) return;
+      const nativeSetter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')?.set;
+      if (nativeSetter) nativeSetter.call(textarea, 'おすすめを教えて');
+      textarea.dispatchEvent(new Event('input', { bubbles: true }));
+      const sendBtn = host.shadowRoot.querySelector('.send-btn') as HTMLButtonElement;
+      if (sendBtn) sendBtn.click();
+    });
+
+    await page.waitForTimeout(3000);
+
+    const xssCheck = await page.evaluate(() => {
+      const host = document.querySelector('#faq-chat-widget-host') as HTMLElement;
+      if (!host?.shadowRoot) return { skipped: true };
+      const card = host.shadowRoot.querySelector('.product-card') as HTMLElement;
+      if (!card) return { skipped: true };
+      const img = card.querySelector('img') as HTMLImageElement | null;
+      const cta = card.querySelector('.product-cta') as HTMLButtonElement | null;
+      return {
+        skipped: false,
+        // img が存在しないか、src が javascript: を含まないことを確認
+        imgExists: !!img,
+        imgSrc: img ? img.src : null,
+        ctaExists: !!cta,
+      };
+    });
+
+    if (xssCheck.skipped) {
+      test.info().annotations.push({
+        type: 'info',
+        description: 'Widget not initialized — P2 skipped',
+      });
+      return;
+    }
+
+    // javascript: URL は img を生成しない（safeHttpUrl が空文字列を返すため）
+    if (xssCheck.imgExists && xssCheck.imgSrc) {
+      expect(xssCheck.imgSrc).not.toMatch(/^javascript:/i);
+    }
+    // CTA ボタンも javascript: URL では生成されない
+    expect(xssCheck.ctaExists).toBe(false);
+  });
+
+  // P3: price のみ存在して image_url/cta_url が空でも price テキストが描画される
+  test('P3: price のみ存在する productCard でも .product-card-price が描画される', async ({ page }) => {
+    await page.route('**/api/chat', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          data: {
+            id: 'msg-test-3',
+            content: '商品情報です。',
+            actions: [],
+            timestamp: Date.now(),
+            flowState: 'recommend',
+            productCard: {
+              product_id: '2',
+              name: '価格だけある商品',
+              price: '¥4,980',
+              image_url: '',
+              cta_url: '',
+            },
+          },
+        }),
+      });
+    });
+
+    await gotoWithRetry(page, DEMO_URL);
+    await page.waitForTimeout(2000);
+
+    const opened = await page.evaluate(() => {
+      const host = document.querySelector('#faq-chat-widget-host') as HTMLElement;
+      if (!host?.shadowRoot) return false;
+      const fab = host.shadowRoot.querySelector('.fab') as HTMLElement;
+      if (!fab) return false;
+      fab.click();
+      return true;
+    });
+
+    if (!opened) {
+      test.info().annotations.push({ type: 'info', description: 'Widget not initialized — P3 skipped' });
+      return;
+    }
+
+    await page.waitForTimeout(500);
+
+    await page.evaluate(() => {
+      const host = document.querySelector('#faq-chat-widget-host') as HTMLElement;
+      if (!host?.shadowRoot) return;
+      const textarea = host.shadowRoot.querySelector('textarea') as HTMLTextAreaElement;
+      if (!textarea) return;
+      const nativeSetter = Object.getOwnPropertyDescriptor(window.HTMLTextAreaElement.prototype, 'value')?.set;
+      if (nativeSetter) nativeSetter.call(textarea, 'おすすめを教えて');
+      textarea.dispatchEvent(new Event('input', { bubbles: true }));
+      const sendBtn = host.shadowRoot.querySelector('.send-btn') as HTMLButtonElement;
+      if (sendBtn) sendBtn.click();
+    });
+
+    await page.waitForTimeout(3000);
+
+    const priceInfo = await page.evaluate(() => {
+      const host = document.querySelector('#faq-chat-widget-host') as HTMLElement;
+      if (!host?.shadowRoot) return null;
+      const card = host.shadowRoot.querySelector('.product-card') as HTMLElement;
+      if (!card) return null;
+      const price = card.querySelector('.product-card-price') as HTMLElement | null;
+      const img = card.querySelector('img');
+      const cta = card.querySelector('.product-cta');
+      return {
+        priceText: price ? price.textContent : null,
+        hasImg: !!img,
+        hasCta: !!cta,
+      };
+    });
+
+    if (!priceInfo) {
+      test.info().annotations.push({ type: 'info', description: 'Widget not initialized — P3 skipped' });
+      return;
+    }
+
+    expect(priceInfo.priceText).toBe('¥4,980');
+    expect(priceInfo.hasImg).toBe(false); // 空 URL → img なし
+    expect(priceInfo.hasCta).toBe(false); // 空 URL → CTA なし
+  });
+});


### PR DESCRIPTION
## 概要

SalesFlow 商品カードの **PR-2（フロント描画 + 会話マッチ精度 + 多層 URL ガード）**。PR-1（#404）のバックエンド基盤の上に積み、`recommend` 応答に載った商品メタをウィジェットに描画します。

Asana: 【CV↑↑】SalesFlow × 商品カード同期表示（GID 1215698617354635）

> ⚠️ **このPRは PR-1（#404）にスタックしています。** base は `feature/4635-salesflow-product-card-backend`。PR-1 を先に merge してください。

## このPRの範囲（PR-2）

1. **商品マッチ精度**（`src/agent/dialog/dialogAgent.ts`）: PR-1 の暫定 `ORDER BY id DESC LIMIT 1`（最新行）を廃止し、**今ターンの RAG 関連度順**でマッチ。`orchestrated.ragSources` の `source==='faq'` チャンクを rerank スコア降順に並べ、`faq_embeddings.id = ANY($2)` → `faq_docs` JOIN で上位 ranked の商品メタ行を取得。**関連 FAQ チャンクが無い / 商品メタが無い場合は productCard を設定しない（fallback 禁止）**。
2. **ウィジェット描画**（`public/widget.js`）: `recommend` 応答の `productCard` をスライドインの商品カード（画像 / 名前 / 価格 / CTA）として描画。`el()` + `textContent` のみ（innerHTML 不使用、XSS 安全）。
3. **多層 URL ガード**: `safeHttpUrl()` を **取り込み時**（チャットハンドラ）と **描画時**（renderMessages）の両方で適用。`http(s)` 以外（`javascript:` / `data:` 等）は空文字化し、`img.src` / `window.open` には**ガード済み値のみ**設定。ガードが空なら img / CTA ボタン自体を生成しない。DB 値を信用しない多層防御（PR-1 の保存時サニタイズと二重化）。

## セキュリティ確認（orchestrator 直接検証済み）

- 商品クエリは **二重テナント分離**（`fe.tenant_id = $1 AND fd.tenant_id = $1`）、`effectiveTenantId`（解決済みコンテキスト由来、body 不使用）、完全パラメータ化（注入なし）、`~ '^[0-9]+$'` で `::bigint` キャスト前にガード。
- ウィジェットは innerHTML 不使用、URL ガード二段、`noopener,noreferrer` 付き window.open。

## Gate 結果

- Gate 1 typecheck: PASS（0 errors）
- Gate 1 test: PASS（2006 tests / 169 suites。dialogAgent 商品マッチ 6 ケース含む）
- Gate 1 lint: PASS（60 警告 ≤ cap 63）
- Gate 2 security-scan: PASS（CRITICAL/HIGH=0）

## E2E

- `tests/e2e/widget-product-card.spec.ts`（新規、390px iPhone 12 エミュ）: route インターセプトで `/api/chat` に productCard を注入し Shadow DOM 内 `.product-card` をアサート。P1 フル描画 / P2 `javascript:` URL XSS ガード / P3 価格のみ。`E2E_ENABLED=1` or `CI=true` でのみ実行（本環境では SKIP）。

## 人間ゲート（このPRはまだ Asana 完了にしない）

1. **PR-1（#404）を先に merge** + migration を psql 実行（product_* カラムが無いと productCard は常に空）
2. このPRの merge は PR-1 適用後
3. avatar/LemonSlice 実機での商品カード目視確認
4. Gate 2.5 Codex review（Tier A、人間手動）

## 別タスク候補（本PR対象外）

- `public/widget.js` L2288 付近の診断 `console.log`（ragContent ではないが本番不要の可能性）→ 別タスクでログ整理
- `faq_embeddings`↔`faq_docs` 間に物理 FK が無い設計（カスケード削除簡略化の余地）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
