### PR TITLE
fix(widget): アバター大表示が映像到着前に33秒で畳まれる症状を解消

### DIFF
--- a/public/widget.js
+++ b/public/widget.js
@@ -2152,6 +2152,13 @@
   function resetAvatarInactivityTimer() {
     if (avatarInactivityTimer) { clearTimeout(avatarInactivityTimer); avatarInactivityTimer = null; }
     if (!panel.classList.contains('avatar-active')) return;
+    // 折りたたみタイマーは「ライブアバターが実際に表示されている時」だけ起動する。
+    // 接続前の静止画プレースホルダー表示中（fabVideoEl 未設定 / Anam 未ストリーム）に
+    // アームすると、映像が来ないまま 33 秒で大表示が畳まれ「大表示にしたのに静止画のまま、
+    // ~10 秒でアバターが消えて通常チャットに戻る」症状になる。#424 は映像到着パス（L1707）
+    // のみ対処しており、映像が来ない／アバター OFF パスはここで防ぐ。
+    var avatarLive = !!fabVideoEl || (avatarProvider === 'anam' && (anamClient || window.__anamClient));
+    if (!avatarLive) return;
     avatarInactivityTimer = setTimeout(collapseAvatarLargeView, AVATAR_INACTIVITY_MS);
   }
 


### PR DESCRIPTION
## 症状
リアルタイムアバター大表示時、映像が来ないと静止画プレースホルダーのまま大表示が約10秒(実体は33秒タイマー − コールドスタート待ち)で畳まれ、通常チャットUIに戻る。

## 根本原因
`resetAvatarInactivityTimer()` が呼ばれる `setAvatarActive()` は openPanel / fetchAvatarConfig / room.connect 成功など**ライブ映像が来る前**の地点でも実行され、その都度33秒折りたたみタイマーをアームしていた。PR #424 は「映像が実際に表示された瞬間(TrackSubscribed video)に再アーム」して映像が来るパスのみ対処したが、**映像が来ない / アバターOFFパスは未対応**で旧症状が残存していた。

## 修正
`resetAvatarInactivityTimer()` 内で、ライブアバターが実際に表示されている時だけタイマーをアームするようガード:

```js
var avatarLive = !!fabVideoEl || (avatarProvider === 'anam' && (anamClient || window.__anamClient));
if (!avatarLive) return;
```

- 静止画プレースホルダー表示中 → 畳まない(大表示を維持、映像が立つまで待つ)
- ライブ映像表示後 → 従来どおり無操作33秒で畳む

`public/widget.js` 1ファイル / 1関数のみ、7行追加。`node --check` パス。

## 検証メモ
- 本修正で直るのは「静止画→約10秒で消える」UX。
- 「静止画のまま映像が来ない(アバターが動かない)」根本は LiveKit 無料枠超過(429) / avatar-agent 状態のインフラ側で、別途実機確認が必要。
- widget.js は本番VPS配信のため、反映には通常のデプロイ手順(人間承認)が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
