### PR TITLE
feat(admin-agent): 知識ギャップの一覧取得・片付けをR2Cエージェント経由で可能に

### DIFF
--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -10,7 +10,7 @@ import {
 import { callGroq8bSuggestFromText } from '../tuning/routes';
 import { listRules, createRule } from '../tuning/tuningRulesRepository';
 import { searchKnowledgeForSuggestion, formatKnowledgeContext } from '../../../lib/knowledgeSearchUtil';
-import { getGaps } from '../knowledge/knowledgeGapRepository';
+import { getGaps, updateGapStatus } from '../knowledge/knowledgeGapRepository';
 import { textToFaqs } from '../knowledge/routes';
 import { suggestEngagementRuleFromText } from './engagementSuggest';
 import { checkSaiMonthlyCostCeiling } from '../options/routes';
@@ -498,6 +498,53 @@ export async function executeToolCall(
       } catch (err) {
         logger.warn('[actionExecutor] get_weekly_briefing failed', err);
         return truncate('週次サマリーの取得に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    case 'get_knowledge_gaps': {
+      if (!tenantId) {
+        return truncate('テナントが特定できません。super_admin の場合は対象テナントを指定してください');
+      }
+      const limit = Math.min(Math.max(Number(args['limit'] ?? 10), 1), 20);
+
+      try {
+        const { gaps, total } = await getGaps({ tenantId, status: 'open', limit });
+        if (gaps.length === 0) {
+          return truncate('未対応の知識ギャップはありません');
+        }
+        const lines = gaps.map((g) => `[${g.id}] ${g.user_question.slice(0, 100)}（${g.rag_hit_count}件ヒット）`);
+        return truncate(`知識ギャップ一覧（未対応${total}件中${gaps.length}件）:\n` + lines.join('\n'));
+      } catch (err) {
+        logger.warn('[actionExecutor] get_knowledge_gaps failed', err);
+        return truncate('知識ギャップ一覧の取得に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    case 'dismiss_knowledge_gap': {
+      const id = Number(args['id']);
+      const confirmed = Boolean(args['confirmed']);
+
+      if (!confirmed) {
+        return truncate(`知識ギャップ（ID: ${id}）を片付けるには確認が必要です。confirmed=true を指定して再度実行してください`);
+      }
+      if (!Number.isFinite(id)) {
+        return truncate('id が不正です');
+      }
+      if (!tenantId) {
+        return truncate('テナントが特定できません。super_admin の場合は対象テナントを指定してください');
+      }
+
+      try {
+        const ok = await updateGapStatus(id, 'dismissed', tenantId, null);
+        if (!ok) {
+          return truncate(`知識ギャップ（ID: ${id}）が見つかりません`);
+        }
+        return truncate(`知識ギャップ（ID: ${id}）を「対応不要」として片付けました`);
+      } catch (err) {
+        logger.warn('[actionExecutor] dismiss_knowledge_gap failed', err);
+        return truncate('知識ギャップの更新に失敗しました');
       }
     }
 

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -57,10 +57,12 @@ jest.mock('../../../lib/knowledgeSearchUtil', () => ({
   formatKnowledgeContext: (...args: any[]) => mockFormatKnowledgeContext(...args),
 }));
 
-// get_weekly_briefing が使う依存をモック
+// get_weekly_briefing / get_knowledge_gaps / dismiss_knowledge_gap が使う依存をモック
 const mockGetGaps = jest.fn();
+const mockUpdateGapStatus = jest.fn();
 jest.mock('../knowledge/knowledgeGapRepository', () => ({
   getGaps: (...args: any[]) => mockGetGaps(...args),
+  updateGapStatus: (...args: any[]) => mockUpdateGapStatus(...args),
 }));
 
 // suggest_faq / save_faq が使う依存をモック
@@ -699,6 +701,109 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(mockQuery).not.toHaveBeenCalled();
       expect(mockGetGaps).not.toHaveBeenCalled();
       expect(res.body.actions[0].result).toContain('テナントが特定できません');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // get_knowledge_gaps / dismiss_knowledge_gap
+  // -------------------------------------------------------------------------
+  describe('get_knowledge_gaps / dismiss_knowledge_gap', () => {
+    function toolCallResponse(id: string, name: string, args: Record<string, unknown> = {}) {
+      return {
+        ok: true,
+        json: async () => ({
+          choices: [{
+            message: {
+              content: null,
+              tool_calls: [{ id, type: 'function', function: { name, arguments: JSON.stringify(args) } }],
+            },
+          }],
+        }),
+        text: async () => '',
+      };
+    }
+
+    it('get_knowledge_gaps: 未対応の知識ギャップ一覧を1つの結果文字列にまとめる', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-kg-1', 'get_knowledge_gaps', {}))
+        .mockResolvedValueOnce(makeGroqResponse('未対応の質問は2件あります。'));
+
+      mockGetGaps.mockResolvedValueOnce({
+        gaps: [
+          { id: 1, tenant_id: 'tenant-abc', user_question: '送料はいくらですか？', session_id: null, message_id: null, rag_hit_count: 9, rag_top_score: 0, status: 'open', resolved_faq_id: null, created_at: '' },
+          { id: 2, tenant_id: 'tenant-abc', user_question: '返品はできますか？', session_id: null, message_id: null, rag_hit_count: 2, rag_top_score: 0, status: 'open', resolved_faq_id: null, created_at: '' },
+        ],
+        total: 11,
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '知識ギャップを見せて', sessionId: 'sess-kg-01' });
+
+      expect(res.status).toBe(200);
+      expect(mockGetGaps).toHaveBeenCalledWith({ tenantId: 'tenant-abc', status: 'open', limit: 10 });
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain('未対応11件中2件');
+      expect(result).toContain('送料はいくらですか？');
+      expect(result).toContain('返品はできますか？');
+    });
+
+    it('get_knowledge_gaps: 0件の場合は「ありません」と返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-kg-2', 'get_knowledge_gaps', {}))
+        .mockResolvedValueOnce(makeGroqResponse('未対応の質問はありません。'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '知識ギャップを見せて', sessionId: 'sess-kg-03' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('ありません');
+    });
+
+    it('dismiss_knowledge_gap: confirmed=false → 更新されずブロックされる', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-kg-4', 'dismiss_knowledge_gap', { id: 1, confirmed: false }))
+        .mockResolvedValueOnce(makeGroqResponse('確認してから片付けます。'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'この質問は片付けて', sessionId: 'sess-kg-04' });
+
+      expect(res.status).toBe(200);
+      expect(mockUpdateGapStatus).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('確認が必要');
+    });
+
+    it('dismiss_knowledge_gap: confirmed=true → tenant_idスコープでdismissedに更新される', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-kg-5', 'dismiss_knowledge_gap', { id: 1, confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('片付けました。'));
+
+      mockUpdateGapStatus.mockResolvedValueOnce(true);
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'この質問は片付けて', sessionId: 'sess-kg-05' });
+
+      expect(res.status).toBe(200);
+      expect(mockUpdateGapStatus).toHaveBeenCalledWith(1, 'dismissed', 'tenant-abc', null);
+      expect(res.body.actions[0].result).toContain('片付けました');
+    });
+
+    it('dismiss_knowledge_gap: 対象が見つからない場合はその旨を返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-kg-6', 'dismiss_knowledge_gap', { id: 999, confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('見つかりませんでした。'));
+
+      mockUpdateGapStatus.mockResolvedValueOnce(false);
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'この質問は片付けて', sessionId: 'sess-kg-06' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('見つかりません');
     });
   });
 

