### PR TITLE
feat: App Switcher (R2C ⇄ R2C2) — auth bridge + has_r2c2

### DIFF
--- a/admin-ui/.env.production.example
+++ b/admin-ui/.env.production.example
@@ -1,3 +1,5 @@
 VITE_API_BASE=http://65.108.159.161:3100
 VITE_SUPABASE_URL=https://YOUR_PROJECT.supabase.co
 VITE_SUPABASE_ANON_KEY=YOUR_ANON_KEY
+# R2C2 (AaaS) Admin UI — App Switcher の切り替え先。未設定ならスイッチャー非表示。
+VITE_AAAS_ADMIN_URL=https://admin.r2c2.r2c.biz

--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import { BrowserRouter, Navigate, Route, Routes, useLocation } from "react-router-dom";
 import { AppSidebar, MobileHeader, MobileBottomBar } from "./components/AppSidebar";
 import { PreviewModeBanner, PREVIEW_MODE_BANNER_HEIGHT } from "./components/PreviewModeBanner";
@@ -35,6 +35,8 @@ import EngagementPage from "./pages/admin/engagement/index";
 import ConversionDashboardPage from "./pages/admin/conversion/index";
 import OptionManagementPage from "./pages/admin/options/index";
 import ResetPasswordPage from "./pages/ResetPassword";
+import AuthBridgePage from "./pages/AuthBridgePage";
+import { AdminAgentUIProvider, useAdminAgentUI } from "./contexts/AdminAgentUIContext";
 import { supabaseConfigured } from "./lib/supabaseClient";
 
 // ─── 層2: Supabase 未設定ガード ───────────────────────────────────────────────
