### PR TITLE
🚨 hotfix(admin-ui): Cloudflare Pages CDNキャッシュ破損によるアプリ起動不能を回避

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -83,6 +83,14 @@ function ConfigErrorScreen() {
   );
 }
 
+// build-hash cache-bust 2026-07-17: Cloudflare Pages エッジで /assets/*.js に
+// 誤って index.html の SPA fallback がキャッシュされる不整合(immutable設定のため
+// 自然回復しない)を、ファイル名ハッシュを変えて新規URLに切り替えることで回避する。
+// (console.* は vite.config.ts の terser drop_console:true で消えるため window 代入を使う)
+if (typeof window !== "undefined") {
+  (window as unknown as Record<string, string>).__r2cAdminBuildTag = "20260717-1";
+}
+
 function AppInner() {
   const { isClientAdmin, isSuperAdmin, user, previewMode, previewTenantId } = useAuth();
   const { isOpen: agentOpen, seedQuery, toggle: toggleAgent, close: closeAgent } = useAdminAgentUI();


### PR DESCRIPTION
## 緊急度: 高

本番(admin.r2c.biz)で管理画面全体が起動不能になっていることを、PR #486の動作検証中に発見。

## 症状
```
⚠️ 起動エラー
Uncaught SyntaxError: Unexpected token '<'
```
`/admin`を含む管理画面全ページで発生(特定のPR/機能に限定されない)。

## 原因(コードではなくCDN配信インフラ側)
- `index.html`は正しく最新JS(`/assets/index-Cpnl7Gmg.js`)を参照
- しかし一部のCDNエッジが該当URLに対し `content-type: application/javascript` ヘッダーは正しく返しつつ、**実際のボディに`index.html`(SPA fallback)の中身を誤ってキャッシュ**している(curlでは正常なJSが返る場合とHTMLが返る場合があり、エッジロケーションによって応答が分かれている)
- `public/_headers`で`/assets/*.js`に`Cache-Control: immutable, max-age=31536000`(1年間不変)を設定しているため、一度この破損キャッシュが乗ると自然回復しない

ローカルビルド(`pnpm build` → `vite preview`)ではエラーが再現せず、コード自体は正常であることを確認済み。

## 対応
無害な`window`代入を1行追加し、ビルド出力のファイル名ハッシュを変更(`index-DeOMV9JI.js` → `index-BCLXMRoZ.js`)。新しいURLは未キャッシュのため、破損したエッジキャッシュを実質的に回避してデプロイし直す。

`console.*`は`vite.config.ts`のterser `drop_console:true`で削除されるため、`window`代入で副作用を持たせている。

## 残課題(スコープ外)
CDNキャッシュ層の根本対策(Cloudflareダッシュボードでのキャッシュpurge手順の整備、再発防止)は別途検討が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)