### PR TITLE
test: PR #463の新規ロジックに自動テストを追加

### DIFF
--- a/admin-ui/src/components/admin/TenantTuningTab.test.tsx
+++ b/admin-ui/src/components/admin/TenantTuningTab.test.tsx
@@ -1,0 +1,58 @@
+// GID 1215923339719876: 判定ルールトグルがFEのPATCH/BEのPUT不一致で404していた不具合の回帰テスト
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import TenantTuningTab from './TenantTuningTab';
+import { useAuth } from '../../auth/useAuth';
+import { authFetch } from '../../lib/api';
+
+vi.mock('../../auth/useAuth', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('../../lib/api', () => ({
+  API_BASE: 'http://localhost:3100',
+  authFetch: vi.fn(),
+}));
+
+const mockOk = (data: unknown): Promise<Response> =>
+  Promise.resolve({ ok: true, json: () => Promise.resolve(data) } as Response);
+
+const RULE = {
+  id: 42,
+  tenant_id: 'tenant-a',
+  trigger_pattern: '価格について質問',
+  expected_behavior: '社会的証明を活用',
+  priority: 5,
+  is_active: true,
+  created_by: 'system',
+  created_at: '2026-01-01T00:00:00Z',
+};
+
+describe('TenantTuningTab — 判定ルールトグル', () => {
+  beforeEach(() => {
+    vi.mocked(useAuth).mockReturnValue({ isSuperAdmin: true } as ReturnType<typeof useAuth>);
+    vi.mocked(authFetch).mockReset();
+  });
+
+  it('無効化ボタンクリック時、PUTメソッドで/v1/admin/tuning-rules/:idを呼ぶ（修正前はPATCHで404していた）', async () => {
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (String(url).includes('/tuning-rules?')) return mockOk({ rules: [RULE] });
+      return mockOk({});
+    });
+
+    render(<TenantTuningTab tenantId="tenant-a" tenantName="Tenant A" />);
+
+    const toggleBtn = await screen.findByRole('button', { name: '無効化' });
+    fireEvent.click(toggleBtn);
+
+    await waitFor(() => {
+      const toggleCall = vi.mocked(authFetch).mock.calls.find(
+        ([url]) => String(url) === 'http://localhost:3100/v1/admin/tuning-rules/42',
+      );
+      expect(toggleCall).toBeTruthy();
+      expect(toggleCall![1]).toEqual(
+        expect.objectContaining({ method: 'PUT', body: JSON.stringify({ is_active: false }) }),
+      );
+    });
+  });
+});

