### PR TITLE
feat(fishaudio): TTSモデルをs2.1-pro-freeに切替

### DIFF
--- a/avatar-agent/agent.py
+++ b/avatar-agent/agent.py
@@ -345,7 +345,7 @@ class FishAudioChunkedStream(agents_tts.ChunkedStream):
         try:
             request_body = {
                 "text": self._input_text,
-                "model": "s2-pro",  # Phase A: S2-Pro 明示指定（デフォルト依存を排除）
+                "model": "s2.1-pro-free",  # Phase A: S2.1 Pro (Free) 明示指定（デフォルト依存を排除、低遅延+多言語）
                 "format": "mp3",   # Fish Audio デフォルト形式。WAV より確実。
                 "normalize": True,
                 "latency": "balanced",

--- a/src/api/avatar/fishTtsRoutes.test.ts
+++ b/src/api/avatar/fishTtsRoutes.test.ts
@@ -2,7 +2,7 @@
 // POST /api/avatar/tts — FishAudio Phase A の検証
 //
 // 検証内容:
-//   - S2-Pro モデル明示指定 (model: 's2-pro')
+//   - S2.1 Pro (Free) モデル明示指定 (model: 's2.1-pro-free')
 //   - ハードコード reference_id 撤去 → テナント voice_id を DB 解決
 //   - DB に voice_id がない場合は env FISH_AUDIO_REFERENCE_ID へフォールバック
 //   - 両方ない場合は reference_id フィールド自体を省略
@@ -72,7 +72,7 @@ describe("POST /api/avatar/tts", () => {
     process.env = savedEnv;
   });
 
-  it("正常系: DB の voice_id を reference_id に使い、model=s2-pro で Fish Audio を呼ぶ", async () => {
+  it("正常系: DB の voice_id を reference_id に使い、model=s2.1-pro-free で Fish Audio を呼ぶ", async () => {
     mockQuery.mockResolvedValueOnce({ rows: [{ voice_id: "db-voice-123" }] });
     mockFishAudioOk();
 
@@ -91,7 +91,7 @@ describe("POST /api/avatar/tts", () => {
     expect(params).toEqual(["tenant-a"]);
 
     const body = sentBody();
-    expect(body.model).toBe("s2-pro");
+    expect(body.model).toBe("s2.1-pro-free");
     expect(body.reference_id).toBe("db-voice-123");
     // ハードコード ID が復活していないこと
     expect(JSON.stringify(body)).not.toContain("63bc41e652214372b15d9416a30a60b4");
@@ -139,7 +139,7 @@ describe("POST /api/avatar/tts", () => {
     expect(res.status).toBe(200);
     const body = sentBody();
     expect("reference_id" in body).toBe(false);
-    expect(body.model).toBe("s2-pro");
+    expect(body.model).toBe("s2.1-pro-free");
   });
 
   it("voice 解決: DB エラー時は env フォールバックで継続（500 にしない）", async () => {

--- a/src/api/avatar/fishTtsRoutes.ts
+++ b/src/api/avatar/fishTtsRoutes.ts
@@ -54,7 +54,7 @@ export function registerFishTtsRoutes(app: Express, apiStack: RequestHandler[]):
         },
         body: JSON.stringify({
           text: text,
-          model: 's2-pro',
+          model: 's2.1-pro-free',
           ...(referenceId ? { reference_id: referenceId } : {}),
           format: 'mp3',
           latency: 'balanced',
@@ -86,7 +86,7 @@ export function registerFishTtsRoutes(app: Express, apiStack: RequestHandler[]):
       trackUsage({
         tenantId,
         requestId: (req as any).requestId ?? `tts-${Date.now()}`,
-        model: 'fish-audio-s2-pro',
+        model: 'fish-audio-s2.1-pro-free',
         inputTokens: 0,
         outputTokens: 0,
         featureUsed: 'voice',


### PR DESCRIPTION
## Summary
- Node(`src/api/avatar/fishTtsRoutes.ts`)・Python(`avatar-agent/agent.py`)の両方で、Fish AudioのTTSモデル指定を `s2-pro` → `s2.1-pro-free` に変更。
- Fish Audio公式発表: S2.1 ProはTTFA(初音声応答)が約90ms(旧100ms+)に短縮、83言語対応。2026年7月まで文字数上限なしで無料提供。
- `voice_id`(テナントのボイスクローン参照)はモデル非依存の設定のため、そのまま引き継がれる。
- `trackUsage`のmodelラベルも合わせて更新(コスト計算はバイト数ベースのため課金ロジックへの影響なし)。voice-clone作成イベント側のラベル(`routes.ts`)はTTS再生とは別イベントのため対象外とした。

Asana: GID 1216275179251709([FishAudio] TTSモデルを s2.1-pro-free に切替)

## 関連(人間作業・別チケット)
無料期間(2026年7月まで)終了後の料金体系確認は [人間作業] チケットで別途対応予定(GID 1216277831647022)。

## Test plan
- [x] `npx jest src/api/avatar/fishTtsRoutes.test.ts` — 既存テストのmodelアサーションを更新し全件pass
- [x] `npx jest`(全体) — 870 passed, 既存テスト含め regressionなし
- [x] `npx tsc --noEmit` — エラーなし
- [x] `python3 -m py_compile avatar-agent/agent.py` — 構文エラーなし
- バックエンドのモデル文字列変更のみでUI変更を伴わないため、ブラウザ実機確認は対象外(実際のFish Audio API疎通は本番相当のAPIキーが必要なためこのタスクでは未検証)

🤖 Generated with [Claude Code](https://claude.com/claude-code)