### PR TITLE
fix(admin-ui): テストチャットで選択と別のアバターが接続される不具合を修正

### DIFF
--- a/admin-ui/src/pages/admin/chat-test/index.tsx
+++ b/admin-ui/src/pages/admin/chat-test/index.tsx
@@ -27,6 +27,7 @@ interface AvatarConfigOption {
   name: string;
   image_url: string | null;
   is_default: boolean;
+  is_active?: boolean;
   tenant_id: string;
 }
 
@@ -164,7 +165,14 @@ export default function ChatTestPage() {
     void authFetch(url)
       .then((res) => (res.ok ? res.json() : Promise.reject(new Error(`HTTP ${res.status}`))))
       .then((data: { configs?: AvatarConfigOption[] }) => {
-        const configs = data.configs ?? [];
+        // is_active=false のアバターは選んでも実際には使われない（LiveKit room-token 発行時
+        // /api/avatar/room-token と avatar-agent 側 /api/internal/avatar-config が両方
+        // is_active=true を必須にしているため検証で弾かれ、環境変数の汎用デフォルトLemonSlice
+        // エージェントに無言でフォールバックしてしまう）。同名で is_active=false の重複が
+        // テナント作成時に自動生成される(tenants/routes.ts の DEFAULT_AVATARS seed)ため、
+        // このドロップダウンでは非アクティブな候補を最初から除外し、選んでも繋がらない状態を防ぐ。
+        const allConfigs = data.configs ?? [];
+        const configs = allConfigs.filter((c) => c.is_active !== false);
         setAvailableAvatars(configs);
         const urlMatch = configs.find((c) => c.id === queryAvatarConfigId);
         if (urlMatch) {


### PR DESCRIPTION
## 概要
ユーザー報告(スクリーンショット): 「選択しているアバターとは別のアバターが接続された。しかもR2Cにいなくて、LemonSliceにいるアバター。デフォルトの右下アイコンにはアバターが表示されない」。super_adminプレビューのテナントスコープ問題(PR #480/481/483/485)とは**別原因**、より根深いバグ。

## 原因(コード確認済み)
テナント作成時(`tenants/routes.ts:303`)、R2Cデフォルトアバター18体がテナント固有コピーとして **`is_active: false`** で自動生成される(`DEFAULT_AVATARS` seed)。同名(例: SERAPH)のアクティブな共用版が `tenant_id='r2c_default'` に別途存在するため、実質同名の重複が2つ存在する。

`GET /v1/admin/avatar/configs`(一覧取得)は`is_active`を一切フィルタしないため、テストチャットのドロップダウンには無効な複製も区別なく表示され、選択順序(`created_at DESC`)でテナント固有の無効な複製が先頭に来て自動選択される。

しかし実際にLiveKitルームを発行する側(`livekitTokenRoutes.ts`)とavatar-agent側(`agent.py` → `/api/internal/avatar-config`)は、どちらも`is_active=true`を必須にしているため、選ばれた無効な複製は検証で弾かれ、`avatar_config=None`となり、agent.pyが環境変数のデフォルト(`LEMONSLICE_AGENT_ID`、R2Cの管理外のLemonSlice汎用デモエージェント)に無言でフォールバックする。**これが「選択と別の、R2Cにいないアバター」の正体。**

実データ確認:
```
SERAPH  tenant=lp-demo      is_active=false  ← 無効な複製、選ばれてしまう
SERAPH  tenant=r2c_default  is_active=true   ← 本来使われるべき共用アクティブ版
```

## 修正
`chat-test/index.tsx`の`avatar/configs`取得後、`is_active=false`の候補を除外してから選択・ドロップダウン表示する。選んでも実際には機能しない候補を最初から見せない、UI側の安全な修正(バックエンドの一覧APIは他画面と共有のため変更しない)。

## 補足
FABアイコンにアバター画像が表示されない症状も同根(imageUrlがnullになる)の可能性が高く、本修正で解消される見込み。デプロイ後に併せて確認する。

`is_active: false`でのseed自体の設計意図(将来カスタマイズ後に有効化する運用フローなのか、単なるバグなのか)は不明なため、DB挿入ロジックやシード仕様自体には手を入れていない。

## 関連
- Asana: 起票予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)