### PR TITLE
Phase74: Hermes Agent MVP — CVR向上の戦略提案エージェント(提案→人間承認ゲート)

### DIFF
--- a/src/agent/hermes/featureFlag.test.ts
+++ b/src/agent/hermes/featureFlag.test.ts
@@ -1,0 +1,74 @@
+// src/agent/hermes/featureFlag.test.ts
+// Phase74: Hermes Agent Feature Flag テスト
+
+import {
+  isHermesTenantAllowed,
+  isHermesEnabled,
+  isHermesNotifyEnabled,
+  isHermesLlmEnabled,
+} from "./featureFlag";
+
+const ENV_KEYS = [
+  "HERMES_ENABLED",
+  "HERMES_TENANTS",
+  "HERMES_NOTIFY_ENABLED",
+  "HERMES_LLM_ENABLED",
+] as const;
+
+beforeEach(() => {
+  for (const k of ENV_KEYS) delete process.env[k];
+});
+
+afterEach(() => {
+  for (const k of ENV_KEYS) delete process.env[k];
+});
+
+describe("isHermesEnabled", () => {
+  it("未設定なら false", () => {
+    expect(isHermesEnabled()).toBe(false);
+  });
+
+  it("'true' で true", () => {
+    process.env.HERMES_ENABLED = "true";
+    expect(isHermesEnabled()).toBe(true);
+  });
+});
+
+describe("isHermesTenantAllowed", () => {
+  it("対象テナントのみ true", () => {
+    process.env.HERMES_TENANTS = "carnation";
+    expect(isHermesTenantAllowed("carnation")).toBe(true);
+    expect(isHermesTenantAllowed("other")).toBe(false);
+  });
+
+  it("'*' で全テナント true", () => {
+    process.env.HERMES_TENANTS = "*";
+    expect(isHermesTenantAllowed("anyone")).toBe(true);
+  });
+
+  it("未設定なら常に false", () => {
+    expect(isHermesTenantAllowed("carnation")).toBe(false);
+  });
+});
+
+describe("isHermesNotifyEnabled", () => {
+  it("既定 true", () => {
+    expect(isHermesNotifyEnabled()).toBe(true);
+  });
+
+  it("'false' 明示で false", () => {
+    process.env.HERMES_NOTIFY_ENABLED = "false";
+    expect(isHermesNotifyEnabled()).toBe(false);
+  });
+});
+
+describe("isHermesLlmEnabled", () => {
+  it("既定 false", () => {
+    expect(isHermesLlmEnabled()).toBe(false);
+  });
+
+  it("'true' で true", () => {
+    process.env.HERMES_LLM_ENABLED = "true";
+    expect(isHermesLlmEnabled()).toBe(true);
+  });
+});

