### PR TITLE
docs(proposals): LemonSlice / Fish Audio / LiveKit 提案書を追加（実装ステータス反映）

### DIFF
--- a/docs/proposals/FISH_AUDIO_UPGRADE_PROPOSAL.md
+++ b/docs/proposals/FISH_AUDIO_UPGRADE_PROPOSAL.md
@@ -1,0 +1,470 @@
+# Fish Audio S2-Pro 全機能統合 実装提案書
+
+> 作成日: 2026-06-10  
+> 対象ブランチ: 新規 `feature/<asana-id>-fish-audio-upgrade`  
+> 前提: 現状コード実機調査済み（`avatar-agent/agent.py`, `src/api/avatar/fishTtsRoutes.ts`, `src/api/admin/avatar/routes.ts`, `src/lib/billing/costCalculator.ts`）
+
+---
+
+## 1. 現状ギャップ分析
+
+### 1.1 現在の実装状態
+
+| 機能 | 実装状態 | ファイル | 問題点 |
+|------|---------|---------|--------|
+| Fish Audio TTS 呼び出し | ✅ 動作中 | `avatar-agent/agent.py:218` | モデル未指定（S1デフォルト） |
+| 音声クローン (reference_id) | ✅ DBから取得 | `agent.py:237` | 動く |
+| 感情タグ (emotion_tags) | ⚠️ DBには保存 | `routes.ts:118` | TTS呼び出しに**注入されていない** |
+| WebSocket ストリーミング | ❌ 未実装 | `agent.py:177` | `streaming=False` ハードコード |
+| S2-Pro 明示指定 | ❌ 未指定 | `agent.py:231` | Fish Audio側のデフォルトに依存 |
+| 永続クローン管理 UI | ❌ 未実装 | — | 音声ファイルのアップロード・クローン作成機能なし |
+| インスタントクローン | ❌ 未実装 | — | `references` 配列形式未対応 |
+| fish-audio-sdk 活用 | ❌ 未使用 | `requirements.txt:5` | インストール済みだが aiohttp 直接呼び出し |
+| REST TTS エンドポイント | ⚠️ 動作中 | `fishTtsRoutes.ts:43` | reference_id がハードコード |
+| コスト計算 | ✅ 実装済み | `costCalculator.ts:33` | S2-Pro 単価 $15/M bytes は正確 |
+
+### 1.2 S2-Pro で新たに使える機能（未活用）
+
+```
+S2-Pro 新機能                現状のギャップ
+─────────────────────────────────────────────────────
+[bracket] 自然言語感情制御   → emotion_tags はDBにあるが TTS テキストに挿入されていない
+80+ 言語自動検出            → 日本語テキストはそのまま送信（変わらず機能するが最適化余地）
+マルチスピーカーダイアログ  → 未検討
+TTFA 100ms                  → streaming=False で活かせていない（HTTP 一括受信）
+enhance_audio_quality       → リクエストボディに未設定
+```
+
+---
+
+## 2. 実装フェーズ設計
+
+### Phase A — 即効・低リスク（推定 1 日）
+
+**変更ファイル 2 本、Gate 1 通過見込み高**
+
+#### A-1: S2-Pro モデル明示指定
+
+**対象**: `avatar-agent/agent.py:231`、`src/api/avatar/fishTtsRoutes.ts:41`
+
+```python
+# avatar-agent/agent.py — request_body に追加
+request_body = {
+    "text": self._input_text,
+    "model": "s2-pro",          # ← 追加
+    "format": "mp3",
+    "normalize": True,
+    "latency": "balanced",
+}
+```
+
+```typescript
+// fishTtsRoutes.ts — body に追加
+body: JSON.stringify({
+  text: text,
+  model: 's2-pro',              // ← 追加
+  reference_id: referenceId || '63bc41e652214372b15d9416a30a60b4',
+  format: 'mp3',
+  latency: 'balanced',
+}),
+```
+
+**リスク**: ゼロ。Fish Audio のモデル ID `s2-pro` は 2026-03 から本番稼働・公式認定。  
+**影響範囲**: アバター音声の品質向上のみ。既存テストへの影響なし（TTS は外部モック）。
+
+---
+
+#### A-2: 感情タグの TTS テキスト自動注入
+
+**対象**: `avatar-agent/agent.py`（`FishAudioTTS.__init__` と `synthesize`）
+
+現状: `emotion_tags: ["empathetic","calm"]` が DB に保存されているが、TTS 呼び出し時に一切使われていない。
+
+**実装方針**: `FishAudioTTS.__init__` に `emotion_tags: list[str]` を追加し、`synthesize` 時にテキスト先頭へ `[empathetic][calm]` 形式で挿入。
+
+```python
+class FishAudioTTS(agents_tts.TTS):
+    def __init__(
+        self,
+        api_key: str,
+        reference_id: str | None = None,
+        tenant_id: str | None = None,
+        emotion_tags: list[str] | None = None,   # ← 追加
+    ):
+        ...
+        self._emotion_tags = emotion_tags or []
+
+    def synthesize(self, text: str, *, conn_options=...) -> "FishAudioChunkedStream":
+        # タグ挿入: 3個まで（過剰タグは音質劣化リスクあり）
+        prefix = "".join(f"[{t}]" for t in self._emotion_tags[:3])
+        tagged_text = f"{prefix}{text}" if prefix else text
+        return FishAudioChunkedStream(..., input_text=tagged_text, ...)
+```
+
+`entrypoint` での初期化部分:
+
+```python
+effective_emotion_tags = (
+    avatar_config.get("emotion_tags") if avatar_config else None
+) or []
+# emotion_tags は JSON 文字列として格納されている場合に parse
+if isinstance(effective_emotion_tags, str):
+    import json as _j
+    effective_emotion_tags = _j.loads(effective_emotion_tags)
+
+fish_tts = FishAudioTTS(
+    api_key=os.environ["FISH_AUDIO_API_KEY"],
+    reference_id=effective_reference_id,
+    tenant_id=tenant_id,
+    emotion_tags=effective_emotion_tags,    # ← 追加
+)
+```
+
+**DB 確認事項**: `avatar_configs.emotion_tags` が JSON 配列として格納されているか VPS で要確認。
+```sql
+-- 確認クエリ
+SELECT id, name, emotion_tags, pg_typeof(emotion_tags)
+FROM avatar_configs
+WHERE emotion_tags IS NOT NULL
+LIMIT 5;
+```
+
+**副作用**: タグが空の場合（既存アバター設定なし）は動作変化なし。
+
+---
+
+#### A-3: fishTtsRoutes.ts のハードコード reference_id 修正
+
+**対象**: `src/api/avatar/fishTtsRoutes.ts:29,43`
+
+現状: `process.env.FISH_AUDIO_REFERENCE_ID` が未設定の場合、ハードコードの ID `63bc41e652214372b15d9416a30a60b4` にフォールバックしている。これはテナント別ではない。
+
+**修正**: `voiceId` を `req.body` で受け取れるようにし、環境変数フォールバックは残しつつハードコード ID を削除。Fish Audio は `reference_id` 省略時にデフォルト音声を使用するため安全。
+
+```typescript
+// fishTtsRoutes.ts — POST /api/avatar/tts body に voice_id を追加受付
+const { text, voiceId } = req.body;
+const effectiveReferenceId = voiceId || process.env.FISH_AUDIO_REFERENCE_ID?.trim() || undefined;
+// undefined の場合は Fish Audio がデフォルト音声を使用（安全）
+```
+
+**影響**: widget.js からの呼び出しフローを事前 grep 確認（下記チェックリスト参照）。
+
+---
+
+### Phase B — 中規模実装（推定 2–3 日）
+
+**Gate 1–3 全パス前提、LiveKit SDK 互換確認が必須**
+
+#### B-1: HTTP ストリーミング対応（低遅延化）
+
+**目的**: HTTP 一括受信（現状 ~300–500ms）からチャンク転送（TTFA ~200ms）へ移行し、Lemonslice 口パク同期を改善。WebSocket は複雑度が高いため HTTP チャンクを先行実装。
+
+**技術前提確認**（実装前に VPS で実行）:
+```bash
+python3 -c "
+from livekit.agents.tts import AudioEmitter
+import inspect
+print(inspect.signature(AudioEmitter.initialize))
+"
+```
+
+**実装方針**:
+
+```python
+# FishAudioTTS.__init__ — streaming=True に変更
+super().__init__(
+    capabilities=agents_tts.TTSCapabilities(streaming=True),
+    sample_rate=44100,
+    num_channels=1,
+)
+
+# FishAudioChunkedStream._run — chunk 転送
+output_emitter.initialize(
+    request_id=f"fish-audio-{id(self)}",
+    sample_rate=self._tts.sample_rate,
+    num_channels=self._tts.num_channels,
+    mime_type="audio/mpeg",
+    stream=True,   # ← True に変更
+)
+async with http_session.post("https://api.fish.audio/v1/tts", ...) as resp:
+    async for chunk in resp.content.iter_chunked(4096):
+        if chunk:
+            output_emitter.push(chunk)
+output_emitter.flush()
+```
+
+**リスク**: LiveKit Agents の `stream=True` が lemonslice プラグインと互換か未検証。  
+**必須**: staging VPS での実機テスト（TTFA 計測 200ms 以下が合格基準）。  
+互換問題が発生した場合は `streaming=False` を維持し、HTTP chunk 転送のみ実装（flush タイミングを変える）。
+
+---
+
+#### B-2: 永続音声クローン管理 API
+
+**目的**: 管理者がテナント専用の音声ファイルをアップロードし、Fish Audio で永続クローンを作成して `avatar_configs.voice_id` に保存できるようにする。
+
+**新規エンドポイント**: `POST /api/admin/avatar/:configId/voice-clone`
+
+```typescript
+// src/api/admin/avatar/routes.ts 内に追加
+// multipart/form-data: audio file
+app.post('/api/admin/avatar/:configId/voice-clone',
+  supabaseAuthMiddleware, requireAvatarOwnership,
+  multer({ limits: { fileSize: 10 * 1024 * 1024 } }).single('audio'),
+  async (req, res) => {
+    const { configId } = req.params;
+    const { name } = req.body;
+    const audioFile = req.file;
+
+    // 1. Fish Audio POST /model (FormData)
+    const fd = new FormData();
+    fd.append('visibility', 'private');
+    fd.append('type', 'tts');
+    fd.append('title', name);
+    fd.append('voices', new Blob([audioFile.buffer], { type: audioFile.mimetype }), 'voice.mp3');
+
+    const fishRes = await fetch('https://api.fish.audio/model', {
+      method: 'POST',
+      headers: { 'Authorization': `Bearer ${FISH_AUDIO_API_KEY}` },
+      body: fd,
+    });
+    const { _id: voiceId } = await fishRes.json();
+
+    // 2. avatar_configs.voice_id を更新（tenantId は JWT から）
+    await db.query(
+      'UPDATE avatar_configs SET voice_id = $1 WHERE id = $2 AND tenant_id = $3',
+      [voiceId, configId, tenantId]
+    );
+
+    return res.json({ voiceId });
+  }
+);
+```
+
+**セキュリティ考慮**:
+- `tenantId` は JWT から取得（body 禁止 — CLAUDE.md 準拠）
+- MIME タイプ検証: `audio/mpeg`, `audio/wav`, `audio/mp4`, `audio/ogg` のみ許可
+- `requireAvatarOwnership` ミドルウェアで他テナントのアバター設定変更を防止
+
+**必須テスト**:
+- `avatarAuthGuard.test.ts` に voice-clone エンドポイントの auth guard テスト追加
+- 他テナント ID での変更試みが 403 を返すことを確認
+
+---
+
+### Phase C — 大規模実装（推定 4–5 日）
+
+#### C-1: Admin UI 音声クローン管理
+
+**対象**: `admin-ui/src/pages/admin/avatar/studio.tsx`
+
+**追加コンポーネント**: 音声クローン管理セクション
+
+```
+┌─────────────────────────────────────┐
+│ 🎙️ カスタム音声クローン             │
+│                                     │
+│ 現在の音声 ID: [63bc41e6...]        │
+│                                     │
+│ [音声ファイルをアップロード]        │
+│  .mp3/.wav/.m4a, 最大10MB           │
+│  推奨: 1〜2分、背景ノイズなし       │
+│                                     │
+│ クローン名: [____________]          │
+│                                     │
+│ [クローン作成] ← B-2 API を呼ぶ    │
+│                                     │
+│ ※ 作成には30〜60秒かかります       │
+└─────────────────────────────────────┘
+```
+
+**影響**: `studio.tsx` のみ（新規セクション追加）。  
+既存の voice_description → voice_id 検索フロー（`generationRoutes.ts`）とは独立して動作。
+
+---
+
+#### C-2: インスタントクローン対応
+
+**目的**: `reference_id`（永続クローン）に加え、1回限りの音声参照（`references` 配列）をサポート。  
+**用途**: デモ時にユーザーの声でリアルタイム音声生成（将来の差別化機能）。
+
+```python
+# agent.py — references 配列サポート追加
+if self._reference_audio_bytes:
+    request_body["references"] = [{
+        "audio": base64.b64encode(self._reference_audio_bytes).decode(),
+        "text": self._reference_text or "",
+    }]
+elif self._reference_id:
+    request_body["reference_id"] = self._reference_id
+```
+
+**優先度**: 低（現状の永続クローンで十分）。Phase B-2 の完了後に検討。
+
+---
+
+#### C-3: マルチスピーカーダイアログ（Phase D 以降）
+
+S2-Pro の独占機能。複数スピーカーが登場するコンテンツ生成（FAQ 解説動画、商品デモナレーション等）に有用。現状のアバター音声（単一スピーカー）には不要なため **Phase D 以降**で検討。
+
+---
+
+## 3. 影響ファイル一覧
+
+| フェーズ | ファイル | 変更種別 | 変更規模 |
+|---------|---------|---------|---------|
+| A-1 | `avatar-agent/agent.py` | 修正 | 1行追加 |
+| A-1 | `src/api/avatar/fishTtsRoutes.ts` | 修正 | 1行追加 |
+| A-2 | `avatar-agent/agent.py` | 修正 | ~20行追加 |
+| A-3 | `src/api/avatar/fishTtsRoutes.ts` | 修正 | ~5行変更 |
+| B-1 | `avatar-agent/agent.py` | 修正 | ~30行変更 |
+| B-2 | `src/api/admin/avatar/routes.ts` | 修正 | ~60行追加 |
+| B-2 | `src/api/admin/avatar/avatarAuthGuard.test.ts` | テスト追加 | ~40行 |
+| C-1 | `admin-ui/src/pages/admin/avatar/studio.tsx` | 修正 | ~80行追加 |
+| C-2 | `avatar-agent/agent.py` | 修正 | ~20行 |
+
+**変更なし（影響なし）のファイル**:
+
+| ファイル | 理由 |
+|---------|------|
+| `src/lib/billing/costCalculator.ts` | S2-Pro 単価は既存の `$15/M bytes` と同一 |
+| `src/lib/billing/usageTracker.ts` | TTS バイト計上ロジック変更不要 |
+| `src/api/internal/usageRoutes.ts` | ttsTextBytes 計上フロー変更なし |
+| `src/lib/avatar/voiceSettings.ts` | Fish Audio API は speed/pitch 非対応。S2-Pro は自動最適化 |
+| `public/widget.js` | TTS は server-side のみ |
+| `src/index.ts` | route 登録変更なし |
+| `.env` / `ecosystem.config.cjs` | 新規 env var なし（`FISH_AUDIO_API_KEY` は既存） |
+| `src/lib/billing/costCalculator.ts` の `FISH_AUDIO_COST_PER_BYTE_USD` | S1/S2-Pro どちらも $15/M bytes で同一 |
+
+---
+
+## 4. DB 変更
+
+**Phase A–B では DB マイグレーション不要。** 既存カラムを活用:
+
+| カラム | テーブル | 用途 | 現状 |
+|-------|---------|------|------|
+| `emotion_tags` | `avatar_configs` | JSON 配列 | 保存済み、TTS 未接続 |
+| `voice_id` | `avatar_configs` | Fish Audio reference_id | 設定済みアバターあり |
+
+**Phase B-2 前に VPS で実行する確認クエリ**:
+
+```sql
+-- voice_id の現在の使用状況
+SELECT tenant_id, name, voice_id, voice_description
+FROM avatar_configs WHERE voice_id IS NOT NULL LIMIT 20;
+
+-- emotion_tags の格納形式確認
+SELECT name, emotion_tags, pg_typeof(emotion_tags)
+FROM avatar_configs WHERE emotion_tags IS NOT NULL LIMIT 5;
+```
+
+---
+
+## 5. リスク・依存関係マトリクス
+
+| リスク | 対象 Phase | 影響度 | 回避策 |
+|--------|-----------|--------|--------|
+| LiveKit ChunkedStream `stream=True` が lemonslice と未互換 | B-1 | 高 | staging で計測先行。問題なら stream=False のまま chunk 転送に留める |
+| Fish Audio `/model` POST 仕様変更 | B-2 | 中 | OpenAPI `api.fish.audio/openapi.json` で事前確認 |
+| 感情タグがテキスト品質を下げる | A-2 | 低 | 3タグ上限。日本語テキストで staging 確認 |
+| multer 10MB 音声ファイルの PM2 メモリ | B-2 | 低 | limits 設定済み。大ファイルは 400 拒否 |
+| fish-audio-sdk 1.3.0 の S2-Pro 対応 | B-1 方針B | 中 | SDK CHANGELOG 確認。未対応なら aiohttp 直接呼び出しを継続 |
+
+---
+
+## 6. Gate 通過要件
+
+### Phase A
+- Gate 1: `pnpm verify` — TypeScript 変更のみ、型エラーなし
+- Gate 1.5: dead-code-check — 関数追加のみで dead export なし
+- Gate 2: `bash SCRIPTS/security-scan.sh` — ハードコード ID 削除で gitleaks 誤検知なし確認
+- Gate 3: `pnpm build && cd admin-ui && pnpm build`
+
+### Phase B
+- Gate 1–3 に加え: VPS ステージングでの TTFA 計測（200ms 以下）
+- `avatarAuthGuard.test.ts` に voice-clone auth guard テスト追加
+
+### Phase C
+- Gate 1–3 に加え: `pnpm test:e2e` — avatar studio ページで UI 表示確認
+
+---
+
+## 7. 実装順序と推奨 Asana タスク構成
+
+```
+Phase A (1日) — 同一 PR 可
+  ├─ A-1: S2-Pro モデル指定 (2ファイル / 2行)
+  ├─ A-2: 感情タグ TTS 注入 (agent.py / ~20行)
+  └─ A-3: fishTtsRoutes reference_id ハードコード修正
+
+Phase B (3日) — A 完了後
+  ├─ B-1: HTTP ストリーミング (staging テスト必須)
+  └─ B-2: 音声クローン API + auth guard テスト
+
+Phase C (5日) — B 完了後
+  ├─ C-1: Admin UI クローン管理 (studio.tsx)
+  └─ C-2: インスタントクローン (agent.py)
+
+Phase D (未定)
+  └─ C-3: マルチスピーカーダイアログ
+```
+
+---
+
+## 8. 実装前チェックリスト
+
+### Phase A 着手前（必須）
+
+```bash
+# 1. emotion_tags の格納形式を VPS DB で確認
+psql $DATABASE_URL -c "SELECT name, emotion_tags, pg_typeof(emotion_tags) FROM avatar_configs WHERE emotion_tags IS NOT NULL LIMIT 5;"
+
+# 2. Fish Audio で s2-pro モデルが有効か確認
+curl -s -o /dev/null -w "%{http_code}" -X POST https://api.fish.audio/v1/tts \
+  -H "Authorization: Bearer $FISH_AUDIO_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{"text":"テスト","model":"s2-pro","format":"mp3"}'
+# 200 が返れば OK
+
+# 3. widget.js での reference_id 使用箇所確認
+grep -n "tts\|fishAudio\|reference_id\|63bc41e6" public/widget.js | head -20
+```
+
+### Phase B-1 着手前（必須）
+
+```bash
+# LiveKit Agents AudioEmitter.initialize シグネチャ確認
+python3 -c "
+from livekit.agents.tts import AudioEmitter
+import inspect
+print(inspect.signature(AudioEmitter.initialize))
+"
+
+# fish-audio-sdk の WebSocket API 確認
+python3 -c "from fish_audio_sdk import AsyncSession; help(AsyncSession.tts)" 2>&1 | head -30
+```
+
+---
+
+## 9. コスト影響
+
+| 項目 | 変化 |
+|------|------|
+| S1 → S2-Pro 単価 | 変化なし（どちらも $15/M UTF-8 bytes）|
+| `costCalculator.ts` 変更 | 不要 |
+| 音声クローン作成 API コスト | 無料（TTS 呼び出し時の通常料金のみ） |
+| ストリーミング化によるコスト | 変化なし（API 呼び出し回数は同じ） |
+
+---
+
+## 10. 却下項目
+
+| 項目 | 却下理由 |
+|------|---------|
+| `voiceSettings.ts` の `speakingRate`/`pitch` を Fish Audio に渡す | Fish Audio API は speed/pitch パラメータを持たない |
+| Gemini TTS への乗り換え | Fish Audio S2-Pro が TTS-Arena2 #1。移行コストに見合わない |
+| Fish Audio ASR 導入 | VAD/STT は LiveKit 側で処理。スコープ外 |
+| `enhance_audio_quality=True` デフォルト化 | 推論コスト増・遅延増リスク。クローン作成 API のオプションとしてのみ提供 |
+| WebSocket 直接実装（B-1 方針B）を Phase B に入れる | HTTP chunk が目標を達成できない場合の次フェーズ候補 |

