### PR TITLE
fix: super_adminのプレビュー終了バナーを全ページ共通表示にする

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { BrowserRouter, Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { AppSidebar, MobileHeader, MobileBottomBar } from "./components/AppSidebar";
+import { PreviewModeBanner, PREVIEW_MODE_BANNER_HEIGHT } from "./components/PreviewModeBanner";
 import { ThemeProvider } from "./contexts/ThemeContext";
 import "./App.css";
 import { LangProvider } from "./i18n/LangContext";
@@ -78,7 +79,7 @@ function ConfigErrorScreen() {
 }
 
 function AppInner() {
-  const { isClientAdmin, isSuperAdmin, user } = useAuth();
+  const { isClientAdmin, isSuperAdmin, user, previewMode } = useAuth();
   const [agentOpen, setAgentOpen] = useState(false);
   const location = useLocation();
   const showAIChat = isClientAdmin && location.pathname !== "/admin/chat-test";
@@ -100,6 +101,8 @@ function AppInner() {
     <div className="app-layout">
       {isAdmin && <AppSidebar />}
       <div className="app-main">
+        <PreviewModeBanner />
+        {previewMode && <div style={{ height: PREVIEW_MODE_BANNER_HEIGHT }} />}
         {isAdmin && <MobileHeader />}
         {isAdmin && <MobileBottomBar />}
         <Routes>

--- a/admin-ui/src/components/PreviewModeBanner.tsx
+++ b/admin-ui/src/components/PreviewModeBanner.tsx
@@ -1,0 +1,59 @@
+// admin-ui/src/components/PreviewModeBanner.tsx
+// super_adminの「クライアントビューで見る」プレビュー中に全ページ共通で表示する終了バナー。
+// 旧実装はadmin/index.tsx(ダッシュボード)にのみ存在し、他ページへ遷移すると
+// バナーごと「元に戻す」導線が消えていた(GID 1216274382443624)。App.tsxのAppInnerで
+// 一度だけレンダリングすることで、どのページからでもプレビューを終了できるようにする。
+
+import { useAuth } from "../auth/useAuth";
+import { useLang } from "../i18n/LangContext";
+
+export const PREVIEW_MODE_BANNER_HEIGHT = 44;
+
+export function PreviewModeBanner() {
+  const { previewMode, previewTenantName, exitPreview } = useAuth();
+  const { t } = useLang();
+
+  if (!previewMode) return null;
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        top: 0,
+        left: 0,
+        right: 0,
+        zIndex: 9999,
+        background: "rgba(234,179,8,0.95)",
+        padding: "10px 20px",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: 12,
+        fontSize: 14,
+        fontWeight: 600,
+        color: "#1c1917",
+        boxShadow: "0 2px 12px rgba(0,0,0,0.2)",
+      }}
+    >
+      <span>👁 {t("preview.mode_label")}</span>
+      <span style={{ color: "#78350f" }}>
+        {t("preview.viewing_as", { tenant: previewTenantName ?? "" })}
+      </span>
+      <button
+        onClick={exitPreview}
+        style={{
+          padding: "6px 14px",
+          borderRadius: 999,
+          border: "1px solid #78350f",
+          background: "rgba(0,0,0,0.15)",
+          color: "#1c1917",
+          fontSize: 13,
+          fontWeight: 700,
+          cursor: "pointer",
+        }}
+      >
+        {t("preview.exit")}
+      </button>
+    </div>
+  );
+}

--- a/admin-ui/src/pages/admin/index.tsx
+++ b/admin-ui/src/pages/admin/index.tsx
@@ -151,7 +151,7 @@ function QuickAction({
 export default function AdminDashboard() {
   const navigate = useNavigate();
   const { t, lang } = useLang();
-  const { user, isSuperAdmin, logout, previewMode, previewTenantId, previewTenantName, exitPreview } = useAuth();
+  const { user, isSuperAdmin, logout, previewMode, previewTenantId } = useAuth();
   const [stats, setStats] = useState<DashboardStats | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -251,51 +251,6 @@ export default function AdminDashboard() {
         maxWidth: 880,
       }}
     >
-      {previewMode && <div style={{ height: 44 }} />}
-
-      {/* Preview mode banner */}
-      {previewMode && (
-        <div
-          style={{
-            position: "fixed",
-            top: 0,
-            left: 0,
-            right: 0,
-            zIndex: 9999,
-            background: "rgba(234,179,8,0.95)",
-            padding: "10px 20px",
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            gap: 12,
-            fontSize: 14,
-            fontWeight: 600,
-            color: "#1c1917",
-            boxShadow: "0 2px 12px rgba(0,0,0,0.2)",
-          }}
-        >
-          <span>👁 {t("preview.mode_label")}</span>
-          <span style={{ color: "#78350f" }}>
-            {t("preview.viewing_as", { tenant: previewTenantName ?? "" })}
-          </span>
-          <button
-            onClick={exitPreview}
-            style={{
-              padding: "6px 14px",
-              borderRadius: 999,
-              border: "1px solid #78350f",
-              background: "rgba(0,0,0,0.15)",
-              color: "#1c1917",
-              fontSize: 13,
-              fontWeight: 700,
-              cursor: "pointer",
-            }}
-          >
-            {t("preview.exit")}
-          </button>
-        </div>
-      )}
-
       {/* Page header */}
       <header
         style={{


### PR DESCRIPTION
## Summary
- プレビューモードの終了バナー(「👁プレビューモード ... 元に戻す」)が `admin/index.tsx`(ダッシュボードページ)にのみ実装されており、`/admin/avatar` など他ページに遷移するとバナーごと消え、プレビューを終了する導線がなくなっていた。
- `PreviewModeBanner` コンポーネントとして切り出し、`App.tsx` の `AppInner`(`app-main` 直下、全ルート共通の位置)で1箇所レンダリングするよう変更。`admin/index.tsx` からは重複するバナー/スペーサーのJSXを削除。
- スタイル・翻訳キー(`preview.mode_label` / `preview.viewing_as` / `preview.exit`)は変更なし、挙動を維持したまま表示範囲のみ全ページに拡張。

Asana: GID 1216274382443624 ([Bug] super_adminのプレビュー終了バナー(「元に戻す」)がダッシュボード以外のページに表示されない)
関連: #443 (GID 1216273315887508) の調査中に発見した別件。

## Test plan
- [x] `npx tsc --noEmit`(admin-ui) — エラーなし
- [x] `npx vitest run`(admin-ui) — 42 passed, 5 test files
- [x] ブラウザ実機確認(super_adminでログイン→テナントで「クライアントビューで見る」→サイドバーからSPA内遷移で`/admin/avatar`へ):
  - プレビューバナーが表示され、「元に戻す」ボタンがそのページ上で機能する(バナー消滅を確認)
  - コンソールエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)