--- a/src/api/admin/agent/toolDefinitions.ts
+++ b/src/api/admin/agent/toolDefinitions.ts
@@ -265,6 +265,37 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
   {
     type: 'function',
     function: {
+      name: 'get_knowledge_gaps',
+      description:
+        'AIが答えられなかった質問（知識ギャップ、未対応=openのもの）の一覧を取得する読み取り専用ツール。件数や内容を確認したい時に使う。',
+      parameters: {
+        type: 'object',
+        properties: {
+          limit: { type: 'number', description: '取得件数の上限（任意、省略時10、最大20）' },
+        },
+        required: [],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'dismiss_knowledge_gap',
+      description:
+        '知識ギャップを「対応不要」として片付ける（FAQ登録はしない、ステータスをdismissedに変更するだけ）。削除ではない。必ず先にどの質問を片付けるか提示し、明確な同意を得たターンでのみ confirmed=true を指定して呼び出すこと。',
+      parameters: {
+        type: 'object',
+        properties: {
+          id: { type: 'number', description: 'get_knowledge_gapsの結果に含まれるギャップID' },
+          confirmed: { type: 'boolean', description: '確認フラグ（true でのみ実行される）' },
+        },
+        required: ['id', 'confirmed'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
       name: 'suggest_faq',
       description:
         '店舗管理者の自然な言葉による指示から、FAQ（質問・回答・分類）の下書きを生成する。書き込みは行わない読み取り専用ツール。提案内容は必ずユーザーに提示して明確な同意を得てから save_faq で保存すること。',


### PR DESCRIPTION
## Summary
旧UI機能の新UI(チャット)対応 計画の **PR A**。`/admin/knowledge-gaps` 画面が持つ機能のうち、視覚的操作を必要としない一覧取得・ステータス変更をチャットツール化。

- `get_knowledge_gaps`(読み取り専用): 未対応(open)の知識ギャップを最大20件まで取得。既存の`get_weekly_briefing`が使っている`getGaps`リポジトリ関数(`src/api/admin/knowledge/knowledgeGapRepository.ts`)をそのまま再利用
- `dismiss_knowledge_gap`(confirmed必須): 知識ギャップを「対応不要」として片付ける(削除ではなくstatus更新)。既存の`delete_faq`等と同じconfirmedゲートパターン、`tenant_id`スコープは`effectiveTenantId`で固定(super_admin/client_admin問わず対象テナント外を操作できない)

## Test plan
- [x] `npx tsc --noEmit` クリーン
- [x] `npx jest src/api/admin/agent/agentRoutes.test.ts` → 49/49 pass(新規5件: 一覧/0件/confirmed=false/confirmed=true/対象なし)
- [x] `npx jest src/api/admin/knowledge` → 関連5スイート・61件 無回帰確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SaK6mK6nvpj9GEAwPkWYRW