### PR TITLE
feat: Sai Judge学習ループの配線を先行実装(Phase6、提案ロジックは未実装)

### DIFF
--- a/admin-ui/src/pages/admin/options/index.test.tsx
+++ b/admin-ui/src/pages/admin/options/index.test.tsx
@@ -120,3 +120,42 @@ describe('OptionManagementPage — Sai(Agent S)セクション', () => {
     expect(screen.getByText('✅ 完了マーク')).toBeTruthy();
   });
 });
+
+describe('OptionManagementPage — Phase6 Sai提案ルール承認キュー', () => {
+  beforeEach(() => {
+    vi.mocked(useAuth).mockReturnValue(SUPER_ADMIN as ReturnType<typeof useAuth>);
+    vi.mocked(authFetch).mockReset();
+  });
+
+  it('承認待ちルールが0件の場合はパネルを表示しない(現状のデフォルト)', async () => {
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (url.includes('/v1/admin/options?')) return mockOk({ items: [], total: 0 });
+      if (url.includes('/sai-rules')) return mockOk({ items: [] });
+      return mockOk({});
+    });
+
+    render(<OptionManagementPage />);
+    await waitFor(() => expect(screen.queryByText('該当する発注はありません')).toBeTruthy());
+    expect(screen.queryByText(/Sai提案ルール/)).toBeNull();
+  });
+
+  it('承認待ちルールがある場合はパネルに件数を表示し、承認できる', async () => {
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (url.includes('/v1/admin/options?')) return mockOk({ items: [], total: 0 });
+      if (url.includes('/sai-rules/1/approve')) return mockOk({ item: { id: 1, status: 'active' } });
+      if (url.includes('/sai-rules')) {
+        return mockOk({ items: [{ id: 1, tenant_id: 'global', trigger_pattern: 'FAQ登録', expected_behavior: '保存ボタンは右上にある', priority: 0, is_active: false, status: 'pending', source: 'sai_judge', evidence: null, created_at: '' }] });
+      }
+      return mockOk({});
+    });
+
+    render(<OptionManagementPage />);
+    await waitFor(() => expect(screen.queryByText(/Sai提案ルール — 承認待ち 1件/)).toBeTruthy());
+
+    fireEvent.click(screen.getByText(/Sai提案ルール/));
+    await waitFor(() => expect(screen.queryByText('「FAQ登録」')).toBeTruthy());
+
+    fireEvent.click(screen.getByText('✅ 承認'));
+    await waitFor(() => expect(screen.queryByText('「FAQ登録」')).toBeNull());
+  });
+});

--- a/admin-ui/src/pages/admin/options/index.tsx
+++ b/admin-ui/src/pages/admin/options/index.tsx
@@ -45,6 +45,19 @@ interface SaiTask {
   final_screenshot_base64?: string;
 }
 
+interface SaiTaskRule {
+  id: number;
+  tenant_id: string;
+  trigger_pattern: string;
+  expected_behavior: string;
+  priority: number;
+  is_active: boolean;
+  status: string;
+  source: string;
+  evidence: { taskIds?: string[]; orderIds?: string[]; outcome?: string; note?: string } | null;
+  created_at: string;
+}
+
 const SAI_OUTCOME_LABEL: Record<string, string> = {
   agent_reported_done: "Saiが完了を報告",
   agent_reported_fail: "Saiが失敗を報告",
@@ -161,6 +174,8 @@ export default function OptionManagementPage() {
       <div style={{ maxWidth: 1100, margin: "0 auto" }}>
         <h1 style={{ fontSize: 20, fontWeight: 700, marginBottom: 4 }}>💼 代行作業の依頼・管理</h1>
         <p style={{ fontSize: 13, color: TEXT_SUB, marginBottom: 20 }}>テナントから依頼された代行作業の管理・金額確定・完了処理を行います</p>
+
+        <SaiRulesPanel />
 
         {/* フィルタータブ */}
         <div style={{ display: "flex", gap: 8, marginBottom: 16, flexWrap: "wrap" }}>
@@ -726,6 +741,108 @@ function SaiSection({ orderId }: { orderId: string }) {
               )}
             </>
           )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Phase6 (Sai Judge学習ループ): 提案ルールの承認キュー