--- a/admin-ui/src/pages/admin/chat-history/index.test.tsx
+++ b/admin-ui/src/pages/admin/chat-history/index.test.tsx
@@ -1,0 +1,94 @@
+// GID 1216277595663810: super_adminプレビューmode中に会話履歴が
+// テナントスコープされず全テナント横断データが表示されていた不具合の回帰テスト
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ChatHistoryPage from './index';
+import { useAuth } from '../../../auth/useAuth';
+import { authFetch } from '../../../lib/api';
+
+vi.mock('../../../auth/useAuth', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('../../../i18n/LangContext', () => ({
+  useLang: () => ({ t: (k: string) => k, lang: 'ja' }),
+}));
+
+vi.mock('../../../lib/api', () => ({
+  API_BASE: 'http://localhost:3100',
+  authFetch: vi.fn(),
+}));
+
+const SUPER_ADMIN_PREVIEWING = {
+  user: { id: '1', email: 'admin@example.com', role: 'super_admin', tenantId: null, tenantName: null },
+  isSuperAdmin: false, // プレビュー中は client_admin 相当にフォールバック
+  isClientAdmin: true,
+  isLoading: false,
+  logout: vi.fn(),
+  previewMode: true,
+  previewTenantId: 'lp-demo-avator',
+  previewTenantName: 'LP Demo',
+  enterPreview: vi.fn(),
+  exitPreview: vi.fn(),
+};
+
+const SUPER_ADMIN_NOT_PREVIEWING = {
+  user: { id: '1', email: 'admin@example.com', role: 'super_admin', tenantId: null, tenantName: null },
+  isSuperAdmin: true,
+  isClientAdmin: false,
+  isLoading: false,
+  logout: vi.fn(),
+  previewMode: false,
+  previewTenantId: null,
+  previewTenantName: null,
+  enterPreview: vi.fn(),
+  exitPreview: vi.fn(),
+};
+
+const mockOk = (data: unknown): Promise<Response> =>
+  Promise.resolve({ ok: true, json: () => Promise.resolve(data) } as Response);
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <ChatHistoryPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('ChatHistoryPage — super_adminプレビューmodeのテナントスコープ', () => {
+  beforeEach(() => {
+    vi.mocked(authFetch).mockReset();
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (url.includes('/evaluations')) return mockOk({ evaluations: [] });
+      return mockOk({ sessions: [], total: 0 });
+    });
+  });
+
+  it('プレビューmode中はpreviewTenantIdでスコープされたリクエストを送る（修正前は tenant パラメータ無しで全件取得していた）', async () => {
+    vi.mocked(useAuth).mockReturnValue(SUPER_ADMIN_PREVIEWING as ReturnType<typeof useAuth>);
+    renderPage();
+
+    await waitFor(() => {
+      const sessionCall = vi.mocked(authFetch).mock.calls.find(([url]) =>
+        String(url).includes('/v1/admin/chat-history/sessions'),
+      );
+      expect(sessionCall).toBeTruthy();
+      expect(String(sessionCall![0])).toContain('tenant=lp-demo-avator');
+    });
+  });
+
+  it('プレビューしていない通常のsuper_adminはtenantパラメータ無しで全テナント取得のまま（回帰確認）', async () => {
+    vi.mocked(useAuth).mockReturnValue(SUPER_ADMIN_NOT_PREVIEWING as ReturnType<typeof useAuth>);
+    renderPage();
+
+    await waitFor(() => {
+      const sessionCall = vi.mocked(authFetch).mock.calls.find(([url]) =>
+        String(url).includes('/v1/admin/chat-history/sessions'),
+      );
+      expect(sessionCall).toBeTruthy();
+      expect(String(sessionCall![0])).not.toContain('tenant=');
+    });
+  });
+});