--- a/docs/proposals/LEMONSLICE_UPGRADE_2026-06.md
+++ b/docs/proposals/LEMONSLICE_UPGRADE_2026-06.md
@@ -1,0 +1,379 @@
+# LemonSlice 全機能実装提案書
+**作成日**: 2026-06-10  
+**対象ブランチ**: feature/<asana-id>-lemonslice-upgrade  
+**承認前確認**: hkobayashi
+
+---
+
+## 実装ステータス（2026-06-15 更新）
+
+| # | 項目 | ステータス | PR | 備考 |
+|---|------|----------|-----|------|
+| I-1 | パッケージ 1.5.5 → 1.5.12 | ✅ MERGED | #342 | 1.5.17 まで更新済み |
+| I-2 | LemonSlice 2.1 Flash + `response_done_timeout` 調整 | ⏳ PENDING | — | staging 計測待ち（response_done_timeout=4.0 維持中） |
+| I-3 | WebRTC Simulcast 有効化 | ✅ MERGED | #360 | `simulcast: True` 適用済み |
+| I-4 | In-Call Dynamic Update（動的プロンプト差し替え） | ✅ MERGED | #364 | SalesFlow 連動実装済み |
+| I-5 | Actions (LLM Tool Calls) — Emotion & Gesture Trigger | 🚫 BLOCKED | — | Enterprise 申請待ち（support@lemonslice.com） |
+| I-6 | Full-body Avatar — 入力画像サイズ最適化 | ✅ MERGED | #362 | 368×560 リサイズ実装済み |
+
+**残作業**:
+- **I-2**: staging で `response_done_timeout` を 4.0 → 3.0 → 2.5 と段階的に計測し、日本語長文応答が途切れない最小値を確定してから PR を作成すること。
+- **I-5**: `support@lemonslice.com` に Enterprise 申請後、承認されたら `trigger_avatar_gesture` function_tool を追加する。
+
+---
+
+## 0. エグゼクティブサマリー
+
+R2C は LemonSlice の Self-Managed Pipeline を `livekit-agents[lemonslice]==1.5.5` で利用中。  
+LemonSlice 2.1 / 2.1 Flash / 2.5 の一連リリースで以下の新機能が追加されており、  
+**6 つの実装項目** でアバター品質・レイテンシ・表現力を大きく引き上げられる。
+
+| # | 項目 | 効果 | 工数目安 | 依存 |
+|---|------|------|---------|------|
+| I-1 | パッケージ 1.5.5 → 1.5.12 | バグ修正・LemonSlice 2.1 対応基盤 | XS (1h) | なし |
+| I-2 | LemonSlice 2.1 Flash + `response_done_timeout` 調整 | 応答遅延 ~2s 短縮 | S (半日) | I-1 |
+| I-3 | WebRTC Simulcast 有効化 | モバイル回線の映像品質改善 | XS (1h) | I-1 |
+| I-4 | In-Call Dynamic Update（動的プロンプト差し替え） | 会話コンテキスト対応の表情変化 | M (1日) | I-1 |
+| I-5 | Actions (LLM Tool Calls) — Emotion & Gesture Trigger | 会話連動ジェスチャー | M (1日) | I-4 ※要Enterprise申請 |
+| I-6 | Full-body Avatar — 入力画像サイズ最適化 | 全身アバター品質向上 | S (半日) | I-1 |
+
+> **Enterprise 申請が必要なもの**: I-5 (Actions), Green Screen (別提案)  
+> Green Screen は現状 R2C の縦型 widget UI と合わず対象外とした。
+
+---
+
+## 1. 現状把握（実機確認済み）
+
+### 1-1. 利用バージョン
+```
+# avatar-agent/requirements.txt
+livekit-agents[lemonslice,openai]==1.5.5   ← 初期状態
+# 2026-06-10 PR #342 で 1.5.17 に更新済み（1.5.12 を超えて最新版を適用）
+```
+
+### 1-2. 現在の AvatarSession 呼び出し（agent.py:575-597）
+```python
+avatar_kwargs = {
+    "agent_id": effective_agent_id,         # または agent_image_url（排他）
+    "agent_prompt": effective_agent_prompt,
+    "idle_timeout": 300,
+    "response_done_timeout": 4.0,           # Fish Audio TTS の複数文間ギャップ対応で延長済み
+    "agent_idle_prompt": effective_agent_idle_prompt,
+    "width": 1080,
+    "height": 1920,
+    "simulcast": True,                      # I-3: PR #360 で追加済み
+}
+```
+
+### 1-3. DB スキーマ（avatar_configs テーブル）の関連フィールド
+```sql
+lemonslice_agent_id  TEXT
+image_url            TEXT
+agent_prompt         TEXT
+agent_idle_prompt    TEXT
+avatar_provider      TEXT  -- 現在は全テナント 'lemonslice'
+```
+`lemonslice_model_version`・`simulcast` などの新フィールドはまだ存在しない。
+
+### 1-4. 影響ファイル全体マップ
+```
+avatar-agent/
+  requirements.txt        ← I-1: バージョン変更（完了）
+  agent.py                ← I-1, I-2, I-3, I-4, I-5
+
+src/
+  api/admin/avatar/
+    routes.ts             ← I-6: 画像リサイズ処理（完了）
+  api/internal/
+    avatar-config.ts 等   ← I-4: session_id 取得・control API 追加（完了）
+
+docs/migrations/          ← DB マイグレーション（I-4/I-5 で必要な場合）
+tests/agent/avatar/       ← 全項目: テスト追加・更新
+```
+
+---
+
+## 2. 実装詳細
+
+---
+
+### I-1. パッケージ 1.5.5 → 1.5.12 アップグレード（✅ MERGED PR #342）
+
+#### 変更内容
+```diff
+# avatar-agent/requirements.txt
+-livekit-agents[lemonslice,openai]==1.5.5
++livekit-agents[lemonslice,openai]==1.5.17  # 目標 1.5.12 を超えて最新版を適用
+```
+
+#### 実装前確認手順（必須）
+| # | 確認事項 | コマンド / 方法 | 期待値 |
+|---|---------|--------------|--------|
+| 1 | 依存解決テスト | `pip install livekit-agents[lemonslice,openai]==1.5.12 --dry-run` | エラーなし |
+| 2 | Breaking change 有無 | [GitHub Releases livekit/agents](https://github.com/livekit/agents/releases) で 1.5.6〜1.5.12 の CHANGELOG 確認 | `AvatarSession` API 変更なし |
+| 3 | fish-audio-sdk 互換 | `pip install` 後に `python -c "from livekit.plugins import lemonslice"` | ImportError なし |
+| 4 | staging アバター映像確認 | `python agent.py dev` → LiveKit ルームに参加 | 映像・音声が正常に返る |
+
+#### 影響範囲
+- `avatar-agent/requirements.txt` の 1 行のみ。
+- VPS の `.venv` 再構築が必要（`pip install -r requirements.txt`）。
+- **VPS 本番適用は Gate 1〜3 + staging テスト後に限定**（INFRA_AUDIT 準拠）。
+
+#### 注意
+`requirements.txt` は `==` ピン留め方針を維持。`>=` に変更しない。
+
+---
+
+### I-2. LemonSlice 2.1 Flash モデル対応 + `response_done_timeout` 再調整（⏳ PENDING）
+
+#### 背景
+LemonSlice 2.1 Flash は DiT（Diffusion Transformer）モデルで  
+**TTFB 471ms / エンドツーエンド応答 2.04s**（従来比大幅短縮）。  
+現在の `response_done_timeout=4.0` は Fish Audio TTS の複数文間ギャップ（~1-2s）対策で設定されたが、  
+2.1 Flash のレイテンシ改善に合わせて調整余地がある。
+
+#### 実装前調査（必須）
+
+**Q: プラグイン側でのモデル選択方法は？**  
+`livekit-plugins-lemonslice` に `model_version` パラメータが存在するか確認する。
+
+```bash
+# 1.5.17 インストール後
+python -c "import inspect; from livekit.plugins import lemonslice; print(inspect.signature(lemonslice.AvatarSession.__init__))"
+```
+
+- **存在する場合**: `avatar_kwargs` に `model_version="2.1-flash"` を追加
+- **存在しない場合**: LemonSlice ダッシュボードの Agent 設定またはアカウント設定でモデルを切り替え  
+  （API key に紐付くグローバル設定の可能性が高い）
+
+#### response_done_timeout の調整方針
+
+> ⚠️ `response_done_timeout=4.0` は Fish Audio TTS の複数文間ギャップ（~1-2s）を考慮して  
+> 0.5 から延長した値（agent.py コメント参照）。むやみに下げると長文応答で  
+> 文の途中にアバターが idle に戻る既知バグが再発する。
+
+段階的に調整し、各ステップで staging 実測する:
+
+```
+4.0 → 3.0 → 2.5 → (2.0 は Fish Audio との組み合わせで様子見)
+```
+
+**テスト手順（各ステップ）**:
+1. FAQの長い回答（3文以上）を 10 回試行
+2. 文の途中でアバターが idle に戻らないことを目視確認
+3. 応答終了後、設定値 ± 0.3s 以内に idle 状態へ遷移することを確認
+
+#### 変更内容（調査・計測後に決定）
+```python
+# agent.py の response_done_timeout 2 箇所（agent_image_url / agent_id 両ブランチ）
+"response_done_timeout": 2.5,  # 4.0 → X.X (staging 計測値で決定)
+```
+
+---
+
+### I-3. WebRTC Simulcast 有効化（✅ MERGED PR #360）
+
+#### 背景
+`simulcast: boolean (default: false)` — LemonSlice API 公式パラメータ（LiveKit 専用）。  
+複数解像度を同時配信し、クライアント帯域に応じた映像品質を自動選択。  
+モバイル回線ユーザーの映像劣化・カクツキを改善する。
+
+#### 変更内容（実装済み）
+```diff
+# agent.py（agent_id / agent_image_url 両ブランチ両方に追加済み）
+ avatar_kwargs = {
+     ...
++    "simulcast": True,
+ }
+```
+
+#### 影響範囲
+- `agent.py` の `avatar_kwargs` 2 箇所のみ。
+- DB 変更なし（全テナント一律で有効化）。
+- LemonSlice 請求への影響: 公式未記載 → **有効化後、最初の請求サイクルで確認**。
+
+---
+
+### I-4. In-Call Dynamic Update（動的プロンプト差し替え）（✅ MERGED PR #364）
+
+#### 背景
+LemonSlice 2.1 の目玉機能。アクティブセッション中に REST API で以下を動的変更可能:
+- `update_agent_prompt`: 発話中の表情・動作プロンプト
+- `update_idle_prompt`: アイドル中の表情・動作プロンプト
+- `update_image`: 参照画像の差し替え（場面転換）
+
+```
+POST https://lemonslice.com/api/liveai/sessions/{session_id}/control
+{ "event": "update_agent_prompt", "agent_prompt": "excited and energetic" }
+```
+
+#### R2C での活用シナリオ（実装済み）
+| 会話ステート（Phase22/SalesFlow） | 変更する prompt | 内容 |
+|----------------------------------|----------------|------|
+| `clarify` | agent_prompt | `"attentive and curious, leaning in slightly"` |
+| `propose` | agent_prompt | `"enthusiastic and persuasive"` |
+| `close` | agent_prompt | `"joyful and celebratory"` |
+| `answer` | agent_prompt | `"confident and helpful"` |
+
+#### 実装内容（agent.py に追加済み）
+
+**control_lemonslice ヘルパー**: LemonSlice Control API への fire-and-forget ラッパー。  
+**session_id 保持**: `avatar.start()` の戻り値を `_lemonslice_session_id` グローバルに保持。  
+**DataChannel リスナー**: `data_received` イベントで SalesFlow ステート変化を受信し、`control_lemonslice` を呼ぶ。
+
+---
+
+### I-5. Actions — Emotion & Gesture Trigger（🚫 BLOCKED — Enterprise 申請待ち）
+
+#### 前提条件
+Actions は **Enterprise 専用機能**。各 agent_id に LemonSlice チームがカスタムモーションシーケンスを設定する必要がある。  
+→ **実装着手前に `support@lemonslice.com` に申請**。デフォルト 18 アバター（current: default_01〜default_18）全員分の設定が必要。
+
+申請時に伝えるべき情報:
+- 対象 agent_id 一覧（`src/api/admin/avatar/routes.ts:21-43` の `lemonslice_agent_id` 全 18 件）
+- 必要なアクション名のリスト（下記設計案）
+
+#### R2C 向けアクション設計案
+| アクション名 | 動作 | トリガー条件 |
+|------------|------|-------------|
+| `bow` | お辞儀 | セッション開始・終了の挨拶 |
+| `nod_strong` | 大きく頷く | ユーザーの要望確認（clarify） |
+| `cheer` | 喜ぶ・祝う | 商談成立（close ステート） |
+| `point` | 前方を指差す | 具体的な商品説明（propose） |
+| `wave` | 手を振る | 長時間アイドル後の呼びかけ |
+
+#### 実装内容（Enterprise 申請完了後）
+
+```python
+# agent.py — function_tool として追加（申請完了後に有効化）
+from livekit.agents import function_tool
+
+@function_tool
+async def trigger_avatar_gesture(action: str) -> str:
+    """
+    Trigger a physical avatar gesture for emphasis or emotional expression.
+    - Use 'bow' at session start or end greeting.
+    - Use 'nod_strong' when acknowledging the user's request.
+    - Use 'cheer' when the user confirms a purchase or expresses happiness.
+    - Use 'point' when emphasizing a specific product feature.
+    - Use 'wave' when reactivating from idle.
+    action: one of 'bow', 'nod_strong', 'cheer', 'point', 'wave'
+    """
+    ok = await control_lemonslice("action", action=action)
+    return "gesture triggered" if ok else "gesture unavailable"
+```
+
+この `function_tool` を `Agent(instructions=..., tools=[trigger_avatar_gesture])` に渡すと  
+Groq LLM が会話コンテキストから自動的に呼び出す。
+
+#### 影響ファイル
+- `avatar-agent/agent.py` — function_tool 追加、Agent インスタンス化の変更
+- DB: 将来的に `avatar_configs.available_actions TEXT[]` カラム追加で  
+  テナント別アクション有効化ができるが、今フェーズは全体一律で OK
+
+---
+
+### I-6. Full-body Avatar — 入力画像サイズ最適化（✅ MERGED PR #362）
+
+#### 背景
+LemonSlice API の `agent_image_url` 推奨サイズ: **368 × 560 px（縦型・全身）**。  
+`agent_id` を使うデフォルトアバター 18 体は LemonSlice 側で最適化済みのため影響なし。  
+カスタム画像アバター（`agent_image_url`）でのみ問題が生じる。
+
+#### 実装内容（実装済み）
+```typescript
+// src/api/admin/avatar/routes.ts
+const LEMONSLICE_IMAGE_WIDTH = 368;
+const LEMONSLICE_IMAGE_HEIGHT = 560;
+// sharp でリサイズ後に Supabase Storage へアップロード
+```
+
+#### 注意事項
+- `is_default=true` のアバター画像変更は API で禁止済み（routes.ts:427）。デフォルト 18 体への影響なし。
+- 既存の Supabase Storage に保存済みの画像は遡及リサイズしない（別タスク起票）。
+- クロップ位置（`position: "top"`）は全身画像の顔が上部という前提。  
+  Leonardo.ai の生成プロンプトに「full body, standing」を含むよう admin UI のガイドに追記推奨。
+
+---
+
+## 3. 実装順序と依存グラフ
+
+```
+I-6（調査・確認のみ → 他と独立して最小リスク）
+  ↓
+I-1（パッケージ更新 — 全ての基盤）
+  ├── I-3（Simulcast — 1 行追加。I-1 staging テストに同乗可）
+  ├── I-2（Flash + timeout — I-1 の staging 計測結果を見てから）
+  └── I-4（Dynamic Update — session_id 取得方法確認後に設計）
+        └── I-5（Actions — Enterprise 申請完了後）
+```
+
+**推奨 PR 分割:**
+
+| PR | 内容 | Gate 2.5 | ステータス |
+|---|------|---------|---------|
+| PR-A | I-1 + I-3 | スキップ可 | ✅ MERGED（#342 + #360） |
+| PR-B | I-2 | スキップ可 | ⏳ PENDING（staging 計測後に作成） |
+| PR-C | I-6 | スキップ可 | ✅ MERGED（#362） |
+| PR-D | I-4 | **必須** | ✅ MERGED（#364） |
+| PR-E | I-5 | **必須** | 🚫 BLOCKED（Enterprise 申請待ち） |
+
+---
+
+## 4. 未解決確認事項（全て実装着手前に解消が必要）
+
+| # | 質問 | 確認方法 | ブロックする項目 | 状態 |
+|---|------|---------|--------------|------|
+| Q1 | 1.5.6〜1.5.12 に breaking change があるか | [GitHub Releases livekit/agents](https://github.com/livekit/agents/releases) を読む | I-1 | ✅ 解消（PR #342 で 1.5.17 適用済み） |
+| Q2 | `AvatarSession` に `simulcast` kwarg があるか | `inspect.signature` で確認 | I-3 | ✅ 解消（extra_payload 経由で渡す方式） |
+| Q3 | 2.1 Flash への切り替えはパラメータ指定か、ダッシュボードか | `inspect.signature` + LemonSlice サポートに確認 | I-2 | ⏳ 未解消 |
+| Q4 | `AvatarSession` が `session_id` を公開しているか | `dir(avatar)` で確認 | I-4 | ✅ 解消（`avatar.start()` の戻り値） |
+| Q5 | Actions 申請の処理期間はどのくらいか | support@lemonslice.com に問い合わせ | I-5 | ⏳ 未申請 |
+| Q6 | 現在の `uploadAvatarImage` にリサイズ処理が存在するか | `routes.ts:364` 周辺を読む | I-6 | ✅ 解消（PR #362 で実装済み） |
+| Q7 | Simulcast 有効化で LemonSlice の課金は変わるか | 請求ページ確認 or サポートに確認 | I-3 | ⏳ 未確認（次の請求サイクルで確認） |
+
+---
+
+## 5. Gate チェックリスト（各 PR 共通）
+
+```
+Gate 1:   pnpm verify (typecheck + lint + test)
+Gate 1.5: bash SCRIPTS/dead-code-check.sh
+Gate 2:   bash SCRIPTS/security-scan.sh (High/Critical = 0)
+Gate 2.5: /codex:review --base main --background  ← PR-D, PR-E は必須
+Gate 3:   pnpm build && cd admin-ui && pnpm build
+```
+
+**Python コードは Gate 1 の `pnpm verify` 対象外**のため、以下を追加推奨:
+```bash
+# PR-A 以降、agent.py を変更する PR に追加
+cd avatar-agent && pip install ruff mypy && ruff check agent.py && mypy agent.py
+```
+
+---
+
+## 6. コスト・リスク評価
+
+| 項目 | コスト影響 | リスク | 軽減策 |
+|------|-----------|--------|--------|
+| I-1 | なし | pip 依存解決失敗 | dry-run + staging で事前確認（実施済み） |
+| I-2 | モデル切り替えで LemonSlice 請求増の可能性 | timeout 短縮で日本語長文が mid-sentence idle | staging 段階的計測（未実施） |
+| I-3 | LemonSlice 請求影響不明 | AvatarSession が未対応なら映像落ち | `inspect.signature` で先確認（実施済み） |
+| I-4 | LemonSlice API コール増（微小） | session_id 取得失敗 | try-except + graceful fallback（実装済み） |
+| I-5 | Enterprise プラン料金発生 | 申請〜設定に時間がかかる | 先行申請（未実施） |
+| I-6 | なし | クロップで顔が切れる | `position: "top"` + QA 目視確認（実施済み） |
+
+---
+
+## 7. 参考リンク
+
+- [LemonSlice Self-Managed Capabilities](https://lemonslice.com/docs/self-managed/capabilities)
+- [Create Session API](https://lemonslice.com/docs/api-reference/create-self-managed-session)
+- [Control Session API](https://lemonslice.com/docs/api-reference/control-self-managed-session)
+- [Actions Guide](https://lemonslice.com/docs/guides/actions-guide)
+- [LemonSlice 2.1 Capabilities](https://lemonslice.com/docs/overview/capabilities)
+- [LemonSlice 2.1 Flash Blog](https://lemonslice.com/blog/lemonslice-flash)
+- [livekit-plugins-lemonslice PyPI](https://pypi.org/project/livekit-plugins-lemonslice/)
+- [LiveKit × LemonSlice Integration](https://docs.livekit.io/agents/models/avatar/plugins/lemonslice/)
+- 実装済み: `avatar-agent/agent.py:61-107` (control_lemonslice, session_id)
+- 実装済み: `src/api/admin/avatar/routes.ts` (368×560 リサイズ)

--- a/docs/proposals/LIVEKIT_UPGRADE_PROPOSAL.md
+++ b/docs/proposals/LIVEKIT_UPGRADE_PROPOSAL.md
@@ -1,0 +1,415 @@
+# LiveKit アップグレード実装提案書
+
+**作成日**: 2026-06-10  
+**対象ブランチ**: `fix/avatar-startup-speed`（または後継 feature ブランチ）  
+**優先度区分**: P0（即時）/ P1（次スプリント）/ P2（検討）
+
+---
+
+## 0. 現状サマリーと問題点
+
+| コンポーネント | 現在バージョン | 最新バージョン | 遅れ |
+|---|---|---|---|
+| `livekit-agents` (Python, avatar-agent) | **1.5.5** | 1.5.17 | 12リリース |
+| `livekit-client` (JS, public/widget.js) | **2.9.1** | 2.19.2 | 10リリース |
+| `livekit-server-sdk` (Node.js, token route) | `^2.15.0` | 2.15.4 | 範囲内 |
+
+### 現在観測されている問題（アップグレードで解消が期待できるもの）
+- アバター起動時に音声バインドタイミングがズレる（#5837 で修正済み）
+- 長時間セッションで Widget のメモリリーク（#1944/#1896 で修正済み）
+- 複数センテンス TTS の間に不要フレームドロップが発生（#5815 で修正済み）
+
+---
+
+## 1. P0: バージョンアップ（リスク低・効果大）
+
+### 1-A. livekit-agents 1.5.5 → 1.5.17
+
+**対象ファイル**: `avatar-agent/requirements.txt`
+
+```diff
+-livekit-agents[lemonslice,openai]==1.5.5
++livekit-agents[lemonslice,openai]==1.5.17
+```
+
+**自動で得られる改善**（コード変更不要）:
+- `#5837` LemonSlice: HTTP呼び出し前にアバター音声出力をバインド → 起動時の音声タイミング修正
+- `#5815` フレームドロップ→サイレンスフレームに置換 → TTS間の音声途切れ軽減
+- `#5874` IPC spawn 失敗時のリトライ → VPS での安定性向上
+- `#5824` ChatMessage.interrupted の proto シリアライズ修正
+- `#5846` ToolError の LLM への返却改善（ArgValidation）
+- `#5861` Field() アノテーション保持（function tool 引数）
+
+**影響範囲**:
+- `avatar-agent/agent.py`: lemonslice・openai プラグイン使用 → 互換性確認必須
+- VPS の pip 環境: 再インストールが必要（`pip install -r requirements.txt`）
+- FishAudioTTS カスタムクラス: `agents_tts.TTS` / `ChunkedStream` 継承 → 1.5.x で API 変更なし（確認済み範囲）
+
+**確認事項**:
+- [ ] `livekit-agents[lemonslice,openai]==1.5.17` が lemonslice プラグイン含むか PyPI で確認
+- [ ] FishAudioTTS の `TTSCapabilities` / `AudioEmitter` API が 1.5.17 で変更されていないか changelog 確認
+- [ ] VPS で `pip install -r requirements.txt` → avatar-agent 起動テスト
+
+---
+
+### 1-B. livekit-client 2.9.1 → 2.19.2
+
+**対象ファイル**: `public/widget.js` (line 1031)
+
+```diff
+-var LIVEKIT_SDK_URL = 'https://cdn.jsdelivr.net/npm/livekit-client@2.9.1/dist/livekit-client.umd.min.js';
++var LIVEKIT_SDK_URL = 'https://cdn.jsdelivr.net/npm/livekit-client@2.19.2/dist/livekit-client.umd.min.js';
+```
+
+**自動で得られる改善**:
+- `#1944` `devicechange` リスナーのメモリリーク修正（長時間セッションに効く）
+- `#1896` `waitForBufferStatusLow` のイベントリスナー蓄積修正
+- `#1954` Firefox: publisher offer 最適化（モバイルブラウザ互換性向上）
+- `#1963` Firefox: v1 シグナリングで初期 media sections 送信
+- `#1893` transport manager reset（legacy fallback 前）
+- `#1900` 更新トークンの regionUrlProvider への確実な設定
+
+**影響範囲**:
+- widget.js 内の Room 初期化: `new LK.Room({ adaptiveStream: true, dynacast: true })`
+  - 2.9.1 → 2.19.2 間で Room コンストラクタの options schema に破壊的変更なし（minor リリース）
+- RoomEvent ハンドラ（DataReceived / TrackSubscribed / Disconnected / Reconnecting / Reconnected）: 変更なし
+- `room.localParticipant.publishData()`: API 変更なし
+
+**確認事項**:
+- [ ] `livekit-client@2.19.2` の UMD ビルドが jsdelivr に存在するか確認
+- [ ] `LK.Room` / `LK.RoomEvent` / `LK.Track.Kind.Audio` などの名前が 2.19.2 で同一か確認
+- [ ] Playwright e2e でアバター接続フロー通過確認（`tests/e2e/phase65-demo.spec.ts`）
+- [ ] `src/lib/headers.csp.ts` の `script-src` に `cdn.jsdelivr.net` が含まれるか確認
+
+---
+
+## 2. P1: コード改善（agent.py の新 API 活用）
+
+### 2-A. wait_for_join ヘルパーの活用（#5836）
+
+**概要**: アバター参加者の Room 参加を確実に待機。現在は `avatar.start()` 後すぐ `session.start()` を呼んでいるが、LemonSlice の join 前に session が始まる可能性がある。
+
+**現在のコード** (`agent.py` lines 471-482):
+```python
+avatar = lemonslice.AvatarSession(**avatar_kwargs)
+await avatar.start(session, room=ctx.room)
+logger.info("=== LEMONSLICE AVATAR STARTED ===")
+
+await session.start(
+    room=ctx.room,
+    agent=Agent(instructions=effective_system_prompt),
+)
+```
+
+**変更案**:
+```python
+avatar = lemonslice.AvatarSession(**avatar_kwargs)
+await avatar.start(session, room=ctx.room)
+logger.info("=== LEMONSLICE AVATAR STARTED ===")
+
+# 1.5.17新API: avatarがroomにjoinするまで最大10秒待機
+# これがないとsession.start()がavatarの準備前に音声送信を開始する可能性がある
+try:
+    await avatar.wait_for_join(timeout=10.0)
+    logger.info("=== AVATAR PARTICIPANT JOINED ROOM ===")
+except Exception as e:
+    logger.warning(f"[avatar] wait_for_join timeout (continuing): {e}")
+
+await session.start(
+    room=ctx.room,
+    agent=Agent(instructions=effective_system_prompt),
+)
+```
+
+**影響範囲**:
+- `entrypoint()` 内のアバター起動シーケンスのみ
+- タイムアウト時は except で続行するため既存動作にフォールバック
+
+**確認事項**:
+- [ ] `lemonslice.AvatarSession.wait_for_join()` の存在と引数シグネチャを `pip install` 後に確認
+- [ ] タイムアウト値（10秒）が LemonSlice の join 所要時間と整合するか実測
+
+---
+
+### 2-B. aclose 時のアバターキック（#5836）
+
+**概要**: セッション終了時にアバター参加者を Room から明示的に退出させる。現在は明示的な cleanup なし → LemonSlice Cloud 側でゾンビ参加者が残り続けるリスクがある。
+
+**変更案** (`entrypoint()` 末尾):
+```python
+await session.start(
+    room=ctx.room,
+    agent=Agent(instructions=effective_system_prompt),
+)
+logger.info("=== SESSION STARTED ===")
+
+# セッション終了まで待機
+try:
+    await session.wait_for_shutdown()
+except Exception as e:
+    logger.warning(f"[session] shutdown error: {e}")
+finally:
+    # 1.5.17: aclose時にアバター参加者をkick（孤立防止）
+    try:
+        await avatar.aclose()
+        logger.info("[avatar] aclose completed")
+    except Exception as e:
+        logger.warning(f"[avatar] aclose error: {e}")
+```
+
+**影響範囲**:
+- `entrypoint()` 末尾のみ
+- `avatar.aclose()` 例外は finally 内なので session 終了には影響なし
+
+**確認事項**:
+- [ ] `AgentSession.wait_for_shutdown()` API の存在確認（または等価の待機方法）
+- [ ] LemonSlice Cloud の参加者数課金に影響するか確認（ゾンビ対策の優先度判断）
+
+---
+
+### 2-C. バックグラウンド音声フェード（#5832）
+
+**概要**: `AgentSession` の `AudioConfig` で音声開始・終了をフェードイン/アウトし、TTS 開始の唐突感を排除。
+
+**変更案**（`agent.py` の `AgentSession` 初期化）:
+```python
+from livekit.agents import AudioConfig  # 1.5.17で追加
+
+session = AgentSession(
+    llm=groq_llm,
+    tts=fish_tts,
+    user_away_timeout=None,
+    # 1.5.17新API: フェードイン/アウト設定
+    audio_config=AudioConfig(
+        fade_in=0.1,   # 秒: 音声開始時（FishAudio MP3デコード遅延を考慮して0.1s）
+        fade_out=0.1,  # 秒: 音声終了時
+    ),
+)
+```
+
+**影響範囲**:
+- `AgentSession` 初期化部分のみ
+- FishAudioTTS のサンプルレート（44100Hz）との互換性要確認
+
+**確認事項**:
+- [ ] `AudioConfig` クラスが `livekit-agents==1.5.17` に存在するか確認
+- [ ] fade_in 値が FishAudio の MP3 デコード遅延（~100-200ms）と競合しないか確認
+- [ ] `agent.py` の既存コードで `AudioConfig` が既にインポートされていないか確認（重複防止）
+
+---
+
+## 3. P1: widget.js の新機能追加
+
+### 3-A. ノイズキャンセレーション（LiveKit Blog 2026-06-10）
+
+**概要**: Room 初期化時に `audioCaptureDefaults` を設定し、マイク入力の音声品質を向上。
+
+**現在のコード** (widget.js line 1553):
+```javascript
+var room = new LK.Room({ adaptiveStream: true, dynacast: true });
+```
+
+**変更案**:
+```javascript
+var room = new LK.Room({
+  adaptiveStream: true,
+  dynacast: true,
+  // 2.19.2: ノイズキャンセレーション（マイク入力時に適用）
+  audioCaptureDefaults: {
+    noiseSuppression: true,
+    echoCancellation: true,
+    autoGainControl: true,
+  },
+});
+```
+
+**影響範囲**:
+- widget.js の Room 初期化のみ（1行変更）
+- アバターの音声受信（TrackSubscribed）には影響なし
+- mic-btn でマイク入力を有効化した場合にのみ適用される
+
+**確認事項**:
+- [ ] livekit-client 2.19.2 の `RoomOptions` 型定義で `audioCaptureDefaults` が存在するか確認
+- [ ] エコーキャンセレーションが LemonSlice 音声ループ（スピーカー→マイク）を防ぐか Playwright で確認
+- [ ] ブラウザネイティブの MediaTrackConstraints と重複しないか確認
+
+---
+
+### 3-B. publishData の Promise 化対応（#1892 関連）
+
+**概要**: livekit-client 2.19.2 では `publishData()` が Promise を返す。現在のコードは戻り値を無視しているため、送信失敗が無音で消える。
+
+**現在のコード** (`sendTTSRequest()` 内):
+```javascript
+room.localParticipant.publishData(payload, { reliable: true });
+```
+
+**変更案**:
+```javascript
+var sendPromise = room.localParticipant.publishData(payload, { reliable: true });
+if (sendPromise && typeof sendPromise.catch === 'function') {
+  sendPromise.catch(function(e) {
+    console.warn('[FAQ Widget] publishData error:', e);
+  });
+}
+```
+
+**影響範囲**:
+- `sendTTSRequest()` 関数のみ（widget.js）
+- `reliable: true` は既に設定済みなので動作変更なし、エラー可視化のみ
+
+**確認事項**:
+- [ ] 2.19.2 で `publishData()` が Promise を返すことを型定義で確認
+- [ ] 2.9.1 では void 戻り値だったため、Promise 判定の `if (sendPromise)` ガードが必要
+
+---
+
+## 4. P2: 新機能追加（検討段階）
+
+### 4-A. Agent Console の有効化
+
+**概要**: LiveKit のリアルタイムエージェントデバッグダッシュボード。コード変更不要、LiveKit Cloud の Settings から有効化。
+
+**R2C での活用**:
+- アバター起動の遅延箇所（Room 参加 / Agent Dispatch / LemonSlice join）をビジュアル確認
+- TTS パイプラインのレイテンシ計測
+- 本番インシデント時の状態確認
+
+**確認事項**:
+- [ ] LiveKit Cloud の契約プランで Agent Console が使用可能か確認
+- [ ] 本番テナントデータが Agent Console に表示される範囲のプライバシー確認
+
+---
+
+### 4-B. claim_user_turn による会話フロー制御（#5806/#5911）
+
+**概要**: `AgentSession.claim_user_turn()` でエージェントが会話ターンを明示的に取得。`tts_request` と `chat` が同時に到着した場合の TTS 重複発話を防止。
+
+**変更案** (`handle_tts_request()` 内):
+```python
+async def handle_tts_request(reply_text: str) -> None:
+    try:
+        await session.claim_user_turn()  # 1.5.17新API
+        session.say(reply_text)
+    except Exception as e:
+        logger.error(f"[handle_tts_request] error: {e}")
+```
+
+**確認事項**:
+- [ ] `claim_user_turn()` が 1.5.17 のパブリック API か確認
+- [ ] 現在の実装で TTS 重複が実際に発生しているか確認（事前に問題があるか検証してから適用）
+- [ ] `asyncio.create_task()` との組み合わせで `await` が正しく機能するか確認
+
+---
+
+### 4-C. Groq → Gemini 移行時のコンテキストキャッシュ（#5675）
+
+**概要**: Google AI Platform 移行時に `cached_content` オプションでシステムプロンプトをキャッシュ → レイテンシ削減。現在は Groq 継続のため P2。Groq 移行検討時に再評価。
+
+---
+
+## 5. 実装順序とゲート要件
+
+```
+Phase 1: バージョンバンプ（P0 — 1-A + 1-B）
+  ├── avatar-agent/requirements.txt: 1.5.5 → 1.5.17
+  ├── public/widget.js: CDN URL @2.9.1 → @2.19.2
+  ├── Gate 1: pnpm verify（typecheck + lint + test 全パス）
+  ├── Gate 2: bash SCRIPTS/security-scan.sh（CDN URL 変更による CSP 影響確認）
+  ├── Gate 3: pnpm build
+  ├── Gate 2.5: /codex:review --base main（スキップ可否: CSS/ドキュメントのみではないため実行推奨）
+  └── VPS: pip install -r requirements.txt → pm2 restart avatar-agent
+
+Phase 2: agent.py 改善（P1 — 2-A + 2-B + 2-C）
+  ├── wait_for_join + aclose cleanup（2-A + 2-B）
+  ├── AudioConfig fade_in/fade_out（2-C）
+  ├── Gate 1: pnpm verify
+  └── Playwright e2e: アバター起動から TTS まで一気通貫テスト
+
+Phase 3: widget.js 改善（P1 — 3-A + 3-B）
+  ├── audioCaptureDefaults ノイズキャンセル（3-A）
+  ├── publishData Promise エラーハンドリング（3-B）
+  ├── Gate 1: pnpm verify
+  └── Playwright e2e: マイク入力 + TTS 受信テスト（390px viewport）
+```
+
+---
+
+## 6. 影響する既存機能マトリクス
+
+| 機能 | ファイル | 影響レベル | 備考 |
+|---|---|---|---|
+| アバター起動（`fix/avatar-startup-speed`） | `avatar-agent/agent.py` | **高** | 1.5.17 の LemonSlice fix が目的と直結 |
+| Widget テキストチャット | `public/widget.js` | 低 | JS SDK 更新のみ、チャット動作変更なし |
+| Widget マイク入力 | `public/widget.js` | 中 | audioCaptureDefaults で音質向上 |
+| LiveKit Token Route | `src/api/avatar/livekitTokenRoutes.ts` | なし | server-sdk は^2.15.0範囲内で自動更新 |
+| CSP ヘッダー | `src/lib/headers.csp.ts` | **要確認** | jsdelivr が script-src に含まれるか確認 |
+| Playwright e2e | `tests/e2e/phase65-demo.spec.ts` | **要テスト** | アバター起動シーケンス変更後に確認 |
+| FishAudio TTS クラス | `avatar-agent/agent.py` | **要確認** | `ChunkedStream` / `AudioEmitter` API 互換性 |
+| Phase48 LLM Defense | `src/middleware/` | なし | ノイズキャンセルは独立レイヤー |
+
+---
+
+## 7. リスク評価
+
+| リスク | 確率 | 影響 | 対策 |
+|---|---|---|---|
+| lemonslice プラグイン API 変更（1.5.5→1.5.17） | 低 | 高 | `pip install` 後に `dir(lemonslice.AvatarSession)` で確認 |
+| FishAudioTTS の `ChunkedStream` API 変更 | 低 | 高 | 1.5.17 changelog で `tts.ChunkedStream` 変更有無確認 |
+| widget.js CDN URL 変更でロード失敗 | 低 | 高 | `curl -I` で @2.19.2 存在事前確認 |
+| audioCaptureDefaults が Firefox でクラッシュ | 中 | 中 | Firefox e2e テスト追加 |
+| wait_for_join タイムアウトで起動遅延 | 中 | 中 | timeout 値を調整、失敗時は continue でフォールバック |
+| AudioConfig の fade 値で TTS 先頭が切れる | 中 | 低 | 0.1s から始め、実測で調整 |
+| Agent Console で本番テナントデータ露出 | 低 | 高 | 本番環境では無効、開発環境のみ |
+
+---
+
+## 8. 不適用項目（R2C スコープ外）
+
+| 機能 | 理由 |
+|---|---|
+| AMD（Answering Machine Detection） | 電話アウトバウンド非使用 |
+| Respeecher / Inworld / Smallestai TTS | FishAudio TTS 固定 |
+| GnaniAI / Cartesia / Gradium STT | STT 未使用（data channel で text 受信） |
+| Google AI Platform LLM | Groq 継続 |
+| MongoDB Vector Search 連携 | PostgreSQL pgvector 使用 |
+| MCP `mcp_servers` deprecate 対応 | MCP 未使用 |
+| Voicemail / IVR 検知 | アウトバウンドコール非使用 |
+| C++ SDK | Python/JS 実装 |
+
+---
+
+## 9. 実装前の必須確認アクション
+
+### Phase 1（バージョンバンプ）実施前
+```bash
+# 1. PyPI でバージョン存在確認
+pip index versions livekit-agents 2>&1 | grep "1.5.17"
+
+# 2. CDN で 2.19.2 の UMD ビルド存在確認
+curl -sI "https://cdn.jsdelivr.net/npm/livekit-client@2.19.2/dist/livekit-client.umd.min.js" | grep "HTTP"
+
+# 3. CSP ヘッダーに jsdelivr が含まれるか確認
+grep -n "jsdelivr\|cdn\|script-src" src/lib/headers.csp.ts src/lib/headers.csp.test.ts
+```
+
+### Phase 2（agent.py 改善）実施前
+```bash
+# ローカル venv or VPS で
+pip install "livekit-agents[lemonslice,openai]==1.5.17"
+python -c "from livekit.plugins import lemonslice; print([m for m in dir(lemonslice.AvatarSession) if 'join' in m or 'close' in m])"
+python -c "from livekit.agents import AudioConfig; print(AudioConfig.__init__.__doc__)"
+```
+
+### Phase 3（widget.js 改善）実施前
+```bash
+# 型定義で audioCaptureDefaults の存在確認
+curl -s "https://cdn.jsdelivr.net/npm/livekit-client@2.19.2/dist/livekit-client.d.ts" | grep -A5 "audioCaptureDefaults"
+# または npm でローカル確認
+cd /tmp && npm pack livekit-client@2.19.2 && tar xf livekit-client-2.19.2.tgz && grep -r "audioCaptureDefaults" package/
+```
+
+---
+
+*この提案書は 2026-06-10 の LiveKit GitHub リリースノート・公式ブログ調査に基づく。  
+実装前に各「確認事項」を実機照合すること（memory・anatomy.md 記載情報は古い可能性あり）。*


### PR DESCRIPTION
## Summary

- `docs/proposals/LEMONSLICE_UPGRADE_2026-06.md` を新規追加（実装ステータス 2026-06-15 時点を反映）
- `docs/proposals/FISH_AUDIO_UPGRADE_PROPOSAL.md` を新規追加
- `docs/proposals/LIVEKIT_UPGRADE_PROPOSAL.md` を新規追加

### LemonSlice 各項目の実装状況

| 項目 | ステータス | PR |
|------|----------|-----|
| I-1 パッケージ 1.5.5→1.5.17 | ✅ MERGED | #342 |
| I-2 Flash + timeout 調整 | ⏳ PENDING | staging 計測待ち |
| I-3 WebRTC Simulcast | ✅ MERGED | #360 |
| I-4 In-Call Dynamic Update | ✅ MERGED | #364 |
| I-5 Actions (Enterprise) | 🚫 BLOCKED | 申請待ち |
| I-6 画像リサイズ 368×560 | ✅ MERGED | #362 |

## DoD Checklist

- [x] 変更が docs/markdown のみ (`git diff --name-only main...HEAD` で確認)
- [x] 既存リンク・アンカーが壊れていない
- [x] 機密情報（API key / .env 値 / 内部 IP）が markdown に混入していない
- [x] commit メッセージが `docs(<scope>):` プレフィックス
- [x] Gate 2.5 スキップ（docs only）

**Asana GID**: 1215583480435865