### PR TITLE
fix: super_adminプレビュー テナントスコープ + 監査Batch A (5件)

### DIFF
--- a/admin-ui/src/components/admin/AIReportTab.tsx
+++ b/admin-ui/src/components/admin/AIReportTab.tsx
@@ -27,7 +27,14 @@ interface SuggestedRule {
   id: string;
   trigger: string;
   response: string;
-  reason: string;
+  reason?: string;
+  evidence?: RuleEvidence | null;
+}
+
+interface TuningRuleApiRow {
+  id: number;
+  trigger_pattern: string;
+  expected_behavior: string;
   evidence?: RuleEvidence | null;
 }
 
@@ -99,21 +106,6 @@ function buildMockStats(days: 7 | 30): EvalStats {
     ],
   };
 }
-
-const MOCK_RULES: SuggestedRule[] = [
-  {
-    id: "r1",
-    trigger: "検討します",
-    response: "ご検討いただきありがとうございます。具体的なご要望をお聞かせいただけますか？",
-    reason: "返報性の原則：先に情報を提供することで、より具体的な返信を促します",
-  },
-  {
-    id: "r2",
-    trigger: "他社と比較中",
-    response: "比較検討されているとのこと、ありがとうございます。弊社の強みをご説明してもよろしいでしょうか？",
-    reason: "権威性の原則：専門知識をアピールし、差別化を図ります",
-  },
-];
 
 // ─── スタイル定数 ─────────────────────────────────────────────────────────────
 