--- a/admin-ui/src/pages/admin/conversion/index.test.tsx
+++ b/admin-ui/src/pages/admin/conversion/index.test.tsx
@@ -1,0 +1,71 @@
+// GID 1216277595663810 派生棚卸し: super_adminプレビューmode中に成約・効果分析ページも
+// テナントスコープされず全テナント横断データが表示されていた不具合の回帰テスト
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import ConversionDashboardPage from './index';
+import { useAuth } from '../../../auth/useAuth';
+import { authFetch } from '../../../lib/api';
+
+vi.mock('../../../auth/useAuth', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('../../../i18n/LangContext', () => ({
+  useLang: () => ({ t: (k: string) => k, lang: 'ja' }),
+}));
+
+vi.mock('../../../lib/api', () => ({
+  API_BASE: 'http://localhost:3100',
+  authFetch: vi.fn(),
+}));
+
+const SUPER_ADMIN_PREVIEWING = {
+  user: { id: '1', email: 'admin@example.com', role: 'super_admin', tenantId: null, tenantName: null },
+  isSuperAdmin: false,
+  isClientAdmin: true,
+  isLoading: false,
+  logout: vi.fn(),
+  previewMode: true,
+  previewTenantId: 'lp-demo-avator',
+  previewTenantName: 'LP Demo',
+  enterPreview: vi.fn(),
+  exitPreview: vi.fn(),
+};
+
+const mockOk = (data: unknown): Promise<Response> =>
+  Promise.resolve({ ok: true, json: () => Promise.resolve(data) } as Response);
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <ConversionDashboardPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('ConversionDashboardPage — super_adminプレビューmodeのテナントスコープ', () => {
+  beforeEach(() => {
+    vi.mocked(authFetch).mockReset();
+    vi.mocked(authFetch).mockImplementation(() => mockOk({}));
+  });
+
+  it('プレビューmode中はpreviewTenantIdでtenant_idパラメータをリクエストに含める（修正前は空のuser.tenantIdでフィルタ無しになっていた）', async () => {
+    vi.mocked(useAuth).mockReturnValue(SUPER_ADMIN_PREVIEWING as ReturnType<typeof useAuth>);
+    renderPage();
+
+    await waitFor(() => {
+      const attrCall = vi.mocked(authFetch).mock.calls.find(([url]) =>
+        String(url).includes('/v1/admin/conversion/attributions'),
+      );
+      expect(attrCall).toBeTruthy();
+      expect(String(attrCall![0])).toContain('tenant_id=lp-demo-avator');
+
+      const expCall = vi.mocked(authFetch).mock.calls.find(([url]) =>
+        String(url).includes('/v1/admin/ab/experiments'),
+      );
+      expect(expCall).toBeTruthy();
+      expect(String(expCall![0])).toContain('tenant_id=lp-demo-avator');
+    });
+  });
+});

--- a/src/agent/judge/evaluationAnalyzer.test.ts
+++ b/src/agent/judge/evaluationAnalyzer.test.ts
@@ -147,6 +147,23 @@ describe('analyzeTuningRules', () => {
     expect(insertCalls[0][0]).toContain('ON CONFLICT DO NOTHING');
   });
 
+  it('3b. INSERT文にevidence列が含まれ、返り値と同じevidenceがJSON永続化される（GID 1215916762299598: 以前は計算のみでDB未保存だった）', async () => {
+    const mockRepo = createMockRepo(sampleEvaluations);
+    const mockPool = createMockPool();
+    mockCallGroq.mockResolvedValueOnce(mockRulesResponse);
+
+    const result = await analyzeTuningRules('tenant-test', mockRepo as any, mockPool as any);
+
+    const insertCalls = (mockPool.query as jest.Mock).mock.calls.filter(
+      (call: any[]) => call[0].includes('INSERT INTO tuning_rules'),
+    );
+    expect(insertCalls[0][0]).toContain('evidence');
+
+    const [, params] = insertCalls[0];
+    const persistedEvidence = JSON.parse(params[params.length - 1]);
+    expect(persistedEvidence).toEqual(result[0]!.evidence);
+  });
+
   it('4. 重複ルールは挿入されない（ON CONFLICT DO NOTHING）', async () => {
     const mockRepo = createMockRepo(sampleEvaluations);
     const mockPool = createMockPool();

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -40,6 +40,12 @@ jest.mock('../../../lib/logger', () => ({
   logger: { warn: jest.fn(), info: jest.fn(), error: jest.fn() },
 }));
 
+// usageTracker モック（GID 1215915182786983: admin_agent 課金計上のテスト用）
+const mockTrackUsage = jest.fn();
+jest.mock('../../../lib/billing/usageTracker', () => ({
+  trackUsage: (...args: any[]) => mockTrackUsage(...args),
+}));
+
 // ---------------------------------------------------------------------------
 // テスト対象を import
 // ---------------------------------------------------------------------------
@@ -72,7 +78,11 @@ const SUPER_ADMIN_USER = {
   app_metadata: { role: 'super_admin', tenant_id: '' },
 };
 
-function makeGroqResponse(content: string, tool_calls: any[] = []) {
+function makeGroqResponse(
+  content: string,
+  tool_calls: any[] = [],
+  usage: { prompt_tokens: number; completion_tokens: number } = { prompt_tokens: 10, completion_tokens: 5 },
+) {
   return {
     ok: true,
     json: async () => ({
@@ -84,6 +94,7 @@ function makeGroqResponse(content: string, tool_calls: any[] = []) {
           },
         },
       ],
+      usage,
     }),
     text: async () => content,
   };
@@ -252,6 +263,90 @@ describe('POST /v1/admin/agent/chat', () => {
       const fetchCallBody = JSON.parse(mockFetch.mock.calls[0][1].body as string);
       const systemMessage = fetchCallBody.messages.find((m: any) => m.role === 'system');
       expect(systemMessage?.content).toContain('tenant-target');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GID 1215915182786983: admin_agent の trackUsage 配線
+  // -------------------------------------------------------------------------
+  describe('usage tracking (admin_agent 原価計上)', () => {
+    it('tool_calls なし → featureUsed:admin_agent でtrackUsageが1回呼ばれる', async () => {
+      mockFetch.mockResolvedValueOnce(
+        makeGroqResponse('設定を確認しました。', [], { prompt_tokens: 100, completion_tokens: 20 }),
+      );
+
+      await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'GA4の設定を教えて', sessionId: 'sess-010' });
+
+      expect(mockTrackUsage).toHaveBeenCalledTimes(1);
+      expect(mockTrackUsage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tenantId: 'tenant-abc',
+          featureUsed: 'admin_agent',
+          inputTokens: 100,
+          outputTokens: 20,
+        }),
+      );
+    });
+
+    it('tool_calls あり → 第1回+第2回のトークンが合算されてtrackUsageに渡る', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            choices: [
+              {
+                message: {
+                  content: null,
+                  tool_calls: [
+                    { id: 'call-001', type: 'function', function: { name: 'get_tenant_settings', arguments: '{}' } },
+                  ],
+                },
+              },
+            ],
+            usage: { prompt_tokens: 50, completion_tokens: 10 },
+          }),
+          text: async () => '',
+        })
+        .mockResolvedValueOnce(makeGroqResponse('GA4は未設定です。', [], { prompt_tokens: 30, completion_tokens: 15 }));
+
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ ga4_measurement_id: null, posthog_host: 'https://app.posthog.com', widget_theme: {} }],
+      });
+
+      await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '設定を確認して', sessionId: 'sess-011' });
+
+      expect(mockTrackUsage).toHaveBeenCalledTimes(1);
+      expect(mockTrackUsage).toHaveBeenCalledWith(
+        expect.objectContaining({
+          featureUsed: 'admin_agent',
+          inputTokens: 80, // 50 + 30
+          outputTokens: 25, // 10 + 15
+        }),
+      );
+    });
+
+    it('super_admin がテナント未特定(targetTenantId省略) → trackUsageはスキップされる', async () => {
+      mockFetch.mockResolvedValueOnce(makeGroqResponse('こんにちは'));
+
+      await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '設定を確認して', sessionId: 'sess-012' });
+
+      expect(mockTrackUsage).not.toHaveBeenCalled();
+    });
+
+    it('GROQ_API_KEY 未設定（グレースフルダウングレード）→ trackUsageは呼ばれない', async () => {
+      delete process.env.GROQ_API_KEY;
+
+      await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'hello', sessionId: 'sess-013' });
+
+      expect(mockTrackUsage).not.toHaveBeenCalled();
     });
   });
 