--- a/src/agent/hermes/featureFlag.ts
+++ b/src/agent/hermes/featureFlag.ts
@@ -1,0 +1,44 @@
+// src/agent/hermes/featureFlag.ts
+// Phase74: Hermes Agent Feature Flag
+//
+// 常駐スケジューラのマスタースイッチ・対象テナント・通知有無・LLM整形有無を
+// 独立に制御する。段階導入(生成のみ観測 → 通知ON → LLM整形ON)を可能にする。
+//
+//   HERMES_ENABLED=true          マスタースイッチ (常駐スケジューラ起動の前提)
+//   HERMES_TENANTS=carnation     tenant別提案の対象テナント (カンマ区切り。'*' で全テナント)
+//                                横断(global)提案はこのリストと無関係に生成される
+//   HERMES_NOTIFY_ENABLED=true   既定true。falseで生成・永続化のみ(通知は送らない)
+//   HERMES_LLM_ENABLED=false     既定false。trueでもMVP時点ではテンプレート整形のまま
+//                                (Groq整形は将来PRで実装するためのフラグ予約)
+
+function parseTenants(raw: string | undefined): string[] {
+  return (raw ?? "")
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+/** tenant別提案の対象テナントとして許可されているか。 */
+export function isHermesTenantAllowed(tenantId: string): boolean {
+  const allowed = parseTenants(process.env.HERMES_TENANTS);
+  if (allowed.includes("*")) return true;
+  return allowed.includes(tenantId);
+}
+
+/** 常駐スケジューラ (setInterval) を起動してよいか。マスタースイッチ。 */
+export function isHermesEnabled(): boolean {
+  return process.env.HERMES_ENABLED === "true";
+}
+
+/** 生成した提案を通知(In-App/Slack)として送るか。既定true。falseなら生成・永続化のみ。 */
+export function isHermesNotifyEnabled(): boolean {
+  return process.env.HERMES_NOTIFY_ENABLED !== "false";
+}
+
+/**
+ * Groqによる提案文の自然言語整形を使うか。既定false。
+ * MVP時点では未実装 (テンプレート整形のみ)。将来のLLM整形実装のためのフラグ予約。
+ */
+export function isHermesLlmEnabled(): boolean {
+  return process.env.HERMES_LLM_ENABLED === "true";
+}

--- a/src/agent/hermes/hermesAgent.test.ts
+++ b/src/agent/hermes/hermesAgent.test.ts
@@ -1,0 +1,229 @@
+// src/agent/hermes/hermesAgent.test.ts
+// Phase74: hermesAgent テスト (依存モジュールをモック、heartbeatHandler.test.ts と同型)
+
+import {
+  runHermesCycle,
+  startHermes,
+  stopHermes,
+} from "./hermesAgent";
+import { collectAllProposalCandidates, listActiveTenantIds } from "./strategyAggregator";
+import { createHermesProposalRepository } from "./proposalRepository";
+import { createNotification } from "../../lib/notifications";
+import { sendSlackAlert } from "../../lib/alerts/slackNotifier";
+
+jest.mock("./strategyAggregator", () => ({
+  collectAllProposalCandidates: jest.fn(),
+  listActiveTenantIds: jest.fn(),
+}));
+
+jest.mock("./proposalRepository", () => ({
+  createHermesProposalRepository: jest.fn(),
+}));
+
+jest.mock("../../lib/notifications", () => ({
+  createNotification: jest.fn(),
+}));
+
+jest.mock("../../lib/alerts/slackNotifier", () => ({
+  sendSlackAlert: jest.fn(),
+}));
+
+const mockCollectAll = collectAllProposalCandidates as jest.Mock;
+const mockListActive = listActiveTenantIds as jest.Mock;
+const mockCreateRepo = createHermesProposalRepository as jest.Mock;
+const mockCreateNotification = createNotification as jest.Mock;
+const mockSendSlackAlert = sendSlackAlert as jest.Mock;
+
+const mockInsertProposal = jest.fn();
+const mockFindProposalIdByDedupKey = jest.fn();
+
+const ENV_KEYS = [
+  "HERMES_ENABLED",
+  "HERMES_TENANTS",
+  "HERMES_NOTIFY_ENABLED",
+] as const;
+
+const globalCandidate = {
+  scope: "global" as const,
+  proposalType: "xt_principle" as const,
+  title: "心理原則「scarcity」の全体採用を検討",
+  rationale: "全テナント横断でCV率12%(サンプル340件)",
+  suggestedAction: "デフォルト戦略に追加検討",
+  evidence: { principle: "scarcity", conversionRate: 12, sampleSize: 340 },
+  dedupKey: "xt_principle:scarcity",
+};
+
+const tenantCandidate = {
+  scope: "tenant" as const,
+  tenantId: "carnation",
+  proposalType: "ab_winner" as const,
+  title: "A/Bテスト「価格訴求」でVariant Bが勝利",
+  rationale: "CV率+7%",
+  suggestedAction: "Variant Bを適用",
+  evidence: { experimentId: "exp-1" },
+  dedupKey: "tenant:carnation:ab_winner:exp-1",
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  for (const k of ENV_KEYS) delete process.env[k];
+  mockCreateRepo.mockReturnValue({
+    insertProposal: mockInsertProposal,
+    findProposalIdByDedupKey: mockFindProposalIdByDedupKey,
+  });
+  mockListActive.mockResolvedValue([]);
+  mockCollectAll.mockResolvedValue([]);
+  mockInsertProposal.mockResolvedValue(true);
+  mockFindProposalIdByDedupKey.mockResolvedValue("1");
+});
+
+afterEach(() => {
+  // 順序が重要: フェイクタイマー下で作られた interval を real timers に切り替える前に
+  // stopHermes() で clearInterval しないと、次テストへ intervalHandle が漏れて
+  // 二重起動ガードが誤発火する(heartbeatHandler.test.ts と同じ落とし穴)。
+  stopHermes();
+  jest.useRealTimers();
+  for (const k of ENV_KEYS) delete process.env[k];
+});
+
+describe("runHermesCycle", () => {
+  it("global提案は super_admin へ通知される", async () => {
+    mockCollectAll.mockResolvedValue([globalCandidate]);
+
+    const result = await runHermesCycle();
+
+    expect(result).toEqual({ generated: 1, skipped: 0 });
+    expect(mockCreateNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipientRole: "super_admin",
+        recipientTenantId: undefined,
+        type: "hermes_proposal",
+        link: "/admin/hermes",
+      }),
+    );
+  });
+
+  it("tenant提案は client_admin へ tenantId 付きで通知される", async () => {
+    mockCollectAll.mockResolvedValue([tenantCandidate]);
+
+    await runHermesCycle();
+
+    expect(mockCreateNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        recipientRole: "client_admin",
+        recipientTenantId: "carnation",
+        link: "/admin/conversion",
+      }),
+    );
+  });
+
+  it("insertProposalがfalse(重複)なら通知せずskippedをカウント", async () => {
+    mockCollectAll.mockResolvedValue([globalCandidate]);
+    mockInsertProposal.mockResolvedValue(false);
+
+    const result = await runHermesCycle();
+
+    expect(result).toEqual({ generated: 0, skipped: 1 });
+    expect(mockCreateNotification).not.toHaveBeenCalled();
+  });
+
+  it("HERMES_NOTIFY_ENABLED=false なら永続化はするが通知しない", async () => {
+    process.env.HERMES_NOTIFY_ENABLED = "false";
+    mockCollectAll.mockResolvedValue([globalCandidate]);
+
+    const result = await runHermesCycle();
+
+    expect(result).toEqual({ generated: 1, skipped: 0 });
+    expect(mockInsertProposal).toHaveBeenCalledTimes(1);
+    expect(mockCreateNotification).not.toHaveBeenCalled();
+  });
+
+  it("アクティブテナントをHERMES_TENANTSで絞り込んでcollectAllProposalCandidatesに渡す", async () => {
+    process.env.HERMES_TENANTS = "carnation";
+    mockListActive.mockResolvedValue(["carnation", "other-tenant"]);
+
+    await runHermesCycle();
+
+    expect(mockCollectAll).toHaveBeenCalledWith(["carnation"]);
+  });
+
+  it("generated>0のときSlackサマリを送る", async () => {
+    mockCollectAll.mockResolvedValue([globalCandidate]);
+
+    await runHermesCycle();
+
+    expect(mockSendSlackAlert).toHaveBeenCalledWith(
+      expect.objectContaining({ ruleId: "hermes-agent-cycle", level: "INFO" }),
+    );
+  });
+
+  it("generated=0のときSlackサマリを送らない", async () => {
+    mockCollectAll.mockResolvedValue([]);
+
+    await runHermesCycle();
+
+    expect(mockSendSlackAlert).not.toHaveBeenCalled();
+  });
+
+  it("collectAllProposalCandidatesが失敗しても例外を投げず{generated:0,skipped:0}を返す", async () => {
+    mockCollectAll.mockRejectedValue(new Error("db down"));
+
+    await expect(runHermesCycle()).resolves.toEqual({ generated: 0, skipped: 0 });
+  });
+
+  it("1件のinsertProposalが失敗しても他の候補の処理は継続する", async () => {
+    mockCollectAll.mockResolvedValue([globalCandidate, tenantCandidate]);
+    mockInsertProposal
+      .mockRejectedValueOnce(new Error("insert failed"))
+      .mockResolvedValueOnce(true);
+
+    const result = await runHermesCycle();
+
+    expect(result).toEqual({ generated: 1, skipped: 0 });
+    expect(mockCreateNotification).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("startHermes / stopHermes", () => {
+  it("HERMES_ENABLED未設定ならintervalを作らない", () => {
+    jest.useFakeTimers();
+
+    startHermes();
+    jest.advanceTimersByTime(6 * 60 * 60 * 1000 + 1000);
+
+    expect(mockCollectAll).not.toHaveBeenCalled();
+  });
+
+  it("HERMES_ENABLED=trueなら6時間周期でrunHermesCycleが走る", () => {
+    jest.useFakeTimers();
+    process.env.HERMES_ENABLED = "true";
+
+    startHermes();
+    jest.advanceTimersByTime(6 * 60 * 60 * 1000 + 1000);
+
+    expect(mockListActive).toHaveBeenCalled();
+  });
+
+  it("二重起動してもintervalは1本のみ", () => {
+    jest.useFakeTimers();
+    process.env.HERMES_ENABLED = "true";
+
+    startHermes();
+    startHermes();
+    jest.advanceTimersByTime(6 * 60 * 60 * 1000 + 1000);
+
+    expect(mockListActive).toHaveBeenCalledTimes(1);
+  });
+
+  it("stopHermes後はintervalが再度作れる状態に戻る", () => {
+    jest.useFakeTimers();
+    process.env.HERMES_ENABLED = "true";
+
+    startHermes();
+    stopHermes();
+    startHermes();
+    jest.advanceTimersByTime(6 * 60 * 60 * 1000 + 1000);
+
+    expect(mockListActive).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/agent/hermes/hermesAgent.ts
+++ b/src/agent/hermes/hermesAgent.ts
@@ -1,0 +1,160 @@
+// src/agent/hermes/hermesAgent.ts
+// Phase74: Hermes Agent — 常駐スケジューラ
+//
+// strategyAggregator が生成する提案候補(横断=crossTenantContext由来の匿名集計 /
+// tenant別=autoTuning detect群由来)を新規分のみ永続化(proposalRepository)し、
+// 承認ゲートのため管理者に通知するだけの常駐ジョブ。
+// system_prompt / system_prompt_variants は一切自動書き換えしない(提案→人間承認ゲート)。
+//
+// heartbeatHandler.ts と同型: setInterval + 二重起動ガード + unref()。
+
+import pino from "pino";
+import {
+  isHermesEnabled,
+  isHermesNotifyEnabled,
+  isHermesTenantAllowed,
+} from "./featureFlag";
+import {
+  collectAllProposalCandidates,
+  listActiveTenantIds,
+  type HermesProposalCandidate,
+} from "./strategyAggregator";
+import { createHermesProposalRepository } from "./proposalRepository";
+import { createNotification } from "../../lib/notifications";
+import { sendSlackAlert } from "../../lib/alerts/slackNotifier";
+
+const logger = pino({ name: "hermes-agent" });
+
+const HERMES_INTERVAL_MS = 6 * 60 * 60 * 1000; // 6時間周期(MVPは低頻度で十分)
+
+let intervalHandle: NodeJS.Timeout | null = null;
+
+export interface HermesCycleResult {
+  generated: number;
+  skipped: number;
+}
+
+async function notifyProposal(
+  candidate: HermesProposalCandidate,
+  proposalId: string | null,
+): Promise<void> {
+  if (!isHermesNotifyEnabled()) return;
+
+  const recipientRole = candidate.scope === "global" ? "super_admin" : "client_admin";
+  try {
+    await createNotification({
+      recipientRole,
+      recipientTenantId: candidate.tenantId,
+      type: "hermes_proposal",
+      title: candidate.title,
+      message: candidate.rationale,
+      link: candidate.scope === "global" ? "/admin/hermes" : "/admin/conversion",
+      metadata: {
+        proposal_id: proposalId,
+        dedup_key: candidate.dedupKey,
+        proposal_type: candidate.proposalType,
+        scope: candidate.scope,
+      },
+    });
+  } catch (err) {
+    logger.warn({ err }, "hermes.notify_failed");
+  }
+}
+
+/**
+ * 1サイクル分の処理: アクティブテナントをFlagで絞り込み → 提案候補を集約 →
+ * 新規分のみ永続化 → 通知(In-App) → Slackサマリ(件数のみ)。
+ *
+ * Flag マスタースイッチ(isHermesEnabled)の判定は startHermes 側の責務。
+ * ここでは無条件に実行する(手動検証:
+ * `HERMES_ENABLED=true HERMES_NOTIFY_ENABLED=false pnpm dev` から直接呼べるように)。
+ */
+export async function runHermesCycle(): Promise<HermesCycleResult> {
+  const repo = createHermesProposalRepository();
+
+  let targetTenantIds: string[] = [];
+  try {
+    const activeTenantIds = await listActiveTenantIds();
+    targetTenantIds = activeTenantIds.filter((tenantId) => isHermesTenantAllowed(tenantId));
+  } catch (err) {
+    logger.warn({ err }, "hermes.list_active_tenants_failed");
+  }
+
+  let candidates: HermesProposalCandidate[] = [];
+  try {
+    candidates = await collectAllProposalCandidates(targetTenantIds);
+  } catch (err) {
+    logger.warn({ err }, "hermes.collect_candidates_failed");
+    return { generated: 0, skipped: 0 };
+  }
+
+  let generated = 0;
+  let skipped = 0;
+
+  for (const candidate of candidates) {
+    try {
+      const inserted = await repo.insertProposal({
+        scope: candidate.scope,
+        tenantId: candidate.tenantId,
+        proposalType: candidate.proposalType,
+        title: candidate.title,
+        rationale: candidate.rationale,
+        suggestedAction: candidate.suggestedAction,
+        evidence: candidate.evidence,
+        dedupKey: candidate.dedupKey,
+      });
+
+      if (!inserted) {
+        skipped++;
+        continue;
+      }
+      generated++;
+
+      const proposalId = await repo.findProposalIdByDedupKey(candidate.dedupKey);
+      await notifyProposal(candidate, proposalId);
+    } catch (err) {
+      logger.warn({ err, dedupKey: candidate.dedupKey }, "hermes.proposal_failed");
+    }
+  }
+
+  logger.info(
+    { generated, skipped, totalCandidates: candidates.length },
+    "hermes.cycle_done",
+  );
+
+  if (generated > 0) {
+    try {
+      // カウントのみ(会話内容・PII・principle名の列挙はしない)
+      await sendSlackAlert({
+        ruleId: "hermes-agent-cycle",
+        name: "Hermes Agent — 戦略提案サイクル",
+        level: "INFO",
+        status: "FIRING",
+        details: `今サイクルで${generated}件の新規提案を生成しました(重複スキップ${skipped}件)。管理画面で確認してください。`,
+      });
+    } catch (err) {
+      logger.warn({ err }, "hermes.slack_summary_failed");
+    }
+  }
+
+  return { generated, skipped };
+}
+
+export function startHermes(): void {
+  if (!isHermesEnabled()) return; // マスタースイッチ OFF は no-op
+  if (intervalHandle) return; // 二重起動ガード
+
+  intervalHandle = setInterval(() => {
+    runHermesCycle().catch((err) => {
+      logger.warn({ err }, "hermes.cycle_failed");
+    });
+  }, HERMES_INTERVAL_MS);
+  intervalHandle.unref(); // プロセス終了 / jest をブロックしない
+}
+
+export function stopHermes(): void {
+  if (intervalHandle) {
+    clearInterval(intervalHandle);
+    intervalHandle = null;
+  }
+}

--- a/src/agent/hermes/proposalRepository.test.ts
+++ b/src/agent/hermes/proposalRepository.test.ts
@@ -106,6 +106,45 @@ describe("insertProposal", () => {
   });
 });
 
+describe("getProposalById", () => {
+  it("IDから提案を1件取得しキャメルケースに変換する", async () => {
+    const query: QueryMock = jest.fn().mockResolvedValue({
+      rows: [
+        {
+          id: "5",
+          scope: "tenant",
+          tenant_id: "carnation",
+          proposal_type: "ab_winner",
+          title: "t",
+          rationale: "r",
+          suggested_action: "a",
+          evidence: {},
+          status: "pending",
+          dedup_key: "k",
+          created_at: new Date(),
+          decided_at: null,
+          decided_by: null,
+        },
+      ],
+    });
+    const repo = createHermesProposalRepository(makePool(query));
+
+    const proposal = await repo.getProposalById("5");
+
+    expect(proposal).toMatchObject({ id: "5", scope: "tenant", tenantId: "carnation" });
+    const [sql, args] = query.mock.calls[0]!;
+    expect(sql).toContain("WHERE id = $1");
+    expect(args).toEqual(["5"]);
+  });
+
+  it("該当なしはnull", async () => {
+    const query: QueryMock = jest.fn().mockResolvedValue({ rows: [] });
+    const repo = createHermesProposalRepository(makePool(query));
+
+    expect(await repo.getProposalById("999")).toBeNull();
+  });
+});
+
 describe("listProposals", () => {
   it("フィルタ無しでLIMIT付きSELECT", async () => {
     const query: QueryMock = jest.fn().mockResolvedValue({ rows: [] });

--- a/src/agent/hermes/proposalRepository.test.ts
+++ b/src/agent/hermes/proposalRepository.test.ts
@@ -177,6 +177,29 @@ describe("listProposals", () => {
   });
 });
 
+describe("findProposalIdByDedupKey", () => {
+  it("dedup_keyから最新のIDを取得する", async () => {
+    const query: QueryMock = jest.fn().mockResolvedValue({ rows: [{ id: "42" }] });
+    const repo = createHermesProposalRepository(makePool(query));
+
+    const id = await repo.findProposalIdByDedupKey("xt_principle:scarcity");
+
+    expect(id).toBe("42");
+    const [sql, args] = query.mock.calls[0]!;
+    expect(sql).toContain("WHERE dedup_key = $1");
+    expect(args).toEqual(["xt_principle:scarcity"]);
+  });
+
+  it("該当なしはnull", async () => {
+    const query: QueryMock = jest.fn().mockResolvedValue({ rows: [] });
+    const repo = createHermesProposalRepository(makePool(query));
+
+    const id = await repo.findProposalIdByDedupKey("nonexistent");
+
+    expect(id).toBeNull();
+  });
+});
+
 describe("updateProposalStatus", () => {
   it("UPDATE を発行しdecided_by/decided_atを設定", async () => {
     const query: QueryMock = jest.fn().mockResolvedValue({

--- a/src/agent/hermes/proposalRepository.test.ts
+++ b/src/agent/hermes/proposalRepository.test.ts
@@ -1,0 +1,220 @@
+// src/agent/hermes/proposalRepository.test.ts
+// Phase74: hermesProposalRepository テスト (fake pool 注入)
+
+import { createHermesProposalRepository } from "./proposalRepository";
+
+type QueryMock = jest.Mock<Promise<{ rows: unknown[] }>, [string, unknown[]?]>;
+
+function makePool(queryMock: QueryMock) {
+  return { query: queryMock } as unknown as Parameters<
+    typeof createHermesProposalRepository
+  >[0];
+}
+
+describe("insertProposal", () => {
+  it("global提案: INSERT を発行し、挿入されたら true", async () => {
+    const query: QueryMock = jest.fn().mockResolvedValue({ rows: [{ id: "1" }] });
+    const repo = createHermesProposalRepository(makePool(query));
+
+    const inserted = await repo.insertProposal({
+      scope: "global",
+      proposalType: "xt_principle",
+      title: "心理原則Xの全体採用を検討",
+      rationale: "全テナント横断でCV率+12%(サンプル340件)",
+      suggestedAction: "デフォルト戦略に心理原則Xを追加",
+      evidence: { principle: "scarcity", conversionRate: 12, sampleSize: 340 },
+      dedupKey: "xt_principle:scarcity",
+    });
+
+    expect(inserted).toBe(true);
+    expect(query).toHaveBeenCalledTimes(1);
+    const [sql, args] = query.mock.calls[0]!;
+    expect(sql).toContain("INSERT INTO hermes_strategy_proposals");
+    expect(sql).toContain("ON CONFLICT (dedup_key) WHERE status = 'pending' DO NOTHING");
+    expect(args![0]).toBe("global");
+    expect(args![1]).toBeNull(); // tenant_id は必ず null
+  });
+
+  it("tenant提案: tenant_idが引数に渡る", async () => {
+    const query: QueryMock = jest.fn().mockResolvedValue({ rows: [{ id: "2" }] });
+    const repo = createHermesProposalRepository(makePool(query));
+
+    await repo.insertProposal({
+      scope: "tenant",
+      tenantId: "carnation",
+      proposalType: "ab_winner",
+      title: "variant B を昇格検討",
+      rationale: "A/BテストでCV率+7%(サンプル120件)",
+      suggestedAction: "variant B を昇格",
+      dedupKey: "tenant:carnation:ab:exp-1",
+    });
+
+    const [, args] = query.mock.calls[0]!;
+    expect(args![0]).toBe("tenant");
+    expect(args![1]).toBe("carnation");
+  });
+
+  it("scope='global' に tenantId を渡すと例外(越境ガード)", async () => {
+    const query: QueryMock = jest.fn();
+    const repo = createHermesProposalRepository(makePool(query));
+
+    await expect(
+      repo.insertProposal({
+        scope: "global",
+        tenantId: "carnation", // 不変条件違反
+        proposalType: "xt_principle",
+        title: "t",
+        rationale: "r",
+        suggestedAction: "a",
+        dedupKey: "bad",
+      }),
+    ).rejects.toThrow(/scope='global' must not carry tenantId/);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it("scope='tenant' で tenantId 無しは例外", async () => {
+    const query: QueryMock = jest.fn();
+    const repo = createHermesProposalRepository(makePool(query));
+
+    await expect(
+      repo.insertProposal({
+        scope: "tenant",
+        proposalType: "ab_winner",
+        title: "t",
+        rationale: "r",
+        suggestedAction: "a",
+        dedupKey: "bad2",
+      }),
+    ).rejects.toThrow(/scope='tenant' requires tenantId/);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it("ON CONFLICT で行が返らなければ false (重複スキップ)", async () => {
+    const query: QueryMock = jest.fn().mockResolvedValue({ rows: [] });
+    const repo = createHermesProposalRepository(makePool(query));
+
+    const inserted = await repo.insertProposal({
+      scope: "global",
+      proposalType: "xt_principle",
+      title: "t",
+      rationale: "r",
+      suggestedAction: "a",
+      dedupKey: "dup",
+    });
+
+    expect(inserted).toBe(false);
+  });
+});
+
+describe("listProposals", () => {
+  it("フィルタ無しでLIMIT付きSELECT", async () => {
+    const query: QueryMock = jest.fn().mockResolvedValue({ rows: [] });
+    const repo = createHermesProposalRepository(makePool(query));
+
+    await repo.listProposals();
+
+    const [sql, args] = query.mock.calls[0]!;
+    expect(sql).not.toContain("WHERE");
+    expect(sql).toContain("ORDER BY created_at DESC");
+    expect(args![0]).toBe(100);
+  });
+
+  it("scope + status で絞り込み", async () => {
+    const query: QueryMock = jest.fn().mockResolvedValue({ rows: [] });
+    const repo = createHermesProposalRepository(makePool(query));
+
+    await repo.listProposals({ scope: "global", status: "pending", limit: 20 });
+
+    const [sql, args] = query.mock.calls[0]!;
+    expect(sql).toContain("scope = $1");
+    expect(sql).toContain("status = $2");
+    expect(args).toEqual(["global", "pending", 20]);
+  });
+
+  it("tenantId で絞り込み(client_admin向けAPIが使用)", async () => {
+    const query: QueryMock = jest.fn().mockResolvedValue({ rows: [] });
+    const repo = createHermesProposalRepository(makePool(query));
+
+    await repo.listProposals({ tenantId: "carnation" });
+
+    const [sql, args] = query.mock.calls[0]!;
+    expect(sql).toContain("tenant_id = $1");
+    expect(args![0]).toBe("carnation");
+  });
+
+  it("DBの行をキャメルケースに変換する", async () => {
+    const query: QueryMock = jest.fn().mockResolvedValue({
+      rows: [
+        {
+          id: "1",
+          scope: "global",
+          tenant_id: null,
+          proposal_type: "xt_principle",
+          title: "t",
+          rationale: "r",
+          suggested_action: "a",
+          evidence: { foo: "bar" },
+          status: "pending",
+          dedup_key: "k",
+          created_at: new Date("2026-01-01T00:00:00Z"),
+          decided_at: null,
+          decided_by: null,
+        },
+      ],
+    });
+    const repo = createHermesProposalRepository(makePool(query));
+
+    const [proposal] = await repo.listProposals();
+
+    expect(proposal).toMatchObject({
+      id: "1",
+      scope: "global",
+      tenantId: null,
+      proposalType: "xt_principle",
+      suggestedAction: "a",
+      evidence: { foo: "bar" },
+    });
+  });
+});
+
+describe("updateProposalStatus", () => {
+  it("UPDATE を発行しdecided_by/decided_atを設定", async () => {
+    const query: QueryMock = jest.fn().mockResolvedValue({
+      rows: [
+        {
+          id: "1",
+          scope: "tenant",
+          tenant_id: "carnation",
+          proposal_type: "ab_winner",
+          title: "t",
+          rationale: "r",
+          suggested_action: "a",
+          evidence: {},
+          status: "approved",
+          dedup_key: "k",
+          created_at: new Date(),
+          decided_at: new Date(),
+          decided_by: "admin@example.com",
+        },
+      ],
+    });
+    const repo = createHermesProposalRepository(makePool(query));
+
+    const result = await repo.updateProposalStatus("1", "approved", "admin@example.com");
+
+    expect(result?.status).toBe("approved");
+    expect(result?.decidedBy).toBe("admin@example.com");
+    const [sql, args] = query.mock.calls[0]!;
+    expect(sql).toContain("UPDATE hermes_strategy_proposals");
+    expect(args).toEqual(["1", "approved", "admin@example.com"]);
+  });
+
+  it("該当行が無ければ null", async () => {
+    const query: QueryMock = jest.fn().mockResolvedValue({ rows: [] });
+    const repo = createHermesProposalRepository(makePool(query));
+
+    const result = await repo.updateProposalStatus("999", "rejected", "admin@example.com");
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/agent/hermes/proposalRepository.ts
+++ b/src/agent/hermes/proposalRepository.ts
@@ -146,6 +146,23 @@ export function createHermesProposalRepository(pool?: InstanceType<typeof Pool>)
     },
 
     /**
+     * IDから提案を1件取得する。Admin API の approve/reject が、実行前に
+     * scope/tenant_id を見て越境チェックする(client_adminが他テナント/global提案を
+     * 決定できないようにする)ために使う。
+     */
+    async getProposalById(id: string): Promise<HermesProposal | null> {
+      const result = await getPool().query(
+        `SELECT id::text, scope, tenant_id, proposal_type, title, rationale,
+                suggested_action, evidence, status, dedup_key, created_at, decided_at, decided_by
+         FROM hermes_strategy_proposals
+         WHERE id = $1`,
+        [id],
+      );
+      const row = result.rows[0] as ProposalRow | undefined;
+      return row ? toProposal(row) : null;
+    },
+
+    /**
      * 提案一覧を取得する。scope/tenantId/status で絞り込み可能。
      * tenantId を渡した場合、呼び出し側の越境チェック(role != super_admin等)は
      * ルーティング層(Admin API)の責務とする。

--- a/src/agent/hermes/proposalRepository.ts
+++ b/src/agent/hermes/proposalRepository.ts
@@ -184,6 +184,23 @@ export function createHermesProposalRepository(pool?: InstanceType<typeof Pool>)
     },
 
     /**
+     * dedup_key から最新の提案IDを引く。insertProposal 直後に呼び出し元(hermesAgent)が
+     * 通知メタデータへ proposal_id を含めるために使う(insertProposal 自体は重複防止のため
+     * boolean のみ返す設計を変えない、追加専用のヘルパー)。
+     */
+    async findProposalIdByDedupKey(dedupKey: string): Promise<string | null> {
+      const result = await getPool().query(
+        `SELECT id::text FROM hermes_strategy_proposals
+         WHERE dedup_key = $1
+         ORDER BY created_at DESC
+         LIMIT 1`,
+        [dedupKey],
+      );
+      const row = result.rows[0] as { id: string } | undefined;
+      return row?.id ?? null;
+    },
+
+    /**
      * 提案のステータスを更新する (承認/却下)。Hermes 自身はこれを呼ばない。
      * 管理者の意思決定を記録するのみで、system_prompt 等の実適用はしない。
      */

--- a/src/agent/hermes/proposalRepository.ts
+++ b/src/agent/hermes/proposalRepository.ts
@@ -1,0 +1,207 @@
+// src/agent/hermes/proposalRepository.ts
+// Phase74: Hermes Agent — hermes_strategy_proposals テーブルのリポジトリ
+//
+// learnedMemoryRepository.ts のファクトリ + 遅延 pool 解決パターンを踏襲。
+// 提案は insert / list / updateStatus のみ。system_prompt 等の自動適用は一切行わない
+// (提案→人間承認ゲート)。
+
+import { Pool } from "pg";
+import { getPool as _getDefaultPool } from "../../lib/db";
+
+export type HermesProposalScope = "global" | "tenant";
+
+export type HermesProposalType =
+  | "xt_principle"
+  | "ab_winner"
+  | "judge_repeated"
+  | "effectiveness_top";
+
+export type HermesProposalStatus =
+  | "pending"
+  | "approved"
+  | "rejected"
+  | "applied";
+
+export interface HermesProposalInput {
+  scope: HermesProposalScope;
+  /** scope='tenant' のとき必須。scope='global' のときは必ず undefined/null。 */
+  tenantId?: string | null;
+  proposalType: HermesProposalType;
+  title: string;
+  /** 匿名集計/tenant別集計に基づく根拠。生の会話ログ・PIIを含めないこと。 */
+  rationale: string;
+  suggestedAction: string;
+  /** 集計値のみ (CV率/サンプル数/principle名/experiment_id)。 */
+  evidence?: Record<string, unknown>;
+  dedupKey: string;
+}
+
+export interface HermesProposal {
+  id: string;
+  scope: HermesProposalScope;
+  tenantId: string | null;
+  proposalType: HermesProposalType;
+  title: string;
+  rationale: string;
+  suggestedAction: string;
+  evidence: Record<string, unknown>;
+  status: HermesProposalStatus;
+  dedupKey: string;
+  createdAt: Date;
+  decidedAt: Date | null;
+  decidedBy: string | null;
+}
+
+export interface ListProposalsParams {
+  scope?: HermesProposalScope;
+  tenantId?: string;
+  status?: HermesProposalStatus;
+  limit?: number;
+}
+
+/**
+ * scope/tenant_id の不変条件を JS 層でも検証する (DB の chk_hermes_scope と二重防御)。
+ * global 提案に tenant_id が付く/tenant 提案に tenant_id が無いバグを呼び出し前に落とす。
+ */
+function assertScopeInvariant(scope: HermesProposalScope, tenantId?: string | null): void {
+  if (scope === "global" && tenantId) {
+    throw new Error(
+      "hermes proposal invariant violation: scope='global' must not carry tenantId",
+    );
+  }
+  if (scope === "tenant" && !tenantId) {
+    throw new Error(
+      "hermes proposal invariant violation: scope='tenant' requires tenantId",
+    );
+  }
+}
+
+type ProposalRow = {
+  id: string;
+  scope: HermesProposalScope;
+  tenant_id: string | null;
+  proposal_type: HermesProposalType;
+  title: string;
+  rationale: string;
+  suggested_action: string;
+  evidence: Record<string, unknown> | null;
+  status: HermesProposalStatus;
+  dedup_key: string;
+  created_at: Date;
+  decided_at: Date | null;
+  decided_by: string | null;
+};
+
+function toProposal(row: ProposalRow): HermesProposal {
+  return {
+    id: row.id,
+    scope: row.scope,
+    tenantId: row.tenant_id,
+    proposalType: row.proposal_type,
+    title: row.title,
+    rationale: row.rationale,
+    suggestedAction: row.suggested_action,
+    evidence: row.evidence ?? {},
+    status: row.status,
+    dedupKey: row.dedup_key,
+    createdAt: row.created_at,
+    decidedAt: row.decided_at,
+    decidedBy: row.decided_by,
+  };
+}
+
+export function createHermesProposalRepository(pool?: InstanceType<typeof Pool>) {
+  // pool 解決は実 DB 呼び出し時まで遅延 (DATABASE_URL 無しのテスト環境を許容)
+  function getPool(): InstanceType<typeof Pool> {
+    return pool ?? _getDefaultPool();
+  }
+
+  return {
+    /**
+     * 戦略提案を保存する。同一 dedup_key が pending で既存なら何もしない
+     * (ON CONFLICT (dedup_key) WHERE status='pending' DO NOTHING = uniq_hermes_dedup 部分インデックス)。
+     * @returns 挿入されたら true、重複でスキップされたら false
+     */
+    async insertProposal(input: HermesProposalInput): Promise<boolean> {
+      assertScopeInvariant(input.scope, input.tenantId);
+
+      const result = await getPool().query(
+        `INSERT INTO hermes_strategy_proposals
+           (scope, tenant_id, proposal_type, title, rationale, suggested_action, evidence, dedup_key)
+         VALUES ($1, $2, $3, $4, $5, $6, $7::jsonb, $8)
+         ON CONFLICT (dedup_key) WHERE status = 'pending' DO NOTHING
+         RETURNING id`,
+        [
+          input.scope,
+          input.tenantId ?? null,
+          input.proposalType,
+          input.title,
+          input.rationale,
+          input.suggestedAction,
+          JSON.stringify(input.evidence ?? {}),
+          input.dedupKey,
+        ],
+      );
+      return result.rows.length > 0;
+    },
+
+    /**
+     * 提案一覧を取得する。scope/tenantId/status で絞り込み可能。
+     * tenantId を渡した場合、呼び出し側の越境チェック(role != super_admin等)は
+     * ルーティング層(Admin API)の責務とする。
+     */
+    async listProposals(params: ListProposalsParams = {}): Promise<HermesProposal[]> {
+      const conditions: string[] = [];
+      const values: unknown[] = [];
+
+      if (params.scope) {
+        values.push(params.scope);
+        conditions.push(`scope = $${values.length}`);
+      }
+      if (params.tenantId) {
+        values.push(params.tenantId);
+        conditions.push(`tenant_id = $${values.length}`);
+      }
+      if (params.status) {
+        values.push(params.status);
+        conditions.push(`status = $${values.length}`);
+      }
+
+      const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+      values.push(params.limit ?? 100);
+
+      const result = await getPool().query(
+        `SELECT id::text, scope, tenant_id, proposal_type, title, rationale,
+                suggested_action, evidence, status, dedup_key, created_at, decided_at, decided_by
+         FROM hermes_strategy_proposals
+         ${whereClause}
+         ORDER BY created_at DESC
+         LIMIT $${values.length}`,
+        values,
+      );
+
+      return (result.rows as ProposalRow[]).map(toProposal);
+    },
+
+    /**
+     * 提案のステータスを更新する (承認/却下)。Hermes 自身はこれを呼ばない。
+     * 管理者の意思決定を記録するのみで、system_prompt 等の実適用はしない。
+     */
+    async updateProposalStatus(
+      id: string,
+      status: HermesProposalStatus,
+      decidedBy: string,
+    ): Promise<HermesProposal | null> {
+      const result = await getPool().query(
+        `UPDATE hermes_strategy_proposals
+         SET status = $2, decided_at = NOW(), decided_by = $3
+         WHERE id = $1
+         RETURNING id::text, scope, tenant_id, proposal_type, title, rationale,
+                   suggested_action, evidence, status, dedup_key, created_at, decided_at, decided_by`,
+        [id, status, decidedBy],
+      );
+      const row = result.rows[0] as ProposalRow | undefined;
+      return row ? toProposal(row) : null;
+    },
+  };
+}

--- a/src/agent/hermes/strategyAggregator.test.ts
+++ b/src/agent/hermes/strategyAggregator.test.ts
@@ -1,0 +1,238 @@
+// src/agent/hermes/strategyAggregator.test.ts
+// Phase74: strategyAggregator テスト (crossTenantContext / autoTuning / pool をモック)
+
+import {
+  collectGlobalProposalCandidates,
+  collectTenantProposalCandidates,
+  listActiveTenantIds,
+  collectAllProposalCandidates,
+} from "./strategyAggregator";
+import { getCrossTenantContext } from "../../lib/crossTenantContext";
+import {
+  detectABWinners,
+  detectRepeatedJudgeSuggestions,
+  detectTopPrinciples,
+} from "../../api/conversion/autoTuning";
+import { pool } from "../../lib/db";
+
+jest.mock("../../lib/crossTenantContext", () => ({
+  getCrossTenantContext: jest.fn(),
+}));
+
+jest.mock("../../api/conversion/autoTuning", () => ({
+  detectABWinners: jest.fn(),
+  detectRepeatedJudgeSuggestions: jest.fn(),
+  detectTopPrinciples: jest.fn(),
+}));
+
+jest.mock("../../lib/db", () => ({
+  pool: { query: jest.fn() },
+}));
+
+const mockGetCrossTenantContext = getCrossTenantContext as jest.Mock;
+const mockDetectABWinners = detectABWinners as jest.Mock;
+const mockDetectRepeatedJudgeSuggestions = detectRepeatedJudgeSuggestions as jest.Mock;
+const mockDetectTopPrinciples = detectTopPrinciples as jest.Mock;
+const mockPoolQuery = pool!.query as jest.Mock;
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockDetectABWinners.mockResolvedValue([]);
+  mockDetectRepeatedJudgeSuggestions.mockResolvedValue([]);
+  mockDetectTopPrinciples.mockResolvedValue([]);
+});
+
+describe("collectGlobalProposalCandidates", () => {
+  it("crossTenantContextの匿名集計から global 提案を生成し、tenantIdを持たない", async () => {
+    mockGetCrossTenantContext.mockResolvedValue({
+      avgScores: null,
+      topPsychologyPrinciples: [
+        { principle: "scarcity", conversionRate: 12, sampleSize: 340 },
+        { principle: "social_proof", conversionRate: 9, sampleSize: 210 },
+      ],
+      commonGapPatterns: [],
+      effectiveRulePatterns: [],
+      totalTenants: 5,
+      dataAsOf: "2026-07-01T00:00:00.000Z",
+    });
+
+    const candidates = await collectGlobalProposalCandidates();
+
+    expect(candidates).toHaveLength(2);
+    expect(candidates[0]).toMatchObject({
+      scope: "global",
+      proposalType: "xt_principle",
+      dedupKey: "xt_principle:scarcity",
+      evidence: { principle: "scarcity", conversionRate: 12, sampleSize: 340 },
+    });
+    expect(candidates[0]!.tenantId).toBeUndefined();
+  });
+
+  it("上位3件までに絞る(通知過多防止)", async () => {
+    mockGetCrossTenantContext.mockResolvedValue({
+      avgScores: null,
+      topPsychologyPrinciples: Array.from({ length: 10 }, (_, i) => ({
+        principle: `p${i}`,
+        conversionRate: 10 - i,
+        sampleSize: 100,
+      })),
+      commonGapPatterns: [],
+      effectiveRulePatterns: [],
+      totalTenants: 5,
+      dataAsOf: "2026-07-01T00:00:00.000Z",
+    });
+
+    const candidates = await collectGlobalProposalCandidates();
+
+    expect(candidates).toHaveLength(3);
+    expect(candidates.map((c) => c.evidence.principle)).toEqual(["p0", "p1", "p2"]);
+  });
+
+  it("匿名集計が空なら空配列", async () => {
+    mockGetCrossTenantContext.mockResolvedValue({
+      avgScores: null,
+      topPsychologyPrinciples: [],
+      commonGapPatterns: [],
+      effectiveRulePatterns: [],
+      totalTenants: 0,
+      dataAsOf: "2026-07-01T00:00:00.000Z",
+    });
+
+    const candidates = await collectGlobalProposalCandidates();
+    expect(candidates).toEqual([]);
+  });
+});
+
+describe("collectTenantProposalCandidates", () => {
+  it("ab_winner候補を正規化し、scope='tenant'+tenantIdを持つ", async () => {
+    mockDetectABWinners.mockResolvedValue([
+      {
+        type: "ab_winner",
+        description: "A/Bテスト「価格訴求」でVariant Bが勝利",
+        suggestedAction: "Variant Bを適用",
+        data: { experimentId: "exp-1", rateA: 0.1, rateB: 0.18, winner: "B" },
+      },
+    ]);
+
+    const candidates = await collectTenantProposalCandidates("carnation");
+
+    expect(candidates).toHaveLength(1);
+    expect(candidates[0]).toMatchObject({
+      scope: "tenant",
+      tenantId: "carnation",
+      proposalType: "ab_winner",
+      dedupKey: "tenant:carnation:ab_winner:exp-1",
+      suggestedAction: "Variant Bを適用",
+    });
+  });
+
+  it("effectiveness_top候補のdedupKeyはprincipleベース", async () => {
+    mockDetectTopPrinciples.mockResolvedValue([
+      {
+        type: "effectiveness_top",
+        description: "「urgency」が8回のCVに貢献",
+        suggestedAction: "「urgency」をチューニングルールで優先設定",
+        data: { principle: "urgency", count: 8, avgTemp: 70 },
+      },
+    ]);
+
+    const candidates = await collectTenantProposalCandidates("carnation");
+
+    expect(candidates[0]!.dedupKey).toBe("tenant:carnation:effectiveness_top:urgency");
+  });
+
+  it("judge_repeated候補は自由記述のruleをslug化してdedupKeyにする", async () => {
+    mockDetectRepeatedJudgeSuggestions.mockResolvedValue([
+      {
+        type: "judge_repeated",
+        description: "AIが3回同じ提案をしています",
+        suggestedAction: "在庫切れ時は代替商品を提案する",
+        data: { count: 3, rule: "在庫切れ時は代替商品を提案する" },
+      },
+    ]);
+
+    const candidates = await collectTenantProposalCandidates("carnation");
+
+    expect(candidates[0]!.dedupKey).toMatch(/^tenant:carnation:judge_repeated:/);
+    expect(candidates[0]!.dedupKey).not.toContain(" ");
+  });
+
+  it("3系統を並列で束ね、順不同で全件返す", async () => {
+    mockDetectABWinners.mockResolvedValue([
+      { type: "ab_winner", description: "d1", suggestedAction: "a1", data: { experimentId: "e1" } },
+    ]);
+    mockDetectRepeatedJudgeSuggestions.mockResolvedValue([
+      { type: "judge_repeated", description: "d2", suggestedAction: "a2", data: { rule: "r2" } },
+    ]);
+    mockDetectTopPrinciples.mockResolvedValue([
+      { type: "effectiveness_top", description: "d3", suggestedAction: "a3", data: { principle: "p3" } },
+    ]);
+
+    const candidates = await collectTenantProposalCandidates("carnation");
+    expect(candidates).toHaveLength(3);
+    expect(candidates.every((c) => c.tenantId === "carnation")).toBe(true);
+  });
+});
+
+describe("listActiveTenantIds", () => {
+  it("INTERVAL付きクエリを発行しtenant_idの配列を返す", async () => {
+    mockPoolQuery.mockResolvedValue({
+      rows: [{ tenant_id: "carnation" }, { tenant_id: "english-demo" }],
+    });
+
+    const ids = await listActiveTenantIds();
+
+    expect(ids).toEqual(["carnation", "english-demo"]);
+    const [sql, args] = mockPoolQuery.mock.calls[0]!;
+    expect(sql).toContain("SELECT DISTINCT tenant_id FROM conversation_evaluations");
+    expect(sql).toContain("INTERVAL");
+    expect(args).toEqual([30]);
+  });
+
+  it("windowDaysを指定できる", async () => {
+    mockPoolQuery.mockResolvedValue({ rows: [] });
+    await listActiveTenantIds(7);
+    const [, args] = mockPoolQuery.mock.calls[0]!;
+    expect(args).toEqual([7]);
+  });
+});
+
+describe("collectAllProposalCandidates", () => {
+  it("明示的なtenantIdsを渡すとlistActiveTenantIdsを呼ばずglobal+tenant提案を合算する", async () => {
+    mockGetCrossTenantContext.mockResolvedValue({
+      avgScores: null,
+      topPsychologyPrinciples: [{ principle: "scarcity", conversionRate: 12, sampleSize: 340 }],
+      commonGapPatterns: [],
+      effectiveRulePatterns: [],
+      totalTenants: 5,
+      dataAsOf: "2026-07-01T00:00:00.000Z",
+    });
+    mockDetectABWinners.mockResolvedValue([
+      { type: "ab_winner", description: "d1", suggestedAction: "a1", data: { experimentId: "e1" } },
+    ]);
+
+    const candidates = await collectAllProposalCandidates(["carnation"]);
+
+    expect(mockPoolQuery).not.toHaveBeenCalled();
+    expect(candidates).toHaveLength(2);
+    expect(candidates.filter((c) => c.scope === "global")).toHaveLength(1);
+    expect(candidates.filter((c) => c.scope === "tenant")).toHaveLength(1);
+  });
+
+  it("tenantIds省略時はlistActiveTenantIds経由でDBから母集団を取得する", async () => {
+    mockGetCrossTenantContext.mockResolvedValue({
+      avgScores: null,
+      topPsychologyPrinciples: [],
+      commonGapPatterns: [],
+      effectiveRulePatterns: [],
+      totalTenants: 0,
+      dataAsOf: "2026-07-01T00:00:00.000Z",
+    });
+    mockPoolQuery.mockResolvedValue({ rows: [{ tenant_id: "carnation" }] });
+
+    await collectAllProposalCandidates();
+
+    expect(mockPoolQuery).toHaveBeenCalledTimes(1);
+    expect(mockDetectABWinners).toHaveBeenCalledWith("carnation");
+  });
+});

--- a/src/agent/hermes/strategyAggregator.ts
+++ b/src/agent/hermes/strategyAggregator.ts
@@ -1,0 +1,141 @@
+// src/agent/hermes/strategyAggregator.ts
+// Phase74: Hermes Agent — 横断・tenant別シグナルを戦略提案候補に変換する
+//
+// crossTenantContext(匿名横断集計)と autoTuning の detect 群(tenant別、tenant_id=$1 付き)を
+// そのまま呼び出し、新規の横断生SQLは書かない(越境リスクをゼロに保つレビュー基準)。
+// ここで作るのは「提案候補」のみで、DB永続化(proposalRepository)・通知は
+// 呼び出し側(hermesAgent.ts)の責務とする。純関数の集合として単体テスト可能に保つ。
+
+import { pool } from "../../lib/db";
+import { getCrossTenantContext } from "../../lib/crossTenantContext";
+import {
+  detectABWinners,
+  detectRepeatedJudgeSuggestions,
+  detectTopPrinciples,
+  type AutoTuningCandidate,
+} from "../../api/conversion/autoTuning";
+import type { HermesProposalScope, HermesProposalType } from "./proposalRepository";
+
+export interface HermesProposalCandidate {
+  scope: HermesProposalScope;
+  /** scope='tenant' のときのみ設定される。 */
+  tenantId?: string;
+  proposalType: HermesProposalType;
+  title: string;
+  rationale: string;
+  suggestedAction: string;
+  evidence: Record<string, unknown>;
+  dedupKey: string;
+}
+
+/** 横断提案として採用する心理原則の上限件数(通知過多を避ける)。 */
+const GLOBAL_PRINCIPLE_TOP_N = 3;
+
+/** アクティブテナント判定に使う既定の窓(日数)。 */
+const DEFAULT_ACTIVE_WINDOW_DAYS = 30;
+
+/** dedup_key に使うため、自由記述のルール文を短い識別子に正規化する。 */
+function slugifyRule(rule: string): string {
+  return rule
+    .normalize("NFKC")
+    .replace(/[^\p{L}\p{N}]+/gu, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 60)
+    .toLowerCase();
+}
+
+/**
+ * crossTenantContext の匿名集計から、横断戦略提案を生成する。
+ * 生ログ・tenant_id は一切扱わない(getCrossTenantContext の返り値のみを材料にする)。
+ */
+export async function collectGlobalProposalCandidates(): Promise<HermesProposalCandidate[]> {
+  const ctx = await getCrossTenantContext();
+
+  return ctx.topPsychologyPrinciples.slice(0, GLOBAL_PRINCIPLE_TOP_N).map((p) => ({
+    scope: "global" as const,
+    proposalType: "xt_principle" as const,
+    title: `心理原則「${p.principle}」の全体採用を検討`,
+    rationale: `全テナント横断でCV率${p.conversionRate}%(直近90日・サンプル${p.sampleSize}件、匿名集計)`,
+    suggestedAction: `デフォルト戦略に心理原則「${p.principle}」を優先ルールとして追加検討`,
+    evidence: {
+      principle: p.principle,
+      conversionRate: p.conversionRate,
+      sampleSize: p.sampleSize,
+    },
+    dedupKey: `xt_principle:${p.principle}`,
+  }));
+}
+
+function candidateDedupKey(tenantId: string, candidate: AutoTuningCandidate): string {
+  switch (candidate.type) {
+    case "ab_winner":
+      return `tenant:${tenantId}:ab_winner:${String(candidate.data.experimentId)}`;
+    case "effectiveness_top":
+      return `tenant:${tenantId}:effectiveness_top:${String(candidate.data.principle)}`;
+    case "judge_repeated":
+      return `tenant:${tenantId}:judge_repeated:${slugifyRule(
+        String(candidate.data.rule ?? candidate.suggestedAction),
+      )}`;
+    default:
+      return `tenant:${tenantId}:unknown:${slugifyRule(candidate.description)}`;
+  }
+}
+
+/**
+ * 既存の autoTuning detect 群(全て tenant_id=$1 付き)をそのまま呼び、
+ * tenant別の戦略提案候補に正規化する。
+ */
+export async function collectTenantProposalCandidates(
+  tenantId: string,
+): Promise<HermesProposalCandidate[]> {
+  const [judgeResults, abResults, principleResults] = await Promise.all([
+    detectRepeatedJudgeSuggestions(tenantId),
+    detectABWinners(tenantId),
+    detectTopPrinciples(tenantId),
+  ]);
+
+  return [...judgeResults, ...abResults, ...principleResults].map((candidate) => ({
+    scope: "tenant" as const,
+    tenantId,
+    proposalType: candidate.type,
+    title: candidate.description,
+    rationale: candidate.description,
+    suggestedAction: candidate.suggestedAction,
+    evidence: candidate.data,
+    dedupKey: candidateDedupKey(tenantId, candidate),
+  }));
+}
+
+/**
+ * アクティブテナント一覧(直近windowDays日にJudge評価があるテナント)。
+ * hermesAgent 側で Feature Flag によるテナント絞り込みの母集団として使う。
+ */
+export async function listActiveTenantIds(
+  windowDays: number = DEFAULT_ACTIVE_WINDOW_DAYS,
+): Promise<string[]> {
+  if (!pool) return [];
+  const result = await pool.query(
+    `SELECT DISTINCT tenant_id FROM conversation_evaluations
+     WHERE evaluated_at > NOW() - ($1 * INTERVAL '1 day')`,
+    [windowDays],
+  );
+  return (result.rows as Array<{ tenant_id: string }>).map((r) => r.tenant_id);
+}
+
+/**
+ * 横断提案 + 指定テナント群のtenant別提案をまとめて集約する。
+ * tenantIds は呼び出し側(hermesAgent)が Feature Flag で絞り込んだ後に渡す想定。
+ * 省略時は listActiveTenantIds() で母集団を自動取得する(絞り込み無し)。
+ */
+export async function collectAllProposalCandidates(
+  tenantIds?: string[],
+): Promise<HermesProposalCandidate[]> {
+  const targetTenantIds = tenantIds ?? (await listActiveTenantIds());
+
+  const [globalCandidates, ...tenantCandidateLists] = await Promise.all([
+    collectGlobalProposalCandidates(),
+    ...targetTenantIds.map((tenantId) => collectTenantProposalCandidates(tenantId)),
+  ]);
+
+  return [...globalCandidates, ...tenantCandidateLists.flat()];
+}

--- a/src/api/admin/hermes/routes.test.ts
+++ b/src/api/admin/hermes/routes.test.ts
@@ -1,0 +1,236 @@
+// src/api/admin/hermes/routes.test.ts
+// Phase74: Hermes Agent Admin API — 認可ガード + 越境防止テスト
+
+jest.mock("../../../admin/http/supabaseAuthMiddleware", () => ({
+  supabaseAuthMiddleware: (req: any, _res: any, next: any) => {
+    req.supabaseUser = req._mockUser ?? null;
+    next();
+  },
+}));
+
+const mockListProposals = jest.fn();
+const mockGetProposalById = jest.fn();
+const mockUpdateProposalStatus = jest.fn();
+
+jest.mock("../../../agent/hermes/proposalRepository", () => ({
+  createHermesProposalRepository: jest.fn(() => ({
+    listProposals: mockListProposals,
+    getProposalById: mockGetProposalById,
+    updateProposalStatus: mockUpdateProposalStatus,
+  })),
+}));
+
+import express from "express";
+import request from "supertest";
+import { registerHermesRoutes } from "./routes";
+
+const FAKE_DB = { query: jest.fn() } as any;
+
+function makeApp(user: Record<string, unknown> | null, db: unknown = FAKE_DB) {
+  const app = express();
+  app.use(express.json());
+  app.use((req: any, _res: any, next: any) => {
+    req._mockUser = user;
+    next();
+  });
+  registerHermesRoutes(app, db as any);
+  return app;
+}
+
+const SUPER_ADMIN = { app_metadata: { role: "super_admin", tenant_id: null }, email: "root@example.com" };
+const CLIENT_ADMIN = { app_metadata: { role: "client_admin", tenant_id: "carnation" }, email: "owner@carnation.example" };
+
+const ALL_ROUTES = [
+  { method: "get" as const, path: "/v1/admin/hermes/proposals" },
+  { method: "post" as const, path: "/v1/admin/hermes/proposals/1/approve" },
+  { method: "post" as const, path: "/v1/admin/hermes/proposals/1/reject" },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockListProposals.mockResolvedValue([]);
+  mockGetProposalById.mockResolvedValue(null);
+  mockUpdateProposalStatus.mockResolvedValue(null);
+});
+
+describe("認可ガード(ALLOWED_ROLES)", () => {
+  ALL_ROUTES.forEach(({ method, path }) => {
+    it(`${method.toUpperCase()} ${path} — viewer → 403`, async () => {
+      const app = makeApp({ app_metadata: { role: "viewer", tenant_id: "t1" }, email: "v@t.com" });
+      const res = await (request(app) as any)[method](path);
+      expect(res.status).toBe(403);
+    });
+
+    it(`${method.toUpperCase()} ${path} — stale JWT(user_metadataのみ) → 403`, async () => {
+      const app = makeApp({ user_metadata: { role: "super_admin", tenant_id: "t1" }, email: "v@t.com" });
+      const res = await (request(app) as any)[method](path);
+      expect(res.status).toBe(403);
+    });
+
+    it(`${method.toUpperCase()} ${path} — 未認証(null) → 403`, async () => {
+      const app = makeApp(null);
+      const res = await (request(app) as any)[method](path);
+      expect(res.status).toBe(403);
+    });
+  });
+});
+
+describe("GET /v1/admin/hermes/proposals", () => {
+  it("db未接続なら503", async () => {
+    const app = makeApp(SUPER_ADMIN, null);
+    const res = await request(app).get("/v1/admin/hermes/proposals");
+    expect(res.status).toBe(503);
+  });
+
+  it("super_adminはフィルタ無しで全件取得できる", async () => {
+    mockListProposals.mockResolvedValue([{ id: "1", scope: "global" }]);
+    const app = makeApp(SUPER_ADMIN);
+
+    const res = await request(app).get("/v1/admin/hermes/proposals");
+
+    expect(res.status).toBe(200);
+    expect(res.body.proposals).toHaveLength(1);
+    expect(mockListProposals).toHaveBeenCalledWith({
+      scope: undefined,
+      tenantId: undefined,
+      status: undefined,
+    });
+  });
+
+  it("super_adminはscope/tenant_id/statusで絞り込める", async () => {
+    const app = makeApp(SUPER_ADMIN);
+
+    await request(app).get(
+      "/v1/admin/hermes/proposals?scope=tenant&tenant_id=carnation&status=pending",
+    );
+
+    expect(mockListProposals).toHaveBeenCalledWith({
+      scope: "tenant",
+      tenantId: "carnation",
+      status: "pending",
+    });
+  });
+
+  it("不正なscopeは400", async () => {
+    const app = makeApp(SUPER_ADMIN);
+    const res = await request(app).get("/v1/admin/hermes/proposals?scope=bogus");
+    expect(res.status).toBe(400);
+  });
+
+  it("不正なstatusは400", async () => {
+    const app = makeApp(SUPER_ADMIN);
+    const res = await request(app).get("/v1/admin/hermes/proposals?status=bogus");
+    expect(res.status).toBe(400);
+  });
+
+  it("client_adminがscope=globalを要求すると403(匿名横断提案はsuper_admin専用)", async () => {
+    const app = makeApp(CLIENT_ADMIN);
+    const res = await request(app).get("/v1/admin/hermes/proposals?scope=global");
+    expect(res.status).toBe(403);
+    expect(mockListProposals).not.toHaveBeenCalled();
+  });
+
+  it("client_adminが他テナントのtenant_idを指定すると403(越境防止)", async () => {
+    const app = makeApp(CLIENT_ADMIN);
+    const res = await request(app).get("/v1/admin/hermes/proposals?tenant_id=other-tenant");
+    expect(res.status).toBe(403);
+  });
+
+  it("client_adminはフィルタ無しでも自テナントのtenantスコープのみに強制される", async () => {
+    const app = makeApp(CLIENT_ADMIN);
+
+    await request(app).get("/v1/admin/hermes/proposals");
+
+    expect(mockListProposals).toHaveBeenCalledWith({
+      scope: "tenant",
+      tenantId: "carnation",
+      status: undefined,
+    });
+  });
+});
+
+describe("POST /v1/admin/hermes/proposals/:id/approve", () => {
+  it("db未接続なら503", async () => {
+    const app = makeApp(SUPER_ADMIN, null);
+    const res = await request(app).post("/v1/admin/hermes/proposals/1/approve");
+    expect(res.status).toBe(503);
+  });
+
+  it("提案が存在しなければ404", async () => {
+    mockGetProposalById.mockResolvedValue(null);
+    const app = makeApp(SUPER_ADMIN);
+
+    const res = await request(app).post("/v1/admin/hermes/proposals/999/approve");
+
+    expect(res.status).toBe(404);
+    expect(mockUpdateProposalStatus).not.toHaveBeenCalled();
+  });
+
+  it("client_adminがglobal提案を承認しようとすると403", async () => {
+    mockGetProposalById.mockResolvedValue({ id: "1", scope: "global", tenantId: null });
+    const app = makeApp(CLIENT_ADMIN);
+
+    const res = await request(app).post("/v1/admin/hermes/proposals/1/approve");
+
+    expect(res.status).toBe(403);
+    expect(mockUpdateProposalStatus).not.toHaveBeenCalled();
+  });
+
+  it("client_adminが他テナントのtenant提案を承認しようとすると403(越境防止)", async () => {
+    mockGetProposalById.mockResolvedValue({ id: "1", scope: "tenant", tenantId: "other-tenant" });
+    const app = makeApp(CLIENT_ADMIN);
+
+    const res = await request(app).post("/v1/admin/hermes/proposals/1/approve");
+
+    expect(res.status).toBe(403);
+    expect(mockUpdateProposalStatus).not.toHaveBeenCalled();
+  });
+
+  it("client_adminは自テナントのtenant提案を承認でき、decided_byにemailが記録される", async () => {
+    mockGetProposalById.mockResolvedValue({ id: "1", scope: "tenant", tenantId: "carnation" });
+    mockUpdateProposalStatus.mockResolvedValue({ id: "1", status: "approved" });
+    const app = makeApp(CLIENT_ADMIN);
+
+    const res = await request(app).post("/v1/admin/hermes/proposals/1/approve");
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateProposalStatus).toHaveBeenCalledWith(
+      "1",
+      "approved",
+      "owner@carnation.example",
+    );
+  });
+
+  it("super_adminはどのscope/tenantの提案でも承認できる", async () => {
+    mockGetProposalById.mockResolvedValue({ id: "1", scope: "global", tenantId: null });
+    mockUpdateProposalStatus.mockResolvedValue({ id: "1", status: "approved" });
+    const app = makeApp(SUPER_ADMIN);
+
+    const res = await request(app).post("/v1/admin/hermes/proposals/1/approve");
+
+    expect(res.status).toBe(200);
+  });
+
+  it("updateProposalStatusがnullを返す(競合等)場合は404", async () => {
+    mockGetProposalById.mockResolvedValue({ id: "1", scope: "global", tenantId: null });
+    mockUpdateProposalStatus.mockResolvedValue(null);
+    const app = makeApp(SUPER_ADMIN);
+
+    const res = await request(app).post("/v1/admin/hermes/proposals/1/approve");
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /v1/admin/hermes/proposals/:id/reject", () => {
+  it("super_adminが却下でき、statusに'rejected'が渡る", async () => {
+    mockGetProposalById.mockResolvedValue({ id: "1", scope: "global", tenantId: null });
+    mockUpdateProposalStatus.mockResolvedValue({ id: "1", status: "rejected" });
+    const app = makeApp(SUPER_ADMIN);
+
+    const res = await request(app).post("/v1/admin/hermes/proposals/1/reject");
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateProposalStatus).toHaveBeenCalledWith("1", "rejected", "root@example.com");
+  });
+});

--- a/src/api/admin/hermes/routes.ts
+++ b/src/api/admin/hermes/routes.ts
@@ -1,0 +1,132 @@
+// src/api/admin/hermes/routes.ts
+// Phase74: Hermes Agent — 戦略提案の管理者向け承認ゲートAPI
+//
+// GET  /v1/admin/hermes/proposals             — 提案一覧(scope/tenant_id/statusで絞り込み)
+// POST /v1/admin/hermes/proposals/:id/approve — 承認(意思決定の記録のみ)
+// POST /v1/admin/hermes/proposals/:id/reject  — 却下
+//
+// 重要: このAPIはどのエンドポイントも system_prompt / system_prompt_variants を
+// 自動書き換えしない。承認は「管理者が既存の PUT /v1/admin/variants を手動で叩く」
+// 前段の意思決定を記録するだけ(提案→人間承認ゲート)。
+//
+// 認可: conversion routes (src/api/conversion/conversionRoutes.ts) の
+// effectiveness ハンドラの越境チェックパターンを踏襲。
+//   - client_admin は scope='tenant' かつ自テナントの提案のみ閲覧・決定可能
+//   - scope='global'(匿名横断集計由来)の提案は super_admin のみ閲覧・決定可能
+
+import type { Express, Request, Response } from "express";
+import type { Pool } from "pg";
+import { supabaseAuthMiddleware } from "../../../admin/http/supabaseAuthMiddleware";
+import { roleAuthMiddleware, requireRole } from "../../middleware/roleAuth";
+import type { AuthenticatedUser } from "../../middleware/roleAuth";
+import {
+  createHermesProposalRepository,
+  type HermesProposalScope,
+  type HermesProposalStatus,
+} from "../../../agent/hermes/proposalRepository";
+
+const VALID_SCOPES: readonly HermesProposalScope[] = ["global", "tenant"];
+const VALID_STATUSES: readonly HermesProposalStatus[] = [
+  "pending",
+  "approved",
+  "rejected",
+  "applied",
+];
+
+const ADMIN_AUTH = [
+  supabaseAuthMiddleware,
+  roleAuthMiddleware,
+  requireRole("super_admin", "client_admin"),
+];
+
+export function registerHermesRoutes(app: Express, db: Pool | null): void {
+  app.use("/v1/admin/hermes", ...ADMIN_AUTH);
+
+  const repo = createHermesProposalRepository(db ?? undefined);
+
+  // ----------------------------------------------------------------
+  // GET /v1/admin/hermes/proposals
+  // ----------------------------------------------------------------
+  app.get("/v1/admin/hermes/proposals", async (req: Request, res: Response) => {
+    if (!db) return res.status(503).json({ error: "database_unavailable" });
+
+    const user = (req as Request & { user?: AuthenticatedUser }).user;
+    if (!user) return res.status(403).json({ error: "forbidden" });
+
+    const queryScope = req.query["scope"] as string | undefined;
+    const queryTenantId = req.query["tenant_id"] as string | undefined;
+    const queryStatus = req.query["status"] as string | undefined;
+
+    if (queryScope && !VALID_SCOPES.includes(queryScope as HermesProposalScope)) {
+      return res.status(400).json({ error: "invalid_scope" });
+    }
+    if (queryStatus && !VALID_STATUSES.includes(queryStatus as HermesProposalStatus)) {
+      return res.status(400).json({ error: "invalid_status" });
+    }
+
+    let scope = queryScope as HermesProposalScope | undefined;
+    let tenantId = queryTenantId;
+
+    if (user.role === "client_admin") {
+      // client_admin は自テナントの tenant スコープ提案のみ閲覧可能
+      // (scope='global' は匿名横断集計由来の全社戦略提案のため super_admin 専用)
+      if (scope === "global") {
+        return res.status(403).json({ error: "forbidden" });
+      }
+      if (tenantId && tenantId !== user.tenantId) {
+        return res.status(403).json({ error: "forbidden" });
+      }
+      scope = "tenant";
+      tenantId = user.tenantId ?? undefined;
+    }
+
+    try {
+      const proposals = await repo.listProposals({
+        scope,
+        tenantId,
+        status: queryStatus as HermesProposalStatus | undefined,
+      });
+      return res.json({ proposals });
+    } catch {
+      return res.status(500).json({ error: "internal_error" });
+    }
+  });
+
+  // ----------------------------------------------------------------
+  // POST /v1/admin/hermes/proposals/:id/approve
+  // POST /v1/admin/hermes/proposals/:id/reject
+  // ----------------------------------------------------------------
+  function makeDecideHandler(status: "approved" | "rejected") {
+    return async (req: Request, res: Response) => {
+      if (!db) return res.status(503).json({ error: "database_unavailable" });
+
+      const user = (req as Request & { user?: AuthenticatedUser }).user;
+      if (!user) return res.status(403).json({ error: "forbidden" });
+
+      const id = req.params["id"] as string;
+
+      try {
+        const proposal = await repo.getProposalById(id);
+        if (!proposal) return res.status(404).json({ error: "not_found" });
+
+        if (
+          user.role === "client_admin" &&
+          (proposal.scope !== "tenant" || proposal.tenantId !== user.tenantId)
+        ) {
+          return res.status(403).json({ error: "forbidden" });
+        }
+
+        const decidedBy = user.email || user.tenantId || "unknown";
+        const updated = await repo.updateProposalStatus(id, status, decidedBy);
+        if (!updated) return res.status(404).json({ error: "not_found" });
+
+        return res.json({ proposal: updated });
+      } catch {
+        return res.status(500).json({ error: "internal_error" });
+      }
+    };
+  }
+
+  app.post("/v1/admin/hermes/proposals/:id/approve", makeDecideHandler("approved"));
+  app.post("/v1/admin/hermes/proposals/:id/reject", makeDecideHandler("rejected"));
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,7 @@ import { registerEventRoutes } from "./api/events/eventRoutes";
 import { registerEngagementRoutes } from "./api/engagement/engagementRoutes";
 import { registerConversionRoutes } from "./api/conversion/conversionRoutes";
 import { registerAbTestRoutes } from "./api/conversion/abTestRoutes";
+import { registerHermesRoutes } from "./api/admin/hermes/routes";
 import { registerKnowledgeGapPhase46Routes } from "./api/admin/knowledge-gaps/routes";
 import { registerNotificationRoutes } from "./api/admin/notifications/routes";
 import { registerOptionRoutes } from "./api/admin/options/routes";
@@ -626,6 +627,9 @@ registerEngagementRoutes(app, apiStack, db);
 // Phase58: コンバージョン最適化ループ
 registerConversionRoutes(app, apiStack, db);
 if (db) registerAbTestRoutes(app, db);
+
+// Phase74: Hermes Agent — 戦略提案の承認ゲートAPI(system_prompt等は自動適用しない)
+registerHermesRoutes(app, db);
 
 // Phase55: Widget features check (event_tracking フラグ取得)
 app.get('/api/widget/features', ...apiStack, async (req: express.Request, res: express.Response) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import "./config/env";
 import { pool as db } from "./lib/db";
 import { alertEngine } from "./lib/alerts/alertEngine";
 import { startOpenClawHeartbeat } from "./agent/openclaw/heartbeatHandler";
+import { startHermes } from "./agent/hermes/hermesAgent";
 import express from "express";
 import multer from "multer";
 import path from "node:path";
@@ -711,6 +712,10 @@ async function startServer() {
   // Phase47-D: OpenClaw Heartbeat — flow 統計を30分周期で監視（Flag 判定は handler 内部）
   startOpenClawHeartbeat();
   logger.info("[startup] OpenClaw Heartbeat initialized");
+
+  // Phase74: Hermes Agent — CVR向上の戦略提案を6時間周期で生成（Flag 判定は handler 内部、既定オフ）
+  startHermes();
+  logger.info("[startup] Hermes Agent scheduler initialized");
 
   // Phase37 Step6: Stripe 日次使用量送信（24時間ごと）
   if (db && process.env.STRIPE_SECRET_KEY) {

--- a/src/migrations/phase74_hermes_proposals.sql
+++ b/src/migrations/phase74_hermes_proposals.sql
@@ -1,0 +1,77 @@
+-- Phase74: Hermes Agent — hermes_strategy_proposals
+-- 実行日: VPS で手動実行
+-- 対象: VPS PostgreSQL (65.108.159.161)
+--
+-- 設計意図:
+--   Hermes Agent (中央学習エージェント) が既存の crossTenantContext (匿名横断集計) と
+--   autoTuning の detect 群 (tenant 別 A/B 勝者・Judge 反復提案・心理原則ランキング) を
+--   束ねて生成する「CVR向上のための戦略提案」を永続化する。
+--
+--   Hermes は提案を作るだけで、system_prompt / system_prompt_variants を自動書き換えしない。
+--   実適用は管理者が既存の PUT /v1/admin/variants を手動で叩く (提案→人間承認ゲート)。
+--
+-- テナント越境防止方針 (重要):
+--   scope='global' の行は crossTenantContext 由来の匿名集計にのみ基づく。
+--   生の会話ログ・PII は rationale/evidence に一切含めない (集計値・principle名・experiment_id のみ)。
+--   scope='tenant' の行は必ず tenant_id を持ち、global 行は必ず tenant_id を持たない
+--   ことを chk_hermes_scope で DB 層から構造的に保証する。
+
+-- ============================================================
+-- 1. hermes_strategy_proposals テーブル本体
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS hermes_strategy_proposals (
+  id               BIGSERIAL PRIMARY KEY,
+  scope            TEXT NOT NULL,                    -- 'global' | 'tenant'
+  tenant_id        TEXT,                             -- scope='tenant' のみ非NULL
+  proposal_type    TEXT NOT NULL,                    -- 'xt_principle' | 'ab_winner' | 'judge_repeated' | 'effectiveness_top'
+  title            TEXT NOT NULL,
+  rationale        TEXT NOT NULL,                    -- 匿名集計/tenant別集計に基づく根拠 (生ログ不可)
+  suggested_action TEXT NOT NULL,                    -- 例: "variant B を昇格" (Hermesは適用しない)
+  evidence         JSONB DEFAULT '{}'::jsonb,         -- 集計値のみ (CV率/サンプル数/principle名/experiment_id)
+  status           TEXT NOT NULL DEFAULT 'pending',   -- pending | approved | rejected | applied
+  dedup_key        TEXT NOT NULL,
+  created_at       TIMESTAMPTZ DEFAULT NOW(),
+  decided_at       TIMESTAMPTZ,
+  decided_by       TEXT
+);
+
+-- 越境ガード: global は tenant_id を持てない / tenant は tenant_id 必須
+ALTER TABLE hermes_strategy_proposals
+  DROP CONSTRAINT IF EXISTS chk_hermes_scope;
+ALTER TABLE hermes_strategy_proposals
+  ADD CONSTRAINT chk_hermes_scope
+  CHECK (
+    (scope = 'global' AND tenant_id IS NULL)
+    OR (scope = 'tenant' AND tenant_id IS NOT NULL)
+  );
+
+-- ============================================================
+-- 2. インデックス
+-- ============================================================
+
+-- 同一提案の再生成を弾く (pending の間のみ一意)
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_hermes_dedup
+  ON hermes_strategy_proposals (dedup_key)
+  WHERE status = 'pending';
+
+-- Admin API 一覧表示用 (scope + status で絞り込み、新しい順)
+CREATE INDEX IF NOT EXISTS idx_hermes_scope_status
+  ON hermes_strategy_proposals (scope, status, created_at DESC);
+
+-- tenant 別一覧用
+CREATE INDEX IF NOT EXISTS idx_hermes_tenant
+  ON hermes_strategy_proposals (tenant_id)
+  WHERE tenant_id IS NOT NULL;
+
+COMMENT ON TABLE hermes_strategy_proposals IS 'Phase74: Hermes Agent が生成するCVR向上戦略提案。提案→人間承認ゲート方式で自動適用はしない。';
+COMMENT ON COLUMN hermes_strategy_proposals.scope IS 'global=crossTenantContext由来の匿名横断提案 / tenant=既存autoTuning detect群由来のテナント別提案';
+COMMENT ON COLUMN hermes_strategy_proposals.evidence IS '集計値のみ格納。会話文・顧客情報・PIIを含めないこと。';
+
+-- ============================================================
+-- 確認クエリ (実行後に手動確認)
+-- ============================================================
+-- SELECT column_name, data_type FROM information_schema.columns
+-- WHERE table_name = 'hermes_strategy_proposals' ORDER BY ordinal_position;
+-- SELECT indexname FROM pg_indexes WHERE tablename = 'hermes_strategy_proposals';
+-- SELECT conname FROM pg_constraint WHERE conrelid = 'hermes_strategy_proposals'::regclass;


### PR DESCRIPTION
## Summary

R2C(RAJIUCE)の中央学習エージェント「Hermes Agent」のMVPを実装。グローバルAI SaaS調査(Intercom Fin / AWS Bedrock / Azure OpenAI / Gartner)を踏まえ、以下の方針で設計:

- **データ境界 = 匿名集計のみ横断**: 生ログ・PIIはテナント内に留める。既存 `crossTenantContext.ts`(匿名横断集計)/ `autoTuning.ts`(tenant別detect群、`tenant_id=$1`付き)をそのまま再利用し、新規の横断生SQLは書かない
- **スコープ = 既存資産の統合MVP**: `autoTuning.ts` の detect 群(A/B勝者検出・Judge反復提案・心理原則ランキング)は実装済みだが駆動するスケジューラが未接続のデッドコードだった。Hermes Agent はこの欠けているスケジューラ層になる
- **自動適用度 = 提案→人間承認ゲート**: `system_prompt` / `system_prompt_variants` は一切自動書き換えしない。Hermesは戦略提案を生成・永続化・通知するのみ。実適用は管理者が既存の `PUT /v1/admin/variants` を手動実行する

## 構成(4コミット、各コミットが独立してレビュー可能)

1. **`hermes_strategy_proposals` テーブル + `proposalRepository.ts`**
   `scope='global'`(匿名横断)/`scope='tenant'` の混在を `chk_hermes_scope` CHECK制約でDB層から構造的に禁止(越境防止)。`dedup_key` の部分unique indexで重複提案を防止。

2. **Feature Flag + `strategyAggregator.ts`**
   `HERMES_ENABLED` / `HERMES_TENANTS` / `HERMES_NOTIFY_ENABLED` / `HERMES_LLM_ENABLED` による段階導入。`crossTenantContext.ts` / `autoTuning.ts` 自体は改変せず、新規モジュールで束ねる。

3. **`hermesAgent.ts` 常駐スケジューラ**
   `rajiuce-api` プロセス内 `setInterval`(6時間周期、`heartbeatHandler.ts` と同型の二重起動ガード+`unref()`)。`HERMES_ENABLED` 未設定時は no-op のため既定オフで安全にデプロイに載る。

4. **Admin API(承認ゲート)**
   `GET/POST /v1/admin/hermes/proposals*`。`conversion routes` の effectiveness ハンドラと同型の越境403チェック。client_admin は自テナントの tenant 提案のみ、global(匿名横断)提案は super_admin 専用。

## スコープ外(意図的)

- 重いRL/GPU/LoRA学習、OpenClaw-RLサーバーの本格デプロイ(コスト制約・PoC保留の経緯を踏襲)
- 生ログのテナント横断学習
- Slack詳細通知 + admin-ui表示(admin-uiはTier S=人間merge必須のため別PRに隔離予定)

## Test plan

- [x] `pnpm typecheck` — 全PR段階で通過
- [x] `pnpm test src/agent/hermes src/api/admin/hermes` — 73件全て通過
- [x] `pnpm test`(全体) — 2089件中2080件通過(残り9件は無関係な既存のavatar/fetch環境issue、mainブランチでも同様に失敗することを確認済み)
- [x] `pnpm lint` — hermes関連ファイルに警告なし
- [x] `bash SCRIPTS/security-scan.sh` — PASS
- [x] `bash SCRIPTS/dead-code-check.sh` — hermes関連の新規デッドコードなし、ルート登録確認済み
- [ ] マイグレーション適用(手動): `psql -f src/migrations/phase74_hermes_proposals.sql`(ローカル/VPS両方で未実施、レビュー後に実施)
- [ ] `HERMES_ENABLED=true HERMES_NOTIFY_ENABLED=false pnpm dev` での手動サイクル検証(マイグレーション適用後)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01Ge87SQjsJXevC6eBp1PqU6