### PR TITLE
feat(admin-agent): 指示ルールの一覧取得・編集・削除をR2Cエージェント経由で可能に

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -50,6 +50,9 @@ const REAL_TOOL_LABEL: Record<string, string> = {
   activate_avatar: "アバターの有効化",
   get_embed_code: "埋め込みコードの取得",
   set_widget_theme: "ウィジェットテーマの変更",
+  get_tuning_rules: "指示ルール一覧の取得",
+  update_tuning_rule: "指示ルールの更新",
+  delete_tuning_rule: "指示ルールの削除",
 };
 
 // 実際にDBを書き換える(=「進捗」としてカウントしてよい)ツール名
@@ -551,11 +554,8 @@ export default function CopilotPreviewPage() {
         { label: "あとで", action: "later", tone: "ghost" },
       ]));
     } else if (key === "rules") {
-      push(me("指示ルールの状況を見せて"));
-      push(say("現在3件の指示ルールが有効です。最近「丁寧すぎて説明が長い」というお客様の反応が増えているので、応答を少し簡潔にするルールを追加できます。設定しますか？", [
-        { label: "設定する", action: "do2", tone: "primary" },
-        { label: "あとで", action: "later", tone: "ghost" },
-      ]));
+      // Phase B: get_tuning_rules(実API)に接続。以前はモック固定文言だった
+      void sendReal("指示ルールの状況を教えて");
     } else if (key === "avatar") {
       push(me("アバターの状況を見せて"));
       push(say("アバターは稼働中です。今週は142件の会話のうち98件でアバターが応答しました(平均応答時間1.8秒)。夜21時台の離脱がやや多いので、声がけを1つ追加すると引き止められそうです。設定しますか？", [

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -8,7 +8,7 @@ import {
   upsertToEsAsync,
 } from '../knowledge/faqCrudRoutes';
 import { callGroq8bSuggestFromText } from '../tuning/routes';
-import { listRules, createRule } from '../tuning/tuningRulesRepository';
+import { listRules, createRule, updateRule, deleteRule } from '../tuning/tuningRulesRepository';
 import { searchKnowledgeForSuggestion, formatKnowledgeContext } from '../../../lib/knowledgeSearchUtil';
 import { getGaps, updateGapStatus } from '../knowledge/knowledgeGapRepository';
 import { textToFaqs } from '../knowledge/routes';
@@ -431,6 +431,89 @@ export async function executeToolCall(
       } catch (err) {
         logger.warn('[actionExecutor] save_tuning_rule failed', err);
         return truncate('ルールの保存に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    case 'get_tuning_rules': {
+      if (!tenantId) {
+        return truncate('テナントが特定できません。super_admin の場合は対象テナントを指定してください');
+      }
+
+      try {
+        const rules = await listRules(tenantId);
+        if (rules.length === 0) {
+          return truncate('有効な指示ルールはありません');
+        }
+        const lines = rules.slice(0, 15).map((r) =>
+          `[${r.id}]${r.is_active ? '' : '(無効)'} 「${r.trigger_pattern.slice(0, 60)}」→ ${r.expected_behavior.slice(0, 100)}`
+        );
+        return truncate(`指示ルール一覧（${rules.length}件）:\n` + lines.join('\n'));
+      } catch (err) {
+        logger.warn('[actionExecutor] get_tuning_rules failed', err);
+        return truncate('指示ルール一覧の取得に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    case 'update_tuning_rule': {
+      const id = Number(args['id']);
+      const confirmed = Boolean(args['confirmed']);
+
+      if (!confirmed) {
+        return truncate(`指示ルール（ID: ${id}）の更新には確認が必要です。confirmed=true を指定して再度実行してください`);
+      }
+      if (!Number.isFinite(id)) {
+        return truncate('id が不正です');
+      }
+
+      const triggerPattern = typeof args['trigger_pattern'] === 'string' ? args['trigger_pattern'].slice(0, 1000) : undefined;
+      const expectedBehavior = typeof args['expected_behavior'] === 'string' ? args['expected_behavior'].slice(0, 4000) : undefined;
+      const isActive = typeof args['is_active'] === 'boolean' ? args['is_active'] : undefined;
+
+      if (triggerPattern === undefined && expectedBehavior === undefined && isActive === undefined) {
+        return truncate('変更する内容がありません（trigger_pattern・expected_behavior・is_active のいずれかを指定してください）');
+      }
+
+      try {
+        const ownerFilter = isSuperAdmin ? undefined : tenantId;
+        const updated = await updateRule(
+          id,
+          { trigger_pattern: triggerPattern, expected_behavior: expectedBehavior, is_active: isActive },
+          ownerFilter,
+        );
+        if (!updated) {
+          return truncate(`指示ルール（ID: ${id}）が見つからないかアクセス権限がありません`);
+        }
+        return truncate(`指示ルール（ID: ${id}）を更新しました: 「${updated.trigger_pattern}」${updated.is_active ? '' : '（現在無効）'}`);
+      } catch (err) {
+        logger.warn('[actionExecutor] update_tuning_rule failed', err);
+        return truncate('指示ルールの更新に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    case 'delete_tuning_rule': {
+      const id = Number(args['id']);
+      const confirmed = Boolean(args['confirmed']);
+
+      if (!confirmed) {
+        return truncate(`指示ルール（ID: ${id}）の削除には確認が必要です。confirmed=true を指定して再度実行してください`);
+      }
+      if (!Number.isFinite(id)) {
+        return truncate('id が不正です');
+      }
+
+      try {
+        const ownerFilter = isSuperAdmin ? undefined : tenantId;
+        const ok = await deleteRule(id, ownerFilter);
+        if (!ok) {
+          return truncate(`指示ルール（ID: ${id}）が見つからないかアクセス権限がありません`);
+        }
+        return truncate(`指示ルール（ID: ${id}）を削除しました`);
+      } catch (err) {
+        logger.warn('[actionExecutor] delete_tuning_rule failed', err);
+        return truncate('指示ルールの削除に失敗しました');
       }
     }
 

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -43,9 +43,13 @@ jest.mock('../tuning/routes', () => ({
 
 const mockListRules = jest.fn();
 const mockCreateRule = jest.fn();
+const mockUpdateRule = jest.fn();
+const mockDeleteRule = jest.fn();
 jest.mock('../tuning/tuningRulesRepository', () => ({
   listRules: (...args: any[]) => mockListRules(...args),
   createRule: (...args: any[]) => mockCreateRule(...args),
+  updateRule: (...args: any[]) => mockUpdateRule(...args),
+  deleteRule: (...args: any[]) => mockDeleteRule(...args),
 }));
 
 // 名前付きラッパーにする(jest.mock factory内の匿名 jest.fn() は resetAllMocks() で
@@ -618,6 +622,165 @@ describe('POST /v1/admin/agent/chat', () => {
         }),
       );
       expect(res.body.actions[0].result).toContain('ID: 42');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // get_tuning_rules / update_tuning_rule / delete_tuning_rule
+  // -------------------------------------------------------------------------
+  describe('get_tuning_rules / update_tuning_rule / delete_tuning_rule', () => {
+    function toolCallResponse(id: string, name: string, args: Record<string, unknown> = {}) {
+      return {
+        ok: true,
+        json: async () => ({
+          choices: [{
+            message: {
+              content: null,
+              tool_calls: [{ id, type: 'function', function: { name, arguments: JSON.stringify(args) } }],
+            },
+          }],
+        }),
+        text: async () => '',
+      };
+    }
+
+    it('get_tuning_rules: 一覧を1つの結果文字列にまとめる（無効ルールは(無効)を付ける）', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-tr-1', 'get_tuning_rules', {}))
+        .mockResolvedValueOnce(makeGroqResponse('現在2件のルールがあります。'));
+
+      mockListRules.mockResolvedValueOnce([
+        { id: 1, tenant_id: 'tenant-abc', trigger_pattern: '保証', expected_behavior: '2年と案内する', priority: 5, is_active: true, created_by: null, source_message_id: null, created_at: '', updated_at: '' },
+        { id: 2, tenant_id: 'global', trigger_pattern: '価格交渉', expected_behavior: '応じない', priority: 3, is_active: false, created_by: null, source_message_id: null, created_at: '', updated_at: '' },
+      ]);
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '指示ルールを見せて', sessionId: 'sess-tr-01' });
+
+      expect(res.status).toBe(200);
+      expect(mockListRules).toHaveBeenCalledWith('tenant-abc');
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain('2件');
+      expect(result).toContain('保証');
+      expect(result).toContain('価格交渉');
+      expect(result).toContain('(無効)');
+    });
+
+    it('update_tuning_rule: confirmed=false → 更新されずブロックされる', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-tr-2', 'update_tuning_rule', { id: 1, is_active: false, confirmed: false }))
+        .mockResolvedValueOnce(makeGroqResponse('確認してから更新します。'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルール1を無効にして', sessionId: 'sess-tr-02' });
+
+      expect(res.status).toBe(200);
+      expect(mockUpdateRule).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('確認が必要');
+    });
+
+    it('update_tuning_rule: client_admin・confirmed=true → tenant_idスコープ(super_admin以外はundefined渡さない)で更新される', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-tr-3', 'update_tuning_rule', { id: 1, is_active: false, confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('無効にしました。'));
+
+      mockUpdateRule.mockResolvedValueOnce({
+        id: 1, tenant_id: 'tenant-abc', trigger_pattern: '保証', expected_behavior: '2年と案内する', priority: 5, is_active: false, created_by: null, source_message_id: null, created_at: '', updated_at: '',
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルール1を無効にして', sessionId: 'sess-tr-03' });
+
+      expect(res.status).toBe(200);
+      expect(mockUpdateRule).toHaveBeenCalledWith(
+        1,
+        { trigger_pattern: undefined, expected_behavior: undefined, is_active: false },
+        'tenant-abc',
+      );
+      expect(res.body.actions[0].result).toContain('現在無効');
+    });
+
+    it('update_tuning_rule: super_admin・confirmed=true → tenant_idスコープ無し(undefined)で更新される', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-tr-4', 'update_tuning_rule', { id: 2, is_active: true, confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('有効にしました。'));
+
+      mockUpdateRule.mockResolvedValueOnce({
+        id: 2, tenant_id: 'global', trigger_pattern: '価格交渉', expected_behavior: '応じない', priority: 3, is_active: true, created_by: null, source_message_id: null, created_at: '', updated_at: '',
+      });
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルール2を有効にして', sessionId: 'sess-tr-04', targetTenantId: 'tenant-abc' });
+
+      expect(res.status).toBe(200);
+      expect(mockUpdateRule).toHaveBeenCalledWith(
+        2,
+        { trigger_pattern: undefined, expected_behavior: undefined, is_active: true },
+        undefined,
+      );
+    });
+
+    it('update_tuning_rule: 変更内容が空 → DB呼び出しせずその旨を返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-tr-5', 'update_tuning_rule', { id: 1, confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('変更内容を教えてください。'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルール1を更新して', sessionId: 'sess-tr-05' });
+
+      expect(res.status).toBe(200);
+      expect(mockUpdateRule).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('変更する内容がありません');
+    });
+
+    it('delete_tuning_rule: confirmed=false → 削除されずブロックされる', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-tr-6', 'delete_tuning_rule', { id: 1, confirmed: false }))
+        .mockResolvedValueOnce(makeGroqResponse('確認してから削除します。'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルール1を削除して', sessionId: 'sess-tr-06' });
+
+      expect(res.status).toBe(200);
+      expect(mockDeleteRule).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('確認が必要');
+    });
+
+    it('delete_tuning_rule: confirmed=true → tenant_idスコープで削除される', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-tr-7', 'delete_tuning_rule', { id: 1, confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('削除しました。'));
+
+      mockDeleteRule.mockResolvedValueOnce(true);
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルール1を削除して', sessionId: 'sess-tr-07' });
+
+      expect(res.status).toBe(200);
+      expect(mockDeleteRule).toHaveBeenCalledWith(1, 'tenant-abc');
+      expect(res.body.actions[0].result).toContain('削除しました');
+    });
+
+    it('delete_tuning_rule: 対象が見つからない場合はその旨を返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-tr-8', 'delete_tuning_rule', { id: 999, confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('見つかりませんでした。'));
+
+      mockDeleteRule.mockResolvedValueOnce(false);
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルール999を削除して', sessionId: 'sess-tr-08' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('見つからないかアクセス権限がありません');
     });
   });
 

--- a/src/api/admin/agent/toolDefinitions.ts
+++ b/src/api/admin/agent/toolDefinitions.ts
@@ -252,6 +252,54 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
   {
     type: 'function',
     function: {
+      name: 'get_tuning_rules',
+      description:
+        '現在の指示ルール（AIの振る舞いルール）の一覧を取得する読み取り専用ツール。suggest_tuning_rule/save_tuning_ruleで作成済みのものも含め、有効/無効の状態ごと全件を確認したい時に使う。',
+      parameters: {
+        type: 'object',
+        properties: {},
+        required: [],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'update_tuning_rule',
+      description:
+        '既存の指示ルールを編集する、または有効/無効を切り替える。編集する場合は trigger_pattern/expected_behavior を、有効/無効の切り替えのみの場合は is_active だけを指定する。必ず先に変更内容をユーザーに提示し、明確な同意を得たターンでのみ confirmed=true で呼び出すこと。',
+      parameters: {
+        type: 'object',
+        properties: {
+          id: { type: 'number', description: 'get_tuning_rulesの結果に含まれるルールID' },
+          trigger_pattern: { type: 'string', description: '新しいトリガー内容（変更する場合のみ指定）' },
+          expected_behavior: { type: 'string', description: '新しい対応方針（変更する場合のみ指定）' },
+          is_active: { type: 'boolean', description: '有効/無効の切り替え（変更する場合のみ指定）' },
+          confirmed: { type: 'boolean', description: '確認フラグ（true でのみ実行される）' },
+        },
+        required: ['id', 'confirmed'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'delete_tuning_rule',
+      description:
+        '指示ルールを削除する。必ず先にどのルールを削除するか提示し、明確な同意を得たターンでのみ confirmed=true で呼び出すこと。',
+      parameters: {
+        type: 'object',
+        properties: {
+          id: { type: 'number', description: 'get_tuning_rulesの結果に含まれるルールID' },
+          confirmed: { type: 'boolean', description: '確認フラグ（true でのみ実行される）' },
+        },
+        required: ['id', 'confirmed'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
       name: 'get_weekly_briefing',
       description:
         '直近7日間のテナントの状況（会話数・前週比・応答品質スコア・成約・AIが答えられなかった質問トップ3）をまとめて取得する読み取り専用ツール。ログイン直後など、ユーザーから明示的な依頼がなくても状況を能動的に説明する際に使う。',


### PR DESCRIPTION
## Summary
旧UI機能の新UI(チャット)対応 計画の **PR B**。`/admin/tuning` 画面が持つ機能のうち、視覚的なウィザードを必要としない一覧・編集・トグル・削除をチャットツール化。`suggest_tuning_rule`/`save_tuning_rule`(作成のみ)は維持し、それを補う形で追加。

- `get_tuning_rules`(読み取り専用): 有効/無効を問わず一覧取得。既存の`listRules`(tenant + global)をそのまま再利用
- `update_tuning_rule`(confirmed必須): `trigger_pattern`/`expected_behavior`の編集、または`is_active`のみ指定でトグル。tenant_idスコープは既存の`PUT /v1/admin/tuning-rules/:id`ルートと全く同じ「isSuperAdminならundefined(制限なし)、それ以外はtenantId」パターンを踏襲し、super_adminのみglobalルールも編集可能にした
- `delete_tuning_rule`(confirmed必須): 同様のtenant_idスコープで削除

**copilot-preview側**: 「指示ルール」サイドバーカテゴリーをモック固定文言から`sendReal("指示ルールの状況を教えて")`呼び出しに変更(`get_tuning_rules`経由で実データを表示)。`REAL_TOOL_LABEL`に3ツールのラベルを追加。

## Test plan
- [x] `npx tsc --noEmit`(バックエンド + admin-ui) クリーン
- [x] `npx jest src/api/admin/agent/agentRoutes.test.ts` → 57/57 pass(新規8件)
- [x] ローカルでPlaywright確認: 「指示ルール」クリックがモックではなく実API(`sendReal`→`authFetch`)経路を通ることを確認(未ログインのため「ログインが必要です」応答が返り、モックの固定文言ではないことで配線が正しいことを確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SaK6mK6nvpj9GEAwPkWYRW