### PR TITLE
fix(admin-ui): 知識データ「成約への貢献度」タブの白画面を解消（Chart.js未登録）

### DIFF
--- a/admin-ui/src/components/knowledge/KnowledgeAttributionTab.tsx
+++ b/admin-ui/src/components/knowledge/KnowledgeAttributionTab.tsx
@@ -3,8 +3,23 @@
 // FAQ/書籍チャンクの利用頻度・CV寄与を可視化する。
 
 import { useCallback, useEffect, useMemo, useState, type CSSProperties } from "react";
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Title,
+  Tooltip,
+  Legend,
+} from "chart.js";
 import { Bar } from "react-chartjs-2";
 import { authFetch, API_BASE } from "../../lib/api";
+
+// react-chartjs-2 の <Bar> 描画に必要な Chart.js コンポーネントを登録（idempotent）。
+// 登録は analytics ページ側のモジュールでしか実行されておらず、analytics を先に開いて
+// いないセッションで知識データの「成約への貢献度」タブを開くと未登録で <Bar> が throw し、
+// エラーバウンダリが無いためページ全体が白くなる。本コンポーネントでも登録して防ぐ。
+ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend);
 
 type Period = "7d" | "30d" | "90d";
 type SourceType = "all" | "faq" | "book";


### PR DESCRIPTION
## 症状
Admin管理画面「AIの知識データ」ページが真っ白になる。

## 根本原因
`KnowledgeAttributionTab`（「成約への貢献度」タブ）は `react-chartjs-2` の `<Bar>` を使うが、Chart.js コンポーネント（CategoryScale 等）を `ChartJS.register()` していない。登録は analytics ページのモジュール（`analytics/index.tsx`・`FlowAnalyticsPage.tsx`）でしか実行されない。

→ analytics を先に開いていないセッションでこのタブを開くと、未登録のまま `<Bar>` が throw。admin-ui にエラーバウンダリが無いため、ページ全体が白画面になる（「時々は動く」間欠症状＝analyticsを先に踏んだ時だけ登録済みで動く）。

## 修正
`FlowAnalyticsPage.tsx` と同一セット（CategoryScale/LinearScale/BarElement/Title/Tooltip/Legend）を `KnowledgeAttributionTab.tsx` でも `ChartJS.register()`（idempotent）。

`admin-ui/src/components/knowledge/KnowledgeAttributionTab.tsx` のみ。typecheck / lint パス。

## 補足（別途検討）
admin-ui にエラーバウンダリが無く、1コンポーネントの throw で画面全体が白くなる構造。今回の直接原因とは別に、エラーバウンダリ追加を別タスクで検討推奨。

## デプロイ
admin-ui は Cloudflare Pages（main push で自動ビルド）。
