### PR TITLE
security: 本番Postgresパスワードの平文記載をドキュメントから削除

### DIFF
--- a/.claude/agents/deploy-checker.md
+++ b/.claude/agents/deploy-checker.md
@@ -47,4 +47,4 @@ bash SCRIPTS/deploy-vps.sh
    ssh root@65.108.159.161 "pm2 logs rajiuce-api --lines 20 --nostream 2>&1 | grep -i error | head -5"
 
 ## DBマイグレーションが必要な場合
-ssh root@65.108.159.161 "psql 'postgresql://postgres:hezdus-4jygWy-pyqrub@127.0.0.1:5432/commerce_faq' -f /opt/rajiuce/<path_to_migration>.sql"
+ssh root@65.108.159.161 "psql 'postgresql://postgres:<DB_PASSWORD>@127.0.0.1:5432/commerce_faq' -f /opt/rajiuce/<path_to_migration>.sql"

--- a/.claude/skills/r2c-deploy-prompt/SKILL.md
+++ b/.claude/skills/r2c-deploy-prompt/SKILL.md
@@ -251,7 +251,7 @@ ssh root@65.108.159.161 "pm2 logs rajiuce-api --lines 20 --nostream 2>&1 | grep 
 | プロジェクトパス | `/opt/rajiuce` |
 | API URL | `https://api.r2c.biz` |
 | Admin UI URL | `https://admin.r2c.biz` |
-| DB 接続 | `postgresql://postgres:hezdus-4jygWy-pyqrub@127.0.0.1:5432/commerce_faq` |
+| DB 接続 | `postgresql://postgres:<DB_PASSWORD>@127.0.0.1:5432/commerce_faq` |
 | Admin UI デプロイ | Cloudflare Pages auto-deploy from main |
 | PM2 processes | rajiuce-api (0) / rajiuce-avatar (5) / rajiuce-sentiment (6) |
 

--- a/VPS_OPS_GUIDE.md
+++ b/VPS_OPS_GUIDE.md
@@ -3,6 +3,13 @@
 > 2026-03-18 作成。実際のインシデント対応から得られた教訓を文書化。
 > VPS: `root@65.108.159.161` | Project: `/opt/rajiuce`
 
+> **`<DB_PASSWORD>` について:** 本ドキュメント内のpsqlコマンド例に含まれる
+> `<DB_PASSWORD>` は、旧バージョンで実際のパスワードが平文記載されていたため
+> プレースホルダーに置換したもの。当該パスワードは漏洩済みとして扱い、
+> **Postgres側でのローテーションを推奨**（未対応の場合は要検討）。
+> 現在の値は以下でVPSの`.env`から取得する:
+> `ssh root@65.108.159.161 "grep '^DATABASE_URL=' /opt/rajiuce/.env"`
+
 ---
 
 ## 1. デプロイ後の必須確認事項
@@ -70,7 +77,7 @@ ssh root@65.108.159.161 "pm2 logs rajiuce-api --lines 50 --nostream 2>&1 | grep 
 find src/ -name "*.sql" -path "*/migration*"
 
 # 2. VPS で実行
-ssh root@65.108.159.161 "psql 'postgresql://postgres:hezdus-4jygWy-pyqrub@127.0.0.1:5432/commerce_faq' -f /opt/rajiuce/<path_to_migration>.sql"
+ssh root@65.108.159.161 "psql 'postgresql://postgres:<DB_PASSWORD>@127.0.0.1:5432/commerce_faq' -f /opt/rajiuce/<path_to_migration>.sql"
 ```
 
 **既知のマイグレーション一覧:**
@@ -102,7 +109,7 @@ Phase45 E2E修正: Geminiエラー時に作られた不完全レコード（scor
 
 実行方法:
 ```bash
-ssh root@65.108.159.161 "psql 'postgresql://postgres:hezdus-4jygWy-pyqrub@127.0.0.1:5432/commerce_faq' -f /opt/rajiuce/src/agent/judge/migration_cleanup_zero_scores.sql"
+ssh root@65.108.159.161 "psql 'postgresql://postgres:<DB_PASSWORD>@127.0.0.1:5432/commerce_faq' -f /opt/rajiuce/src/agent/judge/migration_cleanup_zero_scores.sql"
 ```
 
 ---
@@ -358,13 +365,13 @@ ssh root@65.108.159.161 "pm2 restart rajiuce-api"
 
 ```bash
 # migration_book_uploads.sql を実行（book_uploads テーブル + faq_embeddings インデックス）
