### PR TITLE
fix(ux): 会話履歴の空状態をFAQ管理と同水準のパターンに統一

### DIFF
--- a/admin-ui/src/i18n/en.ts
+++ b/admin-ui/src/i18n/en.ts
@@ -364,6 +364,8 @@ const en: Record<TranslationKey, string> = {
   "chat_history.sessions": "Conversation Sessions",
   "chat_history.loading": "Loading...",
   "chat_history.no_sessions": "No chat history yet",
+  "chat_history.no_sessions_sub": "Check your widget installation, or try the test chat to see it in action",
+  "chat_history.try_test_chat": "Try Test Chat →",
   "chat_history.message_count": "{n} messages",
   "chat_history.view_detail": "View Details →",
   "chat_history.user_message": "Customer",

--- a/admin-ui/src/i18n/ja.ts
+++ b/admin-ui/src/i18n/ja.ts
@@ -362,6 +362,8 @@ const ja = {
   "chat_history.sessions": "会話セッション",
   "chat_history.loading": "読み込んでいます...",
   "chat_history.no_sessions": "まだ会話履歴がありません",
+  "chat_history.no_sessions_sub": "ウィジェットの設置状況を確認するか、テストチャットで動作を試してみましょう",
+  "chat_history.try_test_chat": "テストチャットを試す →",
   "chat_history.message_count": "{n}件のメッセージ",
   "chat_history.view_detail": "詳細を見る →",
   "chat_history.user_message": "お客様",

--- a/admin-ui/src/pages/admin/chat-history/index.tsx
+++ b/admin-ui/src/pages/admin/chat-history/index.tsx
@@ -302,14 +302,34 @@ export default function ChatHistoryPage() {
           style={{
             padding: "48px 24px",
             textAlign: "center",
-            color: "var(--muted-foreground)",
-            fontSize: 15,
             borderRadius: 14,
             border: "1px solid var(--border)",
             background: "linear-gradient(145deg, var(--card), var(--card))",
           }}
         >
-          {t("chat_history.no_sessions")}
+          <div style={{ fontSize: 40, marginBottom: 12 }}>💬</div>
+          <p style={{ color: "var(--foreground)", fontSize: 15, fontWeight: 600, margin: "0 0 6px" }}>
+            {t("chat_history.no_sessions")}
+          </p>
+          <p style={{ color: "var(--muted-foreground)", fontSize: 13.5, margin: "0 0 20px" }}>
+            {t("chat_history.no_sessions_sub")}
+          </p>
+          <button
+            onClick={() => navigate("/admin/chat-test")}
+            style={{
+              padding: "10px 20px",
+              minHeight: 44,
+              borderRadius: 10,
+              border: "none",
+              background: "#2563eb",
+              color: "#fff",
+              fontSize: 14,
+              fontWeight: 700,
+              cursor: "pointer",
+            }}
+          >
+            {t("chat_history.try_test_chat")}
+          </button>
         </div>
       ) : (
         <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>


### PR DESCRIPTION
## Summary
- 実機UI/UX調査(GID 1216274344545765)で見つかった、会話履歴の空状態が単なる1行テキストのみだった問題を修正。
- FAQ管理(`knowledge.empty_title`/`empty_sub`)・お客様への声がけ設定(`engagement.empty`)で既に確立されている「アイコン + タイトル + 補足説明 + 次のアクション」のパターンに揃えた。
- 次のアクションとして「テストチャットを試す →」ボタンを追加(`/admin/chat-test`へ遷移)。データを手動追加できない受動的な画面のため、ウィジェット設置確認 or テストチャットでの動作確認を提案する導線にした。

Asana: GID 1216274344545765([UX・即対応 04] FAQ管理の「空状態+次の一歩」を他画面に横展開)

## 別途見つかったバグ(このPRのスコープ外)
検証中に、会話履歴ページ(`chat-history/index.tsx`)がsuper_adminの「クライアントビューで見る」プレビューモードに対応しておらず、プレビュー中でも全テナント横断のデータが表示されてしまう不具合を発見した。これは以前修正したアバター設定ページの不具合(#443, GID 1216273315887508)と同種のバグ。別チケットとして起票予定、このPRには含めていない。

## Test plan
- [x] `npx tsc --noEmit`(admin-ui) — エラーなし
- [x] `npx vitest run`(admin-ui) — 46 passed
- [x] ブラウザ実機確認: データがある状態での表示崩れ・コンソールエラーがないことを確認(true zero件状態は上記の別バグにより本環境では再現できなかったが、既に実機確認済みの`engagement/index.tsx`と同一の構造のため低リスクと判断)

🤖 Generated with [Claude Code](https://claude.com/claude-code)