### PR TITLE
feat: Sai(Agent S)実行分の社内原価トラッキング(Phase3課金配線)

### DIFF
--- a/src/api/admin/options/routes.ts
+++ b/src/api/admin/options/routes.ts
@@ -8,6 +8,7 @@ import { logger } from '../../../lib/logger';
 import { chargeOneOffJpy } from '../../../lib/billing/stripeSync';
 import { createNotification } from '../../../lib/notifications';
 import { submitSaiTask, getSaiTask } from '../../../lib/sai/saiClient';
+import { trackUsage } from '../../../lib/billing/usageTracker';
 
 // ---------------------------------------------------------------------------
 // ALLOWED_ROLES whitelist (Phase69-1.5 PR-C4 v2)
@@ -394,14 +395,15 @@ export function registerOptionRoutes(app: Express): void {
     try {
       const pool = getPool();
       const orderResult = await pool.query(
-        `SELECT sai_task_id FROM option_orders WHERE id = $1`,
+        `SELECT tenant_id, sai_task_id FROM option_orders WHERE id = $1`,
         [id],
       ).catch((err: any) => {
         if (err?.code === '42703') return { rowCount: 0, rows: [] } as any;
         throw err;
       });
 
-      const saiTaskId = orderResult.rows[0]?.sai_task_id as string | undefined;
+      const orderRow = orderResult.rows[0] as { tenant_id?: string; sai_task_id?: string } | undefined;
+      const saiTaskId = orderRow?.sai_task_id;
       if (!saiTaskId) {
         return res.status(404).json({ error: 'この発注はまだSaiで試行されていません' });
       }
@@ -414,6 +416,21 @@ export function registerOptionRoutes(app: Express): void {
           .catch((err: any) => {
             if (err?.code !== '42703') throw err;
           });
+
+        // 社内原価集計のみ(テナント請求は既存の /complete → chargeOneOffJpy で完結)。
+        // requestIdをsai_task_idで固定し、再ポーリングでも二重計上しない(ON CONFLICT DO NOTHING)。
+        if (orderRow?.tenant_id) {
+          trackUsage({
+            tenantId: orderRow.tenant_id,
+            requestId: `sai-task:${saiTaskId}`,
+            model: 'agent-s',
+            inputTokens: 0,
+            outputTokens: 0,
+            featureUsed: 'sai_agent',
+            marginOverride: 1,
+            saiAgentSteps: task.steps,
+          });
+        }
       }
 
       return res.json({ task });

--- a/src/api/admin/options/saiBridge.test.ts
+++ b/src/api/admin/options/saiBridge.test.ts
@@ -29,6 +29,11 @@ jest.mock('../../../lib/sai/saiClient', () => ({
   getSaiTask: (...args: unknown[]) => mockGetSaiTask(...args),
 }));
 
+const mockTrackUsage = jest.fn();
+jest.mock('../../../lib/billing/usageTracker', () => ({
+  trackUsage: (...args: unknown[]) => mockTrackUsage(...args),
+}));
+
 function makeApp(role = 'client_admin', tenantId = 'tenant-x') {
   const app = express();
   app.use(express.json());
@@ -113,19 +118,20 @@ describe('GET /v1/admin/options/:id/sai-task', () => {
   });
 
   it('実行中タスクの状態(スクリーンショットなし)を返す', async () => {
-    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ sai_task_id: 'sai-task-1' }] });
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ tenant_id: 'tenant-x', sai_task_id: 'sai-task-1' }] });
     mockGetSaiTask.mockResolvedValueOnce({ status: 'running', steps: 2, description: 'x', max_steps: 15 });
 
     const res = await request(superAdminApp()).get('/v1/admin/options/order-1/sai-task');
 
     expect(res.status).toBe(200);
     expect(res.body.task.status).toBe('running');
-    // 完了前はDBを更新しない
+    // 完了前はDBを更新しない・課金記録もしない
     expect(mockQuery).toHaveBeenCalledTimes(1);