+//
+// 現時点ではルールを自動提案するSai Judge本体は未実装(実行ログが十分に蓄積
+// してから着手予定)のため、通常は「提案されたルールはありません」の空状態になる。
+// 承認・却下の配線と注入経路(saiClient呼び出し前のtry-saiハンドラ)だけを
+// 先行して用意しておく。
+// ---------------------------------------------------------------------------
+
+function SaiRulesPanel() {
+  const BORDER = "var(--border)";
+  const TEXT_MAIN = "var(--foreground)";
+  const TEXT_SUB = "var(--muted-foreground)";
+
+  const [rules, setRules] = useState<SaiTaskRule[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [expanded, setExpanded] = useState(false);
+  const [processingId, setProcessingId] = useState<number | null>(null);
+
+  const fetchRules = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await authFetch(`${API_BASE}/v1/admin/sai-rules?status=pending`);
+      if (!res.ok) return;
+      const data = await res.json() as { items: SaiTaskRule[] };
+      setRules(data.items ?? []);
+    } catch {
+      // silent
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void fetchRules(); }, [fetchRules]);
+
+  const handleDecision = async (id: number, action: "approve" | "reject") => {
+    setProcessingId(id);
+    try {
+      await authFetch(`${API_BASE}/v1/admin/sai-rules/${id}/${action}`, { method: "PUT" });
+      setRules((prev) => prev.filter((r) => r.id !== id));
+    } catch {
+      // silent
+    } finally {
+      setProcessingId(null);
+    }
+  };
+
+  if (loading || rules.length === 0) return null; // 空状態はページを圧迫しないよう非表示
+
+  return (
+    <div style={{ marginBottom: 20, border: `1px solid ${BORDER}`, borderRadius: 10, overflow: "hidden" }}>
+      <button
+        onClick={() => setExpanded((v) => !v)}
+        style={{
+          width: "100%", display: "flex", alignItems: "center", justifyContent: "space-between",
+          padding: "12px 16px", background: "transparent", border: "none", cursor: "pointer",
+          color: TEXT_MAIN, fontSize: 14, fontWeight: 600,
+        }}
+      >
+        <span>🧠 Sai提案ルール — 承認待ち {rules.length}件</span>
+        <span style={{ color: TEXT_SUB, fontSize: 12 }}>{expanded ? "▲ 閉じる" : "▼ 開く"}</span>
+      </button>
+      {expanded && (
+        <div style={{ padding: "0 16px 16px", display: "flex", flexDirection: "column", gap: 12 }}>
+          {rules.map((rule) => (
+            <div key={rule.id} style={{ border: `1px solid ${BORDER}`, borderRadius: 8, padding: 12 }}>
+              <p style={{ fontSize: 12, color: TEXT_SUB, margin: "0 0 4px" }}>トリガー</p>
+              <p style={{ fontSize: 13, color: TEXT_MAIN, margin: "0 0 8px" }}>「{rule.trigger_pattern}」</p>
+              <p style={{ fontSize: 12, color: TEXT_SUB, margin: "0 0 4px" }}>提案内容</p>
+              <p style={{ fontSize: 13, color: TEXT_MAIN, margin: "0 0 10px", lineHeight: 1.6 }}>{rule.expected_behavior}</p>
+              <div style={{ display: "flex", gap: 8 }}>
+                <button
+                  onClick={() => void handleDecision(rule.id, "approve")}
+                  disabled={processingId === rule.id}
+                  style={{
+                    flex: 1, padding: "8px 14px", borderRadius: 8, border: "1px solid rgba(74,222,128,0.4)",
+                    background: "rgba(34,197,94,0.15)", color: "#4ade80", fontSize: 13, fontWeight: 600,
+                    cursor: processingId === rule.id ? "not-allowed" : "pointer", opacity: processingId === rule.id ? 0.6 : 1, minHeight: 36,
+                  }}
+                >
+                  ✅ 承認
+                </button>
+                <button
+                  onClick={() => void handleDecision(rule.id, "reject")}
+                  disabled={processingId === rule.id}
+                  style={{
+                    flex: 1, padding: "8px 14px", borderRadius: 8, border: "1px solid rgba(248,113,113,0.4)",
+                    background: "rgba(239,68,68,0.15)", color: "#f87171", fontSize: 13, fontWeight: 600,
+                    cursor: processingId === rule.id ? "not-allowed" : "pointer", opacity: processingId === rule.id ? 0.6 : 1, minHeight: 36,
+                  }}
+                >
+                  ❌ 却下
+                </button>
+              </div>
+            </div>
+          ))}
         </div>
       )}
     </div>

--- a/src/api/admin/options/routes.ts
+++ b/src/api/admin/options/routes.ts
@@ -9,6 +9,14 @@ import { chargeOneOffJpy } from '../../../lib/billing/stripeSync';
 import { createNotification } from '../../../lib/notifications';
 import { submitSaiTask, getSaiTask } from '../../../lib/sai/saiClient';
 import { trackUsage } from '../../../lib/billing/usageTracker';
+import {
+  listSaiRules,
+  approveSaiRule,
+  rejectSaiRule,
+  getActiveSaiRulesForTenant,
+  matchesSaiTriggerPattern,
+  buildSaiPromptSection,
+} from '../../../lib/sai/saiTaskRulesRepository';
 
 // ---------------------------------------------------------------------------
 // ALLOWED_ROLES whitelist (Phase69-1.5 PR-C4 v2)
@@ -80,6 +88,7 @@ async function checkSaiMonthlyCostCeiling(pool: any): Promise<{ ok: true } | { o
 
 export function registerOptionRoutes(app: Express): void {
   app.use('/v1/admin/options', supabaseAuthMiddleware);
+  app.use('/v1/admin/sai-rules', supabaseAuthMiddleware);
 
   // -------------------------------------------------------------------------
   // GET /v1/admin/options
@@ -371,16 +380,28 @@ export function registerOptionRoutes(app: Express): void {
       }
 
       const orderResult = await pool.query(
-        `SELECT id, description FROM option_orders WHERE id = $1`,
+        `SELECT id, tenant_id, description FROM option_orders WHERE id = $1`,
         [id],
       );
       if (orderResult.rowCount === 0) {
         return res.status(404).json({ error: '発注が見つかりません' });
       }
-      const order = orderResult.rows[0] as { id: string; description: string };
+      const order = orderResult.rows[0] as { id: string; tenant_id: string; description: string };
+
+      // Phase6 (Sai Judge学習ループ): 承認済みルールがあれば作業内容に注入する。
+      // ルールが0件(現状)なら buildSaiPromptSection は空文字を返し、既存の挙動と完全に同じになる。
+      let description = order.description;
+      try {
+        const activeRules = await getActiveSaiRulesForTenant(order.tenant_id);
+        const matched = activeRules.filter((r) => matchesSaiTriggerPattern(order.description, r.trigger_pattern));
+        const guidance = buildSaiPromptSection(matched);
+        if (guidance) description = `${guidance}\n\n${order.description}`;
+      } catch (err: any) {
+        if (err?.code !== '42P01') logger.warn('[POST /v1/admin/options/:id/try-sai] sai_task_rules lookup failed', err);
+      }
 
       const { task_id } = await submitSaiTask({
-        description: order.description,
+        description,
         orderId: order.id,
         maxSteps: max_steps,
       });
@@ -468,6 +489,73 @@ export function registerOptionRoutes(app: Express): void {
       }
       logger.warn('[GET /v1/admin/options/:id/sai-task]', err);
       return res.status(502).json({ error: 'Saiエージェントの状態取得に失敗しました' });
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // Phase6 (Sai Judge学習ループ): sai_task_rules 一覧・承認・却下
+  // 現時点ではルールを自動提案するSai Judge本体は未実装(実行ログが十分に
+  // 蓄積してから着手)。ここでは配線(一覧・承認・却下・注入)のみを用意し、
+  // ルールが0件の間は何も注入せず既存の挙動と完全に同じになる。
+  // -------------------------------------------------------------------------
+
+  app.get('/v1/admin/sai-rules', async (req: Request, res: Response) => {
+    const { su, role, isSuperAdmin } = extractAuth(req);
+    if (!isAllowedOptionRole(role)) {
+      return denyRole(req, res, su, role, ALLOWED_OPTION_ROLES);
+    }
+    if (!isSuperAdmin) {
+      return denyInsufficient(req, res, su, role);
+    }
+
+    const source = req.query['source'] as string | undefined;
+    const status = req.query['status'] as string | undefined;
+
+    try {
+      const rules = await listSaiRules(undefined, { source, status });
+      return res.json({ items: rules });
+    } catch (err: any) {
+      if (err?.code === '42P01') return res.json({ items: [] });
+      logger.warn('[GET /v1/admin/sai-rules]', err);
+      return res.status(500).json({ error: 'ルール一覧の取得に失敗しました' });
+    }
+  });
+
+  app.put('/v1/admin/sai-rules/:id/approve', async (req: Request, res: Response) => {
+    const { su, role, isSuperAdmin } = extractAuth(req);
+    if (!isAllowedOptionRole(role)) {
+      return denyRole(req, res, su, role, ALLOWED_OPTION_ROLES);
+    }
+    if (!isSuperAdmin) {
+      return denyInsufficient(req, res, su, role);
+    }
+
+    try {
+      const rule = await approveSaiRule(Number(req.params['id']));
+      if (!rule) return res.status(404).json({ error: 'ルールが見つかりません' });
+      return res.json({ item: rule });
+    } catch (err: any) {
+      logger.warn('[PUT /v1/admin/sai-rules/:id/approve]', err);
+      return res.status(500).json({ error: '承認に失敗しました' });
+    }
+  });
+
+  app.put('/v1/admin/sai-rules/:id/reject', async (req: Request, res: Response) => {
+    const { su, role, isSuperAdmin } = extractAuth(req);
+    if (!isAllowedOptionRole(role)) {
+      return denyRole(req, res, su, role, ALLOWED_OPTION_ROLES);
+    }
+    if (!isSuperAdmin) {
+      return denyInsufficient(req, res, su, role);
+    }
+
+    try {
+      const rule = await rejectSaiRule(Number(req.params['id']));
+      if (!rule) return res.status(404).json({ error: 'ルールが見つかりません' });
+      return res.json({ item: rule });
+    } catch (err: any) {
+      logger.warn('[PUT /v1/admin/sai-rules/:id/reject]', err);
+      return res.status(500).json({ error: '却下に失敗しました' });
     }
   });
 }

--- a/src/api/admin/options/saiBridge.test.ts
+++ b/src/api/admin/options/saiBridge.test.ts
@@ -34,6 +34,22 @@ jest.mock('../../../lib/billing/usageTracker', () => ({
   trackUsage: (...args: unknown[]) => mockTrackUsage(...args),
 }));
 
+// Phase6 (Sai Judge学習ループ): デフォルトはルール0件(=現状データなし)で既存挙動と同じにする
+const mockGetActiveSaiRulesForTenant = jest.fn().mockResolvedValue([]);
+const mockListSaiRules = jest.fn();
+const mockApproveSaiRule = jest.fn();
+const mockRejectSaiRule = jest.fn();
+jest.mock('../../../lib/sai/saiTaskRulesRepository', () => {
+  const actual = jest.requireActual('../../../lib/sai/saiTaskRulesRepository');
+  return {
+    ...actual,
+    getActiveSaiRulesForTenant: (...args: unknown[]) => mockGetActiveSaiRulesForTenant(...args),
+    listSaiRules: (...args: unknown[]) => mockListSaiRules(...args),
+    approveSaiRule: (...args: unknown[]) => mockApproveSaiRule(...args),
+    rejectSaiRule: (...args: unknown[]) => mockRejectSaiRule(...args),
+  };
+});
+
 function makeApp(role = 'client_admin', tenantId = 'tenant-x') {
   const app = express();
   app.use(express.json());
@@ -75,7 +91,7 @@ describe('POST /v1/admin/options/:id/try-sai', () => {
   });
 
   it('Saiにタスクを投げ、sai_task_idを保存して202を返す', async () => {
-    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'order-1', description: 'FAQ登録代行' }] });
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'order-1', tenant_id: 'tenant-x', description: 'FAQ登録代行' }] });
     mockSubmitSaiTask.mockResolvedValueOnce({ task_id: 'sai-task-1', status: 'queued' });
     mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [] }); // sai_task_id UPDATE
 
