### PR TITLE
fix(avatar-agent): 歓迎メッセージをチャット吹き出しにも表示

### DIFF
--- a/avatar-agent/agent.py
+++ b/avatar-agent/agent.py
@@ -669,6 +669,14 @@ async def entrypoint(ctx: agents.JobContext) -> None:
     session.say(initial_greeting)
     logger.info(f"[avatar] idle animation kickstart: {initial_greeting!r}")
 
+    # 歓迎メッセージも通常返信(handle_chat)と同様に Data Channel へ送り、Widget の
+    # チャット吹き出し(messages UI)に表示させる。これが無いと session.say() の音声/字幕
+    # だけが出てチャット履歴に吹き出しが残らない（agent_reply 未送出の不整合）。
+    if ctx.room.local_participant:
+        payload = json.dumps({"type": "agent_reply", "text": initial_greeting}).encode()
+        await ctx.room.local_participant.publish_data(payload, reliable=True)
+        logger.info("[data_channel] initial_greeting agent_reply sent to widget")
+
 
 if __name__ == "__main__":
     agents.cli.run_app(


### PR DESCRIPTION
## 症状
大表示でアバターが自動で喋り始めても、チャットメッセージUI(吹き出し)に表示されず、アバターの下に素のテキストだけが出る。

## 根本原因
`avatar-agent/agent.py` で、Widget のチャット吹き出しに出るのは Data Channel 経由で `{"type":"agent_reply","text":...}` を publish した時だけ（widget.js の DataReceived は agent_reply のみ吹き出し化）。

通常返信(`handle_chat`)は `session.say(reply)` の後に `publish_data(agent_reply)` を送るが、**歓迎メッセージ(entrypoint 末尾)は `session.say()` だけで publish_data が抜けていた**。そのため音声/字幕（LiveKit transcription / LemonSlice）だけが出て、チャット履歴に吹き出しが残らなかった。

## 修正
歓迎メッセージの `session.say()` 直後に、通常返信と同型の `publish_data({"type":"agent_reply","text":initial_greeting})` を追加。`session.say()` と `publish_data(agent_reply)` は必ずペアで呼ぶ規約に合わせた。

`avatar-agent/agent.py` のみ、8行追加。`python3 -m py_compile` パス。

## デプロイ
avatar-agent の再デプロイが必要（widget.js とは別経路）。
