### PR TITLE
feat(admin-agent): G1多段ループ・SSEストリーミング・Sai委譲・Phase4既定切替の仕組み

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -44,6 +44,7 @@ import AuthBridgePage from "./pages/AuthBridgePage";
 import CopilotPreviewPage from "./pages/copilot-preview/index";
 import { AdminAgentUIProvider, useAdminAgentUI } from "./contexts/AdminAgentUIContext";
 import { supabaseConfigured } from "./lib/supabaseClient";
+import { isChatFirstDefaultEnabled } from "./lib/chatFirstDefault";
 
 // ─── 層2: Supabase 未設定ガード ───────────────────────────────────────────────
 // supabaseConfigured=false の場合、Reactはマウントできるが
@@ -105,7 +106,12 @@ function AppInner() {
   const isAuthBridge = location.pathname === "/auth/bridge";
   // 【追加専用・プロトタイプ】チャット・ファースト管理画面のプレビュー。
   // 認証ゲートより手前で隔離返却するため、既存のルート/サイドバー/認可には触れない。
-  const isCopilotPreview = location.pathname === "/copilot-preview";
+  // Phase4: このブラウザだけの個人オプトイン(localStorage)で有効化した場合のみ、
+  // 従来のランディング(/ , /admin)からもこの画面に入る。既定は無効=従来のダッシュボードのまま。
+  // テナント全体・他ユーザーの挙動には一切影響しない。
+  const isLandingPath = location.pathname === "/" || location.pathname === "/admin";
+  const isCopilotPreview =
+    location.pathname === "/copilot-preview" || (isLandingPath && isChatFirstDefaultEnabled());
 
   if (isAuthBridge) {
     return (
@@ -116,11 +122,7 @@ function AppInner() {
   }
 
   if (isCopilotPreview) {
-    return (
-      <Routes>
-        <Route path="/copilot-preview" element={<CopilotPreviewPage />} />
-      </Routes>
-    );
+    return <CopilotPreviewPage />;
   }
 
   if (isLogin) {

--- a/admin-ui/src/lib/chatFirstDefault.test.ts
+++ b/admin-ui/src/lib/chatFirstDefault.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { CHAT_FIRST_DEFAULT_KEY, isChatFirstDefaultEnabled, setChatFirstDefaultEnabled } from "./chatFirstDefault";
+
+// このプロジェクトのvitest環境(happy-dom)は window.localStorage を提供しないため、
+// テスト用に最小限のMap実装で補う(本番のブラウザでは標準のlocalStorageが使われる。
+// chatFirstDefault.ts 自体はlocalStorage不在時にtry/catchでfalseへ安全側フォールバックする設計)。
+function installFakeLocalStorage() {
+  const store = new Map<string, string>();
+  const fakeStorage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => void store.clear(),
+  };
+  Object.defineProperty(window, "localStorage", { value: fakeStorage, configurable: true });
+}
+
+describe("chatFirstDefault (Phase4: 個人オプトイン、既定OFF)", () => {
+  beforeEach(() => {
+    installFakeLocalStorage();
+  });
+
+  it("既定(未設定)では無効", () => {
+    expect(isChatFirstDefaultEnabled()).toBe(false);
+  });
+
+  it("setChatFirstDefaultEnabled(true) で有効になる", () => {
+    setChatFirstDefaultEnabled(true);
+    expect(isChatFirstDefaultEnabled()).toBe(true);
+    expect(window.localStorage.getItem(CHAT_FIRST_DEFAULT_KEY)).toBe("true");
+  });
+
+  it("setChatFirstDefaultEnabled(false) で無効に戻る(キーが削除される)", () => {
+    setChatFirstDefaultEnabled(true);
+    setChatFirstDefaultEnabled(false);
+    expect(isChatFirstDefaultEnabled()).toBe(false);
+    expect(window.localStorage.getItem(CHAT_FIRST_DEFAULT_KEY)).toBeNull();
+  });
+
+  it("localStorageに無関係な値が入っていても有効とは判定しない(fail-safe)", () => {
+    window.localStorage.setItem(CHAT_FIRST_DEFAULT_KEY, "1");
+    expect(isChatFirstDefaultEnabled()).toBe(false);
+  });
+});

--- a/admin-ui/src/lib/chatFirstDefault.ts
+++ b/admin-ui/src/lib/chatFirstDefault.ts
@@ -1,0 +1,25 @@
+// admin-ui/src/lib/chatFirstDefault.ts
+// Phase4: チャット・ファーストを既定ランディングにするかどうかの、ブラウザ単位オプトイン設定。
+// このlocalStorageフラグだけで完結し、テナント全体・他ユーザー・サーバー側には一切影響しない。
+// 既定は無効(false) = 従来のダッシュボードのまま。App.tsx と copilot-preview の両方から参照するため
+// 循環import回避のためこのファイルに切り出している。
+
+export const CHAT_FIRST_DEFAULT_KEY = "r2c_chat_first_default";
+
+export function isChatFirstDefaultEnabled(): boolean {
+  try {
+    return typeof window !== "undefined" && window.localStorage.getItem(CHAT_FIRST_DEFAULT_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+export function setChatFirstDefaultEnabled(enabled: boolean): void {
+  try {
+    if (typeof window === "undefined") return;
+    if (enabled) window.localStorage.setItem(CHAT_FIRST_DEFAULT_KEY, "true");
+    else window.localStorage.removeItem(CHAT_FIRST_DEFAULT_KEY);
+  } catch {
+    // localStorage無効環境(プライベートブラウズ等)では静かに無視
+  }
+}

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -14,6 +14,7 @@
 import { useState, useRef, useEffect, useCallback } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import { authFetch, API_BASE } from "../../lib/api";
+import { isChatFirstDefaultEnabled, setChatFirstDefaultEnabled } from "../../lib/chatFirstDefault";
 
 // ─── モデル ──────────────────────────────────────────────────────────────────
 
@@ -560,8 +561,11 @@ export default function CopilotPreviewPage() {
             <span style={{ fontSize: 15 }}>{c.icon}</span>{c.label}
           </button>
         ))}
-        <div style={{ marginTop: "auto", fontSize: 10.5, color: "var(--muted-foreground)", lineHeight: 1.5, padding: "8px" }}>
-          「くわしい設定」は従来画面のまま。会話UIは<strong style={{ color: "var(--foreground)" }}>追加</strong>で、既存は消していません。
+        <div style={{ marginTop: "auto" }}>
+          <Phase4DefaultToggle />
+          <div style={{ fontSize: 10.5, color: "var(--muted-foreground)", lineHeight: 1.5, padding: "8px" }}>
+            「くわしい設定」は従来画面のまま。会話UIは<strong style={{ color: "var(--foreground)" }}>追加</strong>で、既存は消していません。
+          </div>
         </div>
       </aside>
 
@@ -633,6 +637,49 @@ function AgentMark() {
       <div style={{ position: "absolute", inset: 3, borderRadius: "50%", background: "var(--card, var(--background))" }} />
       <span style={{ position: "relative", zIndex: 1, fontSize: 17 }}>✨</span>
     </div>
+  );
+}
+
+// Phase4: チャット・ファーストを既定ランディングにするかの個人オプトイン(このブラウザのみ)。
+// ONにすると次回以降 /admin, / を開いた時にこの画面が開くようになる。テナント全体・
+// 他ユーザーには一切影響しない。既定はOFF(従来のダッシュボードのまま)。
+function Phase4DefaultToggle() {
+  const [enabled, setEnabled] = useState(() => isChatFirstDefaultEnabled());
+
+  const toggle = () => {
+    const next = !enabled;
+    setChatFirstDefaultEnabled(next);
+    setEnabled(next);
+  };
+
+  return (
+    <button
+      onClick={toggle}
+      style={{
+        display: "flex", alignItems: "center", gap: 8, width: "calc(100% - 16px)", margin: "0 8px 8px",
+        padding: "8px 10px", borderRadius: 8, border: "1px solid var(--border)",
+        background: enabled ? AGENT_SOFT : "transparent", cursor: "pointer", textAlign: "left",
+      }}
+    >
+      <span
+        style={{
+          width: 30, height: 17, borderRadius: 999, background: enabled ? AGENT : "var(--border)",
+          position: "relative", flexShrink: 0, transition: "background 0.15s",
+        }}
+      >
+        <span
+          style={{
+            position: "absolute", top: 2, left: enabled ? 15 : 2, width: 13, height: 13, borderRadius: "50%",
+            background: "#fff", transition: "left 0.15s",
+          }}
+        />
+      </span>
+      <span style={{ fontSize: 11, color: enabled ? AGENT : "var(--muted-foreground)", lineHeight: 1.4 }}>
+        これを既定の画面にする
+        <br />
+        <span style={{ fontSize: 9.5, opacity: 0.75 }}>このブラウザだけの設定です</span>
+      </span>
+    </button>
   );
 }
 

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -13,6 +13,8 @@ import { searchKnowledgeForSuggestion, formatKnowledgeContext } from '../../../l
 import { getGaps } from '../knowledge/knowledgeGapRepository';
 import { textToFaqs } from '../knowledge/routes';
 import { suggestEngagementRuleFromText } from './engagementSuggest';
+import { checkSaiMonthlyCostCeiling } from '../options/routes';
+import { submitSaiTask, getSaiTask } from '../../../lib/sai/saiClient';
 
 // ---------------------------------------------------------------------------
 // Avatar activate（avatar/routes.ts は無改変、ここで再実装）
@@ -65,7 +67,8 @@ export async function executeToolCall(
   toolName: string,
   args: Record<string, unknown>,
   tenantId: string,
-  db: Pool
+  db: Pool,
+  isSuperAdmin: boolean = false
 ): Promise<string> {
   // 結果は500字以内日本語
   const truncate = (s: string) => s.slice(0, 500);
@@ -649,6 +652,69 @@ export async function executeToolCall(
       } catch (err) {
         logger.warn('[actionExecutor] save_engagement_rule failed', err);
         return truncate('声がけルールの保存に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    // Sai委譲(Tier A設計の土台): 現時点では super_admin 限定を維持し、client_admin には
+    // 開放しない（信頼モデル変更は別途判断が必要なため、既存のtry-sai同様の認可を踏襲）。
+    case 'request_sai_task': {
+      if (!isSuperAdmin) {
+        return truncate('この操作は現在 super_admin 限定です。テナント管理者向けの代行依頼は「代行作業の依頼」からお願いします');
+      }
+
+      const confirmed = Boolean(args['confirmed']);
+      const description = String(args['description'] ?? '').trim().slice(0, 2000);
+      const maxStepsRaw = Number(args['max_steps']);
+      const maxSteps = Number.isFinite(maxStepsRaw) && maxStepsRaw > 0 ? Math.round(maxStepsRaw) : undefined;
+
+      if (!confirmed) {
+        return truncate('Saiへの依頼には確認が必要です。作業内容と発生しうる費用をユーザーに提示し、同意を得てから confirmed=true で再度呼び出してください');
+      }
+      if (!description) {
+        return truncate('description は必須です');
+      }
+
+      try {
+        const ceilingCheck = await checkSaiMonthlyCostCeiling(db);
+        if (!ceilingCheck.ok) {
+          return truncate('Saiの月次コスト上限に達しているため、今回は依頼できません。管理者に確認してください');
+        }
+
+        const { task_id } = await submitSaiTask({ description, maxSteps });
+        return truncate(`Saiにタスクを依頼しました（タスクID: ${task_id}）。get_sai_task_status で進捗を確認できます`);
+      } catch (err: any) {
+        if (err?.message === 'SAI_API_KEY not set') {
+          return truncate('Saiが設定されていません');
+        }
+        logger.warn('[actionExecutor] request_sai_task failed', err);
+        return truncate('Saiへの依頼に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    case 'get_sai_task_status': {
+      if (!isSuperAdmin) {
+        return truncate('この操作は現在 super_admin 限定です');
+      }
+
+      const taskId = String(args['task_id'] ?? '').trim();
+      if (!taskId) {
+        return truncate('task_id は必須です');
+      }
+
+      try {
+        const task = await getSaiTask(taskId);
+        const lines = [
+          `状態: ${task.status}`,
+          `ステップ: ${task.steps}/${task.max_steps}`,
+        ];
+        if (task.outcome) lines.push(`自己申告: ${task.outcome}（自己申告は信用しない設計のため、最終スクリーンショットを目視確認してから完了させてください）`);
+        if (task.last_action) lines.push(`直近の操作: ${task.last_action}`);
+        return truncate(lines.join('\n'));
+      } catch (err) {
+        logger.warn('[actionExecutor] get_sai_task_status failed', err);
+        return truncate('Saiタスクの状態取得に失敗しました');
       }
     }
 

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -946,4 +946,120 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(res.body.actions[0].result).toContain('ID: 7');
     });
   });
+
+  // -------------------------------------------------------------------------
+  // G1: 多段エージェントループ
+  // -------------------------------------------------------------------------
+  describe('G1: 多段エージェントループ', () => {
+    function toolCallResponse(id: string, name: string, args: Record<string, unknown> = {}) {
+      return {
+        ok: true,
+        json: async () => ({
+          choices: [{
+            message: {
+              content: null,
+              tool_calls: [{ id, type: 'function', function: { name, arguments: JSON.stringify(args) } }],
+            },
+          }],
+        }),
+        text: async () => '',
+      };
+    }
+
+    it('3ホップ: ツール→ツール→最終応答 が正しく連鎖する', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-1', 'get_tenant_settings'))
+        .mockResolvedValueOnce(toolCallResponse('call-2', 'get_faq_list'))
+        .mockResolvedValueOnce(makeGroqResponse('設定とFAQを確認しました。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ ga4_measurement_id: null, posthog_host: null, widget_theme: {} }] })
+        .mockResolvedValueOnce({ rows: [{ id: 1, question: 'q', answer: 'a' }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '設定とFAQを両方確認して', sessionId: 'sess-070' });
+
+      expect(res.status).toBe(200);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+      expect(res.body.actions.map((a: any) => a.tool)).toEqual(['get_tenant_settings', 'get_faq_list']);
+      expect(res.body.reply).toBe('設定とFAQを確認しました。');
+    });
+
+    it('MAX_TOOL_HOPS(4回)に達しても収束しない場合、tools無しの強制まとめ呼び出しで終了する', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-1', 'get_tenant_settings'))
+        .mockResolvedValueOnce(toolCallResponse('call-2', 'get_tenant_settings'))
+        .mockResolvedValueOnce(toolCallResponse('call-3', 'get_tenant_settings'))
+        .mockResolvedValueOnce(toolCallResponse('call-4', 'get_tenant_settings'))
+        .mockResolvedValueOnce(makeGroqResponse('（強制まとめ）これ以上の確認はできませんでした。'));
+
+      mockQuery.mockResolvedValue({ rows: [{ ga4_measurement_id: null, posthog_host: null, widget_theme: {} }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ループしてみて', sessionId: 'sess-071' });
+
+      expect(res.status).toBe(200);
+      // 4ホップ(tools付き) + 1回の強制まとめ(tools無し) = 合計5回のGroq呼び出し
+      expect(mockFetch).toHaveBeenCalledTimes(5);
+      expect(res.body.actions.length).toBe(4);
+      expect(res.body.reply).toBe('（強制まとめ）これ以上の確認はできませんでした。');
+    });
+
+    it('同一ターン内で suggest_faq → save_faq(confirmed=true) を連鎖しようとするとブロックされ、DBには書き込まれない', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-1', 'suggest_faq', { free_text: '送料は550円' }))
+        .mockResolvedValueOnce(toolCallResponse('call-2', 'save_faq', { question: 'q', answer: 'a', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('確認をお願いします。'));
+
+      mockQuery.mockResolvedValueOnce({ rows: [{ question: '既存FAQ' }] }); // suggest_faq内の既存質問取得
+      mockTextToFaqs.mockResolvedValueOnce([{ question: '送料はいくらですか？', answer: '550円です。' }]);
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '送料は550円で登録して', sessionId: 'sess-072' });
+
+      expect(res.status).toBe(200);
+      // save_faq の INSERT が発火していないこと(suggest_faq用の1回のSELECTのみ)
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      expect(mockQuery).not.toHaveBeenCalledWith(expect.stringContaining('INSERT INTO faq_docs'), expect.anything());
+
+      const saveAction = res.body.actions.find((a: any) => a.tool === 'save_faq');
+      expect(saveAction.result).toContain('同一ターン内での連続実行');
+    });
+
+    it('同一ホップ内で suggest_tuning_rule と save_tuning_rule(confirmed=true) が同時に来ても後者はブロックされる', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            choices: [{
+              message: {
+                content: null,
+                tool_calls: [
+                  { id: 'call-1', type: 'function', function: { name: 'suggest_tuning_rule', arguments: JSON.stringify({ free_text: '保証は2年' }) } },
+                  { id: 'call-2', type: 'function', function: { name: 'save_tuning_rule', arguments: JSON.stringify({ trigger_pattern: '保証', expected_behavior: '2年', confirmed: true }) } },
+                ],
+              },
+            }],
+          }),
+          text: async () => '',
+        })
+        .mockResolvedValueOnce(makeGroqResponse('確認をお願いします。'));
+
+      mockCallGroq8bSuggestFromText.mockResolvedValueOnce({
+        trigger_pattern: '保証', instruction: '2年と伝える', priority: 5, reason: '',
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '保証は2年で登録して', sessionId: 'sess-073' });
+
+      expect(res.status).toBe(200);
+      expect(mockCreateRule).not.toHaveBeenCalled();
+      const saveAction = res.body.actions.find((a: any) => a.tool === 'save_tuning_rule');
+      expect(saveAction.result).toContain('同一ターン内での連続実行');
+    });
+  });
 });

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -75,6 +75,19 @@ jest.mock('./engagementSuggest', () => ({
   suggestEngagementRuleFromText: (...args: any[]) => mockSuggestEngagementRuleFromText(...args),
 }));
 
