### PR TITLE
feat: 発注時にR2Cエージェント(Sai)を自動試行 + 表示名を「R2Cエージェント」に統一

### DIFF
--- a/admin-ui/src/pages/admin/options/index.test.tsx
+++ b/admin-ui/src/pages/admin/options/index.test.tsx
@@ -66,12 +66,12 @@ describe('OptionManagementPage — Sai(Agent S)セクション', () => {
     render(<OptionManagementPage />);
     await waitFor(() => expect(screen.queryByText('FAQ登録代行')).toBeTruthy());
     fireEvent.click(screen.getByText('FAQ登録代行'));
-    await waitFor(() => expect(screen.queryByText('▶ Saiに依頼する')).toBeTruthy());
+    await waitFor(() => expect(screen.queryByText('▶ R2Cエージェントに依頼する')).toBeTruthy());
   }
 
   it('未試行の発注では「Saiに依頼する」ボタンが表示される', async () => {
     await openOrderDetail();
-    expect(screen.getByText('▶ Saiに依頼する')).toBeTruthy();
+    expect(screen.getByText('▶ R2Cエージェントに依頼する')).toBeTruthy();
   });
 
   it('依頼するとtry-saiを叩き、以後sai-taskをポーリングして状態を表示する', async () => {
@@ -87,7 +87,7 @@ describe('OptionManagementPage — Sai(Agent S)セクション', () => {
     });
 
     window.confirm = vi.fn().mockReturnValue(true);
-    fireEvent.click(screen.getByText('▶ Saiに依頼する'));
+    fireEvent.click(screen.getByText('▶ R2Cエージェントに依頼する'));
 
     await waitFor(() => expect(screen.queryByText('実行中')).toBeTruthy());
     expect(screen.getByText(/click\(100,200\)/)).toBeTruthy();
@@ -111,17 +111,17 @@ describe('OptionManagementPage — Sai(Agent S)セクション', () => {
     });
 
     window.confirm = vi.fn().mockReturnValue(true);
-    fireEvent.click(screen.getByText('▶ Saiに依頼する'));
+    fireEvent.click(screen.getByText('▶ R2Cエージェントに依頼する'));
 
-    await waitFor(() => expect(screen.queryByText('Saiが完了を報告')).toBeTruthy());
-    expect(screen.getByAltText('Sai実行後の最終スクリーンショット')).toBeTruthy();
+    await waitFor(() => expect(screen.queryByText('R2Cエージェントが完了を報告')).toBeTruthy());
+    expect(screen.getByAltText('R2Cエージェント実行後の最終スクリーンショット')).toBeTruthy();
     expect(screen.getByText(/実際の成否は下のスクリーンショットを目視確認/)).toBeTruthy();
     // 完了マークボタンは既存のまま独立して存在する(Saiが自動で押すことはない)
     expect(screen.getByText('✅ 完了マーク')).toBeTruthy();
   });
 });
 
