### PR TITLE
feat: 代行作業管理画面にSai(Agent S)依頼・結果レビューUIを追加(Phase4)

### DIFF
--- a/admin-ui/src/pages/admin/options/index.test.tsx
+++ b/admin-ui/src/pages/admin/options/index.test.tsx
@@ -1,0 +1,122 @@
+// Phase4 (Sai接続ブリッジ管理UI): Saiセクションの表示・依頼・結果レビューの回帰テスト
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import OptionManagementPage from './index';
+import { useAuth } from '../../../auth/useAuth';
+import { authFetch } from '../../../lib/api';
+
+vi.mock('../../../auth/useAuth', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('react-router-dom', async () => {
+  const actual = await vi.importActual('react-router-dom');
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+
+vi.mock('../../../lib/api', () => ({
+  API_BASE: 'http://localhost:3100',
+  authFetch: vi.fn(),
+}));
+
+const SUPER_ADMIN = {
+  user: { id: '1', email: 'admin@example.com', role: 'super_admin', tenantId: null, tenantName: null },
+  isSuperAdmin: true,
+  isClientAdmin: false,
+  isLoading: false,
+  logout: vi.fn(),
+  previewMode: false,
+  previewTenantId: null,
+  previewTenantName: null,
+  enterPreview: vi.fn(),
+  exitPreview: vi.fn(),
+};
+
+const ORDER = {
+  id: 'order-1',
+  tenant_id: 'tenant-x',
+  chat_session_id: null,
+  description: 'FAQ登録代行',
+  llm_estimate_amount: 10000,
+  final_amount: null,
+  status: 'pending' as const,
+  stripe_usage_recorded: false,
+  ordered_at: '2026-07-01T00:00:00Z',
+  completed_at: null,
+  created_at: '2026-07-01T00:00:00Z',
+  updated_at: '2026-07-01T00:00:00Z',
+};
+
+const mockOk = (data: unknown, status = 200): Promise<Response> =>
+  Promise.resolve({ ok: status < 300, status, json: () => Promise.resolve(data) } as Response);
+
+describe('OptionManagementPage — Sai(Agent S)セクション', () => {
+  beforeEach(() => {
+    vi.mocked(useAuth).mockReturnValue(SUPER_ADMIN as ReturnType<typeof useAuth>);
+    vi.mocked(authFetch).mockReset();
+  });
+
+  async function openOrderDetail() {
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (url.includes('/v1/admin/options?')) return mockOk({ items: [ORDER], total: 1 });
+      if (url.includes('/sai-task')) return mockOk({}, 404);
+      return mockOk({});
+    });
+
+    render(<OptionManagementPage />);
+    await waitFor(() => expect(screen.queryByText('FAQ登録代行')).toBeTruthy());
+    fireEvent.click(screen.getByText('FAQ登録代行'));
+    await waitFor(() => expect(screen.queryByText('▶ Saiに依頼する')).toBeTruthy());
+  }
+
+  it('未試行の発注では「Saiに依頼する」ボタンが表示される', async () => {
+    await openOrderDetail();
+    expect(screen.getByText('▶ Saiに依頼する')).toBeTruthy();
+  });
+
+  it('依頼するとtry-saiを叩き、以後sai-taskをポーリングして状態を表示する', async () => {
+    await openOrderDetail();
+
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (url.includes('/try-sai')) return mockOk({ task_id: 'sai-task-1', status: 'queued' });
+      if (url.includes('/sai-task')) {
+        return mockOk({ task: { status: 'running', steps: 2, max_steps: 15, description: 'x', last_action: 'click(100,200)' } });
+      }
+      if (url.includes('/v1/admin/options?')) return mockOk({ items: [ORDER], total: 1 });
+      return mockOk({});
+    });
+
+    window.confirm = vi.fn().mockReturnValue(true);
+    fireEvent.click(screen.getByText('▶ Saiに依頼する'));
+
+    await waitFor(() => expect(screen.queryByText('実行中')).toBeTruthy());
+    expect(screen.getByText(/click\(100,200\)/)).toBeTruthy();
+  });
+
+  it('完了タスクはスクリーンショットと自己申告の注意書きを表示する（自動完了はしない）', async () => {
+    await openOrderDetail();
+
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (url.includes('/try-sai')) return mockOk({ task_id: 'sai-task-1', status: 'queued' });
+      if (url.includes('/sai-task')) {
+        return mockOk({
+          task: {
+            status: 'complete', steps: 3, max_steps: 15, description: 'x',
+            outcome: 'agent_reported_done', final_screenshot_base64: 'AAAA', steps_log: [],
+          },
+        });
+      }
+      if (url.includes('/v1/admin/options?')) return mockOk({ items: [ORDER], total: 1 });
+      return mockOk({});
+    });
+
+    window.confirm = vi.fn().mockReturnValue(true);
+    fireEvent.click(screen.getByText('▶ Saiに依頼する'));
+
+    await waitFor(() => expect(screen.queryByText('Saiが完了を報告')).toBeTruthy());
+    expect(screen.getByAltText('Sai実行後の最終スクリーンショット')).toBeTruthy();
+    expect(screen.getByText(/実際の成否は下のスクリーンショットを目視確認/)).toBeTruthy();
+    // 完了マークボタンは既存のまま独立して存在する(Saiが自動で押すことはない)
+    expect(screen.getByText('✅ 完了マーク')).toBeTruthy();
+  });
+});

