### PR TITLE
fix(avatar): 33秒折りたたみタイマーを映像表示時点に起点変更

### DIFF
--- a/public/widget.js
+++ b/public/widget.js
@@ -1696,6 +1696,11 @@
           if (isOpen) {
             // パネル展開中: avatarAreaに直接追加
             avatarArea.appendChild(videoEl);
+            // アバター映像が実際に表示された瞬間を 33 秒タイマーの起点にする。
+            // 接続成功(room.connect)時点で起動すると LemonSlice のコールドスタート
+            // (映像表示まで ~20s) 分だけ前倒しで折りたたまれ、「立ち上がって ~10 秒で消える」
+            // 症状になる。映像表示時に起動し直して全 33 秒を可視時間に充てる。
+            setAvatarActive();
           } else {
             // パネル閉鎖中: FABにビデオを表示（アイドルモーション表示）
             showFabMedia(videoEl);


### PR DESCRIPTION
## 症状

初回 open でアバターが立ち上がってから **~10秒で大表示が折りたたまれ**、通常チャットに戻る（LiveKit 接続自体は切れていない）。

## 根本原因

`AVATAR_INACTIVITY_MS`（33秒）の非アクティブ折りたたみタイマー（PR #401）が **`room.connect()` 成功時点**で起動していた。

LemonSlice はコールドスタートで映像表示まで **~20秒**かかるため、ユーザーに映像が見えた時点で既に 33秒の大半が経過 → 残り ~10秒で `collapseAvatarLargeView()` が発火していた。

タイムライン:
| t | イベント | タイマー |
|---|---|---|
| 0s | openPanel（キャッシュありなら setAvatarActive） | 33秒開始 |
| ~3-5s | room.connect().then() → setAvatarActive | 33秒リセット |
| ~20-25s | TrackSubscribed(video) でアバター映像表示 | **リセットされない** ← バグ |
| ~36s | タイマー発火 → 大表示折りたたみ | 映像表示から ~10秒後 |

「33秒の実装が反映されていないのでは」という見立てに対し、値（33000ms）自体は本番に正しく入っていたが、**タイマーの起点が映像表示前**だったのが真因。

## 修正

`TrackSubscribed`(video) で映像が**実際に表示された瞬間**に `setAvatarActive()` を呼び、33秒タイマーを起動し直す。可視時間の全 33秒を確保する。パネル展開中（`isOpen`）のみ。閉鎖中は FAB 表示なので従来通り。

```js
if (isOpen) {
  avatarArea.appendChild(videoEl);
  setAvatarActive();   // ← 追加: 映像表示時にタイマー起点をリセット
} else {
  showFabMedia(videoEl);
}
```

## 影響範囲

`public/widget.js`（Tier S）5行追加のみ。接続ロジック・CSS 変更なし。`fix/avatar-immediate-collapse-race`(#420, merged) / 黒帯修正(#422) とは独立。

🤖 Generated with [Claude Code](https://claude.com/claude-code)