### PR TITLE
feat: Sai(Agent S)接続ブリッジ実装

### DIFF
--- a/src/api/admin/options/migration_sai_bridge.sql
+++ b/src/api/admin/options/migration_sai_bridge.sql
@@ -1,0 +1,9 @@
+-- Phase2 (Sai接続ブリッジ): option_orders拡張マイグレーション
+-- sai_task_id: Sai VPS側のタスクID（試行のたびに上書き、履歴は持たない）
+-- sai_outcome: Sai側の自己申告結果（人間レビュー前の参考情報。確定判断には使わない）
+-- sai_tried_at: 最後にSaiで試行した日時
+
+ALTER TABLE option_orders
+  ADD COLUMN IF NOT EXISTS sai_task_id TEXT,
+  ADD COLUMN IF NOT EXISTS sai_outcome VARCHAR(50),
+  ADD COLUMN IF NOT EXISTS sai_tried_at TIMESTAMPTZ;

--- a/src/api/admin/options/routes.ts
+++ b/src/api/admin/options/routes.ts
@@ -7,6 +7,7 @@ import { getPool } from '../../../lib/db';
 import { logger } from '../../../lib/logger';
 import { chargeOneOffJpy } from '../../../lib/billing/stripeSync';
 import { createNotification } from '../../../lib/notifications';
+import { submitSaiTask, getSaiTask } from '../../../lib/sai/saiClient';
 
 // ---------------------------------------------------------------------------
 // ALLOWED_ROLES whitelist (Phase69-1.5 PR-C4 v2)
