### PR TITLE
feat: LP料金表(Starter/Growth/Enterprise)に対応するプラン別機能制限

### DIFF
--- a/admin-ui/src/auth/useAuth.test.tsx
+++ b/admin-ui/src/auth/useAuth.test.tsx
@@ -1,0 +1,130 @@
+// GID: LP料金表プラン別機能制限のため、AuthContextにtenantPlanを追加した回帰テスト
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { AuthProvider, useAuth } from "./useAuth";
+
+const mockGetSession = vi.fn();
+const mockOnAuthStateChange = vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } }));
+
+vi.mock("../lib/supabaseClient", () => ({
+  supabase: {
+    auth: {
+      getSession: (...args: any[]) => mockGetSession(...args),
+      onAuthStateChange: (...args: any[]) => mockOnAuthStateChange(...args),
+      signOut: vi.fn(),
+    },
+  },
+}));
+
+vi.mock("../lib/api", () => ({
+  authFetch: vi.fn(),
+  API_BASE: "http://localhost:3100",
+}));
+
+import { authFetch } from "../lib/api";
+
+const mockOk = (data: unknown): Promise<Response> =>
+  Promise.resolve({ ok: true, json: () => Promise.resolve(data) } as Response);
+
+function CLIENT_ADMIN_SESSION() {
+  return {
+    data: {
+      session: {
+        user: {
+          id: "u1",
+          email: "client@example.com",
+          app_metadata: { role: "client_admin", tenant_id: "tenant-a" },
+          user_metadata: {},
+        },
+      },
+    },
+  };
+}
+
+function SUPER_ADMIN_SESSION() {
+  return {
+    data: {
+      session: {
+        user: {
+          id: "u2",
+          email: "admin@example.com",
+          app_metadata: { role: "super_admin" },
+          user_metadata: {},
+        },
+      },
+    },
+  };
+}
+
+function Probe() {
+  const { tenantPlan, isLoading, previewMode } = useAuth();
+  if (isLoading) return <div>loading</div>;
+  return <div data-testid="probe">plan={String(tenantPlan)} preview={String(previewMode)}</div>;
+}
+
+describe("useAuth — tenantPlan", () => {
+  beforeEach(() => {
+    vi.mocked(authFetch).mockReset();
+  });
+
+  it("client_admin: /v1/admin/my-tenant のplanを取得する", async () => {
+    mockGetSession.mockResolvedValue(CLIENT_ADMIN_SESSION());
+    vi.mocked(authFetch).mockReturnValueOnce(mockOk({ plan: "growth" }));
+
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("probe").textContent).toContain("plan=growth");
+    });
+    expect(vi.mocked(authFetch)).toHaveBeenCalledWith("http://localhost:3100/v1/admin/my-tenant");
+  });
+
+  it("super_admin(プレビューなし): tenantPlanはnullのまま(集約ビュー)", async () => {
+    mockGetSession.mockResolvedValue(SUPER_ADMIN_SESSION());
+
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("probe").textContent).toContain("plan=null");
+    });
+    expect(vi.mocked(authFetch)).not.toHaveBeenCalled();
+  });
+
+  it("plan未設定(undefined)時はstarterにフォールバックする", async () => {
+    mockGetSession.mockResolvedValue(CLIENT_ADMIN_SESSION());
+    vi.mocked(authFetch).mockReturnValueOnce(mockOk({}));
+
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("probe").textContent).toContain("plan=starter");
+    });
+  });
+
+  it("取得失敗時はnullのまま(機能側で制限あり扱いにできる)", async () => {
+    mockGetSession.mockResolvedValue(CLIENT_ADMIN_SESSION());
+    vi.mocked(authFetch).mockRejectedValueOnce(new Error("network"));
+
+    render(
+      <AuthProvider>
+        <Probe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("probe").textContent).toContain("plan=null");
+    });
+  });
+});

--- a/admin-ui/src/auth/useAuth.tsx
+++ b/admin-ui/src/auth/useAuth.tsx
@@ -1,5 +1,6 @@
 import { createContext, useCallback, useContext, useEffect, useState } from "react";
 import { supabase } from "../lib/supabaseClient";
