### PR TITLE
feat: Sai利用の月次コスト上限ガードレールを追加(Phase5セキュリティ強化)

### DIFF
--- a/src/api/admin/options/routes.ts
+++ b/src/api/admin/options/routes.ts
@@ -57,6 +57,27 @@ function denyInsufficient(req: Request, res: Response, su: Record<string, any> |
   return res.status(403).json({ error: '権限がありません', code: 'AUTHZ_ROLE_DENIED' });
 }
 
+// ---------------------------------------------------------------------------
+// Phase5 (Saiセキュリティ強化): 支出上限ガードレール
+// Sai VPS側の日次タスク数上限(SAI_MAX_TASKS_PER_DAY)とは独立した、
+// R2C本体側での月次コスト上限チェック(多層防御)。デフォルトOFF(未設定なら無制限)。
+// ---------------------------------------------------------------------------
+async function checkSaiMonthlyCostCeiling(pool: any): Promise<{ ok: true } | { ok: false; spentCents: number; ceilingCents: number }> {
+  const ceilingCents = Number(process.env.SAI_MONTHLY_COST_CEILING_CENTS ?? '0');
+  if (!ceilingCents || ceilingCents <= 0) return { ok: true };
+
+  const result = await pool.query(
+    `SELECT COALESCE(SUM(cost_total_cents), 0) AS total
+     FROM usage_logs
+     WHERE feature_used = 'sai_agent' AND created_at >= date_trunc('month', NOW())`,
+  );
+  const spentCents = parseInt(result.rows[0]?.total ?? '0', 10);
+  if (spentCents >= ceilingCents) {
+    return { ok: false, spentCents, ceilingCents };
+  }
+  return { ok: true };
+}
+
 export function registerOptionRoutes(app: Express): void {
   app.use('/v1/admin/options', supabaseAuthMiddleware);
 
@@ -342,6 +363,13 @@ export function registerOptionRoutes(app: Express): void {
 
     try {
       const pool = getPool();
+
+      const ceilingCheck = await checkSaiMonthlyCostCeiling(pool);
+      if (!ceilingCheck.ok) {
+        logger.warn({ event: 'sai_cost_ceiling_blocked', ...ceilingCheck }, 'try-sai blocked: monthly cost ceiling reached');
+        return res.status(429).json({ error: 'Sai利用の月次コスト上限に達しています。管理者に確認してください。' });
+      }
+
       const orderResult = await pool.query(
         `SELECT id, description FROM option_orders WHERE id = $1`,
         [id],

--- a/src/api/admin/options/saiBridge.test.ts
+++ b/src/api/admin/options/saiBridge.test.ts
@@ -50,8 +50,16 @@ function superAdminApp() {
 }
 
 describe('POST /v1/admin/options/:id/try-sai', () => {
+  const savedCeiling = process.env.SAI_MONTHLY_COST_CEILING_CENTS;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    delete process.env.SAI_MONTHLY_COST_CEILING_CENTS;
+  });
+
+  afterEach(() => {
+    if (savedCeiling === undefined) delete process.env.SAI_MONTHLY_COST_CEILING_CENTS;
+    else process.env.SAI_MONTHLY_COST_CEILING_CENTS = savedCeiling;
   });
 
   it('super_admin以外は403', async () => {
@@ -82,6 +90,41 @@ describe('POST /v1/admin/options/:id/try-sai', () => {
       expect.stringContaining('UPDATE option_orders SET sai_task_id'),
       ['order-1', 'sai-task-1'],
     );
+  });
+
+  it('SAI_MONTHLY_COST_CEILING_CENTS未設定時は上限チェックをスキップする(デフォルト無制限)', async () => {
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'order-1', description: 'x' }] });
+    mockSubmitSaiTask.mockResolvedValueOnce({ task_id: 'sai-task-1', status: 'queued' });
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+    const res = await request(superAdminApp()).post('/v1/admin/options/order-1/try-sai').send({});
+
+    expect(res.status).toBe(202);
+    // 上限チェックのSELECTは発火しない(合計2回=発注SELECT+sai_task_id UPDATEのみ)
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it('月次コスト上限に達している場合は429を返しSaiに依頼しない', async () => {
+    process.env.SAI_MONTHLY_COST_CEILING_CENTS = '1000';
+    mockQuery.mockResolvedValueOnce({ rows: [{ total: '1000' }] }); // 上限チェックSELECT
+
+    const res = await request(superAdminApp()).post('/v1/admin/options/order-1/try-sai').send({});
+
+    expect(res.status).toBe(429);
+    expect(mockSubmitSaiTask).not.toHaveBeenCalled();
+  });
+
+  it('月次コスト上限未満なら通常通りSaiに依頼する', async () => {
+    process.env.SAI_MONTHLY_COST_CEILING_CENTS = '1000';
+    mockQuery.mockResolvedValueOnce({ rows: [{ total: '500' }] }); // 上限チェックSELECT
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'order-1', description: 'x' }] });
+    mockSubmitSaiTask.mockResolvedValueOnce({ task_id: 'sai-task-1', status: 'queued' });
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+    const res = await request(superAdminApp()).post('/v1/admin/options/order-1/try-sai').send({});
+
+    expect(res.status).toBe(202);
+    expect(mockSubmitSaiTask).toHaveBeenCalled();
   });
 
   it('SAI_API_KEY未設定時は503', async () => {


### PR DESCRIPTION
## Summary
Phase5(セキュリティ強化)の一部。Sai VPS側で実施した非root化・監査ログ整備とあわせ、R2C本体側にも独立した支出上限ガードレールを追加。

- `checkSaiMonthlyCostCeiling()`: `usage_logs`の`feature_used='sai_agent'`(Phase3で追加済み)を当月分集計し、`SAI_MONTHLY_COST_CEILING_CENTS`を超えていたら`try-sai`を429でブロック
- デフォルトOFF(未設定なら無制限)。既存の`LEMONSLICE_MONTHLY_FEE_JPY`等と同じ「明示設定するまで無効」の方針を踏襲
- Sai VPS側の`SAI_MAX_TASKS_PER_DAY`(日次タスク数上限、こちらは既にVPS側へ反映・動作確認済み)とは別レイヤーの歯止めとして多層防御を構成

## Test plan
- [x] `npx jest src/api/admin/options/saiBridge.test.ts` — 12件パス
- [x] `npx jest`(フルスイート) — パス
- [x] `npx tsc --noEmit` — エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bu7k7x6P4Aa7MGMF4ymjSp