### PR TITLE
Phase75: Hermes Agent(実物)向けMCP連携 — 会話ログ同意ゲート付き公開

### DIFF
--- a/avatar-agent/agent.py
+++ b/avatar-agent/agent.py
@@ -223,6 +223,33 @@ async def _report_tts_usage(tenant_id: str, tts_text_bytes: int) -> None:
 LEMONSLICE_CREDITS_PER_MINUTE = 24.5
 
 
+async def _report_avatar_transcript(
+    tenant_id: str, session_id: str, role: str, content: str
+) -> None:
+    """Phase75: legacy/fallbackパス(agent内でGroqを直接呼ぶ経路)の会話テキストを
+    RAJIUCE APIへ永続化リクエスト（fire-and-forget）。
+    LemonSlice経由の「本体API」応答パス(tts_request)はwidget側が既に
+    通常のchat APIでsaveMessage済みのため、ここでは呼ばない(二重保存防止)。
+    """
+    api_url = os.environ.get("RAJIUCE_API_URL", "http://localhost:3100")
+    try:
+        async with aiohttp.ClientSession() as http_session:
+            await http_session.post(
+                f"{api_url}/api/internal/avatar-transcript",
+                headers={"X-Internal-Request": "1", "Content-Type": "application/json"},
+                json={
+                    "tenantId": tenant_id,
+                    "sessionId": session_id,
+                    "role": role,
+                    "content": content,
+                },
+                timeout=aiohttp.ClientTimeout(total=5),
+            )
+        logger.debug(f"[transcript] reported: tenant={tenant_id} role={role}")
+    except Exception as e:
+        logger.warning(f"[transcript] report failed (non-critical): {e}")
+
+
 async def _report_avatar_usage(tenant_id: str, session_ms: int) -> None:
     """LemonSlice アバターのセッション課金をRAJIUCE APIへ非同期レポート（fire-and-forget）。
 
@@ -525,6 +552,16 @@ async def entrypoint(ctx: agents.JobContext) -> None:
             # 2. session.say() で FishAudio TTS パイプラインに渡す
             session.say(reply)
             logger.debug(f"[say] sent to TTS: {reply!r}")
+
+            # Phase75: 会話ログ永続化(fire-and-forget)。room名をsession_idとして使う。
+            if tenant_id:
+                asyncio.ensure_future(
+                    _report_avatar_transcript(tenant_id, ctx.room.name, "user", user_text)
+                )
+                if reply != FALLBACK_MSG:
+                    asyncio.ensure_future(
+                        _report_avatar_transcript(tenant_id, ctx.room.name, "assistant", reply)
+                    )
 
             # 3. Data Channel 経由で Widget にもテキスト送信（フォールバックメッセージはスキップ）
             if reply != FALLBACK_MSG and ctx.room.local_participant:

--- a/src/api/admin/tenants/routes.ts
+++ b/src/api/admin/tenants/routes.ts
@@ -26,6 +26,11 @@ const featuresSchema = z.object({
   rag: z.boolean(),
   deep_research: z.boolean().optional(),
   pre_dispatch: z.boolean().optional(),
+  // Phase75: Hermes Agent(CVR学習エージェント)が会話ログ生データを横断利用することへの
+  // テナント同意フラグ。既定false(未設定=同意なし、fail-safe)。同意は本来テナント自身が
+  // 行うべきものなので、super_admin用スキーマだけでなく client_admin 自己申告の
+  // PATCH /v1/admin/my-tenant(下記)にも同じキーを追加している。
+  hermes_raw_data_consent: z.boolean().optional(),
 });
 
 const updateTenantSchema = z.object({
@@ -140,6 +145,8 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
         rag: z.boolean(),
         deep_research: z.boolean().optional(),
         pre_dispatch: z.boolean().optional(),
+        // Phase75: テナント自身によるHermes Agent向け生データ利用同意の自己申告
+        hermes_raw_data_consent: z.boolean().optional(),
       }),
     });
     const parsed = bodySchema.safeParse(req.body ?? {});

--- a/src/api/avatar/anamChatStreamRoutes.test.ts
+++ b/src/api/avatar/anamChatStreamRoutes.test.ts
@@ -1,0 +1,141 @@
+// src/api/avatar/anamChatStreamRoutes.test.ts
+// Phase75: 会話ログ永続化(avatar経由の会話をchat_messagesへsaveMessage)の検証
+
+import express from 'express';
+import request from 'supertest';
+import type { RequestHandler } from 'express';
+import { registerAnamChatStreamRoutes } from './anamChatStreamRoutes';
+
+jest.mock('../admin/chat-history/chatHistoryRepository', () => ({
+  saveMessage: jest.fn(),
+}));
+
+import { saveMessage } from '../admin/chat-history/chatHistoryRepository';
+const mockSaveMessage = saveMessage as jest.Mock;
+
+// apiStack: テナントコンテキストをreqに注入するダミーミドルウェア
+function makeTenantStack(tenantId: string | null): RequestHandler[] {
+  return [
+    (req, _res, next) => {
+      (req as any).tenantId = tenantId;
+      next();
+    },
+  ];
+}
+
+function makeApp(tenantId: string | null = 'carnation') {
+  const app = express();
+  app.use(express.json());
+  registerAnamChatStreamRoutes(app, makeTenantStack(tenantId));
+  return app;
+}
+
+/** Groqのstreaming SSEレスポンスを模したReadableStream風オブジェクトを作る。 */
+function makeGroqStreamResponse(contentChunks: string[]) {
+  const lines = contentChunks.map(
+    (c) => `data: ${JSON.stringify({ choices: [{ delta: { content: c } }] })}\n`,
+  );
+  lines.push('data: [DONE]\n');
+  const fullText = lines.join('');
+  const encoder = new TextEncoder();
+  const bytes = encoder.encode(fullText);
+
+  let sent = false;
+  return {
+    ok: true,
+    body: {
+      getReader: () => ({
+        read: async () => {
+          if (sent) return { done: true, value: undefined };
+          sent = true;
+          return { done: false, value: bytes };
+        },
+      }),
+    },
+  };
+}
+
+beforeEach(() => {
+  mockSaveMessage.mockReset();
+  mockSaveMessage.mockResolvedValue(undefined);
+  process.env.GROQ_API_KEY = 'test-groq-key';
+  (global as any).fetch = jest.fn().mockResolvedValue(makeGroqStreamResponse(['こんにちは', '！']));
+});
+
+afterEach(() => {
+  delete (global as any).fetch;
+});
+
+describe('POST /api/avatar/chat-stream', () => {
+  it('正常系: ユーザーの最新発話とアシスタント応答(結合済み)をmetadata.source=avatarで保存する', async () => {
+    const res = await request(makeApp())
+      .post('/api/avatar/chat-stream')
+      .send({ messages: [{ role: 'user', content: '保証はありますか' }], sessionId: 'sess-1' });
+
+    expect(res.status).toBe(200);
+    expect(mockSaveMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: 'carnation',
+        sessionId: 'sess-1',
+        role: 'user',
+        content: '保証はありますか',
+        metadata: { source: 'avatar', channel: 'anam' },
+      }),
+    );
+    expect(mockSaveMessage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: 'carnation',
+        sessionId: 'sess-1',
+        role: 'assistant',
+        content: 'こんにちは！',
+        metadata: { source: 'avatar', channel: 'anam' },
+      }),
+    );
+  });
+
+  it('sessionId未指定時はランダム生成され、user/assistant両方に同じIDが使われる', async () => {
+    await request(makeApp())
+      .post('/api/avatar/chat-stream')
+      .send({ messages: [{ role: 'user', content: 'こんにちは' }] });
+
+    const userCall = mockSaveMessage.mock.calls.find((c) => c[0].role === 'user');
+    const assistantCall = mockSaveMessage.mock.calls.find((c) => c[0].role === 'assistant');
+    expect(userCall![0].sessionId).toBeTruthy();
+    expect(userCall![0].sessionId).toBe(assistantCall![0].sessionId);
+  });
+
+  it('複数ターンのmessages配列では最新のuserメッセージのみ保存する(履歴の重複保存を防ぐ)', async () => {
+    await request(makeApp())
+      .post('/api/avatar/chat-stream')
+      .send({
+        sessionId: 'sess-2',
+        messages: [
+          { role: 'user', content: '1つ目の質問' },
+          { role: 'assistant', content: '1つ目の回答' },
+          { role: 'user', content: '2つ目の質問' },
+        ],
+      });
+
+    const userCalls = mockSaveMessage.mock.calls.filter((c) => c[0].role === 'user');
+    expect(userCalls).toHaveLength(1);
+    expect(userCalls[0][0].content).toBe('2つ目の質問');
+  });
+
+  it('認証エラー: tenantId欠落は401、saveMessageは呼ばれない', async () => {
+    const res = await request(makeApp(null))
+      .post('/api/avatar/chat-stream')
+      .send({ messages: [{ role: 'user', content: 'こんにちは' }] });
+
+    expect(res.status).toBe(401);
+    expect(mockSaveMessage).not.toHaveBeenCalled();
+  });
+
+  it('バリデーションエラー: messages配列が空/不正は400', async () => {
+    const res = await request(makeApp())
+      .post('/api/avatar/chat-stream')
+      .send({ messages: [] });
+
+    expect(res.status).toBe(400);
+    expect(mockSaveMessage).not.toHaveBeenCalled();
+  });
+});

--- a/src/api/avatar/anamChatStreamRoutes.ts
+++ b/src/api/avatar/anamChatStreamRoutes.ts
@@ -6,10 +6,12 @@
 //   widget.jsからの会話履歴を受け取り、Groq LLMでストリーミング応答を返す。
 //   Anam JS SDKのcreateTalkMessageStream()でTTS化される。
 
+import { randomUUID } from 'node:crypto';
 import { GROQ_VERSATILE_70B } from '../../config/groqModels';
 import type { Express, Request, Response, RequestHandler } from 'express';
 import type { AuthedRequest } from '../../agent/http/authMiddleware';
 import { logger } from '../../lib/logger';
+import { saveMessage } from '../admin/chat-history/chatHistoryRepository';
 
 const GROQ_API_BASE = 'https://api.groq.com/openai/v1/chat/completions';
 
@@ -22,9 +24,30 @@ export function registerAnamChatStreamRoutes(app: Express, apiStack: RequestHand
       return res.status(401).json({ error: 'unauthorized' });
     }
 
-    const { messages } = req.body as { messages?: Array<{ role: string; content: string }> };
+    const { messages, sessionId: bodySessionId } = req.body as {
+      messages?: Array<{ role: string; content: string }>;
+      sessionId?: string;
+    };
     if (!Array.isArray(messages) || messages.length === 0) {
       return res.status(400).json({ error: 'messages array required' });
+    }
+
+    // Phase75: 会話ログ永続化。Widgetがsession_idを送ってこない場合、この呼び出し単位を
+    // 1セッションとして扱う(継続性は失うが、Hermes MCP等の学習用途には十分な単発Q&Aとして
+    // 記録できる)。将来widget.js側でsessionIdを継続送信するよう改修すれば自動的に連続化する。
+    const sessionId =
+      typeof bodySessionId === 'string' && bodySessionId.trim().length > 0
+        ? bodySessionId
+        : randomUUID();
+    const latestUserMessage = [...messages].reverse().find((m) => m.role === 'user');
+    if (latestUserMessage?.content) {
+      saveMessage({
+        tenantId,
+        sessionId,
+        role: 'user',
+        content: latestUserMessage.content,
+        metadata: { source: 'avatar', channel: 'anam' },
+      }).catch((err) => logger.warn('[anamChatStream] saveMessage(user) failed:', err));
     }
 
     const groqApiKey = process.env.GROQ_API_KEY?.trim();
@@ -105,6 +128,7 @@ export function registerAnamChatStreamRoutes(app: Express, apiStack: RequestHand
 
       const decoder = new TextDecoder();
       let buffer = '';
+      let assistantContent = '';
 
       while (true) {
         const { done, value } = await reader.read();
@@ -126,6 +150,7 @@ export function registerAnamChatStreamRoutes(app: Express, apiStack: RequestHand
             };
             const content = parsed.choices?.[0]?.delta?.content ?? '';
             if (content) {
+              assistantContent += content;
               res.write(JSON.stringify({ content }) + '\n');
             }
           } catch {
@@ -135,6 +160,17 @@ export function registerAnamChatStreamRoutes(app: Express, apiStack: RequestHand
       }
 
       res.end();
+
+      // Phase75: 会話ログ永続化(assistant側)。fire-and-forget、レスポンス送信後に実行。
+      if (assistantContent) {
+        saveMessage({
+          tenantId,
+          sessionId,
+          role: 'assistant',
+          content: assistantContent,
+          metadata: { source: 'avatar', channel: 'anam' },
+        }).catch((err) => logger.warn('[anamChatStream] saveMessage(assistant) failed:', err));
+      }
 
     } catch (err) {
       logger.error('[anamChatStream] Stream error:', err);

--- a/src/api/hermes-mcp/hermesMcpAuth.test.ts
+++ b/src/api/hermes-mcp/hermesMcpAuth.test.ts
@@ -1,0 +1,59 @@
+// src/api/hermes-mcp/hermesMcpAuth.test.ts
+
+import express from "express";
+import request from "supertest";
+import { hermesMcpAuthMiddleware } from "./hermesMcpAuth";
+
+function makeApp() {
+  const app = express();
+  app.get("/protected", hermesMcpAuthMiddleware, (_req, res) => res.json({ ok: true }));
+  return app;
+}
+
+const ENV_KEY = "HERMES_MCP_API_KEY";
+
+beforeEach(() => {
+  delete process.env[ENV_KEY];
+});
+
+afterEach(() => {
+  delete process.env[ENV_KEY];
+});
+
+describe("hermesMcpAuthMiddleware", () => {
+  it("HERMES_MCP_API_KEY未設定は503(fail-closed)", async () => {
+    const res = await request(makeApp()).get("/protected").set("Authorization", "Bearer anything");
+    expect(res.status).toBe(503);
+  });
+
+  it("Authorizationヘッダなしは401", async () => {
+    process.env[ENV_KEY] = "secret-key-123";
+    const res = await request(makeApp()).get("/protected");
+    expect(res.status).toBe(401);
+  });
+
+  it("Bearer以外のスキームは401", async () => {
+    process.env[ENV_KEY] = "secret-key-123";
+    const res = await request(makeApp()).get("/protected").set("Authorization", "Basic xxx");
+    expect(res.status).toBe(401);
+  });
+
+  it("不正なトークンは401", async () => {
+    process.env[ENV_KEY] = "secret-key-123";
+    const res = await request(makeApp()).get("/protected").set("Authorization", "Bearer wrong-key");
+    expect(res.status).toBe(401);
+  });
+
+  it("正しいトークンは200で通過", async () => {
+    process.env[ENV_KEY] = "secret-key-123";
+    const res = await request(makeApp()).get("/protected").set("Authorization", "Bearer secret-key-123");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it("長さが違うトークンでも例外を投げず401を返す", async () => {
+    process.env[ENV_KEY] = "secret-key-123";
+    const res = await request(makeApp()).get("/protected").set("Authorization", "Bearer x");
+    expect(res.status).toBe(401);
+  });
+});

--- a/src/api/hermes-mcp/hermesMcpAuth.ts
+++ b/src/api/hermes-mcp/hermesMcpAuth.ts
@@ -1,0 +1,40 @@
+// src/api/hermes-mcp/hermesMcpAuth.ts
+// Phase75: Hermes MCP エンドポイント用 Bearer トークン認証
+//
+// 呼び出し元(Hermes Agent VPS)は R2C 本番VPSとは別ホストのため、
+// internalNetworkOnly(loopback限定)パターンは使えない。
+// 代わりに HERMES_MCP_API_KEY 環境変数との定数時間比較で認証する。
+// 生の文字列同士を timingSafeEqual すると長さ不一致で例外/タイミング漏洩の
+// リスクがあるため、SHA-256ダイジェスト同士(常に32byte固定長)を比較する。
+
+import { createHash, timingSafeEqual } from "node:crypto";
+import type { NextFunction, Request, Response } from "express";
+
+function sha256(input: string): Buffer {
+  return createHash("sha256").update(input, "utf8").digest();
+}
+
+export function hermesMcpAuthMiddleware(req: Request, res: Response, next: NextFunction): void {
+  const expected = process.env.HERMES_MCP_API_KEY;
+  if (!expected) {
+    // 未設定(開発環境等)では機能全体をfail-closedで無効化する
+    res.status(503).json({ error: "hermes_mcp_not_configured" });
+    return;
+  }
+
+  const authHeader = req.headers.authorization ?? "";
+  if (!authHeader.startsWith("Bearer ")) {
+    res.status(401).json({ error: "missing_bearer_token" });
+    return;
+  }
+  const provided = authHeader.slice("Bearer ".length).trim();
+
+  const providedHash = sha256(provided);
+  const expectedHash = sha256(expected);
+  if (!timingSafeEqual(providedHash, expectedHash)) {
+    res.status(401).json({ error: "invalid_token" });
+    return;
+  }
+
+  next();
+}

--- a/src/api/hermes-mcp/hermesMcpRepository.test.ts
+++ b/src/api/hermes-mcp/hermesMcpRepository.test.ts
@@ -1,0 +1,103 @@
+// src/api/hermes-mcp/hermesMcpRepository.test.ts
+
+import { searchConversations } from "./hermesMcpRepository";
+
+jest.mock("../../lib/db", () => ({
+  getPool: jest.fn(),
+}));
+
+import { getPool } from "../../lib/db";
+const mockGetPool = getPool as jest.Mock;
+
+function mockQuery(rows: object[]) {
+  const query = jest.fn().mockResolvedValue({ rows });
+  mockGetPool.mockReturnValue({ query });
+  return query;
+}
+
+beforeEach(() => {
+  mockGetPool.mockReset();
+});
+
+describe("searchConversations", () => {
+  it("tenant_idのみ指定: 全条件無しでSELECTし結果を返す", async () => {
+    const query = mockQuery([
+      {
+        session_id: "sess-1",
+        role: "user",
+        content: "保証はありますか",
+        created_at: "2026-07-01T00:00:00.000Z",
+        judge_score: 85,
+        converted: true,
+      },
+    ]);
+
+    const results = await searchConversations({ tenantId: "carnation" });
+
+    expect(results).toEqual([
+      {
+        sessionId: "sess-1",
+        role: "user",
+        content: "保証はありますか",
+        createdAt: "2026-07-01T00:00:00.000Z",
+        judgeScore: 85,
+        converted: true,
+      },
+    ]);
+    const [sql, args] = query.mock.calls[0];
+    expect(sql).toContain("s.tenant_id = $1");
+    expect(args).toEqual(["carnation", 50]); // デフォルトlimit=50
+  });
+
+  it("query指定時: ILIKE条件を追加する", async () => {
+    const query = mockQuery([]);
+    await searchConversations({ tenantId: "carnation", query: "保証" });
+
+    const [sql, args] = query.mock.calls[0];
+    expect(sql).toContain("m.content ILIKE");
+    expect(args).toContain("%保証%");
+  });
+
+  it("minJudgeScore指定時: conversation_evaluations EXISTS条件を追加する", async () => {
+    const query = mockQuery([]);
+    await searchConversations({ tenantId: "carnation", minJudgeScore: 80 });
+
+    const [sql, args] = query.mock.calls[0];
+    expect(sql).toContain("conversation_evaluations");
+    expect(sql).toContain("ce.score >=");
+    expect(args).toContain(80);
+  });
+
+  it("convertedOnly指定時: conversion_attributions EXISTS条件を追加する", async () => {
+    const query = mockQuery([]);
+    await searchConversations({ tenantId: "carnation", convertedOnly: true });
+
+    const [sql] = query.mock.calls[0];
+    expect(sql).toContain("conversion_attributions");
+    expect(sql).toContain("ca.session_id = s.id");
+  });
+
+  it("limitは200を超えられない", async () => {
+    const query = mockQuery([]);
+    await searchConversations({ tenantId: "carnation", limit: 9999 });
+
+    const [, args] = query.mock.calls[0];
+    expect(args[args.length - 1]).toBe(200);
+  });
+
+  it("judge_scoreがnullの場合はjudgeScore: null", async () => {
+    mockQuery([
+      {
+        session_id: "sess-2",
+        role: "assistant",
+        content: "はい、3ヶ月保証です",
+        created_at: "2026-07-01T00:00:00.000Z",
+        judge_score: null,
+        converted: false,
+      },
+    ]);
+    const [result] = await searchConversations({ tenantId: "carnation" });
+    expect(result!.judgeScore).toBeNull();
+    expect(result!.converted).toBe(false);
+  });
+});

--- a/src/api/hermes-mcp/hermesMcpRepository.ts
+++ b/src/api/hermes-mcp/hermesMcpRepository.ts
@@ -1,0 +1,97 @@
+// src/api/hermes-mcp/hermesMcpRepository.ts
+// Phase75: Hermes Agent(CVR学習エージェント)向けMCPデータアクセス層
+//
+// 重要: ここで返すデータは同意済みテナントのみを対象にすること。
+// 同意チェック自体はこのファイルでは行わない(呼び出し側 routes.ts の責務)。
+// このファイルは「同意済みと確認された tenantId」を渡された前提で動く。
+
+import { getPool } from "../../lib/db";
+
+export interface HermesConversationMessage {
+  sessionId: string; // chat_sessions.session_id (アプリ側の文字列ID)
+  role: "user" | "assistant";
+  content: string;
+  createdAt: string;
+  judgeScore: number | null;
+  converted: boolean;
+}
+
+export interface SearchConversationsParams {
+  tenantId: string;
+  query?: string;
+  minJudgeScore?: number;
+  convertedOnly?: boolean;
+  limit?: number;
+}
+
+const MAX_LIMIT = 200;
+const DEFAULT_LIMIT = 50;
+
+/**
+ * 同意済みテナントの会話メッセージを検索する。
+ * - minJudgeScore: conversation_evaluations.score(TEXTのsession_idで結合) >= 指定値のセッションのみ
+ * - convertedOnly: conversion_attributions(UUIDのsession_idで結合)に紐づくセッションのみ
+ * - query: content の ILIKE 部分一致
+ */
+export async function searchConversations(
+  params: SearchConversationsParams,
+): Promise<HermesConversationMessage[]> {
+  const pool = getPool();
+  const limit = Math.min(params.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
+
+  const conditions: string[] = [`s.tenant_id = $1`];
+  const args: unknown[] = [params.tenantId];
+
+  if (params.query?.trim()) {
+    args.push(`%${params.query.trim()}%`);
+    conditions.push(`m.content ILIKE $${args.length}`);
+  }
+
+  if (params.minJudgeScore !== undefined) {
+    args.push(params.minJudgeScore);
+    conditions.push(
+      `EXISTS (SELECT 1 FROM conversation_evaluations ce WHERE ce.session_id = s.session_id AND ce.score >= $${args.length})`,
+    );
+  }
+
+  if (params.convertedOnly) {
+    conditions.push(
+      `EXISTS (SELECT 1 FROM conversion_attributions ca WHERE ca.session_id = s.id)`,
+    );
+  }
+
+  args.push(limit);
+  const limitPlaceholder = `$${args.length}`;
+
+  const result = await pool.query<{
+    session_id: string;
+    role: "user" | "assistant";
+    content: string;
+    created_at: string;
+    judge_score: number | null;
+    converted: boolean;
+  }>(
+    `SELECT
+       s.session_id,
+       m.role,
+       m.content,
+       m.created_at,
+       (SELECT MAX(ce.score) FROM conversation_evaluations ce WHERE ce.session_id = s.session_id) AS judge_score,
+       EXISTS (SELECT 1 FROM conversion_attributions ca WHERE ca.session_id = s.id) AS converted
+     FROM chat_messages m
+     JOIN chat_sessions s ON s.id = m.session_id
+     WHERE ${conditions.join(" AND ")}
+     ORDER BY m.created_at DESC
+     LIMIT ${limitPlaceholder}`,
+    args,
+  );
+
+  return result.rows.map((row) => ({
+    sessionId: row.session_id,
+    role: row.role,
+    content: row.content,
+    createdAt: row.created_at,
+    judgeScore: row.judge_score !== null ? Number(row.judge_score) : null,
+    converted: row.converted,
+  }));
+}

--- a/src/api/hermes-mcp/routes.test.ts
+++ b/src/api/hermes-mcp/routes.test.ts
@@ -1,0 +1,114 @@
+// src/api/hermes-mcp/routes.test.ts
+
+import express from "express";
+import request from "supertest";
+import { registerHermesMcpRoutes } from "./routes";
+
+jest.mock("../../lib/hermesConsent", () => ({
+  isHermesDataConsentGranted: jest.fn(),
+  listHermesConsentingTenantIds: jest.fn(),
+}));
+jest.mock("./hermesMcpRepository", () => ({
+  searchConversations: jest.fn(),
+}));
+
+import { isHermesDataConsentGranted, listHermesConsentingTenantIds } from "../../lib/hermesConsent";
+import { searchConversations } from "./hermesMcpRepository";
+
+const mockIsConsentGranted = isHermesDataConsentGranted as jest.Mock;
+const mockListConsenting = listHermesConsentingTenantIds as jest.Mock;
+const mockSearchConversations = searchConversations as jest.Mock;
+
+const API_KEY = "test-hermes-mcp-key";
+
+function makeApp() {
+  const app = express();
+  registerHermesMcpRoutes(app);
+  return app;
+}
+
+function authedGet(path: string) {
+  return request(makeApp()).get(path).set("Authorization", `Bearer ${API_KEY}`);
+}
+
+beforeEach(() => {
+  process.env.HERMES_MCP_API_KEY = API_KEY;
+  mockIsConsentGranted.mockReset();
+  mockListConsenting.mockReset();
+  mockSearchConversations.mockReset();
+});
+
+afterEach(() => {
+  delete process.env.HERMES_MCP_API_KEY;
+});
+
+describe("認証ガード", () => {
+  it("Bearerトークンなしは401(tenants)", async () => {
+    const res = await request(makeApp()).get("/v1/hermes-mcp/tenants");
+    expect(res.status).toBe(401);
+  });
+
+  it("Bearerトークンなしは401(conversations)", async () => {
+    const res = await request(makeApp()).get("/v1/hermes-mcp/conversations?tenant_id=carnation");
+    expect(res.status).toBe(401);
+  });
+});
+
+describe("GET /v1/hermes-mcp/tenants", () => {
+  it("同意済みテナントID一覧を返す", async () => {
+    mockListConsenting.mockResolvedValue(["carnation"]);
+    const res = await authedGet("/v1/hermes-mcp/tenants");
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ tenantIds: ["carnation"] });
+  });
+});
+
+describe("GET /v1/hermes-mcp/conversations", () => {
+  it("tenant_id未指定は400", async () => {
+    const res = await authedGet("/v1/hermes-mcp/conversations");
+    expect(res.status).toBe(400);
+    expect(mockIsConsentGranted).not.toHaveBeenCalled();
+  });
+
+  it("未同意テナントは403、searchConversationsは呼ばれない(同意チェック最優先)", async () => {
+    mockIsConsentGranted.mockResolvedValue(false);
+    const res = await authedGet("/v1/hermes-mcp/conversations?tenant_id=other-tenant");
+    expect(res.status).toBe(403);
+    expect(mockSearchConversations).not.toHaveBeenCalled();
+  });
+
+  it("同意済みテナントは検索結果を返す", async () => {
+    mockIsConsentGranted.mockResolvedValue(true);
+    mockSearchConversations.mockResolvedValue([
+      { sessionId: "s1", role: "user", content: "hi", createdAt: "x", judgeScore: 80, converted: true },
+    ]);
+    const res = await authedGet("/v1/hermes-mcp/conversations?tenant_id=carnation");
+    expect(res.status).toBe(200);
+    expect(res.body.conversations).toHaveLength(1);
+    expect(mockSearchConversations).toHaveBeenCalledWith(
+      expect.objectContaining({ tenantId: "carnation" }),
+    );
+  });
+
+  it("不正なmin_judge_score(範囲外)は400", async () => {
+    mockIsConsentGranted.mockResolvedValue(true);
+    const res = await authedGet("/v1/hermes-mcp/conversations?tenant_id=carnation&min_judge_score=150");
+    expect(res.status).toBe(400);
+    expect(mockSearchConversations).not.toHaveBeenCalled();
+  });
+
+  it("不正なlimit(範囲外)は400", async () => {
+    mockIsConsentGranted.mockResolvedValue(true);
+    const res = await authedGet("/v1/hermes-mcp/conversations?tenant_id=carnation&limit=99999");
+    expect(res.status).toBe(400);
+  });
+
+  it("converted_only=trueがsearchConversationsに伝搬する", async () => {
+    mockIsConsentGranted.mockResolvedValue(true);
+    mockSearchConversations.mockResolvedValue([]);
+    await authedGet("/v1/hermes-mcp/conversations?tenant_id=carnation&converted_only=true");
+    expect(mockSearchConversations).toHaveBeenCalledWith(
+      expect.objectContaining({ convertedOnly: true }),
+    );
+  });
+});

--- a/src/api/hermes-mcp/routes.ts
+++ b/src/api/hermes-mcp/routes.ts
@@ -1,0 +1,95 @@
+// src/api/hermes-mcp/routes.ts
+// Phase75: Hermes Agent(CVR学習エージェント)向けMCPデータエンドポイント
+//
+// GET /v1/hermes-mcp/tenants        — 同意済みテナントID一覧
+// GET /v1/hermes-mcp/conversations  — 会話メッセージ検索(同意済みテナントのみ)
+//
+// 認証: Bearer HERMES_MCP_API_KEY(hermesMcpAuthMiddleware、定数時間比較)。
+// 呼び出し元は Hermes Agent VPS(135.181.194.34)上の stdio MCP サーバーラッパー。
+//
+// 設計上の要: 同意チェックは他の何よりも先に行う。tenant_id が
+// listHermesConsentingTenantIds() に含まれない限り、絶対にデータへ到達させない。
+
+import type { Express, Request, Response } from "express";
+import { hermesMcpAuthMiddleware } from "./hermesMcpAuth";
+import { isHermesDataConsentGranted, listHermesConsentingTenantIds } from "../../lib/hermesConsent";
+import { searchConversations } from "./hermesMcpRepository";
+import { logger } from "../../lib/logger";
+
+const MAX_QUERY_LEN = 200;
+
+export function registerHermesMcpRoutes(app: Express): void {
+  app.use("/v1/hermes-mcp", hermesMcpAuthMiddleware);
+
+  // ----------------------------------------------------------------
+  // GET /v1/hermes-mcp/tenants
+  // ----------------------------------------------------------------
+  app.get("/v1/hermes-mcp/tenants", async (_req: Request, res: Response) => {
+    try {
+      const tenantIds = await listHermesConsentingTenantIds();
+      return res.json({ tenantIds });
+    } catch (err) {
+      logger.warn({ err }, "[hermes-mcp] list tenants failed");
+      return res.status(500).json({ error: "internal_error" });
+    }
+  });
+
+  // ----------------------------------------------------------------
+  // GET /v1/hermes-mcp/conversations
+  // ----------------------------------------------------------------
+  app.get("/v1/hermes-mcp/conversations", async (req: Request, res: Response) => {
+    const tenantId = req.query["tenant_id"];
+    if (!tenantId || typeof tenantId !== "string") {
+      return res.status(400).json({ error: "tenant_id required" });
+    }
+
+    // 同意チェックを最優先で実行(他の何よりも先)。
+    // 未同意テナントには、存在確認すら与えないよう 403 で統一する。
+    const consented = await isHermesDataConsentGranted(tenantId);
+    if (!consented) {
+      return res.status(403).json({ error: "tenant_not_consented" });
+    }
+
+    const rawQuery = req.query["query"];
+    const query =
+      typeof rawQuery === "string" && rawQuery.trim().length > 0
+        ? rawQuery.slice(0, MAX_QUERY_LEN)
+        : undefined;
+
+    const rawMinScore = req.query["min_judge_score"];
+    let minJudgeScore: number | undefined;
+    if (typeof rawMinScore === "string" && rawMinScore.trim() !== "") {
+      const parsed = Number(rawMinScore);
+      if (Number.isNaN(parsed) || parsed < 0 || parsed > 100) {
+        return res.status(400).json({ error: "invalid_min_judge_score" });
+      }
+      minJudgeScore = parsed;
+    }
+
+    const convertedOnly = req.query["converted_only"] === "true";
+
+    const rawLimit = req.query["limit"];
+    let limit: number | undefined;
+    if (typeof rawLimit === "string" && rawLimit.trim() !== "") {
+      const parsed = Number(rawLimit);
+      if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 200) {
+        return res.status(400).json({ error: "invalid_limit" });
+      }
+      limit = parsed;
+    }
+
+    try {
+      const conversations = await searchConversations({
+        tenantId,
+        query,
+        minJudgeScore,
+        convertedOnly,
+        limit,
+      });
+      return res.json({ conversations });
+    } catch (err) {
+      logger.warn({ err }, "[hermes-mcp] search conversations failed");
+      return res.status(500).json({ error: "internal_error" });
+    }
+  });
+}

--- a/src/api/internal/avatarTranscriptRoutes.test.ts
+++ b/src/api/internal/avatarTranscriptRoutes.test.ts
@@ -1,0 +1,90 @@
+// src/api/internal/avatarTranscriptRoutes.test.ts
+// POST /api/internal/avatar-transcript のテスト
+
+import express from "express";
+import request from "supertest";
+import { registerInternalAvatarTranscriptRoutes } from "./avatarTranscriptRoutes";
+
+jest.mock("../admin/chat-history/chatHistoryRepository", () => ({
+  saveMessage: jest.fn(),
+}));
+
+import { saveMessage } from "../admin/chat-history/chatHistoryRepository";
+const mockSaveMessage = saveMessage as jest.Mock;
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  registerInternalAvatarTranscriptRoutes(app);
+  return app;
+}
+
+const VALID_BODY = {
+  tenantId: "carnation",
+  sessionId: "rajiuce-carnation-abc123",
+  role: "user",
+  content: "保証はありますか",
+};
+
+beforeEach(() => {
+  mockSaveMessage.mockReset();
+  mockSaveMessage.mockResolvedValue(undefined);
+});
+
+describe("POST /api/internal/avatar-transcript", () => {
+  it("正常系: X-Internal-Request付きで202を返し、metadata.source=avatarでsaveMessageを呼ぶ", async () => {
+    const res = await request(makeApp())
+      .post("/api/internal/avatar-transcript")
+      .set("X-Internal-Request", "1")
+      .send(VALID_BODY);
+
+    expect(res.status).toBe(202);
+    expect(mockSaveMessage).toHaveBeenCalledWith({
+      tenantId: "carnation",
+      sessionId: "rajiuce-carnation-abc123",
+      role: "user",
+      content: "保証はありますか",
+      metadata: { source: "avatar", channel: "livekit" },
+    });
+  });
+
+  it("認証エラー: X-Internal-Requestヘッダなしは403", async () => {
+    const res = await request(makeApp())
+      .post("/api/internal/avatar-transcript")
+      .send(VALID_BODY);
+
+    expect(res.status).toBe(403);
+    expect(mockSaveMessage).not.toHaveBeenCalled();
+  });
+
+  it("バリデーションエラー: tenantId欠落は400", async () => {
+    const res = await request(makeApp())
+      .post("/api/internal/avatar-transcript")
+      .set("X-Internal-Request", "1")
+      .send({ ...VALID_BODY, tenantId: undefined });
+
+    expect(res.status).toBe(400);
+    expect(mockSaveMessage).not.toHaveBeenCalled();
+  });
+
+  it("バリデーションエラー: roleが'user'/'assistant'以外は400", async () => {
+    const res = await request(makeApp())
+      .post("/api/internal/avatar-transcript")
+      .set("X-Internal-Request", "1")
+      .send({ ...VALID_BODY, role: "system" });
+
+    expect(res.status).toBe(400);
+    expect(mockSaveMessage).not.toHaveBeenCalled();
+  });
+
+  it("saveMessage失敗時は500(内部処理は継続、例外は投げない)", async () => {
+    mockSaveMessage.mockRejectedValue(new Error("db down"));
+
+    const res = await request(makeApp())
+      .post("/api/internal/avatar-transcript")
+      .set("X-Internal-Request", "1")
+      .send(VALID_BODY);
+
+    expect(res.status).toBe(500);
+  });
+});

--- a/src/api/internal/avatarTranscriptRoutes.ts
+++ b/src/api/internal/avatarTranscriptRoutes.ts
@@ -1,0 +1,66 @@
+// src/api/internal/avatarTranscriptRoutes.ts
+//
+// POST /api/internal/avatar-transcript
+//   認証: X-Internal-Request: 1（他のinternalエンドポイントと同じ方式）
+//   avatar-agent/agent.py の legacy/fallback パス(handle_chat: agent内でGroqを直接呼ぶ経路)
+//   から、ユーザー発話・アバター応答テキストを受け取り chat_messages に永続化する。
+//
+//   注意: LemonSlice経由の「本体API」応答パス(tts_request経由)は、widget側が既に
+//   通常のchat API(src/api/chat/route.ts)を叩いておりそちらで saveMessage() 済みのため、
+//   ここで二重保存はしない。このエンドポイントは agent.py 内でGroqを直接呼ぶ
+//   フォールバック経路の会話だけを対象にする。
+//
+// Body: { tenantId, sessionId, role: 'user'|'assistant', content }
+
+import type { Express, Request, Response } from "express";
+import { INTERNAL_REQUEST_HEADER } from "../../lib/metrics/kpiDefinitions";
+import { internalNetworkOnly } from "../middleware/internalNetworkOnly";
+import { saveMessage } from "../admin/chat-history/chatHistoryRepository";
+import { logger } from "../../lib/logger";
+
+export function registerInternalAvatarTranscriptRoutes(app: Express): void {
+  app.post(
+    "/api/internal/avatar-transcript",
+    internalNetworkOnly,
+    async (req: Request, res: Response) => {
+      if (req.headers[INTERNAL_REQUEST_HEADER] !== "1") {
+        return res.status(403).json({ error: "forbidden" });
+      }
+
+      const body = req.body ?? {};
+      const { tenantId, sessionId, role, content } = body as {
+        tenantId?: unknown;
+        sessionId?: unknown;
+        role?: unknown;
+        content?: unknown;
+      };
+
+      if (!tenantId || typeof tenantId !== "string") {
+        return res.status(400).json({ error: "tenantId required" });
+      }
+      if (!sessionId || typeof sessionId !== "string") {
+        return res.status(400).json({ error: "sessionId required" });
+      }
+      if (role !== "user" && role !== "assistant") {
+        return res.status(400).json({ error: "role must be 'user' or 'assistant'" });
+      }
+      if (!content || typeof content !== "string") {
+        return res.status(400).json({ error: "content required" });
+      }
+
+      try {
+        await saveMessage({
+          tenantId,
+          sessionId,
+          role,
+          content,
+          metadata: { source: "avatar", channel: "livekit" },
+        });
+        return res.status(202).json({ accepted: true });
+      } catch (err) {
+        logger.warn({ err }, "[avatar-transcript] saveMessage failed");
+        return res.status(500).json({ error: "internal_error" });
+      }
+    },
+  );
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -87,6 +87,7 @@ import { registerEventRoutes } from "./api/events/eventRoutes";
 import { registerEngagementRoutes } from "./api/engagement/engagementRoutes";
 import { registerConversionRoutes } from "./api/conversion/conversionRoutes";
 import { registerAbTestRoutes } from "./api/conversion/abTestRoutes";
+import { registerHermesMcpRoutes } from "./api/hermes-mcp/routes";
 import { registerKnowledgeGapPhase46Routes } from "./api/admin/knowledge-gaps/routes";
 import { registerNotificationRoutes } from "./api/admin/notifications/routes";
 import { registerOptionRoutes } from "./api/admin/options/routes";
@@ -629,6 +630,9 @@ registerEngagementRoutes(app, apiStack, db);
 // Phase58: コンバージョン最適化ループ
 registerConversionRoutes(app, apiStack, db);
 if (db) registerAbTestRoutes(app, db);
+
+// Phase75: Hermes Agent(外部, 別VPS)向けMCPデータエンドポイント(Bearer認証、同意ゲート)
+registerHermesMcpRoutes(app);
 
 // Phase55: Widget features check (event_tracking フラグ取得)
 app.get('/api/widget/features', ...apiStack, async (req: express.Request, res: express.Response) => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ import { registerFalGenerationRoutes } from "./api/admin/avatar/falGenerationRou
 import { registerPremiumGenerationRoutes } from "./api/admin/avatar/premiumGenerationRoutes";
 import { registerInternalUsageRoutes } from "./api/internal/usageRoutes";
 import { registerInternalAvatarConfigRoutes } from "./api/internal/avatarConfigRoutes";
+import { registerInternalAvatarTranscriptRoutes } from "./api/internal/avatarTranscriptRoutes";
 import { registerGa4TenantRoutes } from "./api/admin/tenants/ga4Routes";
 import { registerPostHogTenantRoutes } from "./api/admin/tenants/posthogRoutes";
 import { flushPostHog } from "./lib/posthog/posthogClient";
@@ -594,6 +595,9 @@ registerInternalUsageRoutes(app);
 
 // Internal: avatar-agent → テナント別アバター設定取得（X-Internal-Request: 1 認証）
 registerInternalAvatarConfigRoutes(app);
+
+// Phase75: Internal: avatar-agent(legacy Groqフォールバック経路) → 会話ログ永続化（X-Internal-Request: 1 認証）
+registerInternalAvatarTranscriptRoutes(app);
 
 // Phase A: GA4連携 内部API (Cloudflare Workers Cron用, HMAC認証)
 if (db) registerInternalGa4SyncRoutes(app, db);

--- a/src/lib/hermesConsent.test.ts
+++ b/src/lib/hermesConsent.test.ts
@@ -1,0 +1,66 @@
+// src/lib/hermesConsent.test.ts
+// Phase75: hermesConsent テスト
+
+import { isHermesDataConsentGranted, listHermesConsentingTenantIds } from "./hermesConsent";
+
+jest.mock("./db", () => ({
+  getPool: jest.fn(),
+}));
+
+import { getPool } from "./db";
+const mockGetPool = getPool as jest.Mock;
+
+function mockQuery(impl: jest.Mock) {
+  mockGetPool.mockReturnValue({ query: impl });
+}
+
+beforeEach(() => {
+  mockGetPool.mockReset();
+});
+
+describe("isHermesDataConsentGranted", () => {
+  it("features.hermes_raw_data_consent === true のときのみ true", async () => {
+    mockQuery(jest.fn().mockResolvedValue({ rows: [{ features: { hermes_raw_data_consent: true } }] }));
+    expect(await isHermesDataConsentGranted("carnation")).toBe(true);
+  });
+
+  it("キーが存在しない場合はfalse(fail-safe)", async () => {
+    mockQuery(jest.fn().mockResolvedValue({ rows: [{ features: { avatar: true } }] }));
+    expect(await isHermesDataConsentGranted("carnation")).toBe(false);
+  });
+
+  it("features自体がnullの場合はfalse", async () => {
+    mockQuery(jest.fn().mockResolvedValue({ rows: [{ features: null }] }));
+    expect(await isHermesDataConsentGranted("carnation")).toBe(false);
+  });
+
+  it("該当テナントが存在しない場合はfalse", async () => {
+    mockQuery(jest.fn().mockResolvedValue({ rows: [] }));
+    expect(await isHermesDataConsentGranted("nonexistent")).toBe(false);
+  });
+
+  it("DB障害時はfalse(fail-safe、例外を投げない)", async () => {
+    mockQuery(jest.fn().mockRejectedValue(new Error("db down")));
+    await expect(isHermesDataConsentGranted("carnation")).resolves.toBe(false);
+  });
+
+  it("false明示のテナントはfalse", async () => {
+    mockQuery(jest.fn().mockResolvedValue({ rows: [{ features: { hermes_raw_data_consent: false } }] }));
+    expect(await isHermesDataConsentGranted("carnation")).toBe(false);
+  });
+});
+
+describe("listHermesConsentingTenantIds", () => {
+  it("同意済みテナントのIDのみ返す", async () => {
+    const query = jest.fn().mockResolvedValue({ rows: [{ id: "carnation" }, { id: "other" }] });
+    mockQuery(query);
+    const ids = await listHermesConsentingTenantIds();
+    expect(ids).toEqual(["carnation", "other"]);
+    expect(query.mock.calls[0][0]).toContain("hermes_raw_data_consent");
+  });
+
+  it("DB障害時は空配列", async () => {
+    mockQuery(jest.fn().mockRejectedValue(new Error("db down")));
+    expect(await listHermesConsentingTenantIds()).toEqual([]);
+  });
+});

--- a/src/lib/hermesConsent.ts
+++ b/src/lib/hermesConsent.ts
@@ -1,0 +1,38 @@
+// src/lib/hermesConsent.ts
+// Phase75: Hermes Agent(CVR学習エージェント)向けデータ利用同意チェック
+//
+// テナントの会話ログ生データをHermes Agent(外部, MCP経由)に公開してよいかを判定する。
+// fail-safe設計: features.hermes_raw_data_consent が明示的に true でない限り、
+// 常に false(=非公開)として扱う。新規テナント・未設定テナントは自動的に除外される。
+
+import { getPool } from "./db";
+
+export async function isHermesDataConsentGranted(tenantId: string): Promise<boolean> {
+  const pool = getPool();
+  try {
+    const result = await pool.query<{ features: { hermes_raw_data_consent?: boolean } | null }>(
+      `SELECT features FROM tenants WHERE id = $1`,
+      [tenantId],
+    );
+    return result.rows[0]?.features?.hermes_raw_data_consent === true;
+  } catch {
+    // DB障害時は fail-safe で非公開扱い(データ露出よりも可用性低下を優先)
+    return false;
+  }
+}
+
+/**
+ * 同意済みテナントのIDを全件取得する。
+ * MCPサーバーが公開してよいテナント一覧を返す用途。
+ */
+export async function listHermesConsentingTenantIds(): Promise<string[]> {
+  const pool = getPool();
+  try {
+    const result = await pool.query<{ id: string }>(
+      `SELECT id FROM tenants WHERE features->>'hermes_raw_data_consent' = 'true'`,
+    );
+    return result.rows.map((r) => r.id);
+  } catch {
+    return [];
+  }
+}


### PR DESCRIPTION
## Summary

外部の実在するAIエージェント「Hermes Agent」(Nous Research製、https://github.com/NousResearch/hermes-agent)を、R2CのテナントのQA AI応答・アバター応答を学習してCVR向上の提案を行う頭脳として連携させるための、R2C側の受け入れ準備。

Hermes Agent本体は別Hetzner VPS(r2c-hermes-agent, 135.181.194.34)に導入済み(本PRの対象外)。このPRはR2C側で必要な以下3点を実装する:

1. **アバター会話ログの永続化**(現状ゼロだった)
2. **テナントのデータ利用同意フラグ**(全テナント横断で生ログを扱うため必須)
3. **Hermes向けMCPデータエンドポイント**(同意ゲート付き)

## 背景・設計方針

- データ範囲: 会話ログ全文 + Judge高スコア応答 + CV紐付き応答(匿名集計ではなく生データ)
- テナント範囲: 全テナント横断、**ただし同意が必須**(`tenants.features.hermes_raw_data_consent`)。未設定=同意なし(fail-safe)
- 同意は本来テナント自身が行うべきもの(Microsoft/AWSのマルチテナントガバナンス調査結果を踏まえた判断)なので、super_admin用スキーマだけでなくclient_admin自己申告の`PATCH /v1/admin/my-tenant`にも同じキーを追加
- R2C本番VPSは空きメモリ222MBしかないため、**新規プロセスは追加しない**(既存rajiuce-apiに新規route追加のみ)。MCPサーバー本体は別リポジトリ(`r2c-cvr-mcp`)としてHermes VPS側に配置

## 変更内容(4コミット)

1. **アバター会話ログの永続化**
   - `anamChatStreamRoutes.ts`: ストリーム完了後に`saveMessage()`を直接呼ぶ(`metadata: {source:'avatar', channel:'anam'}`)
   - 新規`POST /api/internal/avatar-transcript`: `agent.py`(別プロセス、legacy/fallbackパスのみ)からの永続化用。`internalNetworkOnly` + `X-Internal-Request`パターンを踏襲
   - LemonSlice経由の「本体API」応答パス(`tts_request`)は既存chat APIで保存済みのため対象外(二重保存防止)

2. **テナント同意フラグ**
   - `tenants.features`に`hermes_raw_data_consent`キーを追加(新規マイグレーション不要)
   - 既存の`tenant_settings_history`監査ログ(Phase72-A)がfeatures変更を自動記録済みのため追加実装不要
   - `isHermesDataConsentGranted()` / `listHermesConsentingTenantIds()`ヘルパー追加

3. **`/v1/hermes-mcp/*` エンドポイント**
   - `GET /v1/hermes-mcp/tenants`: 同意済みテナントID一覧
   - `GET /v1/hermes-mcp/conversations`: 同意チェックを他の何よりも先に実行(未同意は403)。`min_judge_score`/`converted_only`/`query`/`limit`でフィルタ
   - 認証: `HERMES_MCP_API_KEY`とのBearerトークン比較(SHA-256ダイジェスト同士のtimingSafeEqual)

## Test plan

- [x] `pnpm typecheck` — 全コミット段階で通過
- [x] `pnpm test` — 2055件中2046件通過(残り9件は無関係な既存のavatar/fetch環境issue、mainブランチでも同様に失敗することを確認済み)
- [x] `bash SCRIPTS/security-scan.sh` — 全ステップでPASS
- [x] `bash SCRIPTS/dead-code-check.sh` — 新規デッドコードなし、ルート登録確認済み
- [x] **実機E2E検証済み**: ローカルHomebrew Postgres(Docker不使用、社内ポリシー準拠)+実サーバー起動で、`/v1/hermes-mcp/*`エンドポイントを実データ・実HTTPリクエストで検証(同意済み/未同意テナントの分岐、min_judge_score/converted_onlyフィルタ、すべて実際のレスポンスで確認)
- [x] **実際のHermes Agent CLIからの疎通確認済み**: SSHリバーストンネル経由でHermes VPS(135.181.194.34)からこのローカル検証サーバーへ接続し、実際の`hermes -z "..."`プロンプトで`list_consenting_tenants`/`search_conversations`両ツールが正しく動作し、実データ(アバター会話・Judge評価・コンバージョン)を正確に返すことを確認
- [ ] マイグレーション適用(手動、本番VPS): 今回は新規マイグレーション不要(既存`features` JSONBカラムを使用)
- [ ] 本番デプロイ後: `HERMES_MCP_API_KEY`を新規生成しR2C VPS `.env`とHermes VPS `~/.hermes/config.yaml`両方に設定、`hermes mcp test r2c-cvr`で疎通確認

## 関連

- MCPサーバー本体は別リポジトリ: `~/projects/r2c-cvr-mcp`(Hermes VPS `/opt/r2c-cvr-mcp/`にデプロイ済み)
- 既存の`docs/HERMES_AGENT_VS_MANAGED_AGENTS_EVAL.md`は本件とは無関係(R2Cの24h自律開発ループ置き換え候補としての別評価)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Ge87SQjsJXevC6eBp1PqU6