### PR TITLE
fix(lp): CSP img-srcにアバター画像配信元のSupabaseドメインを許可

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -167,7 +167,7 @@ app.use(
         "default-src 'self'",
         "script-src 'self' 'unsafe-inline' https://cdn.jsdelivr.net https://cdn.tailwindcss.com",
         "style-src 'self' 'unsafe-inline' https://cdn.tailwindcss.com",
-        "img-src 'self' data: https://cdn.leonardo.ai",
+        "img-src 'self' data: https://cdn.leonardo.ai https://rpqrwifbrhlebbelyqog.supabase.co",
         "connect-src 'self' https://api.r2c.biz wss://*.livekit.cloud",
         "media-src 'self' https: blob:",
         "frame-ancestors 'self'",


### PR DESCRIPTION
## Summary
本番LPのFAB(フローティングチャットボタン)でアバター画像が表示されず、チャットアイコンにフォールバックしていた不具合を修正。`/api/avatar/room-token`が返す`imageUrl`はSupabase Storage(`rpqrwifbrhlebbelyqog.supabase.co`)から配信されるが、CSPの`img-src`が未許可のためブラウザがブロックし`onerror`でリセットされていた。

## 経緯
放置されていた古いローカルブランチ`fix/lp-avatar-csp-supabase`(2026-07-05作成、未マージのまま残存)から、既にマージ済みの重複コミット(ウィザード機能、PR #453で別途マージ済み)を除いてこの修正のみをcherry-pickした。

## Test plan
- [x] `npx tsc --noEmit` — エラーなし
- [x] `npx jest`(フルスイート) — パス
- [x] `npx jest src/lib/headers.csp.test.ts` — パス(別モジュールのCSP設定、影響なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bu7k7x6P4Aa7MGMF4ymjSp