### PR TITLE
feat(admin-agent): フィードバックの一覧取得・トリアージをR2Cエージェント経由で可能に(super_admin限定)

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -56,6 +56,8 @@ const REAL_TOOL_LABEL: Record<string, string> = {
   get_engagement_rules: "声がけルール一覧の取得",
   update_engagement_rule: "声がけルールの更新",
   delete_engagement_rule: "声がけルールの削除",
+  get_feedback_list: "フィードバック一覧の取得",
+  triage_feedback: "フィードバックの更新",
 };
 
 // 実際にDBを書き換える(=「進捗」としてカウントしてよい)ツール名

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -917,6 +917,102 @@ export async function executeToolCall(
     }
 
     // -----------------------------------------------------------------------
+    case 'get_feedback_list': {
+      if (!isSuperAdmin) {
+        return truncate('この操作は現在 super_admin 限定です');
+      }
+
+      const status = typeof args['status'] === 'string' ? args['status'] : undefined;
+      const VALID_STATUS = new Set(['new', 'reviewed', 'needs_improvement', 'resolved']);
+      if (status !== undefined && !VALID_STATUS.has(status)) {
+        return truncate('status が不正です（new/reviewed/needs_improvement/resolved のいずれか）');
+      }
+      const limit = Math.min(Math.max(Number(args['limit'] ?? 10), 1), 20);
+
+      try {
+        const params: unknown[] = [];
+        const where = status ? `WHERE status = $${params.push(status)}` : '';
+        params.push(limit);
+        const result = await db.query(
+          `SELECT id, tenant_id, message, status, category, priority, created_at
+           FROM admin_feedback ${where}
+           ORDER BY created_at DESC LIMIT $${params.length}`,
+          params,
+        );
+        if (result.rows.length === 0) {
+          return truncate('フィードバックはありません');
+        }
+        const lines = (result.rows as { id: string; tenant_id: string; message: string; status: string; category: string; priority: string }[]).map(
+          (r) => `[${r.id.slice(0, 8)}] (${r.tenant_id}/${r.status}/${r.priority}) ${r.message.slice(0, 80)}`,
+        );
+        return truncate(`フィードバック一覧（${result.rows.length}件）:\n` + lines.join('\n'));
+      } catch (err: any) {
+        if (err?.code === '42P01') {
+          return truncate('フィードバックはありません');
+        }
+        logger.warn('[actionExecutor] get_feedback_list failed', err);
+        return truncate('フィードバック一覧の取得に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    case 'triage_feedback': {
+      if (!isSuperAdmin) {
+        return truncate('この操作は現在 super_admin 限定です');
+      }
+
+      const id = String(args['id'] ?? '').trim();
+      const confirmed = Boolean(args['confirmed']);
+
+      if (!confirmed) {
+        return truncate(`フィードバック（ID: ${id.slice(0, 8)}）の更新には確認が必要です。confirmed=true を指定して再度実行してください`);
+      }
+      if (!id) {
+        return truncate('id が不正です');
+      }
+
+      const VALID_STATUS = new Set(['new', 'reviewed', 'needs_improvement', 'resolved']);
+      const VALID_PRIORITY = new Set(['low', 'normal', 'high']);
+      const statusRaw = args['status'];
+      if (statusRaw !== undefined && !VALID_STATUS.has(String(statusRaw))) {
+        return truncate('status が不正です（new/reviewed/needs_improvement/resolved のいずれか）');
+      }
+      const priorityRaw = args['priority'];
+      if (priorityRaw !== undefined && !VALID_PRIORITY.has(String(priorityRaw))) {
+        return truncate('priority が不正です（low/normal/high のいずれか）');
+      }
+      const status = typeof statusRaw === 'string' ? statusRaw : undefined;
+      const priority = typeof priorityRaw === 'string' ? priorityRaw : undefined;
+      const adminNotes = typeof args['admin_notes'] === 'string' ? args['admin_notes'].slice(0, 4000) : undefined;
+
+      if (status === undefined && priority === undefined && adminNotes === undefined) {
+        return truncate('変更する内容がありません（status・priority・admin_notes のいずれかを指定してください）');
+      }
+
+      try {
+        const setClauses: string[] = [];
+        const values: unknown[] = [];
+        if (status !== undefined) { values.push(status); setClauses.push(`status = $${values.length}`); }
+        if (priority !== undefined) { values.push(priority); setClauses.push(`priority = $${values.length}`); }
+        if (adminNotes !== undefined) { values.push(adminNotes); setClauses.push(`admin_notes = $${values.length}`); }
+        values.push(id);
+
+        const result = await db.query(
+          `UPDATE admin_feedback SET ${setClauses.join(', ')} WHERE id = $${values.length} RETURNING id, status, priority`,
+          values,
+        );
+        if (result.rows.length === 0) {
+          return truncate(`フィードバック（ID: ${id.slice(0, 8)}）が見つかりません`);
+        }
+        const row = result.rows[0] as { id: string; status: string; priority: string };
+        return truncate(`フィードバック（ID: ${row.id.slice(0, 8)}）を更新しました: status=${row.status}, priority=${row.priority}`);
+      } catch (err) {
+        logger.warn('[actionExecutor] triage_feedback failed', err);
+        return truncate('フィードバックの更新に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
     // Sai委譲(Tier A設計の土台): 現時点では super_admin 限定を維持し、client_admin には
     // 開放しない（信頼モデル変更は別途判断が必要なため、既存のtry-sai同様の認可を踏襲）。
     case 'request_sai_task': {

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -1412,6 +1412,156 @@ describe('POST /v1/admin/agent/chat', () => {
   });
 
   // -------------------------------------------------------------------------
+  // get_feedback_list / triage_feedback（super_admin限定）
+  // -------------------------------------------------------------------------
+  describe('get_feedback_list / triage_feedback', () => {
+    function toolCallResponse(id: string, name: string, args: Record<string, unknown> = {}) {
+      return {
+        ok: true,
+        json: async () => ({
+          choices: [{
+            message: {
+              content: null,
+              tool_calls: [{ id, type: 'function', function: { name, arguments: JSON.stringify(args) } }],
+            },
+          }],
+        }),
+        text: async () => '',
+      };
+    }
+
+    it('get_feedback_list: client_admin が呼び出すと super_admin 限定メッセージが返る', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-fb-1', 'get_feedback_list', {}))
+        .mockResolvedValueOnce(makeGroqResponse('現在は対応できません。'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'フィードバックを見せて', sessionId: 'sess-fb-01' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('super_admin 限定');
+    });
+
+    it('get_feedback_list: super_admin → 一覧を1つの結果文字列にまとめる', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-fb-2', 'get_feedback_list', {}))
+        .mockResolvedValueOnce(makeGroqResponse('2件のフィードバックがあります。'));
+
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          { id: '11111111-aaaa-bbbb-cccc-111111111111', tenant_id: 'tenant-abc', message: 'FAQ検索がわかりにくい', status: 'new', category: 'bug_report', priority: 'high' },
+          { id: '22222222-aaaa-bbbb-cccc-222222222222', tenant_id: 'tenant-xyz', message: 'CSVエクスポートが欲しい', status: 'reviewed', category: 'feature_request', priority: 'normal' },
+        ],
+      });
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'フィードバックを見せて', sessionId: 'sess-fb-02' });
+
+      expect(res.status).toBe(200);
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain('2件');
+      expect(result).toContain('FAQ検索がわかりにくい');
+      expect(result).toContain('CSVエクスポートが欲しい');
+    });
+
+    it('get_feedback_list: 0件の場合は「ありません」と返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-fb-3', 'get_feedback_list', {}))
+        .mockResolvedValueOnce(makeGroqResponse('フィードバックはまだありません。'));
+
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'フィードバックを見せて', sessionId: 'sess-fb-03' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('ありません');
+    });
+
+    it('triage_feedback: client_admin が呼び出すと super_admin 限定メッセージが返る', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-fb-4', 'triage_feedback', { id: '11111111-aaaa-bbbb-cccc-111111111111', status: 'resolved', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('現在は対応できません。'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '解決済みにして', sessionId: 'sess-fb-04' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('super_admin 限定');
+    });
+
+    it('triage_feedback: super_admin・confirmed=false → 更新されずブロックされる', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-fb-5', 'triage_feedback', { id: '11111111-aaaa-bbbb-cccc-111111111111', status: 'resolved', confirmed: false }))
+        .mockResolvedValueOnce(makeGroqResponse('確認してから更新します。'));
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '解決済みにして', sessionId: 'sess-fb-05' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('確認が必要');
+    });
+
+    it('triage_feedback: super_admin・変更内容が空 → DB呼び出しせずその旨を返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-fb-6', 'triage_feedback', { id: '11111111-aaaa-bbbb-cccc-111111111111', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('変更内容を教えてください。'));
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '更新して', sessionId: 'sess-fb-06' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('変更する内容がありません');
+    });
+
+    it('triage_feedback: super_admin・confirmed=true → status/priorityが更新される', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-fb-7', 'triage_feedback', { id: '11111111-aaaa-bbbb-cccc-111111111111', status: 'resolved', priority: 'low', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('更新しました。'));
+
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ id: '11111111-aaaa-bbbb-cccc-111111111111', status: 'resolved', priority: 'low' }],
+      });
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '解決済み・低優先度にして', sessionId: 'sess-fb-07' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE admin_feedback SET status = $1, priority = $2'),
+        ['resolved', 'low', '11111111-aaaa-bbbb-cccc-111111111111'],
+      );
+      expect(res.body.actions[0].result).toContain('status=resolved, priority=low');
+    });
+
+    it('triage_feedback: 対象が見つからない場合はその旨を返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-fb-8', 'triage_feedback', { id: '99999999-aaaa-bbbb-cccc-999999999999', status: 'resolved', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('見つかりませんでした。'));
+
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '更新して', sessionId: 'sess-fb-08' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('見つかりません');
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // G1: 多段エージェントループ
   // -------------------------------------------------------------------------
   describe('G1: 多段エージェントループ', () => {

--- a/src/api/admin/agent/toolDefinitions.ts
+++ b/src/api/admin/agent/toolDefinitions.ts
@@ -483,6 +483,53 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
   {
     type: 'function',
     function: {
+      name: 'get_feedback_list',
+      description:
+        '店舗管理者から寄せられたフィードバック（要望・不具合報告等）の一覧を取得する読み取り専用ツール。super_admin限定。',
+      parameters: {
+        type: 'object',
+        properties: {
+          status: {
+            type: 'string',
+            enum: ['new', 'reviewed', 'needs_improvement', 'resolved'],
+            description: 'ステータスで絞り込み（任意、省略時は全件）',
+          },
+          limit: { type: 'number', description: '取得件数の上限（任意、省略時10、最大20）' },
+        },
+        required: [],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'triage_feedback',
+      description:
+        'フィードバックのステータス・優先度・管理メモを更新する（トリアージ）。super_admin限定。変更したい項目だけを指定すればよい。必ず先に変更内容をユーザーに提示し、明確な同意を得たターンでのみ confirmed=true で呼び出すこと。',
+      parameters: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', description: 'get_feedback_listの結果に含まれるフィードバックID' },
+          status: {
+            type: 'string',
+            enum: ['new', 'reviewed', 'needs_improvement', 'resolved'],
+            description: '新しいステータス（変更する場合のみ指定）',
+          },
+          priority: {
+            type: 'string',
+            enum: ['low', 'normal', 'high'],
+            description: '新しい優先度（変更する場合のみ指定）',
+          },
+          admin_notes: { type: 'string', description: '管理メモ（変更する場合のみ指定）' },
+          confirmed: { type: 'boolean', description: '確認フラグ（true でのみ実行される）' },
+        },
+        required: ['id', 'confirmed'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
       name: 'request_sai_task',
       description:
         'R2Cエージェント(Sai)にブラウザ操作の代行作業を依頼する。ユーザーが管理画面の操作に苦戦している、または苦戦しそうだと判断した場合にのみ、他の対応より先に「代わりに画面操作を行いましょうか？」と尋ねること。ユーザーが明確に依頼していない、または苦戦している様子がない状態で自発的に呼び出してはならない。実際に外部サービスへの課金が発生する。現時点ではsuper_admin限定の機能で、それ以外のロールで呼び出すと拒否される。必ず先にユーザーに作業内容と発生しうる費用を提示し、明確な同意を得たターンでのみ confirmed=true を指定して呼び出すこと。',


### PR DESCRIPTION
## Summary
旧UI機能の新UI(チャット)対応 計画の **PR D**。`/admin/feedback` 画面(super_admin限定、`admin_feedback`テーブルのチケットスタイル管理)が持つ機能のうち、一覧取得とステータス/優先度/管理メモのトリアージをチャットツール化。削除・「拒否ルールを一発作成」ショートカットはスコープ外(Phase2で検討)。

- `get_feedback_list`(読み取り専用、super_admin限定): statusフィルタ対応、最大20件。既存の`GET /v1/admin/feedback`と同じ`admin_feedback`テーブルを参照
- `triage_feedback`(confirmed必須、super_admin限定): `status`/`priority`/`admin_notes`のうち変更したい項目だけを指定すればよい部分更新(既存のPATCHルートと同じUPDATE構築ロジック)。`id`はUUID文字列(`admin_feedback.id`の型に合わせた、既存のnumber型ID系ツールとは異なる)

`request_sai_task`/`get_sai_task_status`と同じ「isSuperAdminでなければ即座に拒否メッセージを返す」パターンをそのまま踏襲。

**copilot-preview側**: `REAL_TOOL_LABEL`に2ツールのラベルを追加。

## Test plan
- [x] `npx tsc --noEmit`(バックエンド + admin-ui) クリーン
- [x] `npx jest src/api/admin/agent/agentRoutes.test.ts` → 74/74 pass(新規8件)
- [x] `npx jest src/api/admin/feedback` → 53/53 pass(無回帰確認)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SaK6mK6nvpj9GEAwPkWYRW