### PR TITLE
fix(ux): CV未発火バナーのボタン文字崩れを修正

### DIFF
--- a/admin-ui/src/components/dashboard/CVUnfiredAlert.tsx
+++ b/admin-ui/src/components/dashboard/CVUnfiredAlert.tsx
@@ -86,6 +86,8 @@ export function CVUnfiredAlert() {
               fontSize: 13,
               fontWeight: 600,
               cursor: "pointer",
+              whiteSpace: "nowrap",
+              flexShrink: 0,
             }}
           >
             一覧を見る
@@ -101,6 +103,7 @@ export function CVUnfiredAlert() {
               color: "#6b7280",
               fontSize: 13,
               cursor: "pointer",
+              flexShrink: 0,
             }}
           >
             ✕
@@ -157,6 +160,8 @@ export function CVUnfiredAlert() {
               fontSize: 13,
               fontWeight: 600,
               cursor: "pointer",
+              whiteSpace: "nowrap",
+              flexShrink: 0,
             }}
           >
             搭載状況を確認
@@ -173,6 +178,7 @@ export function CVUnfiredAlert() {
             color: "#6b7280",
             fontSize: 13,
             cursor: "pointer",
+            flexShrink: 0,
           }}
         >
           ✕


### PR DESCRIPTION
## Summary
- 実機UI/UX調査で見つかった軽微な不具合の修正(GID 1216274344491399)。
- 「一覧を見る」「搭載状況を確認」ボタンに `whiteSpace: "nowrap"` + `flexShrink: 0` を追加し、バナー幅が狭い場面でボタン内テキストが折り返し/圧縮されないようにした。
- 折り返しが必要な場合は既存の `flexWrap` によりボタングループ全体が下段に送られる(ボタン内部でのテキスト圧縮ではなくレイアウトレベルでの折り返し)。

Asana: GID 1216274344491399([UX・即対応 01] ダッシュボード警告バナーのボタン崩れを修正)

## Test plan
- [x] `npx tsc --noEmit`(admin-ui) — エラーなし
- [x] ブラウザ実機確認(super_adminプレビューでclient_adminとして表示、CV未発火バナーを1280px/480px幅の両方でスクリーンショット確認。テキストの折り返し・圧縮なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)