### PR TITLE
Phase75: Hermes Agent学習への同意トグルUI(admin-ui, Tier S)

### DIFF
--- a/admin-ui/src/pages/admin/avatar/HermesConsentToggle.test.tsx
+++ b/admin-ui/src/pages/admin/avatar/HermesConsentToggle.test.tsx
@@ -1,0 +1,148 @@
+// Phase75: HermesConsentToggle unit tests
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { HermesConsentToggle } from "./HermesConsentToggle";
+
+vi.mock("../../../lib/api", () => ({
+  authFetch: vi.fn(),
+  API_BASE: "http://localhost:3100",
+}));
+
+import { authFetch } from "../../../lib/api";
+
+const mockOk = (data: unknown): Promise<Response> =>
+  Promise.resolve({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(data),
+  } as Response);
+
+const mockErr = (status: number): Promise<Response> =>
+  Promise.resolve({
+    ok: false,
+    status,
+    json: () => Promise.resolve({ error: "err" }),
+  } as Response);
+
+function mockInitialFetch(consent: boolean) {
+  vi.mocked(authFetch).mockReturnValueOnce(
+    mockOk({ features: { avatar: true, voice: false, rag: true, hermes_raw_data_consent: consent } }),
+  );
+}
+
+beforeEach(() => {
+  vi.mocked(authFetch).mockReset();
+});
+
+describe("HermesConsentToggle", () => {
+  it("T1: 初期取得でhermes_raw_data_consent=false → 「未同意」ボタンを表示する", async () => {
+    mockInitialFetch(false);
+    render(<HermesConsentToggle />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /データ提供に同意する/ })).toBeTruthy();
+    });
+    expect(screen.getByText("⏸️ 未同意")).toBeTruthy();
+  });
+
+  it("T2: 初期取得でhermes_raw_data_consent=true → 「同意済み」ボタンを表示する", async () => {
+    mockInitialFetch(true);
+    render(<HermesConsentToggle />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /同意を取り消す/ })).toBeTruthy();
+    });
+    expect(screen.getByText("✅ 同意済み")).toBeTruthy();
+  });
+
+  it("T3: クリックで楽観的更新→PATCH成功で「同意済み」に変わる", async () => {
+    mockInitialFetch(false);
+    vi.mocked(authFetch).mockReturnValueOnce(
+      mockOk({ features: { avatar: true, voice: false, rag: true, hermes_raw_data_consent: true } }),
+    );
+    render(<HermesConsentToggle />);
+
+    const btn = await screen.findByRole("button");
+    fireEvent.click(btn);
+
+    // 楽観的更新: 即座に「保存中...」になる
+    expect(screen.getByText("保存中...")).toBeTruthy();
+
+    await waitFor(() => {
+      expect(screen.getByText("✅ 同意済み")).toBeTruthy();
+    });
+  });
+
+  it("T4: PATCH失敗(500)でロールバックし「未同意」のまま、エラートーストが出る", async () => {
+    mockInitialFetch(false);
+    vi.mocked(authFetch).mockReturnValueOnce(mockErr(500));
+    render(<HermesConsentToggle />);
+
+    const btn = await screen.findByRole("button");
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      expect(screen.getByText("⏸️ 未同意")).toBeTruthy();
+      expect(screen.getByText("❌ 保存に失敗しました。もう一度お試しください。")).toBeTruthy();
+    });
+  });
+
+  it("T5: ネットワーク例外でもロールバックする", async () => {
+    mockInitialFetch(false);
+    vi.mocked(authFetch).mockRejectedValueOnce(new Error("network"));
+    render(<HermesConsentToggle />);
+
+    const btn = await screen.findByRole("button");
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      expect(screen.getByText("⏸️ 未同意")).toBeTruthy();
+    });
+  });
+
+  it("T6: PATCHリクエストの本文に既存features(avatar/voice/rag)を保持したまま送る", async () => {
+    mockInitialFetch(false);
+    vi.mocked(authFetch).mockReturnValueOnce(mockOk({ features: {} }));
+    render(<HermesConsentToggle />);
+
+    const btn = await screen.findByRole("button");
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      expect(vi.mocked(authFetch)).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/admin/my-tenant",
+        expect.objectContaining({
+          method: "PATCH",
+          body: JSON.stringify({
+            features: {
+              avatar: true,
+              voice: false,
+              rag: true,
+              deep_research: undefined,
+              pre_dispatch: undefined,
+              hermes_raw_data_consent: true,
+            },
+          }),
+        }),
+      );
+    });
+  });
+
+  it("T7: saving中はボタンがdisabledになる", async () => {
+    mockInitialFetch(false);
+    let resolve!: (v: Response) => void;
+    vi.mocked(authFetch).mockReturnValueOnce(
+      new Promise<Response>((r) => {
+        resolve = r;
+      }),
+    );
+    render(<HermesConsentToggle />);
+
+    const btn = (await screen.findByRole("button")) as HTMLButtonElement;
+    fireEvent.click(btn);
+    expect(btn.disabled).toBe(true);
+
+    resolve({ ok: true, status: 200, json: () => Promise.resolve({ features: {} }) } as Response);
+    await waitFor(() => expect(btn.disabled).toBe(false));
+  });
+});