@@ -80,12 +82,21 @@ function ConfigErrorScreen() {
 
 function AppInner() {
   const { isClientAdmin, isSuperAdmin, user, previewMode } = useAuth();
-  const [agentOpen, setAgentOpen] = useState(false);
+  const { isOpen: agentOpen, seedQuery, toggle: toggleAgent, close: closeAgent } = useAdminAgentUI();
   const location = useLocation();
   const showAIChat = isClientAdmin && location.pathname !== "/admin/chat-test";
   const isAdmin = location.pathname.startsWith("/admin") || location.pathname === "/";
   const isLogin =
     location.pathname === "/login" || location.pathname === "/reset-password";
+  const isAuthBridge = location.pathname === "/auth/bridge";
+
+  if (isAuthBridge) {
+    return (
+      <Routes>
+        <Route path="/auth/bridge" element={<AuthBridgePage />} />
+      </Routes>
+    );
+  }
 
   if (isLogin) {
     return (
@@ -193,14 +204,15 @@ function AppInner() {
       {showAIChat && (
         <>
           <AdminAgentButton
-            onClick={() => setAgentOpen((v) => !v)}
+            onClick={toggleAgent}
             isOpen={agentOpen}
           />
           <AdminAgentPanel
             isOpen={agentOpen}
-            onClose={() => setAgentOpen(false)}
+            onClose={closeAgent}
             tenantId={user?.tenantId ?? null}
             isSuperAdmin={isSuperAdmin}
+            initialQuery={seedQuery}
           />
         </>
       )}
@@ -220,7 +232,9 @@ export default function App() {
     <LangProvider>
     <BrowserRouter>
       <AuthProvider>
-        <AppInner />
+        <AdminAgentUIProvider>
+          <AppInner />
+        </AdminAgentUIProvider>
       </AuthProvider>
     </BrowserRouter>
     </LangProvider>

--- a/admin-ui/src/components/AdminAgent/AdminAgentPanel.tsx
+++ b/admin-ui/src/components/AdminAgent/AdminAgentPanel.tsx
@@ -8,6 +8,7 @@ interface AdminAgentPanelProps {
   onClose: () => void;
   tenantId: string | null;
   isSuperAdmin: boolean;
+  initialQuery?: string | null;
 }
 
 const INITIAL_MESSAGE = "こんにちは！設定の変更やFAQの追加など、何でもお手伝いします。";
@@ -17,12 +18,14 @@ export default function AdminAgentPanel({
   onClose,
   tenantId,
   isSuperAdmin,
+  initialQuery,
 }: AdminAgentPanelProps) {
   const { messages, isLoading, sendMessage } = useAdminAgent();
   const [input, setInput] = useState("");
   const [isComposing, setIsComposing] = useState(false);
   const bottomRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const sentInitialQueryRef = useRef<string | null>(null);
 
   // 最新メッセージへ自動スクロール
   useEffect(() => {
@@ -35,6 +38,15 @@ export default function AdminAgentPanel({
       setTimeout(() => inputRef.current?.focus(), 50);
     }
   }, [isOpen]);
+
+  // AppSwitcher のロックタブクリックなど、質問を種まきして開いた場合は自動送信
+  useEffect(() => {
+    if (!isOpen || !initialQuery) return;
+    if (sentInitialQueryRef.current === initialQuery) return;
+    sentInitialQueryRef.current = initialQuery;
+    const targetTenantId = isSuperAdmin ? (tenantId ?? undefined) : undefined;
+    void sendMessage(initialQuery, targetTenantId);
+  }, [isOpen, initialQuery, isSuperAdmin, tenantId, sendMessage]);
 
   const handleSend = useCallback(async () => {
     const text = input.trim();

--- a/admin-ui/src/components/AppSidebar.tsx
+++ b/admin-ui/src/components/AppSidebar.tsx
@@ -24,6 +24,7 @@ import {
 import { useAuth } from "../auth/useAuth";
 import { useTheme } from "../contexts/ThemeContext";
 import { NotificationBell } from "./common/NotificationBell";
+import AppSwitcher from "./AppSwitcher";
 import { cn } from "../lib/utils";
 
 // ─── Nav item types ───────────────────────────────────────────────────
@@ -263,6 +264,11 @@ function SidebarContent({ onClose }: SidebarContentProps) {
             </button>
           )}
         </div>
+      </div>
+
+      {/* App Switcher (R2C ⇄ R2C2) */}
+      <div style={{ padding: "10px 12px 0" }}>
+        <AppSwitcher />
       </div>
 
       {/* Nav */}

--- a/admin-ui/src/components/AppSwitcher.tsx
+++ b/admin-ui/src/components/AppSwitcher.tsx
@@ -1,0 +1,90 @@
+import { useEffect, useState } from "react";
+import { useAuth } from "../auth/useAuth";
+import { useAdminAgentUI } from "../contexts/AdminAgentUIContext";
+import { authFetch, API_BASE } from "../lib/api";
+import { supabase } from "../lib/supabaseClient";
+
+const AAAS_ADMIN_URL = import.meta.env.VITE_AAAS_ADMIN_URL as string | undefined;
+
+/** Hand off the current Supabase session to R2C2 (AaaS) via /auth/bridge.
+ *
+ * Both apps share the same Supabase project but have no shared session
+ * mechanism (each app's session lives in its own origin's localStorage) —
+ * so switching passes the access/refresh token pair through the URL
+ * fragment (never sent to a server) rather than requiring a shared
+ * cookie domain.
+ */
+async function bridgeToR2C2() {
+  const { data } = await supabase.auth.getSession();
+  const session = data.session;
+  if (!session || !AAAS_ADMIN_URL) return;
+  const hash = new URLSearchParams({
+    access_token: session.access_token,
+    refresh_token: session.refresh_token,
+  }).toString();
+  window.location.href = `${AAAS_ADMIN_URL}/auth/bridge#${hash}`;
+}
+
+export default function AppSwitcher() {
+  const { isSuperAdmin } = useAuth();
+  const { openWithQuery } = useAdminAgentUI();
+  const [hasR2c2, setHasR2c2] = useState(isSuperAdmin);
+
+  useEffect(() => {
+    if (isSuperAdmin) {
+      setHasR2c2(true);
+      return;
+    }
+    authFetch(`${API_BASE}/v1/admin/my-tenant`)
+      .then((r) => r.json())
+      .then((data: { has_r2c2?: boolean }) => setHasR2c2(Boolean(data.has_r2c2)))
+      .catch(() => setHasR2c2(false));
+  }, [isSuperAdmin]);
+
+  if (!AAAS_ADMIN_URL) return null;
+
+  return (
+    <div style={{ display: "flex", borderRadius: 9999, background: "var(--sidebar-accent)", padding: 3, gap: 2 }}>
+      <span
+        style={{
+          flex: 1,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 6,
+          padding: "6px 10px",
+          borderRadius: 9999,
+          fontSize: 12,
+          fontWeight: 700,
+          background: "var(--card)",
+          color: "var(--primary)",
+          boxShadow: "0 1px 3px rgba(0,0,0,0.12)",
+        }}
+      >
+        <span style={{ width: 5, height: 5, borderRadius: "50%", background: "currentColor" }} />
+        R2C
+      </span>
+      <button
+        onClick={() => (hasR2c2 ? void bridgeToR2C2() : openWithQuery("R2C2について教えて"))}
+        title={hasR2c2 ? "R2C2に切り替え" : "R2C2とは？ AIアシスタントに聞いてみる"}
+        style={{
+          flex: 1,
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          gap: 6,
+          padding: "6px 10px",
+          borderRadius: 9999,
+          fontSize: 12,
+          fontWeight: 700,
+          border: "none",
+          background: "transparent",
+          color: hasR2c2 ? "var(--muted-foreground)" : "color-mix(in oklab, var(--muted-foreground) 45%, transparent)",
+          cursor: "pointer",
+        }}
+      >
+        R2C2{!hasR2c2 && " 🔒"}
+      </button>
+    </div>
+  );
+}

--- a/admin-ui/src/contexts/AdminAgentUIContext.tsx
+++ b/admin-ui/src/contexts/AdminAgentUIContext.tsx
@@ -1,0 +1,38 @@
+import { createContext, useContext, useState, useCallback, type ReactNode } from "react";
+
+interface AdminAgentUIContextValue {
+  isOpen: boolean;
+  seedQuery: string | null;
+  toggle: () => void;
+  close: () => void;
+  openWithQuery: (query: string) => void;
+}
+
+const AdminAgentUIContext = createContext<AdminAgentUIContextValue | null>(null);
+
+/** Shares Admin Agent panel open/seed-query state between App.tsx (which
+ * mounts the panel) and AppSwitcher's locked R2C2 tab, which opens the
+ * assistant with a seeded question instead of just linking out. */
+export function AdminAgentUIProvider({ children }: { children: ReactNode }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [seedQuery, setSeedQuery] = useState<string | null>(null);
+
+  const toggle = useCallback(() => setIsOpen((v) => !v), []);
+  const close = useCallback(() => setIsOpen(false), []);
+  const openWithQuery = useCallback((query: string) => {
+    setSeedQuery(query);
+    setIsOpen(true);
+  }, []);
+
+  return (
+    <AdminAgentUIContext.Provider value={{ isOpen, seedQuery, toggle, close, openWithQuery }}>
+      {children}
+    </AdminAgentUIContext.Provider>
+  );
+}
+
+export function useAdminAgentUI(): AdminAgentUIContextValue {
+  const ctx = useContext(AdminAgentUIContext);
+  if (!ctx) throw new Error("useAdminAgentUI must be used inside AdminAgentUIProvider");
+  return ctx;
+}

--- a/admin-ui/src/pages/AuthBridgePage.tsx
+++ b/admin-ui/src/pages/AuthBridgePage.tsx
@@ -1,0 +1,50 @@
+import { useEffect, useState } from "react";
+import { Navigate } from "react-router-dom";
+import { supabase } from "../lib/supabaseClient";
+
+/**
+ * One-time token bridge for the App Switcher (R2C ⇄ R2C2).
+ *
+ * Neither app shares a session mechanism the other can read directly — each
+ * app's Supabase client keeps its session in localStorage, which is
+ * per-origin and does not cross subdomains. So switching apps hands off the
+ * CURRENT app's access/refresh token pair via the URL fragment (never sent
+ * to any server, unlike a query string) to the target app's /auth/bridge
+ * route, which calls supabase.auth.setSession() to establish its own local
+ * session — both apps share the same Supabase project, so the token is
+ * valid on either side.
+ */
+export default function AuthBridgePage() {
+  const [status, setStatus] = useState<"pending" | "ok" | "error">("pending");
+
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.hash.replace(/^#/, ""));
+    const accessToken = params.get("access_token");
+    const refreshToken = params.get("refresh_token");
+
+    if (!accessToken || !refreshToken) {
+      setStatus("error");
+      return;
+    }
+
+    supabase.auth
+      .setSession({ access_token: accessToken, refresh_token: refreshToken })
+      .then(({ error }) => setStatus(error ? "error" : "ok"))
+      .catch(() => setStatus("error"));
+  }, []);
+
+  if (status === "ok") return <Navigate to="/admin" replace />;
+
+  return (
+    <div style={{ minHeight: "100vh", display: "flex", alignItems: "center", justifyContent: "center", background: "#111827", color: "#e5e7eb" }}>
+      {status === "pending" ? (
+        <p style={{ fontSize: 14, color: "#9ca3af" }}>切り替え中...</p>
+      ) : (
+        <div style={{ textAlign: "center" }}>
+          <p style={{ fontSize: 14, color: "#fca5a5", marginBottom: 12 }}>セッションの引き継ぎに失敗しました</p>
+          <a href="/login" style={{ fontSize: 13, color: "#60a5fa" }}>ログイン画面へ</a>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/api/admin/tenants/routes.test.ts
+++ b/src/api/admin/tenants/routes.test.ts
@@ -288,3 +288,56 @@ describe("PATCH /v1/admin/tenants/:id — changed_by にメールが入る", () 
     expect(insertCall![1][1]).toBe("admin@example.com");
   });
 });
+
+// --------------------------------------------------------------------------
+// ⑥ GET /v1/admin/my-tenant — has_r2c2 (App Switcher 用、AaaS aaas_clients 連携)
+// --------------------------------------------------------------------------
+
+describe("GET /v1/admin/my-tenant — has_r2c2", () => {
+  const TENANT_ROW = { id: "tenant-a", name: "テストテナント", features: null, lemonslice_agent_id: null, conversion_types: [] };
+
+  it("aaas_clients に紐付くテナントは has_r2c2: true を返す", async () => {
+    const dbQuery = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [TENANT_ROW], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ 1: 1 }], rowCount: 1 });
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "client_admin"))
+      .get("/v1/admin/my-tenant")
+      .set("Authorization", "Bearer dummy");
+
+    expect(res.status).toBe(200);
+    expect(res.body.has_r2c2).toBe(true);
+  });
+
+  it("aaas_clients に紐付かないテナントは has_r2c2: false を返す", async () => {
+    const dbQuery = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [TENANT_ROW], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "client_admin"))
+      .get("/v1/admin/my-tenant")
+      .set("Authorization", "Bearer dummy");
+
+    expect(res.status).toBe(200);
+    expect(res.body.has_r2c2).toBe(false);
+  });
+
+  it("aaas_clients クエリが失敗しても(未マイグレーション等) 500にせず has_r2c2: false で返す", async () => {
+    const dbQuery = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [TENANT_ROW], rowCount: 1 })
+      .mockRejectedValueOnce(new Error('relation "aaas_clients" does not exist'));
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "client_admin"))
+      .get("/v1/admin/my-tenant")
+      .set("Authorization", "Bearer dummy");
+
+    expect(res.status).toBe(200);
+    expect(res.body.has_r2c2).toBe(false);
+  });
+});