+// request_sai_task / get_sai_task_status が使う依存をモック
+const mockCheckSaiMonthlyCostCeiling = jest.fn();
+jest.mock('../options/routes', () => ({
+  checkSaiMonthlyCostCeiling: (...args: any[]) => mockCheckSaiMonthlyCostCeiling(...args),
+}));
+
+const mockSubmitSaiTask = jest.fn();
+const mockGetSaiTask = jest.fn();
+jest.mock('../../../lib/sai/saiClient', () => ({
+  submitSaiTask: (...args: any[]) => mockSubmitSaiTask(...args),
+  getSaiTask: (...args: any[]) => mockGetSaiTask(...args),
+}));
+
 // logger モック
 jest.mock('../../../lib/logger', () => ({
   logger: { warn: jest.fn(), info: jest.fn(), error: jest.fn() },
@@ -156,6 +169,7 @@ describe('POST /v1/admin/agent/chat', () => {
     mockGetGaps.mockResolvedValue({ gaps: [], total: 0 });
     mockSearchKnowledgeForSuggestion.mockResolvedValue({ results: [] });
     mockFormatKnowledgeContext.mockReturnValue('');
+    mockCheckSaiMonthlyCostCeiling.mockResolvedValue({ ok: true });
   });
 
   // -------------------------------------------------------------------------
@@ -1209,6 +1223,121 @@ describe('POST /v1/admin/agent/chat', () => {
 
       expect(res.status).toBe(200);
       expect(res.body.reply).toBe('AIアシスタントは現在利用できません');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Sai委譲(Tier A設計の土台): super_admin限定を維持、client_adminには開放しない
+  // -------------------------------------------------------------------------
+  describe('request_sai_task / get_sai_task_status', () => {
+    function toolCallResponse(name: string, args: Record<string, unknown>) {
+      return {
+        ok: true,
+        json: async () => ({
+          choices: [{
+            message: {
+              content: null,
+              tool_calls: [{ id: 'call-1', type: 'function', function: { name, arguments: JSON.stringify(args) } }],
+            },
+          }],
+        }),
+        text: async () => '',
+      };
+    }
+
+    it('client_admin が呼び出すと super_admin 限定メッセージが返り、Saiには依頼されない', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('request_sai_task', { description: '商品ページを更新して', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('現在は対応できません。'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '商品ページを更新して', sessionId: 'sess-090' });
+
+      expect(res.status).toBe(200);
+      expect(mockSubmitSaiTask).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('super_admin 限定');
+    });
+
+    it('super_admin: confirmed=false → 依頼されずブロックされる', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('request_sai_task', { description: '商品ページを更新して', confirmed: false }))
+        .mockResolvedValueOnce(makeGroqResponse('確認してから依頼します。'));
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '商品ページを更新して', sessionId: 'sess-091' });
+
+      expect(res.status).toBe(200);
+      expect(mockSubmitSaiTask).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('確認が必要');
+    });
+
+    it('super_admin: 月次コスト上限に達している場合は依頼されない', async () => {
+      mockCheckSaiMonthlyCostCeiling.mockResolvedValueOnce({ ok: false, spentCents: 100000, ceilingCents: 100000 });
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('request_sai_task', { description: '商品ページを更新して', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('上限に達しています。'));
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '商品ページを更新して', sessionId: 'sess-092' });
+
+      expect(res.status).toBe(200);
+      expect(mockSubmitSaiTask).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('上限');
+    });
+
+    it('super_admin: confirmed=true かつ上限内 → Saiに依頼されタスクIDが返る', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('request_sai_task', { description: '商品ページの送料表記を更新して', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('依頼しました。'));
+
+      mockSubmitSaiTask.mockResolvedValueOnce({ task_id: 'sai-task-99', status: 'queued' });
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '商品ページの送料表記を更新して', sessionId: 'sess-093' });
+
+      expect(res.status).toBe(200);
+      expect(mockSubmitSaiTask).toHaveBeenCalledWith(
+        expect.objectContaining({ description: '商品ページの送料表記を更新して' }),
+      );
+      expect(res.body.actions[0].result).toContain('sai-task-99');
+    });
+
+    it('client_admin が get_sai_task_status を呼び出すと super_admin 限定メッセージが返る', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('get_sai_task_status', { task_id: 'sai-task-99' }))
+        .mockResolvedValueOnce(makeGroqResponse('現在は対応できません。'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '進捗を教えて', sessionId: 'sess-094' });
+
+      expect(res.status).toBe(200);
+      expect(mockGetSaiTask).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('super_admin 限定');
+    });
+
+    it('super_admin: get_sai_task_status で状態と自己申告非信用の注記を返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('get_sai_task_status', { task_id: 'sai-task-99' }))
+        .mockResolvedValueOnce(makeGroqResponse('進捗を確認しました。'));
+
+      mockGetSaiTask.mockResolvedValueOnce({
+        status: 'complete', steps: 3, max_steps: 15, description: 'x',
+        outcome: 'agent_reported_done', last_action: 'click save button',
+      });
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '進捗を教えて', sessionId: 'sess-095' });
+
+      expect(res.status).toBe(200);
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain('complete');
+      expect(result).toContain('自己申告は信用しない');
     });
   });
 });

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -48,9 +48,13 @@ jest.mock('../tuning/tuningRulesRepository', () => ({
   createRule: (...args: any[]) => mockCreateRule(...args),
 }));
 