@@ -317,6 +318,111 @@ export function registerOptionRoutes(app: Express): void {
     } catch (err: any) {
       logger.warn('[PUT /v1/admin/options/:id/complete]', err);
       return res.status(500).json({ error: '完了処理に失敗しました' });
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // POST /v1/admin/options/:id/try-sai — SaiエージェントにGUI代行作業を試行させる（super_adminのみ）
+  // Saiの成否自己申告は信用しない設計のため、ここでは status/final_amount 等を一切更新しない。
+  // 結果はGET .../sai-task で取得し、人間が最終スクリーンショットを見て
+  // 既存の /complete フローで完了させるか判断する。
+  // -------------------------------------------------------------------------
+  app.post('/v1/admin/options/:id/try-sai', async (req: Request, res: Response) => {
+    const { su, role, isSuperAdmin } = extractAuth(req);
+    if (!isAllowedOptionRole(role)) {
+      return denyRole(req, res, su, role, ALLOWED_OPTION_ROLES);
+    }
+    if (!isSuperAdmin) {
+      return denyInsufficient(req, res, su, role);
+    }
+
+    const { id } = req.params;
+    const { max_steps } = req.body as { max_steps?: number };
+
+    try {
+      const pool = getPool();
+      const orderResult = await pool.query(
+        `SELECT id, description FROM option_orders WHERE id = $1`,
+        [id],
+      );
+      if (orderResult.rowCount === 0) {
+        return res.status(404).json({ error: '発注が見つかりません' });
+      }
+      const order = orderResult.rows[0] as { id: string; description: string };
+
+      const { task_id } = await submitSaiTask({
+        description: order.description,
+        orderId: order.id,
+        maxSteps: max_steps,
+      });
+
+      await pool
+        .query(
+          `UPDATE option_orders SET sai_task_id = $2, sai_outcome = NULL, sai_tried_at = NOW() WHERE id = $1`,
+          [id, task_id],
+        )
+        .catch((err: any) => {
+          if (err?.code !== '42703') throw err;
+          logger.warn('[POST /v1/admin/options/:id/try-sai] sai_* columns not migrated yet');
+        });
+
+      return res.status(202).json({ task_id, status: 'queued' });
+    } catch (err: any) {
+      if (err?.message === 'SAI_API_KEY not set') {
+        return res.status(503).json({ error: 'Saiエージェントが設定されていません' });
+      }
+      logger.warn('[POST /v1/admin/options/:id/try-sai]', err);
+      return res.status(502).json({ error: 'Saiエージェントへの依頼に失敗しました' });
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // GET /v1/admin/options/:id/sai-task — Sai実行結果の取得（super_adminのみ）
+  // 最終スクリーンショットを含む生の実行結果を返す。完了判断は人間が行う。
+  // -------------------------------------------------------------------------
+  app.get('/v1/admin/options/:id/sai-task', async (req: Request, res: Response) => {
+    const { su, role, isSuperAdmin } = extractAuth(req);
+    if (!isAllowedOptionRole(role)) {
+      return denyRole(req, res, su, role, ALLOWED_OPTION_ROLES);
+    }
+    if (!isSuperAdmin) {
+      return denyInsufficient(req, res, su, role);
+    }
+
+    const { id } = req.params;
+
+    try {
+      const pool = getPool();
+      const orderResult = await pool.query(
+        `SELECT sai_task_id FROM option_orders WHERE id = $1`,
+        [id],
+      ).catch((err: any) => {
+        if (err?.code === '42703') return { rowCount: 0, rows: [] } as any;
+        throw err;
+      });
+
+      const saiTaskId = orderResult.rows[0]?.sai_task_id as string | undefined;
+      if (!saiTaskId) {
+        return res.status(404).json({ error: 'この発注はまだSaiで試行されていません' });
+      }
+
+      const task = await getSaiTask(saiTaskId);
+
+      if (task.status === 'complete') {
+        await pool
+          .query(`UPDATE option_orders SET sai_outcome = $2 WHERE id = $1`, [id, task.outcome ?? 'unknown'])
+          .catch((err: any) => {
+            if (err?.code !== '42703') throw err;
+          });
+      }
+
+      return res.json({ task });
+    } catch (err: any) {
+      if (err?.message === 'SAI_API_KEY not set') {
+        return res.status(503).json({ error: 'Saiエージェントが設定されていません' });
+      }
+      logger.warn('[GET /v1/admin/options/:id/sai-task]', err);
+      return res.status(502).json({ error: 'Saiエージェントの状態取得に失敗しました' });
     }
   });
 }

--- a/src/api/admin/options/saiBridge.test.ts
+++ b/src/api/admin/options/saiBridge.test.ts
@@ -1,0 +1,145 @@
+// src/api/admin/options/saiBridge.test.ts
+// Phase2 (Sai接続ブリッジ): try-sai / sai-task エンドポイントのテスト
+
+import express from 'express';
+import request from 'supertest';
+import { registerOptionRoutes } from './routes';
+
+jest.mock('../../../admin/http/supabaseAuthMiddleware', () => ({
+  supabaseAuthMiddleware: (_req: any, _res: any, next: any) => next(),
+}));
+
+jest.mock('../../../lib/billing/stripeSync', () => ({
+  chargeOneOffJpy: jest.fn(),
+}));
+
+jest.mock('../../../lib/notifications', () => ({
+  createNotification: jest.fn(),
+}));
+
+const mockQuery = jest.fn();
+jest.mock('../../../lib/db', () => ({
+  getPool: () => ({ query: mockQuery }),
+}));
+
+const mockSubmitSaiTask = jest.fn();
+const mockGetSaiTask = jest.fn();
+jest.mock('../../../lib/sai/saiClient', () => ({
+  submitSaiTask: (...args: unknown[]) => mockSubmitSaiTask(...args),
+  getSaiTask: (...args: unknown[]) => mockGetSaiTask(...args),
+}));
+
+function makeApp(role = 'client_admin', tenantId = 'tenant-x') {
+  const app = express();
+  app.use(express.json());
+  app.use((req: any, _res: any, next: any) => {
+    req.supabaseUser = { app_metadata: { tenant_id: tenantId, role } };
+    next();
+  });
+  registerOptionRoutes(app);
+  return app;
+}
+
+function superAdminApp() {
+  return makeApp('super_admin', '');
+}
+
+describe('POST /v1/admin/options/:id/try-sai', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('super_admin以外は403', async () => {
+    const res = await request(makeApp()).post('/v1/admin/options/order-1/try-sai').send({});
+    expect(res.status).toBe(403);
+    expect(mockSubmitSaiTask).not.toHaveBeenCalled();
+  });
+
+  it('存在しない発注は404', async () => {
+    mockQuery.mockResolvedValueOnce({ rowCount: 0, rows: [] });
+    const res = await request(superAdminApp()).post('/v1/admin/options/missing/try-sai').send({});
+    expect(res.status).toBe(404);
+  });
+
+  it('Saiにタスクを投げ、sai_task_idを保存して202を返す', async () => {
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'order-1', description: 'FAQ登録代行' }] });
+    mockSubmitSaiTask.mockResolvedValueOnce({ task_id: 'sai-task-1', status: 'queued' });
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [] }); // sai_task_id UPDATE
+
+    const res = await request(superAdminApp()).post('/v1/admin/options/order-1/try-sai').send({});
+
+    expect(res.status).toBe(202);
+    expect(res.body).toEqual({ task_id: 'sai-task-1', status: 'queued' });
+    expect(mockSubmitSaiTask).toHaveBeenCalledWith(
+      expect.objectContaining({ description: 'FAQ登録代行', orderId: 'order-1' }),
+    );
+    expect(mockQuery).toHaveBeenLastCalledWith(
+      expect.stringContaining('UPDATE option_orders SET sai_task_id'),
+      ['order-1', 'sai-task-1'],
+    );
+  });
+
+  it('SAI_API_KEY未設定時は503', async () => {
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'order-1', description: 'x' }] });
+    mockSubmitSaiTask.mockRejectedValueOnce(new Error('SAI_API_KEY not set'));
+
+    const res = await request(superAdminApp()).post('/v1/admin/options/order-1/try-sai').send({});
+    expect(res.status).toBe(503);
+  });
+
+  it('Sai API呼び出し失敗時は502', async () => {
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'order-1', description: 'x' }] });
+    mockSubmitSaiTask.mockRejectedValueOnce(new Error('Sai API error: 503'));
+
+    const res = await request(superAdminApp()).post('/v1/admin/options/order-1/try-sai').send({});
+    expect(res.status).toBe(502);
+  });
+});
+
+describe('GET /v1/admin/options/:id/sai-task', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('super_admin以外は403', async () => {
+    const res = await request(makeApp()).get('/v1/admin/options/order-1/sai-task');
+    expect(res.status).toBe(403);
+  });
+
+  it('未試行の発注は404', async () => {
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ sai_task_id: null }] });
+    const res = await request(superAdminApp()).get('/v1/admin/options/order-1/sai-task');
+    expect(res.status).toBe(404);
+  });
+
+  it('実行中タスクの状態(スクリーンショットなし)を返す', async () => {
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ sai_task_id: 'sai-task-1' }] });
+    mockGetSaiTask.mockResolvedValueOnce({ status: 'running', steps: 2, description: 'x', max_steps: 15 });
+
+    const res = await request(superAdminApp()).get('/v1/admin/options/order-1/sai-task');
+
+    expect(res.status).toBe(200);
+    expect(res.body.task.status).toBe('running');
+    // 完了前はDBを更新しない
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it('完了タスクはfinal_screenshot_base64を含めて返し、sai_outcomeを保存する（自動完了はしない）', async () => {
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ sai_task_id: 'sai-task-1' }] });
+    mockGetSaiTask.mockResolvedValueOnce({
+      status: 'complete', steps: 3, description: 'x', max_steps: 15,
+      outcome: 'agent_reported_done', final_screenshot_base64: 'AAAA', steps_log: [],
+    });
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [] }); // sai_outcome UPDATE
+
+    const res = await request(superAdminApp()).get('/v1/admin/options/order-1/sai-task');
+
+    expect(res.status).toBe(200);
+    expect(res.body.task.final_screenshot_base64).toBe('AAAA');
+    expect(mockQuery).toHaveBeenLastCalledWith(
+      expect.stringContaining('UPDATE option_orders SET sai_outcome'),
+      ['order-1', 'agent_reported_done'],
+    );
+    // status/final_amount/completed_atなどは一切更新しない = /complete エンドポイントとは別経路
+  });
+});

