### PR TITLE
fix: super_admin briefly showed R2C2 as locked (race in AppSwitcher)

### DIFF
--- a/admin-ui/src/components/AppSwitcher.tsx
+++ b/admin-ui/src/components/AppSwitcher.tsx
@@ -26,20 +26,33 @@ async function bridgeToR2C2() {
 }
 
 export default function AppSwitcher() {
-  const { isSuperAdmin } = useAuth();
+  const { isSuperAdmin, isLoading } = useAuth();
   const { openWithQuery } = useAdminAgentUI();
   const [hasR2c2, setHasR2c2] = useState(isSuperAdmin);
 
   useEffect(() => {
+    // 認証ロード完了前は isSuperAdmin が一時的に false になる。ここで確定前に
+    // fetch すると super_admin でも /v1/admin/my-tenant が 403 になり、後から
+    // その古い応答が isSuperAdmin=true 判定後の setHasR2c2(true) を上書きしてしまう
+    // (race condition)。ロード完了を待ち、かつ ignore フラグで古い応答を捨てる。
+    if (isLoading) return;
     if (isSuperAdmin) {
       setHasR2c2(true);
       return;
     }
+    let ignore = false;
     authFetch(`${API_BASE}/v1/admin/my-tenant`)
       .then((r) => r.json())
-      .then((data: { has_r2c2?: boolean }) => setHasR2c2(Boolean(data.has_r2c2)))
-      .catch(() => setHasR2c2(false));
-  }, [isSuperAdmin]);
+      .then((data: { has_r2c2?: boolean }) => {
+        if (!ignore) setHasR2c2(Boolean(data.has_r2c2));
+      })
+      .catch(() => {
+        if (!ignore) setHasR2c2(false);
+      });
+    return () => {
+      ignore = true;
+    };
+  }, [isSuperAdmin, isLoading]);
 
   if (!AAAS_ADMIN_URL) return null;
 


### PR DESCRIPTION
## Summary
Follow-up to #448. User reported (with screenshot) that a genuine Super Admin account saw the R2C2 tab locked in the App Switcher.

Reproduced live on admin.r2c.biz with the `playwright-probe-super-admin` test account: console showed a 403 on `/v1/admin/my-tenant`, and the lock icon appeared despite the sidebar footer correctly showing "Super Admin".

Root cause: `isSuperAdmin` from `useAuth()` starts `false` while the Supabase session is still loading. `AppSwitcher`'s effect had no loading guard, so it could kick off the `/v1/admin/my-tenant` fetch during that window — which always 403s for super_admin accounts (they have no `tenant_id`). If that fetch resolved *after* the auth load flipped `isSuperAdmin` to `true` (which correctly set `hasR2c2(true)` synchronously), the stale 403 handler ran later and clobbered it back to `false`.

Fix: skip the fetch until `isLoading` from `useAuth()` is false, and add an `ignore` flag on effect cleanup so a late-resolving stale response can never overwrite newer state.

## Test plan
- [x] `pnpm typecheck` (admin-ui) — clean
- [x] `pnpm build` (admin-ui) — succeeds
- [ ] Gate 2.5 (Codex review) — flagged for human review per project policy
- [ ] Live re-verification with the same test account after merge/deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wwc9zdW9DoGH9VnuWAcMjk