### PR TITLE
feat(admin-ui): copilot-preview「知識データ」「指示ルール」「アバター」を実装

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -176,9 +176,9 @@ const CATEGORIES: Category[] = [
   { key: "assistant", label: "アシスタント", icon: "✨" },
   { key: "weekly", label: "今週のまとめ", icon: "📊" },
   { key: "history", label: "会話の履歴", icon: "💬" },
-  { key: "knowledge", label: "知識データ", icon: "📚", dim: true },
-  { key: "rules", label: "指示ルール", icon: "🎛️", dim: true },
-  { key: "avatar", label: "アバター", icon: "🎭", dim: true },
+  { key: "knowledge", label: "知識データ", icon: "📚" },
+  { key: "rules", label: "指示ルール", icon: "🎛️" },
+  { key: "avatar", label: "アバター", icon: "🎭" },
 ];
 
 // ─── ページ ──────────────────────────────────────────────────────────────────
@@ -543,6 +543,24 @@ export default function CopilotPreviewPage() {
       push(me("最近の会話を教えて"));
       push(say("直近142件のうち、AIが答えに困ったのは11件でした。そのうち9件が「送料」に関する質問です。まずここを直しますか？", [
         { label: "送料を直す", action: "do1", tone: "primary" },
+      ]));
+    } else if (key === "knowledge") {
+      push(me("知識データの状況を見せて"));
+      push(say("現在84件のFAQを登録済みです。直近1週間でAIが答えられなかった質問が11件あり、うち9件が「送料」に関するものでした。まずここから登録しますか？", [
+        { label: "登録する", action: "do1", tone: "primary" },
+        { label: "あとで", action: "later", tone: "ghost" },
+      ]));
+    } else if (key === "rules") {
+      push(me("指示ルールの状況を見せて"));
+      push(say("現在3件の指示ルールが有効です。最近「丁寧すぎて説明が長い」というお客様の反応が増えているので、応答を少し簡潔にするルールを追加できます。設定しますか？", [
+        { label: "設定する", action: "do2", tone: "primary" },
+        { label: "あとで", action: "later", tone: "ghost" },
+      ]));
+    } else if (key === "avatar") {
+      push(me("アバターの状況を見せて"));
+      push(say("アバターは稼働中です。今週は142件の会話のうち98件でアバターが応答しました(平均応答時間1.8秒)。夜21時台の離脱がやや多いので、声がけを1つ追加すると引き止められそうです。設定しますか？", [
+        { label: "設定する", action: "do3", tone: "primary" },
+        { label: "あとで", action: "later", tone: "ghost" },
       ]));
     }
   };


### PR DESCRIPTION
## Summary
これまでdim表示(薄いプレースホルダ)で、クリックしても選択状態が変わるだけだった3カテゴリーに、既存の「今週のまとめ」「会話の履歴」と同じパターンでモックの会話導線を実装。

- **知識データ**: FAQ登録状況(84件登録済み、未回答11件)を提示 → 「登録する」で `do1`(FAQ登録フロー)へ
- **指示ルール**: 有効なルール件数(3件)を提示 → 「設定する」で `do2`(ルール追加フロー)へ
- **アバター**: 稼働状況・応答実績(142件中98件応答、平均1.8秒)を提示 → 「設定する」で `do3`(声がけ設定フロー)へ

`CATEGORIES` 定義から `dim: true` を削除。PR #496 で実装済みのロック機構(`busy = sending || pendingTimer || awaitingUserDecision`)がそのまま効くため、追加のロック実装は不要。

## Test plan
- [x] `npx tsc --noEmit` クリーン
- [x] Playwrightで3カテゴリーそれぞれ動作確認:
  - クリック → 会話がスレッドに追加される
  - 選択中は他5カテゴリーが `LOCKED`(アクティブなカテゴリーのみ `open`)
  - チップ(「あとで」)消化後、全カテゴリーが `open` に解放
- [x] フルページスクリーンショットで見た目確認(アバタータブの会話まで)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SaK6mK6nvpj9GEAwPkWYRW