+// 名前付きラッパーにする(jest.mock factory内の匿名 jest.fn() は resetAllMocks() で
+// 既定値ごと消えてしまい、beforeEachで再設定できないため他の依存と同じパターンに統一)
+const mockSearchKnowledgeForSuggestion = jest.fn();
+const mockFormatKnowledgeContext = jest.fn();
 jest.mock('../../../lib/knowledgeSearchUtil', () => ({
-  searchKnowledgeForSuggestion: jest.fn().mockResolvedValue({ results: [] }),
-  formatKnowledgeContext: jest.fn().mockReturnValue(''),
+  searchKnowledgeForSuggestion: (...args: any[]) => mockSearchKnowledgeForSuggestion(...args),
+  formatKnowledgeContext: (...args: any[]) => mockFormatKnowledgeContext(...args),
 }));
 
 // get_weekly_briefing が使う依存をモック
@@ -142,10 +146,16 @@ function makeGroqResponse(
 
 describe('POST /v1/admin/agent/chat', () => {
   beforeEach(() => {
-    jest.clearAllMocks();
+    // resetAllMocks: clearAllMocksだとmockResolvedValue(永続的な既定値)がテストを跨いで
+    // 残り続け、後続テストのmockResolvedValueOnceキューを使い切った際にリークして
+    // 結果が汚染される(実際にこの不具合でテストがフレーキーになったため修正)。
+    // 実装(モック値)も含めて毎回完全にリセットする。
+    jest.resetAllMocks();
     process.env.GROQ_API_KEY = 'test-groq-key';
     mockListRules.mockResolvedValue([]);
     mockGetGaps.mockResolvedValue({ gaps: [], total: 0 });
+    mockSearchKnowledgeForSuggestion.mockResolvedValue({ results: [] });
+    mockFormatKnowledgeContext.mockReturnValue('');
   });
 
   // -------------------------------------------------------------------------
@@ -966,6 +976,34 @@ describe('POST /v1/admin/agent/chat', () => {
       };
     }
 
+    it('実測されたGroqの挙動: 無引数ツールで arguments が文字列"null"で来てもクラッシュせず空引数扱いになる', async () => {
+      // 実際にGroq APIを叩いて観測した実データ形式: {"function":{"name":"get_tenant_settings","arguments":"null"}}
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            choices: [{
+              message: {
+                content: null,
+                tool_calls: [{ id: 'call-1', type: 'function', function: { name: 'get_tenant_settings', arguments: 'null' } }],
+              },
+            }],
+          }),
+          text: async () => '',
+        })
+        .mockResolvedValueOnce(makeGroqResponse('確認しました。'));
+
+      mockQuery.mockResolvedValueOnce({ rows: [{ ga4_measurement_id: null, posthog_host: null, widget_theme: {} }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '設定を確認して', sessionId: 'sess-074' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].tool).toBe('get_tenant_settings');
+      expect(res.body.actions[0].result).not.toContain('失敗');
+    });
+
     it('3ホップ: ツール→ツール→最終応答 が正しく連鎖する', async () => {
       mockFetch
         .mockResolvedValueOnce(toolCallResponse('call-1', 'get_tenant_settings'))
@@ -1060,6 +1098,117 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(mockCreateRule).not.toHaveBeenCalled();
       const saveAction = res.body.actions.find((a: any) => a.tool === 'save_tuning_rule');
       expect(saveAction.result).toContain('同一ターン内での連続実行');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // SSE: 本物のトークンストリーミング (stream:true オプトイン)
+  // -------------------------------------------------------------------------
+  describe('SSE ストリーミング (stream:true)', () => {
+    function makeStreamingGroqResponse(fullSseText: string) {
+      const bytes = new TextEncoder().encode(fullSseText);
+      let sent = false;
+      return {
+        ok: true,
+        body: {
+          getReader: () => ({
+            read: async () => {
+              if (!sent) {
+                sent = true;
+                return { done: false, value: bytes };
+              }
+              return { done: true, value: undefined };
+            },
+          }),
+        },
+        text: async () => '',
+      };
+    }
+
+    it('content delta を逐次イベントとして送出し、event: done で最終replyを返す', async () => {
+      const sse =
+        'data: {"choices":[{"delta":{"content":"こん"}}]}\n\n' +
+        'data: {"choices":[{"delta":{"content":"にちは"}}]}\n\n' +
+        'data: {"usage":{"prompt_tokens":10,"completion_tokens":2}}\n\n' +
+        'data: [DONE]\n\n';
+
+      mockFetch.mockResolvedValueOnce(makeStreamingGroqResponse(sse));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'hello', sessionId: 'sess-080', stream: true });
+
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toContain('text/event-stream');
+      expect(res.text).toContain('event: delta');
+      expect(res.text).toContain('"text":"こん"');
+      expect(res.text).toContain('"text":"にちは"');
+      expect(res.text).toContain('event: done');
+      expect(res.text).toContain('"reply":"こんにちは"');
+      expect(mockTrackUsage).toHaveBeenCalledWith(
+        expect.objectContaining({ inputTokens: 10, outputTokens: 2, featureUsed: 'admin_agent' }),
+      );
+    });
+
+    it('tool_calls delta をindexごとに蓄積して実行し、event: action → event: done の順で送出する', async () => {
+      const hop1Sse =
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call-1","function":{"name":"get_tenant_settings","arguments":""}}]}}]}\n\n' +
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{}"}}]}}]}\n\n' +
+        'data: [DONE]\n\n';
+      const hop2Sse = 'data: {"choices":[{"delta":{"content":"設定を確認しました。"}}]}\n\n' + 'data: [DONE]\n\n';
+
+      mockFetch
+        .mockResolvedValueOnce(makeStreamingGroqResponse(hop1Sse))
+        .mockResolvedValueOnce(makeStreamingGroqResponse(hop2Sse));
+
+      mockQuery.mockResolvedValueOnce({ rows: [{ ga4_measurement_id: null, posthog_host: null, widget_theme: {} }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '設定を確認して', sessionId: 'sess-081', stream: true });
+
+      expect(res.status).toBe(200);
+      expect(res.text).toContain('event: action');
+      expect(res.text).toContain('"tool":"get_tenant_settings"');
+      expect(res.text.indexOf('event: action')).toBeLessThan(res.text.indexOf('event: done'));
+      expect(res.text).toContain('設定を確認しました。');
+    });
+
+    it('stream:true でも suggest_faq→save_faq の同一ターン連鎖はブロックされ、DBに書き込まれない', async () => {
+      const hop1Sse =
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call-1","function":{"name":"suggest_faq","arguments":"{\\"free_text\\":\\"送料は550円\\"}"}}]}}]}\n\n' +
+        'data: [DONE]\n\n';
+      const hop2Sse =
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call-2","function":{"name":"save_faq","arguments":"{\\"question\\":\\"q\\",\\"answer\\":\\"a\\",\\"confirmed\\":true}"}}]}}]}\n\n' +
+        'data: [DONE]\n\n';
+      const hop3Sse = 'data: {"choices":[{"delta":{"content":"確認をお願いします。"}}]}\n\n' + 'data: [DONE]\n\n';
+
+      mockFetch
+        .mockResolvedValueOnce(makeStreamingGroqResponse(hop1Sse))
+        .mockResolvedValueOnce(makeStreamingGroqResponse(hop2Sse))
+        .mockResolvedValueOnce(makeStreamingGroqResponse(hop3Sse));
+
+      mockQuery.mockResolvedValueOnce({ rows: [{ question: '既存FAQ' }] });
+      mockTextToFaqs.mockResolvedValueOnce([{ question: '送料はいくらですか？', answer: '550円です。' }]);
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '送料は550円で登録して', sessionId: 'sess-082', stream: true });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).toHaveBeenCalledTimes(1); // suggest_faq用のSELECTのみ、INSERTは発火しない
+      expect(res.text).toContain('同一ターン内での連続実行');
+    });
+
+    it('GROQ_API_KEY未設定でstream:trueでもJSONのグレースフルダウングレードを返す(SSEにはしない)', async () => {
+      delete process.env.GROQ_API_KEY;
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'hello', sessionId: 'sess-083', stream: true });
+
+      expect(res.status).toBe(200);
+      expect(res.body.reply).toBe('AIアシスタントは現在利用できません');
     });
   });
 });

