### PR TITLE
FAQ登録フォームの質問/回答欄にテナント別カスタムヒントを追加

### DIFF
--- a/admin-ui/src/components/KnowledgeFaqEditModal.tsx
+++ b/admin-ui/src/components/KnowledgeFaqEditModal.tsx
@@ -21,6 +21,9 @@ interface Props {
   item?: KnowledgeFaqItem;
   onClose: () => void;
   onSuccess: (message: string) => void;
+  /** GID 1216274385106667: テナントごとにカスタマイズされた質問/回答欄の入力例 */
+  questionHint?: string | null;
+  answerHint?: string | null;
 }
 
 async function getToken(): Promise<string | null> {
@@ -56,7 +59,7 @@ const LABEL_STYLE: React.CSSProperties = {
   marginBottom: 8,
 };
 
-export default function KnowledgeFaqEditModal({ mode, tenantId, item, onClose, onSuccess }: Props) {
+export default function KnowledgeFaqEditModal({ mode, tenantId, item, onClose, onSuccess, questionHint, answerHint }: Props) {
   const { t } = useLang();
   const [question, setQuestion] = useState(item?.question ?? "");
   const [answer, setAnswer] = useState(item?.answer ?? "");
@@ -250,7 +253,7 @@ export default function KnowledgeFaqEditModal({ mode, tenantId, item, onClose, o
               value={question}
               onChange={(e) => setQuestion(e.target.value)}
               rows={3}
-              placeholder={t("modal.question_placeholder")}
+              placeholder={questionHint || t("modal.question_placeholder")}
               style={TEXTAREA_STYLE}
             />
           </div>
@@ -266,7 +269,7 @@ export default function KnowledgeFaqEditModal({ mode, tenantId, item, onClose, o
               value={answer}
               onChange={(e) => setAnswer(e.target.value)}
               rows={6}
-              placeholder={t("modal.answer_placeholder")}
+              placeholder={answerHint || t("modal.answer_placeholder")}
               style={TEXTAREA_STYLE}
             />
           </div>

--- a/admin-ui/src/components/knowledge/FaqHintSettings.tsx
+++ b/admin-ui/src/components/knowledge/FaqHintSettings.tsx
@@ -1,0 +1,213 @@
+// admin-ui/src/components/knowledge/FaqHintSettings.tsx
+// GID 1216274385106667: FAQ登録フォームの質問/回答欄に、テナントごとのカスタム入力例
+// (プレースホルダー)を設定できる折りたたみ設定パネル
+// (HermesConsentToggleの fetch/楽観的更新+ロールバック パターンを踏襲)
+
+import { useEffect, useState } from "react";
+import { authFetch, API_BASE } from "../../lib/api";
+import { useLang } from "../../i18n/LangContext";
+
+interface TenantHints {
+  faq_question_hint?: string | null;
+  faq_answer_hint?: string | null;
+}
+
+interface FaqHintSettingsProps {
+  tenantId: string;
+  isSuperAdmin: boolean;
+  onHintsLoaded?: (hints: { questionHint: string | null; answerHint: string | null }) => void;
+}
+
+export default function FaqHintSettings({ tenantId, isSuperAdmin, onHintsLoaded }: FaqHintSettingsProps) {
+  const { t } = useLang();
+  const [open, setOpen] = useState(false);
+  const [questionHint, setQuestionHint] = useState("");
+  const [answerHint, setAnswerHint] = useState("");
+  const [loaded, setLoaded] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [toast, setToast] = useState<string | null>(null);
+
+  const endpoint = isSuperAdmin
+    ? `${API_BASE}/v1/admin/tenants/${tenantId}`
+    : `${API_BASE}/v1/admin/my-tenant`;
+
+  useEffect(() => {
+    if (!tenantId || tenantId === "global") return;
+    authFetch(endpoint)
+      .then((r) => r.json())
+      .then((data: TenantHints) => {
+        setQuestionHint(data.faq_question_hint ?? "");
+        setAnswerHint(data.faq_answer_hint ?? "");
+        setLoaded(true);
+        onHintsLoaded?.({
+          questionHint: data.faq_question_hint ?? null,
+          answerHint: data.faq_answer_hint ?? null,
+        });
+      })
+      .catch(() => {});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [endpoint, tenantId]);
+
+  const showToast = (msg: string) => {
+    setToast(msg);
+    setTimeout(() => setToast(null), 3000);
+  };
+
+  const handleSave = async () => {
+    if (saving) return;
+    const prevQ = questionHint;
+    const prevA = answerHint;
+    setSaving(true);
+    try {
+      const res = await authFetch(endpoint, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          faq_question_hint: questionHint.trim() || null,
+          faq_answer_hint: answerHint.trim() || null,
+        }),
+      });
+      if (!res.ok) {
+        setQuestionHint(prevQ);
+        setAnswerHint(prevA);
+        showToast(t("knowledge.faq_hint_save_error"));
+        return;
+      }
+      const updated = (await res.json()) as TenantHints;
+      const nextQ = updated.faq_question_hint ?? "";
+      const nextA = updated.faq_answer_hint ?? "";
+      setQuestionHint(nextQ);
+      setAnswerHint(nextA);
+      onHintsLoaded?.({ questionHint: nextQ || null, answerHint: nextA || null });
+      showToast(t("knowledge.faq_hint_saved"));
+    } catch {
+      setQuestionHint(prevQ);
+      setAnswerHint(prevA);
+      showToast(t("knowledge.faq_hint_save_error"));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  if (!tenantId || tenantId === "global") return null;
+
+  return (
+    <div
+      style={{
+        marginBottom: 16,
+        borderRadius: 14,
+        border: "1px solid #374151",
+        background: "rgba(15,23,42,0.4)",
+        overflow: "hidden",
+      }}
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        style={{
+          width: "100%",
+          padding: "14px 18px",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          background: "transparent",
+          border: "none",
+          cursor: "pointer",
+          color: "#d1d5db",
+          fontSize: 14,
+          fontWeight: 600,
+        }}
+      >
+        <span>💡 {t("knowledge.faq_hint_settings_title")}</span>
+        <span style={{ color: "#6b7280", fontSize: 12 }}>{open ? "▲" : "▼"}</span>
+      </button>
+
+      {open && (
+        <div style={{ padding: "0 18px 18px" }}>
+          <p style={{ fontSize: 13, color: "#6b7280", margin: "0 0 14px", lineHeight: 1.6 }}>
+            {t("knowledge.faq_hint_settings_desc")}
+          </p>
+          <div style={{ marginBottom: 12 }}>
+            <label style={{ display: "block", fontSize: 13, fontWeight: 600, color: "#9ca3af", marginBottom: 6 }}>
+              {t("knowledge.faq_hint_question_label")}
+            </label>
+            <input
+              type="text"
+              value={questionHint}
+              onChange={(e) => setQuestionHint(e.target.value)}
+              disabled={!loaded}
+              maxLength={200}
+              placeholder={t("modal.question_placeholder")}
+              style={{
+                width: "100%",
+                padding: "10px 12px",
+                borderRadius: 8,
+                border: "1px solid #374151",
+                background: "rgba(15,23,42,0.8)",
+                color: "#e5e7eb",
+                fontSize: 14,
+                boxSizing: "border-box",
+              }}
+            />
+          </div>
+          <div style={{ marginBottom: 16 }}>
+            <label style={{ display: "block", fontSize: 13, fontWeight: 600, color: "#9ca3af", marginBottom: 6 }}>
+              {t("knowledge.faq_hint_answer_label")}
+            </label>
+            <input
+              type="text"
+              value={answerHint}
+              onChange={(e) => setAnswerHint(e.target.value)}
+              disabled={!loaded}
+              maxLength={200}
+              placeholder={t("modal.answer_placeholder")}
+              style={{
+                width: "100%",
+                padding: "10px 12px",
+                borderRadius: 8,
+                border: "1px solid #374151",
+                background: "rgba(15,23,42,0.8)",
+                color: "#e5e7eb",
+                fontSize: 14,
+                boxSizing: "border-box",
+              }}
+            />
+          </div>
+          <button
+            type="button"
+            onClick={() => void handleSave()}
+            disabled={saving || !loaded}
+            style={{
+              padding: "10px 20px",
+              minHeight: 40,
+              borderRadius: 10,
+              border: "1px solid rgba(59,130,246,0.4)",
+              background: saving ? "rgba(59,130,246,0.1)" : "rgba(59,130,246,0.18)",
+              color: "#93c5fd",
+              fontSize: 14,
+              fontWeight: 600,
+              cursor: saving || !loaded ? "not-allowed" : "pointer",
+              opacity: saving || !loaded ? 0.6 : 1,
+            }}
+          >
+            {saving ? t("common.saving") : t("common.save")}
+          </button>
+          {toast && (
+            <div
+              style={{
+                marginTop: 12,
+                padding: "8px 12px",
+                borderRadius: 8,
+                background: toast.startsWith("❌") ? "rgba(239,68,68,0.12)" : "rgba(34,197,94,0.12)",
+                color: toast.startsWith("❌") ? "#fca5a5" : "#86efac",
+                fontSize: 13,
+              }}
+            >
+              {toast}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/admin-ui/src/components/knowledge/KnowledgeListTab.tsx
+++ b/admin-ui/src/components/knowledge/KnowledgeListTab.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import KnowledgeFaqEditModal, { type KnowledgeFaqItem } from "../KnowledgeFaqEditModal";
+import FaqHintSettings from "./FaqHintSettings";
 import { useLang } from "../../i18n/LangContext";
+import { useAuth } from "../../auth/useAuth";
 import { API_BASE } from "../../lib/api";
 import { fetchWithAuth, formatDate, CARD_STYLE, BTN_DANGER } from "./shared";
 
@@ -24,7 +26,12 @@ type DeleteState = "idle" | "confirming" | "deleting" | "success" | "error";
 export default function KnowledgeListTab({ tenantId }: { tenantId: string }) {
   const navigate = useNavigate();
   const { t, lang } = useLang();
+  const { isSuperAdmin } = useAuth();
   const locale = lang === "en" ? "en-US" : "ja-JP";
+  const [faqHints, setFaqHints] = useState<{ questionHint: string | null; answerHint: string | null }>({
+    questionHint: null,
+    answerHint: null,
+  });
 
   const CATEGORIES = [
     { value: "inventory", label: t("category.inventory") },
@@ -149,6 +156,13 @@ export default function KnowledgeListTab({ tenantId }: { tenantId: string }) {
 
   return (
     <div>
+      {/* GID 1216274385106667: FAQ登録フォームの入力例カスタマイズ */}
+      <FaqHintSettings
+        tenantId={tenantId}
+        isSuperAdmin={isSuperAdmin}
+        onHintsLoaded={setFaqHints}
+      />
+
       {/* 新規追加ボタン */}
       <button
         onClick={() => setCreateMode(true)}
@@ -418,6 +432,8 @@ export default function KnowledgeListTab({ tenantId }: { tenantId: string }) {
           item={editTarget}
           onClose={() => setEditTarget(null)}
           onSuccess={handleModalSuccess}
+          questionHint={faqHints.questionHint}
+          answerHint={faqHints.answerHint}
         />
       )}
 
@@ -427,6 +443,8 @@ export default function KnowledgeListTab({ tenantId }: { tenantId: string }) {
           tenantId={tenantId}
           onClose={() => setCreateMode(false)}
           onSuccess={handleModalSuccess}
+          questionHint={faqHints.questionHint}
+          answerHint={faqHints.answerHint}
         />
       )}
 

--- a/admin-ui/src/i18n/en.ts
+++ b/admin-ui/src/i18n/en.ts
@@ -67,6 +67,14 @@ const en: Record<TranslationKey, string> = {
   "knowledge.load_error": "Failed to load. Please try again 🙏",
   "knowledge.delete_error": "Failed to delete. Please try again 🙏",
 
+  // GID 1216274385106667: FAQ registration form hint message settings
+  "knowledge.faq_hint_settings_title": "Customize question/answer field examples",
+  "knowledge.faq_hint_settings_desc": "Customize the example placeholder text shown in the Add FAQ form to match your store. Leave blank to use the default examples.",
+  "knowledge.faq_hint_question_label": "Example for the \"Question\" field",
+  "knowledge.faq_hint_answer_label": "Example for the \"Answer\" field",
+  "knowledge.faq_hint_saved": "✅ Examples saved",
+  "knowledge.faq_hint_save_error": "❌ Failed to save. Please try again.",
+
   // Tabs
   "knowledge.tab_list": "Knowledge List",
   "knowledge.tab_text": "Text Input",

--- a/admin-ui/src/i18n/ja.ts
+++ b/admin-ui/src/i18n/ja.ts
@@ -65,6 +65,14 @@ const ja = {
   "knowledge.load_error": "読み込みに失敗しました。もう一度お試しください 🙏",
   "knowledge.delete_error": "削除に失敗しました。もう一度お試しください 🙏",
 
+  // GID 1216274385106667: FAQ登録フォームのヒントメッセージ設定
+  "knowledge.faq_hint_settings_title": "質問/回答欄の入力例をカスタマイズ",
+  "knowledge.faq_hint_settings_desc": "FAQを追加する画面で表示される入力例（プレースホルダー）を、店舗に合わせて変更できます。空欄のままにすると既定の入力例が使われます。",
+  "knowledge.faq_hint_question_label": "「質問」欄の入力例",
+  "knowledge.faq_hint_answer_label": "「回答」欄の入力例",
+  "knowledge.faq_hint_saved": "✅ 入力例を保存しました",
+  "knowledge.faq_hint_save_error": "❌ 保存に失敗しました。もう一度お試しください。",
+
   // Tabs
   "knowledge.tab_list": "ナレッジ一覧",
   "knowledge.tab_text": "テキスト入力",

--- a/src/api/admin/tenants/migration_faq_hints.sql
+++ b/src/api/admin/tenants/migration_faq_hints.sql
@@ -1,0 +1,5 @@
+-- GID 1216274385106667: FAQ登録フォームの質問/回答欄に、テナントごとの
+-- カスタム入力例(プレースホルダー)を設定できるようにする。
+-- NULL = 組み込みの汎用プレースホルダーを使う(既存動作を維持)。
+ALTER TABLE tenants ADD COLUMN IF NOT EXISTS faq_question_hint TEXT;
+ALTER TABLE tenants ADD COLUMN IF NOT EXISTS faq_answer_hint TEXT;

--- a/src/api/admin/tenants/routes.ts
+++ b/src/api/admin/tenants/routes.ts
@@ -57,6 +57,9 @@ const updateTenantSchema = z.object({
   conversion_types: z.array(z.string().max(50)).max(10).optional(),
   // Phase A Day 6: テナント担当者メールアドレス
   tenant_contact_email: z.string().email().nullable().optional(),
+  // GID 1216274385106667: FAQ登録フォームの質問/回答欄カスタムヒント（空文字/nullで既定プレースホルダーに戻す）
+  faq_question_hint: z.string().max(200).nullable().optional(),
+  faq_answer_hint: z.string().max(200).nullable().optional(),
 });
 
 // aaas_clients は共有Supabaseプロジェクト内のAaaS(R2C2)側所有テーブル
@@ -148,7 +151,7 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
     }
     try {
       const result = await db.query(
-        `SELECT id, name, features, lemonslice_agent_id, conversion_types FROM tenants WHERE id = $1`,
+        `SELECT id, name, features, lemonslice_agent_id, conversion_types, faq_question_hint, faq_answer_hint FROM tenants WHERE id = $1`,
         [tenantId]
       );
       if (result.rowCount === 0) {
@@ -178,17 +181,31 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
         pre_dispatch: z.boolean().optional(),
         // Phase75: テナント自身によるHermes Agent向け生データ利用同意の自己申告
         hermes_raw_data_consent: z.boolean().optional(),
-      }),
+      }).optional(),
+      // GID 1216274385106667: FAQ登録フォームの質問/回答欄カスタムヒント（client_admin自己申告）
+      faq_question_hint: z.string().max(200).nullable().optional(),
+      faq_answer_hint: z.string().max(200).nullable().optional(),
     });
     const parsed = bodySchema.safeParse(req.body ?? {});
     if (!parsed.success) {
       return res.status(400).json({ error: "invalid_request", details: parsed.error.issues });
     }
+    const fields = parsed.data;
+    if (Object.keys(fields).length === 0) {
+      return res.status(400).json({ error: "no_fields", message: "更新フィールドが必要です。" });
+    }
     try {
+      const setClauses: string[] = [];
+      const params: unknown[] = [];
+      if (fields.features !== undefined) { params.push(JSON.stringify(fields.features)); setClauses.push(`features = COALESCE(features, '{}'::jsonb) || $${params.length}::jsonb`); }
+      if ('faq_question_hint' in fields) { params.push(fields.faq_question_hint ?? null); setClauses.push(`faq_question_hint = $${params.length}`); }
+      if ('faq_answer_hint' in fields) { params.push(fields.faq_answer_hint ?? null); setClauses.push(`faq_answer_hint = $${params.length}`); }
+      setClauses.push(`updated_at = NOW()`);
+      params.push(tenantId);
       const result = await db.query(
-        `UPDATE tenants SET features = COALESCE(features, '{}'::jsonb) || $1::jsonb, updated_at = NOW() WHERE id = $2
-         RETURNING id, name, features, lemonslice_agent_id`,
-        [JSON.stringify(parsed.data.features), tenantId]
+        `UPDATE tenants SET ${setClauses.join(", ")} WHERE id = $${params.length}
+         RETURNING id, name, features, lemonslice_agent_id, faq_question_hint, faq_answer_hint`,
+        params
       );
       if (result.rowCount === 0) {
         return res.status(404).json({ error: "not_found", message: "テナントが見つかりません" });
@@ -294,7 +311,7 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
     const { id } = req.params;
     try {
       const result = await db.query(
-        `SELECT id, name, plan, is_active, allowed_origins, system_prompt, billing_enabled, billing_free_from, billing_free_until, features, lemonslice_agent_id, conversion_types, created_at, updated_at FROM tenants WHERE id = $1`,
+        `SELECT id, name, plan, is_active, allowed_origins, system_prompt, billing_enabled, billing_free_from, billing_free_until, features, lemonslice_agent_id, conversion_types, faq_question_hint, faq_answer_hint, created_at, updated_at FROM tenants WHERE id = $1`,
         [id]
       );
       if (result.rowCount === 0) {
@@ -342,10 +359,12 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
       if ('lemonslice_agent_id' in fields) { params.push(fields.lemonslice_agent_id ?? null); setClauses.push(`lemonslice_agent_id = $${params.length}`); }
       if (fields.conversion_types !== undefined) { params.push(JSON.stringify(fields.conversion_types)); setClauses.push(`conversion_types = $${params.length}::jsonb`); }
       if ('tenant_contact_email' in fields) { params.push(fields.tenant_contact_email ?? null); setClauses.push(`tenant_contact_email = $${params.length}`); }
+      if ('faq_question_hint' in fields) { params.push(fields.faq_question_hint ?? null); setClauses.push(`faq_question_hint = $${params.length}`); }
+      if ('faq_answer_hint' in fields) { params.push(fields.faq_answer_hint ?? null); setClauses.push(`faq_answer_hint = $${params.length}`); }
       setClauses.push(`updated_at = NOW()`);
       params.push(id);
       const result = await db.query(
-        `UPDATE tenants SET ${setClauses.join(", ")} WHERE id = $${params.length} RETURNING id, name, plan, is_active, allowed_origins, system_prompt, billing_enabled, billing_free_from, billing_free_until, features, lemonslice_agent_id, conversion_types, tenant_contact_email, created_at, updated_at`,
+        `UPDATE tenants SET ${setClauses.join(", ")} WHERE id = $${params.length} RETURNING id, name, plan, is_active, allowed_origins, system_prompt, billing_enabled, billing_free_from, billing_free_until, features, lemonslice_agent_id, conversion_types, tenant_contact_email, faq_question_hint, faq_answer_hint, created_at, updated_at`,
         params
       );
       // in-memory store を即時同期 (is_active 変更が次リクエストから有効になる)

--- a/tests/api/admin/tenants/routes.test.ts
+++ b/tests/api/admin/tenants/routes.test.ts
@@ -155,6 +155,19 @@ describe("Tenant Admin Routes", () => {
       expect(res.status).toBe(403);
       expect(mockDb.query).not.toHaveBeenCalled();
     });
+
+    it("returns faq_question_hint/faq_answer_hint (GID 1216274385106667)", async () => {
+      mockDb.query.mockResolvedValueOnce({
+        rows: [{ id: "tenant1", name: "Test", features: {}, lemonslice_agent_id: null, conversion_types: [], faq_question_hint: "例: 保証期間は？", faq_answer_hint: "例: 3年間です" }],
+        rowCount: 1,
+      });
+      const res = await request(app)
+        .get("/v1/admin/my-tenant")
+        .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`);
+      expect(res.status).toBe(200);
+      expect(res.body.faq_question_hint).toBe("例: 保証期間は？");
+      expect(res.body.faq_answer_hint).toBe("例: 3年間です");
+    });
   });
 
   describe("PATCH /v1/admin/my-tenant", () => {
@@ -178,6 +191,50 @@ describe("Tenant Admin Routes", () => {
         .send({ features: { avatar: true, voice: false, rag: true } });
       expect(res.status).toBe(403);
       expect(mockDb.query).not.toHaveBeenCalled();
+    });
+
+    it("updates faq_question_hint/faq_answer_hint for client_admin (GID 1216274385106667)", async () => {
+      mockDb.query.mockResolvedValueOnce({
+        rows: [{ id: "tenant1", name: "Test", features: {}, lemonslice_agent_id: null, faq_question_hint: "例: 保証期間は？", faq_answer_hint: "例: 3年間です" }],
+        rowCount: 1,
+      });
+      const res = await request(app)
+        .patch("/v1/admin/my-tenant")
+        .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`)
+        .send({ faq_question_hint: "例: 保証期間は？", faq_answer_hint: "例: 3年間です" });
+      expect(res.status).toBe(200);
+      expect(res.body.faq_question_hint).toBe("例: 保証期間は？");
+      const [sql] = mockDb.query.mock.calls[0];
+      expect(sql).toContain("faq_question_hint");
+      expect(sql).toContain("faq_answer_hint");
+    });
+
+    it("rejects an empty body with no_fields", async () => {
+      const res = await request(app)
+        .patch("/v1/admin/my-tenant")
+        .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`)
+        .send({});
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("no_fields");
+    });
+  });
+
+  describe("PATCH /v1/admin/tenants/:id", () => {
+    it("updates faq_question_hint/faq_answer_hint for super_admin (GID 1216274385106667)", async () => {
+      mockDb.query
+        .mockResolvedValueOnce({ rows: [{ id: "t1", plan: "starter", features: {}, billing_enabled: false, is_active: true }], rowCount: 1 })
+        .mockResolvedValueOnce({
+          rows: [{ id: "t1", name: "T1", plan: "starter", is_active: true, faq_question_hint: "例: 保証期間は？", faq_answer_hint: "例: 3年間です" }],
+          rowCount: 1,
+        })
+        .mockResolvedValue({ rows: [], rowCount: 0 });
+      const res = await request(app)
+        .patch("/v1/admin/tenants/t1")
+        .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`)
+        .send({ faq_question_hint: "例: 保証期間は？", faq_answer_hint: "例: 3年間です" });
+      expect(res.status).toBe(200);
+      expect(res.body.faq_question_hint).toBe("例: 保証期間は？");
+      expect(res.body.faq_answer_hint).toBe("例: 3年間です");
     });
   });
 


### PR DESCRIPTION
## Summary
- FAQ登録フォーム(`KnowledgeFaqEditModal`)の質問/回答欄プレースホルダーを、テナントごとにカスタマイズ可能にする(`FaqHintSettings`)
- client_admin: `PATCH /v1/admin/my-tenant` で自己申告可能。super_admin: `PATCH /v1/admin/tenants/:id` で代理設定可能
- 空欄/NULLの場合は既存の汎用プレースホルダーを維持(後方互換)
- マイグレーション: `tenants.faq_question_hint` / `faq_answer_hint` (TEXT, nullable)

GID: 1216274385106667

## Test plan
- [x] `tsc --noEmit` (backend / admin-ui) 通過
- [x] `jest tests/api/admin/tenants/routes.test.ts` 20/20 通過(新規4件追加: GET/PATCH my-tenant, PATCH tenants/:id のヒントフィールド)
- [x] ローカルDBにマイグレーション適用の上、実ブラウザで動作確認
  - 設定パネルでテナントのヒント値が正しくプリフィルされることを確認
  - FAQ新規追加モーダルの質問/回答プレースホルダーがカスタムヒントに置き換わることを確認
  - 確認後はテストデータをNULLに戻し、admin-ui `.env` も元のVITE_API_BASEに復元済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bu7k7x6P4Aa7MGMF4ymjSp