### PR TITLE
fix(deps): multer 2.2.0 / undici 6.27.0 へ上げ high advisory 2件を解消

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "packageManager": "pnpm@9.15.9",
   "pnpm": {
     "overrides": {
-      "undici": ">=6.24.0",
+      "undici": ">=6.27.0 <7",
       "path-to-regexp": ">=8.4.2",
       "ws": ">=8.21.0 <9",
       "axios": ">=1.15.0",
@@ -133,7 +133,7 @@
     "js-yaml": "^4.1.1",
     "jsonwebtoken": "^9.0.3",
     "livekit-server-sdk": "^2.15.0",
-    "multer": "^2.1.1",
+    "multer": "^2.2.0",
     "pdf-parse": "1.1.1",
     "pdf2pic": "^3.2.0",
     "pg": "8.16.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  undici: '>=6.24.0'
+  undici: '>=6.27.0 <7'
   path-to-regexp: '>=8.4.2'
   ws: '>=8.21.0 <9'
   axios: '>=1.15.0'
@@ -57,8 +57,8 @@ importers:
         specifier: ^2.15.0
         version: 2.15.0
       multer:
-        specifier: ^2.1.1
-        version: 2.1.1
+        specifier: ^2.2.0
+        version: 2.2.0
       pdf-parse:
         specifier: 1.1.1
         version: 1.1.1
@@ -2597,8 +2597,8 @@ packages:
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
 
-  multer@2.1.1:
-    resolution: {integrity: sha512-mo+QTzKlx8R7E5ylSXxWzGoXoZbOsRMpyitcht8By2KHvMbf3tjwosZ/Mu/XYU6UuJ3VZnODIrak5ZrPiPyB6A==}
+  multer@2.2.0:
+    resolution: {integrity: sha512-6rdyFg2kLrMh9Jee7/BMPuV9lEAd7lLW2YUpF9/YxR7njyoUwwQ0ZPh3TaIY50Sw6vlyD2HW3wGOkTS4P79xrQ==}
     engines: {node: '>= 10.16.0'}
 
   multimatch@5.0.0:
@@ -3441,8 +3441,8 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@6.24.1:
-    resolution: {integrity: sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==}
+  undici@6.27.0:
+    resolution: {integrity: sha512-YmfV3YnEDzXRC5lZ2jWtWWHKGUm1zIt8AhesR1tens+HTNv+YZlN/dp6G727LOvMJ8xjP9Be7Y2Sdr96LDm+pg==}
     engines: {node: '>=18.17'}
 
   unpipe@1.0.0:
@@ -3826,7 +3826,7 @@ snapshots:
       ms: 2.1.3
       secure-json-parse: 3.0.2
       tslib: 2.8.1
-      undici: 6.24.1
+      undici: 6.27.0
     transitivePeerDependencies:
       - supports-color
 
@@ -4718,7 +4718,7 @@ snapshots:
       is-buffer: 2.0.5
       is-node-process: 1.2.0
       throttleit: 2.1.0
-      undici: 6.24.1
+      undici: 6.27.0
 
   accepts@2.0.0:
     dependencies:
@@ -6332,7 +6332,7 @@ snapshots:
 
   ms@2.1.3: {}
 
-  multer@2.1.1:
+  multer@2.2.0:
     dependencies:
       append-field: 1.0.0
       busboy: 1.6.0
@@ -7219,7 +7219,7 @@ snapshots:
 
   undici-types@7.16.0: {}
 
-  undici@6.24.1: {}
+  undici@6.27.0: {}
 
   unpipe@1.0.0: {}
 


### PR DESCRIPTION
## 背景
`pnpm audit` (security-scan) が high 2件を検出し、全PRの security-scan が FAIL していた。PR #430 のスキャン失敗もこの依存advisoryが原因（アバター修正自体は無関係）。

## 修正（同一メジャー内バンプ）
| パッケージ | 変更 | Advisory |
|---|---|---|
| multer | `^2.1.1` → `^2.2.0` | GHSA-72gw-mp4g-v24j (deeply nested field names DoS) |
| undici (override) | `>=6.24.0` → `>=6.27.0 <7` | GHSA-vxpw-j846-p89q (WebSocket fragment count bypass DoS) |

undici は `@elastic/elasticsearch` → `@elastic/transport` 経由の推移依存のため override で固定。解決バージョン: undici 6.27.0 / multer 2.2.0。

## 検証
- `bash SCRIPTS/security-scan.sh` → CRITICAL/HIGH: **0** で PASS
- install は Node 20 で実施（lockfile 更新）
- typecheck パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)