-describe('OptionManagementPage — Phase6 Sai提案ルール承認キュー', () => {
+describe('OptionManagementPage — Phase6 R2Cエージェント提案ルール承認キュー', () => {
   beforeEach(() => {
     vi.mocked(useAuth).mockReturnValue(SUPER_ADMIN as ReturnType<typeof useAuth>);
     vi.mocked(authFetch).mockReset();
@@ -136,7 +136,7 @@ describe('OptionManagementPage — Phase6 Sai提案ルール承認キュー', ()
 
     render(<OptionManagementPage />);
     await waitFor(() => expect(screen.queryByText('該当する発注はありません')).toBeTruthy());
-    expect(screen.queryByText(/Sai提案ルール/)).toBeNull();
+    expect(screen.queryByText(/R2Cエージェント提案ルール/)).toBeNull();
   });
 
   it('承認待ちルールがある場合はパネルに件数を表示し、承認できる', async () => {
@@ -150,9 +150,9 @@ describe('OptionManagementPage — Phase6 Sai提案ルール承認キュー', ()
     });
 
     render(<OptionManagementPage />);
-    await waitFor(() => expect(screen.queryByText(/Sai提案ルール — 承認待ち 1件/)).toBeTruthy());
+    await waitFor(() => expect(screen.queryByText(/R2Cエージェント提案ルール — 承認待ち 1件/)).toBeTruthy());
 
-    fireEvent.click(screen.getByText(/Sai提案ルール/));
+    fireEvent.click(screen.getByText(/R2Cエージェント提案ルール/));
     await waitFor(() => expect(screen.queryByText('「FAQ登録」')).toBeTruthy());
 
     fireEvent.click(screen.getByText('✅ 承認'));

--- a/admin-ui/src/pages/admin/options/index.tsx
+++ b/admin-ui/src/pages/admin/options/index.tsx
@@ -59,8 +59,8 @@ interface SaiTaskRule {
 }
 
 const SAI_OUTCOME_LABEL: Record<string, string> = {
-  agent_reported_done: "Saiが完了を報告",
-  agent_reported_fail: "Saiが失敗を報告",
+  agent_reported_done: "R2Cエージェントが完了を報告",
+  agent_reported_fail: "R2Cエージェントが失敗を報告",
   step_limit_reached: "ステップ上限に到達",
   error: "エラーで停止",
   unknown: "不明",
@@ -628,7 +628,7 @@ function SaiSection({ orderId }: { orderId: string }) {
       const res = await authFetch(`${API_BASE}/v1/admin/options/${orderId}/sai-task`);
       if (res.status === 404) return; // 未試行
       if (!res.ok) {
-        setError("Sai実行結果の取得に失敗しました");
+        setError("R2Cエージェントの実行結果の取得に失敗しました");
         return;
       }
       const data = await res.json() as { task: SaiTask };
@@ -637,7 +637,7 @@ function SaiSection({ orderId }: { orderId: string }) {
         pollTimer.current = setTimeout(() => { void fetchTask(true); }, 3000);
       }
     } catch {
-      setError("Sai実行結果の取得に失敗しました");
+      setError("R2Cエージェントの実行結果の取得に失敗しました");
     }
   }, [orderId]);
 
@@ -649,20 +649,20 @@ function SaiSection({ orderId }: { orderId: string }) {
   }, [orderId]);
 
   const handleTrySai = async () => {
-    if (!confirm("Saiエージェントにこの作業を試行させますか？\n実際にブラウザ操作等を行い、API利用コストが発生します。")) return;
+    if (!confirm("R2Cエージェントにこの作業を試行させますか？\n実際にブラウザ操作等を行い、API利用コストが発生します。")) return;
     setStarting(true);
     setError(null);
     try {
       const res = await authFetch(`${API_BASE}/v1/admin/options/${orderId}/try-sai`, { method: "POST" });
       if (!res.ok) {
         const body = await res.json().catch(() => ({}));
-        setError((body as { error?: string }).error ?? "Saiへの依頼に失敗しました");
+        setError((body as { error?: string }).error ?? "R2Cエージェントへの依頼に失敗しました");
         return;
       }
       clearPoll();
       void fetchTask(true);
     } catch {
-      setError("Saiへの依頼に失敗しました");
+      setError("R2Cエージェントへの依頼に失敗しました");
     } finally {
       setStarting(false);
     }
@@ -673,7 +673,7 @@ function SaiSection({ orderId }: { orderId: string }) {
   return (
     <div style={{ marginBottom: 20 }}>
       <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: 10 }}>
-        <p style={{ fontSize: 13, fontWeight: 600, color: TEXT_MAIN, margin: 0 }}>🤖 Sai(Agent S)による代行試行</p>
+        <p style={{ fontSize: 13, fontWeight: 600, color: TEXT_MAIN, margin: 0 }}>🤖 R2Cエージェントによる代行試行</p>
         <button
           onClick={() => void handleTrySai()}
           disabled={starting || !!isRunning}
@@ -684,7 +684,7 @@ function SaiSection({ orderId }: { orderId: string }) {
             opacity: starting || isRunning ? 0.6 : 1, minHeight: 32,
           }}
         >
-          {starting ? "依頼中..." : task ? "🔁 再試行" : "▶ Saiに依頼する"}
+          {starting ? "依頼中..." : task ? "🔁 再試行" : "▶ R2Cエージェントに依頼する"}
         </button>
       </div>
 
@@ -711,12 +711,12 @@ function SaiSection({ orderId }: { orderId: string }) {
           {task.status === "complete" && (
             <>
               <p style={{ fontSize: 11, color: "#fbbf24", margin: "0 0 8px" }}>
-                ⚠️ 上記は Sai の自己申告です。実際の成否は下のスクリーンショットを目視確認してから「完了マーク」で確定してください。
+                ⚠️ 上記は R2Cエージェントの自己申告です。実際の成否は下のスクリーンショットを目視確認してから「完了マーク」で確定してください。
               </p>
               {task.final_screenshot_base64 && (
                 <img
                   src={`data:image/png;base64,${task.final_screenshot_base64}`}
-                  alt="Sai実行後の最終スクリーンショット"
+                  alt="R2Cエージェント実行後の最終スクリーンショット"
                   style={{ width: "100%", borderRadius: 8, border: `1px solid ${BORDER}`, marginBottom: 8 }}
                 />
               )}
@@ -806,7 +806,7 @@ function SaiRulesPanel() {
           color: TEXT_MAIN, fontSize: 14, fontWeight: 600,
         }}
       >
-        <span>🧠 Sai提案ルール — 承認待ち {rules.length}件</span>
+        <span>🧠 R2Cエージェント提案ルール — 承認待ち {rules.length}件</span>
         <span style={{ color: TEXT_SUB, fontSize: 12 }}>{expanded ? "▲ 閉じる" : "▼ 開く"}</span>
       </button>
       {expanded && (

--- a/src/api/admin/options/optionOrders.test.ts
+++ b/src/api/admin/options/optionOrders.test.ts
@@ -20,13 +20,40 @@ jest.mock('../../../lib/notifications', () => ({
   createNotification: jest.fn(),
 }));
 
-const mockQuery = jest.fn();
+// R2Cエージェント自動試行(fire-and-forget)の副次クエリ等、テストが個別に
+// mockResolvedValueOnceを積んでいない呼び出しがあっても例外にならないよう
+// 無害なデフォルトを設定しておく(clearAllMocksでは消えない永続デフォルト)。
+const mockQuery = jest.fn().mockResolvedValue({ rowCount: 0, rows: [] });
 jest.mock('../../../lib/db', () => ({
   getPool: () => ({ query: mockQuery }),
 }));
 
+// R2Cエージェント(Sai) → 人間 自動試行(発注作成時のfire-and-forget)が
+// 実際のSai VPSへネットワーク接続しないよう必ずモックする。
+const mockSubmitSaiTask = jest.fn().mockResolvedValue({ task_id: 'sai-task-auto', status: 'queued' });
+jest.mock('../../../lib/sai/saiClient', () => ({
+  submitSaiTask: (...args: unknown[]) => mockSubmitSaiTask(...args),
+  getSaiTask: jest.fn(),
+}));
+jest.mock('../../../lib/sai/saiTaskRulesRepository', () => ({
+  getActiveSaiRulesForTenant: jest.fn().mockResolvedValue([]),
+  matchesSaiTriggerPattern: jest.fn().mockReturnValue(false),
+  buildSaiPromptSection: jest.fn().mockReturnValue(''),
+  listSaiRules: jest.fn(),
+  approveSaiRule: jest.fn(),
+  rejectSaiRule: jest.fn(),
+}));
+
 import { createNotification } from '../../../lib/notifications';
 const mockCreateNotification = createNotification as jest.Mock;
+// fire-and-forgetのattemptSaiForOrderは複数回のawaitを挟むため、
+// 1回のsetImmediateだけでは完全に完了しない。次のテストのjest.clearAllMocks()より
+// 前に必ず完了させるため、複数サイクル分flushする。
+async function flushAsync(): Promise<void> {
+  for (let i = 0; i < 10; i++) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
 
 // ── ヘルパー ───────────────────────────────────────────────────────────────────
 
@@ -101,6 +128,7 @@ describe('option_orders API', () => {
 
       expect(res.status).toBe(201);
       expect(res.body.item.id).toBe('new-order-1');
+      await flushAsync(); // R2Cエージェント自動試行のfire-and-forgetを完了させてから次のテストへ
     });
 
     it('type=premium_avatar で注文を作成できる', async () => {
@@ -127,6 +155,51 @@ describe('option_orders API', () => {
 
       expect(res.status).toBe(400);
       expect(res.body.error).toContain('description');
+    });
+
+    it('R2Cエージェント(Sai)→人間: 通常注文は作成と同時に自動でR2Cエージェントに試行させる', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ id: 'new-order-1', tenant_id: 'tenant-x', description: 'FAQ登録代行', type: 'general', status: 'pending' }],
+      });
+      mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [] }); // sai_task_id UPDATE (fire-and-forget側)
+
+      const res = await request(makeApp())
+        .post('/v1/admin/options')
+        .send({ description: 'FAQ登録代行', llm_estimate_amount: 10000 });
+
+      expect(res.status).toBe(201);
+      await flushAsync();
+      expect(mockSubmitSaiTask).toHaveBeenCalledWith(
+        expect.objectContaining({ description: 'FAQ登録代行', orderId: 'new-order-1' }),
+      );
+    });
+
+    it('プレミアムアバター注文は自動試行の対象外(専用パイプラインのため)', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ id: 'premium-order-1', tenant_id: 'tenant-x', description: 'プレミアムアバター制作代行', type: 'premium_avatar', status: 'pending' }],
+      });
+
+      const res = await request(makeApp())
+        .post('/v1/admin/options')
+        .send({ description: 'プレミアムアバター制作代行', llm_estimate_amount: 5000, type: 'premium_avatar' });
+
+      expect(res.status).toBe(201);
+      await flushAsync();
+      expect(mockSubmitSaiTask).not.toHaveBeenCalled();
+    });
+
+    it('自動試行が失敗してもテナントへのレスポンス(201)には影響しない', async () => {
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ id: 'new-order-2', tenant_id: 'tenant-x', description: 'FAQ登録代行', type: 'general', status: 'pending' }],
+      });
+      mockSubmitSaiTask.mockRejectedValueOnce(new Error('SAI_API_KEY not set'));
+
+      const res = await request(makeApp())
+        .post('/v1/admin/options')
+        .send({ description: 'FAQ登録代行', llm_estimate_amount: 10000 });
+
+      expect(res.status).toBe(201);
+      await flushAsync();
     });
   });
 