--- a/admin-ui/src/pages/admin/options/index.tsx
+++ b/admin-ui/src/pages/admin/options/index.tsx
@@ -1,7 +1,7 @@
 // admin-ui/src/pages/admin/options/index.tsx
 // Phase63: オプション代行管理ページ（super_admin専用）
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import { authFetch, API_BASE } from "../../../lib/api";
 import { useAuth } from "../../../auth/useAuth";
@@ -26,6 +26,32 @@ interface OptionOrder {
 }
 
 type StatusFilter = "" | "pending" | "in_progress" | "completed";
+
+interface SaiTaskStep {
+  step: number;
+  action: string;
+  reflection?: string;
+  error?: string;
+}
+
+interface SaiTask {
+  status: "queued" | "running" | "complete";
+  steps: number;
+  max_steps: number;
+  description: string;
+  last_action?: string;
+  outcome?: "agent_reported_done" | "agent_reported_fail" | "step_limit_reached" | "error" | "unknown";
+  steps_log?: SaiTaskStep[];
+  final_screenshot_base64?: string;
+}
+
+const SAI_OUTCOME_LABEL: Record<string, string> = {
+  agent_reported_done: "Saiが完了を報告",
+  agent_reported_fail: "Saiが失敗を報告",
+  step_limit_reached: "ステップ上限に到達",
+  error: "エラーで停止",
+  unknown: "不明",
+};
 
 // ---------------------------------------------------------------------------
 // ステータスバッジ
@@ -483,6 +509,14 @@ function OrderDetailModal({
           </p>
         )}
 