--- a/src/api/admin/agent/agentRoutes.ts
+++ b/src/api/admin/agent/agentRoutes.ts
@@ -176,6 +176,7 @@ async function executeHopToolCalls(
   suggestedThisTurn: Set<string>,
   actions: Array<{ tool: string; result: string }>,
   messages: GroqMessage[],
+  isSuperAdmin: boolean,
 ): Promise<void> {
   for (const toolCall of toolCalls) {
     const { id, name, args } = toolCall;
@@ -186,7 +187,7 @@ async function executeHopToolCalls(
       // 同一ターン内で suggest → save が連鎖しようとしている: 人間の確認を経ていないためブロック
       result = 'この保存は同一ターン内での連続実行のため確認をスキップできません。提案内容を確認のうえ、あらためて「保存して」等のメッセージを送ってください。';
     } else {
-      result = await executeToolCall(name, args, effectiveTenantId, db);
+      result = await executeToolCall(name, args, effectiveTenantId, db, isSuperAdmin);
       if (name in SUGGEST_TO_SAVE_TOOL) suggestedThisTurn.add(name);
     }
 
@@ -440,7 +441,7 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
             }));
 
             const beforeCount = actions.length;
-            await executeHopToolCalls(parsedToolCalls, effectiveTenantId, db, suggestedThisTurn, actions, messages);
+            await executeHopToolCalls(parsedToolCalls, effectiveTenantId, db, suggestedThisTurn, actions, messages, isSuperAdmin);
             for (const action of actions.slice(beforeCount)) {
               res.write(`event: action\ndata: ${JSON.stringify(action)}\n\n`);
             }
