### PR TITLE
chore: set VITE_AAAS_ADMIN_URL for App Switcher build

### DIFF
--- a/.github/workflows/deploy-admin-ui.yml
+++ b/.github/workflows/deploy-admin-ui.yml
@@ -41,6 +41,8 @@ jobs:
           VITE_API_BASE: https://api.r2c.biz
           VITE_SUPABASE_URL: https://rpqrwifbrhlebbelyqog.supabase.co
           VITE_SUPABASE_ANON_KEY: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InJwcXJ3aWZicmhsZWJiZWx5cW9nIiwicm9sZSI6ImFub24iLCJpYXQiOjE3NjM3ODA1NzcsImV4cCI6MjA3OTM1NjU3N30.zToHU4VNP1DTkl39BEUSOMI21D337BuXnoAK1OzGYSM
+          # App Switcher (R2C ⇄ R2C2) の切り替え先。R2C2 Admin UI (Cloudflare Pages) の公開URL
+          VITE_AAAS_ADMIN_URL: https://admin.r2c2.r2c.biz
         run: pnpm build
 
       - name: Deploy to Cloudflare Pages


### PR DESCRIPTION
## Summary
Follow-up to #448 (App Switcher R2C ⇄ R2C2). The switcher was deployed but stayed hidden in production because `VITE_AAAS_ADMIN_URL` was never set anywhere — admin-ui is built by `.github/workflows/deploy-admin-ui.yml` (wrangler deploy), not the Cloudflare Pages dashboard's own env var UI, so setting it in the CF dashboard would have had no effect.

Adds `VITE_AAAS_ADMIN_URL: https://admin.r2c2.r2c.biz` alongside the other build-time `VITE_*` values already inlined in that workflow (same treatment — public, client-embedded value, not a secret).

## Test plan
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(...)"`)
- [ ] Gate 2.5 (Codex review) — flagged for human review per project policy
- [ ] After merge: confirm the GitHub Actions deploy run picks up the new env var and the App Switcher appears on admin.r2c.biz

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wwc9zdW9DoGH9VnuWAcMjk