--- a/src/lib/sai/saiClient.test.ts
+++ b/src/lib/sai/saiClient.test.ts
@@ -1,0 +1,85 @@
+// src/lib/sai/saiClient.test.ts
+// Sai VPS 接続クライアントの単体テスト
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+import { submitSaiTask, getSaiTask } from './saiClient';
+
+describe('saiClient', () => {
+  const savedApiKey = process.env['SAI_API_KEY'];
+  const savedBaseUrl = process.env['SAI_API_BASE_URL'];
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env['SAI_API_KEY'] = 'test-sai-key';
+    process.env['SAI_API_BASE_URL'] = 'http://sai.example.internal:8787';
+  });
+
+  afterEach(() => {
+    if (savedApiKey === undefined) delete process.env['SAI_API_KEY'];
+    else process.env['SAI_API_KEY'] = savedApiKey;
+    if (savedBaseUrl === undefined) delete process.env['SAI_API_BASE_URL'];
+    else process.env['SAI_API_BASE_URL'] = savedBaseUrl;
+  });
+
+  describe('submitSaiTask', () => {
+    it('SAI_API_KEY未設定時は例外を投げAPIを呼ばない', async () => {
+      delete process.env['SAI_API_KEY'];
+      await expect(submitSaiTask({ description: 'x' })).rejects.toThrow('SAI_API_KEY not set');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('Bearer認証ヘッダー付きでPOSTし、task_idを返す', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ task_id: 'task-1', status: 'queued' }),
+      });
+
+      const result = await submitSaiTask({ description: 'FAQ登録代行', orderId: 'order-1', maxSteps: 20 });
+
+      expect(result).toEqual({ task_id: 'task-1', status: 'queued' });
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://sai.example.internal:8787/v1/tasks',
+        expect.objectContaining({
+          method: 'POST',
+          headers: expect.objectContaining({ Authorization: 'Bearer test-sai-key' }),
+        }),
+      );
+      const body = JSON.parse((mockFetch.mock.calls[0]![1] as any).body);
+      expect(body).toEqual({ description: 'FAQ登録代行', max_steps: 20, order_id: 'order-1' });
+    });
+
+    it('max_steps省略時はデフォルト15を送る', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => ({ task_id: 't', status: 'queued' }) });
+      await submitSaiTask({ description: 'x' });
+      const body = JSON.parse((mockFetch.mock.calls[0]![1] as any).body);
+      expect(body.max_steps).toBe(15);
+    });
+
+    it('APIエラー時は例外を投げる', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 503, text: async () => 'busy' });
+      await expect(submitSaiTask({ description: 'x' })).rejects.toThrow('Sai API error: 503');
+    });
+  });
+
+  describe('getSaiTask', () => {
+    it('Bearer認証ヘッダー付きでGETし、タスク状態を返す', async () => {
+      const taskBody = { status: 'complete', steps: 3, description: 'x', max_steps: 15, outcome: 'agent_reported_done', final_screenshot_base64: 'AAAA' };
+      mockFetch.mockResolvedValueOnce({ ok: true, json: async () => taskBody });
+
+      const result = await getSaiTask('task-1');
+
+      expect(result).toEqual(taskBody);
+      expect(mockFetch).toHaveBeenCalledWith(
+        'http://sai.example.internal:8787/v1/tasks/task-1',
+        expect.objectContaining({ headers: expect.objectContaining({ Authorization: 'Bearer test-sai-key' }) }),
+      );
+    });
+
+    it('404などAPIエラー時は例外を投げる', async () => {
+      mockFetch.mockResolvedValueOnce({ ok: false, status: 404, text: async () => 'not found' });
+      await expect(getSaiTask('missing')).rejects.toThrow('Sai API error: 404');
+    });
+  });
+});