@@ -521,7 +522,7 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
           args: parseToolArgs(toolCall.function.arguments),
         }));
 
-        await executeHopToolCalls(parsedToolCalls, effectiveTenantId, db, suggestedThisTurn, actions, messages);
+        await executeHopToolCalls(parsedToolCalls, effectiveTenantId, db, suggestedThisTurn, actions, messages, isSuperAdmin);
       }
 
       if (finalReply === null) {

--- a/src/api/admin/agent/agentRoutes.ts
+++ b/src/api/admin/agent/agentRoutes.ts
@@ -39,6 +39,8 @@ const chatSchema = z.object({
   sessionId: z.string().min(1).max(100),
   targetTenantId: z.string().optional(),
   history: z.array(historyItemSchema).max(20).optional(),
+  // 明示的にオプトインした場合のみ true。省略時(既存クライアント)は従来通りJSON一括応答のまま。
+  stream: z.boolean().optional(),
 });
 
 // ---------------------------------------------------------------------------
@@ -141,6 +143,175 @@ async function callGroqFinal(messages: GroqMessage[]): Promise<{ reply: string; 
 }
 
 // ---------------------------------------------------------------------------
+// 共有: tool_calls の実行（confirmed同一ターン連鎖ガード込み）。
+// 非ストリーミング・ストリーミング両方の多段ループから使う単一の実装。
+// ---------------------------------------------------------------------------
+
+interface ParsedToolCall {
+  id: string;
+  name: string;
+  args: Record<string, unknown>;
+}
+
+/**
+ * ツール呼び出しの arguments(JSON文字列)を安全にパースする。
+ * 実際のGroq API観測で、無引数ツールに対し文字列 "null" が送られてくるケースを確認済み。
+ * JSON.parse自体は例外を投げず null を返すため、catch だけでは防げない
+ * （object以外に解決した場合は空オブジェクトへフォールバックする）。
+ */
+function parseToolArgs(raw: string): Record<string, unknown> {
+  try {
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) return parsed;
+    return {};
+  } catch {
+    return {};
+  }
+}
+
+async function executeHopToolCalls(
+  toolCalls: ParsedToolCall[],
+  effectiveTenantId: string,
+  db: Pool,
+  suggestedThisTurn: Set<string>,
+  actions: Array<{ tool: string; result: string }>,
+  messages: GroqMessage[],
+): Promise<void> {
+  for (const toolCall of toolCalls) {
+    const { id, name, args } = toolCall;
+    const suggestCounterpart = Object.entries(SUGGEST_TO_SAVE_TOOL).find(([, save]) => save === name)?.[0];
+
+    let result: string;
+    if (suggestCounterpart && suggestedThisTurn.has(suggestCounterpart)) {
+      // 同一ターン内で suggest → save が連鎖しようとしている: 人間の確認を経ていないためブロック
+      result = 'この保存は同一ターン内での連続実行のため確認をスキップできません。提案内容を確認のうえ、あらためて「保存して」等のメッセージを送ってください。';
+    } else {
+      result = await executeToolCall(name, args, effectiveTenantId, db);
+      if (name in SUGGEST_TO_SAVE_TOOL) suggestedThisTurn.add(name);
+    }
+
+    actions.push({ tool: name, result });
+    messages.push({ role: 'tool', tool_call_id: id, name, content: result });
+  }
+}
+
+// ---------------------------------------------------------------------------
+// SSE: 本物のトークンストリーミング（stream:true オプトイン時のみ）。
+// 各ホップをGroqの stream:true で受け、content デルタは受信次第そのまま
+// クライアントへ転送し、tool_calls デルタはindexごとに蓄積して完成後に実行する。
+// ---------------------------------------------------------------------------
+
+interface StreamHopResult {
+  content: string | null;
+  tool_calls: GroqToolCall[];
+  usage: GroqUsage;
+}
+
+async function runStreamingHop(
+  messages: GroqMessage[],
+  tools: typeof ADMIN_AGENT_TOOLS | undefined,
+  res: Response,
+): Promise<StreamHopResult> {
+  const apiKey = process.env.GROQ_API_KEY?.trim();
+  if (!apiKey) throw new Error('GROQ_API_KEY not configured');
+
+  const body: Record<string, unknown> = {
+    model: GROQ_VERSATILE_70B,
+    messages,
+    max_tokens: 1024,
+    temperature: 0.2,
+    stream: true,
+  };
+  if (tools && tools.length > 0) {
+    body.tools = tools;
+    body.tool_choice = 'auto';
+  }
+
+  const groqRes = await fetch('https://api.groq.com/openai/v1/chat/completions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${apiKey}` },
+    body: JSON.stringify(body),
+  });
+
+  if (!groqRes.ok || !groqRes.body) {
+    const text = await groqRes.text().catch(() => '');
+    throw new Error(`Groq API error ${groqRes.status}: ${text.slice(0, 200)}`);
+  }
+
+  const reader = groqRes.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  let contentAcc = '';
+  let hasContent = false;
+  const toolCallAcc: Array<{ id?: string; name?: string; args: string }> = [];
+  let usage: GroqUsage = { promptTokens: 0, completionTokens: 0 };
+
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+
+    const lines = buffer.split('\n');
+    buffer = lines.pop() ?? ''; // 最後の不完全な行は次のchunkに持ち越す
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed.startsWith('data:')) continue;
+      const payload = trimmed.slice('data:'.length).trim();
+      if (payload === '[DONE]') continue;
+
+      let parsed: any;
+      try {
+        parsed = JSON.parse(payload);
+      } catch {
+        continue;
+      }
+
+      if (parsed.usage) {
+        usage = {
+          promptTokens: parsed.usage.prompt_tokens ?? usage.promptTokens,
+          completionTokens: parsed.usage.completion_tokens ?? usage.completionTokens,
+        };
+      }
+
+      const delta = parsed.choices?.[0]?.delta;
+      if (!delta) continue;
+
+      if (typeof delta.content === 'string' && delta.content.length > 0) {
+        hasContent = true;
+        contentAcc += delta.content;
+        res.write(`event: delta\ndata: ${JSON.stringify({ text: delta.content })}\n\n`);
+      }
+
+      if (Array.isArray(delta.tool_calls)) {
+        for (const tc of delta.tool_calls) {
+          const idx: number = tc.index ?? 0;
+          if (!toolCallAcc[idx]) toolCallAcc[idx] = { args: '' };
+          if (tc.id) toolCallAcc[idx]!.id = tc.id;
+          if (tc.function?.name) toolCallAcc[idx]!.name = tc.function.name;
+          if (tc.function?.arguments) toolCallAcc[idx]!.args += tc.function.arguments;
+        }
+      }
+    }
+  }
+
+  const toolCalls: GroqToolCall[] = toolCallAcc
+    .filter((tc): tc is { id: string; name: string; args: string } => Boolean(tc?.id && tc?.name))
+    .map((tc) => ({
+      id: tc.id,
+      type: 'function' as const,
+      function: { name: tc.name, arguments: tc.args },
+    }));
+
+  // ストリームの usage イベントが得られなかった場合の概算(日本語はおおよそ4文字≒1トークン)
+  if (usage.completionTokens === 0 && contentAcc) {
+    usage = { ...usage, completionTokens: Math.ceil(contentAcc.length / 4) };
+  }
+
+  return { content: hasContent ? contentAcc : null, tool_calls: toolCalls, usage };
+}
+
+// ---------------------------------------------------------------------------
 // G1: 多段エージェントループの設定
 // ---------------------------------------------------------------------------
 
