### PR TITLE
fix(security): /v1/admin/my-tenant にrole検証を追加

### DIFF
--- a/src/api/admin/tenants/routes.ts
+++ b/src/api/admin/tenants/routes.ts
@@ -1,6 +1,7 @@
 // src/api/admin/tenants/routes.ts
 import type { Express, NextFunction, Request, Response } from "express";
 import type { AuthedReq } from "../../middleware/roleAuth";
+import { isAllowedAdminRole } from "../../middleware/roleAuth";
 
 import { Pool } from "pg";
 import { z } from "zod";
@@ -107,10 +108,23 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
     }
     next();
   }
+
+  // セキュリティ要件: /v1/admin/my-tenant はロールを検証せずtenant_id claimのみで認可していた
+  // （どのロールの認証済みユーザーでもapp_metadata.tenant_idさえあれば通過できてしまう不具合）。
+  // super_admin / client_admin のみ許可する（roleAuth.ts の ALLOWED_ADMIN_ROLES と同じ判定）。
+  function requireAdminRole(req: Request, res: Response, next: NextFunction): void {
+    const su = (req as AuthedReq).supabaseUser;
+    const role = su?.app_metadata?.role;
+    if (!isAllowedAdminRole(role)) {
+      res.status(403).json({ error: "forbidden", message: "この操作を行う権限がありません" });
+      return;
+    }
+    next();
+  }
   // ─────────────────────────────────────────────────────────────────────────
 
   // GET /v1/admin/my-tenant — Client Admin専用: JWTのtenant_idで自分のテナント情報を返す
-  app.get("/v1/admin/my-tenant", tenantAuth, async (req: Request, res: Response) => {
+  app.get("/v1/admin/my-tenant", tenantAuth, requireAdminRole, async (req: Request, res: Response) => {
     const su = (req as AuthedReq).supabaseUser;
     const tenantId = su?.app_metadata?.tenant_id as string | undefined;
     if (!tenantId) {
@@ -132,7 +146,7 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
   });
 
   // PATCH /v1/admin/my-tenant — Client Admin専用: featuresのavatar/voiceのみ更新可
-  app.patch("/v1/admin/my-tenant", tenantAuth, async (req: Request, res: Response) => {
+  app.patch("/v1/admin/my-tenant", tenantAuth, requireAdminRole, async (req: Request, res: Response) => {
     const su = (req as AuthedReq).supabaseUser;
     const tenantId = su?.app_metadata?.tenant_id as string | undefined;
     if (!tenantId) {

--- a/tests/api/admin/tenants/routes.test.ts
+++ b/tests/api/admin/tenants/routes.test.ts
@@ -29,6 +29,18 @@ const SUPER_ADMIN_TOKEN = makeDevJwt({
   app_metadata: { role: "super_admin" },
 });
 
+const CLIENT_ADMIN_TOKEN = makeDevJwt({
+  sub: "client-admin-user-id",
+  app_metadata: { role: "client_admin", tenant_id: "tenant1" },
+});
+
+// role が未設定/不正だが tenant_id claim だけは持つトークン
+// (GID 1216273277286371: role検証漏れの再発防止用)
+const NO_ROLE_WITH_TENANT_TOKEN = makeDevJwt({
+  sub: "no-role-user-id",
+  app_metadata: { tenant_id: "tenant1" },
+});
+
 describe("Tenant Admin Routes", () => {
   let app: express.Application;
   let mockDb: any;
@@ -120,6 +132,52 @@ describe("Tenant Admin Routes", () => {
         .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`);
       expect(res.status).toBe(200);
       expect(res.body.keys[0].prefix).toMatch(/\*\*\*\*$/);
+    });
+  });
+
+  describe("GET /v1/admin/my-tenant", () => {
+    it("returns tenant info for client_admin", async () => {
+      mockDb.query.mockResolvedValueOnce({
+        rows: [{ id: "tenant1", name: "Test", features: {}, lemonslice_agent_id: null, conversion_types: [] }],
+        rowCount: 1,
+      });
+      const res = await request(app)
+        .get("/v1/admin/my-tenant")
+        .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`);
+      expect(res.status).toBe(200);
+      expect(res.body.id).toBe("tenant1");
+    });
+
+    it("rejects a request with tenant_id claim but no admin role (GID 1216273277286371)", async () => {
+      const res = await request(app)
+        .get("/v1/admin/my-tenant")
+        .set("Authorization", `Bearer ${NO_ROLE_WITH_TENANT_TOKEN}`);
+      expect(res.status).toBe(403);
+      expect(mockDb.query).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("PATCH /v1/admin/my-tenant", () => {
+    it("updates features for client_admin", async () => {
+      mockDb.query.mockResolvedValueOnce({
+        rows: [{ id: "tenant1", name: "Test", features: { avatar: true, voice: false, rag: true }, lemonslice_agent_id: null }],
+        rowCount: 1,
+      });
+      const res = await request(app)
+        .patch("/v1/admin/my-tenant")
+        .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`)
+        .send({ features: { avatar: true, voice: false, rag: true } });
+      expect(res.status).toBe(200);
+      expect(res.body.features.avatar).toBe(true);
+    });
+
+    it("rejects a request with tenant_id claim but no admin role (GID 1216273277286371)", async () => {
+      const res = await request(app)
+        .patch("/v1/admin/my-tenant")
+        .set("Authorization", `Bearer ${NO_ROLE_WITH_TENANT_TOKEN}`)
+        .send({ features: { avatar: true, voice: false, rag: true } });
+      expect(res.status).toBe(403);
+      expect(mockDb.query).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
## Summary
- `GET`/`PATCH /v1/admin/my-tenant` が `app_metadata.tenant_id` claimの存在のみで認可しており、`role`(super_admin/client_admin)を一切検証していなかった。JWTにたまたま`tenant_id`を持つ認証済みユーザーであれば誰でも自テナント情報の取得/更新が可能な状態だった。
- `roleAuth.ts`の`isAllowedAdminRole`(既存の`ALLOWED_ADMIN_ROLES = ["super_admin","client_admin"]`)を再利用した`requireAdminRole`ミドルウェアを追加し、両ルートに適用。

Asana: GID 1216273277286371 ([Security] /v1/admin/my-tenantがroleを検証せずtenant_id claimだけで認可している)

## Test plan
- [x] `npx jest tests/api/admin/tenants/routes.test.ts` — 16 passed (既存12 + role未検証ケースの新規4)
- [x] `npx tsc --noEmit` — エラーなし
- [x] role未設定/不正だが`tenant_id`だけ持つトークンで403になることを確認するテストを追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)