### PR TITLE
fix(api): テストチャットのアバターがsecurityPolicyのorigin検証で403になる不具合を修正

### DIFF
--- a/src/lib/security-policy.ts
+++ b/src/lib/security-policy.ts
@@ -33,6 +33,15 @@ export function createSecurityPolicyMiddleware(
       return;
     }
 
+    // chat-test tokens are admin-issued (from /admin/chat-test); skip per-tenant
+    // origin enforcement here too — originCheck.ts already does this, but this
+    // middleware runs earlier in the apiStack and was rejecting chat-test avatar
+    // calls (anam-session / room-token) with origin_not_allowed before reaching it.
+    if ((req as any).isChatTestToken) {
+      next();
+      return;
+    }
+
     const authed = req as AuthedRequest;
     const config = authed.tenantConfig;
 


### PR DESCRIPTION
## 概要
ユーザー報告: プレビュー中のテストチャットで「アバターを表示できませんでした」。super_adminプレビューのテナントスコープ問題(PR #480/481/483)とは**別原因**と判明。

## 再現(本番、実データ)
```
POST /api/avatar/anam-session → 403 origin_not_allowed
POST /api/avatar/room-token   → 403 origin_not_allowed
```

## 原因
chat-testトークン(`/admin/chat-test`発行)はadmin管理画面(admin.r2c.biz)から呼ばれるため、テナントの`allowedOrigins`(通常は顧客サイトのオリジン)には含まれない。

`authMiddleware.ts:98`のコメント通り「chat-test tokens are admin-issued; skip per-tenant origin enforcement」という設計意図があり、`originCheck.ts:42`では`req.isChatTestToken`を見てスキップする実装が既にあった。しかし`apiStack`(`src/index.ts:223-230`)は `securityPolicy → originCheck` の順で実行され、**securityPolicy側(`src/lib/security-policy.ts`)には同じスキップ実装が無かった**ため、originCheckに辿り着く前にsecurityPolicy側で先に403を返していた。

## 修正
`security-policy.ts`に`isChatTestToken`チェックを追加し、`originCheck.ts`と同じ意図を先頭のミドルウェアでも適用。

## デプロイについて
**バックエンドのみの変更**、admin-ui/Cloudflare Pages自動デプロイの対象外。本番反映には`deploy-vps.sh`の実行が必要(Tier S、朝承認枠)。

## 関連
- Asana: 起票予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)