@@ -157,6 +328,15 @@ const SUGGEST_TO_SAVE_TOOL: Record<string, string> = {
   suggest_tuning_rule: 'save_tuning_rule',
   suggest_faq: 'save_faq',
   suggest_engagement_rule: 'save_engagement_rule',
+};
+
+// MAX_TOOL_HOPS到達後の強制まとめ呼び出し用。tools無しにしただけでは、モデルがまだ
+// ツールを呼びたい場合に "<function=...>" のような擬似構文をテキストとして出力することが
+// 実測で確認されたため、明示的に禁止する一文を最後に差し込む。
+const WRAP_UP_NOTICE: GroqMessage = {
+  role: 'user',
+  content:
+    'これ以上ツールは呼び出せません。ここまでの情報をもとに、自然な日本語の文章だけで回答してください（関数呼び出しの構文などは一切書かないでください）。',
 };
 
 // ---------------------------------------------------------------------------
@@ -222,7 +402,85 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
 
       let totalPromptTokens = 0;
       let totalCompletionTokens = 0;
+      const actions: Array<{ tool: string; result: string }> = [];
+      // このリクエスト(ターン)内で suggest_* が呼ばれたツール名を記録し、
+      // 対応する save_* が同一ターン内で連鎖実行されるのを防ぐ（G1のリスク軽減策）
+      const suggestedThisTurn = new Set<string>();
 
+      // -----------------------------------------------------------------
+      // SSE: stream:true をオプトインした場合のみ本物のトークンストリーミング経路へ。
+      // 省略時(既存クライアント・本番AdminAgentPanel)は下の非ストリーミング経路のまま、挙動は完全に不変。
+      // -----------------------------------------------------------------
+      if (parsed.data.stream === true) {
+        res.writeHead(200, {
+          'Content-Type': 'text/event-stream; charset=utf-8',
+          'Cache-Control': 'no-cache',
+          Connection: 'keep-alive',
+        });
+
+        try {
+          let finalReply: string | null = null;
+
+          for (let hop = 0; hop < MAX_TOOL_HOPS; hop++) {
+            const hopResult = await runStreamingHop(messages, ADMIN_AGENT_TOOLS, res);
+            totalPromptTokens += hopResult.usage.promptTokens;
+            totalCompletionTokens += hopResult.usage.completionTokens;
+
+            if (hopResult.tool_calls.length === 0) {
+              finalReply = hopResult.content ?? '回答を生成できませんでした';
+              break;
+            }
+
+            messages.push({ role: 'assistant', content: hopResult.content, tool_calls: hopResult.tool_calls });
+
+            const parsedToolCalls: ParsedToolCall[] = hopResult.tool_calls.map((tc) => ({
+              id: tc.id,
+              name: tc.function.name,
+              args: parseToolArgs(tc.function.arguments),
+            }));
+
+            const beforeCount = actions.length;
+            await executeHopToolCalls(parsedToolCalls, effectiveTenantId, db, suggestedThisTurn, actions, messages);
+            for (const action of actions.slice(beforeCount)) {
+              res.write(`event: action\ndata: ${JSON.stringify(action)}\n\n`);
+            }
+          }
+
+          if (finalReply === null) {
+            // MAX_TOOL_HOPS に達しても収束しなかった場合、tools無しで強制的にまとめさせる(これもストリーミング)。
+            // 実測: toolsを外しただけだと、まだ呼びたいツールがある場合にモデルが
+            // "<function=...>" のような擬似構文をテキストとして出力することがあるため、明示的に釘を刺す。
+            messages.push(WRAP_UP_NOTICE);
+            const wrapUp = await runStreamingHop(messages, undefined, res);
+            totalPromptTokens += wrapUp.usage.promptTokens;
+            totalCompletionTokens += wrapUp.usage.completionTokens;
+            finalReply = wrapUp.content ?? '回答を生成できませんでした';
+          }
+
+          if (effectiveTenantId) {
+            trackUsage({
+              tenantId: effectiveTenantId,
+              requestId: `admin-agent-${sessionId}-${Date.now()}`,
+              model: GROQ_VERSATILE_70B,
+              inputTokens: totalPromptTokens,
+              outputTokens: totalCompletionTokens,
+              featureUsed: 'admin_agent',
+            });
+          }
+
+          res.write(`event: done\ndata: ${JSON.stringify({ reply: finalReply, actions })}\n\n`);
+          res.end();
+        } catch (err) {
+          logger.warn('[POST /v1/admin/agent/chat stream]', err);
+          res.write(`event: error\ndata: ${JSON.stringify({ error: 'AIエージェントの応答生成に失敗しました' })}\n\n`);
+          res.end();
+        }
+        return;
+      }
+
+      // -----------------------------------------------------------------
+      // 非ストリーミング経路(既定・既存挙動): JSON一括応答
+      // -----------------------------------------------------------------
       const reportUsage = () => {
         // super_adminがテナント未特定（targetTenantId未指定）の場合は課金対象がないためスキップ
         if (!effectiveTenantId) return;
@@ -236,10 +494,6 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
         });
       };
 
-      const actions: Array<{ tool: string; result: string }> = [];
-      // このリクエスト(ターン)内で suggest_* が呼ばれたツール名を記録し、
-      // 対応する save_* が同一ターン内で連鎖実行されるのを防ぐ（G1のリスク軽減策）
-      const suggestedThisTurn = new Set<string>();
       let finalReply: string | null = null;
 
       // G1: tools付きGroq呼び出しを最大 MAX_TOOL_HOPS 回まで繰り返す。
@@ -261,39 +515,20 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
           tool_calls: hopResponse.tool_calls,
         });
 