+import { authFetch, API_BASE } from "../lib/api";
 
 export interface AuthUser {
   id: string;
@@ -8,6 +9,9 @@ export interface AuthUser {
   tenantId: string | null;
   tenantName: string | null;
 }
+
+// LP(r2c.biz)料金表のプラン。backendのplanValues(src/api/admin/tenants/routes.ts)と一致させること。
+export type TenantPlan = "starter" | "growth" | "enterprise";
 
 interface AuthContextValue {
   user: AuthUser | null;
@@ -20,6 +24,13 @@ interface AuthContextValue {
   previewTenantName: string | null;
   enterPreview: (tenantId: string, tenantName: string) => void;
   exitPreview: () => void;
+  /**
+   * 表示対象テナントの現在のプラン。
+   * - client_admin(プレビュー含む): 自テナント/プレビュー先テナントのプラン
+   * - super_adminの集約ビュー(プレビュー無し): 特定テナントに紐付かないため null
+   * - 未取得時は null（機能表示側はnullを「制限あり(未確認)」として扱うこと）
+   */
+  tenantPlan: TenantPlan | null;
 }
 
 const AuthContext = createContext<AuthContextValue>({
@@ -33,6 +44,7 @@ const AuthContext = createContext<AuthContextValue>({
   previewTenantName: null,
   enterPreview: () => {},
   exitPreview: () => {},
+  tenantPlan: null,
 });
 
 function parseRole(meta: Record<string, unknown>): AuthUser["role"] {
@@ -48,6 +60,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [previewMode, setPreviewMode] = useState(false);
   const [previewTenantId, setPreviewTenantId] = useState<string | null>(null);
   const [previewTenantName, setPreviewTenantName] = useState<string | null>(null);
+  const [tenantPlan, setTenantPlan] = useState<TenantPlan | null>(null);
 
   const loadUser = useCallback(async () => {
     setIsLoading(true);
@@ -97,6 +110,37 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     };
   }, [loadUser]);
 
+  // 表示対象テナントのプランを取得する。プレビュー中はプレビュー先テナント、
+  // 通常のclient_adminは自テナント、それ以外(super_adminの集約ビュー)はnullのまま。
+  useEffect(() => {
+    let cancelled = false;
+
+    async function loadTenantPlan() {
+      try {
+        if (previewMode && previewTenantId) {
+          const res = await authFetch(`${API_BASE}/v1/admin/tenants/${previewTenantId}`);
+          if (!res.ok) { if (!cancelled) setTenantPlan(null); return; }
+          const data = (await res.json()) as { plan?: TenantPlan };
+          if (!cancelled) setTenantPlan(data.plan ?? "starter");
+          return;
+        }
+        if (!previewMode && user?.role === "client_admin") {
+          const res = await authFetch(`${API_BASE}/v1/admin/my-tenant`);
+          if (!res.ok) { if (!cancelled) setTenantPlan(null); return; }
+          const data = (await res.json()) as { plan?: TenantPlan };
+          if (!cancelled) setTenantPlan(data.plan ?? "starter");
+          return;
+        }
+        if (!cancelled) setTenantPlan(null);
+      } catch {
+        if (!cancelled) setTenantPlan(null);
+      }
+    }
+
+    void loadTenantPlan();
+    return () => { cancelled = true; };
+  }, [user, previewMode, previewTenantId]);
+
   const logout = useCallback(async () => {
     await supabase.auth.signOut();
     setUser(null);
@@ -133,6 +177,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       previewTenantName,
       enterPreview,
       exitPreview,
+      tenantPlan,
     }}>
       {children}
     </AuthContext.Provider>

--- a/admin-ui/src/components/AppSidebar.test.tsx
+++ b/admin-ui/src/components/AppSidebar.test.tsx
@@ -1,0 +1,105 @@
+// GID: LP料金表(Growth〜: 会話分析/成約・効果分析)に基づくnav非表示の回帰テスト
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { AppSidebar } from "./AppSidebar";
+import { useAuth } from "../auth/useAuth";
+
+vi.mock("../auth/useAuth", () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock("../contexts/ThemeContext", () => ({
+  useTheme: () => ({ theme: "dark", setTheme: vi.fn() }),
+}));
+
+vi.mock("./common/NotificationBell", () => ({
+  NotificationBell: () => <div />,
+}));
+
+vi.mock("./AppSwitcher", () => ({
+  default: () => <div />,
+}));
+
+function baseAuth(overrides: Partial<ReturnType<typeof useAuth>>) {
+  return {
+    user: { id: "1", email: "a@example.com", role: "client_admin", tenantId: "tenant-a", tenantName: "Tenant A" },
+    isLoading: false,
+    isSuperAdmin: false,
+    isClientAdmin: true,
+    logout: vi.fn(),
+    previewMode: false,
+    previewTenantId: null,
+    previewTenantName: null,
+    enterPreview: vi.fn(),
+    exitPreview: vi.fn(),
+    tenantPlan: null,
+    ...overrides,
+  } as ReturnType<typeof useAuth>;
+}
+
+function renderSidebar() {
+  return render(
+    <MemoryRouter>
+      <AppSidebar />
+    </MemoryRouter>,
+  );
+}
+
+describe("AppSidebar — plan制限によるnav非表示", () => {
+  it("client_admin + plan=starter → 会話分析/成約・効果分析が非表示", () => {
+    vi.mocked(useAuth).mockReturnValue(baseAuth({ tenantPlan: "starter" }));
+    renderSidebar();
+
+    expect(screen.queryByText("会話分析")).toBeNull();
+    expect(screen.queryByText("成約・効果分析")).toBeNull();
+    // 制限対象外の項目は表示されたまま
+    expect(screen.getByText("会話履歴")).toBeTruthy();
+  });
+
+  it("client_admin + plan=growth → 会話分析/成約・効果分析が表示される", () => {
+    vi.mocked(useAuth).mockReturnValue(baseAuth({ tenantPlan: "growth" }));
+    renderSidebar();
+
+    expect(screen.getByText("会話分析")).toBeTruthy();
+    expect(screen.getByText("成約・効果分析")).toBeTruthy();
+  });
+
+  it("client_admin + plan未取得(null) → fail-safeで非表示", () => {
+    vi.mocked(useAuth).mockReturnValue(baseAuth({ tenantPlan: null }));
+    renderSidebar();
+
+    expect(screen.queryByText("会話分析")).toBeNull();
+    expect(screen.queryByText("成約・効果分析")).toBeNull();
+  });
+
+  it("super_adminの自身の集約ビュー(プレビューなし) → planに関わらず表示される", () => {
+    vi.mocked(useAuth).mockReturnValue(
+      baseAuth({
+        isSuperAdmin: true,
+        isClientAdmin: false,
+        tenantPlan: null,
+        user: { id: "2", email: "admin@example.com", role: "super_admin", tenantId: null, tenantName: null },
+      }),
+    );
+    renderSidebar();
+
+    expect(screen.getByText("会話分析")).toBeTruthy();
+    expect(screen.getByText("成約・効果分析")).toBeTruthy();
+  });
+
+  it("super_adminのプレビュー中 + plan=starter → 非表示(実際のクライアント体験を正確に反映)", () => {
+    vi.mocked(useAuth).mockReturnValue(
+      baseAuth({
+        isSuperAdmin: false, // プレビュー中はclient_admin相当にフォールバック
+        previewMode: true,
+        previewTenantId: "preview-tenant",
+        tenantPlan: "starter",
+      }),
+    );
+    renderSidebar();
+
+    expect(screen.queryByText("会話分析")).toBeNull();
+    expect(screen.queryByText("成約・効果分析")).toBeNull();
+  });
+});

--- a/admin-ui/src/components/AppSidebar.tsx
+++ b/admin-ui/src/components/AppSidebar.tsx
@@ -28,6 +28,7 @@ import { useTheme } from "../contexts/ThemeContext";
 import { NotificationBell } from "./common/NotificationBell";
 import AppSwitcher from "./AppSwitcher";
 import { cn } from "../lib/utils";
+import { planHasFeature, type GatedFeature } from "../lib/planFeatures";
 
 // ─── Nav item types ───────────────────────────────────────────────────
 
@@ -37,6 +38,8 @@ interface NavItem {
   icon: React.ElementType;
   end?: boolean;
   superAdminOnly?: boolean;
+  /** GID: LP料金表に基づくplan制限。指定時、そのプラン以上でないと非表示(super_adminの自身の集約ビューは対象外)。 */
+  requiresPlan?: GatedFeature;
 }
 
 interface NavSection {
@@ -64,8 +67,8 @@ const MAIN_SECTIONS: NavSection[] = [
   {
     title: "分析・成果",
     items: [
-      { label: "会話分析", path: "/admin/analytics", icon: BarChart2 },
-      { label: "成約・効果分析", path: "/admin/conversion", icon: TrendingUp },
+      { label: "会話分析", path: "/admin/analytics", icon: BarChart2, requiresPlan: "analytics" },
+      { label: "成約・効果分析", path: "/admin/conversion", icon: TrendingUp, requiresPlan: "conversion" },
       { label: "お客様への声がけ設定", path: "/admin/engagement", icon: Zap },
       { label: "フロー遷移分析", path: "/admin/analytics/flow", icon: GitBranch, superAdminOnly: true },
     ],
@@ -195,7 +198,7 @@ interface SidebarContentProps {
 }
 
 function SidebarContent({ onClose }: SidebarContentProps) {
-  const { user, isSuperAdmin, logout } = useAuth();
+  const { user, isSuperAdmin, tenantPlan, logout } = useAuth();
   const navigate = useNavigate();
 
   const handleLogout = async () => {
@@ -212,6 +215,7 @@ function SidebarContent({ onClose }: SidebarContentProps) {
     ...section,
     items: section.items
       .filter((item) => isSuperAdmin || !item.superAdminOnly)
+      .filter((item) => isSuperAdmin || !item.requiresPlan || planHasFeature(tenantPlan, item.requiresPlan))
       .map((item) =>
         item.path === "/admin/knowledge" ? { ...item, path: knowledgePath } : item
       ),

--- a/admin-ui/src/lib/planFeatures.test.ts
+++ b/admin-ui/src/lib/planFeatures.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { planHasFeature } from "./planFeatures";
+
+describe("planHasFeature", () => {
+  it.each([
+    ["starter", "avatar", false],
+    ["growth", "avatar", true],
+    ["enterprise", "avatar", true],
+    ["starter", "voice_clone", false],
+    ["growth", "voice_clone", false],
+    ["enterprise", "voice_clone", true],
+    ["starter", "analytics", false],
+    ["growth", "analytics", true],
+    ["starter", "conversion", false],
+    ["growth", "conversion", true],
+  ] as const)("%s プランで %s = %s", (plan, feature, expected) => {
+    expect(planHasFeature(plan, feature)).toBe(expected);
+  });
+
+  it("plan=null(未取得)は常にfalse(fail-safe)", () => {
+    expect(planHasFeature(null, "avatar")).toBe(false);
+    expect(planHasFeature(null, "conversion")).toBe(false);
+  });
+});

--- a/admin-ui/src/lib/planFeatures.ts
+++ b/admin-ui/src/lib/planFeatures.ts
@@ -1,0 +1,30 @@
+// admin-ui/src/lib/planFeatures.ts
+// LP(r2c.biz)の料金表に対応するプラン別機能制限。
+// backend(src/lib/billing/planFeatures.ts)のロジックと一致させること。
+
+import type { TenantPlan } from "../auth/useAuth";
+
+const PLAN_RANK: Record<TenantPlan, number> = {
+  starter: 0,
+  growth: 1,
+  enterprise: 2,
+};
+
+export type GatedFeature = "avatar" | "voice_clone" | "analytics" | "conversion";
+
+const FEATURE_MIN_PLAN: Record<GatedFeature, TenantPlan> = {
+  avatar: "growth",
+  voice_clone: "enterprise",
+  analytics: "growth",
+  conversion: "growth",
+};
+
+/**
+ * プランが指定機能を利用できるかを判定する。
+ * plan未取得(null)時はfail-safeで「利用不可」として扱う
+ * （表示側は「まだ確認できていないので隠しておく」が安全なデフォルト）。
+ */
+export function planHasFeature(plan: TenantPlan | null, feature: GatedFeature): boolean {
+  if (plan === null) return false;
+  return PLAN_RANK[plan] >= PLAN_RANK[FEATURE_MIN_PLAN[feature]];
+}

--- a/admin-ui/src/pages/admin/avatar/index.tsx
+++ b/admin-ui/src/pages/admin/avatar/index.tsx
@@ -12,12 +12,13 @@ import { AvatarListHeader } from "./AvatarListHeader";
 import { AvatarFilterPanel } from "./AvatarFilterPanel";
 import { AvatarFeatureToggle } from "./AvatarFeatureToggle";
 import { HermesConsentToggle } from "./HermesConsentToggle";
+import { planHasFeature } from "../../../lib/planFeatures";
 import { AvatarCard } from "./AvatarCard";
 
 export default function AvatarListPage() {
   const { lang } = useLang();
   const locale = lang === "en" ? "en-US" : "ja-JP";
-  const { user, isSuperAdmin, previewMode, previewTenantId } = useAuth();
+  const { user, isSuperAdmin, previewMode, previewTenantId, tenantPlan } = useAuth();
   // super_adminの「クライアントビューで見る」プレビュー中は isSuperAdmin が
   // client_admin相当にフォールバックするため、実テナントIDはpreviewTenantIdから取る必要がある
   const effectiveTenantId = previewMode ? previewTenantId : (user?.tenantId ?? null);
@@ -368,8 +369,8 @@ export default function AvatarListPage() {
         />
       )}
 
-      {/* ── アバター機能 ON/OFF トグル（Client Adminのみ / プレビュー中含む）─────────── */}
-      {!isSuperAdmin && effectiveTenantId && (
+      {/* ── アバター機能 ON/OFF トグル（Client Adminのみ / プレビュー中含む、GID: LP料金表 Growth〜）── */}
+      {!isSuperAdmin && effectiveTenantId && planHasFeature(tenantPlan, "avatar") && (
         <AvatarFeatureToggle
           avatarEnabled={avatarEnabled}
           toggleLoading={toggleLoading}

--- a/admin-ui/src/pages/admin/avatar/studio.tsx
+++ b/admin-ui/src/pages/admin/avatar/studio.tsx
@@ -6,6 +6,8 @@ import { useNavigate, useParams, useSearchParams } from "react-router-dom";
 import { useLang } from "../../../i18n/LangContext";
 import { authFetch, API_BASE } from "../../../lib/api";
 import { containsBannedWord } from "../../../lib/contentGuard";
+import { useAuth } from "../../../auth/useAuth";
+import { planHasFeature } from "../../../lib/planFeatures";
 import type { VoiceRecommendation } from "./types";
 import { BG } from "./types";
 import { StudioBasicSection } from "./StudioBasicSection";
@@ -39,6 +41,7 @@ export default function AvatarStudioPage() {
   const [searchParams] = useSearchParams();
   const tenantQueryParam = searchParams.get("tenant") ?? undefined;
   const { lang } = useLang();
+  const { isSuperAdmin, tenantPlan } = useAuth();
   const isEdit = Boolean(id);
 
   // フォーム状態
@@ -458,8 +461,8 @@ export default function AvatarStudioPage() {
         setVoiceId={setVoiceId}
       />
 
-      {/* 3.5 音声クローン（FishAudio Phase C-1、編集時のみ — 作成前は対象 config が無い） */}
-      {isEdit && id && (
+      {/* 3.5 音声クローン（FishAudio Phase C-1、編集時のみ — 作成前は対象 config が無い。GID: LP料金表 Enterprise〜） */}
+      {isEdit && id && (isSuperAdmin || planHasFeature(tenantPlan, "voice_clone")) && (
         <StudioVoiceCloneSection
           configId={id}
           currentVoiceId={voiceId || null}

--- a/src/api/admin/analytics/analyticsPlanGate.test.ts
+++ b/src/api/admin/analytics/analyticsPlanGate.test.ts
@@ -1,0 +1,77 @@
+// src/api/admin/analytics/analyticsPlanGate.test.ts
+// GID: LP料金表(Growth〜: 高度なAnalytics)に基づくplan制限の回帰テスト。
+// pool可用性チェックの後段でplanを確認し、client_adminのみ対象とすることを検証する。
+
+const mockQuery = jest.fn();
+
+jest.mock("../../../lib/db", () => ({
+  pool: { query: (...args: any[]) => mockQuery(...args) },
+  getPool: () => ({ query: (...args: any[]) => mockQuery(...args) }),
+}));
+jest.mock("../../../lib/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock("../../../lib/notifications", () => ({
+  createNotification: jest.fn(),
+  notificationExists: jest.fn(),
+}));
+jest.mock("../../../admin/http/supabaseAuthMiddleware", () => ({
+  supabaseAuthMiddleware: (req: any, _res: any, next: any) => {
+    req.supabaseUser = req._mockUser ?? null;
+    next();
+  },
+}));
+
+import express from "express";
+import request from "supertest";
+import { registerAnalyticsRoutes } from "./routes";
+
+function makeApp(appMetadata: Record<string, unknown> | null) {
+  const app = express();
+  app.use(express.json());
+  app.use((req: any, _res: any, next: any) => {
+    req._mockUser = appMetadata ? { app_metadata: appMetadata } : null;
+    next();
+  });
+  registerAnalyticsRoutes(app);
+  return app;
+}
+
+describe("GET /v1/admin/analytics/summary — plan ゲート", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it("client_admin + plan=starter → 403 plan_upgrade_required、以降のクエリは実行されない", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ plan: "starter" }] });
+
+    const res = await request(makeApp({ role: "client_admin", tenant_id: "tenant-a" }))
+      .get("/v1/admin/analytics/summary");
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("plan_upgrade_required");
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("client_admin + plan=growth → planゲートを通過する(403にならない)", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ plan: "growth" }] }); // plan確認
+    mockQuery.mockResolvedValue({ rows: [{ total: "0" }], rowCount: 0 }); // 以降の集計クエリ用の汎用フォールバック
+
+    const res = await request(makeApp({ role: "client_admin", tenant_id: "tenant-a" }))
+      .get("/v1/admin/analytics/summary");
+
+    expect(res.status).not.toBe(403);
+  });
+
+  it("super_adminはplanゲートをバイパスする(plan確認クエリが実行されない)", async () => {
+    mockQuery.mockResolvedValue({ rows: [{ total: "0" }], rowCount: 0 });
+
+    const res = await request(makeApp({ role: "super_admin" }))
+      .get("/v1/admin/analytics/summary");
+
+    expect(res.status).not.toBe(403);
+    // 1件目のクエリがplan確認(`SELECT plan FROM tenants`)ではないことを確認
+    const firstCallSql = mockQuery.mock.calls[0]?.[0] ?? "";
+    expect(firstCallSql).not.toMatch(/SELECT plan FROM tenants/);
+  });
+});

--- a/src/api/admin/analytics/cvAggregation.test.ts
+++ b/src/api/admin/analytics/cvAggregation.test.ts
@@ -49,12 +49,13 @@ function makeApp() {
   return app;
 }
 
-/** summary エンドポイントが呼ぶ 9 クエリのデフォルトモック (CV関連含む) */
+/** summary エンドポイントが呼ぶ 9 クエリ + client_admin用planゲート確認クエリのデフォルトモック (CV関連含む) */
 function mockSummaryQueries({
   cvRows = [] as Array<{ conversion_type: string; count: number; total_value: string }>,
   tenantAgeDays = 30,
 } = {}) {
   mockQuery
+    .mockResolvedValueOnce({ rows: [{ plan: 'growth' }] })            // GID: plan ゲート確認(client_admin)
     .mockResolvedValueOnce({ rows: [{ total_sessions: '0' }] })      // sessions
     .mockResolvedValueOnce({ rows: [{ prev_total_sessions: '0' }] }) // prev sessions
     .mockResolvedValueOnce({ rows: [{ avg_judge_score: null }] })     // judge score

--- a/src/api/admin/analytics/routes.ts
+++ b/src/api/admin/analytics/routes.ts
@@ -3,12 +3,14 @@
 // Phase50 Stream A: Analytics集計API
 
 import type { Express, Request, Response } from "express";
+import type { Pool } from "pg";
 import { supabaseAuthMiddleware } from "../../../admin/http/supabaseAuthMiddleware";
 import { pool } from "../../../lib/db";
 import { createNotification, notificationExists } from "../../../lib/notifications";
 import { logger } from '../../../lib/logger';
 import { decryptText } from '../../../lib/crypto/textEncrypt';
 import { isAllowedAdminRole } from "../../middleware/roleAuth";
+import { planHasFeature, queryTenantPlan } from "../../../lib/billing/planFeatures";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -117,6 +119,28 @@ function resolveTenantFilter(
   return jwtTenantId || null;
 }
 
+/**
+ * GID: LP料金表(Growth〜: 高度なAnalytics)に基づくplan制限。
+ * client_adminのみ対象（super_adminの集約/横断ビューは対象外）。
+ * pool可用性チェックの後に呼ぶこと（DB障害時に503を403で覆い隠さないため）。
+ * 許可されなければ403を返し、呼び出し元は即returnすること。
+ */
+async function checkAnalyticsPlanAccess(
+  pool: Pick<Pool, "query">,
+  res: Response,
+  isSuperAdmin: boolean,
+  jwtTenantId: string,
+): Promise<boolean> {
+  if (isSuperAdmin) return true;
+  const plan = await queryTenantPlan(pool, jwtTenantId);
+  if (planHasFeature(plan, "analytics")) return true;
+  res.status(403).json({
+    error: "plan_upgrade_required",
+    message: "高度なAnalyticsはGrowthプラン以上でご利用いただけます",
+  });
+  return false;
+}
+
 // ---------------------------------------------------------------------------
 // Route registration
 // ---------------------------------------------------------------------------
@@ -168,6 +192,7 @@ export function registerAnalyticsRoutes(app: Express): void {
       if (!pool) {
         return res.status(503).json({ error: "データベース接続が利用できません" });
       }
+      if (!(await checkAnalyticsPlanAccess(pool, res, isSuperAdmin, jwtTenantId))) return;
 
       try {
         // Build tenant filter clauses
@@ -426,6 +451,7 @@ export function registerAnalyticsRoutes(app: Express): void {
       if (!pool) {
         return res.status(503).json({ error: "データベース接続が利用できません" });
       }
+      if (!(await checkAnalyticsPlanAccess(pool, res, isSuperAdmin, jwtTenantId))) return;
 
       try {
         const params: (string | number)[] = [`${interval}`];
@@ -576,6 +602,7 @@ export function registerAnalyticsRoutes(app: Express): void {
       if (!pool) {
         return res.status(503).json({ error: "データベース接続が利用できません" });
       }
+      if (!(await checkAnalyticsPlanAccess(pool, res, isSuperAdmin, jwtTenantId))) return;
 
       try {
         const params: (string | number)[] = [`${interval}`];
@@ -734,6 +761,7 @@ export function registerAnalyticsRoutes(app: Express): void {
       if (!pool) {
         return res.status(503).json({ error: "データベース接続が利用できません" });
       }
+      if (!(await checkAnalyticsPlanAccess(pool, res, isSuperAdmin, jwtTenantId))) return;
 
       try {
         const tenantClause = tenantId ? "AND s.tenant_id = $2" : "";

--- a/src/api/admin/avatar/routes.test.ts
+++ b/src/api/admin/avatar/routes.test.ts
@@ -17,6 +17,11 @@ jest.mock("../../../auth/supabaseClient", () => ({
   supabaseAdmin: null,
 }));
 
+const mockTenantHasFeature = jest.fn().mockResolvedValue(true);
+jest.mock("../../../lib/billing/planFeatures", () => ({
+  tenantHasFeature: (...args: any[]) => mockTenantHasFeature(...args),
+}));
+
 // --------------------------------------------------------------------------
 // ヘルパー
 // --------------------------------------------------------------------------
@@ -326,6 +331,7 @@ describe("POST /v1/admin/avatar/configs/:id/voice-clone", () => {
 
   beforeEach(() => {
     process.env.FISH_AUDIO_API_KEY = "test-fish-key";
+    mockTenantHasFeature.mockReset().mockResolvedValue(true);
     fetchSpy = jest.spyOn(global, "fetch" as any).mockResolvedValue({
       ok: true,
       status: 201,
@@ -508,6 +514,46 @@ describe("POST /v1/admin/avatar/configs/:id/voice-clone", () => {
     expect(checkSql).not.toContain("tenant_id");
     const [updateSql] = dbQuery.mock.calls[1] as [string, unknown[]];
     expect(updateSql).not.toContain("tenant_id");
+  });
+
+  it("plan制限(GID: LP料金表 Enterprise〜): client_adminがvoice_clone不可プランだと403、DB所有チェックにも到達しない", async () => {
+    mockTenantHasFeature.mockResolvedValueOnce(false);
+    const dbQuery = jest.fn();
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "client_admin", "tenant-a"))
+      .post("/v1/admin/avatar/configs/config-1/voice-clone")
+      .field("name", "マイボイス")
+      .attach("audio", AUDIO_BUFFER, {
+        filename: "voice.mp3",
+        contentType: "audio/mpeg",
+      });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("plan_upgrade_required");
+    expect(dbQuery).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(mockTenantHasFeature).toHaveBeenCalledWith("tenant-a", "voice_clone");
+  });
+
+  it("super_adminはplan制限をバイパスする(tenantHasFeatureは呼ばれない)", async () => {
+    mockTenantHasFeature.mockResolvedValueOnce(false);
+    const dbQuery = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ id: "config-x" }] })
+      .mockResolvedValueOnce({ rows: [{ id: "config-x" }] });
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "super_admin", ""))
+      .post("/v1/admin/avatar/configs/config-x/voice-clone")
+      .field("name", "マイボイス")
+      .attach("audio", AUDIO_BUFFER, {
+        filename: "voice.wav",
+        contentType: "audio/wav",
+      });
+
+    expect(res.status).toBe(200);
+    expect(mockTenantHasFeature).not.toHaveBeenCalled();
   });
 
   it("Fish Audio エラー: ok=false → 502、DB UPDATE に到達しない・外部エラー本文を返さない", async () => {

--- a/src/api/admin/avatar/routes.ts
+++ b/src/api/admin/avatar/routes.ts
@@ -9,6 +9,7 @@ import { supabaseAdmin } from "../../../auth/supabaseClient";
 import multer from 'multer';
 import { logger } from '../../../lib/logger';
 import { trackUsage } from '../../../lib/billing/usageTracker';
+import { tenantHasFeature } from '../../../lib/billing/planFeatures';
 
 // ---------------------------------------------------------------------------
 // Supabase Storage: base64 data URL → 公開 HTTP URL
@@ -749,6 +750,14 @@ export function registerAvatarConfigRoutes(app: Express, db: any): void {
       const { su, role, tenantId, isSuperAdmin } = extractAuth(req);
       if (!isAllowedAvatarRole(role)) {
         return denyAvatarRole(req, res, su, role);
+      }
+      // GID: LP料金表(Enterprise〜: カスタムアバター)に基づくplan制限。
+      // super_adminはテナント管理・サポート目的でバイパスする。
+      if (!isSuperAdmin && !(await tenantHasFeature(tenantId, "voice_clone"))) {
+        return res.status(403).json({
+          error: "plan_upgrade_required",
+          message: "音声クローン機能はEnterpriseプランでご利用いただけます",
+        });
       }
       const id = req.params["id"];
 

--- a/src/api/admin/tenants/routes.test.ts
+++ b/src/api/admin/tenants/routes.test.ts
@@ -341,3 +341,89 @@ describe("GET /v1/admin/my-tenant — has_r2c2", () => {
     expect(res.body.has_r2c2).toBe(false);
   });
 });
+
+// --------------------------------------------------------------------------
+// ⑦ PATCH /v1/admin/my-tenant — avatar/voice の plan ゲート(LP料金表: Growth〜)
+// --------------------------------------------------------------------------
+
+describe("PATCH /v1/admin/my-tenant — avatar/voice plan ゲート", () => {
+  const UPDATED_ROW = { id: "tenant-a", name: "テストテナント", features: { avatar: true, voice: false, rag: true } };
+
+  it("plan=growth で features.avatar:true → 200(plan確認クエリ→UPDATE の順)", async () => {
+    const dbQuery = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ plan: "growth" }] })
+      .mockResolvedValueOnce({ rows: [UPDATED_ROW], rowCount: 1 });
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "client_admin"))
+      .patch("/v1/admin/my-tenant")
+      .send({ features: { avatar: true, voice: false, rag: true } });
+
+    expect(res.status).toBe(200);
+    expect(dbQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it("plan=starter で features.avatar:true → 403 plan_upgrade_required、UPDATEは呼ばれない", async () => {
+    const dbQuery = jest.fn().mockResolvedValueOnce({ rows: [{ plan: "starter" }] });
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "client_admin"))
+      .patch("/v1/admin/my-tenant")
+      .send({ features: { avatar: true, voice: false, rag: true } });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("plan_upgrade_required");
+    expect(dbQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("plan=starter で features.voice:true → 403", async () => {
+    const dbQuery = jest.fn().mockResolvedValueOnce({ rows: [{ plan: "starter" }] });
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "client_admin"))
+      .patch("/v1/admin/my-tenant")
+      .send({ features: { avatar: false, voice: true, rag: true } });
+
+    expect(res.status).toBe(403);
+  });
+
+  it("plan=starter でも features.avatar/voiceを両方falseにする(OFFにする)場合はplan確認をスキップして200", async () => {
+    const dbQuery = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ ...UPDATED_ROW, features: { avatar: false, voice: false, rag: true } }], rowCount: 1 });
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "client_admin"))
+      .patch("/v1/admin/my-tenant")
+      .send({ features: { avatar: false, voice: false, rag: true } });
+
+    expect(res.status).toBe(200);
+    expect(dbQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("plan=starter でもfeatures以外のフィールド更新はplan確認をスキップする", async () => {
+    const dbQuery = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [UPDATED_ROW], rowCount: 1 });
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "client_admin"))
+      .patch("/v1/admin/my-tenant")
+      .send({ faq_question_hint: "配送は何日かかりますか？" });
+
+    expect(res.status).toBe(200);
+    expect(dbQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("plan列が不正/取得不能(fail-safe: starter扱い) → 403", async () => {
+    const dbQuery = jest.fn().mockResolvedValueOnce({ rows: [{ plan: null }] });
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "client_admin"))
+      .patch("/v1/admin/my-tenant")
+      .send({ features: { avatar: true, voice: false, rag: true } });
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/src/api/admin/tenants/routes.ts
+++ b/src/api/admin/tenants/routes.ts
@@ -12,6 +12,7 @@ import { generateApiKey, hashApiKey, maskApiKeyPrefix } from "./apiKeyUtils";
 import { supabaseAdmin } from "../../../auth/supabaseClient";
 import { DEFAULT_AVATARS } from "../avatar/routes";
 import { logger } from '../../../lib/logger';
+import { planHasFeature, type TenantPlan } from "../../../lib/billing/planFeatures";
 
 const planValues = ["starter", "growth", "enterprise"] as const;
 
@@ -154,7 +155,7 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
     }
     try {
       const result = await db.query(
-        `SELECT id, name, features, lemonslice_agent_id, conversion_types, faq_question_hint, faq_answer_hint, onboarding_industry, onboarding_completed_at FROM tenants WHERE id = $1`,
+        `SELECT id, name, plan, features, lemonslice_agent_id, conversion_types, faq_question_hint, faq_answer_hint, onboarding_industry, onboarding_completed_at FROM tenants WHERE id = $1`,
         [tenantId]
       );
       if (result.rowCount === 0) {
@@ -198,6 +199,20 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
     const fields = parsed.data;
     if (Object.keys(fields).length === 0) {
       return res.status(400).json({ error: "no_fields", message: "更新フィールドが必要です。" });
+    }
+    // GID: LP料金表(Growth〜: AIアバター)に基づくプラン制限。
+    // avatar/voiceをtrueにするにはGrowth以上のプランが必要（UIの非表示に加えAPI側でも防御）。
+    if (fields.features?.avatar === true || fields.features?.voice === true) {
+      const planResult = await db.query<{ plan: TenantPlan | null }>(
+        `SELECT plan FROM tenants WHERE id = $1`,
+        [tenantId]
+      );
+      if (!planHasFeature(planResult.rows[0]?.plan, "avatar")) {
+        return res.status(403).json({
+          error: "plan_upgrade_required",
+          message: "AIアバター機能はGrowthプラン以上でご利用いただけます",
+        });
+      }
     }
     try {
       const setClauses: string[] = [];

--- a/src/api/conversion/abTestRoutes.ts
+++ b/src/api/conversion/abTestRoutes.ts
@@ -13,6 +13,28 @@ import { z } from 'zod';
 import { supabaseAuthMiddleware } from '../../admin/http/supabaseAuthMiddleware';
 import { roleAuthMiddleware, requireRole } from '../middleware/roleAuth';
 import type { AuthenticatedUser, AuthedReq } from '../middleware/roleAuth';
+import { planHasFeature, queryTenantPlan } from '../../lib/billing/planFeatures';
+
+/**
+ * GID: LP料金表(Growth〜: CV計測)に基づくplan制限。
+ * client_adminのみ対象（super_adminの集約/横断ビューは対象外）。
+ * db可用性チェックの後に呼ぶこと（DB障害時に503を403で覆い隠さないため）。
+ * 許可されなければ403を返し、呼び出し元は即returnすること。
+ */
+async function checkAbTestPlanAccess(
+  db: Pool,
+  res: Response,
+  user: AuthenticatedUser,
+): Promise<boolean> {
+  if (user.role === 'super_admin') return true;
+  const plan = await queryTenantPlan(db, user.tenantId ?? "");
+  if (planHasFeature(plan, "conversion")) return true;
+  res.status(403).json({
+    error: "plan_upgrade_required",
+    message: "CV計測はGrowthプラン以上でご利用いただけます",
+  });
+  return false;
+}
 
 const ExperimentSchema = z.object({
   name: z.string().min(1).max(200),
@@ -54,6 +76,7 @@ export function registerAbTestRoutes(app: Express, db: Pool | null): void {
     if (user.role === 'client_admin' && queryTenantId && queryTenantId !== user.tenantId) {
       return res.status(403).json({ error: 'forbidden' });
     }
+    if (!(await checkAbTestPlanAccess(db, res, user))) return;
     const tenantId = user.role === 'super_admin' ? (queryTenantId ?? null) : user.tenantId;
 
     try {

--- a/src/api/conversion/conversionPlanGate.test.ts
+++ b/src/api/conversion/conversionPlanGate.test.ts
@@ -1,0 +1,108 @@
+// src/api/conversion/conversionPlanGate.test.ts
+// GID: LP料金表(Growth〜: CV計測)に基づくplan制限の回帰テスト。
+// db可用性チェックの後段でplanを確認し、client_adminのみ対象とすることを検証する。
+
+import express from 'express';
+import request from 'supertest';
+import { registerConversionRoutes } from './conversionRoutes';
+import { registerAbTestRoutes } from './abTestRoutes';
+
+jest.mock('../../admin/http/supabaseAuthMiddleware', () => ({
+  supabaseAuthMiddleware: (req: any, _res: any, next: any) => {
+    req.supabaseUser = {
+      app_metadata: { role: req._mockRole ?? 'client_admin', tenant_id: req._mockTenantId ?? 'tenant-a' },
+    };
+    next();
+  },
+}));
+
+type Role = 'super_admin' | 'client_admin';
+
+function makeApp(
+  role: Role,
+  tenantId: string,
+  queryResponses: Array<{ rows: any[]; rowCount?: number } | Error>,
+) {
+  const app = express();
+  app.use(express.json());
+  app.use((req: any, _res: any, next: any) => {
+    req._mockRole = role;
+    req._mockTenantId = tenantId;
+    req.tenantId = tenantId;
+    next();
+  });
+
+  let callCount = 0;
+  const mockDb: any = {
+    query: jest.fn().mockImplementation(() => {
+      const resp = queryResponses[callCount++] ?? { rows: [], rowCount: 0 };
+      if (resp instanceof Error) return Promise.reject(resp);
+      return Promise.resolve(resp);
+    }),
+  };
+
+  const apiStack = [(req: any, _: any, next: any) => next()];
+  registerConversionRoutes(app, apiStack, mockDb);
+  registerAbTestRoutes(app, mockDb);
+  return { app, mockDb };
+}
+
+describe('GET /v1/admin/conversion/attributions — plan ゲート', () => {
+  it('client_admin + plan=starter → 403 plan_upgrade_required、以降のクエリは実行されない', async () => {
+    const { app, mockDb } = makeApp('client_admin', 'tenant-a', [{ rows: [{ plan: 'starter' }] }]);
+    const res = await request(app).get('/v1/admin/conversion/attributions');
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('plan_upgrade_required');
+    expect(mockDb.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('super_adminはplanゲートをバイパスする(plan確認クエリが実行されない)', async () => {
+    const { app, mockDb } = makeApp('super_admin', 'tenant-a', [
+      { rows: [] }, { rows: [] }, { rows: [{ total: '0', avg_temp_score: null }] }, { rows: [] },
+    ]);
+    const res = await request(app).get('/v1/admin/conversion/attributions');
+
+    expect(res.status).toBe(200);
+    const firstCallSql = mockDb.query.mock.calls[0]?.[0] ?? '';
+    expect(firstCallSql).not.toMatch(/SELECT plan FROM tenants/);
+  });
+});
+
+describe('GET /v1/admin/conversion/effectiveness — plan ゲート', () => {
+  it('client_admin + plan=starter → 403 plan_upgrade_required', async () => {
+    const { app, mockDb } = makeApp('client_admin', 'tenant-a', [{ rows: [{ plan: 'starter' }] }]);
+    const res = await request(app).get('/v1/admin/conversion/effectiveness');
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('plan_upgrade_required');
+    expect(mockDb.query).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('GET /v1/admin/ab/experiments — plan ゲート', () => {
+  it('client_admin + plan=starter → 403 plan_upgrade_required', async () => {
+    const { app, mockDb } = makeApp('client_admin', 'tenant-a', [{ rows: [{ plan: 'starter' }] }]);
+    const res = await request(app).get('/v1/admin/ab/experiments');
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('plan_upgrade_required');
+    expect(mockDb.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('client_admin + plan=growth → ゲートを通過する(403にならない)', async () => {
+    const { app } = makeApp('client_admin', 'tenant-a', [{ rows: [{ plan: 'growth' }] }, { rows: [] }]);
+    const res = await request(app).get('/v1/admin/ab/experiments');
+
+    expect(res.status).not.toBe(403);
+  });
+
+  it('super_adminはplanゲートをバイパスする', async () => {
+    const { app, mockDb } = makeApp('super_admin', 'tenant-a', [{ rows: [] }]);
+    const res = await request(app).get('/v1/admin/ab/experiments');
+
+    expect(res.status).not.toBe(403);
+    const firstCallSql = mockDb.query.mock.calls[0]?.[0] ?? '';
+    expect(firstCallSql).not.toMatch(/SELECT plan FROM tenants/);
+  });
+});

--- a/src/api/conversion/conversionRoutes.ts
+++ b/src/api/conversion/conversionRoutes.ts
@@ -11,6 +11,28 @@ import { z } from 'zod';
 import { supabaseAuthMiddleware } from '../../admin/http/supabaseAuthMiddleware';
 import { roleAuthMiddleware, requireRole } from '../middleware/roleAuth';
 import type { AuthenticatedUser } from '../middleware/roleAuth';
+import { planHasFeature, queryTenantPlan } from '../../lib/billing/planFeatures';
+
+/**
+ * GID: LP料金表(Growth〜: CV計測)に基づくplan制限。
+ * client_adminのみ対象（super_adminの集約/横断ビューは対象外）。
+ * db可用性チェックの後に呼ぶこと（DB障害時に503を403で覆い隠さないため）。
+ * 許可されなければ403を返し、呼び出し元は即returnすること。
+ */
+async function checkConversionPlanAccess(
+  db: Pool,
+  res: Response,
+  user: AuthenticatedUser,
+): Promise<boolean> {
+  if (user.role === 'super_admin') return true;
+  const plan = await queryTenantPlan(db, user.tenantId ?? "");
+  if (planHasFeature(plan, "conversion")) return true;
+  res.status(403).json({
+    error: "plan_upgrade_required",
+    message: "CV計測はGrowthプラン以上でご利用いただけます",
+  });
+  return false;
+}
 
 const VALID_CONVERSION_TYPES = ['purchase', 'inquiry', 'reservation', 'signup', 'other'] as const;
 
@@ -94,6 +116,7 @@ export function registerConversionRoutes(
     if (user.role === 'client_admin' && queryTenantId && queryTenantId !== user.tenantId) {
       return res.status(403).json({ error: 'forbidden' });
     }
+    if (!(await checkConversionPlanAccess(db, res, user))) return;
     const tenantId = user.role === 'super_admin' ? (queryTenantId ?? null) : user.tenantId;
 
     const period = (req.query['period'] as string | undefined) ?? '30d';
@@ -180,6 +203,7 @@ export function registerConversionRoutes(
     if (user.role === 'client_admin' && queryTenantId && queryTenantId !== user.tenantId) {
       return res.status(403).json({ error: 'forbidden' });
     }
+    if (!(await checkConversionPlanAccess(db, res, user))) return;
     const tenantId = user.role === 'super_admin' ? (queryTenantId ?? null) : user.tenantId;
 
     const period = (req.query['period'] as string | undefined) ?? '30d';

--- a/src/lib/billing/planFeatures.test.ts
+++ b/src/lib/billing/planFeatures.test.ts
@@ -1,0 +1,78 @@
+// src/lib/billing/planFeatures.test.ts
+// LP料金表(Starter/Growth/Enterprise)に対応するプラン別機能制限のテスト
+
+const mockQuery = jest.fn();
+jest.mock("../db", () => ({
+  getPool: () => ({ query: mockQuery }),
+}));
+
+import { planHasFeature, getTenantPlan, tenantHasFeature } from "./planFeatures";
+
+describe("planHasFeature", () => {
+  it.each([
+    ["starter", "avatar", false],
+    ["growth", "avatar", true],
+    ["enterprise", "avatar", true],
+    ["starter", "voice_clone", false],
+    ["growth", "voice_clone", false],
+    ["enterprise", "voice_clone", true],
+    ["starter", "analytics", false],
+    ["growth", "analytics", true],
+    ["starter", "conversion", false],
+    ["growth", "conversion", true],
+  ] as const)("%s プランで %s = %s", (plan, feature, expected) => {
+    expect(planHasFeature(plan, feature)).toBe(expected);
+  });
+
+  it("未知のplan文字列はstarter扱い(fail-safe)", () => {
+    expect(planHasFeature("unknown-plan", "avatar")).toBe(false);
+  });
+
+  it("null/undefinedはstarter扱い", () => {
+    expect(planHasFeature(null, "avatar")).toBe(false);
+    expect(planHasFeature(undefined, "avatar")).toBe(false);
+  });
+});
+
+describe("getTenantPlan", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it("DBのplan列をそのまま返す", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ plan: "growth" }] });
+    expect(await getTenantPlan("tenant-a")).toBe("growth");
+  });
+
+  it("plan列がnull/不正値ならstarterにフォールバック", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ plan: null }] });
+    expect(await getTenantPlan("tenant-a")).toBe("starter");
+
+    mockQuery.mockResolvedValueOnce({ rows: [{ plan: "typo-plan" }] });
+    expect(await getTenantPlan("tenant-a")).toBe("starter");
+  });
+
+  it("テナントが存在しない場合もstarterにフォールバック", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    expect(await getTenantPlan("nonexistent")).toBe("starter");
+  });
+
+  it("DB障害時はfail-safeでstarter扱い", async () => {
+    mockQuery.mockRejectedValueOnce(new Error("db down"));
+    expect(await getTenantPlan("tenant-a")).toBe("starter");
+  });
+});
+
+describe("tenantHasFeature", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it("plan取得結果に基づき機能可否を判定する", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ plan: "enterprise" }] });
+    expect(await tenantHasFeature("tenant-a", "voice_clone")).toBe(true);
+
+    mockQuery.mockResolvedValueOnce({ rows: [{ plan: "growth" }] });
+    expect(await tenantHasFeature("tenant-a", "voice_clone")).toBe(false);
+  });
+});

--- a/src/lib/billing/planFeatures.ts
+++ b/src/lib/billing/planFeatures.ts
@@ -1,0 +1,68 @@
+// src/lib/billing/planFeatures.ts
+// LP(r2c.biz)の料金表に対応するプラン別機能制限。
+// 表示側(admin-ui/src/pages/admin/tenants/types.ts の PLAN_OPTIONS)と一致させること。
+//
+// LPの機能マッピング:
+//   Growth〜: AIアバター（顔・声）、高度なAnalytics、CV計測
+//   Enterprise〜: カスタムアバター（Fish Audio Voice Cloning）
+// 「心理学Sales AI」は現状すべてのプランで提供するため、ここでは制限しない。
+
+import type { Pool } from "pg";
+import { getPool } from "../db";
+
+export type TenantPlan = "starter" | "growth" | "enterprise";
+
+const PLAN_RANK: Record<TenantPlan, number> = {
+  starter: 0,
+  growth: 1,
+  enterprise: 2,
+};
+
+export type GatedFeature = "avatar" | "voice_clone" | "analytics" | "conversion";
+
+const FEATURE_MIN_PLAN: Record<GatedFeature, TenantPlan> = {
+  avatar: "growth",
+  voice_clone: "enterprise",
+  analytics: "growth",
+  conversion: "growth",
+};
+
+function rank(plan: string | null | undefined): number {
+  return PLAN_RANK[plan as TenantPlan] ?? PLAN_RANK.starter;
+}
+
+export function planHasFeature(plan: string | null | undefined, feature: GatedFeature): boolean {
+  return rank(plan) >= PLAN_RANK[FEATURE_MIN_PLAN[feature]];
+}
+
+/**
+ * 指定のPoolを使ってテナントの現在のプランを取得する。
+ * fail-safe: 取得失敗・未設定時は最も制限の強い starter 扱いにする。
+ * 呼び出し元が既にpool可用性を確認済みの場合はこちらを直接使う
+ * （DB障害時に「plan_upgrade_required」で503を覆い隠さないため）。
+ */
+export async function queryTenantPlan(
+  pool: Pick<Pool, "query">,
+  tenantId: string,
+): Promise<TenantPlan> {
+  try {
+    const result = await pool.query<{ plan: string | null }>(
+      `SELECT plan FROM tenants WHERE id = $1`,
+      [tenantId],
+    );
+    const plan = result.rows[0]?.plan;
+    return plan === "growth" || plan === "enterprise" ? plan : "starter";
+  } catch {
+    return "starter";
+  }
+}
+
+/** DBからテナントの現在のプランを取得する（getPool()経由）。 */
+export async function getTenantPlan(tenantId: string): Promise<TenantPlan> {
+  return queryTenantPlan(getPool(), tenantId);
+}
+
+export async function tenantHasFeature(tenantId: string, feature: GatedFeature): Promise<boolean> {
+  const plan = await getTenantPlan(tenantId);
+  return planHasFeature(plan, feature);
+}

--- a/tests/api/admin/tenants/routes.test.ts
+++ b/tests/api/admin/tenants/routes.test.ts
@@ -184,17 +184,29 @@ describe("Tenant Admin Routes", () => {
   });
 
   describe("PATCH /v1/admin/my-tenant", () => {
-    it("updates features for client_admin", async () => {
-      mockDb.query.mockResolvedValueOnce({
-        rows: [{ id: "tenant1", name: "Test", features: { avatar: true, voice: false, rag: true }, lemonslice_agent_id: null }],
-        rowCount: 1,
-      });
+    it("updates features for client_admin (plan=growth: avatar有効化を許可)", async () => {
+      mockDb.query
+        .mockResolvedValueOnce({ rows: [{ plan: "growth" }] }) // GID: avatar/voice の plan ゲート確認クエリ
+        .mockResolvedValueOnce({
+          rows: [{ id: "tenant1", name: "Test", features: { avatar: true, voice: false, rag: true }, lemonslice_agent_id: null }],
+          rowCount: 1,
+        });
       const res = await request(app)
         .patch("/v1/admin/my-tenant")
         .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`)
         .send({ features: { avatar: true, voice: false, rag: true } });
       expect(res.status).toBe(200);
       expect(res.body.features.avatar).toBe(true);
+    });
+
+    it("rejects avatar有効化 for client_admin on plan=starter (GID: LP料金表 Growth〜)", async () => {
+      mockDb.query.mockResolvedValueOnce({ rows: [{ plan: "starter" }] });
+      const res = await request(app)
+        .patch("/v1/admin/my-tenant")
+        .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`)
+        .send({ features: { avatar: true, voice: false, rag: true } });
+      expect(res.status).toBe(403);
+      expect(res.body.error).toBe("plan_upgrade_required");
     });
 
     it("rejects a request with tenant_id claim but no admin role (GID 1216273277286371)", async () => {

--- a/tests/phase50/analytics.test.ts
+++ b/tests/phase50/analytics.test.ts
@@ -50,7 +50,10 @@ function makeApp(role: Role = "client_admin", tenantId = "tenant-a") {
 // ---------------------------------------------------------------------------
 
 beforeEach(() => {
-  jest.clearAllMocks();
+  // resetAllMocks: clearAllMocksだとmockResolvedValueOnceのキューが前テストから
+  // 持ち越されてしまい、planゲート確認クエリの追加でテスト間の呼び出し回数がずれた際に
+  // 意図しない値を消費してしまう。テストごとに完全にリセットする。
+  jest.resetAllMocks();
 });
 
 // ---------------------------------------------------------------------------
@@ -65,7 +68,7 @@ describe("1. GET /v1/admin/analytics/summary", () => {
     total_knowledge_gaps: string;
     avg_messages_per_session: string;
     avatar_session_count: string;
-  }> = {}) {
+  }> = {}, includePlanCheck = true) {
     const defaults = {
       total_sessions: "10",
       prev_total_sessions: "8",
@@ -76,6 +79,10 @@ describe("1. GET /v1/admin/analytics/summary", () => {
     };
     const vals = { ...defaults, ...overrides };
 
+    if (includePlanCheck) {
+      // GID: plan ゲート確認(client_admin)。super_adminはゲートをバイパスするため呼び出し不要。
+      mockQuery.mockResolvedValueOnce({ rows: [{ plan: "growth" }] });
+    }
     mockQuery
       .mockResolvedValueOnce({ rows: [{ total_sessions: vals.total_sessions }] })
       .mockResolvedValueOnce({ rows: [{ prev_total_sessions: vals.prev_total_sessions }] })
@@ -127,6 +134,7 @@ describe("1. GET /v1/admin/analytics/summary", () => {
 
   it("returns null avg_judge_score when no evaluations", async () => {
     mockQuery
+      .mockResolvedValueOnce({ rows: [{ plan: "growth" }] }) // GID: plan ゲート確認(client_admin)
       .mockResolvedValueOnce({ rows: [{ total_sessions: "0" }] })
       .mockResolvedValueOnce({ rows: [{ prev_total_sessions: "0" }] })
       .mockResolvedValueOnce({ rows: [{ avg_judge_score: null }] })
@@ -146,7 +154,7 @@ describe("1. GET /v1/admin/analytics/summary", () => {
   });
 
   it("super_admin can query without tenant filter", async () => {
-    setupSummaryMocks();
+    setupSummaryMocks({}, false);
     const res = await request(makeApp("super_admin"))
       .get("/v1/admin/analytics/summary");
 
@@ -155,7 +163,7 @@ describe("1. GET /v1/admin/analytics/summary", () => {
   });
 
   it("super_admin can filter by specific tenant", async () => {
-    setupSummaryMocks();
+    setupSummaryMocks({}, false);
     const res = await request(makeApp("super_admin"))
       .get("/v1/admin/analytics/summary?tenant=tenant-x");
 
@@ -174,7 +182,9 @@ describe("1. GET /v1/admin/analytics/summary", () => {
   });
 
   it("returns 500 on DB error", async () => {
-    mockQuery.mockRejectedValueOnce(new Error("DB error"));
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ plan: "growth" }] }) // GID: plan ゲート確認(client_admin)
+      .mockRejectedValueOnce(new Error("DB error"));
 
     const res = await request(makeApp())
       .get("/v1/admin/analytics/summary");
@@ -197,6 +207,7 @@ describe("2. GET /v1/admin/analytics/trends", () => {
 
   it("returns daily array with correct shape", async () => {
     mockQuery
+      .mockResolvedValueOnce({ rows: [{ plan: "growth" }] }) // GID: plan ゲート確認(client_admin)
       .mockResolvedValueOnce({ rows: DAILY_ROWS })
       .mockResolvedValueOnce({ rows: [] }); // sentiment trends (Phase51)
 
@@ -218,6 +229,7 @@ describe("2. GET /v1/admin/analytics/trends", () => {
 
   it("avg_score is null when no evaluations for that day", async () => {
     mockQuery
+      .mockResolvedValueOnce({ rows: [{ plan: "growth" }] }) // GID: plan ゲート確認(client_admin)
       .mockResolvedValueOnce({ rows: DAILY_ROWS })
       .mockResolvedValueOnce({ rows: [] }); // sentiment trends (Phase51)
 
@@ -230,6 +242,7 @@ describe("2. GET /v1/admin/analytics/trends", () => {
 
   it("returns empty daily array when no data", async () => {
     mockQuery
+      .mockResolvedValueOnce({ rows: [{ plan: "growth" }] }) // GID: plan ゲート確認(client_admin)
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] }); // sentiment trends (Phase51)
 
@@ -241,7 +254,9 @@ describe("2. GET /v1/admin/analytics/trends", () => {
   });
 
   it("returns 500 on DB error", async () => {
-    mockQuery.mockRejectedValueOnce(new Error("DB error"));
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ plan: "growth" }] }) // GID: plan ゲート確認(client_admin)
+      .mockRejectedValueOnce(new Error("DB error"));
 
     const res = await request(makeApp())
       .get("/v1/admin/analytics/trends");
@@ -255,7 +270,11 @@ describe("2. GET /v1/admin/analytics/trends", () => {
 // ---------------------------------------------------------------------------
 
 describe("3. GET /v1/admin/analytics/evaluations", () => {
-  function setupEvalMocks() {
+  function setupEvalMocks(includePlanCheck = true) {
+    if (includePlanCheck) {
+      // GID: plan ゲート確認(client_admin)。super_adminはゲートをバイパスするため呼び出し不要。
+      mockQuery.mockResolvedValueOnce({ rows: [{ plan: "growth" }] });
+    }
     // score distribution rows
     mockQuery
       .mockResolvedValueOnce({
@@ -351,7 +370,7 @@ describe("3. GET /v1/admin/analytics/evaluations", () => {
   });
 
   it("RBAC: super_admin can query other tenants", async () => {
-    setupEvalMocks();
+    setupEvalMocks(false);
 
     const res = await request(makeApp("super_admin"))
       .get("/v1/admin/analytics/evaluations?tenant=tenant-c");
@@ -361,7 +380,9 @@ describe("3. GET /v1/admin/analytics/evaluations", () => {
   });
 
   it("returns 500 on DB error", async () => {
-    mockQuery.mockRejectedValueOnce(new Error("DB error"));
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ plan: "growth" }] }) // GID: plan ゲート確認(client_admin)
+      .mockRejectedValueOnce(new Error("DB error"));
 
     const res = await request(makeApp())
       .get("/v1/admin/analytics/evaluations");

--- a/tests/phase52/analytics-api.test.ts
+++ b/tests/phase52/analytics-api.test.ts
@@ -57,7 +57,11 @@ function makeUnauthApp() {
 // Helpers
 // ---------------------------------------------------------------------------
 
-function setupSummaryMocks() {
+function setupSummaryMocks(includePlanCheck = true) {
+  if (includePlanCheck) {
+    // GID: plan ゲート確認(client_admin)。super_adminはゲートをバイパスするため呼び出し不要。
+    mockQuery.mockResolvedValueOnce({ rows: [{ plan: "growth" }] });
+  }
   mockQuery
     .mockResolvedValueOnce({ rows: [{ total_sessions: "12" }] })
     .mockResolvedValueOnce({ rows: [{ prev_total_sessions: "10" }] })
@@ -71,7 +75,10 @@ function setupSummaryMocks() {
 }
 
 beforeEach(() => {
-  jest.clearAllMocks();
+  // resetAllMocks: clearAllMocksだとmockResolvedValueOnceのキューが前テストから
+  // 持ち越されてしまい、planゲート確認クエリの追加でテスト間の呼び出し回数がずれた際に
+  // 意図しない値を消費してしまう。テストごとに完全にリセットする。
+  jest.resetAllMocks();
   // Default: auth passes through
   mockAuthMiddleware.mockImplementation((_req: any, _res: any, next: any) => next());
 });
@@ -82,7 +89,7 @@ beforeEach(() => {
 
 describe("1. GET /v1/admin/analytics/summary — super_admin", () => {
   it("super_admin: tenant_id = null (全テナント)", async () => {
-    setupSummaryMocks();
+    setupSummaryMocks(false);
     const res = await request(makeApp("super_admin"))
       .get("/v1/admin/analytics/summary");
 
@@ -92,7 +99,7 @@ describe("1. GET /v1/admin/analytics/summary — super_admin", () => {
   });
 
   it("super_admin: ?tenant= で特定テナント絞り込み可", async () => {
-    setupSummaryMocks();
+    setupSummaryMocks(false);
     const res = await request(makeApp("super_admin"))
       .get("/v1/admin/analytics/summary?tenant=tenant-x");
 
@@ -150,6 +157,7 @@ describe("3. 未認証アクセス — 401", () => {
 describe("4. avg_judge_score — score=0 評価除外", () => {
   it("avg_judge_score が null → null として返す", async () => {
     mockQuery
+      .mockResolvedValueOnce({ rows: [{ plan: "growth" }] }) // GID: plan ゲート確認(client_admin)
       .mockResolvedValueOnce({ rows: [{ total_sessions: "0" }] })
       .mockResolvedValueOnce({ rows: [{ prev_total_sessions: "0" }] })
       .mockResolvedValueOnce({ rows: [{ avg_judge_score: null }] }) // score>0フィルタ後 = null
@@ -171,8 +179,8 @@ describe("4. avg_judge_score — score=0 評価除外", () => {
     setupSummaryMocks();
     await request(makeApp()).get("/v1/admin/analytics/summary");
 
-    // 3番目のクエリが avg_judge_score のクエリ
-    const evalQuery = mockQuery.mock.calls[2]?.[0] as string;
+    // 4番目のクエリ(1番目はplanゲート確認)が avg_judge_score のクエリ
+    const evalQuery = mockQuery.mock.calls[3]?.[0] as string;
     expect(evalQuery).toContain("score > 0");
   });
 });
@@ -184,6 +192,7 @@ describe("4. avg_judge_score — score=0 評価除外", () => {
 describe("5. GET /v1/admin/analytics/evaluations — score>0フィルタ", () => {
   function setupEvalMocks() {
     mockQuery
+      .mockResolvedValueOnce({ rows: [{ plan: "growth" }] }) // GID: plan ゲート確認(client_admin)
       .mockResolvedValueOnce({ rows: [{ range: "40-60", count: "5" }, { range: "60-80", count: "8" }] })
       .mockResolvedValueOnce({
         rows: [{ psychology_fit: "70.0", customer_reaction: "65.0", stage_progress: "72.0", taboo_violation: "88.0" }],
@@ -195,7 +204,7 @@ describe("5. GET /v1/admin/analytics/evaluations — score>0フィルタ", () =>
     setupEvalMocks();
     await request(makeApp()).get("/v1/admin/analytics/evaluations");
 
-    const distQuery = mockQuery.mock.calls[0]?.[0] as string;
+    const distQuery = mockQuery.mock.calls[1]?.[0] as string;
     expect(distQuery).toContain("score > 0");
   });
 

--- a/tests/phase52/conversion-tracking.test.ts
+++ b/tests/phase52/conversion-tracking.test.ts
@@ -66,6 +66,7 @@ function mockConversionsQueries({
   // jest.clearAllMocks() only clears call records, not the once-queue; mockReset() clears everything.
   mockQuery.mockReset();
   mockQuery
+    .mockResolvedValueOnce({ rows: [{ plan: "growth" }] })   // GID: plan ゲート確認(client_admin)
     .mockResolvedValueOnce({ rows: summaryRows })            // 1. summaryResult (GROUP BY outcome)
     .mockResolvedValueOnce({ rows: [{ total: String(total) }] })  // 2. totalCountResult
     .mockResolvedValueOnce({ rows: [{ recorded: String(recorded) }] }) // 3. recordedResult
@@ -200,7 +201,7 @@ describe("3. period=7d — 7日以内のみ", () => {
       .get("/v1/admin/analytics/conversions?period=7d");
 
     // 最初の query 呼び出し (summaryResult) のパラメータを検証
-    const firstCall = mockQuery.mock.calls[0];
+    const firstCall = mockQuery.mock.calls[1];
     expect(firstCall[1]).toContain("7 days");
   });
 
@@ -210,7 +211,7 @@ describe("3. period=7d — 7日以内のみ", () => {
     await request(makeApp("client_admin", "tenant-a"))
       .get("/v1/admin/analytics/conversions?period=90d");
 
-    const firstCall = mockQuery.mock.calls[0];
+    const firstCall = mockQuery.mock.calls[1];
     expect(firstCall[1]).toContain("90 days");
   });
 });
@@ -258,7 +259,7 @@ describe("5. client_admin — テナント絞り込み", () => {
     await request(makeApp("client_admin", "tenant-x"))
       .get("/v1/admin/analytics/conversions");
 
-    const firstCall = mockQuery.mock.calls[0];
+    const firstCall = mockQuery.mock.calls[1];
     expect(firstCall[1]).toContain("tenant-x");
   });
 });

--- a/tests/phase58/conversionRoutes.test.ts
+++ b/tests/phase58/conversionRoutes.test.ts
@@ -138,7 +138,8 @@ describe('GET /v1/admin/conversion/attributions', () => {
   it('Client Admin → 自テナント 200', async () => {
     const { app } = makeApp({
       role: 'client_admin',
-      queryResponses: [{ rows: [] }, { rows: [] }, { rows: [{ total: '0', avg_temp_score: null }] }, { rows: [] }],
+      // GID: 先頭がplanゲート確認クエリ(client_admin)
+      queryResponses: [{ rows: [{ plan: 'growth' }] }, { rows: [] }, { rows: [] }, { rows: [{ total: '0', avg_temp_score: null }] }, { rows: [] }],
     });
     const res = await request(app).get('/v1/admin/conversion/attributions');
     expect(res.status).toBe(200);


### PR DESCRIPTION
## Summary
LPの料金表(Starter/Growth/Enterprise)と実際の機能アクセス権が一致していなかった問題に対応。Starterプランのテナントでも本来Growth以上限定のはずの機能(AIアバター、高度なAnalytics、CV計測)を有効化・アクセスできてしまう状態だったため、UI非表示 + API側403ブロックの両輪で防御する。

### プラン⇔機能マッピング(LP準拠)
| 機能 | 必要プラン |
|---|---|
| AIアバター(顔・声) | Growth〜 |
| 高度なAnalytics | Growth〜 |
| CV計測 | Growth〜 |
| カスタムアバター(音声クローン) | Enterprise〜 |

「心理学Sales AI」はユーザー判断により全プラン提供のため制限対象外。

### Backend
- `src/lib/billing/planFeatures.ts` (新規): プラン別機能制限の共通ロジック
- `PATCH /v1/admin/my-tenant`: avatar/voice有効化にplanゲート追加
- `POST /v1/admin/avatar/configs/:id/voice-clone`: Enterprise限定ゲート追加
- `GET /v1/admin/analytics/{summary,trends,evaluations,conversions}`: Growth+ゲート追加
- `GET /v1/admin/conversion/{attributions,effectiveness}`, `GET /v1/admin/ab/experiments`: Growth+ゲート追加
- いずれもsuper_adminはバイパス、DB可用性チェックの後段に配置(503を403で覆い隠さない設計)

### Frontend
- `admin-ui/src/auth/useAuth.tsx`: AuthContextに`tenantPlan`を追加(自動取得)
- `admin-ui/src/lib/planFeatures.ts` (新規): backendロジックの鏡写し
- アバターON/OFFトグル、音声クローンセクション、サイドバーの「会話分析」「成約・効果分析」をplan制限に応じて非表示化
- super_adminのプレビュー中は実際のクライアント体験を正確に反映(isSuperAdmin=falseへのフォールバックを利用)

## Test plan
- [x] `jest`全体実行 — 2188 passed(avatar/routes.test.tsの11件の失敗は本PRと無関係の既存環境問題。origin/mainでも再現することを確認済み)
- [x] `vitest run`(admin-ui全体) — 70 passed
- [x] `tsc --noEmit`(backend/admin-ui) エラーなし
- [x] `oxlint` クリーン
- [x] `vite build`(admin-ui) 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)