--- a/src/api/admin/tuning/getTuningRulesFilters.test.ts
+++ b/src/api/admin/tuning/getTuningRulesFilters.test.ts
@@ -1,0 +1,94 @@
+// src/api/admin/tuning/getTuningRulesFilters.test.ts
+// GID 1215916762299598: 判定ルール一覧(AIReportTab)がMOCK_RULESにフォールバックし続けていた
+// 不具合の修正 — GET /v1/admin/tuning-rules の source/status クエリパラメータ配線の回帰テスト
+
+jest.mock('../../../lib/db', () => ({
+  pool: null,
+  getPool: () => null,
+}));
+jest.mock('../../../lib/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock('../../../admin/http/supabaseAuthMiddleware', () => ({
+  supabaseAuthMiddleware: (req: any, _res: any, next: any) => {
+    req.supabaseUser = req._mockUser ?? null;
+    next();
+  },
+}));
+
+const mockListRules = jest.fn().mockResolvedValue([]);
+jest.mock('./tuningRulesRepository', () => ({
+  listRules: (...args: any[]) => mockListRules(...args),
+  createRule: jest.fn(),
+  updateRule: jest.fn(),
+  deleteRule: jest.fn(),
+}));
+jest.mock('../../../lib/knowledgeSearchUtil', () => ({
+  searchKnowledgeForSuggestion: jest.fn(),
+  formatKnowledgeContext: jest.fn(),
+}));
+jest.mock('../../../lib/crossTenantContext', () => ({
+  getCrossTenantContext: jest.fn(),
+  formatCrossTenantContext: jest.fn(),
+}));
+jest.mock('../../../lib/research', () => ({ getResearchProvider: jest.fn() }));
+jest.mock('../../../lib/research/featureCheck', () => ({ isDeepResearchEnabled: jest.fn() }));
+jest.mock('../../../lib/research/queryBuilder', () => ({ buildResearchQuery: jest.fn() }));
+
+import express from 'express';
+import request from 'supertest';
+import { registerTuningRoutes } from './routes';
+
+function makeApp(appMetadata: Record<string, unknown> | null) {
+  const app = express();
+  app.use(express.json());
+  app.use((req: any, _res: any, next: any) => {
+    req._mockUser = appMetadata ? { app_metadata: appMetadata, email: 'test@test.com' } : null;
+    next();
+  });
+  registerTuningRoutes(app);
+  return app;
+}
+
+describe('GET /v1/admin/tuning-rules — source/status フィルタ配線', () => {
+  beforeEach(() => {
+    mockListRules.mockClear();
+    mockListRules.mockResolvedValue([]);
+  });
+
+  it('super_admin: ?tenant=&source=judge&status=pending がlistRulesにそのまま渡る', async () => {
+    const res = await request(makeApp({ role: 'super_admin', tenant_id: '' }))
+      .get('/v1/admin/tuning-rules?tenant=tenant-abc&source=judge&status=pending');
+
+    expect(res.status).toBe(200);
+    expect(mockListRules).toHaveBeenCalledWith('tenant-abc', { source: 'judge', status: 'pending' });
+  });
+
+  it('source/statusクエリなし → filtersはundefinedのまま(全件取得の従来挙動を維持)', async () => {
+    const res = await request(makeApp({ role: 'super_admin', tenant_id: '' }))
+      .get('/v1/admin/tuning-rules');
+
+    expect(res.status).toBe(200);
+    expect(mockListRules).toHaveBeenCalledWith(undefined, { source: undefined, status: undefined });
+  });
+
+  it('client_admin: tenantクエリは無視されJWT由来のtenant_idが使われる', async () => {
+    const res = await request(makeApp({ role: 'client_admin', tenant_id: 'own-tenant' }))
+      .get('/v1/admin/tuning-rules?tenant=other-tenant&source=judge&status=pending');
+
+    expect(res.status).toBe(200);
+    expect(mockListRules).toHaveBeenCalledWith('own-tenant', { source: 'judge', status: 'pending' });
+  });
+
+  it('レスポンスは {rules, total} 形式でlistRulesの結果をそのまま返す', async () => {
+    mockListRules.mockResolvedValueOnce([{ id: 1, trigger_pattern: 'x', expected_behavior: 'y' }]);
+
+    const res = await request(makeApp({ role: 'super_admin', tenant_id: '' }))
+      .get('/v1/admin/tuning-rules?source=judge&status=pending');
+
+    expect(res.body).toEqual({
+      rules: [{ id: 1, trigger_pattern: 'x', expected_behavior: 'y' }],
+      total: 1,
+    });
+  });
+});

