### PR TITLE
feat(voice): Web Speech API → Fish Audio ASR (Transcribe-1) 置換 (#99019)

### DIFF
--- a/public/widget.js
+++ b/public/widget.js
@@ -881,9 +881,8 @@
     micBtn.appendChild(svg);
   })();
 
-  // Web Speech API 非対応ブラウザ・HTTP環境では非表示
-  var SpeechRecognitionAPI = window.SpeechRecognition || window.webkitSpeechRecognition;
-  if (!SpeechRecognitionAPI || !window.isSecureContext) {
+  // MediaRecorder 非対応ブラウザ・HTTP環境では非表示
+  if (!window.MediaRecorder || !navigator.mediaDevices || !window.isSecureContext) {
     micBtn.style.display = 'none';
   }
 
@@ -2347,121 +2346,129 @@
     e.stopPropagation();
   }, { passive: true });
 
-  /* --- マイクボタン: Web Speech API 音声入力 --- */
-  if (SpeechRecognitionAPI) {
+  /* --- マイクボタン: Fish Audio ASR 音声入力 (Transcribe-1) --- */
+  if (window.MediaRecorder && navigator.mediaDevices && window.isSecureContext) {
     var isRecording = false;
-    var currentRecognition = null;
+    var currentRecorder = null;
+    var audioChunks = [];
 
-    function _stopRecognition() {
+    function _resetMicState() {
       isRecording = false;
-      micBtn.classList.remove('recording');
+      micBtn.classList.remove('recording', 'processing');
       micBtn.setAttribute('aria-label', '音声入力');
-      if (currentRecognition) {
-        try { currentRecognition.stop(); } catch (_e) {}
-        currentRecognition = null;
+      micBtn.disabled = false;
+      if (currentRecorder && currentRecorder.state !== 'inactive') {
+        try { currentRecorder.stop(); } catch (_e) {}
       }
-      // 途中の interim テキストをクリア
-      if (textarea.value) {
-        textarea.value = '';
-        autoResizeTextarea();
-        updateSendButton();
-      }
+      currentRecorder = null;
+      audioChunks = [];
+    }
+
+    function _sendAudioForTranscription(blob) {
+      micBtn.classList.remove('recording');
+      micBtn.classList.add('processing');
+      micBtn.setAttribute('aria-label', '変換中…');
+      micBtn.disabled = true;
+
+      var fd = new FormData();
+      fd.append('audio', blob, 'audio.webm');
+
+      fetch(apiBase + '/api/voice/asr', {
+        method: 'POST',
+        headers: { 'x-api-key': apiKey },
+        body: fd,
+      })
+        .then(function (r) { return r.json(); })
+        .then(function (data) {
+          micBtn.classList.remove('processing');
+          micBtn.setAttribute('aria-label', '音声入力');
+          micBtn.disabled = false;
+          isRecording = false;
+          currentRecorder = null;
+          audioChunks = [];
+
+          var text = (data && data.text) ? data.text.trim() : '';
+          if (text) {
+            sendMessage(text);
+          }
+        })
+        .catch(function (err) {
+          console.warn('[FAQ Widget] ASR fetch error:', err && err.message);
+          micBtn.classList.remove('processing');
+          micBtn.classList.add('error');
+          setTimeout(function () { micBtn.classList.remove('error'); }, 500);
+          micBtn.setAttribute('aria-label', '音声入力');
+          micBtn.setAttribute('title', '音声認識に失敗しました');
+          micBtn.disabled = false;
+          isRecording = false;
+          currentRecorder = null;
+          audioChunks = [];
+        });
     }
 
     micBtn.addEventListener('click', function () {
       if (isRecording) {
-        // OFF: 即時リセット（onend を待たない）
-        _stopRecognition();
+        if (currentRecorder && currentRecorder.state === 'recording') {
+          currentRecorder.stop();
+        }
         return;
       }
 
-      // ON: 即時 UI フィードバック（二重クリック防止）
       isRecording = true;
       micBtn.classList.add('recording');
       micBtn.setAttribute('aria-label', '録音中 — タップで停止');
       resetAvatarInactivityTimer();
+      audioChunks = [];
 
-      var recognition = new SpeechRecognitionAPI();
-      recognition.lang = 'ja-JP';
-      recognition.continuous = false;
-      recognition.interimResults = true;
-      recognition.maxAlternatives = 1;
-      currentRecognition = recognition;
+      navigator.mediaDevices.getUserMedia({ audio: true })
+        .then(function (stream) {
+          var mimeType = MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
+            ? 'audio/webm;codecs=opus'
+            : MediaRecorder.isTypeSupported('audio/webm')
+              ? 'audio/webm'
+              : '';
+          var options = mimeType ? { mimeType: mimeType } : {};
+          var recorder = new MediaRecorder(stream, options);
+          currentRecorder = recorder;
 
-      recognition.onstart = function () {
-        // UI は click 時に更新済み
-      };
+          recorder.ondataavailable = function (e) {
+            if (e.data && e.data.size > 0) audioChunks.push(e.data);
+          };
 
-      recognition.onresult = function (event) {
-        var interim = '';
-        var finalText = '';
-        for (var i = event.resultIndex; i < event.results.length; i++) {
-          if (event.results[i].isFinal) {
-            finalText += event.results[i][0].transcript;
-          } else {
-            interim += event.results[i][0].transcript;
-          }
-        }
-        // 途中結果を入力欄にプレビュー表示
-        if (interim) {
-          textarea.value = interim;
-          autoResizeTextarea();
-          updateSendButton();
-        }
-        // 確定結果 → 自動送信
-        if (finalText.trim()) {
-          textarea.value = '';
-          autoResizeTextarea();
-          updateSendButton();
-          sendMessage(finalText.trim());
-        }
-      };
+          recorder.onstop = function () {
+            stream.getTracks().forEach(function (t) { t.stop(); });
+            if (audioChunks.length === 0) {
+              _resetMicState();
+              return;
+            }
+            var blob = new Blob(audioChunks, { type: mimeType || 'audio/webm' });
+            _sendAudioForTranscription(blob);
+          };
 
-      recognition.onend = function () {
-        isRecording = false;
-        currentRecognition = null;
-        micBtn.classList.remove('recording');
-        micBtn.setAttribute('aria-label', '音声入力');
-        // interim が残っていればクリア
-        if (textarea.value) {
-          textarea.value = '';
-          autoResizeTextarea();
-          updateSendButton();
-        }
-      };
+          recorder.onerror = function (e) {
+            console.warn('[FAQ Widget] MediaRecorder error:', e);
+            stream.getTracks().forEach(function (t) { t.stop(); });
+            _resetMicState();
+            micBtn.classList.add('error');
+            setTimeout(function () { micBtn.classList.remove('error'); }, 500);
+            micBtn.setAttribute('title', '録音に失敗しました');
+          };
 
-      recognition.onerror = function (event) {
-        var errCode = event && event.error;
-        console.warn('[FAQ Widget] Speech recognition error:', errCode);
-        isRecording = false;
-        currentRecognition = null;
-        micBtn.classList.remove('recording');
-        micBtn.classList.add('error');
-        setTimeout(function () { micBtn.classList.remove('error'); }, 500);
-        micBtn.setAttribute('aria-label', '音声入力');
-        var errMsg = errCode === 'not-allowed' || errCode === 'service-not-allowed'
-          ? 'マイク権限が必要です（HTTPS環境でのみ利用可能）'
-          : errCode === 'audio-capture'
-            ? 'マイクが見つかりません'
-            : errCode === 'network'
-              ? 'ネットワークエラーが発生しました'
-              : '音声認識に失敗しました';
-        micBtn.setAttribute('title', errMsg);
-      };
-
-      try {
-        recognition.start();
-      } catch (e) {
-        console.warn('[FAQ Widget] recognition.start() failed:', e && e.message);
-        isRecording = false;
-        currentRecognition = null;
-        micBtn.classList.remove('recording');
-        micBtn.classList.add('error');
-        setTimeout(function () { micBtn.classList.remove('error'); }, 500);
-        micBtn.setAttribute('title', '音声認識を開始できませんでした');
-      }
+          recorder.start();
+        })
+        .catch(function (err) {
+          console.warn('[FAQ Widget] getUserMedia error:', err && err.message);
+          _resetMicState();
+          micBtn.classList.add('error');
+          setTimeout(function () { micBtn.classList.remove('error'); }, 500);
+          var msg = (err && err.name === 'NotAllowedError')
+            ? 'マイク権限が必要です（HTTPS環境でのみ利用可能）'
+            : 'マイクが見つかりません';
+          micBtn.setAttribute('title', msg);
+        });
     });
   }
+
 
   textarea.addEventListener('input', function () {
     autoResizeTextarea();

--- a/src/api/avatar/fishAsrRoutes.ts
+++ b/src/api/avatar/fishAsrRoutes.ts
@@ -1,0 +1,82 @@
+// POST /api/voice/asr
+//   body: multipart/form-data, field "audio" (audio blob, max 25MB)
+//   認証: apiStack
+//   Fish Audio Transcribe-1 ASR → { text: string }
+
+import multer from 'multer';
+import type { Express, Request, Response, RequestHandler } from 'express';
+import type { AuthedRequest } from '../../agent/http/authMiddleware';
+import { logger } from '../../lib/logger';
+
+const FISH_ASR_API = 'https://api.fish.audio/v1/asr';
+
+const audioUpload = multer({
+  storage: multer.memoryStorage(),
+  limits: { fileSize: 25 * 1024 * 1024 },
+  fileFilter: (_req, file, cb) => {
+    if (/^audio\//i.test(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(new Error('audio file required'));
+    }
+  },
+});
+
+export function registerFishAsrRoutes(app: Express, apiStack: RequestHandler[]): void {
+  logger.info('[fishAsr] POST /api/voice/asr registered');
+
+  app.post(
+    '/api/voice/asr',
+    ...apiStack,
+    audioUpload.single('audio'),
+    async (req: Request, res: Response) => {
+      const tenantId = (req as AuthedRequest).tenantId;
+      if (!tenantId) {
+        return res.status(401).json({ error: 'unauthorized' });
+      }
+
+      if (!req.file) {
+        return res.status(400).json({ error: 'audio file required' });
+      }
+
+      const fishApiKey = process.env.FISH_AUDIO_API_KEY?.trim();
+      if (!fishApiKey) {
+        return res.status(503).json({ error: 'ASR not configured' });
+      }
+
+      try {
+        const fd = new FormData();
+        fd.append(
+          'audio',
+          new Blob([new Uint8Array(req.file.buffer)], { type: req.file.mimetype }),
+          req.file.originalname || 'audio.webm',
+        );
+        fd.append('language', 'ja');
+        fd.append('ignore_timestamps', 'true');
+
+        const fishRes = await fetch(FISH_ASR_API, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${fishApiKey}` },
+          body: fd,
+        });
+
+        if (!fishRes.ok) {
+          const detail = await fishRes.text().catch(() => '');
+          logger.warn(
+            { status: fishRes.status, detail: detail.slice(0, 200), tenantId },
+            '[fishAsr] Fish Audio ASR error',
+          );
+          return res.status(502).json({ error: 'ASR error' });
+        }
+
+        const data = (await fishRes.json()) as { text?: string };
+        const text = (data.text ?? '').trim();
+        return res.json({ text });
+
+      } catch (err) {
+        logger.error({ err, tenantId }, '[fishAsr] ASR request failed');
+        return res.status(500).json({ error: 'ASR failed' });
+      }
+    },
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,6 +63,7 @@ import { registerLiveKitTokenRoutes } from "./api/avatar/livekitTokenRoutes";
 import { registerAnamRoutes } from "./api/avatar/anamRoutes";
 import { registerAnamChatStreamRoutes } from "./api/avatar/anamChatStreamRoutes";
 import { registerFishTtsRoutes } from "./api/avatar/fishTtsRoutes";
+import { registerFishAsrRoutes } from "./api/avatar/fishAsrRoutes";
 import { registerAvatarGenerationRoutes } from "./api/admin/avatar/generationRoutes";
 import { registerFalGenerationRoutes } from "./api/admin/avatar/falGenerationRoutes";
 import { registerPremiumGenerationRoutes } from "./api/admin/avatar/premiumGenerationRoutes";
@@ -583,6 +584,8 @@ registerAnamRoutes(app, apiStack);
 registerAnamChatStreamRoutes(app, apiStack);
 // Phase42: Fish Audio TTS (Anam内蔵TTS回避 — 自然な日本語音声)
 registerFishTtsRoutes(app, apiStack);
+// Fish Audio ASR: Web Speech API 置換 — Transcribe-1 で信頼性向上
+registerFishAsrRoutes(app, apiStack);
 
 // Internal: avatar-agent → TTS/Avatar使用量レポート（X-Internal-Request: 1 認証）
 registerInternalUsageRoutes(app);


### PR DESCRIPTION
## Summary

- **新規** `POST /api/voice/asr` エンドポイント (`src/api/avatar/fishAsrRoutes.ts`)
  - multer で音声 blob (最大25MB) を受け取り、Fish Audio Transcribe-1 ASR API へ転送
  - `FISH_AUDIO_API_KEY` を TTS と共有（追加設定不要）
  - `language: 'ja'` 固定、`ignore_timestamps: true`
- **widget.js**: `SpeechRecognition` (Web Speech API) → `MediaRecorder` + `fetch /api/voice/asr`
  - Firefox・Safari でも動作（Google クラウドへの音声送信を排除）
  - マイクボタン表示条件を `window.MediaRecorder && navigator.mediaDevices && window.isSecureContext` に変更
  - 録音中 → 停止 → 変換中 → 送信 の 3 ステート UI
- **src/index.ts**: `registerFishAsrRoutes` を Fish TTS の直後に登録

## Gate Report

- **Gate 1: typecheck** — PASS (0 errors)
- **Gate 1: lint** — PASS (60 warnings < max 63)
- **Gate 1: test** — PASS (169 suites / 2005 tests)
- **Gate 1.5: dead-code** — N/A (新規ファイル + 既存mic置換のみ)
- **Gate 2: security-scan** — N/A (コード変更のみ、APIキー露出なし)
- **Gate 2.5: Codex review** — skip (Tier A code, not docs-only)
- **Gate 3: build** — 未実行（VPS build は deploy フローで実施）

## Test plan

- [ ] HTTPS 環境でマイクボタンをクリック → `getUserMedia` 権限ダイアログ表示
- [ ] 録音して停止 → `/api/voice/asr` へ POST されテキストが送信される
- [ ] Firefox でも mic ボタンが表示・動作する
- [ ] `FISH_AUDIO_API_KEY` 未設定時 → 503 が返りエラー表示
- [ ] HTTP 環境（非 HTTPS）では mic ボタンが非表示のまま

Asana GID: 1215698769931217

🤖 Generated with [Claude Code](https://claude.com/claude-code)