### PR TITLE
test(e2e): テストチャットのアバターconfig漏洩の回帰テストを追加

### DIFF
--- a/tests/e2e/qa-preview-scope-leak.spec.ts
+++ b/tests/e2e/qa-preview-scope-leak.spec.ts
@@ -9,6 +9,9 @@ import { test, expect } from '@playwright/test';
 // C-LEAK-2: 「AIの知識データ」ナビ(AppSidebar.tsx)がリンク生成時に previewTenantId を見ず
 //   `/admin/knowledge/`(空のtenantId)になり画面が白紙になる不具合。
 //   GID 1216646499090814 / PR #481 で修正・デプロイ確認済み(2026-07-17)。
+// C-LEAK-3: テストチャット(chat-test/index.tsx)の avatar/configs 取得が previewTenantId を
+//   見ず tenant未指定で叩かれ、全テナント混在の一覧から他テナントのアバターが誤選択され
+//   アバターに接続できない不具合。GID 1216646748578275 / PR #483 で修正・デプロイ確認済み(2026-07-17)。
 //
 // 注: preview 状態は useAuth の in-memory state（永続化なし）。投入後にページを reload すると状態が
 // 消えるため、各ページへは SPA 内リンククリックで遷移する（page.goto は使わない）。
@@ -97,5 +100,37 @@ test.describe('Preview scope leak (known bug) — escalations が preview テナ
     // 4. 画面が白紙(不具合時 body長 ~200字)ではなく、ナレッジUI(タブ等)が描画されていること
     await expect(page.getByText('ナレッジ一覧')).toBeVisible({ timeout: 10000 });
     await expect(page.getByRole('button', { name: /テキスト入力/ })).toBeVisible();
+  });
+
+  test('C-LEAK-3: lp-demo プレビュー中のテストチャットで avatar/configs が他テナント混在にならない', async ({
+    page,
+  }) => {
+    // 1. テナント詳細を開き、プレビュー投入
+    await page.goto(`${ADMIN}/admin/tenants/${PREVIEW_TENANT_2}`, { waitUntil: 'domcontentloaded' });
+    const previewBtn = page.getByRole('button', { name: /クライアントビューで見る/ });
+    await previewBtn.waitFor({ timeout: 15000 });
+    await previewBtn.click();
+    await expect(page.getByText(/プレビューモード|元に戻す/).first()).toBeVisible({ timeout: 10000 });
+
+    // 2. SPA内リンククリックでテストチャットへ（page.gotoはpreview状態をリセットしてしまうため使わない）
+    const configsResP = page.waitForResponse(
+      (r) => r.url().includes('/v1/admin/avatar/configs') && r.request().method() === 'GET',
+      { timeout: 15000 },
+    );
+    await page.getByText('テストチャット').first().click();
+    const configsRes = await configsResP;
+
+    // 3. リクエストにプレビュー先テナントが明示的に付与されていること
+    expect(configsRes.url()).toContain(`tenant=${PREVIEW_TENANT_2}`);
+
+    // 4. 返る一覧がプレビュー先テナント + 共用の r2c_default のみで、他テナントが混入しないこと
+    const body = await configsRes.json();
+    const tenantIds: string[] = [...new Set((body.configs ?? []).map((c: { tenant_id: string }) => c.tenant_id))];
+    const foreign = tenantIds.filter((t) => t !== PREVIEW_TENANT_2 && t !== 'r2c_default');
+    test.info().annotations.push({ type: 'avatar-config-tenants', description: JSON.stringify(tenantIds) });
+    expect(
+      foreign,
+      `プレビュー中(lp-demo)に他テナントのアバター設定が漏洩: ${JSON.stringify(foreign)}`,
+    ).toHaveLength(0);
   });
 });


### PR DESCRIPTION
## 概要
PR #483(テストチャットのアバター接続不具合)が本番にデプロイ済み・green化していることを確認した上で、回帰テストを追加。

**C-LEAK-3**: lp-demoプレビュー中に「テストチャット」を開いた際、`avatar/configs`リクエストに`tenant=lp-demo`が付与され、返る一覧が`lp-demo`+共用`r2c_default`のみで他テナントが混入しないことを検証。

本番(admin.r2c.biz)でPR #483デプロイ後、3回連続greenを確認済み。

`tests/e2e/`のみの変更でadmin-ui/srcは含まないため、Tier S対象外です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)