### PR TITLE
自然文からのチューニングルール自動生成

### DIFF
--- a/admin-ui/src/components/tuning/TuningRuleModal.tsx
+++ b/admin-ui/src/components/tuning/TuningRuleModal.tsx
@@ -22,6 +22,8 @@ interface Props {
   mode: "create" | "edit";
   initialData?: TuningRule;
   sourceConversation?: SourceConversation;
+  /** GID 1216275447729242: 自然文からのルール自動生成時、管理者が書いた指示文 */
+  freeTextInstruction?: string;
   tenantId: string; // caller's tenant; "global" if super_admin
   isSuperAdmin: boolean;
   tenantOptions: { value: string; label: string }[];
@@ -70,6 +72,7 @@ export default function TuningRuleModal({
   mode,
   initialData,
   sourceConversation,
+  freeTextInstruction,
   tenantId,
   isSuperAdmin,
   tenantOptions,
@@ -115,9 +118,10 @@ export default function TuningRuleModal({
   const [approveReasons, setApproveReasons] = useState<Record<number, string>>({});
   const [approving, setApproving] = useState<number | null>(null);
 
-  // AI提案: モーダルが開いた時点でsourceConversationがあれば自動実行
+  // AI提案: モーダルが開いた時点でsourceConversationまたはfreeTextInstructionが
+  // あれば自動実行(GID 1216275447729242: 自然文からのルール自動生成)
   useEffect(() => {
-    if (mode !== "create" || !sourceConversation) return;
+    if (mode !== "create" || (!sourceConversation && !freeTextInstruction)) return;
     let cancelled = false;
 
     const suggest = async () => {
@@ -125,10 +129,14 @@ export default function TuningRuleModal({
       try {
         const res = await authFetch(`${API_BASE}/v1/admin/tuning/suggest-rule`, {
           method: "POST",
-          body: JSON.stringify({
-            userMessage: sourceConversation.userMsg,
-            aiMessage: sourceConversation.assistantMsg,
-          }),
+          body: JSON.stringify(
+            sourceConversation
+              ? {
+                  userMessage: sourceConversation.userMsg,
+                  aiMessage: sourceConversation.assistantMsg,
+                }
+              : { freeText: freeTextInstruction }
+          ),
         });
         if (cancelled) return;
         if (!res.ok) return; // 失敗時は手動入力にフォールバック
@@ -572,6 +580,60 @@ export default function TuningRuleModal({
                   }}
                 >
                   （この回答を改善するためにルールを作成しています）
+                </p>
+              </div>
+            </div>
+          )}
+
+          {/* GID 1216275447729242: 自然文の指示（自然文からのルール作成時のみ） */}
+          {freeTextInstruction && (
+            <div
+              style={{
+                borderRadius: 12,
+                border: "1px solid #374151",
+                background: "rgba(15,23,42,0.6)",
+                overflow: "hidden",
+              }}
+            >
+              <div
+                style={{
+                  padding: "10px 14px",
+                  borderBottom: "1px solid #374151",
+                  fontSize: 13,
+                  fontWeight: 600,
+                  color: "#9ca3af",
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 6,
+                }}
+              >
+                📝 あなたの指示
+              </div>
+              <div style={{ padding: "14px" }}>
+                <div
+                  style={{
+                    padding: "8px 12px",
+                    borderRadius: 8,
+                    background: "rgba(31,41,55,0.8)",
+                    border: "1px solid #374151",
+                    color: "#d1d5db",
+                    fontSize: 14,
+                    lineHeight: 1.5,
+                    whiteSpace: "pre-wrap",
+                  }}
+                >
+                  {freeTextInstruction}
+                </div>
+                <p
+                  style={{
+                    fontSize: 12,
+                    color: "#6b7280",
+                    marginTop: 8,
+                    marginBottom: 0,
+                    fontStyle: "italic",
+                  }}
+                >
+                  （この指示をルールとして構造化しています）
                 </p>
               </div>
             </div>

--- a/admin-ui/src/pages/admin/tuning/index.tsx
+++ b/admin-ui/src/pages/admin/tuning/index.tsx
@@ -106,6 +106,9 @@ export default function TuningRulesPage() {
   const [presetTenantId, setPresetTenantId] = useState<string | undefined>(undefined);
   // GID 1216275179995736: 未回答質問からの作成時、保存成功後に元のgapをresolvedにする
   const [resolveGapId, setResolveGapId] = useState<number | undefined>(undefined);
+  // GID 1216275447729242: 自然文からのルール自動生成
+  const [freeTextInstruction, setFreeTextInstruction] = useState<string | undefined>(undefined);
+  const [naturalLangDraft, setNaturalLangDraft] = useState("");
 
   // ─── Delete state ───────────────────────────────────────────────────────────
   const [deleteTarget, setDeleteTarget] = useState<{
@@ -297,10 +300,69 @@ export default function TuningRulesPage() {
         <LangSwitcher />
       </header>
 
+      {/* GID 1216275447729242: 自然文からのルール自動生成 */}
+      <div
+        style={{
+          borderRadius: 14,
+          border: "1px solid rgba(59,130,246,0.3)",
+          background: "rgba(59,130,246,0.06)",
+          padding: "16px 18px",
+          marginBottom: 16,
+        }}
+      >
+        <p style={{ fontSize: 14, fontWeight: 700, color: "#93c5fd", margin: "0 0 6px" }}>
+          🤖 自然文からルールを作成
+        </p>
+        <p style={{ fontSize: 13, color: "var(--muted-foreground)", margin: "0 0 10px" }}>
+          AIへの指示を普段の言葉で書くと、条件と指示文をAIが自動で組み立てます
+        </p>
+        <textarea
+          value={naturalLangDraft}
+          onChange={(e) => setNaturalLangDraft(e.target.value)}
+          placeholder="例: 保証期間について聞かれたら2年とお伝えして"
+          rows={2}
+          style={{
+            width: "100%",
+            padding: "12px 14px",
+            borderRadius: 10,
+            border: "1px solid #374151",
+            background: "rgba(15,23,42,0.8)",
+            color: "#e5e7eb",
+            fontSize: 15,
+            resize: "vertical",
+            boxSizing: "border-box",
+            marginBottom: 10,
+          }}
+        />
+        <button
+          onClick={() => {
+            if (!naturalLangDraft.trim()) return;
+            setSourceConversation(null);
+            setFreeTextInstruction(naturalLangDraft.trim());
+            setCreateMode(true);
+          }}
+          disabled={!naturalLangDraft.trim()}
+          style={{
+            padding: "10px 18px",
+            minHeight: 44,
+            borderRadius: 10,
+            border: "none",
+            background: naturalLangDraft.trim() ? "#1d4ed8" : "#1e3a5f",
+            color: "#fff",
+            fontSize: 14,
+            fontWeight: 700,
+            cursor: naturalLangDraft.trim() ? "pointer" : "not-allowed",
+          }}
+        >
+          この指示でルールを作成する
+        </button>
+      </div>
+
       {/* Add button */}
       <button
         onClick={() => {
           setSourceConversation(null);
+          setFreeTextInstruction(undefined);
           setCreateMode(true);
         }}
         style={{
@@ -600,6 +662,7 @@ export default function TuningRulesPage() {
         <TuningRuleModal
           mode="create"
           sourceConversation={sourceConversation ?? undefined}
+          freeTextInstruction={freeTextInstruction}
           tenantId={tenantId}
           isSuperAdmin={isSuperAdmin}
           tenantOptions={tenantOptions}
@@ -611,6 +674,8 @@ export default function TuningRulesPage() {
             setCreateFromConversation(false);
             setPresetTenantId(undefined);
             setResolveGapId(undefined);
+            setFreeTextInstruction(undefined);
+            setNaturalLangDraft("");
           }}
           onSuccess={handleModalSuccess}
         />

--- a/src/api/admin/tuning/routes.ts
+++ b/src/api/admin/tuning/routes.ts
@@ -130,6 +130,83 @@ ${knowledgePart}${rulesPart}${crossTenantPart}${researchPart}
   }
 }
 
+// GID 1216275447729242: 自然言語からのチューニングルール自動生成
+// 会話ペア(顧客の質問+AIの回答)ではなく、店舗管理者が書いた自然文の指示から
+// トリガー条件と対応指示を構造化して抽出する。
+export async function callGroq8bSuggestFromText(
+  freeText: string,
+  knowledgeSection: string = '',
+  existingRulesSection: string = '',
+  crossTenantSection: string = '',
+): Promise<SuggestRuleResponse> {
+  const apiKey = process.env.GROQ_API_KEY?.trim();
+  if (!apiKey) {
+    return { trigger_pattern: "", instruction: "", priority: 0, reason: "" };
+  }
+
+  const knowledgePart = knowledgeSection
+    ? `\n## 参考ナレッジ（心理学原則・FAQ）\n${knowledgeSection}\n`
+    : '';
+  const rulesPart = existingRulesSection
+    ? `\n## 既存チューニングルール（重複しないルールを提案すること）\n${existingRulesSection}\n`
+    : '';
+  const crossTenantPart = crossTenantSection
+    ? `\n${crossTenantSection}\n`
+    : '';
+
+  const prompt = `以下は店舗管理者が自然な言葉で書いた、AIチャットボットへの指示です。
+これを解析して、チャットボットのチューニングルール（トリガー条件＋AIへの具体的な指示）として構造化してください。
+
+【管理者の指示】
+${freeText.slice(0, 1000)}
+${knowledgePart}${rulesPart}${crossTenantPart}
+以下のJSON形式のみで回答してください（説明不要）:
+{
+  "trigger_pattern": "このルールが適用されるキーワードや状況（例: 保証について聞かれた場合）",
+  "instruction": "AIへの具体的な指示（管理者の意図を明確な指示文として書き直したもの）",
+  "priority": 緊急度・重要度（0〜10の整数）,
+  "reason": "この構造化内容にした理由（1〜2文）"
+}`;
+
+  try {
+    const res = await fetch("https://api.groq.com/openai/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: process.env.GROQ_MODEL_8B ?? GROQ_INSTANT_8B,
+        messages: [{ role: "user", content: prompt }],
+        temperature: 0.4,
+        max_tokens: 400,
+      }),
+    });
+
+    if (!res.ok) {
+      return { trigger_pattern: "", instruction: "", priority: 0, reason: "" };
+    }
+
+    const data = await res.json() as { choices?: Array<{ message?: { content?: string } }> };
+    const raw: string = data.choices?.[0]?.message?.content?.trim() ?? "";
+
+    const jsonMatch = raw.match(/\{[\s\S]*\}/);
+    if (!jsonMatch) {
+      return { trigger_pattern: "", instruction: "", priority: 0, reason: "" };
+    }
+
+    const parsed = JSON.parse(jsonMatch[0]) as Record<string, unknown>;
+    return {
+      trigger_pattern: String(parsed["trigger_pattern"] ?? "").slice(0, 500),
+      instruction: String(parsed["instruction"] ?? "").slice(0, 2000),
+      priority: Math.max(0, Math.min(10, Number(parsed["priority"]) || 0)),
+      reason: String(parsed["reason"] ?? "").slice(0, 500),
+    };
+  } catch {
+    return { trigger_pattern: "", instruction: "", priority: 0, reason: "" };
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Zod スキーマ
 // ---------------------------------------------------------------------------
@@ -193,14 +270,25 @@ export function registerTuningRoutes(app: Express): void {
         return res.status(403).json({ error: "この操作を実行する権限がありません", code: 'AUTHZ_ROLE_DENIED' });
       }
 
-      const { userMessage, aiMessage } = (req.body ?? {}) as Record<string, unknown>;
-      if (typeof userMessage !== "string" || typeof aiMessage !== "string") {
-        return res.status(400).json({ error: "userMessage and aiMessage are required strings" });
-      }
-      if (!userMessage.trim() || !aiMessage.trim()) {
-        return res.status(400).json({ error: "userMessage and aiMessage must not be empty" });
+      // GID 1216275447729242: {freeText} (自然文の指示) または
+      // {userMessage, aiMessage} (会話ペアからの提案・既存) のどちらかを受け付ける
+      const { userMessage, aiMessage, freeText } = (req.body ?? {}) as Record<string, unknown>;
+      const isFreeTextMode = typeof freeText === "string";
+
+      if (isFreeTextMode) {
+        if (!(freeText as string).trim()) {
+          return res.status(400).json({ error: "freeText must not be empty" });
+        }
+      } else {
+        if (typeof userMessage !== "string" || typeof aiMessage !== "string") {
+          return res.status(400).json({ error: "userMessage and aiMessage are required strings" });
+        }
+        if (!userMessage.trim() || !aiMessage.trim()) {
+          return res.status(400).json({ error: "userMessage and aiMessage must not be empty" });
+        }
       }
 
+      const anchorText = isFreeTextMode ? (freeText as string).trim() : (userMessage as string).trim();
       const tenantId: string = su?.app_metadata?.tenant_id ?? su?.tenant_id ?? "";
 
       // deep_researchフラグ確認（DB失敗時はfalse）
@@ -209,14 +297,14 @@ export function registerTuningRoutes(app: Express): void {
       // ナレッジ検索・既存ルール取得・クロステナント統計・外部リサーチを並行実行
       const [knowledgeCtx, existingRules, crossTenantCtx, researchResult] = await Promise.all([
         tenantId
-          ? searchKnowledgeForSuggestion(tenantId, userMessage.trim()).catch(() => ({ results: [] }))
+          ? searchKnowledgeForSuggestion(tenantId, anchorText).catch(() => ({ results: [] }))
           : Promise.resolve({ results: [] }),
         tenantId
           ? listRules(tenantId).catch(() => [])
           : Promise.resolve([]),
         getCrossTenantContext().catch(() => ({ avgScores: null, topPsychologyPrinciples: [], commonGapPatterns: [], effectiveRulePatterns: [], totalTenants: 0, dataAsOf: new Date().toISOString() })),
         deepResearchEnabled
-          ? (getResearchProvider()?.search(buildResearchQuery({ userMessage: userMessage.trim() }), 'ja') ?? Promise.resolve(null)).catch(() => null)
+          ? (getResearchProvider()?.search(buildResearchQuery({ userMessage: anchorText }), 'ja') ?? Promise.resolve(null)).catch(() => null)
           : Promise.resolve(null),
       ]);
 
@@ -230,14 +318,21 @@ export function registerTuningRoutes(app: Express): void {
         ? `## 外部リサーチ（最新の市場動向・学術知見）\n${researchResult.summary}${researchResult.citations.length > 0 ? '\n参照: ' + researchResult.citations.slice(0, 3).join(', ') : ''}`
         : '';
 
-      const suggestion = await callGroq8bSuggest(
-        userMessage.trim(),
-        aiMessage.trim(),
-        knowledgeSection,
-        existingRulesSection,
-        crossTenantSection,
-        researchSection,
-      );
+      const suggestion = isFreeTextMode
+        ? await callGroq8bSuggestFromText(
+            anchorText,
+            knowledgeSection,
+            existingRulesSection,
+            crossTenantSection,
+          )
+        : await callGroq8bSuggest(
+            anchorText,
+            (aiMessage as string).trim(),
+            knowledgeSection,
+            existingRulesSection,
+            crossTenantSection,
+            researchSection,
+          );
       return res.json(suggestion);
     },
   );

--- a/tests/phase54/tuningSuggest.test.ts
+++ b/tests/phase54/tuningSuggest.test.ts
@@ -150,6 +150,64 @@ describe("1. POST /v1/admin/tuning/suggest-rule — 正常系", () => {
 });
 
 // ===========================================================================
+// 1.5. GID 1216275447729242: 自然文(freeText)からの生成
+// ===========================================================================
+
+describe("1.5. POST /v1/admin/tuning/suggest-rule — freeText モード", () => {
+  it("freeText のみで提案を返す", async () => {
+    mockGroqSuccess({
+      trigger_pattern: "保証について",
+      instruction: "保証期間は2年とお伝えする",
+      priority: 4,
+      reason: "管理者の指示を構造化",
+    });
+
+    const res = await request(makeApp("client_admin"))
+      .post("/v1/admin/tuning/suggest-rule")
+      .send({ freeText: "保証期間について聞かれたら2年とお伝えして" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.trigger_pattern).toBe("保証について");
+    expect(res.body.instruction).toBe("保証期間は2年とお伝えする");
+  });
+
+  it("freeText が空文字列 → 400", async () => {
+    const res = await request(makeApp("client_admin"))
+      .post("/v1/admin/tuning/suggest-rule")
+      .send({ freeText: "   " });
+
+    expect(res.status).toBe(400);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("freeText 指定時は userMessage/aiMessage が無くても通る", async () => {
+    mockGroqSuccess({
+      trigger_pattern: "定休日",
+      instruction: "定休日は水曜日と案内する",
+      priority: 2,
+      reason: "よくある質問",
+    });
+
+    const res = await request(makeApp("client_admin"))
+      .post("/v1/admin/tuning/suggest-rule")
+      .send({ freeText: "定休日を聞かれたら水曜日と案内して" });
+
+    expect(res.status).toBe(200);
+  });
+
+  it("Groq失敗時もfreeTextモードで500にならず空提案を返す", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+
+    const res = await request(makeApp("client_admin"))
+      .post("/v1/admin/tuning/suggest-rule")
+      .send({ freeText: "テスト指示" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.trigger_pattern).toBe("");
+  });
+});
+
+// ===========================================================================
 // 2. 認証エラー
 // ===========================================================================
 


### PR DESCRIPTION
## Summary
- 「AIへの指示ルール」画面に、自然な言葉で書いた指示からトリガー条件と対応指示をAIが自動構造化する入力欄を追加(Sierra AI Ghostwriter型のアプローチ)
- 既存の「会話履歴からルール作成」機能(sourceConversation + AI自動提案)とほぼ同じ仕組みを流用し、入力元だけ「会話ペア」→「自然文の指示」に変更

### 実装の要点
- `POST /v1/admin/tuning/suggest-rule`: 既存の`{userMessage, aiMessage}`に加え`{freeText}`を受け付けるよう拡張。専用プロンプト(`callGroq8bSuggestFromText`)で「管理者の指示」として解析
- `TuningRuleModal`: `freeTextInstruction`プロパティを追加、既存の自動提案useEffectを流用してAPI呼び出し先を分岐。プレビューボックス「📝 あなたの指示」を新設(既存の「💬 元の会話」と対になる形)
- `AIへの指示ルール`ページ: 「🤖 自然文からルールを作成」の入力カードを新設。既存の手動作成ボタンは変更なし

GID: 1216275447729242

## Test plan
- [x] `tsc --noEmit` (backend / admin-ui) 通過
- [x] `jest tests/phase54/tuningSuggest.test.ts` 16/16通過(新規4件: freeTextモードの正常系・空文字400・userMessage/aiMessage不要・Groq失敗時のフォールバック)
- [x] ローカル実DBに対し、実ブラウザで一連の流れを確認: 「自然文からルールを作成」への入力 → モーダル自動オープン → プレビューボックス表示 → (ローカル環境のGROQ_API_KEYが期限切れのため実際のAI提案内容は確認できず、Groq失敗時の安全なフォールバックとして空欄になることを確認。フォールバック自体はjestで正常系・異常系ともカバー済み) → 手動での各項目入力 → 保存 → 実際にDBへ正しく登録されることを確認
- 確認後はテストデータ・デバッグ用コード・ローカル環境設定をすべて元に戻し済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bu7k7x6P4Aa7MGMF4ymjSp