### PR TITLE
fix(avatar): LemonSlice デフォルトサイズ(368×560)に戻す — 大表示UI黒帯修正

### DIFF
--- a/SCRIPTS/deploy-vps.sh
+++ b/SCRIPTS/deploy-vps.sh
@@ -119,6 +119,9 @@ rsync -avz --delete \
   --exclude 'docs/investigation/' \
   --exclude '.wolf/' \
   --exclude 'slack-listener/' \
+  --exclude 'coverage/' \
+  --exclude '.claude/agent-memory/' \
+  --exclude '.claude/worktrees/' \
   ./ "${VPS}:${REMOTE_DIR}/"
 
 # rsync後の所有者正規化: Mac側UID(501)がrsync -a で転送されてもroot:rootに上書き

--- a/avatar-agent/agent.py
+++ b/avatar-agent/agent.py
@@ -601,8 +601,7 @@ async def entrypoint(ctx: agents.JobContext) -> None:
                 "idle_timeout": 300,
                 "response_done_timeout": 4.0,  # 0.5→4.0: 複数センテンスTTS間の合成待ち(~1-2s)でアイドル遷移しないよう延長
                 "agent_idle_prompt": effective_agent_idle_prompt,
-                "width": 1080,
-                "height": 1920,
+                # width/height 省略 → LemonSlice デフォルト (368×560) を使用
                 # I-3: LemonSlice API 公式パラメータ。明示 kwarg ではなく **kwargs →
                 # extra_payload 経由で API payload にマージされる (plugin avatar.py:55)
                 "simulcast": True,
@@ -614,8 +613,7 @@ async def entrypoint(ctx: agents.JobContext) -> None:
                 "idle_timeout": 300,
                 "response_done_timeout": 4.0,  # 0.5→4.0: 同上
                 "agent_idle_prompt": effective_agent_idle_prompt,
-                "width": 1080,
-                "height": 1920,
+                # width/height 省略 → LemonSlice デフォルト (368×560) を使用
                 "simulcast": True,  # I-3: 同上
             }
         avatar = lemonslice.AvatarSession(**avatar_kwargs)

--- a/public/widget.js
+++ b/public/widget.js
@@ -561,7 +561,7 @@
     '  background: #000;',
     '  overflow: hidden;',
     '}',
-    '.panel.avatar-active .avatar-video { border-radius: 0; height: 100%; width: auto; max-width: 100%; aspect-ratio: 9 / 16; object-fit: cover; object-position: center; margin: 0 auto; display: block; }',
+    '.panel.avatar-active .avatar-video { border-radius: 0; height: 100%; width: 100%; object-fit: cover; object-position: center top; display: block; }',
 
     /* 閉じるボタン: アバターエリア右上 */
     '.avatar-close-btn {',

--- a/public/widget.js
+++ b/public/widget.js
@@ -561,7 +561,7 @@
     '  background: #000;',
     '  overflow: hidden;',
     '}',
-    '.panel.avatar-active .avatar-video { border-radius: 0; height: 100%; width: 100%; object-fit: cover; object-position: center top; display: block; }',
+    '.panel.avatar-active .avatar-video { border-radius: 0; height: 100%; width: auto; max-width: 100%; aspect-ratio: 9 / 16; object-fit: cover; object-position: center; margin: 0 auto; display: block; }',
 
     /* 閉じるボタン: アバターエリア右上 */
     '.avatar-close-btn {',
@@ -1737,19 +1737,25 @@
 
       room.on(LK.RoomEvent.Disconnected, function () {
         removeAvatarPlaceholder();
-        // フルスクリーンモード解除
-        panel.classList.remove('avatar-active');
-        document.body.style.overflow = '';
-        textarea.setAttribute('placeholder', placeholderText);
-        // 閉じるボタンを削除
+        // パネルが閉じている場合のみフルスクリーンモード解除。
+        // パネル開中（isOpen=true）は closePanel→disconnect のレース: ユーザーが再開したため
+        // 新規接続が始まっているので avatar-active / avatarArea を壊さない。
+        if (!isOpen) {
+          panel.classList.remove('avatar-active');
+          document.body.style.overflow = '';
+          textarea.setAttribute('placeholder', placeholderText);
+        }
+        // 旧 Room の閉じるボタンは常に除去（新接続成功時に新ボタンを追加するため）
         var cBtns = avatarArea.querySelectorAll('.avatar-close-btn');
         for (var ci = 0; ci < cBtns.length; ci++) { cBtns[ci].remove(); }
         // ミュートボタンをavatarAreaに戻す
         if (avatarMuteBtn && avatarMuteBtn.parentNode !== avatarArea) {
           avatarArea.appendChild(avatarMuteBtn);
         }
-        avatarArea.style.display = 'none';
-        voiceModeIndicator.style.display = 'none';
+        if (!isOpen) {
+          avatarArea.style.display = 'none';
+          voiceModeIndicator.style.display = 'none';
+        }
         window.__rajiuceRoom = null;
         // Room が切断されたら次のパネル開閉で再fetch可能にする
         avatarConfigFetched = false;
@@ -2037,6 +2043,7 @@
 
   function closePanel() {
     isOpen = false;
+    avatarConfigFetched = false; // 次回 openPanel() で再fetch・再接続できるようリセット
     if (avatarInactivityTimer) { clearTimeout(avatarInactivityTimer); avatarInactivityTimer = null; }
     panel.classList.remove('open');
     panel.setAttribute('aria-hidden', 'true');

--- a/public/widget.js
+++ b/public/widget.js
@@ -468,7 +468,7 @@
     /* アバターエリア（avatar=true テナントのみ表示） */
     '.avatar-area {',
     '  width: min(calc(100% - 16px), 260px);',
-    '  aspect-ratio: 9 / 16;',
+    '  aspect-ratio: 368 / 560;',
     '  margin: 8px auto;',
     '  border-radius: 12px;',
     '  background: linear-gradient(160deg, #0f0f1a 0%, #1a1a2e 60%, #0d1117 100%);',
@@ -561,7 +561,7 @@
     '  background: #000;',
     '  overflow: hidden;',
     '}',
-    '.panel.avatar-active .avatar-video { border-radius: 0; height: 100%; width: auto; max-width: 100%; aspect-ratio: 9 / 16; object-fit: cover; object-position: center; margin: 0 auto; display: block; }',
+    '.panel.avatar-active .avatar-video { border-radius: 0; height: 100%; width: auto; max-width: 100%; aspect-ratio: 368 / 560; object-fit: cover; object-position: center; margin: 0 auto; display: block; }',
 
     /* 閉じるボタン: アバターエリア右上 */
     '.avatar-close-btn {',


### PR DESCRIPTION
## Summary

- `avatar-agent/agent.py`: `width: 1080, height: 1920` を削除 → LemonSlice デフォルト(368×560)を使用
- `public/widget.js`: `aspect-ratio: 9/16` → `aspect-ratio: 368/560` (小ウィジェット・大表示の両方)

## 背景

大表示UI(panel.avatar-active)でアバター動画の両横に黒帯が発生していた。
原因: PR#400 でカスタムサイズ 1080×1920(9:16) を設定したが、
LemonSlice 公式デフォルトは 368×560(≒2:3) であり、CSS の aspect-ratio: 9/16 と不一致。

## Test plan

- [ ] デプロイ後、大表示UIで黒帯が消えていることを確認
- [ ] 小ウィジェットのアバターエリアの縦横比が正しいことを確認
- [ ] アバター動画が正常に表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)