--- a/src/api/admin/options/routes.ts
+++ b/src/api/admin/options/routes.ts
@@ -86,6 +86,61 @@ async function checkSaiMonthlyCostCeiling(pool: any): Promise<{ ok: true } | { o
   return { ok: true };
 }
 
+export type SaiAttemptResult =
+  | { ok: true; task_id: string }
+  | { ok: false; reason: 'ceiling' | 'not_configured' | 'api_error'; error: string };
+
+/**
+ * R2Cエージェント(Sai)への試行を実行する共通処理。
+ * 手動の「R2Cエージェントに依頼する」ボタン(try-sai)と、発注作成時の自動試行の
+ * 両方から呼ばれる。表示テキストは常に「R2Cエージェント」("Sai"という名称は出さない)。
+ */
+async function attemptSaiForOrder(
+  pool: any,
+  order: { id: string; tenant_id: string; description: string },
+  maxSteps?: number,
+): Promise<SaiAttemptResult> {
+  const ceilingCheck = await checkSaiMonthlyCostCeiling(pool);
+  if (!ceilingCheck.ok) {
+    logger.warn({ event: 'sai_cost_ceiling_blocked', ...ceilingCheck }, 'Sai attempt blocked: monthly cost ceiling reached');
+    return { ok: false, reason: 'ceiling', error: 'R2Cエージェント利用の月次コスト上限に達しています。管理者に確認してください。' };
+  }
+
+  // Phase6 (Sai Judge学習ループ): 承認済みルールがあれば作業内容に注入する。
+  // ルールが0件(現状)なら buildSaiPromptSection は空文字を返し、既存の挙動と完全に同じになる。
+  let description = order.description;
+  try {
+    const activeRules = await getActiveSaiRulesForTenant(order.tenant_id);
+    const matched = activeRules.filter((r) => matchesSaiTriggerPattern(order.description, r.trigger_pattern));
+    const guidance = buildSaiPromptSection(matched);
+    if (guidance) description = `${guidance}\n\n${order.description}`;
+  } catch (err: any) {
+    if (err?.code !== '42P01') logger.warn('[attemptSaiForOrder] sai_task_rules lookup failed', err);
+  }
+
+  try {
+    const { task_id } = await submitSaiTask({ description, orderId: order.id, maxSteps });
+
+    await pool
+      .query(
+        `UPDATE option_orders SET sai_task_id = $2, sai_outcome = NULL, sai_tried_at = NOW() WHERE id = $1`,
+        [order.id, task_id],
+      )
+      .catch((err: any) => {
+        if (err?.code !== '42703') throw err;
+        logger.warn('[attemptSaiForOrder] sai_* columns not migrated yet');
+      });
+
+    return { ok: true, task_id };
+  } catch (err: any) {
+    if (err?.message === 'SAI_API_KEY not set') {
+      return { ok: false, reason: 'not_configured', error: 'R2Cエージェントが設定されていません' };
+    }
+    logger.warn('[attemptSaiForOrder]', err);
+    return { ok: false, reason: 'api_error', error: 'R2Cエージェントへの依頼に失敗しました' };
+  }
+}
+
 export function registerOptionRoutes(app: Express): void {
   app.use('/v1/admin/options', supabaseAuthMiddleware);
   app.use('/v1/admin/sai-rules', supabaseAuthMiddleware);
@@ -195,7 +250,25 @@ export function registerOptionRoutes(app: Express): void {
         throw err;
       });
 
