### PR TITLE
未回答質問からのワンクリック改善導線

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -20,6 +20,7 @@ import ChatHistoryPage from "./pages/admin/chat-history/index";
 import ChatHistorySessionPage from "./pages/admin/chat-history/[sessionId]";
 import EscalationsPage from "./pages/admin/escalations/index";
 import EscalationDetailPage from "./pages/admin/escalations/[sessionId]";
+import KnowledgeGapsPage from "./pages/admin/knowledge-gaps/index";
 import TuningPage from "./pages/admin/tuning/index";
 import FeedbackPage from "./pages/admin/feedback/index";
 import AdminAgentButton from "./components/AdminAgent/AdminAgentButton";
@@ -159,8 +160,8 @@ function AppInner() {
         {/* チューニングルール */}
         <Route path="/admin/tuning" element={<RequireAuth><TuningPage /></RequireAuth>} />
 
-        {/* ナレッジギャップ — 廃止: /admin/chat-history にリダイレクト */}
-        <Route path="/admin/knowledge-gaps" element={<Navigate to="/admin/chat-history?has_knowledge_gaps=true" replace />} />
+        {/* GID 1216275179995736: 未回答質問からのワンクリック改善導線 */}
+        <Route path="/admin/knowledge-gaps" element={<RequireAuth><KnowledgeGapsPage /></RequireAuth>} />
 
         {/* フィードバック — Super Admin専用 */}
         <Route path="/admin/feedback" element={<SuperAdminRoute><FeedbackPage /></SuperAdminRoute>} />

--- a/admin-ui/src/components/AppSidebar.tsx
+++ b/admin-ui/src/components/AppSidebar.tsx
@@ -21,6 +21,7 @@ import {
   X,
   GitBranch,
   Headset,
+  HelpCircle,
 } from "lucide-react";
 import { useAuth } from "../auth/useAuth";
 import { useTheme } from "../contexts/ThemeContext";
@@ -56,6 +57,7 @@ const MAIN_SECTIONS: NavSection[] = [
       { label: "会話履歴", path: "/admin/chat-history", icon: MessageSquare },
       { label: "対応中の会話", path: "/admin/escalations", icon: Headset },
       { label: "AIの知識データ", path: "/admin/knowledge", icon: BookOpen },
+      { label: "未回答質問", path: "/admin/knowledge-gaps", icon: HelpCircle },
       { label: "AI学習・貢献分析", path: "/admin/knowledge-analytics", icon: BarChart2, superAdminOnly: true },
     ],
   },

