### PR TITLE
feat(avatar): SalesFlow × Fish S2 感情インラインタグ連動 — ステート別トーン切替 (#2037)

### DIFF
--- a/avatar-agent/agent.py
+++ b/avatar-agent/agent.py
@@ -32,6 +32,7 @@ from livekit.agents import tts as agents_tts
 from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS, APIConnectOptions
 from livekit.plugins import lemonslice
 from livekit.plugins import openai as openai_plugin
+from emotion_tags import sales_flow_emotion_prefix
 
 logger = logging.getLogger("rajiuce-avatar")
 logger.setLevel(logging.INFO)
@@ -493,6 +494,8 @@ async def entrypoint(ctx: agents.JobContext) -> None:
 
     # フィラーハンドル保持（dict でクロージャ越しに再代入可能にする）
     _filler_state: dict = {"handle": None}
+    # SalesFlow 現在ステート保持（dict でクロージャ越しに再代入可能にする）
+    _sales_state: dict = {"current": None}
 
     async def handle_tts_request(reply_text: str) -> None:
         """本体APIの応答テキストをそのままTTSに渡す（Groq呼び出しなし）。"""
@@ -505,8 +508,9 @@ async def entrypoint(ctx: agents.JobContext) -> None:
                 except Exception:
                     pass
                 _filler_state["handle"] = None
-            logger.info(f"[tts_request] TTS直渡し ({len(reply_text)} chars): {reply_text[:80]!r}")
-            session.say(reply_text)
+            prefix = sales_flow_emotion_prefix(_sales_state["current"])
+            logger.info(f"[tts_request] TTS直渡し state={_sales_state['current']!r} prefix={prefix!r} ({len(reply_text)} chars): {reply_text[:80]!r}")
+            session.say(prefix + reply_text)
         except Exception as e:
             logger.error(f"[handle_tts_request] error: {e}")
 
@@ -556,6 +560,9 @@ async def entrypoint(ctx: agents.JobContext) -> None:
             elif msg_type == "state_change":
                 # I-4: フロー状態に応じて表情プロンプトを差し替え（fire-and-forget）
                 state = msg.get("state")
+                # SalesFlow 感情タグ注入のためステートを常に保存（STATE_AGENT_PROMPTS 未登録でも保存する）
+                if isinstance(state, str):
+                    _sales_state["current"] = state
                 prompt = STATE_AGENT_PROMPTS.get(state) if isinstance(state, str) else None
                 if prompt:
                     logger.info(f"[data_channel] state_change received: state={state}")

--- a/avatar-agent/emotion_tags.py
+++ b/avatar-agent/emotion_tags.py
@@ -1,0 +1,34 @@
+"""
+SalesFlow ステート別 Fish Audio S2 感情インラインタグ。
+
+このモジュールはテナント固定の感情タグ（FishAudioTTS._emotion_tags）とは独立した
+per-utterance 動的レイヤーを提供する。
+タグは session.say() に渡すテキストの先頭に付与する（チャットバブルの content には影響しない）。
+
+合成順: [SalesFlow 動的タグ] + [テナント固定タグ[:3]] + 本文
+"""
+
+from __future__ import annotations
+
+# SalesFlow ステート → Fish Audio S2 感情インラインタグ のマッピング
+SALES_FLOW_EMOTION_TAGS: dict[str, str] = {
+    "clarify": "[穏やかに]",
+    "propose": "[明るく元気に]",
+    "recommend": "[熱意を込めて]",
+    # close は強調ラッパー付き複合タグ（「今なら」はタグテンプレートの一部、応答テキストではない）
+    "close": "[強調]今なら[/強調][明るく]",
+}
+
+
+def sales_flow_emotion_prefix(state: str | None) -> str:
+    """SalesFlow ステートに対応する感情タグプレフィックスを返す。
+
+    Args:
+        state: SalesFlow の現在ステート文字列。None / 空文字 / 未知ステートは "" を返す。
+
+    Returns:
+        Fish Audio S2 向けインライン感情タグ文字列。未知ステートは空文字（フォールバックなし）。
+    """
+    if not state:
+        return ""
+    return SALES_FLOW_EMOTION_TAGS.get(state, "")

--- a/avatar-agent/test_emotion_tags.py
+++ b/avatar-agent/test_emotion_tags.py
@@ -1,0 +1,63 @@
+"""
+emotion_tags.py のユニットテスト。
+agent.py / livekit には依存しない — emotion_tags のみインポート。
+"""
+
+from emotion_tags import SALES_FLOW_EMOTION_TAGS, sales_flow_emotion_prefix
+
+
+class TestSalesFlowEmotionPrefix:
+    def test_clarify(self):
+        assert sales_flow_emotion_prefix("clarify") == "[穏やかに]"
+
+    def test_propose(self):
+        assert sales_flow_emotion_prefix("propose") == "[明るく元気に]"
+
+    def test_recommend(self):
+        assert sales_flow_emotion_prefix("recommend") == "[熱意を込めて]"
+
+    def test_close(self):
+        assert sales_flow_emotion_prefix("close") == "[強調]今なら[/強調][明るく]"
+
+    def test_close_contains_kyoucho(self):
+        result = sales_flow_emotion_prefix("close")
+        assert "強調" in result
+
+    def test_close_contains_akaruku(self):
+        result = sales_flow_emotion_prefix("close")
+        assert "明るく" in result
+
+    def test_none_returns_empty(self):
+        assert sales_flow_emotion_prefix(None) == ""
+
+    def test_empty_string_returns_empty(self):
+        assert sales_flow_emotion_prefix("") == ""
+
+    def test_unknown_state_returns_empty(self):
+        assert sales_flow_emotion_prefix("foo") == ""
+
+    def test_unknown_state_bar_returns_empty(self):
+        assert sales_flow_emotion_prefix("bar") == ""
+
+    def test_mapping_has_all_four_states(self):
+        for key in ("clarify", "propose", "recommend", "close"):
+            assert key in SALES_FLOW_EMOTION_TAGS
+
+
+if __name__ == "__main__":
+    # pytest なし環境向けフォールバック assert ランナー
+    runner = TestSalesFlowEmotionPrefix()
+    tests = [m for m in dir(runner) if m.startswith("test_")]
+    passed = 0
+    failed = 0
+    for t in tests:
+        try:
+            getattr(runner, t)()
+            print(f"  PASS  {t}")
+            passed += 1
+        except AssertionError as e:
+            print(f"  FAIL  {t}: {e}")
+            failed += 1
+    print(f"\n{passed} passed, {failed} failed")
+    if failed:
+        raise SystemExit(1)


### PR DESCRIPTION
## 概要

Fish Audio S2 のインライン感情タグを SalesFlow のステートに連動させ、`recommend → close` の通過率（CV）を向上させます。「マニュアル読み上げ」感を排除し、ステートごとに声のトーンを動的に切り替えます。

Asana: 【CV↑】SalesFlow × Fish Audio S2 感情インラインタグ連動（GID 1215698823652037）

## ステート → タグ マッピング

| SalesFlow ステート | 感情タグ |
|---|---|
| clarify | `[穏やかに]` |
| propose | `[明るく元気に]` |
| recommend | `[熱意を込めて]` |
| close | `[強調]今なら[/強調][明るく]` |

未知 / 未設定ステートは **タグなし**（フォールバック禁止）。

## 実装（avatar-agent のみ — backend/widget 変更なし）

実機照合の結果、Fish TTS への text 組み立ては **avatar-agent/agent.py の `handle_tts_request`** で行われ、SalesFlow ステートは既存の DataChannel `state_change` 配線で avatar-agent に届いていることを確認（backend/widget の追加配線は不要）。

- `avatar-agent/emotion_tags.py`（新規）: ステート→タグの純粋関数 `sales_flow_emotion_prefix(state)`。livekit 非依存で単体テスト可能。
- `avatar-agent/agent.py`（4箇所外科的変更）:
  1. `emotion_tags` から関数を import
  2. `_filler_state` と同じ closure dict パターンで `_sales_state = {"current": None}` を追加
  3. `state_change` ハンドラで `_sales_state["current"]` を保存（`STATE_AGENT_PROMPTS` 未登録の recommend/close も保存）。既存の表情プロンプト更新は変更なし
  4. `handle_tts_request` で `session.say(prefix + reply_text)`。**#402 のフィラー interrupt ロジックはそのまま維持**

### タグ漏洩防止

感情タグは `session.say()` に渡す **TTS 用テキストにのみ**付与。チャットバブルの `content` はウィジェットが `json.data.content`（TS 側が書く JSON フィールド）から描画し、TTS 引数文字列を読み返す経路が存在しないため、タグがバブルに露出することはない。テナント固定の `emotion_tags`（`FishAudioTTS._emotion_tags`）レイヤーとも独立・非競合（合成順: SalesFlow 動的タグ + テナント固定タグ[:3] + 本文）。

## Gate 結果

- `py_compile agent.py emotion_tags.py`: OK
- `import emotion_tags`: OK（agent.py の実行ディレクトリから解決）
- `pytest test_emotion_tags.py -q`: **11 passed**（ステート別タグ / None・未知・空文字→"" / close の強調+明るく を検証）
- `pnpm typecheck`: 0 errors（TS 無変更の回帰確認、Node 20）
- Gate 2 secret scan（gitleaks）: no leaks found

## 照合不一致（スコープ外として現状維持）

- タスク notes の `format:"opus"` → 実機は `format:"mp3"` で稼働中（AudioEmitter の mime_type 連動のため本タスクでは変更せず）
- タスク notes の `latency:"low"` → 実機は `latency:"balanced"` で稼働中（本タスク要件外のため変更せず）

## 人間ゲート（このPRはまだ Asana 完了にしない）

- **avatar-agent の VPS プロセス再起動**（人間が実施）で本番反映。#402（沈黙ゼロ化）と同じプロセスのため、両者をまとめて再起動可能。
- 反映後、recommend / close ステートで実際に声のトーンが変化することを実機（音声）で確認。
- main merge は人間手動（Branch Rule）。Gate 2.5 Codex review（Tier A、人間手動）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