+    expect(mockTrackUsage).not.toHaveBeenCalled();
   });
 
   it('完了タスクはfinal_screenshot_base64を含めて返し、sai_outcomeを保存する（自動完了はしない）', async () => {
-    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ sai_task_id: 'sai-task-1' }] });
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ tenant_id: 'tenant-x', sai_task_id: 'sai-task-1' }] });
     mockGetSaiTask.mockResolvedValueOnce({
       status: 'complete', steps: 3, description: 'x', max_steps: 15,
       outcome: 'agent_reported_done', final_screenshot_base64: 'AAAA', steps_log: [],
@@ -141,5 +147,16 @@ describe('GET /v1/admin/options/:id/sai-task', () => {
       ['order-1', 'agent_reported_done'],
     );
     // status/final_amount/completed_atなどは一切更新しない = /complete エンドポイントとは別経路
+
+    // 社内原価集計: sai_agentとしてtrackUsageを呼ぶ(テナント請求には影響しない marginOverride:1)
+    expect(mockTrackUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: 'tenant-x',
+        requestId: 'sai-task:sai-task-1',
+        featureUsed: 'sai_agent',
+        marginOverride: 1,
+        saiAgentSteps: 3,
+      }),
+    );
   });
 });

--- a/src/lib/billing/costCalculator.test.ts
+++ b/src/lib/billing/costCalculator.test.ts
@@ -524,6 +524,51 @@ describe('calculateBillingAmountCents: imageCount', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Phase3 (Sai接続ブリッジ): saiAgentSteps コスト組み込み
+// ---------------------------------------------------------------------------
+describe('calculateBillingAmountCents: saiAgentSteps', () => {
+  it('saiAgentSteps=0 は既存と同結果', () => {
+    const base = calculateBillingAmountCents({
+      model: 'agent-s', inputTokens: 0, outputTokens: 0,
+    });
+    const withZero = calculateBillingAmountCents({
+      model: 'agent-s', inputTokens: 0, outputTokens: 0, saiAgentSteps: 0,
+    });
+    expect(withZero).toBe(base);
+  });
+
+  it('saiAgentSteps=3: SAI_AGENT_COST_PER_STEP_USD(デフォルト$0.05)の3ステップ分が加算される', () => {
+    // serverCost=0.0001, saiCost=3*0.05=0.15 → total=0.1501 USD → Math.ceil(15.01) = 16 cents
+    const result = calculateBillingAmountCents({
+      model: 'agent-s', inputTokens: 0, outputTokens: 0,
+      featureUsed: 'sai_agent', saiAgentSteps: 3,
+    });
+    expect(result).toBe(16);
+  });
+
+  it('featureUsed=sai_agentはEND_USER_FEATURESに含まれないため原価のみ(×1)', () => {
+    const withMargin = calculateBillingAmountCents({
+      model: 'agent-s', inputTokens: 0, outputTokens: 0,
+      featureUsed: 'sai_agent', saiAgentSteps: 1, marginOverride: 5,
+    });
+    const atCost = calculateBillingAmountCents({
+      model: 'agent-s', inputTokens: 0, outputTokens: 0,
+      featureUsed: 'sai_agent', saiAgentSteps: 1,
+    });
+    // marginOverride を明示しない限り管理機能扱いで×1、明示すればそちらが優先される
+    expect(atCost).toBeLessThan(withMargin);
+  });
+
+  it('整数を返す', () => {
+    const result = calculateBillingAmountCents({
+      model: 'agent-s', inputTokens: 0, outputTokens: 0,
+      saiAgentSteps: 7,
+    });
+    expect(Number.isInteger(result)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Phase53: END_USER_FEATURES 定数チェック
 // ---------------------------------------------------------------------------
 describe('END_USER_FEATURES', () => {

--- a/src/lib/billing/costCalculator.ts
+++ b/src/lib/billing/costCalculator.ts
@@ -57,6 +57,13 @@ function calculateAnamSessionCostCents(sessionSeconds: number): number {
 /** Phase41: DALL-E 3 画像生成単価: $0.04/枚 */
 export const IMAGE_GENERATION_COST_USD = 0.04;
 
+/**
+ * Phase3 (Sai接続ブリッジ): GUI自動化エージェント1ステップあたりの原価見積もり(USD)。
+ * PoC時点ではClaude Opus(推論) + UI-TARS(grounding, OpenRouter経由)の実測コストが
+ * タスクの複雑さで大きく変動するため未確定(要検証)。env override で運用しながら調整する。
+ */
+export const SAI_AGENT_COST_PER_STEP_USD = Number(process.env.SAI_AGENT_COST_PER_STEP_USD ?? '0.05') || 0.05;
+
 export interface UsageRecord {
   model: string;
   inputTokens: number;
@@ -85,6 +92,8 @@ export interface UsageRecord {
    * 各要素はそれぞれ自分の model 単価で計算され、サーバーコストは加算しない。
    */
   extraLlmUsages?: Array<{ model: string; inputTokens: number; outputTokens: number }>;
+  /** Phase3 (Sai接続ブリッジ): Agent Sが実行したステップ数（社内原価集計のみ、テナント請求には使わない） */
+  saiAgentSteps?: number;
 }
 
 /** Subtask 3: 追加 LLM 呼び出し（planner 等）の LLM コストを USD 合算する（モデル別実レート）。 */
@@ -207,6 +216,7 @@ export function calculateBillingAmountCents(usage: UsageRecord): number {
   const anamUSD  = (usage.anam_session_seconds ?? 0) > 0
     ? calculateAnamSessionCostCents(usage.anam_session_seconds!) / 100
     : 0;
-  const totalUSD = llmUSD + SERVER_COST_PER_REQUEST_USD + ttsUSD + avtrUSD + imgUSD + anamUSD;
+  const saiUSD   = (usage.saiAgentSteps ?? 0) * SAI_AGENT_COST_PER_STEP_USD;
+  const totalUSD = llmUSD + SERVER_COST_PER_REQUEST_USD + ttsUSD + avtrUSD + imgUSD + anamUSD + saiUSD;
   return Math.ceil(totalUSD * margin * 100);
 }

--- a/src/lib/billing/migration_sai_agent_feature.sql
+++ b/src/lib/billing/migration_sai_agent_feature.sql
@@ -1,0 +1,28 @@
+-- Phase3 (Sai課金配線): usage_logs.feature_used の CHECK 制約を拡張
+-- 追加: sai_agent
+--
+-- あわせて、既にコード上で使われているが制約に含まれておらず
+-- INSERTがサイレントに失敗していた値も追加する(2026-07-06確認: 本番DBのCHECK制約に
+-- option_service / premium_avatar_generation / admin_agent が含まれていなかった)。
+
+ALTER TABLE usage_logs DROP CONSTRAINT IF EXISTS usage_logs_feature_used_check;
+
+ALTER TABLE usage_logs ADD CONSTRAINT usage_logs_feature_used_check
+  CHECK (feature_used IN (
+    'chat',
+    'avatar',
+    'voice',
+    'admin_guide',
+    'avatar_config_image',
+    'avatar_config_voice',
+    'avatar_config_prompt',
+    'avatar_config_test',
+    'anam_session',
+    'feedback_ai',
+    'book_analysis',
+    'book_structurize',
+    'option_service',
+    'premium_avatar_generation',
+    'admin_agent',
+    'sai_agent'
+  ));

--- a/src/lib/billing/usageTracker.ts
+++ b/src/lib/billing/usageTracker.ts
@@ -4,7 +4,7 @@
 import type pino from 'pino';
 import { calculateLLMCostCents, calculateBillingAmountCents, normalizeModelKey } from './costCalculator';
 
-export type FeatureUsed = 'chat' | 'avatar' | 'voice' | 'avatar_config_image' | 'avatar_config_voice' | 'avatar_config_prompt' | 'avatar_config_test' | 'anam_session' | 'option_service' | 'premium_avatar_generation' | 'admin_agent';
+export type FeatureUsed = 'chat' | 'avatar' | 'voice' | 'avatar_config_image' | 'avatar_config_voice' | 'avatar_config_prompt' | 'avatar_config_test' | 'anam_session' | 'option_service' | 'premium_avatar_generation' | 'admin_agent' | 'sai_agent';
 
 export interface TrackUsageParams {
   tenantId: string;
@@ -30,6 +30,8 @@ export interface TrackUsageParams {
    * モデル別の実レートで本行のコストに内包する（別 usage_log を作らず請求リクエスト数を保つ）。
    */
   extraLlmUsages?: Array<{ model: string; inputTokens: number; outputTokens: number }>;
+  /** Phase3 (Sai接続ブリッジ): Agent Sが実行したステップ数（社内原価集計のみ） */
+  saiAgentSteps?: number;
 }
 
 let _pool: any | null = null;
@@ -59,7 +61,7 @@ async function _insertUsageLog(params: TrackUsageParams): Promise<void> {
   const {
     tenantId, requestId, model, inputTokens, outputTokens,
     featureUsed, marginOverride, ttsTextBytes, avatarCredits, avatarSessionMs, imageCount,
-    anam_session_seconds, extraLlmUsages,
+    anam_session_seconds, extraLlmUsages, saiAgentSteps,
   } = params;
 
   // Subtask 3: 追加 LLM（planner 等）に価格表に無いモデルが来た場合、コストは 0 計上になる。
@@ -82,7 +84,7 @@ async function _insertUsageLog(params: TrackUsageParams): Promise<void> {
     costTotalCents = calculateBillingAmountCents({
       model, inputTokens, outputTokens, marginOverride,
       ttsTextBytes, avatarCredits, avatarSessionMs,
-      featureUsed, imageCount, anam_session_seconds, extraLlmUsages,
+      featureUsed, imageCount, anam_session_seconds, extraLlmUsages, saiAgentSteps,
     });
   } catch (err) {
     _logger?.warn({ err, requestId }, '[usageTracker] cost calculation error, defaulting to 0');


### PR DESCRIPTION
## Summary
- Sai(Agent S)によるGUI自動化作業の実行コストを社内可視化するための課金配線
- テナントへの請求は変更しない: `PUT /:id/complete` → `chargeOneOffJpy` の確定金額請求で完結（Saiでも人間でも同じ）
- `sai_agent` を `FeatureUsed` に追加し、Saiタスク完了時にステップ数ベースの原価を `usage_logs` に記録（`marginOverride: 1` で原価のみ）
- `usage_logs.feature_used` のCHECK制約を拡張。本番DBの実際の制約を確認したところ `option_service` / `premium_avatar_generation` / `admin_agent` が既存コードで使われているのに制約から漏れており、該当の `trackUsage` 呼び出しがサイレントに失敗していたことが判明したため、同じマイグレーションでまとめて追加

## 設計判断の経緯
Phase3当初案では「sai_agentをFeatureUsedに追加しStripe従量課金を配線する」としていたが、本システムのStripe請求は「usage_logsの行数 × プラン倍率」の単純なリクエスト数課金であり金額に連動しない。Sai/人間どちらが代行しても顧客が支払う金額は既存の確定額請求で決まるため、ここで新たに追加すべきは顧客請求ロジックではなく「Sai実行にどれだけAPIコストがかかっているか」というR2C社内の原価可視化。ユーザーとの相談の上でこの方針に確定。

## Test plan
- [x] `npx jest src/lib/billing src/api/admin/options src/lib/sai` — 全170件パス
- [x] `npx jest` フルスイート — パス
- [x] `npx tsc --noEmit` — エラーなし
- [x] 本番DBにマイグレーション適用済み（CHECK制約拡張を確認）

## デプロイ時の注意
特別な環境変数追加は不要（`SAI_AGENT_COST_PER_STEP_USD` は未設定時デフォルト$0.05/ステップで動作、必要なら後から調整可能）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bu7k7x6P4Aa7MGMF4ymjSp