--- a/src/api/admin/tuning/tuningRulesRepository.test.ts
+++ b/src/api/admin/tuning/tuningRulesRepository.test.ts
@@ -1,0 +1,57 @@
+// src/api/admin/tuning/tuningRulesRepository.test.ts
+// GID 1215916762299598: listRules への source/status フィルタ追加の回帰テスト
+
+const mockQuery = jest.fn();
+jest.mock('../../../lib/db', () => ({
+  getPool: () => ({ query: mockQuery }),
+}));
+
+import { listRules } from './tuningRulesRepository';
+
+describe('listRules', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    mockQuery.mockResolvedValue({ rows: [] });
+  });
+
+  it('tenantId指定・filtersなし → 従来通りWHERE tenant_id/global のみ、引数は[tenantId]', async () => {
+    await listRules('tenant-abc');
+
+    const [sql, args] = mockQuery.mock.calls[0];
+    expect(sql).toContain("tenant_id = $1 OR tenant_id = 'global'");
+    expect(sql).not.toContain('source =');
+    expect(sql).not.toContain('status =');
+    expect(args).toEqual(['tenant-abc']);
+  });
+
+  it('tenantId + source + status 指定 → SQLに両条件が追加され、引数が正しい順で渡る', async () => {
+    await listRules('tenant-abc', { source: 'judge', status: 'pending' });
+
+    const [sql, args] = mockQuery.mock.calls[0];
+    expect(sql).toContain('source = $2');
+    expect(sql).toContain('status = $3');
+    expect(args).toEqual(['tenant-abc', 'judge', 'pending']);
+  });
+
+  it('SELECT句にsource/status/evidence列が含まれる（AIReportTabがこれらを必要とする）', async () => {
+    await listRules('tenant-abc');
+    const [sql] = mockQuery.mock.calls[0];
+    expect(sql).toMatch(/SELECT[\s\S]*source[\s\S]*status[\s\S]*evidence/);
+  });
+
+  it('tenantId未指定(super_admin全件) + filters指定 → WHERE句がfiltersのみで構成され、引数は[source, status]', async () => {
+    await listRules(undefined, { source: 'judge', status: 'pending' });
+
+    const [sql, args] = mockQuery.mock.calls[0];
+    expect(sql).toContain('WHERE source = $1 AND status = $2');
+    expect(args).toEqual(['judge', 'pending']);
+  });
+
+  it('tenantId・filters両方未指定 → WHERE句なしで全件取得（従来挙動）', async () => {
+    await listRules();
+
+    const [sql, args] = mockQuery.mock.calls[0];
+    expect(sql).not.toMatch(/WHERE/);
+    expect(args).toEqual([]);
+  });
+});

