### PR TITLE
Phase74: Hermes Agent日次CVR改善提案 — 投稿API+承認ゲート

### DIFF
--- a/src/api/admin/hermes/routes.test.ts
+++ b/src/api/admin/hermes/routes.test.ts
@@ -1,0 +1,236 @@
+// src/api/admin/hermes/routes.test.ts
+// Phase74: Hermes Agent 提案 承認ゲートAPI — 認可ガード + 越境防止テスト
+
+jest.mock("../../../admin/http/supabaseAuthMiddleware", () => ({
+  supabaseAuthMiddleware: (req: any, _res: any, next: any) => {
+    req.supabaseUser = req._mockUser ?? null;
+    next();
+  },
+}));
+
+const mockListProposals = jest.fn();
+const mockGetProposalById = jest.fn();
+const mockUpdateProposalStatus = jest.fn();
+
+jest.mock("../../hermes-mcp/proposalRepository", () => ({
+  createHermesProposalRepository: jest.fn(() => ({
+    listProposals: mockListProposals,
+    getProposalById: mockGetProposalById,
+    updateProposalStatus: mockUpdateProposalStatus,
+  })),
+}));
+
+import express from "express";
+import request from "supertest";
+import { registerHermesProposalAdminRoutes } from "./routes";
+
+const FAKE_DB = { query: jest.fn() } as any;
+
+function makeApp(user: Record<string, unknown> | null, db: unknown = FAKE_DB) {
+  const app = express();
+  app.use(express.json());
+  app.use((req: any, _res: any, next: any) => {
+    req._mockUser = user;
+    next();
+  });
+  registerHermesProposalAdminRoutes(app, db as any);
+  return app;
+}
+
+const SUPER_ADMIN = { app_metadata: { role: "super_admin", tenant_id: null }, email: "root@example.com" };
+const CLIENT_ADMIN = { app_metadata: { role: "client_admin", tenant_id: "carnation" }, email: "owner@carnation.example" };
+
+const ALL_ROUTES = [
+  { method: "get" as const, path: "/v1/admin/hermes/proposals" },
+  { method: "post" as const, path: "/v1/admin/hermes/proposals/1/approve" },
+  { method: "post" as const, path: "/v1/admin/hermes/proposals/1/reject" },
+];
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockListProposals.mockResolvedValue([]);
+  mockGetProposalById.mockResolvedValue(null);
+  mockUpdateProposalStatus.mockResolvedValue(null);
+});
+
+describe("認可ガード(ALLOWED_ROLES)", () => {
+  ALL_ROUTES.forEach(({ method, path }) => {
+    it(`${method.toUpperCase()} ${path} — viewer → 403`, async () => {
+      const app = makeApp({ app_metadata: { role: "viewer", tenant_id: "t1" }, email: "v@t.com" });
+      const res = await (request(app) as any)[method](path);
+      expect(res.status).toBe(403);
+    });
+
+    it(`${method.toUpperCase()} ${path} — stale JWT(user_metadataのみ) → 403`, async () => {
+      const app = makeApp({ user_metadata: { role: "super_admin", tenant_id: "t1" }, email: "v@t.com" });
+      const res = await (request(app) as any)[method](path);
+      expect(res.status).toBe(403);
+    });
+
+    it(`${method.toUpperCase()} ${path} — 未認証(null) → 403`, async () => {
+      const app = makeApp(null);
+      const res = await (request(app) as any)[method](path);
+      expect(res.status).toBe(403);
+    });
+  });
+});
+
+describe("GET /v1/admin/hermes/proposals", () => {
+  it("db未接続なら503", async () => {
+    const app = makeApp(SUPER_ADMIN, null);
+    const res = await request(app).get("/v1/admin/hermes/proposals");
+    expect(res.status).toBe(503);
+  });
+
+  it("super_adminはフィルタ無しで全件取得できる", async () => {
+    mockListProposals.mockResolvedValue([{ id: "1", scope: "global" }]);
+    const app = makeApp(SUPER_ADMIN);
+
+    const res = await request(app).get("/v1/admin/hermes/proposals");
+
+    expect(res.status).toBe(200);
+    expect(res.body.proposals).toHaveLength(1);
+    expect(mockListProposals).toHaveBeenCalledWith({
+      scope: undefined,
+      tenantId: undefined,
+      status: undefined,
+    });
+  });
+
+  it("super_adminはscope/tenant_id/statusで絞り込める", async () => {
+    const app = makeApp(SUPER_ADMIN);
+
+    await request(app).get(
+      "/v1/admin/hermes/proposals?scope=tenant&tenant_id=carnation&status=pending",
+    );
+
+    expect(mockListProposals).toHaveBeenCalledWith({
+      scope: "tenant",
+      tenantId: "carnation",
+      status: "pending",
+    });
+  });
+
+  it("不正なscopeは400", async () => {
+    const app = makeApp(SUPER_ADMIN);
+    const res = await request(app).get("/v1/admin/hermes/proposals?scope=bogus");
+    expect(res.status).toBe(400);
+  });
+
+  it("不正なstatusは400", async () => {
+    const app = makeApp(SUPER_ADMIN);
+    const res = await request(app).get("/v1/admin/hermes/proposals?status=bogus");
+    expect(res.status).toBe(400);
+  });
+
+  it("client_adminがscope=globalを要求すると403(同意済み横断分析はsuper_admin専用)", async () => {
+    const app = makeApp(CLIENT_ADMIN);
+    const res = await request(app).get("/v1/admin/hermes/proposals?scope=global");
+    expect(res.status).toBe(403);
+    expect(mockListProposals).not.toHaveBeenCalled();
+  });
+
+  it("client_adminが他テナントのtenant_idを指定すると403(越境防止)", async () => {
+    const app = makeApp(CLIENT_ADMIN);
+    const res = await request(app).get("/v1/admin/hermes/proposals?tenant_id=other-tenant");
+    expect(res.status).toBe(403);
+  });
+
+  it("client_adminはフィルタ無しでも自テナントのtenantスコープのみに強制される", async () => {
+    const app = makeApp(CLIENT_ADMIN);
+
+    await request(app).get("/v1/admin/hermes/proposals");
+
+    expect(mockListProposals).toHaveBeenCalledWith({
+      scope: "tenant",
+      tenantId: "carnation",
+      status: undefined,
+    });
+  });
+});
+
+describe("POST /v1/admin/hermes/proposals/:id/approve", () => {
+  it("db未接続なら503", async () => {
+    const app = makeApp(SUPER_ADMIN, null);
+    const res = await request(app).post("/v1/admin/hermes/proposals/1/approve");
+    expect(res.status).toBe(503);
+  });
+
+  it("提案が存在しなければ404", async () => {
+    mockGetProposalById.mockResolvedValue(null);
+    const app = makeApp(SUPER_ADMIN);
+
+    const res = await request(app).post("/v1/admin/hermes/proposals/999/approve");
+
+    expect(res.status).toBe(404);
+    expect(mockUpdateProposalStatus).not.toHaveBeenCalled();
+  });
+
+  it("client_adminがglobal提案を承認しようとすると403", async () => {
+    mockGetProposalById.mockResolvedValue({ id: "1", scope: "global", tenantId: null });
+    const app = makeApp(CLIENT_ADMIN);
+
+    const res = await request(app).post("/v1/admin/hermes/proposals/1/approve");
+
+    expect(res.status).toBe(403);
+    expect(mockUpdateProposalStatus).not.toHaveBeenCalled();
+  });
+
+  it("client_adminが他テナントのtenant提案を承認しようとすると403(越境防止)", async () => {
+    mockGetProposalById.mockResolvedValue({ id: "1", scope: "tenant", tenantId: "other-tenant" });
+    const app = makeApp(CLIENT_ADMIN);
+
+    const res = await request(app).post("/v1/admin/hermes/proposals/1/approve");
+
+    expect(res.status).toBe(403);
+    expect(mockUpdateProposalStatus).not.toHaveBeenCalled();
+  });
+
+  it("client_adminは自テナントのtenant提案を承認でき、decided_byにemailが記録される", async () => {
+    mockGetProposalById.mockResolvedValue({ id: "1", scope: "tenant", tenantId: "carnation" });
+    mockUpdateProposalStatus.mockResolvedValue({ id: "1", status: "approved" });
+    const app = makeApp(CLIENT_ADMIN);
+
+    const res = await request(app).post("/v1/admin/hermes/proposals/1/approve");
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateProposalStatus).toHaveBeenCalledWith(
+      "1",
+      "approved",
+      "owner@carnation.example",
+    );
+  });
+
+  it("super_adminはどのscope/tenantの提案でも承認できる", async () => {
+    mockGetProposalById.mockResolvedValue({ id: "1", scope: "global", tenantId: null });
+    mockUpdateProposalStatus.mockResolvedValue({ id: "1", status: "approved" });
+    const app = makeApp(SUPER_ADMIN);
+
+    const res = await request(app).post("/v1/admin/hermes/proposals/1/approve");
+
+    expect(res.status).toBe(200);
+  });
+
+  it("updateProposalStatusがnullを返す(競合等)場合は404", async () => {
+    mockGetProposalById.mockResolvedValue({ id: "1", scope: "global", tenantId: null });
+    mockUpdateProposalStatus.mockResolvedValue(null);
+    const app = makeApp(SUPER_ADMIN);
+
+    const res = await request(app).post("/v1/admin/hermes/proposals/1/approve");
+
+    expect(res.status).toBe(404);
+  });
+});
+
+describe("POST /v1/admin/hermes/proposals/:id/reject", () => {
+  it("super_adminが却下でき、statusに'rejected'が渡る", async () => {
+    mockGetProposalById.mockResolvedValue({ id: "1", scope: "global", tenantId: null });
+    mockUpdateProposalStatus.mockResolvedValue({ id: "1", status: "rejected" });
+    const app = makeApp(SUPER_ADMIN);
+
+    const res = await request(app).post("/v1/admin/hermes/proposals/1/reject");
+
+    expect(res.status).toBe(200);
+    expect(mockUpdateProposalStatus).toHaveBeenCalledWith("1", "rejected", "root@example.com");
+  });
+});

