### PR TITLE
fix(admin-ui): copilot-preview モックのチップ会話中もサイドバーをロック

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -198,6 +198,8 @@ export default function CopilotPreviewPage() {
   const [realHistory, setRealHistory] = useState<{ role: "user" | "assistant"; content: string }[]>([]);
   const [sending, setSending] = useState(false);
   const [realActionCount, setRealActionCount] = useState(0); // 実際に成功した書き込み操作の件数
+  // モックデモ側の非同期待ち（saiYesの疑似処理中など）。sendingと合わせて「会話ビジー」を構成する。
+  const [pendingTimer, setPendingTimer] = useState(false);
 
   const threadRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
@@ -462,7 +464,9 @@ export default function CopilotPreviewPage() {
 
       case "saiYes":
         push(say("承知しました。商品ページを開いて更新します…（30秒ほどお待ちください）"));
+        setPendingTimer(true);
         setTimeout(() => {
+          setPendingTimer(false);
           push(
             say("完了しました。実際の画面がこちらです。仕上がりをご確認ください 👇"),
             {
@@ -512,12 +516,23 @@ export default function CopilotPreviewPage() {
     }
   };
 
-  // 会話中(sending=true、実APIの応答待ち〜タイプライター演出完了まで)は、
-  // 今アクティブなカテゴリー以外への切り替えを禁止する。応答が同じスレッドに
-  // 割り込んで別カテゴリーの定型メッセージと混ざるのを防ぐため。
+  // 会話中は今アクティブなカテゴリー以外への切り替えを禁止する。応答が同じ
+  // スレッドに割り込んで別カテゴリーの定型メッセージと混ざるのを防ぐため。
+  // 「会話中」の定義:
+  //   - sending: 実APIの応答待ち〜タイプライター演出完了まで
+  //   - pendingTimer: モックデモのsaiYes疑似処理中(setTimeout待ち)
+  //   - awaitingUserDecision: 直前のAIメッセージにまだ選ばれていないチップが
+  //     残っている(＝「1番をやる」等のデモ会話がまだ途中で、ユーザーの選択待ち)
+  // いずれかがtrueの間はロックし、"stop"等の終端メッセージ(チップなし)に
+  // 達するか、実APIの応答が完了すると自動的に解放される。
+  const lastMsg = msgs[msgs.length - 1];
+  const awaitingUserDecision =
+    !!lastMsg && lastMsg.role === "ai" && !!lastMsg.chips && lastMsg.chips.length > 0 && !lastMsg.chipsUsed;
+  const busy = sending || pendingTimer || awaitingUserDecision;
+
   // ボタン側のdisabledで大半は弾かれるが、ここでも二重に防御する。
   const handleCategory = (key: string) => {
-    if (sending && key !== active) return;
+    if (busy && key !== active) return;
     setActive(key);
     if (key === "weekly") {
       push(me("今週のまとめを見せて"));
@@ -551,7 +566,7 @@ export default function CopilotPreviewPage() {
         </div>
         <PreviewBadge />
         {CATEGORIES.map((c) => {
-          const locked = sending && c.key !== active;
+          const locked = busy && c.key !== active;
           return (
             <button
               key={c.key}


### PR DESCRIPTION
## Summary
PR #495 で追加した「会話中はサイドバーをロック」機能が `sending`(実API呼び出し中)しかカバーしておらず、デモ本編であるモックのチップ会話(「1番をやる」→FAQ登録→指示ルール→声がけ→Sai代行)は `sending` を一切使わないため対象外でした。ユーザー確認の結果、チップ操作で会話を進めている間は他カテゴリーが押せてしまうことが判明。

「会話中」の判定を拡張し、以下いずれかが true の間ロックするよう変更:
- `sending`: 実APIの応答待ち〜タイプライター演出完了まで(既存)
- `pendingTimer`: `saiYes` の疑似処理中(`setTimeout` 1400ms、新規追加)
- `awaitingUserDecision`: 直前のAIメッセージに未消化のチップが残っている(＝デモ会話がまだ途中でユーザーの選択待ち、新規追加)

チップなしの終端メッセージ(`stop`/`saiOk`/`saiLater`等)に達すると自動的に解放されます。

## Test plan
- [x] `npx tsc --noEmit` クリーン
- [x] Playwrightでデモ全ステップを自動実行し検証:
  - bootstrap直後(チップ待ち) → LOCKED
  - FAQ確定 → LOCKED
  - 指示ルール適用 → LOCKED
  - 声がけ設定 → LOCKED
  - `saiYes` の `setTimeout(1400ms)` 疑似処理中 → LOCKED
  - `saiYes` 解決後(OK/直したいチップ待ち) → LOCKED
  - `saiOk`(終端メッセージ、チップなし) → **open に解放**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SaK6mK6nvpj9GEAwPkWYRW