### PR TITLE
fix(deps): ws 8.21.0 へ — GHSA-96hv-2xvq-fx4p (HIGH) 解消で security-scan を緑化

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "overrides": {
       "undici": ">=6.24.0",
       "path-to-regexp": ">=8.4.2",
+      "ws": ">=8.21.0 <9",
       "axios": ">=1.15.0",
       "minimatch": ">=9.0.7 <10",
       "protobufjs": ">=7.5.6 <8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,7 @@ settings:
 overrides:
   undici: '>=6.24.0'
   path-to-regexp: '>=8.4.2'
+  ws: '>=8.21.0 <9'
   axios: '>=1.15.0'
   minimatch: '>=9.0.7 <10'
   protobufjs: '>=7.5.6 <8'
@@ -3549,8 +3550,8 @@ packages:
     resolution: {integrity: sha512-+QU2zd6OTD8XWIJCbffaiQeH9U73qIqafo1x6V1snCWYGJf6cVE0cDR4D8xRzcEnfI21IFrUPzPGtcPf8AC+Rw==}
     engines: {node: ^14.17.0 || ^16.13.0 || >=18.0.0}
 
-  ws@8.18.3:
-    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+  ws@8.21.0:
+    resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
     peerDependencies:
       bufferutil: ^4.0.1
@@ -4449,7 +4450,7 @@ snapshots:
       '@types/phoenix': 1.6.6
       '@types/ws': 8.18.1
       tslib: 2.8.1
-      ws: 8.18.3
+      ws: 8.21.0
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -7349,7 +7350,7 @@ snapshots:
       imurmurhash: 0.1.4
       signal-exit: 4.1.0
 
-  ws@8.18.3: {}
+  ws@8.21.0: {}
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
## 問題
open PR (#427, #428) の `security-scan` が両方 FAIL。原因は私のCI変更ではなく**既存の依存脆弱性**:

- `ws@8.18.3`（経路: `@supabase/supabase-js > @supabase/realtime-js > ws`）が DoS 脆弱性 **GHSA-96hv-2xvq-fx4p**（patched: `>=8.21.0`）
- `security-scan.sh` の `pnpm audit --production --audit-level=high` が HIGH=1 で exit 1 → ゲート赤

## 修正
既存 `pnpm.overrides` の**同一メジャー作法**（例: `minimatch ">=9.0.7 <10"`）に倣い:

```json
"ws": ">=8.21.0 <9"
```

`ws@8.18.3 → 8.21.0`（同一メジャー patch・安全）。

## 検証（Node 20.19.5）
- `pnpm install` OK → `ws@8.21.0` 解決
- `pnpm audit --production --audit-level=high` → **exit 0**（残 high は ignore 済 `CVE-2026-45134` のみ）
- `bash SCRIPTS/security-scan.sh` → **Result: PASS**（CRITICAL/HIGH=0）

## 補足
本PRがマージされれば main の security-scan が緑に戻る。#427/#428 は main を取り込めば（rebase / update-branch）同ゲートが緑化する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)