### PR TITLE
fix: アバター音声入力・再接続競合・通知パネル左端はみ出しを修正

### DIFF
--- a/admin-ui/src/components/common/NotificationBell.tsx
+++ b/admin-ui/src/components/common/NotificationBell.tsx
@@ -1,7 +1,7 @@
 // admin-ui/src/components/common/NotificationBell.tsx
 // Phase52h: In-App通知センター — ベルアイコン + ドロップダウン
 
-import { useState, useEffect, useRef, useCallback } from "react";
+import { useState, useEffect, useLayoutEffect, useRef, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
 import { authFetch, API_BASE } from "../../lib/api";
 
@@ -56,6 +56,11 @@ export function NotificationBell() {
   const [unreadCount, setUnreadCount] = useState(0);
   const [loading, setLoading] = useState(false);
   const dropRef = useRef<HTMLDivElement>(null);
+  const panelRef = useRef<HTMLDivElement>(null);
+  // デフォルトは right:0（ベルの右端に揃える）。ただし幅240pxの左サイドバー内でベルを
+  // 開いた場合、320px幅のパネルがビューポート左端をはみ出す（GID: 通知パネル左はみ出しfix）。
+  // 開いた直後に実際の位置を測り、はみ出す場合だけ left 指定に切り替えて画面内に収める。
+  const [panelLeftPx, setPanelLeftPx] = useState<number | null>(null);
 
   const fetchNotifications = useCallback(async () => {
     try {
@@ -73,6 +78,25 @@ export function NotificationBell() {
   useEffect(() => {
     void fetchNotifications();
   }, [fetchNotifications]);
+
+  // パネルを開いた際、ビューポート左端をはみ出していないか測って補正する
+  useLayoutEffect(() => {
+    if (!open) {
+      setPanelLeftPx(null);
+      return;
+    }
+    const panel = panelRef.current;
+    const wrapper = dropRef.current;
+    if (!panel || !wrapper) return;
+    const margin = 8;
+    const panelRect = panel.getBoundingClientRect();
+    if (panelRect.left < margin) {
+      const wrapperRect = wrapper.getBoundingClientRect();
+      setPanelLeftPx(margin - wrapperRect.left);
+    } else {
+      setPanelLeftPx(null);
+    }
+  }, [open, items.length]);
 
   // 30秒ポーリング
   useEffect(() => {
@@ -188,10 +212,11 @@ export function NotificationBell() {
       {/* Dropdown */}
       {open && (
         <div
+          ref={panelRef}
           style={{
             position: "absolute",
             top: "calc(100% + 8px)",
-            right: 0,
+            ...(panelLeftPx !== null ? { left: panelLeftPx } : { right: 0 }),
             width: 320,
             maxWidth: "calc(100vw - 16px)",
             background: "rgba(9,14,28,0.98)",

--- a/public/widget.js
+++ b/public/widget.js
@@ -1607,18 +1607,46 @@
   function connectLiveKit() {
     if (!avatarConfig || !window.LivekitClient) return;
 
-    // 切断済み・エラー状態の古いRoomを先にクリーンアップ
-    if (window.__rajiuceRoom && window.__rajiuceRoom.state !== 'connected') {
-      try { window.__rajiuceRoom.disconnect(); } catch (_e) {}
-      window.__rajiuceRoom = null;
-    }
     // 既に接続済みなら再利用
     if (window.__rajiuceRoom && window.__rajiuceRoom.state === 'connected') {
       avatarArea.style.display = 'flex';
       return;
     }
 
-    // 再接続前: Disconnected ハンドラが非同期で戻した stale 要素も含めて完全削除
+    // 切断済み・エラー状態の古いRoomを先にクリーンアップする。
+    // disconnect() の完了を待たずに新規Room.connect()を開始すると、WebRTCの
+    // ネゴシエーションが前後で競合し ("could not createOffer with closed peer
+    // connection" 等) 再接続が失敗しうる（GID: パネル高速開閉時のreconnect race fix）。
+    // disconnect完了を待ってから新規接続へ進む。closePanel() は window.__rajiuceRoom を
+    // 即座に null化するため、ローカル参照だけでなく window.__rajiuceRoomDisconnecting
+    // （closePanel/cleanupLiveKit が設定する共有Promise）も必ず待つ。
+    var _pendingDisconnect = window.__rajiuceRoomDisconnecting || Promise.resolve();
+    if (window.__rajiuceRoom) {
+      var _oldRoom = window.__rajiuceRoom;
+      window.__rajiuceRoom = null;
+      try {
+        var _dp = _oldRoom.disconnect();
+        if (_dp && typeof _dp.then === 'function') {
+          _pendingDisconnect = Promise.all([_pendingDisconnect, _dp]).then(function () {}, function () {});
+        }
+      } catch (_e) { /* 切断済み等は無視 */ }
+    }
+
+    Promise.resolve(_pendingDisconnect).catch(function () {}).then(function () {
+      _connectLiveKitAfterCleanup();
+    });
+  }
+
+  function _connectLiveKitAfterCleanup() {
+    // avatarConfig / LivekitClient が上のPromise待機中に失われるケース（パネル再クローズ等）に備える
+    if (!avatarConfig || !window.LivekitClient) return;
+    // 待機中に別の呼び出しが先に接続済みならそれを使う
+    if (window.__rajiuceRoom && window.__rajiuceRoom.state === 'connected') {
+      avatarArea.style.display = 'flex';
+      return;
+    }
+
+    // Disconnected ハンドラが非同期で戻した stale 要素も含めて完全削除
     var _rkClose = avatarArea.querySelectorAll('.avatar-close-btn');
     for (var _rki = 0; _rki < _rkClose.length; _rki++) { _rkClose[_rki].remove(); }
     var _rkMuteA = avatarArea.querySelectorAll('.avatar-mute-btn');
@@ -1915,12 +1943,18 @@
   }
 
   function cleanupLiveKit() {
-    // 明示的な完全終了用（ページ離脱など）
+    // 明示的な完全終了用（ページ離脱・SPA再注入前のdestroy()など）
     // 通常の closePanel() では呼ばない — Room は切断せず保持する
     try {
       if (window.__rajiuceRoom) {
-        window.__rajiuceRoom.disconnect();
+        var _cleanupRoom = window.__rajiuceRoom;
         window.__rajiuceRoom = null;
+        var _cleanupDp = _cleanupRoom.disconnect();
+        // SPA再注入で新しいwidgetインスタンスが直後にconnectLiveKit()する場合に備え、
+        // 完了をwindow越しに伝搬しておく（GID: reconnect race fix）
+        window.__rajiuceRoomDisconnecting = (_cleanupDp && typeof _cleanupDp.then === 'function')
+          ? _cleanupDp.catch(function () {})
+          : Promise.resolve();
       }
     } catch (_e) {}
     panel.classList.remove('avatar-active');
@@ -2120,10 +2154,21 @@
     _fabRestored = true; // 以降の非同期resetFabIcon呼び出しをブロック
     emitToHost('widget:closed', {});
     capturePostHog('widget_closed', {});
-    // LiveKit Room を切断（次回開閉時に新規接続で安定化）
+    // LiveKit Room を切断（次回開閉時に新規接続で安定化）。
+    // disconnect() は非同期なので、完了前に __rajiuceRoom を null化しても
+    // 次の connectLiveKit() が正しく待てるよう window.__rajiuceRoomDisconnecting に
+    // Promise を残しておく（GID: パネル高速開閉時のreconnect race fix）。
     if (window.__rajiuceRoom) {
-      try { window.__rajiuceRoom.disconnect(); } catch (_e) {}
+      var _closingRoom = window.__rajiuceRoom;
       window.__rajiuceRoom = null;
+      try {
+        var _closeDp = _closingRoom.disconnect();
+        window.__rajiuceRoomDisconnecting = (_closeDp && typeof _closeDp.then === 'function')
+          ? _closeDp.catch(function () {})
+          : Promise.resolve();
+      } catch (_e) {
+        window.__rajiuceRoomDisconnecting = Promise.resolve();
+      }
     }
     // アバターUI要素を同期的にクリーンアップ
     // （Disconnected イベントは非同期のため、ここで先に削除しておく）
@@ -2501,21 +2546,103 @@
       audioChunks = [];
     }
 
+    // MediaRecorder が出力する webm/opus 等は Fish Audio ASR の音声デコーダが
+    // "unsupported codec" として拒否するケースがある（GID: ASR 502 fix）。
+    // AudioContext.decodeAudioData でデコードし、ASR が確実に受理する
+    // 16bit PCM WAV に変換してから送信する。
+    function _blobToWav(blob) {
+      return blob.arrayBuffer().then(function (arrayBuffer) {
+        var AudioCtx = window.AudioContext || window.webkitAudioContext;
+        var ctx = new AudioCtx();
+        return ctx.decodeAudioData(arrayBuffer.slice(0)).then(function (audioBuffer) {
+          try { ctx.close(); } catch (_e) {}
+          return _encodeWav(audioBuffer);
+        }).catch(function (err) {
+          try { ctx.close(); } catch (_e) {}
+          throw err;
+        });
+      });
+    }
+
+    function _encodeWav(audioBuffer) {
+      var numChannels = audioBuffer.numberOfChannels;
+      var sampleRate = audioBuffer.sampleRate;
+      var numFrames = audioBuffer.length;
+      var bytesPerSample = 2; // 16-bit PCM
+      var blockAlign = numChannels * bytesPerSample;
+      var dataSize = numFrames * blockAlign;
+      var buffer = new ArrayBuffer(44 + dataSize);
+      var view = new DataView(buffer);
+
+      function writeString(offset, str) {
+        for (var i = 0; i < str.length; i++) view.setUint8(offset + i, str.charCodeAt(i));
+      }
+
+      writeString(0, 'RIFF');
+      view.setUint32(4, 36 + dataSize, true);
+      writeString(8, 'WAVE');
+      writeString(12, 'fmt ');
+      view.setUint32(16, 16, true); // fmt chunk size
+      view.setUint16(20, 1, true); // PCM
+      view.setUint16(22, numChannels, true);
+      view.setUint32(24, sampleRate, true);
+      view.setUint32(28, sampleRate * blockAlign, true); // byte rate
+      view.setUint16(32, blockAlign, true);
+      view.setUint16(34, bytesPerSample * 8, true); // bits per sample
+      writeString(36, 'data');
+      view.setUint32(40, dataSize, true);
+
+      var channelData = [];
+      for (var c = 0; c < numChannels; c++) channelData.push(audioBuffer.getChannelData(c));
+
+      var offset = 44;
+      for (var i = 0; i < numFrames; i++) {
+        for (var ch = 0; ch < numChannels; ch++) {
+          var sample = Math.max(-1, Math.min(1, channelData[ch][i]));
+          view.setInt16(offset, sample < 0 ? sample * 0x8000 : sample * 0x7fff, true);
+          offset += 2;
+        }
+      }
+
+      return new Blob([buffer], { type: 'audio/wav' });
+    }
+
     function _sendAudioForTranscription(blob) {
       micBtn.classList.remove('recording');
       micBtn.classList.add('processing');
       micBtn.setAttribute('aria-label', '変換中…');
       micBtn.disabled = true;
 
-      var fd = new FormData();
-      fd.append('audio', blob, 'audio.webm');
+      function postAudio(audioBlob, filename) {
+        var fd = new FormData();
+        fd.append('audio', audioBlob, filename);
+        return fetch(apiBase + '/api/voice/asr', {
+          method: 'POST',
+          headers: { 'x-api-key': apiKey },
+          body: fd,
+        }).then(function (r) {
+          return r.json().catch(function () { return {}; }).then(function (data) {
+            if (!r.ok) {
+              var err = new Error((data && data.error) || ('ASR HTTP ' + r.status));
+              err.status = r.status;
+              throw err;
+            }
+            return data;
+          });
+        });
+      }
 
-      fetch(apiBase + '/api/voice/asr', {
-        method: 'POST',
-        headers: { 'x-api-key': apiKey },
-        body: fd,
-      })
-        .then(function (r) { return r.json(); })
+      _blobToWav(blob)
+        .catch(function (err) {
+          // デコード不可（非対応ブラウザ等）の場合は元のBlobで送信を試みる（フォールバック）
+          console.warn('[FAQ Widget] WAV変換に失敗、元フォーマットで送信します:', err && err.message);
+          return null;
+        })
+        .then(function (wavBlob) {
+          return wavBlob
+            ? postAudio(wavBlob, 'audio.wav')
+            : postAudio(blob, 'audio.webm');
+        })
         .then(function (data) {
           micBtn.classList.remove('processing');
           micBtn.setAttribute('aria-label', '音声入力');
@@ -2527,19 +2654,22 @@
           var text = (data && data.text) ? data.text.trim() : '';
           if (text) {
             sendMessage(text);
+          } else {
+            showError('音声を認識できませんでした。もう一度お話しください。');
           }
         })
         .catch(function (err) {
           console.warn('[FAQ Widget] ASR fetch error:', err && err.message);
           micBtn.classList.remove('processing');
           micBtn.classList.add('error');
-          setTimeout(function () { micBtn.classList.remove('error'); }, 500);
+          setTimeout(function () { micBtn.classList.remove('error'); }, 2000);
           micBtn.setAttribute('aria-label', '音声入力');
           micBtn.setAttribute('title', '音声認識に失敗しました');
           micBtn.disabled = false;
           isRecording = false;
           currentRecorder = null;
           audioChunks = [];
+          showError('音声認識に失敗しました。もう一度お試しください。');
         });
     }
 


### PR DESCRIPTION
## Summary
- **音声入力(#1216414626540069)**: Fish Audio ASRがwebm/opusを「unsupported codec」で拒否(502)し、発話がアバターに届かなかった問題を修正。録音Blobを送信前にWAV(16bit PCM)へ変換。あわせてエラー/無音時に可視バナーを表示するよう改善(従来は無言で何も起きなかった)
- **アバター再接続競合(#1216414775383967)**: パネルを高速に開閉すると、前回のLiveKit disconnect完了を待たずに次のconnectが始まり競合(`could not createOffer with closed peer connection`)する問題を修正。disconnect完了を確実に待ってから再接続するようシーケンス制御を追加
- **通知パネルの左端はみ出し**(ユーザー報告のスクリーンショットで発覚): 幅240pxのサイドバー内で通知ベルを開くと320px幅のドロップダウンがビューポート左端を最大約100pxはみ出し、タイトル冒頭が見えなくなっていた。開いた直後に実位置を測定し、画面内に収まるよう補正

## Test plan
- [x] `page.route()`でwidget.jsをローカル差し替えし、本番admin.r2c.biz/adminのバックエンドに対し検証:
  - ASR: 送信データがWAV(RIFF/WAVEヘッダ)であること、エラー時に可視バナーが出ることを確認
  - 再接続: 5回連続の高速開閉で競合エラー(`could not createOffer`)が0件になったことを確認、最終的に正常接続
- [x] admin-ui開発サーバー(本番Supabase/API接続)でNotificationBellの位置を検証: 修正前 x=-97(画面外)→ 修正後 x=8(画面内)
- [x] `admin-ui`: `tsc --noEmit` / `eslint` エラーなし
- [x] セルフレビュー(code-reviewスキル, medium) — 問題なし

Asana:
- https://app.asana.com/1/817733952351708/project/1213607637045514/task/1216414626540069
- https://app.asana.com/1/817733952351708/project/1213607637045514/task/1216414775383967

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N4GerbJZQMPFqBSnFbLzMe