### PR TITLE
fix: 同意トグルの説明文に過去履歴対象・撤回の限界を明記

### DIFF
--- a/admin-ui/src/pages/admin/avatar/HermesConsentToggle.tsx
+++ b/admin-ui/src/pages/admin/avatar/HermesConsentToggle.tsx
@@ -117,7 +117,7 @@ export function HermesConsentToggle({ overrideTenantId }: HermesConsentTogglePro
             🧠 R2Cエージェント 学習への同意
           </h2>
           <p style={{ fontSize: 14, color: "var(--muted-foreground)", margin: "6px 0 0", maxWidth: 480 }}>
-            ONにすると、貴社の会話ログ(QA AI・アバターの応答)がR2Cエージェントの学習・CVR向上のための分析に利用されます。いつでもOFFに戻せます。
+            ONにすると、貴社の過去分を含む会話ログ(QA AI・アバターの応答)がR2Cエージェントの学習・CVR向上のための分析に利用されます。OFFにすると以降の新規データ提供は停止しますが、それまでに提供済みのデータへの反映は取り消せません。
           </p>
         </div>
         <button


### PR DESCRIPTION
## Summary
ユーザーからの指摘: 「R2Cエージェント学習への同意」トグルをONにすると、実装上は過去の会話ログ全履歴(蓄積分含む)がHermes Agent(外部)に公開される。しかし説明文は「ONにすると〜利用されます」としか書いておらず、テナントが以下を認識できない:

1. ONにすると**過去分も含めて**全履歴が対象になること（未来分だけではない）
2. OFFは**以降の新規データ提供を止めるだけ**で、それまでに外部(Hermes Agent、R2Cの管理外)へ提供済みのデータへの学習結果は取り消せないこと

説明文にこの2点を追記し、透明性を改善した。

## 補足（技術的背景）
- 同意チェックはAPI呼び出しの都度DBを見るリアルタイムゲート方式(`src/lib/hermesConsent.ts`)のため、OFF→ONの切り替え自体は即時反映される
- ただし`searchConversations`(`src/api/hermes-mcp/hermesMcpRepository.ts`)はテナントIDのみでフィルタし、同意付与のタイムスタンプでの絞り込みは行っていないため、ONにした瞬間に過去全履歴が対象になる
- Hermes Agentは外部の別システムのため、R2C側は「渡す/渡さない」の門番はできるが、既に渡したデータをHermes側で忘れさせる(遡及的撤回)手段はない

## Test plan
- [x] `vitest run` HermesConsentToggle.test.tsx — 8 passed
- [x] `tsc --noEmit` (admin-ui) エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)