### PR TITLE
fix: super_adminのクライアントビュープレビューを/admin/avatarページで機能させる

### DIFF
--- a/admin-ui/src/pages/admin/avatar/HermesConsentToggle.test.tsx
+++ b/admin-ui/src/pages/admin/avatar/HermesConsentToggle.test.tsx
@@ -128,6 +128,28 @@ describe("HermesConsentToggle", () => {
     });
   });
 
+  it("T8: overrideTenantId指定時は /tenants/:id をGET/PATCHする(プレビュー対応, GID 1216273315887508)", async () => {
+    mockInitialFetch(false);
+    vi.mocked(authFetch).mockReturnValueOnce(
+      mockOk({ features: { avatar: true, voice: false, rag: true, hermes_raw_data_consent: true } }),
+    );
+    render(<HermesConsentToggle overrideTenantId="preview-tenant" />);
+
+    await waitFor(() => {
+      expect(vi.mocked(authFetch)).toHaveBeenCalledWith("http://localhost:3100/v1/admin/tenants/preview-tenant");
+    });
+
+    const btn = await screen.findByRole("button");
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      expect(vi.mocked(authFetch)).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/admin/tenants/preview-tenant",
+        expect.objectContaining({ method: "PATCH" }),
+      );
+    });
+  });
+
   it("T7: saving中はボタンがdisabledになる", async () => {
     mockInitialFetch(false);
     let resolve!: (v: Response) => void;

--- a/admin-ui/src/pages/admin/avatar/HermesConsentToggle.tsx
+++ b/admin-ui/src/pages/admin/avatar/HermesConsentToggle.tsx
@@ -14,13 +14,23 @@ interface TenantFeatures {
   hermes_raw_data_consent?: boolean;
 }
 
-export function HermesConsentToggle() {
+interface HermesConsentToggleProps {
+  // super_adminの「クライアントビューで見る」プレビュー中のテナントID。
+  // 指定時は自テナント専用の /my-tenant ではなく super_admin用の /tenants/:id を使う。
+  overrideTenantId?: string;
+}
+
+export function HermesConsentToggle({ overrideTenantId }: HermesConsentToggleProps = {}) {
   const [features, setFeatures] = useState<TenantFeatures | null>(null);
   const [saving, setSaving] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
 
+  const endpoint = overrideTenantId
+    ? `${API_BASE}/v1/admin/tenants/${overrideTenantId}`
+    : `${API_BASE}/v1/admin/my-tenant`;
+
   useEffect(() => {
-    authFetch(`${API_BASE}/v1/admin/my-tenant`)
+    authFetch(endpoint)
       .then((r) => r.json())
       .then((data: { features?: TenantFeatures }) => {
         setFeatures({
@@ -33,7 +43,7 @@ export function HermesConsentToggle() {
         });
       })
       .catch(() => {});
-  }, []);
+  }, [endpoint]);
 
   const showToast = (msg: string) => {
     setToast(msg);
@@ -52,7 +62,7 @@ export function HermesConsentToggle() {
     setSaving(true);
 
     try {
-      const res = await authFetch(`${API_BASE}/v1/admin/my-tenant`, {
+      const res = await authFetch(endpoint, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ features: { ...prev, hermes_raw_data_consent: next } }),

--- a/admin-ui/src/pages/admin/avatar/index.tsx
+++ b/admin-ui/src/pages/admin/avatar/index.tsx
@@ -17,7 +17,10 @@ import { AvatarCard } from "./AvatarCard";
 export default function AvatarListPage() {
   const { lang } = useLang();
   const locale = lang === "en" ? "en-US" : "ja-JP";
-  const { user, isSuperAdmin } = useAuth();
+  const { user, isSuperAdmin, previewMode, previewTenantId } = useAuth();
+  // super_adminの「クライアントビューで見る」プレビュー中は isSuperAdmin が
+  // client_admin相当にフォールバックするため、実テナントIDはpreviewTenantIdから取る必要がある
+  const effectiveTenantId = previewMode ? previewTenantId : (user?.tenantId ?? null);
 
   const [configs, setConfigs] = useState<AvatarConfig[]>([]);
   const [total, setTotal] = useState(0);
@@ -45,8 +48,13 @@ export default function AvatarListPage() {
   };
 
   useEffect(() => {
-    if (!user?.tenantId || isSuperAdmin) return;
-    authFetch(`${API_BASE}/v1/admin/my-tenant`)
+    if (!effectiveTenantId || isSuperAdmin) return;
+    // プレビュー中は自テナント専用の /my-tenant ではなく、super_admin用の
+    // /tenants/:id で明示的にpreview対象テナントを指定して取得する
+    const url = previewMode
+      ? `${API_BASE}/v1/admin/tenants/${effectiveTenantId}`
+      : `${API_BASE}/v1/admin/my-tenant`;
+    authFetch(url)
       .then((r) => r.json())
       .then((data: { features?: { avatar?: boolean; voice?: boolean; rag?: boolean } }) => {
         const f = { avatar: data.features?.avatar ?? false, voice: data.features?.voice ?? false, rag: data.features?.rag ?? true };
@@ -54,14 +62,17 @@ export default function AvatarListPage() {
         setAvatarEnabled(f.avatar);
       })
       .catch(() => {});
-  }, [user?.tenantId, isSuperAdmin]);
+  }, [effectiveTenantId, isSuperAdmin, previewMode]);
 
   const handleAvatarToggle = async () => {
-    if (!user?.tenantId || !tenantFeatures || toggleLoading) return;
+    if (!effectiveTenantId || !tenantFeatures || toggleLoading) return;
     const next = !avatarEnabled;
     setToggleLoading(true);
     try {
-      const res = await authFetch(`${API_BASE}/v1/admin/my-tenant`, {
+      const url = previewMode
+        ? `${API_BASE}/v1/admin/tenants/${effectiveTenantId}`
+        : `${API_BASE}/v1/admin/my-tenant`;
+      const res = await authFetch(url, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ features: { ...tenantFeatures, avatar: next } }),
@@ -86,9 +97,13 @@ export default function AvatarListPage() {
     setLoading(true);
     setError(null);
     try {
+      // プレビュー中は isSuperAdmin が false にフォールバックするため、
+      // super_adminの実JWTでも tenant クエリを明示しないと全テナント分が返ってしまう
       const url = isSuperAdmin
         ? `${API_BASE}/v1/admin/avatar/configs/all`
-        : `${API_BASE}/v1/admin/avatar/configs`;
+        : previewMode && previewTenantId
+          ? `${API_BASE}/v1/admin/avatar/configs?tenant=${previewTenantId}`
+          : `${API_BASE}/v1/admin/avatar/configs`;
       const res = await authFetch(url);
       if (!res.ok) {
         setError(lang === "ja" ? "設定の読み込みに失敗しました" : "Failed to load configs");
@@ -102,7 +117,7 @@ export default function AvatarListPage() {
     } finally {
       setLoading(false);
     }
-  }, [lang, isSuperAdmin]);
+  }, [lang, isSuperAdmin, previewMode, previewTenantId]);
 
   useEffect(() => { void fetchConfigs(); }, [fetchConfigs]);
 
@@ -353,8 +368,8 @@ export default function AvatarListPage() {
         />
       )}
 
-      {/* ── アバター機能 ON/OFF トグル（Client Adminのみ）─────────────────────────────── */}
-      {!isSuperAdmin && user?.tenantId && (
+      {/* ── アバター機能 ON/OFF トグル（Client Adminのみ / プレビュー中含む）─────────── */}
+      {!isSuperAdmin && effectiveTenantId && (
         <AvatarFeatureToggle
           avatarEnabled={avatarEnabled}
           toggleLoading={toggleLoading}
@@ -364,8 +379,12 @@ export default function AvatarListPage() {
         />
       )}
 
-      {/* ── Phase75: Hermes Agent学習への同意 ON/OFF トグル（Client Adminのみ）───────── */}
-      {!isSuperAdmin && user?.tenantId && <HermesConsentToggle />}
+      {/* ── Phase75: Hermes Agent学習への同意 ON/OFF トグル（Client Adminのみ / プレビュー中含む）── */}
+      {!isSuperAdmin && effectiveTenantId && (
+        <HermesConsentToggle
+          overrideTenantId={previewMode ? effectiveTenantId : undefined}
+        />
+      )}
 
       {/* エラーメッセージ */}
       {error && (


### PR DESCRIPTION
## Summary
- `/admin/avatar` ページで super_adminの「クライアントビューで見る」プレビューが機能していなかった。原因: `useAuth().isSuperAdmin` はプレビュー中 `client_admin` 相当にフォールバックするが、ページ側が `previewTenantId` を一切参照していなかったため:
  1. `fetchConfigs` が tenant絞り込みなしで `/v1/admin/avatar/configs` を叩き、全テナント分のアバター設定が混在表示される(軽微なテナント間データ露出でもある)
  2. アバター機能 ON/OFF トグルが `user?.tenantId`(=実super_adminの自テナントID、通常null)を条件にしていたため非表示になる
  3. Hermes同意トグルも同様に非表示 + 常に `/v1/admin/my-tenant` (実JWT基準)を叩くため、プレビュー対象テナントのデータを反映できない
- `billing/index.tsx` で既に確立されている「previewMode時は明示的にテナントIDをクエリ/エンドポイントに渡す」パターンに合わせて修正。
- `HermesConsentToggle` に任意の `overrideTenantId` propを追加し、指定時は super_admin専用の `/v1/admin/tenants/:id` を使う(既存の呼び出し元は非破壊)。

Asana: GID 1216273315887508 ([Bug] super_adminの「クライアントビューで見る」プレビュー機能が/admin/avatarページで機能していない)

## Test plan
- [x] `npx vitest run src/pages/admin/avatar` — 15 passed(既存14 + overrideTenantId用の新規1)
- [x] `npx tsc --noEmit` — エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)