-ssh root@65.108.159.161 "psql 'postgresql://postgres:hezdus-4jygWy-pyqrub@127.0.0.1:5432/commerce_faq' -f /opt/rajiuce/src/api/admin/knowledge/migration_book_uploads.sql"
+ssh root@65.108.159.161 "psql 'postgresql://postgres:<DB_PASSWORD>@127.0.0.1:5432/commerce_faq' -f /opt/rajiuce/src/api/admin/knowledge/migration_book_uploads.sql"
 
 # テーブル確認
-ssh root@65.108.159.161 "psql 'postgresql://postgres:hezdus-4jygWy-pyqrub@127.0.0.1:5432/commerce_faq' -c '\dt book_uploads'"
+ssh root@65.108.159.161 "psql 'postgresql://postgres:<DB_PASSWORD>@127.0.0.1:5432/commerce_faq' -c '\dt book_uploads'"
 
 # インデックス確認
-ssh root@65.108.159.161 "psql 'postgresql://postgres:hezdus-4jygWy-pyqrub@127.0.0.1:5432/commerce_faq' -c '\di idx_faq_embeddings_*'"
+ssh root@65.108.159.161 "psql 'postgresql://postgres:<DB_PASSWORD>@127.0.0.1:5432/commerce_faq' -c '\di idx_faq_embeddings_*'"
 ```
 
 ### 6.4 Phase44 デプロイ後確認

--- a/docs/R2C_DEVELOPMENT_PLAYBOOK.md
+++ b/docs/R2C_DEVELOPMENT_PLAYBOOK.md
@@ -520,7 +520,7 @@ grep -rn "metadata.*source" src/api/
 | プロジェクトパス | `/opt/rajiuce` |
 | API URL | `https://api.r2c.biz` |
 | Admin UI URL | `https://admin.r2c.biz` |
-| DB接続 | `postgresql://postgres:hezdus-4jygWy-pyqrub@127.0.0.1:5432/commerce_faq` |
+| DB接続 | `postgresql://postgres:<DB_PASSWORD>@127.0.0.1:5432/commerce_faq` |
 | Supabase | `https://rpqrwifbrhlebbelyqog.supabase.co` |
 | Slack Channel | #r2c / #rajiuce-dev, ID: `C0AG07HFJTB` |
 | Asana Primary | GID: `1213607637045514` |

--- a/src/api/admin/tenants/migration_r2c_default.sql
+++ b/src/api/admin/tenants/migration_r2c_default.sql
@@ -3,7 +3,7 @@
 --       livekitTokenRoutes の Q2 クエリ (OR is_default=true) 経由でクロステナント誤表示が発生。
 --       専用テナント 'r2c_default' に分離することで構造的に解消する。
 --
--- 実行: psql 'postgresql://postgres:hezdus-4jygWy-pyqrub@127.0.0.1:5432/commerce_faq' \
+-- 実行: psql 'postgresql://postgres:<DB_PASSWORD>@127.0.0.1:5432/commerce_faq' \
 --           -f /opt/rajiuce/src/api/admin/tenants/migration_r2c_default.sql
 
 BEGIN;


### PR DESCRIPTION
## Summary
- KNOWLEDGE_ENCRYPTION_KEY の保管場所調査中に、本番VPS上PostgreSQLの実パスワードが以下7箇所にpsqlコマンド例として平文でコミットされていることを発見:
  - `VPS_OPS_GUIDE.md`（5箇所）
  - `docs/R2C_DEVELOPMENT_PLAYBOOK.md`
  - `.claude/skills/r2c-deploy-prompt/SKILL.md`
  - `.claude/agents/deploy-checker.md`
  - `src/api/admin/tenants/migration_r2c_default.sql`
- gitleaks(`.github/workflows/gitleaks.yml`)は標準ルールではこの `postgresql://user:pass@host/db` 形式を検知しないパターンだったため、これまで見落とされていた(ローカルで `gitleaks detect --no-git` 実行し確認済み)。
- 全箇所を `<DB_PASSWORD>` プレースホルダーに置換し、`VPS_OPS_GUIDE.md` 冒頭に実行時の値の取得方法(`ssh root@65.108.159.161 "grep '^DATABASE_URL=' /opt/rajiuce/.env"`)を追記。

## 重要な注意事項
- **このPRはドキュメントの平文除去のみ**。git履歴には旧パスワードがそのまま残るため、当該パスワードは漏洩済みとして扱うべき。
- **Postgres側でのパスワードローテーションを別途強く推奨**(本番DBへの影響があるため、このPRには含めていません。ローテーション時はVPSの`.env`の`DATABASE_URL`更新 + `pm2 restart rajiuce-api`が必要)。

## Test plan
- [x] `grep -rn "hezdus-4jygWy-pyqrub"` — リポジトリ全体で0件になったことを確認
- [x] `gitleaks detect --config .gitleaks.toml --no-git -s .` — no leaks found
- [x] 各ファイルのdiffを目視確認、コマンド構文が壊れていないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)