### PR TITLE
ci(claude-review): API クレジット切れによる赤 CI を continue-on-error で抑制

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,6 +19,8 @@ jobs:
     name: Claude PR Review
     runs-on: ubuntu-latest
     timeout-minutes: 30
+    # API クレジット切れ等の一時障害で PR をブロックしない (CI fix #99032)
+    continue-on-error: true
     # pull_request は全件実行、コメントは @claude メンション時のみ
     if: |
       github.event_name == 'pull_request' ||


### PR DESCRIPTION
## 問題

PR #416 (commit 67bfc4a) で Claude PR Review CI が失敗し、CI fix task が自動生成された。

**根本原因**: `ANTHROPIC_API_KEY` のクレジット残高不足
```
Action failed with error: SDK execution error: Error: Claude Code returned an error result: Credit balance is too low
```

このエラーは複数 PR で発生中（#416, lemonslice-default-size, avatar-immediate-collapse-race 等）。

## 対応

`continue-on-error: true` を Claude PR Review ジョブに追加し、API 障害時に赤 CI が出ないようにする。

- このチェックはブランチ保護の required 対象外（merge はもともと阻害されていない）
- クレジット補充後は `continue-on-error: true` を削除することで自動的にブロッキング動作に戻る

## 別途必要な対応（コードで不可）

⚠️ Anthropic コンソールで `ANTHROPIC_API_KEY` アカウントのクレジットを補充してください

## Gate 1-3

- typecheck: N/A (CI config only)
- lint: N/A
- test: N/A
- security: N/A (no secrets, CI config change only)
- build: N/A
- Gate 2.5: skip (CI config only)

## Asana GID

ci-27532509149

🤖 Generated with [Claude Code](https://claude.com/claude-code)