--- a/admin-ui/src/pages/admin/avatar/HermesConsentToggle.tsx
+++ b/admin-ui/src/pages/admin/avatar/HermesConsentToggle.tsx
@@ -1,0 +1,163 @@
+// admin-ui/src/pages/admin/avatar/HermesConsentToggle.tsx
+// Phase75: Hermes Agent(会話ログ学習エージェント)へのデータ提供同意 ON/OFF トグル
+// （Client Adminのみ、自己完結型。ExcludeSearchToggleの楽観的更新+ロールバックパターンを踏襲）
+
+import { useEffect, useState } from "react";
+import { authFetch, API_BASE } from "../../../lib/api";
+
+interface TenantFeatures {
+  avatar: boolean;
+  voice: boolean;
+  rag: boolean;
+  deep_research?: boolean;
+  pre_dispatch?: boolean;
+  hermes_raw_data_consent?: boolean;
+}
+
+export function HermesConsentToggle() {
+  const [features, setFeatures] = useState<TenantFeatures | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [toast, setToast] = useState<string | null>(null);
+
+  useEffect(() => {
+    authFetch(`${API_BASE}/v1/admin/my-tenant`)
+      .then((r) => r.json())
+      .then((data: { features?: TenantFeatures }) => {
+        setFeatures({
+          avatar: data.features?.avatar ?? false,
+          voice: data.features?.voice ?? false,
+          rag: data.features?.rag ?? true,
+          deep_research: data.features?.deep_research,
+          pre_dispatch: data.features?.pre_dispatch,
+          hermes_raw_data_consent: data.features?.hermes_raw_data_consent ?? false,
+        });
+      })
+      .catch(() => {});
+  }, []);
+
+  const showToast = (msg: string) => {
+    setToast(msg);
+    setTimeout(() => setToast(null), 3000);
+  };
+
+  const consentGranted = features?.hermes_raw_data_consent === true;
+
+  const handleToggle = async () => {
+    if (!features || saving) return;
+    const next = !consentGranted;
+    const prev = features;
+
+    // 楽観的更新
+    setFeatures({ ...features, hermes_raw_data_consent: next });
+    setSaving(true);
+
+    try {
+      const res = await authFetch(`${API_BASE}/v1/admin/my-tenant`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ features: { ...prev, hermes_raw_data_consent: next } }),
+      });
+
+      if (!res.ok) {
+        setFeatures(prev); // ロールバック
+        showToast("❌ 保存に失敗しました。もう一度お試しください。");
+        return;
+      }
+
+      const updated = (await res.json()) as { features?: TenantFeatures };
+      setFeatures({ ...prev, ...updated.features });
+      showToast(
+        next
+          ? "✅ Hermes Agentへのデータ提供に同意しました"
+          : "✅ 同意を取り消しました",
+      );
+    } catch {
+      setFeatures(prev); // ロールバック
+      showToast("❌ 保存に失敗しました。もう一度お試しください。");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        marginBottom: 24,
+        padding: "20px 24px",
+        borderRadius: 14,
+        border: consentGranted
+          ? "1px solid rgba(74,222,128,0.35)"
+          : "1px solid rgba(107,114,128,0.3)",
+        background: consentGranted
+          ? "rgba(34,197,94,0.07)"
+          : "rgba(255,255,255,0.03)",
+      }}
+    >
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          gap: 16,
+          flexWrap: "wrap",
+        }}
+      >
+        <div>
+          <h2 style={{ fontSize: 18, fontWeight: 700, margin: 0, color: "var(--foreground)" }}>
+            🧠 Hermes Agent 学習への同意
+          </h2>
+          <p style={{ fontSize: 14, color: "var(--muted-foreground)", margin: "6px 0 0", maxWidth: 480 }}>
+            ONにすると、貴社の会話ログ(QA AI・アバターの応答)がHermes Agentの学習・CVR向上のための分析に利用されます。いつでもOFFに戻せます。
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => void handleToggle()}
+          disabled={saving || features === null}
+          aria-pressed={consentGranted}
+          aria-label={
+            consentGranted
+              ? "Hermes Agentへのデータ提供同意を取り消す"
+              : "Hermes Agentへのデータ提供に同意する"
+          }
+          style={{
+            padding: "12px 28px",
+            minHeight: 48,
+            minWidth: 120,
+            borderRadius: 10,
+            border: consentGranted
+              ? "1px solid rgba(74,222,128,0.5)"
+              : "1px solid rgba(107,114,128,0.4)",
+            background: consentGranted
+              ? "rgba(34,197,94,0.22)"
+              : "rgba(107,114,128,0.18)",
+            color: consentGranted ? "#4ade80" : "#9ca3af",
+            fontSize: 16,
+            fontWeight: 700,
+            cursor: saving || features === null ? "not-allowed" : "pointer",
+            opacity: saving || features === null ? 0.6 : 1,
+            transition: "all 0.15s",
+          }}
+        >
+          {saving ? "保存中..." : consentGranted ? "✅ 同意済み" : "⏸️ 未同意"}
+        </button>
+      </div>
+      {toast && (
+        <div
+          style={{
+            marginTop: 12,
+            padding: "10px 14px",
+            borderRadius: 8,
+            background: toast.startsWith("❌")
+              ? "rgba(239,68,68,0.12)"
+              : "rgba(34,197,94,0.12)",
+            color: toast.startsWith("❌") ? "#fca5a5" : "#86efac",
+            fontSize: 14,
+          }}
+        >
+          {toast}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/admin-ui/src/pages/admin/avatar/index.tsx
+++ b/admin-ui/src/pages/admin/avatar/index.tsx
@@ -11,6 +11,7 @@ import { AvatarWarningModal } from "./AvatarWarningModal";
 import { AvatarListHeader } from "./AvatarListHeader";
 import { AvatarFilterPanel } from "./AvatarFilterPanel";
 import { AvatarFeatureToggle } from "./AvatarFeatureToggle";
+import { HermesConsentToggle } from "./HermesConsentToggle";
 import { AvatarCard } from "./AvatarCard";
 
 export default function AvatarListPage() {
@@ -362,6 +363,9 @@ export default function AvatarListPage() {
           toggleToast={toggleToast}
         />
       )}
+
+      {/* ── Phase75: Hermes Agent学習への同意 ON/OFF トグル（Client Adminのみ）───────── */}
+      {!isSuperAdmin && user?.tenantId && <HermesConsentToggle />}
 
       {/* エラーメッセージ */}
       {error && (

--- a/admin-ui/src/pages/admin/tenants/types.ts
+++ b/admin-ui/src/pages/admin/tenants/types.ts
@@ -16,6 +16,8 @@ export interface TenantFeatures {
   rag: boolean;
   deep_research?: boolean;
   pre_dispatch?: boolean;
+  // Phase75: Hermes Agent(会話ログ学習エージェント)へのデータ提供同意
+  hermes_raw_data_consent?: boolean;
 }
 
 export interface TenantDetail {


### PR DESCRIPTION
## Summary

`/admin/avatar`ページ(client_admin向け自己申告設定画面)に、Hermes Agent(会話ログ学習エージェント)へのデータ提供同意をテナント自身がON/OFFできるトグルUIを追加。

バックエンド側(`hermes_raw_data_consent`フラグ、`PATCH /v1/admin/my-tenant`)は#438で既に実装済み。本PRはそのフロントエンド対応。

## 実装

- 新規`HermesConsentToggle.tsx`: 既存`ExcludeSearchToggle.tsx`と同じ「楽観的更新→失敗時ロールバック」パターンの自己完結型コンポーネント
- マウント時に`GET /v1/admin/my-tenant`で現在の同意状態を取得
- トグル時は`PATCH /v1/admin/my-tenant`で`features`全体(avatar/voice/rag等の既存値を保持)を送信、`hermes_raw_data_consent`のみ変更
- `admin-ui/src/pages/admin/tenants/types.ts`の`TenantFeatures`型に`hermes_raw_data_consent?: boolean`を追加

## Test plan

- [x] `pnpm typecheck`(admin-ui) — 通過
- [x] `pnpm test:ui`(admin-ui) — 5ファイル41件全通過(新規7件含む)
- [x] 新規テスト: 初期状態表示(同意済み/未同意)、楽観的更新、PATCH失敗時ロールバック(500・ネットワーク例外)、featuresの他フィールド保持、saving中disabled
- [x] `bash SCRIPTS/security-scan.sh` — PASS
- [x] **実ブラウザでの目視確認済み**: Vite dev server + Playwrightで、Supabaseセッションとネットワークのみスタブし本物のコンポーネントコードをそのまま描画。「未同意→クリック→同意済み(緑・トーストあり)→再クリック→未同意」の一連の流れをスクリーンショットで確認(auth基盤を持つ既存e2eフローとは別に、コンポーネント単体を実ブラウザでレンダリングする軽量ハーネスを使用、検証後は削除済み)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Ge87SQjsJXevC6eBp1PqU6