-      return res.status(201).json({ item: (result as any).rows[0] });
+      const order = (result as any).rows[0];
+
+      // R2Cエージェント(Sai) → 人間、の流れ: 一般作業は発注と同時に自動でR2Cエージェントに
+      // 試行させる(テナントへのレスポンスは待たせない fire-and-forget)。
+      // プレミアムアバター等は専用パイプラインがあるためGUI自動化の対象外。
+      if (orderType === 'general') {
+        const pool = getPool();
+        setImmediate(() => {
+          void attemptSaiForOrder(pool, { id: order.id, tenant_id: order.tenant_id, description: order.description })
+            .then((r) => {
+              if (!r.ok) {
+                logger.info({ event: 'sai_auto_attempt_skipped', orderId: order.id, reason: r.reason }, 'auto Sai attempt not started');
+              }
+            })
+            .catch((err: any) => logger.warn('[POST /v1/admin/options] auto sai attempt failed', err));
+        });
+      }
+
+      return res.status(201).json({ item: order });
     } catch (err: any) {
       logger.warn('[POST /v1/admin/options]', err);
       return res.status(500).json({ error: 'オプション発注の作成に失敗しました' });
@@ -373,12 +446,6 @@ export function registerOptionRoutes(app: Express): void {
     try {
       const pool = getPool();
 
-      const ceilingCheck = await checkSaiMonthlyCostCeiling(pool);
-      if (!ceilingCheck.ok) {
-        logger.warn({ event: 'sai_cost_ceiling_blocked', ...ceilingCheck }, 'try-sai blocked: monthly cost ceiling reached');
-        return res.status(429).json({ error: 'Sai利用の月次コスト上限に達しています。管理者に確認してください。' });
-      }
-
       const orderResult = await pool.query(
         `SELECT id, tenant_id, description FROM option_orders WHERE id = $1`,
         [id],
@@ -388,41 +455,16 @@ export function registerOptionRoutes(app: Express): void {
       }
       const order = orderResult.rows[0] as { id: string; tenant_id: string; description: string };
 
-      // Phase6 (Sai Judge学習ループ): 承認済みルールがあれば作業内容に注入する。
-      // ルールが0件(現状)なら buildSaiPromptSection は空文字を返し、既存の挙動と完全に同じになる。
-      let description = order.description;
-      try {
-        const activeRules = await getActiveSaiRulesForTenant(order.tenant_id);
-        const matched = activeRules.filter((r) => matchesSaiTriggerPattern(order.description, r.trigger_pattern));
-        const guidance = buildSaiPromptSection(matched);
-        if (guidance) description = `${guidance}\n\n${order.description}`;
-      } catch (err: any) {
-        if (err?.code !== '42P01') logger.warn('[POST /v1/admin/options/:id/try-sai] sai_task_rules lookup failed', err);
+      const result = await attemptSaiForOrder(pool, order, max_steps);
+      if (!result.ok) {
+        const status = result.reason === 'ceiling' ? 429 : result.reason === 'not_configured' ? 503 : 502;
+        return res.status(status).json({ error: result.error });
       }
 
-      const { task_id } = await submitSaiTask({
-        description,
-        orderId: order.id,
-        maxSteps: max_steps,
-      });
-
-      await pool
-        .query(
-          `UPDATE option_orders SET sai_task_id = $2, sai_outcome = NULL, sai_tried_at = NOW() WHERE id = $1`,
-          [id, task_id],
-        )
-        .catch((err: any) => {
-          if (err?.code !== '42703') throw err;
-          logger.warn('[POST /v1/admin/options/:id/try-sai] sai_* columns not migrated yet');
-        });
-
-      return res.status(202).json({ task_id, status: 'queued' });
+      return res.status(202).json({ task_id: result.task_id, status: 'queued' });
     } catch (err: any) {
-      if (err?.message === 'SAI_API_KEY not set') {
-        return res.status(503).json({ error: 'Saiエージェントが設定されていません' });
-      }
       logger.warn('[POST /v1/admin/options/:id/try-sai]', err);
-      return res.status(502).json({ error: 'Saiエージェントへの依頼に失敗しました' });
+      return res.status(502).json({ error: 'R2Cエージェントへの依頼に失敗しました' });
     }
   });
 
@@ -454,7 +496,7 @@ export function registerOptionRoutes(app: Express): void {
       const orderRow = orderResult.rows[0] as { tenant_id?: string; sai_task_id?: string } | undefined;
       const saiTaskId = orderRow?.sai_task_id;
       if (!saiTaskId) {
-        return res.status(404).json({ error: 'この発注はまだSaiで試行されていません' });
+        return res.status(404).json({ error: 'この発注はまだR2Cエージェントで試行されていません' });
       }
 
       const task = await getSaiTask(saiTaskId);
@@ -485,10 +527,10 @@ export function registerOptionRoutes(app: Express): void {
       return res.json({ task });
     } catch (err: any) {
       if (err?.message === 'SAI_API_KEY not set') {
-        return res.status(503).json({ error: 'Saiエージェントが設定されていません' });
+        return res.status(503).json({ error: 'R2Cエージェントが設定されていません' });
       }
       logger.warn('[GET /v1/admin/options/:id/sai-task]', err);
-      return res.status(502).json({ error: 'Saiエージェントの状態取得に失敗しました' });
+      return res.status(502).json({ error: 'R2Cエージェントの状態取得に失敗しました' });
     }
   });
 

--- a/src/api/admin/options/saiBridge.test.ts
+++ b/src/api/admin/options/saiBridge.test.ts
@@ -148,6 +148,7 @@ describe('POST /v1/admin/options/:id/try-sai', () => {
 
   it('月次コスト上限に達している場合は429を返しSaiに依頼しない', async () => {
     process.env.SAI_MONTHLY_COST_CEILING_CENTS = '1000';
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'order-1', tenant_id: 'tenant-x', description: 'x' }] }); // 発注SELECT
     mockQuery.mockResolvedValueOnce({ rows: [{ total: '1000' }] }); // 上限チェックSELECT
 
     const res = await request(superAdminApp()).post('/v1/admin/options/order-1/try-sai').send({});
@@ -158,8 +159,8 @@ describe('POST /v1/admin/options/:id/try-sai', () => {
 
   it('月次コスト上限未満なら通常通りSaiに依頼する', async () => {
     process.env.SAI_MONTHLY_COST_CEILING_CENTS = '1000';
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'order-1', tenant_id: 'tenant-x', description: 'x' }] }); // 発注SELECT
     mockQuery.mockResolvedValueOnce({ rows: [{ total: '500' }] }); // 上限チェックSELECT
-    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'order-1', description: 'x' }] });
     mockSubmitSaiTask.mockResolvedValueOnce({ task_id: 'sai-task-1', status: 'queued' });
     mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [] });
 