--- a/src/api/admin/hermes/routes.ts
+++ b/src/api/admin/hermes/routes.ts
@@ -1,0 +1,127 @@
+// src/api/admin/hermes/routes.ts
+// Phase74: Hermes Agent — CVR改善提案の管理者向け承認ゲートAPI
+//
+// GET  /v1/admin/hermes/proposals             — 提案一覧(scope/tenant_id/statusで絞り込み)
+// POST /v1/admin/hermes/proposals/:id/approve — 承認(意思決定の記録のみ)
+// POST /v1/admin/hermes/proposals/:id/reject  — 却下
+//
+// 重要: このAPIはどのエンドポイントも system_prompt / system_prompt_variants を
+// 自動書き換えしない。承認は「管理者が既存の PUT /v1/admin/variants を手動で叩く」
+// 前段の意思決定を記録するだけ(提案→人間承認ゲート)。
+//
+// 認可: conversion routes (src/api/conversion/conversionRoutes.ts) の
+// effectiveness ハンドラの越境チェックパターンを踏襲。
+//   - client_admin は scope='tenant' かつ自テナントの提案のみ閲覧・決定可能
+//   - scope='global'(同意済みテナント横断の分析)の提案は super_admin のみ閲覧・決定可能
+
+import type { Express, Request, Response } from "express";
+import type { Pool } from "pg";
+import { supabaseAuthMiddleware } from "../../../admin/http/supabaseAuthMiddleware";
+import { roleAuthMiddleware, requireRole } from "../../middleware/roleAuth";
+import type { AuthenticatedUser } from "../../middleware/roleAuth";
+import {
+  createHermesProposalRepository,
+  type HermesProposalScope,
+  type HermesProposalStatus,
+} from "../../hermes-mcp/proposalRepository";
+
+const VALID_SCOPES: readonly HermesProposalScope[] = ["global", "tenant"];
+const VALID_STATUSES: readonly HermesProposalStatus[] = ["pending", "approved", "rejected"];
+
+const ADMIN_AUTH = [
+  supabaseAuthMiddleware,
+  roleAuthMiddleware,
+  requireRole("super_admin", "client_admin"),
+];
+
+export function registerHermesProposalAdminRoutes(app: Express, db: Pool | null): void {
+  app.use("/v1/admin/hermes", ...ADMIN_AUTH);
+
+  const repo = createHermesProposalRepository(db ?? undefined);
+
+  // ----------------------------------------------------------------
+  // GET /v1/admin/hermes/proposals
+  // ----------------------------------------------------------------
+  app.get("/v1/admin/hermes/proposals", async (req: Request, res: Response) => {
+    if (!db) return res.status(503).json({ error: "database_unavailable" });
+
+    const user = (req as Request & { user?: AuthenticatedUser }).user;
+    if (!user) return res.status(403).json({ error: "forbidden" });
+
+    const queryScope = req.query["scope"] as string | undefined;
+    const queryTenantId = req.query["tenant_id"] as string | undefined;
+    const queryStatus = req.query["status"] as string | undefined;
+
+    if (queryScope && !VALID_SCOPES.includes(queryScope as HermesProposalScope)) {
+      return res.status(400).json({ error: "invalid_scope" });
+    }
+    if (queryStatus && !VALID_STATUSES.includes(queryStatus as HermesProposalStatus)) {
+      return res.status(400).json({ error: "invalid_status" });
+    }
+
+    let scope = queryScope as HermesProposalScope | undefined;
+    let tenantId = queryTenantId;
+
+    if (user.role === "client_admin") {
+      // client_admin は自テナントの tenant スコープ提案のみ閲覧可能
+      // (scope='global' は同意済みテナント横断分析のため super_admin 専用)
+      if (scope === "global") {
+        return res.status(403).json({ error: "forbidden" });
+      }
+      if (tenantId && tenantId !== user.tenantId) {
+        return res.status(403).json({ error: "forbidden" });
+      }
+      scope = "tenant";
+      tenantId = user.tenantId ?? undefined;
+    }
+
+    try {
+      const proposals = await repo.listProposals({
+        scope,
+        tenantId,
+        status: queryStatus as HermesProposalStatus | undefined,
+      });
+      return res.json({ proposals });
+    } catch {
+      return res.status(500).json({ error: "internal_error" });
+    }
+  });
+
+  // ----------------------------------------------------------------
+  // POST /v1/admin/hermes/proposals/:id/approve
+  // POST /v1/admin/hermes/proposals/:id/reject
+  // ----------------------------------------------------------------
+  function makeDecideHandler(status: "approved" | "rejected") {
+    return async (req: Request, res: Response) => {
+      if (!db) return res.status(503).json({ error: "database_unavailable" });
+
+      const user = (req as Request & { user?: AuthenticatedUser }).user;
+      if (!user) return res.status(403).json({ error: "forbidden" });
+
+      const id = req.params["id"] as string;
+
+      try {
+        const proposal = await repo.getProposalById(id);
+        if (!proposal) return res.status(404).json({ error: "not_found" });
+
+        if (
+          user.role === "client_admin" &&
+          (proposal.scope !== "tenant" || proposal.tenantId !== user.tenantId)
+        ) {
+          return res.status(403).json({ error: "forbidden" });
+        }
+
+        const decidedBy = user.email || user.tenantId || "unknown";
+        const updated = await repo.updateProposalStatus(id, status, decidedBy);
+        if (!updated) return res.status(404).json({ error: "not_found" });
+
+        return res.json({ proposal: updated });
+      } catch {
+        return res.status(500).json({ error: "internal_error" });
+      }
+    };
+  }
+
+  app.post("/v1/admin/hermes/proposals/:id/approve", makeDecideHandler("approved"));
+  app.post("/v1/admin/hermes/proposals/:id/reject", makeDecideHandler("rejected"));
+}