+        {/* Sai(Agent S)セクション */}
+        {order.status !== "completed" && (
+          <>
+            <hr style={{ border: "none", borderTop: `1px solid ${BORDER}`, margin: "16px 0" }} />
+            <SaiSection orderId={order.id} />
+          </>
+        )}
+
         {/* お知らせ送信フォーム */}
         {showNotifyForm && (
           <div style={{ marginTop: 16, padding: 16, background: "rgba(255,255,255,0.03)", border: `1px solid ${BORDER}`, borderRadius: 10 }}>
@@ -544,6 +578,156 @@ function OrderDetailModal({
           </div>
         )}
       </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Sai(Agent S)セクション — GUI自動化エージェントへの試行・結果レビュー
+//
+// 重要: Saiの自己申告(outcome)は成否の確定情報ではない。最終スクリーンショットを
+// 人間(super_admin)が目視確認した上で、上の「完了マーク」ボタンで完了させる運用。
+// ここでは status/final_amount 等を一切自動更新しない。
+// ---------------------------------------------------------------------------
+
+function SaiSection({ orderId }: { orderId: string }) {
+  const BORDER = "#1f2937";
+  const TEXT_MAIN = "#f9fafb";
+  const TEXT_SUB = "#9ca3af";
+
+  const [task, setTask] = useState<SaiTask | null>(null);
+  const [starting, setStarting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showLog, setShowLog] = useState(false);
+  const pollTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const clearPoll = useCallback(() => {
+    if (pollTimer.current) {
+      clearTimeout(pollTimer.current);
+      pollTimer.current = null;
+    }
+  }, []);
+
+  const fetchTask = useCallback(async (schedule: boolean) => {
+    try {
+      const res = await authFetch(`${API_BASE}/v1/admin/options/${orderId}/sai-task`);
+      if (res.status === 404) return; // 未試行
+      if (!res.ok) {
+        setError("Sai実行結果の取得に失敗しました");
+        return;
+      }
+      const data = await res.json() as { task: SaiTask };
+      setTask(data.task);
+      if (schedule && data.task.status !== "complete") {
+        pollTimer.current = setTimeout(() => { void fetchTask(true); }, 3000);
+      }
+    } catch {
+      setError("Sai実行結果の取得に失敗しました");
+    }
+  }, [orderId]);
+
+  // マウント時: 既に試行済みなら状態を復元してポーリング再開
+  useEffect(() => {
+    void fetchTask(true);
+    return () => clearPoll();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [orderId]);
+
+  const handleTrySai = async () => {
+    if (!confirm("Saiエージェントにこの作業を試行させますか？\n実際にブラウザ操作等を行い、API利用コストが発生します。")) return;
+    setStarting(true);
+    setError(null);
+    try {
+      const res = await authFetch(`${API_BASE}/v1/admin/options/${orderId}/try-sai`, { method: "POST" });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setError((body as { error?: string }).error ?? "Saiへの依頼に失敗しました");
+        return;
+      }
+      clearPoll();
+      void fetchTask(true);
+    } catch {
+      setError("Saiへの依頼に失敗しました");
+    } finally {
+      setStarting(false);
+    }
+  };
+
+  const isRunning = task && task.status !== "complete";
+
+  return (
+    <div style={{ marginBottom: 20 }}>
+      <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 10 }}>
+        <p style={{ fontSize: 13, fontWeight: 600, color: TEXT_MAIN, margin: 0 }}>🤖 Sai(Agent S)による代行試行</p>
+        <button
+          onClick={() => void handleTrySai()}
+          disabled={starting || !!isRunning}
+          style={{
+            padding: "6px 14px", borderRadius: 8, border: "none",
+            background: "#7c3aed", color: "#fff", fontSize: 12, fontWeight: 600,
+            cursor: starting || isRunning ? "not-allowed" : "pointer",
+            opacity: starting || isRunning ? 0.6 : 1, minHeight: 32,
+          }}
+        >
+          {starting ? "依頼中..." : task ? "🔁 再試行" : "▶ Saiに依頼する"}
+        </button>
+      </div>
+
+      {error && <p style={{ fontSize: 12, color: "#f87171", margin: "0 0 8px" }}>{error}</p>}
+
+      {task && (
+        <div style={{ background: "rgba(124,58,237,0.08)", border: "1px solid rgba(124,58,237,0.25)", borderRadius: 10, padding: 12 }}>
+          <div style={{ display: "flex", gap: 12, fontSize: 12, color: TEXT_SUB, marginBottom: 8, flexWrap: "wrap" }}>
+            <span>状態: <strong style={{ color: TEXT_MAIN }}>
+              {task.status === "queued" ? "待機中" : task.status === "running" ? "実行中" : "完了"}
+            </strong></span>
+            <span>ステップ: <strong style={{ color: TEXT_MAIN }}>{task.steps} / {task.max_steps}</strong></span>
+            {task.outcome && (
+              <span>自己申告: <strong style={{ color: TEXT_MAIN }}>{SAI_OUTCOME_LABEL[task.outcome] ?? task.outcome}</strong></span>
+            )}
+          </div>
+
+          {isRunning && task.last_action && (
+            <p style={{ fontSize: 11, color: TEXT_SUB, fontFamily: "monospace", margin: "0 0 8px", wordBreak: "break-all" }}>
+              直近の操作: {task.last_action}
+            </p>
+          )}
+
+          {task.status === "complete" && (
+            <>
+              <p style={{ fontSize: 11, color: "#fbbf24", margin: "0 0 8px" }}>
+                ⚠️ 上記は Sai の自己申告です。実際の成否は下のスクリーンショットを目視確認してから「完了マーク」で確定してください。
+              </p>
+              {task.final_screenshot_base64 && (
+                <img
+                  src={`data:image/png;base64,${task.final_screenshot_base64}`}
+                  alt="Sai実行後の最終スクリーンショット"
+                  style={{ width: "100%", borderRadius: 8, border: `1px solid ${BORDER}`, marginBottom: 8 }}
+                />
+              )}
+              {task.steps_log && task.steps_log.length > 0 && (
+                <>
+                  <button
+                    onClick={() => setShowLog((v) => !v)}
+                    style={{ background: "none", border: "none", color: "#a78bfa", fontSize: 11, cursor: "pointer", padding: 0 }}
+                  >
+                    {showLog ? "▲ 操作ログを隠す" : "▼ 操作ログを見る"}
+                  </button>
+                  {showLog && (
+                    <div style={{ marginTop: 8, display: "flex", flexDirection: "column", gap: 6 }}>
+                      {task.steps_log.map((s) => (
+                        <div key={s.step} style={{ fontSize: 11, color: TEXT_SUB, fontFamily: "monospace", wordBreak: "break-all" }}>
+                          #{s.step} {s.error ? `error: ${s.error}` : s.action}
+                        </div>
+                      ))}
+                    </div>
+                  )}
+                </>
+              )}
+            </>
+          )}
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- `/admin/options` の発注詳細モーダルに「🤖 Sai(Agent S)による代行試行」セクションを追加(super_adminのみ、未完了の発注のみ表示)
- 「▶ Saiに依頼する」で `POST .../try-sai` を実行、以後3秒間隔で `GET .../sai-task` をポーリングし、状態(待機中/実行中/完了)・ステップ数・直近の操作を表示
- 完了時は最終スクリーンショットと操作ログ(折りたたみ)を表示。自己申告(outcome)は「Saiが完了を報告」等のラベルとして見せるのみで、発注の自動完了は一切行わない
- モーダルを開いた時点で既に試行済みの発注があれば状態を復元してポーリング再開

## 設計方針
PoC検証で判明した「Agent Sの自己申告だけでは成否を判断できない」という前提を維持。UI上にも「⚠️ 上記はSaiの自己申告です。実際の成否は下のスクリーンショットを目視確認してから『完了マーク』で確定してください」と明示し、既存の完了フロー(人間によるレビュー→完了マーク→確定金額請求)は一切変更していない。

## Test plan
- [x] `npx vitest run src/pages/admin/options/index.test.tsx` — 3件パス(未試行時の表示/依頼→ポーリング/完了時のスクリーンショット表示)
- [x] `npx vitest run`(admin-ui フルスイート) — パス
- [x] `npx tsc --noEmit`(admin-ui) — エラーなし
- [ ] 実ブラウザでの目視確認は未実施(ブラウザ操作ツールが利用できないセッションのため、React Testing Libraryによるレンダリング・クリック・状態遷移の検証のみ実施)。マージ後、実際にsuper_adminでログインしてSai依頼→スクリーンショット表示までの一連の流れをご確認いただけると確実です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bu7k7x6P4Aa7MGMF4ymjSp