### PR TITLE
fix(widget): アバター大表示の正方形潰れを堅牢化 + 10秒切断DIAG

### DIFF
--- a/public/widget.js
+++ b/public/widget.js
@@ -531,11 +531,13 @@
     '.panel.avatar-active {',
     '  background: linear-gradient(135deg, #050510 0%, #0a0a1a 100%);',
     '  overscroll-behavior: contain;',
+    /* アバター列は LemonSlice 既定 368×560 をパネル高さから算出（auto+aspect-ratio の正方形潰れを回避） */
+    '  --avatar-h: min(640px, calc(100vh - 80px));',
     '  display: grid;',
-    '  grid-template-columns: auto minmax(280px, 1fr);',
+    '  grid-template-columns: calc(var(--avatar-h) * 368 / 560) minmax(280px, 1fr);',
     '  grid-template-rows: auto 1fr auto;',
     '  width: min(1080px, calc(100vw - 48px));',
-    '  height: min(640px, calc(100vh - 80px));',
+    '  height: var(--avatar-h);',
     '}',
 
     /* ヘッダー: 右カラム上部（ダークテーマ） */
@@ -554,9 +556,7 @@
     '  grid-row: 1 / 4;',
     '  position: relative;',
     '  height: 100%;',
-    '  width: auto;',
-    '  aspect-ratio: 368 / 560;',
-    '  max-width: 48%;',
+    '  width: 100%;',
     '  min-height: unset;',
     '  max-height: unset;',
     '  margin: 0;',
@@ -1691,6 +1691,7 @@
 
       room.on(LK.RoomEvent.TrackSubscribed, function (track) {
         if (track.kind === 'video') {
+          console.log('[FAQ Widget][DIAG] video TrackSubscribed source=' + track.source + ' sid=' + track.sid + ' t=' + Math.round(performance.now()) + 'ms');
           removeAvatarPlaceholder();
           var videoEl = track.attach();
           videoEl.className = 'avatar-video';
@@ -1734,6 +1735,7 @@
       });
 
       room.on(LK.RoomEvent.TrackUnsubscribed, function (track) {
+        console.warn('[FAQ Widget][DIAG] TrackUnsubscribed kind=' + track.kind + ' source=' + track.source + ' sid=' + track.sid + ' t=' + Math.round(performance.now()) + 'ms');
         if (track.kind === 'video') {
           var videos = avatarArea.querySelectorAll('.avatar-video');
           for (var i = 0; i < videos.length; i++) { videos[i].remove(); }
@@ -1744,7 +1746,9 @@
         }
       });
 
-      room.on(LK.RoomEvent.Disconnected, function () {
+      room.on(LK.RoomEvent.Disconnected, function (reason) {
+        console.warn('[FAQ Widget][DIAG] room Disconnected reason=' + reason + ' isOpen=' + isOpen + ' t=' + Math.round(performance.now()) + 'ms');
+        emitAvatarStatus({ enabled: false, provider: 'lemonslice', reason: 'disconnected:' + reason });
         removeAvatarPlaceholder();
         // パネルが閉じている場合のみフルスクリーンモード解除。
         // パネル開中（isOpen=true）は closePanel→disconnect のレース: ユーザーが再開したため


### PR DESCRIPTION
## 背景（重要な発見）
- 本番 widget.js は `47129536`(6/15デプロイ・正方形フィル版)で、これは **origin/main に存在しないローカル直コミット**。一方 main には #421(368×560)/#422(黒帯解消)がマージ済みだが**未デプロイ**だった。
- 旧 PR #426 はその取り残し基準+9:16で作ってしまい obsolete → close 済み。本PRは **origin/main 基準で作り直し**。

## ① サイズ（正方形潰れの根治）
#422 の `grid-template-columns: auto` + `.avatar-area{aspect-ratio:368/560}` は、avatar-area が `1fr` 行をスパンして高さが不定になり **auto 列がアスペクト比から幅を解決できず正方形に潰れる**(ブラウザ依存の脆さ)。
→ パネル高さ起点の calc で列幅を固定:
```
--avatar-h: min(640px, calc(100vh - 80px));
grid-template-columns: calc(var(--avatar-h) * 368 / 560) minmax(280px, 1fr);
```
avatar-area は `width:100%` に簡素化。368×560 に厳密一致、黒帯/正方形なし。循環参照なし。

## ② 10秒切断 DIAG（暫定計測）
"大表示後 ~10秒でアバターが消え通常チャットUIに戻る" は **LiveKit ルーム切断**が原因(widgetは正しく反応しているだけ)。reason 不明のため計測ログを追加:
- TrackSubscribed/TrackUnsubscribed/Disconnected に `[FAQ Widget][DIAG]` + 経過ms
- Disconnected の LiveKit `reason` を console + テストチャット状態表示へ surface

→ デプロイ後に reason を確定し、本修正(おそらく avatar-agent 側=人間承認デプロイ)へ。**DIAG は根因特定後に撤去**。

## 確認
CSSのみ+console計測。`node --check` 通過。本番反映は `bash SCRIPTS/deploy-vps.sh`(人間承認)。デプロイ→Cmd+Shift+R→大表示で再現し reason を共有してください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)