### PR TITLE
fix: テナント向け同意トグルの表示名をR2Cエージェントに変更

### DIFF
--- a/admin-ui/src/pages/admin/avatar/HermesConsentToggle.tsx
+++ b/admin-ui/src/pages/admin/avatar/HermesConsentToggle.tsx
@@ -78,7 +78,7 @@ export function HermesConsentToggle({ overrideTenantId }: HermesConsentTogglePro
       setFeatures({ ...prev, ...updated.features });
       showToast(
         next
-          ? "✅ Hermes Agentへのデータ提供に同意しました"
+          ? "✅ R2Cエージェントへのデータ提供に同意しました"
           : "✅ 同意を取り消しました",
       );
     } catch {
@@ -114,10 +114,10 @@ export function HermesConsentToggle({ overrideTenantId }: HermesConsentTogglePro
       >
         <div>
           <h2 style={{ fontSize: 18, fontWeight: 700, margin: 0, color: "var(--foreground)" }}>
-            🧠 Hermes Agent 学習への同意
+            🧠 R2Cエージェント 学習への同意
           </h2>
           <p style={{ fontSize: 14, color: "var(--muted-foreground)", margin: "6px 0 0", maxWidth: 480 }}>
-            ONにすると、貴社の会話ログ(QA AI・アバターの応答)がHermes Agentの学習・CVR向上のための分析に利用されます。いつでもOFFに戻せます。
+            ONにすると、貴社の会話ログ(QA AI・アバターの応答)がR2Cエージェントの学習・CVR向上のための分析に利用されます。いつでもOFFに戻せます。
           </p>
         </div>
         <button
@@ -127,8 +127,8 @@ export function HermesConsentToggle({ overrideTenantId }: HermesConsentTogglePro
           aria-pressed={consentGranted}
           aria-label={
             consentGranted
-              ? "Hermes Agentへのデータ提供同意を取り消す"
-              : "Hermes Agentへのデータ提供に同意する"
+              ? "R2Cエージェントへのデータ提供同意を取り消す"
+              : "R2Cエージェントへのデータ提供に同意する"
           }
           style={{
             padding: "12px 28px",


### PR DESCRIPTION
## Summary
- `/admin/avatar`の「Hermes Agent学習への同意」トグルで、内部システム名「Hermes Agent」がテナント向け画面にそのまま表示されていた
- ユーザー指摘を受け、表示テキスト(見出し/説明文/トースト/aria-label)を「R2Cエージェント」に変更
- feature flag名`hermes_raw_data_consent`・コンポーネント名`HermesConsentToggle`・バックエンドAPI等の内部識別子は変更していない（表示文言のみのスコープ）

## Test plan
- [x] `vitest run` HermesConsentToggle.test.tsx — 8 passed
- [x] `tsc --noEmit` (admin-ui) エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)