@@ -90,6 +106,32 @@ describe('POST /v1/admin/options/:id/try-sai', () => {
       expect.stringContaining('UPDATE option_orders SET sai_task_id'),
       ['order-1', 'sai-task-1'],
     );
+  });
+
+  it('Phase6: 承認済みルールが0件なら作業内容はそのまま渡す(現状のデフォルト挙動)', async () => {
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'order-1', tenant_id: 'tenant-x', description: 'FAQ登録代行' }] });
+    mockSubmitSaiTask.mockResolvedValueOnce({ task_id: 'sai-task-1', status: 'queued' });
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+    await request(superAdminApp()).post('/v1/admin/options/order-1/try-sai').send({});
+
+    expect(mockGetActiveSaiRulesForTenant).toHaveBeenCalledWith('tenant-x');
+    expect(mockSubmitSaiTask).toHaveBeenCalledWith(expect.objectContaining({ description: 'FAQ登録代行' }));
+  });
+
+  it('Phase6: trigger_patternが一致する承認済みルールがあれば作業内容の先頭に注入する', async () => {
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'order-1', tenant_id: 'tenant-x', description: 'FAQ登録代行をお願いします' }] });
+    mockGetActiveSaiRulesForTenant.mockResolvedValueOnce([
+      { id: 1, tenant_id: 'tenant-x', trigger_pattern: 'FAQ登録', expected_behavior: '保存ボタンは画面右上にある', priority: 0, is_active: true, status: 'active', source: 'sai_judge', evidence: null, created_by: null, approved_at: null, rejected_at: null, created_at: '', updated_at: '' },
+    ]);
+    mockSubmitSaiTask.mockResolvedValueOnce({ task_id: 'sai-task-1', status: 'queued' });
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+    await request(superAdminApp()).post('/v1/admin/options/order-1/try-sai').send({});
+
+    const sentDescription = mockSubmitSaiTask.mock.calls[0]![0].description as string;
+    expect(sentDescription).toContain('保存ボタンは画面右上にある');
+    expect(sentDescription).toContain('FAQ登録代行をお願いします');
   });
 
   it('SAI_MONTHLY_COST_CEILING_CENTS未設定時は上限チェックをスキップする(デフォルト無制限)', async () => {
@@ -201,5 +243,59 @@ describe('GET /v1/admin/options/:id/sai-task', () => {
         saiAgentSteps: 3,
       }),
     );
+  });
+});
+
+describe('Phase6 (Sai Judge学習ループ): /v1/admin/sai-rules', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetActiveSaiRulesForTenant.mockResolvedValue([]);
+  });
+
+  it('GET: super_admin以外は403', async () => {
+    const res = await request(makeApp()).get('/v1/admin/sai-rules');
+    expect(res.status).toBe(403);
+  });
+
+  it('GET: ルール一覧を返す(source/statusフィルタをクエリから渡す)', async () => {
+    mockListSaiRules.mockResolvedValueOnce([{ id: 1, trigger_pattern: 'x', expected_behavior: 'y' }]);
+
+    const res = await request(superAdminApp()).get('/v1/admin/sai-rules?source=sai_judge&status=pending');
+
+    expect(res.status).toBe(200);
+    expect(res.body.items).toHaveLength(1);
+    expect(mockListSaiRules).toHaveBeenCalledWith(undefined, { source: 'sai_judge', status: 'pending' });
+  });
+
+  it('PUT /:id/approve: super_admin以外は403', async () => {
+    const res = await request(makeApp()).put('/v1/admin/sai-rules/1/approve');
+    expect(res.status).toBe(403);
+    expect(mockApproveSaiRule).not.toHaveBeenCalled();
+  });
+
+  it('PUT /:id/approve: ルールを承認する', async () => {
+    mockApproveSaiRule.mockResolvedValueOnce({ id: 1, status: 'active', is_active: true });
+
+    const res = await request(superAdminApp()).put('/v1/admin/sai-rules/1/approve');
+
+    expect(res.status).toBe(200);
+    expect(res.body.item.status).toBe('active');
+    expect(mockApproveSaiRule).toHaveBeenCalledWith(1);
+  });
+
+  it('PUT /:id/approve: 存在しないルールは404', async () => {
+    mockApproveSaiRule.mockResolvedValueOnce(null);
+    const res = await request(superAdminApp()).put('/v1/admin/sai-rules/999/approve');
+    expect(res.status).toBe(404);
+  });
+
+  it('PUT /:id/reject: ルールを却下する', async () => {
+    mockRejectSaiRule.mockResolvedValueOnce({ id: 1, status: 'rejected', is_active: false });
+
+    const res = await request(superAdminApp()).put('/v1/admin/sai-rules/1/reject');
+
+    expect(res.status).toBe(200);
+    expect(res.body.item.status).toBe('rejected');
+    expect(mockRejectSaiRule).toHaveBeenCalledWith(1);
   });
 });