--- a/src/api/admin/tenants/routes.ts
+++ b/src/api/admin/tenants/routes.ts
@@ -59,6 +59,22 @@ const updateTenantSchema = z.object({
   tenant_contact_email: z.string().email().nullable().optional(),
 });
 
+// aaas_clients は共有Supabaseプロジェクト内のAaaS(R2C2)側所有テーブル
+// (r2c_tenant_id で tenants.id を参照)。AaaS側マイグレーション未適用環境でも
+// /v1/admin/my-tenant 全体を壊さないよう、失敗時は「R2C2未契約」扱いにフォールバックする。
+async function checkHasR2c2(db: Pool, tenantId: string): Promise<boolean> {
+  try {
+    const result = await db.query(
+      `SELECT 1 FROM aaas_clients WHERE r2c_tenant_id = $1 LIMIT 1`,
+      [tenantId]
+    );
+    return (result.rowCount ?? 0) > 0;
+  } catch (err) {
+    logger.warn("[checkHasR2c2] aaas_clients query failed (migration not applied yet?)", err);
+    return false;
+  }
+}
+
 export function registerTenantAdminRoutes(app: Express, db: Pool): void {
   // ── インライン認証スタック（knowledge/routes.ts と同パターン） ──────────────
   function tenantAuth(req: Request, res: Response, next: NextFunction): void {
@@ -138,7 +154,8 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
       if (result.rowCount === 0) {
         return res.status(404).json({ error: "not_found", message: "テナントが見つかりません" });
       }
-      return res.json(result.rows[0]);
+      const has_r2c2 = await checkHasR2c2(db, tenantId);
+      return res.json({ ...result.rows[0], has_r2c2 });
     } catch (err) {
       logger.warn("[GET /v1/admin/my-tenant]", err);
       return res.status(500).json({ error: "取得に失敗しました" });


### PR DESCRIPTION
## Summary
Mirrors the App Switcher already shipped on the AaaS (R2C2) side, so Super Admins and dual-subscription tenants can move between the two admin dashboards without re-authenticating (companion to AaaS PR, ties off cross-cutting task "R2C側: AppSwitcher.tsx + Sidebar組み込み + /auth/bridge + has_r2c2").

- `GET /v1/admin/my-tenant` now also returns `has_r2c2`, via a best-effort `EXISTS` check against `aaas_clients.r2c_tenant_id` (a table AaaS owns in the shared Supabase Postgres). Falls back to `false` instead of 500ing if that table isn't migrated in yet — **AaaS's own migrations 001-006 are still pending human approval**, so this is currently the expected path in production until those are applied.
- New `/auth/bridge` route + `AuthBridgePage`: receives an access/refresh token pair via the URL fragment from R2C2 and calls `supabase.auth.setSession()`, then redirects to `/admin`.
- New `AppSwitcher` in the sidebar: bridges to R2C2 if subscribed; otherwise the locked "R2C2 🔒" tab opens the existing AdminAgent panel with a seeded "R2C2について教えて" question instead of just being disabled (marketing/discovery flow).
- `AdminAgentPanel` gains an optional `initialQuery` prop + a new `AdminAgentUIContext` so `AppSwitcher` (sidebar) and the FAB/panel (mounted in `App.tsx`) can share open/seed-query state.

## Test plan
- [x] Gate 1: `pnpm typecheck` (backend + admin-ui) — clean
- [x] `pnpm lint` — exit 0, within the 63-warning budget (all pre-existing)
- [x] Backend: `npx jest src/api/admin/tenants/routes.test.ts` — 10/10 pass (3 new tests for `has_r2c2`, including the missing-table fallback)
- [x] Backend: full `npx jest` suite — 2102/2111 pass; the 9 failures are pre-existing (`avatar/routes.test.ts` `global.fetch` spy issue under Node v26, reproduced identically on `main` before this change)
- [x] `admin-ui`: `pnpm test:ui` — 46/46 pass
- [x] Gate 1.5: `bash SCRIPTS/dead-code-check.sh` — 4 pre-existing dead exports (unrelated `notionSchemas.ts`), nothing new
- [x] Gate 2: `bash SCRIPTS/security-scan.sh` — PASS, 0 critical/high
- [ ] Gate 2.5 (Codex review) — flagged for human review per project policy
- [ ] Live browser verification after deploy

## Note for reviewer
`VITE_AAAS_ADMIN_URL` needs to be added to the real `/opt/rajiuce/admin-ui/.env.production` on the VPS before this is useful in prod (added to `.env.production.example` only — didn't touch the real prod env file per the "`.env.production`変更は承認必須" rule).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wwc9zdW9DoGH9VnuWAcMjk