--- a/src/lib/sai/saiClient.ts
+++ b/src/lib/sai/saiClient.ts
@@ -1,0 +1,87 @@
+// src/lib/sai/saiClient.ts
+// Sai (Agent S) VPS への接続クライアント（Phase2: 接続ブリッジ）
+//
+// 重要: エージェントの自己申告(outcome)は信用しない設計。
+// getTask() は常に final_screenshot_base64 を含んだ生のタスク状態を返すので、
+// 呼び出し元（options routes）は必ず人間のレビュー（既存の /complete フロー）を
+// 経由させること。ここでは自動完了判定を一切行わない。
+
+import pino from 'pino';
+
+const logger = pino();
+
+const SAI_DEFAULT_MAX_STEPS = 15;
+
+function baseUrl(): string {
+  return process.env['SAI_API_BASE_URL'] ?? 'http://204.168.207.52:8787';
+}
+
+export type SaiTaskStatus = 'queued' | 'running' | 'complete';
+
+export interface SaiTaskStep {
+  step: number;
+  action: string;
+  reflection?: string;
+  error?: string;
+}
+
+export interface SaiTask {
+  status: SaiTaskStatus;
+  steps: number;
+  order_id?: string | null;
+  description: string;
+  max_steps: number;
+  last_action?: string;
+  outcome?: 'agent_reported_done' | 'agent_reported_fail' | 'step_limit_reached' | 'error' | 'unknown';
+  steps_log?: SaiTaskStep[];
+  final_screenshot_base64?: string;
+  started_at?: number;
+  finished_at?: number;
+}
+
+function apiKey(): string {
+  const key = process.env['SAI_API_KEY'];
+  if (!key) throw new Error('SAI_API_KEY not set');
+  return key;
+}
+
+export async function submitSaiTask(opts: {
+  description: string;
+  orderId?: string;
+  maxSteps?: number;
+}): Promise<{ task_id: string; status: string }> {
+  const res = await fetch(`${baseUrl()}/v1/tasks`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey()}`,
+    },
+    body: JSON.stringify({
+      description: opts.description,
+      max_steps: opts.maxSteps ?? SAI_DEFAULT_MAX_STEPS,
+      order_id: opts.orderId ?? null,
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    logger.warn({ status: res.status, body }, 'submitSaiTask: API error');
+    throw new Error(`Sai API error: ${res.status}`);
+  }
+
+  return res.json() as Promise<{ task_id: string; status: string }>;
+}
+
+export async function getSaiTask(taskId: string): Promise<SaiTask> {
+  const res = await fetch(`${baseUrl()}/v1/tasks/${taskId}`, {
+    headers: { Authorization: `Bearer ${apiKey()}` },
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => '');
+    logger.warn({ status: res.status, body }, 'getSaiTask: API error');
+    throw new Error(`Sai API error: ${res.status}`);
+  }
+
+  return res.json() as Promise<SaiTask>;
+}


### PR DESCRIPTION
## Summary
- R2C本体からSai(Agent S) VPS(204.168.207.52)へHTTPで接続する `saiClient.ts` を追加
- `POST /v1/admin/options/:id/try-sai` — 代行作業をSaiエージェントに試行させる(super_adminのみ)
- `GET /v1/admin/options/:id/sai-task` — 実行結果(ステップログ・最終スクリーンショット)を取得(super_adminのみ)
- `option_orders` に `sai_task_id` / `sai_outcome` / `sai_tried_at` を追加するマイグレーション

## 設計方針
PoC検証で、Agent Sの自己申告(done/fail)は必ずしも実際の作業結果と一致しないことが確認済み。
そのため本PRでは **完了判定を一切自動化しない**:
- try-sai / sai-task は `status` / `final_amount` / `completed_at` を更新しない
- 人間(super_admin)が `final_screenshot_base64` を見て、既存の `PUT /:id/complete` を叩いて確定する

## Test plan
- [x] `npx jest src/lib/sai src/api/admin/options` — 全33件パス
- [x] `npx jest` フルスイート — パス
- [x] `npx tsc --noEmit` — エラーなし
- [x] R2C本番VPS(65.108.159.161) → Sai VPS(204.168.207.52:8787) のUFW疎通確認済み(curl /v1/health成功)
- [x] Sai VPS側でE2Eテスト実施済み(タスク投入→ポーリング→完了→スクリーンショット取得まで確認)
- [ ] デプロイ後、実際の `option_orders` レコードに対して try-sai → sai-task の一連の流れを本番で確認

## デプロイ時の注意
- 本番VPSの `.env` に `SAI_API_BASE_URL` / `SAI_API_KEY` を追加済み(このPRとは別にSSHで直接設定、コミット対象外)
- `deploy-vps.sh` によるデプロイでPM2再起動され、新しい環境変数が反映される想定

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bu7k7x6P4Aa7MGMF4ymjSp