### PR TITLE
test(e2e): widget-fab-avatarが本番LemonSliceに実課金していたのを修正

### DIFF
--- a/tests/e2e/widget-fab-avatar.spec.ts
+++ b/tests/e2e/widget-fab-avatar.spec.ts
@@ -20,6 +20,40 @@ test.describe('Widget FAB — Avatar persistence on chat open/close', () => {
   // 未指定時はアバター版にフォールバック → test 3 は従来どおり skip される（誤検証を防ぐ）。
   const NON_AVATAR_DEMO_URL = process.env.E2E_NON_AVATAR_TEST_URL || AVATAR_DEMO_URL;
 
+  // このスイートは毎回 .fab をクリックして isOpen=true にする → widget.js が
+  // POST /api/avatar/room-token を connect:true で送る → サーバー側で実際に
+  // LiveKitエージェント経由の LemonSlice アバターセッションが起動し課金が発生する
+  // (dispatchAgentToRoom はレスポンスを返す前に fire-and-forget で呼ばれるため、
+  // クライアント側でレスポンスをどう扱っても後から止められない)。
+  // ここでリクエストをブラウザ側でインターセプトし、本番バックエンドに一切到達させずに
+  // FABサムネイル永続化ロジック(UI挙動)だけを検証する。
+  async function mockAvatarBackend(page: any) {
+    await page.route('**/api/avatar/anam-session', (route: any) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ enabled: false }),
+      })
+    );
+    await page.route('**/api/avatar/room-token', (route: any) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          enabled: true,
+          livekitUrl: 'wss://e2e-mock.invalid',
+          token: 'e2e-mock-token',
+          roomName: 'e2e-mock-room',
+          agentId: 'e2e-mock-agent',
+          imageUrl:
+            'https://rpqrwifbrhlebbelyqog.supabase.co/storage/v1/object/public/avatar-defaults/default_01.png',
+          avatarName: 'E2E Mock Avatar',
+          preDispatchEnabled: false,
+        }),
+      })
+    );
+  }
+
   /** Wait for FAB to appear inside the widget Shadow DOM */
   async function getFabState(page: any) {
     return page.evaluate(() => {
@@ -38,6 +72,7 @@ test.describe('Widget FAB — Avatar persistence on chat open/close', () => {
   }
 
   test('FAB retains avatar image after chat close (single cycle)', async ({ page }) => {
+    await mockAvatarBackend(page);
     // Navigate to carnation demo — widget initializes with avatar config
     const resp = await page.goto(AVATAR_DEMO_URL);
     expect(resp?.status()).toBe(200);
@@ -92,6 +127,7 @@ test.describe('Widget FAB — Avatar persistence on chat open/close', () => {
   });
 
   test('FAB retains avatar image across multiple open/close cycles', async ({ page }) => {
+    await mockAvatarBackend(page);
     const resp = await page.goto(AVATAR_DEMO_URL);
     expect(resp?.status()).toBe(200);
 
@@ -135,6 +171,12 @@ test.describe('Widget FAB — Avatar persistence on chat open/close', () => {
   });
 
   test('FAB shows chat SVG icon for non-avatar tenant (demo page without avatar)', async ({ page }) => {
+    // NON_AVATAR_DEMO_URL 未指定時は AVATAR_DEMO_URL(アバター設定済み実ページ)にフォールバックする。
+    // その場合のみモックが必要 — 真の非アバターテナントは backend 側で avatarEnabled=false により
+    // dispatch 前に 403 で早期リターンするため、実バックエンドを叩いても課金は発生しない。
+    if (NON_AVATAR_DEMO_URL === AVATAR_DEMO_URL) {
+      await mockAvatarBackend(page);
+    }
     // Demo page uses a different tenant without avatar configuration
     // If FAB has no avatar image initially, it should have chat SVG — open/close should keep it
     const resp = await page.goto(NON_AVATAR_DEMO_URL);


### PR DESCRIPTION
## Summary
- `tests/e2e/widget-fab-avatar.spec.ts` は実際に本番 `https://api.r2c.biz/carnation-demo/index.html` のFABをクリックしていた
- widget.jsはFABクリック(isOpen=true)で `POST /api/avatar/room-token` を `connect:true` 付きで送信し、サーバー側はレスポンスを返す**前**に fire-and-forget で `dispatchAgentToRoom()` を呼ぶ（LiveKit経由の実LemonSliceアバターセッション起動）
- 製品UI自身が「ページ表示1回あたり約30〜60秒分のアバターセッションコストが発生します」と明記しており、テストの成否に関わらず実行するたびに実課金が発生していた
- `.github/workflows/e2e.yml` は `src/**` / `admin-ui/src/**` / `public/**` 等を触るPRのたびに走るため、2026-06-14/15だけでCIが43回実行されており、直近のLemonSlice請求急増の主因と特定
- `page.route()` でブラウザ側から `POST /api/avatar/room-token` と `/api/avatar/anam-session` をインターセプトし、本番バックエンドに一切到達させずにFABサムネイル永続化ロジック（UI挙動）のみを検証するよう変更
- 3つ目のテスト（非アバターテナント検証）は、NON_AVATAR_DEMO_URL が別途指定される場合のみモックをスキップ（その場合はバックエンド側で`avatarEnabled=false`により dispatch 前に403早期returnするため実課金なしで安全）

## Test plan
- [x] `pnpm typecheck` / lint 通過
- [x] `E2E_ENABLED=1 npx playwright test tests/e2e/widget-fab-avatar.spec.ts --project=chromium` で実行し、3テストとも完走（1件はリトライで復旧、既存のタイミング起因のflakinessで本修正と無関係）
- [x] テストコードのみの変更のためGate 2.5(Codex review)対象外（CLAUDE.md記載のスキップ条件に合致）

## Note
マージは人間の承認後にお願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AWDcQnW6VM1J8nUzWZprqw