### PR TITLE
fix(deploy-guard): git pull を通常開発フローとして許可

### DIFF
--- a/.claude/hooks/deploy_guard.py
+++ b/.claude/hooks/deploy_guard.py
@@ -104,7 +104,6 @@ def is_blocked_in_24h_mode(cmd: str) -> bool:
 # The official deploy command is covered by ALLOWED_DEPLOY_COMMANDS allowlist.
 DEPLOY_KEYWORDS = [
     'pm2',
-    'git pull',
     # 'git push' is intentionally omitted — normal dev workflow, not a deploy action
     # 'pnpm build' / 'npm build' are omitted — local builds are normal dev workflow;
     # VPS builds are already caught via 'ssh root@' keyword


### PR DESCRIPTION
## Summary
- \`git pull\` を DEPLOY_KEYWORDS から除外
- \`git push\` と同様にローカル開発フローとして扱う（VPS での git pull とは無関係）

## Test plan
- [ ] \`git pull\` がClaude Code Bash hookでブロックされないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)