--- a/src/lib/sai/migration_sai_task_rules.sql
+++ b/src/lib/sai/migration_sai_task_rules.sql
@@ -1,0 +1,29 @@
+-- Phase6 (Sai Judge学習ループ): sai_task_rules テーブル
+-- tuning_rules(チャットAI用)と同型のパターンだが、GUI操作エージェントへの
+-- 指示注入用に別テーブルとして新設する(Hermes/Sai Judgeの分離方針と同じ理由)。
+--
+-- tuning_rulesの運用で判明した注意点(is_activeがsource='judge'挿入時に
+-- デフォルトtrueになり承認前から有効化されてしまう問題)を踏まえ、
+-- sai_task_rulesでは is_active を明示的に false スタートにする。
+-- 実際にAgent Sへ注入されるのは is_active=true になった行のみ。
+
+CREATE TABLE IF NOT EXISTS sai_task_rules (
+  id SERIAL PRIMARY KEY,
+  tenant_id TEXT NOT NULL,                    -- 'global' = 全テナント共通
+  trigger_pattern TEXT NOT NULL,               -- カンマ区切りキーワード。option_orders.descriptionとの一致判定に使う
+  expected_behavior TEXT NOT NULL,             -- Agent Sへの指示に注入するガイダンス文
+  priority INTEGER NOT NULL DEFAULT 0,
+  is_active BOOLEAN NOT NULL DEFAULT false,    -- 承認されるまで注入しない
+  status TEXT NOT NULL DEFAULT 'pending',      -- pending | active | rejected
+  source TEXT NOT NULL DEFAULT 'sai_judge',    -- sai_judge(自動提案) | manual
+  evidence JSONB,                              -- 提案の根拠(該当タスクID・アウトカム等)
+  created_by TEXT,
+  approved_at TIMESTAMPTZ,
+  rejected_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT chk_sai_task_rules_status CHECK (status IN ('pending', 'active', 'rejected'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_sai_task_rules_tenant ON sai_task_rules(tenant_id, is_active);
+CREATE INDEX IF NOT EXISTS idx_sai_task_rules_status ON sai_task_rules(status);

--- a/src/lib/sai/saiTaskRulesRepository.test.ts
+++ b/src/lib/sai/saiTaskRulesRepository.test.ts
@@ -1,0 +1,119 @@
+// src/lib/sai/saiTaskRulesRepository.test.ts
+// Phase6 (Sai Judge学習ループ): sai_task_rules DBリポジトリのテスト
+
+const mockQuery = jest.fn();
+jest.mock('../db', () => ({
+  getPool: () => ({ query: mockQuery }),
+}));
+
+import {
+  listSaiRules,
+  getActiveSaiRulesForTenant,
+  insertSuggestedSaiRule,
+  approveSaiRule,
+  rejectSaiRule,
+  matchesSaiTriggerPattern,
+  buildSaiPromptSection,
+  type SaiTaskRule,
+} from './saiTaskRulesRepository';
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+describe('matchesSaiTriggerPattern', () => {
+  it('カンマ区切りキーワードのいずれかが部分一致すればtrue', () => {
+    expect(matchesSaiTriggerPattern('FAQ登録代行をお願いします', 'FAQ登録,在庫更新')).toBe(true);
+    expect(matchesSaiTriggerPattern('在庫更新の作業です', 'FAQ登録,在庫更新')).toBe(true);
+  });
+
+  it('一致しなければfalse', () => {
+    expect(matchesSaiTriggerPattern('全く関係ない作業', 'FAQ登録,在庫更新')).toBe(false);
+  });
+
+  it('大文字小文字を区別しない', () => {
+    expect(matchesSaiTriggerPattern('Please open chromium', 'CHROMIUM')).toBe(true);
+  });
+});
+
+describe('buildSaiPromptSection', () => {
+  it('ルールが空なら空文字を返す', () => {
+    expect(buildSaiPromptSection([])).toBe('');
+  });
+
+  it('ルールをテキストブロックに変換する', () => {
+    const rules = [
+      { trigger_pattern: 'FAQ登録', expected_behavior: '保存ボタンは画面右上にある' } as SaiTaskRule,
+    ];
+    const result = buildSaiPromptSection(rules);
+    expect(result).toContain('FAQ登録');
+    expect(result).toContain('保存ボタンは画面右上にある');
+  });
+});
+
+describe('listSaiRules', () => {
+  it('tenantId指定時はtenant_id/globalの条件を付ける', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await listSaiRules('tenant-x');
+    const [sql, args] = mockQuery.mock.calls[0];
+    expect(sql).toContain("tenant_id = $1 OR tenant_id = 'global'");
+    expect(args).toEqual(['tenant-x']);
+  });
+
+  it('source/statusフィルタを付与する', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await listSaiRules(undefined, { source: 'sai_judge', status: 'pending' });
+    const [sql, args] = mockQuery.mock.calls[0];
+    expect(sql).toContain('source = $1');
+    expect(sql).toContain('status = $2');
+    expect(args).toEqual(['sai_judge', 'pending']);
+  });
+});
+
+describe('getActiveSaiRulesForTenant', () => {
+  it('is_active=trueのみ取得する', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await getActiveSaiRulesForTenant('tenant-x');
+    const [sql, args] = mockQuery.mock.calls[0];
+    expect(sql).toContain('is_active = true');
+    expect(args).toEqual(['tenant-x']);
+  });
+});
+
+describe('insertSuggestedSaiRule', () => {
+  it('デフォルトでsource=sai_judgeとして挿入する(is_activeはテーブルのデフォルトfalseに任せる)', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 1, source: 'sai_judge' }] });
+    await insertSuggestedSaiRule({
+      tenant_id: 'tenant-x', trigger_pattern: 'FAQ登録', expected_behavior: 'y',
+    });
+    const [sql, args] = mockQuery.mock.calls[0];
+    expect(sql).toContain('INSERT INTO sai_task_rules');
+    expect(args).toEqual(['tenant-x', 'FAQ登録', 'y', 0, 'sai_judge', null, null]);
+  });
+});
+
+describe('approveSaiRule / rejectSaiRule', () => {
+  it('approveSaiRule: status=active かつ is_active=true を同時に更新する', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 1, status: 'active' }] });
+    await approveSaiRule(1);
+    const [sql] = mockQuery.mock.calls[0];
+    expect(sql).toContain("status = 'active'");
+    expect(sql).toContain('is_active = true');
+  });
+
+  it('rejectSaiRule: status=rejected かつ is_active=false を同時に更新する', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ id: 1, status: 'rejected' }] });
+    await rejectSaiRule(1);
+    const [sql] = mockQuery.mock.calls[0];
+    expect(sql).toContain("status = 'rejected'");
+    expect(sql).toContain('is_active = false');
+  });
+
+  it('tenantId指定時は所有権チェックの条件を付ける', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await approveSaiRule(1, 'tenant-x');
+    const [sql, args] = mockQuery.mock.calls[0];
+    expect(sql).toContain('AND tenant_id = $2');
+    expect(args).toEqual([1, 'tenant-x']);
+  });
+});

