### PR TITLE
fix(deps): adm-zip を 0.6.0 に更新しHIGH脆弱性を解消

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,7 +126,7 @@
     "@langchain/langgraph": "^0.2.74",
     "@notionhq/client": "^5.4.0",
     "@supabase/supabase-js": "^2.84.0",
-    "adm-zip": "^0.5.17",
+    "adm-zip": "^0.6.0",
     "cors": "^2.8.5",
     "dotenv": "17.2.3",
     "express": "5.1.0",
@@ -148,7 +148,6 @@
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",
-    "@types/adm-zip": "^0.5.8",
     "@types/express": "5.0.5",
     "@types/jest": "^30.0.0",
     "@types/js-yaml": "^4.0.9",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -36,8 +36,8 @@ importers:
         specifier: ^2.84.0
         version: 2.84.0
       adm-zip:
-        specifier: ^0.5.17
-        version: 0.5.17
+        specifier: ^0.6.0
+        version: 0.6.0
       cors:
         specifier: ^2.8.5
         version: 2.8.5
@@ -96,9 +96,6 @@ importers:
       '@playwright/test':
         specifier: ^1.59.1
         version: 1.59.1
-      '@types/adm-zip':
-        specifier: ^0.5.8
-        version: 0.5.8
       '@types/express':
         specifier: 5.0.5
         version: 5.0.5
@@ -985,9 +982,6 @@ packages:
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
-  '@types/adm-zip@0.5.8':
-    resolution: {integrity: sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==}
-
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
 
@@ -1244,9 +1238,9 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  adm-zip@0.5.17:
-    resolution: {integrity: sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==}
-    engines: {node: '>=12.0'}
+  adm-zip@0.6.0:
+    resolution: {integrity: sha512-XleryMhbuksdKtofnWZ9Sk+4CUTbms4Mb/EU32SZwToAyZ5RgVos/ki8n+yr0LWHOGKuakbXTuuYNHLQjhddgg==}
+    engines: {node: '>=14.0'}
 
   agent-base@7.1.4:
     resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
@@ -4487,10 +4481,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@types/adm-zip@0.5.8':
-    dependencies:
-      '@types/node': 24.10.0
-
   '@types/babel__core@7.20.5':
     dependencies:
       '@babel/parser': 7.28.5
@@ -4735,7 +4725,7 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  adm-zip@0.5.17: {}
+  adm-zip@0.6.0: {}
 
   agent-base@7.1.4: {}
 


### PR DESCRIPTION
## Summary
- PR #492 のSecurity Scan失敗を調査したところ、原因は `adm-zip@0.5.17`(package.json)に対する新しいHIGH脆弱性アドバイザリ(GHSA-xcpc-8h2w-3j85 / CVE-2026-39244: 細工されたZIPで巨大メモリ確保→OOM)だと判明。mainブランチも含め、どのPRを立ててもSecurity Scanが落ちる状態だった
- `adm-zip` を修正版 `0.6.0` に更新
- 0.6.0は型定義を同梱するため、`@types/adm-zip` を削除(公式changelogの推奨に従う)
- 実際にZIPアップロードを扱う `src/api/admin/knowledge/bookPdfRoutes.ts` の使用API(`new AdmZip`/`getEntries`/`entryName`/`isDirectory`/`header.size`/`getData`)に変更なし

## Test plan
- [x] `npx tsc --noEmit` クリーン
- [x] `bash SCRIPTS/security-scan.sh` → CRITICAL/HIGH: 0、Result: PASS
- [x] `pnpm audit --production --audit-level=high` → HIGH 0件
- [x] `npx jest src/api/admin/knowledge/bookPdfRoutes.test.ts tests/phase47/bookPdfUpload.test.ts` → 17 tests passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SaK6mK6nvpj9GEAwPkWYRW