--- a/src/api/internal/usageRoutes.test.ts
+++ b/src/api/internal/usageRoutes.test.ts
@@ -1,0 +1,123 @@
+// src/api/internal/usageRoutes.test.ts
+// GID 1215923339649519: avatar-agent のトークン使用量が破棄され課金$0になる不具合の回帰テスト
+
+import express from "express";
+import request from "supertest";
+
+jest.mock("../../lib/logger", () => ({
+  logger: { warn: jest.fn(), info: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+const mockTrackUsage = jest.fn();
+jest.mock("../../lib/billing/usageTracker", () => ({
+  trackUsage: (...args: any[]) => mockTrackUsage(...args),
+}));
+
+import { registerInternalUsageRoutes } from "./usageRoutes";
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  registerInternalUsageRoutes(app);
+  return app;
+}
+
+describe("POST /api/internal/usage", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("X-Internal-Request ヘッダなし → 403", async () => {
+    const res = await request(makeApp())
+      .post("/api/internal/usage")
+      .send({ tenantId: "tenant-abc" });
+
+    expect(res.status).toBe(403);
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
+
+  it("tenantId 欠落 → 400", async () => {
+    const res = await request(makeApp())
+      .post("/api/internal/usage")
+      .set("X-Internal-Request", "1")
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
+
+  it("agent.pyが送るinputTokens/outputTokens/model/featureUsedがそのままtrackUsageに渡る（回帰: 以前は0/固定値にハードコードされていた）", async () => {
+    const res = await request(makeApp())
+      .post("/api/internal/usage")
+      .set("X-Internal-Request", "1")
+      .send({
+        tenantId: "tenant-abc",
+        inputTokens: 123,
+        outputTokens: 45,
+        model: "llama-3.3-70b-versatile",
+        featureUsed: "avatar",
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockTrackUsage).toHaveBeenCalledTimes(1);
+    expect(mockTrackUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: "tenant-abc",
+        inputTokens: 123,
+        outputTokens: 45,
+        model: "llama-3.3-70b-versatile",
+        featureUsed: "avatar",
+      }),
+    );
+  });
+
+  it("featureUsed:voice も許可される", async () => {
+    await request(makeApp())
+      .post("/api/internal/usage")
+      .set("X-Internal-Request", "1")
+      .send({ tenantId: "tenant-abc", inputTokens: 1, outputTokens: 1, featureUsed: "voice" });
+
+    expect(mockTrackUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ featureUsed: "voice" }),
+    );
+  });
+
+  it("許可外のfeatureUsed（なりすまし試行）は'avatar'にフォールバックされる", async () => {
+    await request(makeApp())
+      .post("/api/internal/usage")
+      .set("X-Internal-Request", "1")
+      .send({ tenantId: "tenant-abc", inputTokens: 1, outputTokens: 1, featureUsed: "admin_agent" });
+
+    expect(mockTrackUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ featureUsed: "avatar" }),
+    );
+  });
+
+  it("inputTokens/outputTokens/model/featureUsed省略時は後方互換のデフォルト値(0/0/GROQ_VERSATILE_70B/avatar)を使う", async () => {
+    await request(makeApp())
+      .post("/api/internal/usage")
+      .set("X-Internal-Request", "1")
+      .send({ tenantId: "tenant-abc", ttsTextBytes: 100 });
+
+    expect(mockTrackUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        inputTokens: 0,
+        outputTokens: 0,
+        model: "llama-3.3-70b-versatile",
+        featureUsed: "avatar",
+        ttsTextBytes: 100,
+      }),
+    );
+  });
+
+  it("requestId省略時は自動生成される", async () => {
+    await request(makeApp())
+      .post("/api/internal/usage")
+      .set("X-Internal-Request", "1")
+      .send({ tenantId: "tenant-abc" });
+
+    const call = mockTrackUsage.mock.calls[0][0];
+    expect(typeof call.requestId).toBe("string");
+    expect(call.requestId.length).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## Summary
PR #463 (super_adminプレビュー テナントスコープ + 監査Batch A) はマージ済みだが、レビュー時に「既存テストが壊れていないことは確認したが、新規ロジック自体を検証するテストが無い」ことを指摘されたため追加。

- `src/api/internal/usageRoutes.test.ts` (新規): トークン値がハードコードされず正しく渡ることの回帰テスト
- `src/api/admin/agent/agentRoutes.test.ts`: admin_agentのtrackUsage呼び出し検証を追加
- `src/api/admin/tuning/tuningRulesRepository.test.ts` (新規): listRulesのsource/statusフィルタ単体テスト
- `src/api/admin/tuning/getTuningRulesFilters.test.ts` (新規): GET /v1/admin/tuning-rulesのクエリパラメータ配線テスト
- `src/agent/judge/evaluationAnalyzer.test.ts`: evidence永続化の回帰テストを追加
- `admin-ui/.../chat-history/index.test.tsx`, `.../conversion/index.test.tsx` (新規): プレビューmodeテナントスコープの回帰テスト
- `admin-ui/.../TenantTuningTab.test.tsx` (新規): トグルがPUTで呼ばれることの回帰テスト

avatar/studio.tsxのreset-to-defaultパス修正のみ、BEルートとの直接一致を確認済みの1行修正のためテスト未追加（フルページレンダーのコストに見合わないと判断）。

## Test plan
- [x] `jest`全体実行 — 2155 passed (avatar/routes.test.tsの9件の失敗は本PR/#463と無関係の既存環境問題。origin/mainでも再現することを確認済み)
- [x] `vitest run` (admin-ui全体) — 50 passed
- [x] `tsc --noEmit` (backend/admin-ui) エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)