### PR TITLE
fix(admin-ui): AI FAB を ✨AIアシスタントに一本化（旧「?」サポートAI FAB撤去）

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -19,7 +19,6 @@ import ChatHistoryPage from "./pages/admin/chat-history/index";
 import ChatHistorySessionPage from "./pages/admin/chat-history/[sessionId]";
 import TuningPage from "./pages/admin/tuning/index";
 import FeedbackPage from "./pages/admin/feedback/index";
-import AdminAIChat from "./components/AdminAIChat";
 import AdminAgentButton from "./components/AdminAgent/AdminAgentButton";
 import AdminAgentPanel from "./components/AdminAgent/AdminAgentPanel";
 import AvatarListPage from "./pages/admin/avatar/index";
@@ -186,9 +185,8 @@ function AppInner() {
         {/* それ以外のパスは管理ダッシュボードへ */}
         <Route path="*" element={<Navigate to="/admin" replace />} />
       </Routes>
-      {/* 管理AIチャット — Client Admin、chat-testページを除く */}
-      {showAIChat && <AdminAIChat />}
-      {/* R2C AIアシスタント — super_admin/client_admin 共通、chat-testページを除く */}
+      {/* R2C AIアシスタント（✨）に一本化 — 旧サポートAI(AdminAIChat「?」)のFABは撤去 */}
+      {/* super_admin/client_admin 共通、chat-testページを除く */}
       {showAIChat && (
         <>
           <AdminAgentButton


### PR DESCRIPTION
## 症状
Admin管理画面の右下にAIのFABアイコンが2つ並んで表示され紛らわしい（紫「?」と青「✨」）。

## 調査結果（バグではなく別々の2機能）
- 紫「?」= `AdminAIChat`（Phase43 管理画面サポートAI / 使い方ガイド + business FAQ）right:88px
- 青「✨」= `AdminAgent`（Phase72 AIアシスタント・エージェント）right:24px

ウィジェット(public/widget.js)の二重読み込みではなく、admin-ui内の2コンポーネントが意図的に隣接配置されていた。

## 対応（✨に一本化）
App.tsx から `AdminAIChat` のレンダリング(`{showAIChat && <AdminAIChat />}`)と import を撤去。✨ `AdminAgent`（Button/Panel）は継続。`showAIChat` は AdminAgent 側で引き続き使用。

`AdminAIChat.tsx` コンポーネント本体は残置（ファイル削除は別タスク）。

## 検証
- admin-ui `tsc -b` パス
- `pnpm lint` パス（59 warnings < 閾値63、admin-ui由来の新規警告ゼロ）

## デプロイ
admin-ui は Cloudflare Pages 配信（main push で自動ビルド）。