-        for (const toolCall of hopResponse.tool_calls) {
-          let toolArgs: Record<string, unknown> = {};
-          try {
-            toolArgs = JSON.parse(toolCall.function.arguments);
-          } catch {
-            toolArgs = {};
-          }
+        const parsedToolCalls: ParsedToolCall[] = hopResponse.tool_calls.map((toolCall) => ({
+          id: toolCall.id,
+          name: toolCall.function.name,
+          args: parseToolArgs(toolCall.function.arguments),
+        }));
 
-          const toolName = toolCall.function.name;
-          const suggestCounterpart = Object.entries(SUGGEST_TO_SAVE_TOOL).find(([, save]) => save === toolName)?.[0];
-
-          let result: string;
-          if (suggestCounterpart && suggestedThisTurn.has(suggestCounterpart)) {
-            // 同一ターン内で suggest → save が連鎖しようとしている: 人間の確認を経ていないためブロック
-            result = 'この保存は同一ターン内での連続実行のため確認をスキップできません。提案内容を確認のうえ、あらためて「保存して」等のメッセージを送ってください。';
-          } else {
-            result = await executeToolCall(toolName, toolArgs, effectiveTenantId, db);
-            if (toolName in SUGGEST_TO_SAVE_TOOL) suggestedThisTurn.add(toolName);
-          }
-
-          actions.push({ tool: toolName, result });
-
-          messages.push({
-            role: 'tool',
-            tool_call_id: toolCall.id,
-            name: toolName,
-            content: result,
-          });
-        }
+        await executeHopToolCalls(parsedToolCalls, effectiveTenantId, db, suggestedThisTurn, actions, messages);
       }
 
       if (finalReply === null) {
-        // MAX_TOOL_HOPS に達しても収束しなかった場合、tools無しで強制的にまとめさせる
+        // MAX_TOOL_HOPS に達しても収束しなかった場合、tools無しで強制的にまとめさせる。
+        // 実測: toolsを外しただけだと、まだ呼びたいツールがある場合にモデルが
+        // "<function=...>" のような擬似構文をテキストとして出力することがあるため、明示的に釘を刺す。
+        messages.push(WRAP_UP_NOTICE);
         const wrapUp = await callGroqFinal(messages);
         totalPromptTokens += wrapUp.usage.promptTokens;
         totalCompletionTokens += wrapUp.usage.completionTokens;

--- a/src/api/admin/agent/agentRoutes.ts
+++ b/src/api/admin/agent/agentRoutes.ts
@@ -141,6 +141,25 @@ async function callGroqFinal(messages: GroqMessage[]): Promise<{ reply: string; 
 }
 
 // ---------------------------------------------------------------------------
+// G1: 多段エージェントループの設定
+// ---------------------------------------------------------------------------
+
+// 1リクエストあたり許容する「tools付きGroq呼び出し」の最大回数。
+// 暴走・無限ループ防止のガード。上限に達しても収束しない場合は tools 無しの
+// 強制まとめ呼び出し(callGroqFinal)で必ず自然文の reply を返して終了する。
+const MAX_TOOL_HOPS = 4;
+
+// suggest_* → save_*(confirmed=true) の対応表。
+// G1導入により「suggest→save を同一ターン内で連鎖実行」が技術的に可能になったが、
+// これは人間の確認を経ないまま書き込みが確定してしまう抜け道になるため、
+// プロンプト任せにせずコードで明示的にブロックする（下記ループ内で使用）。
+const SUGGEST_TO_SAVE_TOOL: Record<string, string> = {
+  suggest_tuning_rule: 'save_tuning_rule',
+  suggest_faq: 'save_faq',
+  suggest_engagement_rule: 'save_engagement_rule',
+};
+
+// ---------------------------------------------------------------------------
 // ルート登録
 // ---------------------------------------------------------------------------
 
@@ -182,8 +201,11 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
       const systemPrompt =
         `あなたはテナント管理AIエージェントです。テナントID "${effectiveTenantId}" の管理者をサポートします。` +
         `必要に応じてツールを呼び出して設定を確認・変更してください。回答は日本語で簡潔に行ってください。` +
+        `ツールの実行結果を見てから続けて別のツールを呼び出すこともできます（最大${MAX_TOOL_HOPS}回まで）。` +
         `confirmed フラグを持つツール（save_tuning_rule, delete_faq 等）は、必ず先に内容をユーザーに要約提示し、` +
         `明確な同意を得たターンでのみ confirmed=true を指定して呼び出してください。` +
+        `suggest_* で下書きを提案した直後に、同じターン内で対応する save_* を呼び出すことはできません` +
+        `（ユーザーが確認して次のメッセージを送るまで待つ必要があります）。` +
         `セッションID: ${sessionId}`;
 
       // G2: 直近の会話履歴をそのままシステムプロンプトの後に差し込み、マルチターンの文脈を持たせる
@@ -198,10 +220,8 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
         { role: 'user', content: message },
       ];
 
-      // 第1回 Groq 呼び出し（tool_calls あり）
-      const firstResponse = await callGroqWithTools(messages, ADMIN_AGENT_TOOLS);
-      let totalPromptTokens = firstResponse.usage.promptTokens;
-      let totalCompletionTokens = firstResponse.usage.completionTokens;
+      let totalPromptTokens = 0;
+      let totalCompletionTokens = 0;
 
       const reportUsage = () => {
         // super_adminがテナント未特定（targetTenantId未指定）の場合は課金対象がないためスキップ
@@ -217,17 +237,31 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
       };
 
       const actions: Array<{ tool: string; result: string }> = [];
+      // このリクエスト(ターン)内で suggest_* が呼ばれたツール名を記録し、
+      // 対応する save_* が同一ターン内で連鎖実行されるのを防ぐ（G1のリスク軽減策）
+      const suggestedThisTurn = new Set<string>();
+      let finalReply: string | null = null;
 
-      if (firstResponse.tool_calls.length > 0) {
-        // アシスタントメッセージをコンテキストに追加
+      // G1: tools付きGroq呼び出しを最大 MAX_TOOL_HOPS 回まで繰り返す。
+      // モデルがツール結果を見て追加のツールを呼ぶ「多段推論」を許容しつつ、
+      // 上限に達しても収束しない場合は必ず自然文の reply で終了させる。
+      for (let hop = 0; hop < MAX_TOOL_HOPS; hop++) {
+        const hopResponse = await callGroqWithTools(messages, ADMIN_AGENT_TOOLS);
+        totalPromptTokens += hopResponse.usage.promptTokens;
+        totalCompletionTokens += hopResponse.usage.completionTokens;
+
+        if (hopResponse.tool_calls.length === 0) {
+          finalReply = hopResponse.content ?? '回答を生成できませんでした';
+          break;
+        }
+
         messages.push({
           role: 'assistant',
-          content: firstResponse.content,
-          tool_calls: firstResponse.tool_calls,
+          content: hopResponse.content,
+          tool_calls: hopResponse.tool_calls,
         });
 
-        // tool_calls を順次実行
-        for (const toolCall of firstResponse.tool_calls) {
+        for (const toolCall of hopResponse.tool_calls) {
           let toolArgs: Record<string, unknown> = {};
           try {
             toolArgs = JSON.parse(toolCall.function.arguments);
@@ -235,38 +269,39 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
             toolArgs = {};
           }
 
-          const result = await executeToolCall(
-            toolCall.function.name,
-            toolArgs,
-            effectiveTenantId,
-            db
-          );
+          const toolName = toolCall.function.name;
+          const suggestCounterpart = Object.entries(SUGGEST_TO_SAVE_TOOL).find(([, save]) => save === toolName)?.[0];
 
-          actions.push({ tool: toolCall.function.name, result });
+          let result: string;
+          if (suggestCounterpart && suggestedThisTurn.has(suggestCounterpart)) {
+            // 同一ターン内で suggest → save が連鎖しようとしている: 人間の確認を経ていないためブロック
+            result = 'この保存は同一ターン内での連続実行のため確認をスキップできません。提案内容を確認のうえ、あらためて「保存して」等のメッセージを送ってください。';
+          } else {
+            result = await executeToolCall(toolName, toolArgs, effectiveTenantId, db);
+            if (toolName in SUGGEST_TO_SAVE_TOOL) suggestedThisTurn.add(toolName);
+          }
 
-          // tool 結果をコンテキストに追加
+          actions.push({ tool: toolName, result });
+
           messages.push({
             role: 'tool',
             tool_call_id: toolCall.id,
-            name: toolCall.function.name,
+            name: toolName,
             content: result,
           });
         }
-
-        // 第2回 Groq 呼び出し（最終 reply）
-        const finalResponse = await callGroqFinal(messages);
-        totalPromptTokens += finalResponse.usage.promptTokens;
-        totalCompletionTokens += finalResponse.usage.completionTokens;
-        reportUsage();
-        return res.json({ reply: finalResponse.reply, actions });
       }
 
-      // tool_calls がなかった場合はそのまま返す
+      if (finalReply === null) {
+        // MAX_TOOL_HOPS に達しても収束しなかった場合、tools無しで強制的にまとめさせる
+        const wrapUp = await callGroqFinal(messages);
+        totalPromptTokens += wrapUp.usage.promptTokens;
+        totalCompletionTokens += wrapUp.usage.completionTokens;
+        finalReply = wrapUp.reply;
+      }
+
       reportUsage();
-      return res.json({
-        reply: firstResponse.content ?? '回答を生成できませんでした',
-        actions: [],
-      });
+      return res.json({ reply: finalReply, actions });
     } catch (err) {
       logger.warn('[POST /v1/admin/agent/chat]', err);
       return res.status(500).json({ error: 'AIエージェントの応答生成に失敗しました' });

--- a/src/api/admin/agent/toolDefinitions.ts
+++ b/src/api/admin/agent/toolDefinitions.ts
@@ -343,4 +343,44 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
       },
     },
   },