--- a/src/lib/sai/saiTaskRulesRepository.ts
+++ b/src/lib/sai/saiTaskRulesRepository.ts
@@ -1,0 +1,178 @@
+// src/lib/sai/saiTaskRulesRepository.ts
+// Phase6 (Sai Judge学習ループ): sai_task_rules DBリポジトリ
+// tuning_rulesRepository.ts と同型のパターン。詳細はmigration_sai_task_rules.sqlを参照。
+
+import { getPool } from '../db';
+
+export interface SaiRuleEvidence {
+  taskIds?: string[];
+  orderIds?: string[];
+  outcome?: string;
+  note?: string;
+}
+
+export interface SaiTaskRule {
+  id: number;
+  tenant_id: string;
+  trigger_pattern: string;
+  expected_behavior: string;
+  priority: number;
+  is_active: boolean;
+  status: string;
+  source: string;
+  evidence: SaiRuleEvidence | null;
+  created_by: string | null;
+  approved_at: string | null;
+  rejected_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface ListSaiRulesFilters {
+  source?: string;
+  status?: string;
+}
+
+export interface CreateSaiRuleParams {
+  tenant_id: string;
+  trigger_pattern: string;
+  expected_behavior: string;
+  priority?: number;
+  source?: string;
+  evidence?: SaiRuleEvidence;
+  created_by?: string;
+}
+
+const SELECT_COLUMNS = `id, tenant_id, trigger_pattern, expected_behavior, priority, is_active,
+       status, source, evidence, created_by, approved_at, rejected_at, created_at, updated_at`;
+
+/**
+ * ルール一覧取得。
+ * - tenantId指定: そのテナント + global のルールを返す
+ * - tenantId未指定(super_admin): 全ルールを返す
+ */
+export async function listSaiRules(tenantId?: string, filters?: ListSaiRulesFilters): Promise<SaiTaskRule[]> {
+  const pool = getPool();
+
+  const args: string[] = tenantId ? [tenantId] : [];
+  const conditions: string[] = tenantId ? ["(tenant_id = $1 OR tenant_id = 'global')"] : [];
+  if (filters?.source) { args.push(filters.source); conditions.push(`source = $${args.length}`); }
+  if (filters?.status) { args.push(filters.status); conditions.push(`status = $${args.length}`); }
+  const whereClause = conditions.length > 0 ? `WHERE ${conditions.join(' AND ')}` : '';
+
+  const result = await pool.query<SaiTaskRule>(
+    `SELECT ${SELECT_COLUMNS}
+     FROM sai_task_rules
+     ${whereClause}
+     ORDER BY
+       CASE WHEN tenant_id = 'global' THEN 1 ELSE 0 END ASC,
+       priority DESC, created_at DESC`,
+    args,
+  );
+  return result.rows;
+}
+
+/**
+ * 注入対象のアクティブなルールを取得する(Agent Sへの指示注入向け)。
+ * is_active=true(=承認済み)のもののみ。
+ */
+export async function getActiveSaiRulesForTenant(tenantId: string): Promise<SaiTaskRule[]> {
+  const pool = getPool();
+
+  const result = await pool.query<SaiTaskRule>(
+    `SELECT ${SELECT_COLUMNS}
+     FROM sai_task_rules
+     WHERE (tenant_id = $1 OR tenant_id = 'global')
+       AND is_active = true
+     ORDER BY
+       CASE WHEN tenant_id = 'global' THEN 1 ELSE 0 END ASC,
+       priority DESC`,
+    [tenantId],
+  );
+  return result.rows;
+}
+
+/** ルール提案の作成。Sai Judge(将来実装)が実行ログから抽出した提案をpending状態で挿入する。 */
+export async function insertSuggestedSaiRule(params: CreateSaiRuleParams): Promise<SaiTaskRule> {
+  const pool = getPool();
+
+  const result = await pool.query<SaiTaskRule>(
+    `INSERT INTO sai_task_rules
+       (tenant_id, trigger_pattern, expected_behavior, priority, source, evidence, created_by)
+     VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7)
+     RETURNING ${SELECT_COLUMNS}`,
+    [
+      params.tenant_id,
+      params.trigger_pattern,
+      params.expected_behavior,
+      params.priority ?? 0,
+      params.source ?? 'sai_judge',
+      params.evidence ? JSON.stringify(params.evidence) : null,
+      params.created_by ?? null,
+    ],
+  );
+  return result.rows[0]!;
+}
+
+/**
+ * ルール承認。status='active'とis_activeを同時に更新する
+ * (tuning_rulesでstatusとis_activeが同期していなかった反省を踏まえた設計)。
+ */
+export async function approveSaiRule(id: number, tenantId?: string): Promise<SaiTaskRule | null> {
+  const pool = getPool();
+  const args: unknown[] = [id];
+  let where = 'WHERE id = $1';
+  if (tenantId) {
+    where += ' AND tenant_id = $2';
+    args.push(tenantId);
+  }
+
+  const result = await pool.query<SaiTaskRule>(
+    `UPDATE sai_task_rules
+     SET status = 'active', is_active = true, approved_at = NOW(), rejected_at = NULL, updated_at = NOW()
+     ${where}
+     RETURNING ${SELECT_COLUMNS}`,
+    args,
+  );
+  return result.rows[0] ?? null;
+}
+
+export async function rejectSaiRule(id: number, tenantId?: string): Promise<SaiTaskRule | null> {
+  const pool = getPool();
+  const args: unknown[] = [id];
+  let where = 'WHERE id = $1';
+  if (tenantId) {
+    where += ' AND tenant_id = $2';
+    args.push(tenantId);
+  }
+
+  const result = await pool.query<SaiTaskRule>(
+    `UPDATE sai_task_rules
+     SET status = 'rejected', is_active = false, rejected_at = NOW(), approved_at = NULL, updated_at = NOW()
+     ${where}
+     RETURNING ${SELECT_COLUMNS}`,
+    args,
+  );
+  return result.rows[0] ?? null;
+}
+
+/** カンマ区切りのtrigger_patternのいずれかが対象テキストに部分一致するか(tuning_rulesと同じ判定方式)。 */
+export function matchesSaiTriggerPattern(text: string, triggerPattern: string): boolean {
+  const lower = text.toLowerCase();
+  return triggerPattern
+    .split(',')
+    .map((k) => k.trim())
+    .filter(Boolean)
+    .some((k) => lower.includes(k.toLowerCase()));
+}
+
+/**
+ * アクティブなルールをAgent Sへの指示に注入するテキストに変換する。
+ * ルールが空の場合は空文字を返す(呼び出し元で条件分岐不要)。
+ */
+export function buildSaiPromptSection(rules: SaiTaskRule[]): string {
+  if (rules.length === 0) return '';
+
+  const lines = rules.map((r) => `- 「${r.trigger_pattern}」に関する作業 → ${r.expected_behavior}`);
+  return `過去の実行結果から得られた注意点(優先度順):\n${lines.join('\n')}`;
+}


### PR DESCRIPTION
## Summary
Phase6(Sai Judge学習ループ)着手前に本番データを確認したところ、`option_orders`経由の実際のSai実行は0件、`usage_logs.sai_agent`も0件だった。artifact自身が「実行ログが一定量蓄積してから着手」と明記している通り、学習対象が存在しない状態のため、ルールを自動提案するSai Judge本体は実装せず、**配線(保存・承認・却下・注入)のみ**を先行実装した。ルールが0件の間は既存の挙動と完全に同じになる。

## 実装内容
- `sai_task_rules`テーブル新設(`tuning_rules`と同型)。ただし`tuning_rules`の運用で判明した問題(`source='judge'`挿入時に`is_active`がデフォルトtrueになり承認前から有効化されてしまう)を踏まえ、`is_active`は明示的に`false`スタートにし、approve/rejectで`status`と`is_active`を同時更新する設計に修正
- `GET /v1/admin/sai-rules`, `PUT /:id/approve`, `PUT /:id/reject`(super_adminのみ)
- `try-sai`ハンドラで、承認済みルールの`trigger_pattern`が作業内容(`description`)と一致すればAgent Sへの指示文の先頭に注入する。該当ルールがなければ何もしない(現状のデフォルト)
- `/admin/options`に承認待ちルールのレビューパネルを追加(0件時はパネル自体を非表示にしてページを圧迫しない)

## 残っている本当のブロッカー
Phase6を実際に機能させるには、①Sai実行ログ(ステップ・アウトカム)をDBに永続化する仕組み、②そこから提案ルールを生成するSai Judge本体、の2つが必要。今回はどちらも実装していない。実運用でoption_orders経由のSai実行が一定数蓄積してから、次のステップとして着手する想定。

## Test plan
- [x] `npx jest`(フルスイート) — パス
- [x] `npx vitest run`(admin-ui フルスイート) — パス
- [x] `npx tsc --noEmit`(両方) — エラーなし
- [x] Playwrightで実ブラウザ操作し、承認待ちルールパネルの表示・展開・承認ボタンの動作を確認(本番APIへの通信はモックでブロック、実データには一切触れていない)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bu7k7x6P4Aa7MGMF4ymjSp