--- a/admin-ui/src/pages/admin/index.tsx
+++ b/admin-ui/src/pages/admin/index.tsx
@@ -379,7 +379,7 @@ export default function AdminDashboard() {
                 value={stats?.gapCount ?? 0}
                 accent={(stats?.gapCount ?? 0) > 0 ? "#f59e0b" : undefined}
                 sub="AIが答えられなかった質問数"
-                onClick={() => navigate("/admin/chat-history")}
+                onClick={() => navigate("/admin/knowledge-gaps")}
               />
               <StatCard
                 icon="🕐"

--- a/admin-ui/src/pages/admin/knowledge-gaps/index.tsx
+++ b/admin-ui/src/pages/admin/knowledge-gaps/index.tsx
@@ -1,0 +1,252 @@
+// admin-ui/src/pages/admin/knowledge-gaps/index.tsx
+// GID 1216275179995736: 未回答質問からのワンクリック改善導線
+
+import { useState, useEffect, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { useLang } from "../../../i18n/LangContext";
+import LangSwitcher from "../../../components/LangSwitcher";
+import { authFetch, API_BASE } from "../../../lib/api";
+import { useAuth } from "../../../auth/useAuth";
+
+interface KnowledgeGap {
+  id: number;
+  tenant_id: string;
+  user_question: string;
+  rag_hit_count: number;
+  rag_top_score: number;
+  created_at: string;
+}
+
+export default function KnowledgeGapsPage() {
+  const navigate = useNavigate();
+  const { t, lang } = useLang();
+  const { user, isSuperAdmin, previewMode, previewTenantId } = useAuth();
+
+  const [gaps, setGaps] = useState<KnowledgeGap[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [dismissingId, setDismissingId] = useState<number | null>(null);
+  const [tenants, setTenants] = useState<{ id: string; name: string }[]>([]);
+  const [selectedTenantFilter, setSelectedTenantFilter] = useState<string>("");
+
+  const locale = lang === "en" ? "en-US" : "ja-JP";
+  const ownTenantId = previewMode ? (previewTenantId ?? "") : (user?.tenantId ?? "");
+  const effectiveTenant = isSuperAdmin ? selectedTenantFilter : ownTenantId;
+
+  useEffect(() => {
+    if (!isSuperAdmin) return;
+    authFetch(`${API_BASE}/v1/admin/tenants`)
+      .then((r) => r.json())
+      .then((data: { tenants?: { id: string; name: string }[] }) => setTenants(data.tenants ?? []))
+      .catch(() => {});
+  }, [isSuperAdmin]);
+
+  const loadGaps = useCallback(async () => {
+    if (isSuperAdmin && !selectedTenantFilter) {
+      setGaps([]);
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({ status: "open" });
+      if (effectiveTenant) params.set("tenant", effectiveTenant);
+      const res = await authFetch(`${API_BASE}/v1/admin/knowledge/gaps?${params}`);
+      if (!res.ok) throw new Error();
+      const data = (await res.json()) as { gaps: KnowledgeGap[] };
+      setGaps(data.gaps ?? []);
+      setError(null);
+    } catch {
+      setError("データの取得に失敗しました");
+    } finally {
+      setLoading(false);
+    }
+  }, [isSuperAdmin, selectedTenantFilter, effectiveTenant]);
+
+  useEffect(() => {
+    void loadGaps();
+  }, [loadGaps]);
+
+  const formatRelative = (iso: string) => {
+    const diffMs = Date.now() - new Date(iso).getTime();
+    const mins = Math.floor(diffMs / 60000);
+    if (mins < 1) return "たった今";
+    if (mins < 60) return `${mins}分前`;
+    const hours = Math.floor(mins / 60);
+    if (hours < 24) return `${hours}時間前`;
+    const days = Math.floor(hours / 24);
+    if (days < 30) return `${days}日前`;
+    return new Date(iso).toLocaleDateString(locale, { month: "short", day: "numeric" });
+  };
+
+  const handleCreateFaq = (gap: KnowledgeGap) => {
+    const params = new URLSearchParams({
+      tab: "text",
+      gap_id: String(gap.id),
+      question: gap.user_question,
+    });
+    navigate(`/admin/knowledge/${gap.tenant_id}?${params.toString()}`);
+  };
+
+  const handleCreateTuningRule = (gap: KnowledgeGap) => {
+    const params = new URLSearchParams({
+      create: "1",
+      userMsg: gap.user_question,
+      assistantMsg: "ご質問の内容に完全に一致するFAQは見つかりませんでした。",
+      presetTenantId: gap.tenant_id,
+      resolveGapId: String(gap.id),
+    });
+    navigate(`/admin/tuning?${params.toString()}`);
+  };
+
+  const handleDismiss = async (gap: KnowledgeGap) => {
+    setDismissingId(gap.id);
+    try {
+      const res = await authFetch(`${API_BASE}/v1/admin/knowledge/gaps/${gap.id}`, {
+        method: "PATCH",
+        body: JSON.stringify({ status: "dismissed" }),
+      });
+      if (!res.ok) throw new Error();
+      setGaps((prev) => prev.filter((g) => g.id !== gap.id));
+    } catch {
+      setError("却下に失敗しました");
+    } finally {
+      setDismissingId(null);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        minHeight: "100vh",
+        background: "var(--background)",
+        color: "var(--foreground)",
+        padding: "24px 20px",
+        maxWidth: 900,
+        margin: "0 auto",
+      }}
+    >
+      <header style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 24, flexWrap: "wrap", gap: 12 }}>
+        <div>
+          <button
+            onClick={() => navigate("/admin")}
+            style={{ background: "none", border: "none", color: "var(--muted-foreground)", fontSize: 14, cursor: "pointer", padding: 0, marginBottom: 8, display: "block" }}
+          >
+            {t("common.back_to_dashboard")}
+          </button>
+          <h1 style={{ fontSize: 26, fontWeight: 700, margin: 0, color: "var(--foreground)" }}>
+            🔍 未回答質問
+          </h1>
+          <p style={{ fontSize: 14, color: "var(--muted-foreground)", marginTop: 4, marginBottom: 0 }}>
+            AIが十分に答えられなかった質問です。FAQ登録やチューニングルール化でワンクリック改善できます
+          </p>
+        </div>
+        <LangSwitcher />
+      </header>
+
+      {isSuperAdmin && (
+        <div style={{ marginBottom: 16 }}>
+          <select
+            value={selectedTenantFilter}
+            onChange={(e) => setSelectedTenantFilter(e.target.value)}
+            style={{
+              padding: "8px 12px", minHeight: 38, borderRadius: 10,
+              border: "1px solid var(--border)", background: "var(--card)",
+              color: "var(--foreground)", fontSize: 13, cursor: "pointer",
+            }}
+          >
+            <option value="">テナントを選択してください</option>
+            {tenants.map((tn) => (
+              <option key={tn.id} value={tn.id}>{tn.name}</option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {error && (
+        <div style={{ marginBottom: 20, padding: "14px 18px", borderRadius: 12, background: "rgba(127,29,29,0.4)", border: "1px solid rgba(248,113,113,0.3)", color: "#fca5a5", fontSize: 15 }}>
+          {error}
+        </div>
+      )}
+
+      {isSuperAdmin && !selectedTenantFilter ? (
+        <div style={{ padding: "48px 24px", textAlign: "center", borderRadius: 14, border: "1px dashed var(--border)", color: "var(--muted-foreground)" }}>
+          テナントを選択してください
+        </div>
+      ) : loading ? (
+        <div style={{ padding: 40, textAlign: "center", color: "var(--muted-foreground)" }}>
+          <span style={{ display: "block", fontSize: 32, marginBottom: 8 }}>⏳</span>
+          読み込んでいます...
+        </div>
+      ) : gaps.length === 0 ? (
+        <div style={{ padding: "48px 24px", textAlign: "center", borderRadius: 14, border: "1px solid var(--border)", background: "var(--card)" }}>
+          <div style={{ fontSize: 40, marginBottom: 12 }}>✅</div>
+          <p style={{ color: "var(--foreground)", fontSize: 15, fontWeight: 600, margin: 0 }}>
+            未回答の質問はありません
+          </p>
+        </div>
+      ) : (
+        <div style={{ display: "flex", flexDirection: "column", gap: 12 }}>
+          {gaps.map((gap) => (
+            <div
+              key={gap.id}
+              style={{
+                borderRadius: 14,
+                border: "1px solid var(--border)",
+                background: "var(--card)",
+                padding: "18px 20px",
+                display: "flex",
+                flexDirection: "column",
+                gap: 12,
+              }}
+            >
+              <div>
+                <p style={{ fontSize: 15, color: "var(--foreground)", fontWeight: 600, margin: "0 0 6px", lineHeight: 1.5 }}>
+                  {gap.user_question}
+                </p>
+                <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>
+                  🕐 {formatRelative(gap.created_at)}
+                  {isSuperAdmin && ` · ${gap.tenant_id}`}
+                </span>
+              </div>
+              <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+                <button
+                  onClick={() => handleCreateFaq(gap)}
+                  style={{
+                    padding: "10px 16px", minHeight: 44, borderRadius: 10,
+                    border: "none", background: "linear-gradient(135deg, #22c55e, #4ade80)",
+                    color: "#022c22", fontSize: 14, fontWeight: 700, cursor: "pointer", whiteSpace: "nowrap",
+                  }}
+                >
+                  📚 FAQとして登録
+                </button>
+                <button
+                  onClick={() => handleCreateTuningRule(gap)}
+                  style={{
+                    padding: "10px 16px", minHeight: 44, borderRadius: 10,
+                    border: "1px solid rgba(59,130,246,0.4)", background: "rgba(59,130,246,0.1)",
+                    color: "#93c5fd", fontSize: 14, fontWeight: 600, cursor: "pointer", whiteSpace: "nowrap",
+                  }}
+                >
+                  🎛️ チューニングルールにする
+                </button>
+                <button
+                  onClick={() => void handleDismiss(gap)}
+                  disabled={dismissingId === gap.id}
+                  style={{
+                    marginLeft: "auto",
+                    padding: "10px 14px", minHeight: 44, borderRadius: 10,
+                    border: "1px solid var(--border)", background: "transparent",
+                    color: "var(--muted-foreground)", fontSize: 13, cursor: dismissingId === gap.id ? "default" : "pointer", whiteSpace: "nowrap",
+                  }}
+                >
+                  {dismissingId === gap.id ? "処理中..." : "却下する"}
+                </button>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/admin-ui/src/pages/admin/tuning/index.tsx
+++ b/admin-ui/src/pages/admin/tuning/index.tsx
@@ -104,6 +104,8 @@ export default function TuningRulesPage() {
     useState<SourceConversation | null>(null);
   const [createFromConversation, setCreateFromConversation] = useState(false);
   const [presetTenantId, setPresetTenantId] = useState<string | undefined>(undefined);
+  // GID 1216275179995736: 未回答質問からの作成時、保存成功後に元のgapをresolvedにする
+  const [resolveGapId, setResolveGapId] = useState<number | undefined>(undefined);
 
   // ─── Delete state ───────────────────────────────────────────────────────────
   const [deleteTarget, setDeleteTarget] = useState<{
@@ -157,6 +159,11 @@ export default function TuningRulesPage() {
         setCreateFromConversation(true);
         setPresetTenantId(fromTenantId);
       }
+      const gapIdStr = searchParams.get("resolveGapId");
+      const gapId = gapIdStr ? Number(gapIdStr) : NaN;
+      if (Number.isFinite(gapId) && gapId > 0) {
+        setResolveGapId(gapId);
+      }
       setCreateMode(true);
       // Clean URL without reload
       window.history.replaceState({}, "", "/admin/tuning");
@@ -188,6 +195,14 @@ export default function TuningRulesPage() {
         : [rule, ...prev],
     );
     showToast(msg);
+    // GID 1216275179995736: 未回答質問からの作成であれば、元のgapをresolvedにする
+    if (resolveGapId) {
+      void authFetch(`${API_BASE}/v1/admin/knowledge/gaps/${resolveGapId}`, {
+        method: "PATCH",
+        body: JSON.stringify({ status: "resolved" }),
+      }).catch(() => {/* best-effort */});
+      setResolveGapId(undefined);
+    }
   };
 
   // ─── Toggle active ──────────────────────────────────────────────────────────
@@ -595,6 +610,7 @@ export default function TuningRulesPage() {
             setSourceConversation(null);
             setCreateFromConversation(false);
             setPresetTenantId(undefined);
+            setResolveGapId(undefined);
           }}
           onSuccess={handleModalSuccess}
         />


### PR DESCRIPTION
## Summary
- 新しい「未回答質問」一覧ページ(`/admin/knowledge-gaps`)を追加。ダッシュボードの「未回答質問」カード・サイドバーからここに遷移するよう変更(旧: `/admin/chat-history`への一方通行リダイレクトを廃止)
- 各未回答質問に「📚 FAQとして登録」「🎛️ チューニングルールにする」「却下する」ボタンを表示

### 実装の要点(バックエンド変更なし)
調査の結果、以下の受け皿は既に完成していたため、今回は「一覧ページ」と「導線」の新規構築のみで済んでいます:
- `GET /v1/admin/knowledge/gaps` (一覧) / `PATCH .../gaps/:id` (resolved/dismissed) — Phase38+で既存
- `TextInputTab`/`UrlScrapeTab`の`gapId`/`gapQuestion`props — FAQ登録成功時に自動で`resolveKnowledgeGap`を呼ぶ処理が既存(今回は`/admin/knowledge/:tenantId?tab=text&gap_id=&question=`のURLを新規構築して繋いだだけ)
- `TuningRuleModal`の`sourceConversation`props — 渡すとAI提案を自動実行する処理が既存(`/admin/tuning?create=1&userMsg=&presetTenantId=`のURLを新規構築して繋いだだけ)
- チューニングルール作成方向のみ、保存成功時に元のgapを自動でresolvedにする処理(`resolveGapId`パラメータ)を新規追加

GID: 1216275179995736

## Test plan
- [x] `tsc --noEmit` (admin-ui) 通過
- [x] ローカル実DBに`knowledge_gaps`のテスト行を投入し、実ブラウザで一覧表示・件数・「n分前」表示を確認
- [x] 「FAQとして登録」→ `/admin/knowledge/demo?tab=text&gap_id=...&question=...` へ正しく遷移し、質問バナーとプレースホルダーが正しく表示されることを確認
- [x] 「チューニングルールにする」→ `/admin/tuning`の新規作成モーダルが自動で開き、元の会話(User/AI)が表示されAI提案が自動生成されることを確認
- [x] ダッシュボードの「未回答質問」カードが新しいページへ遷移することを確認
- 確認後はテストデータ・デバッグ用コード・ローカル環境設定をすべて元に戻し済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bu7k7x6P4Aa7MGMF4ymjSp