### PR TITLE
fix(admin-ui): copilot-preview 会話中は他カテゴリーへの切り替えを禁止

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -512,7 +512,12 @@ export default function CopilotPreviewPage() {
     }
   };
 
+  // 会話中(sending=true、実APIの応答待ち〜タイプライター演出完了まで)は、
+  // 今アクティブなカテゴリー以外への切り替えを禁止する。応答が同じスレッドに
+  // 割り込んで別カテゴリーの定型メッセージと混ざるのを防ぐため。
+  // ボタン側のdisabledで大半は弾かれるが、ここでも二重に防御する。
   const handleCategory = (key: string) => {
+    if (sending && key !== active) return;
     setActive(key);
     if (key === "weekly") {
       push(me("今週のまとめを見せて"));
@@ -545,22 +550,28 @@ export default function CopilotPreviewPage() {
           <span style={{ fontSize: 11, fontWeight: 700, color: AGENT, background: AGENT_SOFT, padding: "2px 8px", borderRadius: 6, marginLeft: 7, letterSpacing: "0.04em" }}>店主モード</span>
         </div>
         <PreviewBadge />
-        {CATEGORIES.map((c) => (
-          <button
-            key={c.key}
-            onClick={() => handleCategory(c.key)}
-            style={{
-              display: "flex", alignItems: "center", gap: 11, textAlign: "left",
-              padding: "11px 12px", borderRadius: 10, border: "none", cursor: "pointer",
-              fontSize: 15, fontWeight: active === c.key ? 700 : 500,
-              color: active === c.key ? AGENT : "var(--muted-foreground)",
-              background: active === c.key ? AGENT_SOFT : "transparent",
-              opacity: c.dim ? 0.55 : 1, minHeight: 44,
-            }}
-          >
-            <span style={{ fontSize: 18 }}>{c.icon}</span>{c.label}
-          </button>
-        ))}
+        {CATEGORIES.map((c) => {
+          const locked = sending && c.key !== active;
+          return (
+            <button
+              key={c.key}
+              onClick={() => handleCategory(c.key)}
+              disabled={locked}
+              title={locked ? "会話が完了するまで他のカテゴリーには切り替えられません" : undefined}
+              style={{
+                display: "flex", alignItems: "center", gap: 11, textAlign: "left",
+                padding: "11px 12px", borderRadius: 10, border: "none",
+                cursor: locked ? "not-allowed" : "pointer",
+                fontSize: 15, fontWeight: active === c.key ? 700 : 500,
+                color: active === c.key ? AGENT : "var(--muted-foreground)",
+                background: active === c.key ? AGENT_SOFT : "transparent",
+                opacity: locked ? 0.35 : c.dim ? 0.55 : 1, minHeight: 44,
+              }}
+            >
+              <span style={{ fontSize: 18 }}>{c.icon}</span>{c.label}
+            </button>
+          );
+        })}
         <div style={{ marginTop: "auto" }}>
           <Phase4DefaultToggle />
           <div style={{ fontSize: 12, color: "var(--muted-foreground)", lineHeight: 1.55, padding: "10px" }}>


### PR DESCRIPTION
## Summary
- ユーザーとR2Cエージェントが会話中(実APIの応答待ち〜タイプライター演出完了まで、`sending=true`)は、左サイドバーの現在アクティブなカテゴリー以外をクリック不可にする
- 従来は会話中でも「今週のまとめ」等を押すと、モックの定型メッセージが同じスレッドに割り込んで実APIの応答と混ざってしまう問題があった
- 会話が完了する(`sending=false`)と自動的に他カテゴリーへの切り替えが再び可能になる

## Test plan
- [x] `npx tsc --noEmit` クリーン
- [x] Playwrightで`sending`の初期値を一時的に`true`にして検証:
  - アクティブな「アシスタント」: `opacity:1` / `disabled:false` / クリック可能
  - 他5カテゴリー(今週のまとめ/会話の履歴/知識データ/指示ルール/アバター): `opacity:0.35` / `disabled:true` / `cursor:not-allowed`
  - 検証用の一時変更は元に戻し済み(コミットにはロジック変更のみ含む)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SaK6mK6nvpj9GEAwPkWYRW