@@ -377,9 +369,11 @@ function SuggestedRulesList({
             <p style={{ margin: "0 0 8px", fontSize: 14, color: "#e5e7eb" }}>「{rule.trigger}」</p>
             <p style={{ margin: "0 0 4px", fontSize: 13, color: "#9ca3af", fontWeight: 600 }}>提案返答</p>
             <p style={{ margin: "0 0 8px", fontSize: 14, color: "#e5e7eb", lineHeight: 1.6 }}>{rule.response}</p>
-            <p style={{ margin: 0, fontSize: 12, color: "#6b7280", lineHeight: 1.5, fontStyle: "italic" }}>
-              💡 {rule.reason}
-            </p>
+            {rule.reason && (
+              <p style={{ margin: 0, fontSize: 12, color: "#6b7280", lineHeight: 1.5, fontStyle: "italic" }}>
+                💡 {rule.reason}
+              </p>
+            )}
             {rule.evidence && (
               <div
                 style={{
@@ -585,7 +579,7 @@ export default function AIReportTab({ tenantId }: { tenantId: string }) {
   const { isSuperAdmin } = useAuth();
   const [days, setDays] = useState<7 | 30>(7);
   const [stats, setStats] = useState<EvalStats | null>(null);
-  const [rules, setRules] = useState<SuggestedRule[]>(MOCK_RULES);
+  const [rules, setRules] = useState<SuggestedRule[]>([]);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
@@ -682,15 +676,20 @@ export default function AIReportTab({ tenantId }: { tenantId: string }) {
     const loadRules = async () => {
       try {
         const res = await authFetch(
-          `${API_BASE}/v1/admin/tuning?tenantId=${tenantId}&source=judge&status=suggested`
+          `${API_BASE}/v1/admin/tuning-rules?tenant=${tenantId}&source=judge&status=pending`
         );
         if (res.ok) {
-          // eslint-disable-next-line @typescript-eslint/no-explicit-any
-          const data = (await res.json()) as any;
-          setRules((data.rules as SuggestedRule[]) ?? MOCK_RULES);
+          const data = (await res.json()) as { rules?: TuningRuleApiRow[] };
+          const mapped: SuggestedRule[] = (data.rules ?? []).map((r) => ({
+            id: String(r.id),
+            trigger: r.trigger_pattern,
+            response: r.expected_behavior,
+            evidence: r.evidence ?? null,
+          }));
+          setRules(mapped);
         }
       } catch {
-        // keep mock
+        // 取得失敗時は既存の表示を維持（空状態のまま）
       }
     };
     void loadRules();

--- a/admin-ui/src/components/admin/TenantTuningTab.tsx
+++ b/admin-ui/src/components/admin/TenantTuningTab.tsx
@@ -27,7 +27,7 @@ async function deleteRule(id: number): Promise<void> {
 
 async function toggleRule(id: number, is_active: boolean): Promise<void> {
   const res = await authFetch(`${API_BASE}/v1/admin/tuning-rules/${id}`, {
-    method: "PATCH",
+    method: "PUT",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ is_active }),
   });

--- a/admin-ui/src/pages/admin/avatar/studio.tsx
+++ b/admin-ui/src/pages/admin/avatar/studio.tsx
@@ -287,7 +287,7 @@ export default function AvatarStudioPage() {
     setError(null);
     setSuccess(null);
     try {
-      const res = await authFetch(`${API_BASE}/v1/admin/avatar-configs/${id}/reset-to-default`, {
+      const res = await authFetch(`${API_BASE}/v1/admin/avatar/configs/${id}/reset-to-default`, {
         method: "POST",
       });
       if (!res.ok) {

--- a/admin-ui/src/pages/admin/chat-history/index.tsx
+++ b/admin-ui/src/pages/admin/chat-history/index.tsx
@@ -56,7 +56,7 @@ function ScoreBadge({ score }: { score: number }) {
 export default function ChatHistoryPage() {
   const navigate = useNavigate();
   const { t, lang } = useLang();
-  const { user, isSuperAdmin } = useAuth();
+  const { user, isSuperAdmin, previewMode, previewTenantId } = useAuth();
 
   const [sessions, setSessions] = useState<Session[]>([]);
   const [total, setTotal] = useState(0);
@@ -74,7 +74,13 @@ export default function ChatHistoryPage() {
   const [selectedTenantFilter, setSelectedTenantFilter] = useState<string>("");
 
   const locale = lang === "en" ? "en-US" : "ja-JP";
-  const tenantId = isSuperAdmin ? undefined : (user?.tenantId ?? undefined);
+  // super_adminの「クライアントビューで見る」プレビュー中は isSuperAdmin が
+  // client_admin相当にフォールバックするため、実テナントIDはpreviewTenantIdから取る必要がある
+  const tenantId = previewMode
+    ? (previewTenantId ?? undefined)
+    : isSuperAdmin
+      ? undefined
+      : (user?.tenantId ?? undefined);
 
   // Phase2-A: fetch tenant list for super admin selector
   useEffect(() => {
@@ -135,7 +141,7 @@ export default function ChatHistoryPage() {
     } finally {
       setLoading(false);
     }
-  }, [tenantId, isSuperAdmin, selectedTenantFilter, offset, sortBy, sortOrder, period, sentiment, search]);
+  }, [tenantId, isSuperAdmin, previewMode, previewTenantId, selectedTenantFilter, offset, sortBy, sortOrder, period, sentiment, search]);
 
   useEffect(() => {
     void loadSessions();

--- a/admin-ui/src/pages/admin/conversion/index.tsx
+++ b/admin-ui/src/pages/admin/conversion/index.tsx
@@ -102,7 +102,7 @@ function BarChart({ items }: { items: { label: string; value: number }[] }) {
 export default function ConversionDashboardPage() {
   const { t } = useLang();
   const navigate = useNavigate();
-  const { isSuperAdmin, user } = useAuth();
+  const { isSuperAdmin, user, previewMode, previewTenantId } = useAuth();
 
   const [summary, setSummary] = useState<ConversionSummary | null>(null);
   const [rankings, setRankings] = useState<EffectivenessRanking[]>([]);
@@ -112,7 +112,10 @@ export default function ConversionDashboardPage() {
   const [searchParams, setSearchParams] = useSearchParams();
   const period = (searchParams.get("period") ?? "30d") as "7d" | "30d" | "90d";
   const setPeriod = (p: "7d" | "30d" | "90d") => setSearchParams({ period: p }, { replace: true });
-  const tenantParam = !isSuperAdmin && user?.tenantId ? `&tenant_id=${user.tenantId}` : '';
+  // super_adminの「クライアントビューで見る」プレビュー中は isSuperAdmin が
+  // client_admin相当にフォールバックするため、実テナントIDはpreviewTenantIdから取る必要がある
+  const effectiveTenantId = previewMode ? (previewTenantId ?? undefined) : (user?.tenantId ?? undefined);
+  const tenantParam = !isSuperAdmin && effectiveTenantId ? `&tenant_id=${effectiveTenantId}` : '';
 
   const loadData = useCallback(async () => {
     setLoading(true);
@@ -120,7 +123,7 @@ export default function ConversionDashboardPage() {
       const [attrRes, effRes, expRes] = await Promise.all([
         authFetch(`${API_BASE}/v1/admin/conversion/attributions?period=${period}${tenantParam}`),
         authFetch(`${API_BASE}/v1/admin/conversion/effectiveness?period=${period}${tenantParam}`),
-        authFetch(`${API_BASE}/v1/admin/ab/experiments?${isSuperAdmin ? '' : `tenant_id=${user?.tenantId ?? ''}`}`),
+        authFetch(`${API_BASE}/v1/admin/ab/experiments?${isSuperAdmin ? '' : `tenant_id=${effectiveTenantId ?? ''}`}`),
       ]);
 
       if (attrRes.ok) {
@@ -140,7 +143,7 @@ export default function ConversionDashboardPage() {
     } finally {
       setLoading(false);
     }
-  }, [period, isSuperAdmin, user?.tenantId, tenantParam]);
+  }, [period, isSuperAdmin, effectiveTenantId, tenantParam]);
 
   useEffect(() => { void loadData(); }, [loadData]);
 

--- a/src/agent/judge/evaluationAnalyzer.ts
+++ b/src/agent/judge/evaluationAnalyzer.ts
@@ -129,26 +129,28 @@ export async function analyzeTuningRules(
   for (const rule of suggestedRules) {
     if (!rule.triggerPattern || !rule.expectedBehavior) continue;
 
+    const evidence = {
+      evaluationIds,
+      effectivePrinciples,
+      failedPrinciples,
+      avgScore: Math.round(avgScore),
+    };
+
     try {
       // ON CONFLICT DO NOTHING で重複防止（trigger_pattern と tenant_id でユニーク判定）
       await pool.query(
         `INSERT INTO tuning_rules
            (tenant_id, trigger_pattern, expected_behavior, priority,
-            source, suggested_at)
-         VALUES ($1, $2, $3, $4, 'judge', NOW())
+            source, suggested_at, evidence)
+         VALUES ($1, $2, $3, $4, 'judge', NOW(), $5::jsonb)
          ON CONFLICT DO NOTHING`,
-        [tenantId, rule.triggerPattern, rule.expectedBehavior, 0],
+        [tenantId, rule.triggerPattern, rule.expectedBehavior, 0, JSON.stringify(evidence)],
       );
 
       result.push({
         triggerPattern: rule.triggerPattern,
         expectedBehavior: rule.expectedBehavior,
-        evidence: {
-          evaluationIds,
-          effectivePrinciples,
-          failedPrinciples,
-          avgScore: Math.round(avgScore),
-        },
+        evidence,
       });
     } catch (err) {
       logger.error({ err, tenantId, rule }, 'evaluationAnalyzer.insert.failed');

--- a/src/api/admin/agent/agentRoutes.ts
+++ b/src/api/admin/agent/agentRoutes.ts
@@ -8,6 +8,8 @@ import { supabaseAuthMiddleware } from '../../../admin/http/supabaseAuthMiddlewa
 import { logger } from '../../../lib/logger';
 import { ADMIN_AGENT_TOOLS } from './toolDefinitions';
 import { executeToolCall } from './actionExecutor';
+import { trackUsage } from '../../../lib/billing/usageTracker';
+import { GROQ_VERSATILE_70B } from '../../../config/groqModels';
 
 // ---------------------------------------------------------------------------
 // Auth helper（options/routes.ts と同パターンのローカル定義）
@@ -52,10 +54,15 @@ interface GroqToolCall {
   };
 }
 
+interface GroqUsage {
+  promptTokens: number;
+  completionTokens: number;
+}
+
 async function callGroqWithTools(
   messages: GroqMessage[],
   tools: typeof ADMIN_AGENT_TOOLS
-): Promise<{ content: string | null; tool_calls: GroqToolCall[] }> {
+): Promise<{ content: string | null; tool_calls: GroqToolCall[]; usage: GroqUsage }> {
   const apiKey = process.env.GROQ_API_KEY?.trim();
   if (!apiKey) throw new Error('GROQ_API_KEY not configured');
 
@@ -66,7 +73,7 @@ async function callGroqWithTools(
       Authorization: `Bearer ${apiKey}`,
     },
     body: JSON.stringify({
-      model: 'llama-3.3-70b-versatile',
+      model: GROQ_VERSATILE_70B,
       messages,
       tools,
       tool_choice: 'auto',
@@ -85,10 +92,14 @@ async function callGroqWithTools(
   return {
     content: choice?.message?.content ?? null,
     tool_calls: choice?.message?.tool_calls ?? [],
+    usage: {
+      promptTokens: data.usage?.prompt_tokens ?? 0,
+      completionTokens: data.usage?.completion_tokens ?? 0,
+    },
   };
 }
 
-async function callGroqFinal(messages: GroqMessage[]): Promise<string> {
+async function callGroqFinal(messages: GroqMessage[]): Promise<{ reply: string; usage: GroqUsage }> {
   const apiKey = process.env.GROQ_API_KEY?.trim();
   if (!apiKey) throw new Error('GROQ_API_KEY not configured');
 
@@ -99,7 +110,7 @@ async function callGroqFinal(messages: GroqMessage[]): Promise<string> {
       Authorization: `Bearer ${apiKey}`,
     },
     body: JSON.stringify({
-      model: 'llama-3.3-70b-versatile',
+      model: GROQ_VERSATILE_70B,
       messages,
       max_tokens: 512,
       temperature: 0.2,
@@ -112,7 +123,13 @@ async function callGroqFinal(messages: GroqMessage[]): Promise<string> {
   }
 
   const data = (await res.json()) as any;
-  return data.choices?.[0]?.message?.content?.trim() ?? '';
+  return {
+    reply: data.choices?.[0]?.message?.content?.trim() ?? '',
+    usage: {
+      promptTokens: data.usage?.prompt_tokens ?? 0,
+      completionTokens: data.usage?.completion_tokens ?? 0,
+    },
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -166,6 +183,21 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
 
       // 第1回 Groq 呼び出し（tool_calls あり）
       const firstResponse = await callGroqWithTools(messages, ADMIN_AGENT_TOOLS);
+      let totalPromptTokens = firstResponse.usage.promptTokens;
+      let totalCompletionTokens = firstResponse.usage.completionTokens;
+
+      const reportUsage = () => {
+        // super_adminがテナント未特定（targetTenantId未指定）の場合は課金対象がないためスキップ
+        if (!effectiveTenantId) return;
+        trackUsage({
+          tenantId: effectiveTenantId,
+          requestId: `admin-agent-${sessionId}-${Date.now()}`,
+          model: GROQ_VERSATILE_70B,
+          inputTokens: totalPromptTokens,
+          outputTokens: totalCompletionTokens,
+          featureUsed: 'admin_agent',
+        });
+      };
 
       const actions: Array<{ tool: string; result: string }> = [];
 
@@ -205,11 +237,15 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
         }
 
         // 第2回 Groq 呼び出し（最終 reply）
-        const finalReply = await callGroqFinal(messages);
-        return res.json({ reply: finalReply, actions });
+        const finalResponse = await callGroqFinal(messages);
+        totalPromptTokens += finalResponse.usage.promptTokens;
+        totalCompletionTokens += finalResponse.usage.completionTokens;
+        reportUsage();
+        return res.json({ reply: finalResponse.reply, actions });
       }
 
       // tool_calls がなかった場合はそのまま返す
+      reportUsage();
       return res.json({
         reply: firstResponse.content ?? '回答を生成できませんでした',
         actions: [],

--- a/src/api/admin/tuning/routes.ts
+++ b/src/api/admin/tuning/routes.ts
@@ -365,9 +365,11 @@ export function registerTuningRoutes(app: Express): void {
     const tenantFilter: string | undefined = isSuperAdmin
       ? ((req.query["tenant"] as string | undefined) || undefined)
       : jwtTenantId || undefined;
+    const sourceFilter = (req.query["source"] as string | undefined) || undefined;
+    const statusFilter = (req.query["status"] as string | undefined) || undefined;
 
     try {
-      const rules = await listRules(tenantFilter);
+      const rules = await listRules(tenantFilter, { source: sourceFilter, status: statusFilter });
       return res.json({ rules, total: rules.length });
     } catch (err) {
       logger.warn("[GET /v1/admin/tuning-rules]", err);

--- a/src/api/admin/tuning/tuningRulesRepository.ts
+++ b/src/api/admin/tuning/tuningRulesRepository.ts
@@ -14,6 +14,13 @@ export interface ApprovedResponse {
   approved_at: string;
 }
 
+export interface RuleEvidence {
+  evaluationIds?: number[];
+  effectivePrinciples?: string[];
+  failedPrinciples?: string[];
+  avgScore?: number;
+}
+
 export interface TuningRule {
   id: number;
   tenant_id: string;
@@ -26,6 +33,14 @@ export interface TuningRule {
   created_at: string;
   updated_at: string;
   approved_responses?: ApprovedResponse[];
+  source?: string;
+  status?: string;
+  evidence?: RuleEvidence | null;
+}
+
+export interface ListRulesFilters {
+  source?: string;
+  status?: string;
 }
 
 export interface CreateRuleParams {
@@ -55,20 +70,26 @@ export interface UpdateRuleParams {
  * - tenantId 未指定 (super_admin): 全ルールを返す
  * - ORDER: tenant_id = 'global' を後ろ、各グループ内で priority DESC
  */
-export async function listRules(tenantId?: string): Promise<TuningRule[]> {
+export async function listRules(tenantId?: string, filters?: ListRulesFilters): Promise<TuningRule[]> {
   const pool = getPool();
+
+  const args: string[] = tenantId ? [tenantId] : [];
+  const conditions: string[] = tenantId ? ["(tenant_id = $1 OR tenant_id = 'global')"] : [];
+  if (filters?.source) { args.push(filters.source); conditions.push(`source = $${args.length}`); }
+  if (filters?.status) { args.push(filters.status); conditions.push(`status = $${args.length}`); }
+  const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
 
   if (tenantId) {
     const result = await pool.query<TuningRule>(
       `SELECT id, tenant_id, trigger_pattern, expected_behavior,
               priority, is_active, created_by, source_message_id,
-              created_at, updated_at
+              created_at, updated_at, source, status, evidence
        FROM tuning_rules
-       WHERE tenant_id = $1 OR tenant_id = 'global'
+       ${whereClause}
        ORDER BY
          CASE WHEN tenant_id = 'global' THEN 1 ELSE 0 END ASC,
          priority DESC`,
-      [tenantId],
+      args,
     );
     return result.rows;
   }
@@ -77,11 +98,13 @@ export async function listRules(tenantId?: string): Promise<TuningRule[]> {
   const result = await pool.query<TuningRule>(
     `SELECT id, tenant_id, trigger_pattern, expected_behavior,
             priority, is_active, created_by, source_message_id,
-            created_at, updated_at
+            created_at, updated_at, source, status, evidence
      FROM tuning_rules
+     ${whereClause}
      ORDER BY
        CASE WHEN tenant_id = 'global' THEN 1 ELSE 0 END ASC,
        priority DESC`,
+    args,
   );
   return result.rows;
 }

--- a/src/api/internal/usageRoutes.ts
+++ b/src/api/internal/usageRoutes.ts
@@ -9,8 +9,10 @@
 import { GROQ_VERSATILE_70B } from '../../config/groqModels';
 import type { Express, Request, Response } from 'express';
 import { INTERNAL_REQUEST_HEADER } from '../../lib/metrics/kpiDefinitions';
-import { trackUsage } from '../../lib/billing/usageTracker';
+import { trackUsage, type FeatureUsed } from '../../lib/billing/usageTracker';
 import { internalNetworkOnly } from '../middleware/internalNetworkOnly';
+
+const ALLOWED_FEATURES: readonly FeatureUsed[] = ['avatar', 'voice'];
 
 export function registerInternalUsageRoutes(app: Express): void {
   app.post('/api/internal/usage', internalNetworkOnly, (req: Request, res: Response) => {
@@ -19,7 +21,7 @@ export function registerInternalUsageRoutes(app: Express): void {
     }
 
     const body = req.body ?? {};
-    const { tenantId, requestId, ttsTextBytes, avatarCredits, avatarSessionMs } = body;
+    const { tenantId, requestId, ttsTextBytes, avatarCredits, avatarSessionMs, inputTokens, outputTokens, model, featureUsed } = body;
 
     if (!tenantId || typeof tenantId !== 'string') {
       return res.status(400).json({ error: 'tenantId required' });
@@ -31,13 +33,18 @@ export function registerInternalUsageRoutes(app: Express): void {
         ? requestId
         : `avatar-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`;
 
+    const resolvedFeature: FeatureUsed =
+      typeof featureUsed === 'string' && (ALLOWED_FEATURES as readonly string[]).includes(featureUsed)
+        ? (featureUsed as FeatureUsed)
+        : 'avatar';
+
     trackUsage({
       tenantId,
       requestId: rid,
-      model: GROQ_VERSATILE_70B,  // avatarセッションのLLM
-      inputTokens: 0,
-      outputTokens: 0,
-      featureUsed: 'avatar',
+      model: typeof model === 'string' && model ? model : GROQ_VERSATILE_70B,
+      inputTokens: typeof inputTokens === 'number' && inputTokens >= 0 ? inputTokens : 0,
+      outputTokens: typeof outputTokens === 'number' && outputTokens >= 0 ? outputTokens : 0,
+      featureUsed: resolvedFeature,
       ttsTextBytes:
         typeof ttsTextBytes === 'number' && ttsTextBytes >= 0 ? ttsTextBytes : undefined,
       avatarCredits:

--- a/src/lib/billing/usageTracker.ts
+++ b/src/lib/billing/usageTracker.ts
@@ -4,7 +4,7 @@
 import type pino from 'pino';
 import { calculateLLMCostCents, calculateBillingAmountCents, normalizeModelKey } from './costCalculator';
 
-export type FeatureUsed = 'chat' | 'avatar' | 'voice' | 'avatar_config_image' | 'avatar_config_voice' | 'avatar_config_prompt' | 'avatar_config_test' | 'anam_session' | 'option_service' | 'premium_avatar_generation';
+export type FeatureUsed = 'chat' | 'avatar' | 'voice' | 'avatar_config_image' | 'avatar_config_voice' | 'avatar_config_prompt' | 'avatar_config_test' | 'anam_session' | 'option_service' | 'premium_avatar_generation' | 'admin_agent';
 
 export interface TrackUsageParams {
   tenantId: string;


### PR DESCRIPTION
## Summary
Asana R2Cプロジェクトの緊急タスク一覧から、人間の判断を要さないコード修正6件をまとめて対応。

- fix: 会話履歴/成約分析ページがsuper_adminプレビューmode中にテナントスコープされない問題 (GID 1216277595663810)
- fix: 判定ルールトグルの404 (GID 1215923339719876)
- fix: avatar-agentのトークン使用量が破棄され課金$0になる不具合 (GID 1215923339649519)
- fix: アバター設定リセットの404 (GID 1215916762233071)
- fix: admin_agentチャットのトークン使用量を原価計上 (GID 1215915182786983)
- fix: 判定ルール一覧の偽データ(MOCK_RULES)表示を解消し実データに接続 (GID 1215916762299598)

いずれも2026-06-22マルチエージェント監査(GID 1215927306537606)のBatch A(即修正・低リスク)、および同監査中に派生発見されたテナントスコープ系バグ。

## Test plan
- [x] `tsc --noEmit` (backend / admin-ui) 両方エラーなし
- [x] `jest src/api/admin/agent/agentRoutes.test.ts` 10 passed
- [x] `jest src/agent/judge/evaluationAnalyzer.test.ts src/api/admin/tuning` 36 passed
- [x] `oxlint` 対象ファイル全てクリーン
- [ ] 人間によるステージング確認・承認後マージ (既存運用: 各PRは人間承認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)