+  {
+    type: 'function',
+    function: {
+      name: 'request_sai_task',
+      description:
+        'R2Cエージェント(Sai)にブラウザ操作の代行作業を依頼する。実際に外部サービスへの課金が発生する。現時点ではsuper_admin限定の機能で、それ以外のロールで呼び出すと拒否される。必ず先にユーザーに作業内容と発生しうる費用を提示し、明確な同意を得てから呼び出すこと。',
+      parameters: {
+        type: 'object',
+        properties: {
+          description: {
+            type: 'string',
+            description: 'Saiに依頼する作業内容（具体的な手順や対象ページが分かるように）',
+          },
+          max_steps: {
+            type: 'number',
+            description: '許容する最大操作ステップ数（任意、省略時は既定値）',
+          },
+          confirmed: {
+            type: 'boolean',
+            description: '依頼確認フラグ（true でのみ実行される）',
+          },
+        },
+        required: ['description', 'confirmed'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'get_sai_task_status',
+      description: '依頼済みのSaiタスクの進捗・結果を取得する読み取り専用ツール。super_admin限定。',
+      parameters: {
+        type: 'object',
+        properties: {
+          task_id: { type: 'string', description: 'request_sai_task の結果に含まれるタスクID' },
+        },
+        required: ['task_id'],
+      },
+    },
+  },
 ];

--- a/src/api/admin/options/routes.ts
+++ b/src/api/admin/options/routes.ts
@@ -70,7 +70,7 @@ function denyInsufficient(req: Request, res: Response, su: Record<string, any> |
 // Sai VPS側の日次タスク数上限(SAI_MAX_TASKS_PER_DAY)とは独立した、
 // R2C本体側での月次コスト上限チェック(多層防御)。デフォルトOFF(未設定なら無制限)。
 // ---------------------------------------------------------------------------
-async function checkSaiMonthlyCostCeiling(pool: any): Promise<{ ok: true } | { ok: false; spentCents: number; ceilingCents: number }> {
+export async function checkSaiMonthlyCostCeiling(pool: any): Promise<{ ok: true } | { ok: false; spentCents: number; ceilingCents: number }> {
   const ceilingCents = Number(process.env.SAI_MONTHLY_COST_CEILING_CENTS ?? '0');
   if (!ceilingCents || ceilingCents <= 0) return { ok: true };
 


### PR DESCRIPTION
## Summary

ロードマップ残り4項目を実装。**G1・SSEは本番共有エンドポイント(/v1/admin/agent/chat)を後方互換で拡張、Sai委譲はsuper_admin限定を維持、Phase4は個人オプトイン(既定OFF)** — いずれも既存ユーザーの体験を変えずに機能を追加。

### G1: 多段エージェントループ
- 固定2ホップ(tool_calls実行→無条件で最終応答)を、最大4ホップまで「ツール結果を見て次のツールを呼ぶ」を許容するループに変更
- MAX_TOOL_HOPS=4で暴走防止。上限到達時はtools無しの強制まとめ呼び出しで必ず自然文replyを返す
- **重要な安全対策**: 多段化により「suggest_*→save_*(confirmed=true)を同一ターン内で人間の確認なしに連鎖実行できる」新リスクが生じるため、SUGGEST_TO_SAVE_TOOLマップで対応関係を追跡しコードレベルでブロック(プロンプト任せにしない)

### SSE: 本物のトークンストリーミング
- `stream:true`のオプトインを追加。省略時(既存のAdminAgentPanel等)は完全に従来通りのJSON一括応答のまま
- 各ホップをGroqのstream:trueで受け、contentデルタは受信次第そのまま転送(event: delta)、tool_callsデルタはindexごとに蓄積して実行後event: actionを送出
- 実際にGroq APIを叩いて発見した実データ起因の不具合を2件修正:
  1. 無引数ツールでarguments が文字列"null"で来ることがあり、JSON.parse("null")がnullを返すため潜在的にクラッシュしうるバグ(既存コードにも同じ穴があった)をparseToolArgs()で一元修正
  2. MAX_TOOL_HOPS到達後の強制まとめで、モデルが"<function=...>"という擬似構文をテキスト出力することがあったため、WRAP_UP_NOTICEで明示的に禁止する一文を追加

### Sai委譲(Tier A設計の土台)
- request_sai_task / get_sai_task_status ツールを追加。信頼モデルの変更(client_adminへの開放)は別途判断が必要なため、既存のtry-sai同様**super_admin限定を維持**
- 既存の月次コスト上限チェック(checkSaiMonthlyCostCeiling)を再利用し多層防御を維持
- get_sai_task_statusは「自己申告は信用しない」設計の注記を結果に含める

### Phase4: チャット・ファースト既定切替の仕組み
- ブラウザのlocalStorageだけで完結する個人オプトインフラグ。**既定は無効=従来のダッシュボードのまま**、サーバー側・他ユーザー・同一ユーザーの別ブラウザには一切影響しない
- 有効化したブラウザだけ "/" "/admin" アクセス時に copilot-preview を直接描画
- copilot-previewに「これを既定の画面にする」トグルを追加

## Test plan
- [x] `agentRoutes.test.ts` 44/44パス(G1: 5件、SSE: 5件、Sai: 6件を新規追加)。バックエンド全体typecheck 0件
- [x] クロステストのモックリーク(jest.clearAllMocks→resetAllMocksへの変更に伴う副作用)を発見・修正し、8回連続実行での再現性を確認済み
- [x] 実サーバー+実Groq APIでのエンドツーエンド検証: SSEイベント順序(action→delta→done)・複数ホップの実行・トークン単位の逐次配信・修正後の自然な最終応答を確認
- [x] 実Postgres(Docker不使用)は今回は新規SQL追加なしのため対象外
- [ ] Sai実タスク送信の実地検証は行っていない(外部コスト発生のため意図的にスキップ)
- [x] `chatFirstDefault.test.ts` 4/4パス、admin-ui全体79/79パス、typecheck 0件(この変更起因分)
- [x] Playwrightで実地確認: フラグ未設定の別ブラウザコンテキストは従来通り/loginへ誘導(既定不変)。フラグ有効化ブラウザのみ/adminがcopilot-previewを直接開くことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SaK6mK6nvpj9GEAwPkWYRW