### PR DESCRIPTION
## Summary
「R2Cエージェント(Sai) → 人間」の流れを実際のデフォルト動作にする。

- **自動試行**: 一般作業の発注(`type=general`)は作成と同時に自動でR2Cエージェント(Sai)に試行させる(`type=premium_avatar`は専用パイプラインがあるため対象外)。fire-and-forgetのため、月次コスト上限到達やSAI_API_KEY未設定でスキップされても発注自体のレスポンス(201)には一切影響しない
- **共通化**: 手動の「R2Cエージェントに依頼する」ボタン(try-sai)と発注時自動試行を`attemptSaiForOrder()`に集約し、ロジックの二重化を防止
- **表示名統一**: ユーザーに見えるテキストの「Sai」を全て「R2Cエージェント」に変更(ボタン・確認ダイアログ・エラーメッセージ・自己申告ラベル・提案ルールパネル等)。Hermes Agentの時と同じ方針で、内部のコード変数名・DBカラム名(`sai_task_id`等)・ファイル名(`saiClient.ts`等)は変更していない

完了判定は引き続き完全に人間主導(自動完了はしない)。自動試行はあくまで「最初に誰が試すか」を変えるだけで、既存の安全設計(スクリーンショット目視確認→完了マーク)はそのまま。

## Test plan
- [x] `npx jest`(フルスイート) — パス
- [x] `npx vitest run`(admin-ui フルスイート) — パス
- [x] `npx tsc --noEmit`(両方) — エラーなし
- [x] Playwrightで実ブラウザ確認 — 表示テキストが全て「R2Cエージェント」になっていることを確認(本番APIはモックでブロック、実データ未使用)
- [x] テスト実装中に見つけたバグ修正: 既存の「通常注文を作成できる」テストが新しいfire-and-forget自動試行を暗黙に発火させ、モック未設定のクエリでTypeErrorが後続テストに漏れ出す問題があったため、`mockQuery`に無害な永続デフォルトを設定して解消

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bu7k7x6P4Aa7MGMF4ymjSp