### PR TITLE
feat(admin-agent): 声がけルールの一覧取得・編集・削除をR2Cエージェント経由で可能に

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -53,6 +53,9 @@ const REAL_TOOL_LABEL: Record<string, string> = {
   get_tuning_rules: "指示ルール一覧の取得",
   update_tuning_rule: "指示ルールの更新",
   delete_tuning_rule: "指示ルールの削除",
+  get_engagement_rules: "声がけルール一覧の取得",
+  update_engagement_rule: "声がけルールの更新",
+  delete_engagement_rule: "声がけルールの削除",
 };
 
 // 実際にDBを書き換える(=「進捗」としてカウントしてよい)ツール名

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -786,6 +786,137 @@ export async function executeToolCall(
     }
 
     // -----------------------------------------------------------------------
+    case 'get_engagement_rules': {
+      if (!tenantId) {
+        return truncate('テナントが特定できません。super_admin の場合は対象テナントを指定してください');
+      }
+
+      try {
+        const result = await db.query(
+          `SELECT id, trigger_type, message_template, is_active, priority
+           FROM trigger_rules WHERE tenant_id = $1
+           ORDER BY priority DESC, created_at DESC LIMIT 15`,
+          [tenantId],
+        );
+        if (result.rows.length === 0) {
+          return truncate('声がけルールは登録されていません');
+        }
+        const lines = (result.rows as { id: number; trigger_type: string; message_template: string; is_active: boolean; priority: number }[]).map(
+          (r) => `[${r.id}]${r.is_active ? '' : '(無効)'} ${r.trigger_type} → ${r.message_template.slice(0, 80)}`,
+        );
+        return truncate(`声がけルール一覧（${result.rows.length}件）:\n` + lines.join('\n'));
+      } catch (err) {
+        logger.warn('[actionExecutor] get_engagement_rules failed', err);
+        return truncate('声がけルール一覧の取得に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    case 'update_engagement_rule': {
+      const id = Number(args['id']);
+      const confirmed = Boolean(args['confirmed']);
+
+      if (!confirmed) {
+        return truncate(`声がけルール（ID: ${id}）の更新には確認が必要です。confirmed=true を指定して再度実行してください`);
+      }
+      if (!Number.isFinite(id)) {
+        return truncate('id が不正です');
+      }
+      if (!tenantId) {
+        return truncate('テナントが特定できません。super_admin の場合は対象テナントを指定してください');
+      }
+
+      const VALID_TRIGGER_TYPES = new Set(['scroll_depth', 'idle_time', 'exit_intent', 'page_url_match']);
+      const triggerTypeRaw = args['trigger_type'];
+      if (triggerTypeRaw !== undefined && !VALID_TRIGGER_TYPES.has(String(triggerTypeRaw))) {
+        return truncate('trigger_type が不正です（scroll_depth/idle_time/exit_intent/page_url_match のいずれか）');
+      }
+      const triggerType = typeof triggerTypeRaw === 'string' ? triggerTypeRaw : undefined;
+      const triggerConfigRaw = args['trigger_config'];
+      const triggerConfig =
+        typeof triggerConfigRaw === 'object' && triggerConfigRaw !== null && !Array.isArray(triggerConfigRaw)
+          ? triggerConfigRaw
+          : undefined;
+      const messageTemplate = typeof args['message_template'] === 'string' ? args['message_template'].slice(0, 500) : undefined;
+      const priorityRaw = args['priority'];
+      const priority =
+        typeof priorityRaw === 'number' && Number.isFinite(priorityRaw)
+          ? Math.max(0, Math.min(100, Math.round(priorityRaw)))
+          : undefined;
+      const isActive = typeof args['is_active'] === 'boolean' ? args['is_active'] : undefined;
+
+      if (triggerType === undefined && triggerConfig === undefined && messageTemplate === undefined && priority === undefined && isActive === undefined) {
+        return truncate('変更する内容がありません（trigger_type・trigger_config・message_template・priority・is_active のいずれかを指定してください）');
+      }
+
+      try {
+        const existing = await db.query('SELECT id, tenant_id FROM trigger_rules WHERE id = $1', [id]);
+        if (existing.rows.length === 0) {
+          return truncate(`声がけルール（ID: ${id}）が見つかりません`);
+        }
+        if (!isSuperAdmin && (existing.rows[0] as { tenant_id: string }).tenant_id !== tenantId) {
+          return truncate('この声がけルールへのアクセス権限がありません');
+        }
+
+        const result = await db.query(
+          `UPDATE trigger_rules SET
+             trigger_type   = COALESCE($1, trigger_type),
+             trigger_config = COALESCE($2::jsonb, trigger_config),
+             message_template = COALESCE($3, message_template),
+             priority       = COALESCE($4, priority),
+             is_active      = COALESCE($5, is_active)
+           WHERE id = $6
+           RETURNING id, trigger_type, message_template, is_active`,
+          [
+            triggerType ?? null,
+            triggerConfig ? JSON.stringify(triggerConfig) : null,
+            messageTemplate ?? null,
+            priority ?? null,
+            isActive ?? null,
+            id,
+          ],
+        );
+        const row = result.rows[0] as { id: number; trigger_type: string; message_template: string; is_active: boolean };
+        return truncate(`声がけルール（ID: ${id}）を更新しました: 「${row.trigger_type}」→ ${row.message_template}${row.is_active ? '' : '（現在無効）'}`);
+      } catch (err) {
+        logger.warn('[actionExecutor] update_engagement_rule failed', err);
+        return truncate('声がけルールの更新に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    case 'delete_engagement_rule': {
+      const id = Number(args['id']);
+      const confirmed = Boolean(args['confirmed']);
+
+      if (!confirmed) {
+        return truncate(`声がけルール（ID: ${id}）の削除には確認が必要です。confirmed=true を指定して再度実行してください`);
+      }
+      if (!Number.isFinite(id)) {
+        return truncate('id が不正です');
+      }
+      if (!tenantId) {
+        return truncate('テナントが特定できません。super_admin の場合は対象テナントを指定してください');
+      }
+
+      try {
+        const existing = await db.query('SELECT id, tenant_id FROM trigger_rules WHERE id = $1', [id]);
+        if (existing.rows.length === 0) {
+          return truncate(`声がけルール（ID: ${id}）が見つかりません`);
+        }
+        if (!isSuperAdmin && (existing.rows[0] as { tenant_id: string }).tenant_id !== tenantId) {
+          return truncate('この声がけルールへのアクセス権限がありません');
+        }
+
+        await db.query('DELETE FROM trigger_rules WHERE id = $1', [id]);
+        return truncate(`声がけルール（ID: ${id}）を削除しました`);
+      } catch (err) {
+        logger.warn('[actionExecutor] delete_engagement_rule failed', err);
+        return truncate('声がけルールの削除に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
     // Sai委譲(Tier A設計の土台): 現時点では super_admin 限定を維持し、client_admin には
     // 開放しない（信頼モデル変更は別途判断が必要なため、既存のtry-sai同様の認可を踏襲）。
     case 'request_sai_task': {

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -1240,6 +1240,178 @@ describe('POST /v1/admin/agent/chat', () => {
   });
 
   // -------------------------------------------------------------------------
+  // get_engagement_rules / update_engagement_rule / delete_engagement_rule
+  // -------------------------------------------------------------------------
+  describe('get_engagement_rules / update_engagement_rule / delete_engagement_rule', () => {
+    function toolCallResponse(id: string, name: string, args: Record<string, unknown> = {}) {
+      return {
+        ok: true,
+        json: async () => ({
+          choices: [{
+            message: {
+              content: null,
+              tool_calls: [{ id, type: 'function', function: { name, arguments: JSON.stringify(args) } }],
+            },
+          }],
+        }),
+        text: async () => '',
+      };
+    }
+
+    it('get_engagement_rules: 一覧を1つの結果文字列にまとめる（無効ルールは(無効)を付ける）', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-er-1', 'get_engagement_rules', {}))
+        .mockResolvedValueOnce(makeGroqResponse('現在2件のルールがあります。'));
+
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          { id: 1, trigger_type: 'idle_time', message_template: '人気ランキングもご覧ください🎁', is_active: true, priority: 5 },
+          { id: 2, trigger_type: 'exit_intent', message_template: 'お待ちください', is_active: false, priority: 0 },
+        ],
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '声がけルールを見せて', sessionId: 'sess-er-01' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining('FROM trigger_rules WHERE tenant_id = $1'), ['tenant-abc']);
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain('2件');
+      expect(result).toContain('idle_time');
+      expect(result).toContain('exit_intent');
+      expect(result).toContain('(無効)');
+    });
+
+    it('get_engagement_rules: 0件の場合は「登録されていません」と返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-er-2', 'get_engagement_rules', {}))
+        .mockResolvedValueOnce(makeGroqResponse('声がけルールはまだありません。'));
+
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '声がけルールを見せて', sessionId: 'sess-er-02' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('登録されていません');
+    });
+
+    it('update_engagement_rule: confirmed=false → 更新されずブロックされる', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-er-3', 'update_engagement_rule', { id: 1, is_active: false, confirmed: false }))
+        .mockResolvedValueOnce(makeGroqResponse('確認してから更新します。'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルール1を無効にして', sessionId: 'sess-er-03' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('確認が必要');
+    });
+
+    it('update_engagement_rule: 変更内容が空 → DB呼び出しせずその旨を返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-er-4', 'update_engagement_rule', { id: 1, confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('変更内容を教えてください。'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルール1を更新して', sessionId: 'sess-er-04' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('変更する内容がありません');
+    });
+
+    it('update_engagement_rule: client_admin・他テナントのルール → アクセス権限がありませんと返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-er-5', 'update_engagement_rule', { id: 1, is_active: false, confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('権限がありません。'));
+
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 1, tenant_id: 'other-tenant' }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルール1を無効にして', sessionId: 'sess-er-05' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).toHaveBeenCalledTimes(1); // SELECT のみ、UPDATE は発火しない
+      expect(res.body.actions[0].result).toContain('アクセス権限がありません');
+    });
+
+    it('update_engagement_rule: confirmed=true・自テナント → is_activeのみCOALESCE更新される', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-er-6', 'update_engagement_rule', { id: 1, is_active: false, confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('無効にしました。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ id: 1, tenant_id: 'tenant-abc' }] }) // SELECT ownership
+        .mockResolvedValueOnce({ rows: [{ id: 1, trigger_type: 'idle_time', message_template: 'x', is_active: false }] }); // UPDATE
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルール1を無効にして', sessionId: 'sess-er-06' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).toHaveBeenLastCalledWith(
+        expect.stringContaining('UPDATE trigger_rules'),
+        [null, null, null, null, false, 1],
+      );
+      expect(res.body.actions[0].result).toContain('現在無効');
+    });
+
+    it('delete_engagement_rule: confirmed=false → 削除されずブロックされる', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-er-7', 'delete_engagement_rule', { id: 1, confirmed: false }))
+        .mockResolvedValueOnce(makeGroqResponse('確認してから削除します。'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルール1を削除して', sessionId: 'sess-er-07' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('確認が必要');
+    });
+
+    it('delete_engagement_rule: confirmed=true・自テナント → 削除される', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-er-8', 'delete_engagement_rule', { id: 1, confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('削除しました。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ id: 1, tenant_id: 'tenant-abc' }] }) // SELECT ownership
+        .mockResolvedValueOnce({ rows: [] }); // DELETE
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルール1を削除して', sessionId: 'sess-er-08' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).toHaveBeenLastCalledWith('DELETE FROM trigger_rules WHERE id = $1', [1]);
+      expect(res.body.actions[0].result).toContain('削除しました');
+    });
+
+    it('delete_engagement_rule: 対象が見つからない場合はその旨を返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-er-9', 'delete_engagement_rule', { id: 999, confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('見つかりませんでした。'));
+
+      mockQuery.mockResolvedValueOnce({ rows: [] }); // SELECT: 見つからない
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルール999を削除して', sessionId: 'sess-er-09' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('見つかりません');
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // G1: 多段エージェントループ
   // -------------------------------------------------------------------------
   describe('G1: 多段エージェントループ', () => {

--- a/src/api/admin/agent/toolDefinitions.ts
+++ b/src/api/admin/agent/toolDefinitions.ts
@@ -425,6 +425,64 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
   {
     type: 'function',
     function: {
+      name: 'get_engagement_rules',
+      description:
+        '現在の声がけルール（サイト上のプロアクティブな声がけ設定）の一覧を取得する読み取り専用ツール。suggest_engagement_rule/save_engagement_ruleで作成済みのものも含め、有効/無効の状態ごと全件を確認したい時に使う。',
+      parameters: {
+        type: 'object',
+        properties: {},
+        required: [],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'update_engagement_rule',
+      description:
+        '既存の声がけルールを編集する、または有効/無効を切り替える。変更したい項目（trigger_type/trigger_config/message_template/priority/is_active）だけを指定すればよく、指定しなかった項目は変更されない。trigger_typeを変更する場合はtrigger_configも合わせて指定すること。必ず先に変更内容をユーザーに提示し、明確な同意を得たターンでのみ confirmed=true で呼び出すこと。',
+      parameters: {
+        type: 'object',
+        properties: {
+          id: { type: 'number', description: 'get_engagement_rulesの結果に含まれるルールID' },
+          trigger_type: {
+            type: 'string',
+            enum: ['scroll_depth', 'idle_time', 'exit_intent', 'page_url_match'],
+            description: 'トリガー種別（変更する場合のみ指定、trigger_configとセットで）',
+          },
+          trigger_config: {
+            type: 'object',
+            description:
+              'トリガー種別ごとの設定（変更する場合のみ指定）。scroll_depth: {"threshold": 1-100}, idle_time: {"seconds": 1-3600}, exit_intent: {}, page_url_match: {"patterns": ["/products/*"], "match_type": "glob"}',
+          },
+          message_template: { type: 'string', description: '表示する声がけ文言（変更する場合のみ指定）' },
+          priority: { type: 'number', description: '優先度（0〜100の整数、変更する場合のみ指定）' },
+          is_active: { type: 'boolean', description: '有効/無効の切り替え（変更する場合のみ指定）' },
+          confirmed: { type: 'boolean', description: '確認フラグ（true でのみ実行される）' },
+        },
+        required: ['id', 'confirmed'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'delete_engagement_rule',
+      description:
+        '声がけルールを削除する。必ず先にどのルールを削除するか提示し、明確な同意を得たターンでのみ confirmed=true で呼び出すこと。',
+      parameters: {
+        type: 'object',
+        properties: {
+          id: { type: 'number', description: 'get_engagement_rulesの結果に含まれるルールID' },
+          confirmed: { type: 'boolean', description: '確認フラグ（true でのみ実行される）' },
+        },
+        required: ['id', 'confirmed'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
       name: 'request_sai_task',
       description:
         'R2Cエージェント(Sai)にブラウザ操作の代行作業を依頼する。ユーザーが管理画面の操作に苦戦している、または苦戦しそうだと判断した場合にのみ、他の対応より先に「代わりに画面操作を行いましょうか？」と尋ねること。ユーザーが明確に依頼していない、または苦戦している様子がない状態で自発的に呼び出してはならない。実際に外部サービスへの課金が発生する。現時点ではsuper_admin限定の機能で、それ以外のロールで呼び出すと拒否される。必ず先にユーザーに作業内容と発生しうる費用を提示し、明確な同意を得たターンでのみ confirmed=true を指定して呼び出すこと。',


### PR DESCRIPTION
## Summary
旧UI機能の新UI(チャット)対応 計画の **PR C**。`/admin/engagement` 画面が持つ機能のうち、視覚的な2ステップウィザードを必要としない一覧・編集・トグル・削除をチャットツール化。`suggest_engagement_rule`/`save_engagement_rule`(作成のみ)は維持し、それを補う形で追加。

- `get_engagement_rules`(読み取り専用): `trigger_rules`テーブルからtenant_idスコープで一覧取得(既存の`GET /v1/admin/engagement/rules`と同じクエリパターン)
- `update_engagement_rule`(confirmed必須): `trigger_type`/`trigger_config`/`message_template`/`priority`/`is_active`のうち変更したい項目だけを指定すればよいCOALESCE方式の部分更新(既存のPUTルートは全項目必須だが、チャットの使い勝手を優先し指示ルールのrepository層と同様の部分更新にした)。所有権チェックは`delete_faq`と同じSELECT→比較パターンでisSuperAdmin以外は自テナントのみ操作可能
- `delete_engagement_rule`(confirmed必須): 同様の所有権チェックで削除

**copilot-preview側**: `REAL_TOOL_LABEL`に3ツールのラベルを追加(「知識データ」「アバター」カテゴリーの実データ化はPR Eで対応予定のため今回はラベル追加のみ)。

## Test plan
- [x] `npx tsc --noEmit`(バックエンド + admin-ui) クリーン
- [x] `npx jest src/api/admin/agent/agentRoutes.test.ts` → 66/66 pass(新規9件)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SaK6mK6nvpj9GEAwPkWYRW