--- a/src/api/hermes-mcp/proposalRepository.test.ts
+++ b/src/api/hermes-mcp/proposalRepository.test.ts
@@ -1,0 +1,235 @@
+// src/api/hermes-mcp/proposalRepository.test.ts
+// Phase74: hermesProposalRepository テスト (fake pool 注入)
+
+import { createHermesProposalRepository } from "./proposalRepository";
+
+type QueryMock = jest.Mock<Promise<{ rows: unknown[] }>, [string, unknown[]?]>;
+
+function makePool(queryMock: QueryMock) {
+  return { query: queryMock } as unknown as Parameters<
+    typeof createHermesProposalRepository
+  >[0];
+}
+
+describe("insertProposal", () => {
+  it("global提案: INSERTを発行し、挿入されたらtrue", async () => {
+    const query: QueryMock = jest.fn().mockResolvedValue({ rows: [{ id: "1" }] });
+    const repo = createHermesProposalRepository(makePool(query));
+
+    const inserted = await repo.insertProposal({
+      scope: "global",
+      title: "心理原則「scarcity」の全体採用を検討",
+      rationale: "複数の同意済みテナントの会話で共通するパターンを確認",
+      suggestedAction: "デフォルト戦略に追加検討",
+      evidence: { sessionIds: ["sess-1", "sess-2"] },
+      dedupKey: "global:scarcity-pattern",
+    });
+
+    expect(inserted).toBe(true);
+    expect(query).toHaveBeenCalledTimes(1);
+    const [sql, args] = query.mock.calls[0]!;
+    expect(sql).toContain("INSERT INTO hermes_strategy_proposals");
+    expect(sql).toContain("ON CONFLICT (dedup_key) WHERE status = 'pending' DO NOTHING");
+    expect(args![0]).toBe("global");
+    expect(args![1]).toBeNull();
+    expect(args![7]).toBe("hermes-agent"); // submitted_by既定値
+  });
+
+  it("tenant提案: tenant_idが引数に渡る", async () => {
+    const query: QueryMock = jest.fn().mockResolvedValue({ rows: [{ id: "2" }] });
+    const repo = createHermesProposalRepository(makePool(query));
+
+    await repo.insertProposal({
+      scope: "tenant",
+      tenantId: "carnation",
+      title: "保証訴求の改善",
+      rationale: "会話ログから保証質問への回答が購入に繋がるパターンを確認",
+      suggestedAction: "保証訴求を初回応答に含める",
+      dedupKey: "tenant:carnation:warranty-pitch",
+    });
+
+    const [, args] = query.mock.calls[0]!;
+    expect(args![0]).toBe("tenant");
+    expect(args![1]).toBe("carnation");
+  });
+
+  it("scope='global'にtenantIdを渡すと例外(越境ガード)", async () => {
+    const query: QueryMock = jest.fn();
+    const repo = createHermesProposalRepository(makePool(query));
+
+    await expect(
+      repo.insertProposal({
+        scope: "global",
+        tenantId: "carnation",
+        title: "t",
+        rationale: "r",
+        suggestedAction: "a",
+        dedupKey: "bad",
+      }),
+    ).rejects.toThrow(/scope='global' must not carry tenantId/);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it("scope='tenant'でtenantId無しは例外", async () => {
+    const query: QueryMock = jest.fn();
+    const repo = createHermesProposalRepository(makePool(query));
+
+    await expect(
+      repo.insertProposal({
+        scope: "tenant",
+        title: "t",
+        rationale: "r",
+        suggestedAction: "a",
+        dedupKey: "bad2",
+      }),
+    ).rejects.toThrow(/scope='tenant' requires tenantId/);
+    expect(query).not.toHaveBeenCalled();
+  });
+
+  it("ON CONFLICTで行が返らなければfalse(重複スキップ)", async () => {
+    const query: QueryMock = jest.fn().mockResolvedValue({ rows: [] });
+    const repo = createHermesProposalRepository(makePool(query));
+
+    const inserted = await repo.insertProposal({
+      scope: "global",
+      title: "t",
+      rationale: "r",
+      suggestedAction: "a",
+      dedupKey: "dup",
+    });
+
+    expect(inserted).toBe(false);
+  });
+});
+
+describe("findProposalIdByDedupKey", () => {
+  it("dedup_keyから最新のIDを取得する", async () => {
+    const query: QueryMock = jest.fn().mockResolvedValue({ rows: [{ id: "42" }] });
+    const repo = createHermesProposalRepository(makePool(query));
+
+    const id = await repo.findProposalIdByDedupKey("global:scarcity-pattern");
+
+    expect(id).toBe("42");
+    const [sql, args] = query.mock.calls[0]!;
+    expect(sql).toContain("WHERE dedup_key = $1");
+    expect(args).toEqual(["global:scarcity-pattern"]);
+  });
+
+  it("該当なしはnull", async () => {
+    const query: QueryMock = jest.fn().mockResolvedValue({ rows: [] });
+    const repo = createHermesProposalRepository(makePool(query));
+    expect(await repo.findProposalIdByDedupKey("nonexistent")).toBeNull();
+  });
+});
+
+describe("getProposalById", () => {
+  it("IDから提案を1件取得しキャメルケースに変換する", async () => {
+    const query: QueryMock = jest.fn().mockResolvedValue({
+      rows: [
+        {
+          id: "5",
+          scope: "tenant",
+          tenant_id: "carnation",
+          title: "t",
+          rationale: "r",
+          suggested_action: "a",
+          evidence: {},
+          status: "pending",
+          dedup_key: "k",
+          submitted_by: "hermes-agent",
+          created_at: new Date(),
+          decided_at: null,
+          decided_by: null,
+        },
+      ],
+    });
+    const repo = createHermesProposalRepository(makePool(query));
+
+    const proposal = await repo.getProposalById("5");
+
+    expect(proposal).toMatchObject({ id: "5", scope: "tenant", tenantId: "carnation" });
+  });
+
+  it("該当なしはnull", async () => {
+    const query: QueryMock = jest.fn().mockResolvedValue({ rows: [] });
+    const repo = createHermesProposalRepository(makePool(query));
+    expect(await repo.getProposalById("999")).toBeNull();
+  });
+});
+
+describe("listProposals", () => {
+  it("フィルタ無しでLIMIT付きSELECT", async () => {
+    const query: QueryMock = jest.fn().mockResolvedValue({ rows: [] });
+    const repo = createHermesProposalRepository(makePool(query));
+
+    await repo.listProposals();
+
+    const [sql, args] = query.mock.calls[0]!;
+    expect(sql).not.toContain("WHERE");
+    expect(sql).toContain("ORDER BY created_at DESC");
+    expect(args![0]).toBe(100);
+  });
+
+  it("scope + status で絞り込み", async () => {
+    const query: QueryMock = jest.fn().mockResolvedValue({ rows: [] });
+    const repo = createHermesProposalRepository(makePool(query));
+
+    await repo.listProposals({ scope: "global", status: "pending", limit: 20 });
+
+    const [sql, args] = query.mock.calls[0]!;
+    expect(sql).toContain("scope = $1");
+    expect(sql).toContain("status = $2");
+    expect(args).toEqual(["global", "pending", 20]);
+  });
+
+  it("tenantIdで絞り込み(client_admin向けAPIが使用)", async () => {
+    const query: QueryMock = jest.fn().mockResolvedValue({ rows: [] });
+    const repo = createHermesProposalRepository(makePool(query));
+
+    await repo.listProposals({ tenantId: "carnation" });
+
+    const [sql, args] = query.mock.calls[0]!;
+    expect(sql).toContain("tenant_id = $1");
+    expect(args![0]).toBe("carnation");
+  });
+});
+
+describe("updateProposalStatus", () => {
+  it("UPDATEを発行しdecided_by/decided_atを設定", async () => {
+    const query: QueryMock = jest.fn().mockResolvedValue({
+      rows: [
+        {
+          id: "1",
+          scope: "tenant",
+          tenant_id: "carnation",
+          title: "t",
+          rationale: "r",
+          suggested_action: "a",
+          evidence: {},
+          status: "approved",
+          dedup_key: "k",
+          submitted_by: "hermes-agent",
+          created_at: new Date(),
+          decided_at: new Date(),
+          decided_by: "admin@example.com",
+        },
+      ],
+    });
+    const repo = createHermesProposalRepository(makePool(query));
+
+    const result = await repo.updateProposalStatus("1", "approved", "admin@example.com");
+
+    expect(result?.status).toBe("approved");
+    expect(result?.decidedBy).toBe("admin@example.com");
+    const [sql, args] = query.mock.calls[0]!;
+    expect(sql).toContain("UPDATE hermes_strategy_proposals");
+    expect(args).toEqual(["1", "approved", "admin@example.com"]);
+  });
+
+  it("該当行が無ければnull", async () => {
+    const query: QueryMock = jest.fn().mockResolvedValue({ rows: [] });
+    const repo = createHermesProposalRepository(makePool(query));
+
+    expect(await repo.updateProposalStatus("999", "rejected", "admin@example.com")).toBeNull();
+  });
+});

--- a/src/api/hermes-mcp/proposalRepository.ts
+++ b/src/api/hermes-mcp/proposalRepository.ts
@@ -1,0 +1,218 @@
+// src/api/hermes-mcp/proposalRepository.ts
+// Phase74: Hermes Agent — hermes_strategy_proposals テーブルのリポジトリ
+//
+// 実物のHermes Agent(外部)が投稿するCVR改善提案の永続化・一覧・承認/却下。
+// system_prompt等の自動適用は一切行わない(提案→人間承認ゲート)。
+
+import { Pool } from "pg";
+import { getPool as _getDefaultPool } from "../../lib/db";
+
+export type HermesProposalScope = "global" | "tenant";
+export type HermesProposalStatus = "pending" | "approved" | "rejected";
+
+export interface HermesProposalInput {
+  scope: HermesProposalScope;
+  /** scope='tenant' のとき必須。scope='global' のときは必ずundefined/null。 */
+  tenantId?: string | null;
+  title: string;
+  rationale: string;
+  suggestedAction: string;
+  evidence?: Record<string, unknown>;
+  dedupKey: string;
+  submittedBy?: string;
+}
+
+export interface HermesProposal {
+  id: string;
+  scope: HermesProposalScope;
+  tenantId: string | null;
+  title: string;
+  rationale: string;
+  suggestedAction: string;
+  evidence: Record<string, unknown>;
+  status: HermesProposalStatus;
+  dedupKey: string;
+  submittedBy: string;
+  createdAt: Date;
+  decidedAt: Date | null;
+  decidedBy: string | null;
+}
+
+export interface ListProposalsParams {
+  scope?: HermesProposalScope;
+  tenantId?: string;
+  status?: HermesProposalStatus;
+  limit?: number;
+}
+
+function assertScopeInvariant(scope: HermesProposalScope, tenantId?: string | null): void {
+  if (scope === "global" && tenantId) {
+    throw new Error(
+      "hermes proposal invariant violation: scope='global' must not carry tenantId",
+    );
+  }
+  if (scope === "tenant" && !tenantId) {
+    throw new Error(
+      "hermes proposal invariant violation: scope='tenant' requires tenantId",
+    );
+  }
+}
+
+type ProposalRow = {
+  id: string;
+  scope: HermesProposalScope;
+  tenant_id: string | null;
+  title: string;
+  rationale: string;
+  suggested_action: string;
+  evidence: Record<string, unknown> | null;
+  status: HermesProposalStatus;
+  dedup_key: string;
+  submitted_by: string;
+  created_at: Date;
+  decided_at: Date | null;
+  decided_by: string | null;
+};
+
+function toProposal(row: ProposalRow): HermesProposal {
+  return {
+    id: row.id,
+    scope: row.scope,
+    tenantId: row.tenant_id,
+    title: row.title,
+    rationale: row.rationale,
+    suggestedAction: row.suggested_action,
+    evidence: row.evidence ?? {},
+    status: row.status,
+    dedupKey: row.dedup_key,
+    submittedBy: row.submitted_by,
+    createdAt: row.created_at,
+    decidedAt: row.decided_at,
+    decidedBy: row.decided_by,
+  };
+}
+
+const SELECT_COLUMNS = `id::text, scope, tenant_id, title, rationale, suggested_action,
+                evidence, status, dedup_key, submitted_by, created_at, decided_at, decided_by`;
+
+export function createHermesProposalRepository(pool?: InstanceType<typeof Pool>) {
+  function getPool(): InstanceType<typeof Pool> {
+    return pool ?? _getDefaultPool();
+  }
+
+  return {
+    /**
+     * 提案を保存する。同一 dedup_key が pending で既存なら何もしない
+     * (ON CONFLICT (dedup_key) WHERE status='pending' DO NOTHING = uniq_hermes_proposal_dedup 部分インデックス)。
+     * @returns 挿入されたら true、重複でスキップされたら false
+     */
+    async insertProposal(input: HermesProposalInput): Promise<boolean> {
+      assertScopeInvariant(input.scope, input.tenantId);
+
+      const result = await getPool().query(
+        `INSERT INTO hermes_strategy_proposals
+           (scope, tenant_id, title, rationale, suggested_action, evidence, dedup_key, submitted_by)
+         VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8)
+         ON CONFLICT (dedup_key) WHERE status = 'pending' DO NOTHING
+         RETURNING id`,
+        [
+          input.scope,
+          input.tenantId ?? null,
+          input.title,
+          input.rationale,
+          input.suggestedAction,
+          JSON.stringify(input.evidence ?? {}),
+          input.dedupKey,
+          input.submittedBy ?? "hermes-agent",
+        ],
+      );
+      return result.rows.length > 0;
+    },
+
+    /**
+     * dedup_key から最新の提案IDを引く。insertProposal直後に通知メタデータへ
+     * proposal_id を含めるためのヘルパー(追加専用、insertProposal自体の返り値は変えない)。
+     */
+    async findProposalIdByDedupKey(dedupKey: string): Promise<string | null> {
+      const result = await getPool().query(
+        `SELECT id::text FROM hermes_strategy_proposals
+         WHERE dedup_key = $1
+         ORDER BY created_at DESC
+         LIMIT 1`,
+        [dedupKey],
+      );
+      const row = result.rows[0] as { id: string } | undefined;
+      return row?.id ?? null;
+    },
+
+    /**
+     * IDから提案を1件取得する。Admin APIのapprove/rejectが、実行前に
+     * scope/tenant_idを見て越境チェックするために使う。
+     */
+    async getProposalById(id: string): Promise<HermesProposal | null> {
+      const result = await getPool().query(
+        `SELECT ${SELECT_COLUMNS} FROM hermes_strategy_proposals WHERE id = $1`,
+        [id],
+      );
+      const row = result.rows[0] as ProposalRow | undefined;
+      return row ? toProposal(row) : null;
+    },
+
+    /**
+     * 提案一覧を取得する。scope/tenantId/statusで絞り込み可能。
+     * tenantIdを渡した場合、呼び出し側の越境チェック(role != super_admin等)は
+     * ルーティング層(Admin API)の責務とする。
+     */
+    async listProposals(params: ListProposalsParams = {}): Promise<HermesProposal[]> {
+      const conditions: string[] = [];
+      const values: unknown[] = [];
+
+      if (params.scope) {
+        values.push(params.scope);
+        conditions.push(`scope = $${values.length}`);
+      }
+      if (params.tenantId) {
+        values.push(params.tenantId);
+        conditions.push(`tenant_id = $${values.length}`);
+      }
+      if (params.status) {
+        values.push(params.status);
+        conditions.push(`status = $${values.length}`);
+      }
+
+      const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(" AND ")}` : "";
+      values.push(params.limit ?? 100);
+
+      const result = await getPool().query(
+        `SELECT ${SELECT_COLUMNS}
+         FROM hermes_strategy_proposals
+         ${whereClause}
+         ORDER BY created_at DESC
+         LIMIT $${values.length}`,
+        values,
+      );
+
+      return (result.rows as ProposalRow[]).map(toProposal);
+    },
+
+    /**
+     * 提案のステータスを更新する(承認/却下)。管理者の意思決定を記録するのみで、
+     * system_prompt等の実適用はしない。
+     */
+    async updateProposalStatus(
+      id: string,
+      status: HermesProposalStatus,
+      decidedBy: string,
+    ): Promise<HermesProposal | null> {
+      const result = await getPool().query(
+        `UPDATE hermes_strategy_proposals
+         SET status = $2, decided_at = NOW(), decided_by = $3
+         WHERE id = $1
+         RETURNING ${SELECT_COLUMNS}`,
+        [id, status, decidedBy],
+      );
+      const row = result.rows[0] as ProposalRow | undefined;
+      return row ? toProposal(row) : null;
+    },
+  };
+}

--- a/src/api/hermes-mcp/routes.test.ts
+++ b/src/api/hermes-mcp/routes.test.ts
@@ -11,18 +11,33 @@ jest.mock("../../lib/hermesConsent", () => ({
 jest.mock("./hermesMcpRepository", () => ({
   searchConversations: jest.fn(),
 }));
+jest.mock("../../lib/notifications", () => ({
+  createNotification: jest.fn(),
+}));
+
+const mockInsertProposal = jest.fn();
+const mockFindProposalIdByDedupKey = jest.fn();
+jest.mock("./proposalRepository", () => ({
+  createHermesProposalRepository: jest.fn(() => ({
+    insertProposal: mockInsertProposal,
+    findProposalIdByDedupKey: mockFindProposalIdByDedupKey,
+  })),
+}));
 
 import { isHermesDataConsentGranted, listHermesConsentingTenantIds } from "../../lib/hermesConsent";
 import { searchConversations } from "./hermesMcpRepository";
+import { createNotification } from "../../lib/notifications";
 
 const mockIsConsentGranted = isHermesDataConsentGranted as jest.Mock;
 const mockListConsenting = listHermesConsentingTenantIds as jest.Mock;
 const mockSearchConversations = searchConversations as jest.Mock;
+const mockCreateNotification = createNotification as jest.Mock;
 
 const API_KEY = "test-hermes-mcp-key";
 
 function makeApp() {
   const app = express();
+  app.use(express.json());
   registerHermesMcpRoutes(app);
   return app;
 }
@@ -31,11 +46,35 @@ function authedGet(path: string) {
   return request(makeApp()).get(path).set("Authorization", `Bearer ${API_KEY}`);
 }
 
+function authedPost(path: string, body: object) {
+  return request(makeApp()).post(path).set("Authorization", `Bearer ${API_KEY}`).send(body);
+}
+
+const VALID_TENANT_PROPOSAL = {
+  scope: "tenant",
+  tenant_id: "carnation",
+  title: "保証訴求の改善",
+  rationale: "会話ログから保証質問への回答が購入に繋がるパターンを確認",
+  suggested_action: "保証訴求を初回応答に含める",
+  dedup_key: "tenant:carnation:warranty-pitch",
+};
+
+const VALID_GLOBAL_PROPOSAL = {
+  scope: "global",
+  title: "心理原則scarcityの全体採用を検討",
+  rationale: "複数の同意済みテナントで共通するパターンを確認",
+  suggested_action: "デフォルト戦略に追加検討",
+  dedup_key: "global:scarcity-pattern",
+};
+
 beforeEach(() => {
   process.env.HERMES_MCP_API_KEY = API_KEY;
   mockIsConsentGranted.mockReset();
   mockListConsenting.mockReset();
   mockSearchConversations.mockReset();
+  mockCreateNotification.mockReset().mockResolvedValue(undefined);
+  mockInsertProposal.mockReset().mockResolvedValue(true);
+  mockFindProposalIdByDedupKey.mockReset().mockResolvedValue("1");
 });
 
 afterEach(() => {
@@ -110,5 +149,83 @@ describe("GET /v1/hermes-mcp/conversations", () => {
     expect(mockSearchConversations).toHaveBeenCalledWith(
       expect.objectContaining({ convertedOnly: true }),
     );
+  });
+});
+
+describe("POST /v1/hermes-mcp/proposals", () => {
+  it("認証なしは401", async () => {
+    const res = await request(makeApp()).post("/v1/hermes-mcp/proposals").send(VALID_TENANT_PROPOSAL);
+    expect(res.status).toBe(401);
+  });
+
+  it("正常系: tenant提案(同意済み)を保存し201・通知がclient_admin宛に送られる", async () => {
+    mockIsConsentGranted.mockResolvedValue(true);
+    const res = await authedPost("/v1/hermes-mcp/proposals", VALID_TENANT_PROPOSAL);
+
+    expect(res.status).toBe(201);
+    expect(res.body).toEqual({ proposal_id: "1", duplicate: false });
+    expect(mockIsConsentGranted).toHaveBeenCalledWith("carnation");
+    expect(mockInsertProposal).toHaveBeenCalledWith(
+      expect.objectContaining({ scope: "tenant", tenantId: "carnation" }),
+    );
+    expect(mockCreateNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ recipientRole: "client_admin", recipientTenantId: "carnation" }),
+    );
+  });
+
+  it("正常系: global提案を保存し201・通知がsuper_admin宛に送られる(同意チェックは呼ばれない)", async () => {
+    const res = await authedPost("/v1/hermes-mcp/proposals", VALID_GLOBAL_PROPOSAL);
+
+    expect(res.status).toBe(201);
+    expect(mockIsConsentGranted).not.toHaveBeenCalled();
+    expect(mockCreateNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ recipientRole: "super_admin", recipientTenantId: undefined }),
+    );
+  });
+
+  it("未同意テナントは403、insertProposalは呼ばれない(同意チェック最優先)", async () => {
+    mockIsConsentGranted.mockResolvedValue(false);
+    const res = await authedPost("/v1/hermes-mcp/proposals", VALID_TENANT_PROPOSAL);
+
+    expect(res.status).toBe(403);
+    expect(mockInsertProposal).not.toHaveBeenCalled();
+  });
+
+  it("重複投稿(dedup_key衝突)は200でduplicate:trueを返す(エラー扱いしない)", async () => {
+    mockIsConsentGranted.mockResolvedValue(true);
+    mockInsertProposal.mockResolvedValue(false);
+    const res = await authedPost("/v1/hermes-mcp/proposals", VALID_TENANT_PROPOSAL);
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ duplicate: true });
+    expect(mockCreateNotification).not.toHaveBeenCalled();
+  });
+
+  it("バリデーションエラー: 不正なscopeは400", async () => {
+    const res = await authedPost("/v1/hermes-mcp/proposals", { ...VALID_GLOBAL_PROPOSAL, scope: "bogus" });
+    expect(res.status).toBe(400);
+    expect(mockInsertProposal).not.toHaveBeenCalled();
+  });
+
+  it("バリデーションエラー: scope=tenantでtenant_id欠落は400", async () => {
+    const { tenant_id: _drop, ...rest } = VALID_TENANT_PROPOSAL;
+    const res = await authedPost("/v1/hermes-mcp/proposals", rest);
+    expect(res.status).toBe(400);
+  });
+
+  it("バリデーションエラー: scope=globalでtenant_idを渡すと400", async () => {
+    const res = await authedPost("/v1/hermes-mcp/proposals", { ...VALID_GLOBAL_PROPOSAL, tenant_id: "carnation" });
+    expect(res.status).toBe(400);
+  });
+
+  it("バリデーションエラー: titleが空文字は400", async () => {
+    const res = await authedPost("/v1/hermes-mcp/proposals", { ...VALID_GLOBAL_PROPOSAL, title: "" });
+    expect(res.status).toBe(400);
+  });
+
+  it("バリデーションエラー: dedup_key欠落は400", async () => {
+    const { dedup_key: _drop, ...rest } = VALID_GLOBAL_PROPOSAL;
+    const res = await authedPost("/v1/hermes-mcp/proposals", rest);
+    expect(res.status).toBe(400);
   });
 });

--- a/src/api/hermes-mcp/routes.ts
+++ b/src/api/hermes-mcp/routes.ts
@@ -14,9 +14,14 @@ import type { Express, Request, Response } from "express";
 import { hermesMcpAuthMiddleware } from "./hermesMcpAuth";
 import { isHermesDataConsentGranted, listHermesConsentingTenantIds } from "../../lib/hermesConsent";
 import { searchConversations } from "./hermesMcpRepository";
+import { createHermesProposalRepository, type HermesProposalScope } from "./proposalRepository";
+import { createNotification } from "../../lib/notifications";
 import { logger } from "../../lib/logger";
 
 const MAX_QUERY_LEN = 200;
+const MAX_TEXT_LEN = 2000;
+
+const VALID_PROPOSAL_SCOPES: readonly HermesProposalScope[] = ["global", "tenant"];
 
 export function registerHermesMcpRoutes(app: Express): void {
   app.use("/v1/hermes-mcp", hermesMcpAuthMiddleware);
@@ -89,6 +94,96 @@ export function registerHermesMcpRoutes(app: Express): void {
       return res.json({ conversations });
     } catch (err) {
       logger.warn({ err }, "[hermes-mcp] search conversations failed");
+      return res.status(500).json({ error: "internal_error" });
+    }
+  });
+
+  // ----------------------------------------------------------------
+  // POST /v1/hermes-mcp/proposals
+  // Hermes Agent(外部)がCVR改善提案を投稿するためのエンドポイント。
+  // system_prompt等は一切自動書き換えしない(提案→人間承認ゲート)。
+  // ----------------------------------------------------------------
+  app.post("/v1/hermes-mcp/proposals", async (req: Request, res: Response) => {
+    const body = req.body ?? {};
+    const { scope, tenant_id, title, rationale, suggested_action, evidence, dedup_key } = body as {
+      scope?: unknown;
+      tenant_id?: unknown;
+      title?: unknown;
+      rationale?: unknown;
+      suggested_action?: unknown;
+      evidence?: unknown;
+      dedup_key?: unknown;
+    };
+
+    if (typeof scope !== "string" || !VALID_PROPOSAL_SCOPES.includes(scope as HermesProposalScope)) {
+      return res.status(400).json({ error: "invalid_scope" });
+    }
+    if (scope === "tenant" && (typeof tenant_id !== "string" || !tenant_id)) {
+      return res.status(400).json({ error: "tenant_id required for scope=tenant" });
+    }
+    if (scope === "global" && tenant_id !== undefined) {
+      return res.status(400).json({ error: "tenant_id must be omitted for scope=global" });
+    }
+    if (typeof title !== "string" || !title.trim() || title.length > MAX_TEXT_LEN) {
+      return res.status(400).json({ error: "invalid_title" });
+    }
+    if (typeof rationale !== "string" || !rationale.trim() || rationale.length > MAX_TEXT_LEN) {
+      return res.status(400).json({ error: "invalid_rationale" });
+    }
+    if (typeof suggested_action !== "string" || !suggested_action.trim() || suggested_action.length > MAX_TEXT_LEN) {
+      return res.status(400).json({ error: "invalid_suggested_action" });
+    }
+    if (typeof dedup_key !== "string" || !dedup_key.trim()) {
+      return res.status(400).json({ error: "invalid_dedup_key" });
+    }
+    if (evidence !== undefined && (typeof evidence !== "object" || evidence === null || Array.isArray(evidence))) {
+      return res.status(400).json({ error: "invalid_evidence" });
+    }
+
+    // 同意チェック(defense in depth): search_conversationsは既に同意済みテナントしか
+    // 返さないが、Hermes側の実装ミス・改ざんに備えてここでも必ず再検証する。
+    if (scope === "tenant") {
+      const consented = await isHermesDataConsentGranted(tenant_id as string);
+      if (!consented) {
+        return res.status(403).json({ error: "tenant_not_consented" });
+      }
+    }
+
+    const repo = createHermesProposalRepository();
+    try {
+      const inserted = await repo.insertProposal({
+        scope: scope as HermesProposalScope,
+        tenantId: scope === "tenant" ? (tenant_id as string) : undefined,
+        title,
+        rationale,
+        suggestedAction: suggested_action,
+        evidence: (evidence as Record<string, unknown>) ?? {},
+        dedupKey: dedup_key,
+      });
+
+      if (!inserted) {
+        return res.json({ duplicate: true });
+      }
+
+      const proposalId = await repo.findProposalIdByDedupKey(dedup_key);
+
+      try {
+        await createNotification({
+          recipientRole: scope === "global" ? "super_admin" : "client_admin",
+          recipientTenantId: scope === "tenant" ? (tenant_id as string) : undefined,
+          type: "hermes_proposal",
+          title,
+          message: rationale,
+          link: scope === "global" ? "/admin/hermes" : "/admin/conversion",
+          metadata: { proposal_id: proposalId, dedup_key, scope },
+        });
+      } catch (err) {
+        logger.warn({ err }, "[hermes-mcp] proposal notification failed (non-fatal)");
+      }
+
+      return res.status(201).json({ proposal_id: proposalId, duplicate: false });
+    } catch (err) {
+      logger.warn({ err }, "[hermes-mcp] insert proposal failed");
       return res.status(500).json({ error: "internal_error" });
     }
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,7 @@ import { registerEngagementRoutes } from "./api/engagement/engagementRoutes";
 import { registerConversionRoutes } from "./api/conversion/conversionRoutes";
 import { registerAbTestRoutes } from "./api/conversion/abTestRoutes";
 import { registerHermesMcpRoutes } from "./api/hermes-mcp/routes";
+import { registerHermesProposalAdminRoutes } from "./api/admin/hermes/routes";
 import { registerKnowledgeGapPhase46Routes } from "./api/admin/knowledge-gaps/routes";
 import { registerNotificationRoutes } from "./api/admin/notifications/routes";
 import { registerOptionRoutes } from "./api/admin/options/routes";
@@ -633,6 +634,9 @@ if (db) registerAbTestRoutes(app, db);
 
 // Phase75: Hermes Agent(外部, 別VPS)向けMCPデータエンドポイント(Bearer認証、同意ゲート)
 registerHermesMcpRoutes(app);
+
+// Phase74: Hermes Agent提案の承認ゲートAPI(super_admin/client_admin向け)
+registerHermesProposalAdminRoutes(app, db);
 
 // Phase55: Widget features check (event_tracking フラグ取得)
 app.get('/api/widget/features', ...apiStack, async (req: express.Request, res: express.Response) => {

--- a/src/migrations/phase74_hermes_strategy_proposals.sql
+++ b/src/migrations/phase74_hermes_strategy_proposals.sql
@@ -1,0 +1,80 @@
+-- Phase74: Hermes Agent — hermes_strategy_proposals
+-- 実行日: VPS で手動実行
+-- 対象: VPS PostgreSQL (65.108.159.161)
+--
+-- 設計意図:
+--   実物のHermes Agent(Nous Research製、別VPSで稼働)が、同意済みテナントの
+--   会話ログ(search_conversations経由)を読解・分析して生成したCVR改善提案を、
+--   POST /v1/hermes-mcp/proposals 経由で投稿・永続化するためのテーブル。
+--
+--   Hermesは提案を作るだけで、system_prompt / system_prompt_variants を
+--   自動書き換えしない。実適用は管理者が既存のPUT /v1/admin/variants等を
+--   手動で叩く前提(提案→人間承認ゲート)。
+--
+-- テナント越境防止方針 (重要):
+--   scope='global' の行は、同意済みテナントの会話データのみを横断分析した
+--   結果に基づく(search_conversationsが同意済みテナントしか返さないため、
+--   Hermes側の入力データ自体が既に同意ゲート済み)。
+--   scope='tenant' の行は必ず tenant_id を持ち、global 行は必ず tenant_id を
+--   持たないことを chk_hermes_scope で DB 層から構造的に保証する。
+--   投稿API側でも scope='tenant' の場合は同意状態を再検証する(defense in depth)。
+
+-- ============================================================
+-- 1. hermes_strategy_proposals テーブル本体
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS hermes_strategy_proposals (
+  id               BIGSERIAL PRIMARY KEY,
+  scope            TEXT NOT NULL,                    -- 'global' | 'tenant'
+  tenant_id        TEXT,                             -- scope='tenant' のみ非NULL
+  title            TEXT NOT NULL,
+  rationale        TEXT NOT NULL,                    -- Hermesが会話内容を読解した根拠
+  suggested_action TEXT NOT NULL,                    -- 提案する具体的アクション(Hermesは適用しない)
+  evidence         JSONB DEFAULT '{}'::jsonb,         -- 参照したsession_id等の裏付け情報
+  status           TEXT NOT NULL DEFAULT 'pending',   -- pending | approved | rejected
+  dedup_key        TEXT NOT NULL,
+  submitted_by     TEXT NOT NULL DEFAULT 'hermes-agent',
+  created_at       TIMESTAMPTZ DEFAULT NOW(),
+  decided_at       TIMESTAMPTZ,
+  decided_by       TEXT
+);
+
+-- 越境ガード: global は tenant_id を持てない / tenant は tenant_id 必須
+ALTER TABLE hermes_strategy_proposals
+  DROP CONSTRAINT IF EXISTS chk_hermes_scope;
+ALTER TABLE hermes_strategy_proposals
+  ADD CONSTRAINT chk_hermes_scope
+  CHECK (
+    (scope = 'global' AND tenant_id IS NULL)
+    OR (scope = 'tenant' AND tenant_id IS NOT NULL)
+  );
+
+-- ============================================================
+-- 2. インデックス
+-- ============================================================
+
+-- 同一提案の再投稿を弾く (pending の間のみ一意)
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_hermes_proposal_dedup
+  ON hermes_strategy_proposals (dedup_key)
+  WHERE status = 'pending';
+
+-- Admin API 一覧表示用 (scope + status で絞り込み、新しい順)
+CREATE INDEX IF NOT EXISTS idx_hermes_proposal_scope_status
+  ON hermes_strategy_proposals (scope, status, created_at DESC);
+
+-- tenant 別一覧用
+CREATE INDEX IF NOT EXISTS idx_hermes_proposal_tenant
+  ON hermes_strategy_proposals (tenant_id)
+  WHERE tenant_id IS NOT NULL;
+
+COMMENT ON TABLE hermes_strategy_proposals IS 'Phase74: 実物のHermes Agentが会話ログ分析から生成するCVR向上戦略提案。提案→人間承認ゲート方式で自動適用はしない。';
+COMMENT ON COLUMN hermes_strategy_proposals.scope IS 'global=同意済みテナント横断の分析パターン / tenant=特定テナントの会話に基づく提案';
+COMMENT ON COLUMN hermes_strategy_proposals.evidence IS '参照したsession_id等の裏付け情報。生の会話全文は含めないこと。';
+
+-- ============================================================
+-- 確認クエリ (実行後に手動確認)
+-- ============================================================
+-- SELECT column_name, data_type FROM information_schema.columns
+-- WHERE table_name = 'hermes_strategy_proposals' ORDER BY ordinal_position;
+-- SELECT indexname FROM pg_indexes WHERE tablename = 'hermes_strategy_proposals';
+-- SELECT conname FROM pg_constraint WHERE conrelid = 'hermes_strategy_proposals'::regclass;


### PR DESCRIPTION
## Summary

実物のHermes Agentが同意済みテナントの会話ログを分析して生成するCVR改善提案を、R2C側で受け取り・永続化・人間承認できるようにする。#438/#439のMCP連携基盤の上に構築。

## 変更内容(1コミット)

- `hermes_strategy_proposals`テーブル(chk_hermes_scope制約、dedup_key部分unique index)+ `proposalRepository.ts`
- `POST /v1/hermes-mcp/proposals`: Hermesからの提案投稿。`scope='tenant'`は同意状態をdefense in depthで再検証(search_conversations側の同意ゲートを信用しつつ、Hermes側の実装ミス・改ざんに備える)。dedup衝突は200+`duplicate:true`(エラー扱いしない)
- `GET/POST /v1/admin/hermes/proposals*`: 承認ゲートAPI。conversion routesのeffectivenessハンドラと同型の越境403チェック。**system_prompt等は一切自動適用しない**(意思決定の記録のみ)

MCPサーバー本体(`~/projects/r2c-cvr-mcp`)にも`submit_proposal`ツール + `r2c-cvr-analysis`スキルを追加済み(別リポジトリ、Hermes VPSに配置済み)。

## Test plan

- [x] `pnpm typecheck` — 通過
- [x] `pnpm test` — 2104件中2095件通過(残り9件は無関係な既存のavatar/fetch環境issue)
- [x] `bash SCRIPTS/security-scan.sh` / `dead-code-check.sh` — PASS
- [x] **実機E2E検証済み**: ローカルHomebrew Postgres(非Docker)+実サーバーで、提案投稿→DB保存→通知作成→承認ゲートAPI(越境403含む)を実データで確認
- [x] **実際のHermes Agent CLI + スキルからのフルE2E検証済み**: SSHリバーストンネル経由でHermes VPSからローカル検証サーバーへ接続し、`hermes -z "..." --skill r2c-cvr-analysis`で実際に「同意済みテナント確認→会話ログ分析→CVR改善提案の生成→submit_proposal投稿」の全フローが動作し、DBに正しく永続化されることを確認。Hermesが安定したdedup_keyを自律生成することも確認
- [ ] 本番デプロイ後: 本番向けcron登録(`hermes cron create '0 9 * * *' --skill r2c-cvr-analysis`)は別途実施

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Ge87SQjsJXevC6eBp1PqU6