### PR TITLE
fix(admin-ui): super_admin プレビュー中のテストチャットでアバターに接続できない不具合を修正

### DIFF
--- a/admin-ui/src/pages/admin/chat-test/index.tsx
+++ b/admin-ui/src/pages/admin/chat-test/index.tsx
@@ -152,7 +152,13 @@ export default function ChatTestPage() {
       setAvatarConfigsReady(true);
       return;
     }
-    const url = isSuperAdmin
+    // super_adminの「クライアントビューで見る」プレビュー中は isSuperAdmin が
+    // client_admin相当にフォールバックするが、実ログインユーザー(super_admin)のJWTは
+    // そのままのため、tenant未指定で叩くとバックエンドが全テナント混在の一覧を返してしまう
+    // （avatar/routes.ts:370-372 の isSuperAdmin 判定は実JWT基準）。previewMode中も
+    // effectiveTenantId(=previewTenantId) を明示的に渡し、他テナントのアバターが
+    // 誤って選択されテストチャットのアバター接続に失敗するのを防ぐ。
+    const url = (isSuperAdmin || previewMode)
       ? `${API_BASE}/v1/admin/avatar/configs?tenant=${encodeURIComponent(effectiveTenantId)}`
       : `${API_BASE}/v1/admin/avatar/configs`;
     void authFetch(url)


### PR DESCRIPTION
## 概要
ユーザー報告: 「クライアントビューでテストチャットするとアバターと繋がらない」。escalations/tuning/knowledge (PR #480/#481) と同根の第5のバグ。

## 再現(本番、実データで確認)
lp-demo をプレビュー中に `/admin/chat-test` を開くと、`GET /v1/admin/avatar/configs` が `tenant` パラメータ無しで叩かれ、バックエンドが全テナント混在の一覧を返す。

```
avatar/configs URL called: https://api.r2c.biz/v1/admin/avatar/configs
configs total: 37 | distinct tenant_ids in response: ["lp-demo","r2c_default","carnation"]
```

フロントの選択ロジック(`firstCustom = configs.find(c => !c.is_default)`)がプレビュー中のテナントとは無関係な他テナントのアバター設定を選んでしまい、その `lemonslice_agent_id` 等がプレビュー先テナントのLiveKitルームと噛み合わずアバター接続に失敗する。

## 原因
`avatar/routes.ts:370-372` — `isSuperAdmin`(実JWT基準、preview中もtrue)の場合のみ `?tenant=` クエリでの絞り込みを許可。フロント(`chat-test/index.tsx`)は preview 中 `isSuperAdmin` が `client_admin` 相当にフォールバックするため、`tenant` パラメータを付けずに叩いてしまっていた。

## 修正
`avatar/configs` 取得URLの条件を `isSuperAdmin` のみから `isSuperAdmin || previewMode` に変更し、preview中も `effectiveTenantId`(=`previewTenantId`)を明示的にクエリへ渡すようにした。

同ファイル内の他の `isSuperAdmin` 参照箇所は全て preview対応済み、または preview中非表示が正しい挙動であることを確認済み。型チェック: エラーなし。

## 関連
- Asana: 起票予定
- 類似修正: #480, #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)