### PR TITLE
feat(admin-agent): 会話履歴・エスカレーション・モニタリング・代行注文の一覧取得をR2Cエージェント経由で可能に

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -58,6 +58,14 @@ const REAL_TOOL_LABEL: Record<string, string> = {
   delete_engagement_rule: "声がけルールの削除",
   get_feedback_list: "フィードバック一覧の取得",
   triage_feedback: "フィードバックの更新",
+  get_knowledge_gaps: "知識ギャップの取得",
+  dismiss_knowledge_gap: "知識ギャップの片付け",
+  get_chat_sessions: "会話セッション一覧の取得",
+  get_escalations: "エスカレーション一覧の取得",
+  get_monitoring_summary: "モニタリングサマリーの取得",
+  get_sai_order_list: "代行注文一覧の取得",
+  request_sai_task: "Saiへの代行依頼",
+  get_sai_task_status: "Saiタスク状況の取得",
 };
 
 // 実際にDBを書き換える(=「進捗」としてカウントしてよい)ツール名
@@ -553,11 +561,8 @@ export default function CopilotPreviewPage() {
         { label: "送料を直す", action: "do1", tone: "primary" },
       ]));
     } else if (key === "knowledge") {
-      push(me("知識データの状況を見せて"));
-      push(say("現在84件のFAQを登録済みです。直近1週間でAIが答えられなかった質問が11件あり、うち9件が「送料」に関するものでした。まずここから登録しますか？", [
-        { label: "登録する", action: "do1", tone: "primary" },
-        { label: "あとで", action: "later", tone: "ghost" },
-      ]));
+      // Phase E: get_faq_list/get_knowledge_gaps(実API)に接続。以前はモック固定文言だった
+      void sendReal("知識データの状況を教えて（FAQの件数と、AIが答えられなかった質問があれば教えて）");
     } else if (key === "rules") {
       // Phase B: get_tuning_rules(実API)に接続。以前はモック固定文言だった
       void sendReal("指示ルールの状況を教えて");

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -15,6 +15,8 @@ import { textToFaqs } from '../knowledge/routes';
 import { suggestEngagementRuleFromText } from './engagementSuggest';
 import { checkSaiMonthlyCostCeiling } from '../options/routes';
 import { submitSaiTask, getSaiTask } from '../../../lib/sai/saiClient';
+import { getSessions, getActiveEscalations } from '../chat-history/chatHistoryRepository';
+import { computeKpis } from '../monitoring/routes';
 
 // ---------------------------------------------------------------------------
 // Avatar activate（avatar/routes.ts は無改変、ここで再実装）
@@ -1009,6 +1011,101 @@ export async function executeToolCall(
       } catch (err) {
         logger.warn('[actionExecutor] triage_feedback failed', err);
         return truncate('フィードバックの更新に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    case 'get_chat_sessions': {
+      if (!tenantId) {
+        return truncate('テナントが特定できません。super_admin の場合は対象テナントを指定してください');
+      }
+      const limit = Math.min(Math.max(Number(args['limit'] ?? 10), 1), 20);
+
+      try {
+        const { sessions, total } = await getSessions({ tenantId, limit });
+        if (sessions.length === 0) {
+          return truncate('会話セッションはありません');
+        }
+        const lines = sessions.map(
+          (s) => `[${s.session_id.slice(0, 8)}] ${s.started_at.slice(0, 10)} (${s.message_count}件) 「${s.first_message_preview}」`,
+        );
+        return truncate(`会話セッション一覧（全${total}件中${sessions.length}件）:\n` + lines.join('\n'));
+      } catch (err) {
+        logger.warn('[actionExecutor] get_chat_sessions failed', err);
+        return truncate('会話セッション一覧の取得に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    case 'get_escalations': {
+      if (!tenantId) {
+        return truncate('テナントが特定できません。super_admin の場合は対象テナントを指定してください');
+      }
+
+      try {
+        const escalations = await getActiveEscalations(tenantId);
+        if (escalations.length === 0) {
+          return truncate('対応中のエスカレーションはありません');
+        }
+        const lines = escalations.map(
+          (e) => `[${e.session_id.slice(0, 8)}] ${e.escalated_at.slice(0, 16).replace('T', ' ')} 「${e.first_message_preview}」`,
+        );
+        return truncate(`対応中のエスカレーション（${escalations.length}件）:\n` + lines.join('\n'));
+      } catch (err) {
+        logger.warn('[actionExecutor] get_escalations failed', err);
+        return truncate('エスカレーション一覧の取得に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    case 'get_monitoring_summary': {
+      if (!tenantId) {
+        return truncate('テナントが特定できません。super_admin の場合は対象テナントを指定してください');
+      }
+
+      try {
+        const kpis = await computeKpis(db, tenantId);
+        return truncate(
+          `直近30日間のサマリー:\n会話数 ${kpis.totalSessions}件\n完了率 ${kpis.completionRate}%\nフォールバック率（AIが答えられなかった割合） ${kpis.fallbackRate}%`,
+        );
+      } catch (err) {
+        logger.warn('[actionExecutor] get_monitoring_summary failed', err);
+        return truncate('モニタリングサマリーの取得に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    case 'get_sai_order_list': {
+      if (!isSuperAdmin) {
+        return truncate('この操作は現在 super_admin 限定です');
+      }
+
+      const status = typeof args['status'] === 'string' ? args['status'] : undefined;
+      const limit = Math.min(Math.max(Number(args['limit'] ?? 10), 1), 20);
+
+      try {
+        const params: unknown[] = [];
+        const where = status ? `WHERE status = $${params.push(status)}` : '';
+        params.push(limit);
+        const result = await db.query(
+          `SELECT id, tenant_id, description, status, type, created_at
+           FROM option_orders ${where}
+           ORDER BY created_at DESC LIMIT $${params.length}`,
+          params,
+        );
+        if (result.rows.length === 0) {
+          return truncate('代行作業の注文はありません');
+        }
+        const lines = (result.rows as { id: string; tenant_id: string; description: string; status: string }[]).map(
+          (r) => `[${String(r.id).slice(0, 8)}] (${r.tenant_id}/${r.status}) ${r.description.slice(0, 80)}`,
+        );
+        return truncate(`代行作業の注文一覧（${result.rows.length}件）:\n` + lines.join('\n'));
+      } catch (err: any) {
+        if (err?.code === '42P01') {
+          return truncate('代行作業の注文はありません');
+        }
+        logger.warn('[actionExecutor] get_sai_order_list failed', err);
+        return truncate('注文一覧の取得に失敗しました');
       }
     }
 

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -94,6 +94,20 @@ jest.mock('../../../lib/sai/saiClient', () => ({
   getSaiTask: (...args: any[]) => mockGetSaiTask(...args),
 }));
 
+// get_chat_sessions / get_escalations が使う依存をモック
+const mockGetSessions = jest.fn();
+const mockGetActiveEscalations = jest.fn();
+jest.mock('../chat-history/chatHistoryRepository', () => ({
+  getSessions: (...args: any[]) => mockGetSessions(...args),
+  getActiveEscalations: (...args: any[]) => mockGetActiveEscalations(...args),
+}));
+
+// get_monitoring_summary が使う依存をモック
+const mockComputeKpis = jest.fn();
+jest.mock('../monitoring/routes', () => ({
+  computeKpis: (...args: any[]) => mockComputeKpis(...args),
+}));
+
 // logger モック
 jest.mock('../../../lib/logger', () => ({
   logger: { warn: jest.fn(), info: jest.fn(), error: jest.fn() },
@@ -1558,6 +1572,166 @@ describe('POST /v1/admin/agent/chat', () => {
 
       expect(res.status).toBe(200);
       expect(res.body.actions[0].result).toContain('見つかりません');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // get_chat_sessions / get_escalations / get_monitoring_summary / get_sai_order_list
+  // -------------------------------------------------------------------------
+  describe('get_chat_sessions / get_escalations / get_monitoring_summary / get_sai_order_list', () => {
+    function toolCallResponse(id: string, name: string, args: Record<string, unknown> = {}) {
+      return {
+        ok: true,
+        json: async () => ({
+          choices: [{
+            message: {
+              content: null,
+              tool_calls: [{ id, type: 'function', function: { name, arguments: JSON.stringify(args) } }],
+            },
+          }],
+        }),
+        text: async () => '',
+      };
+    }
+
+    it('get_chat_sessions: 一覧を1つの結果文字列にまとめる', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-rd-1', 'get_chat_sessions', {}))
+        .mockResolvedValueOnce(makeGroqResponse('直近の会話は2件です。'));
+
+      mockGetSessions.mockResolvedValueOnce({
+        sessions: [
+          { id: 'db-1', tenant_id: 'tenant-abc', session_id: 'sess-aaaaaaaa-1111', started_at: '2026-07-17T10:00:00Z', last_message_at: '2026-07-17T10:05:00Z', message_count: 4, first_message_preview: '送料はいくらですか', outcome: null, outcome_recorded_at: null },
+        ],
+        total: 42,
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '最近の会話を見せて', sessionId: 'sess-rd-01' });
+
+      expect(res.status).toBe(200);
+      expect(mockGetSessions).toHaveBeenCalledWith({ tenantId: 'tenant-abc', limit: 10 });
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain('全42件中1件');
+      expect(result).toContain('送料はいくらですか');
+    });
+
+    it('get_chat_sessions: 0件の場合は「ありません」と返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-rd-2', 'get_chat_sessions', {}))
+        .mockResolvedValueOnce(makeGroqResponse('まだ会話はありません。'));
+
+      mockGetSessions.mockResolvedValueOnce({ sessions: [], total: 0 });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '最近の会話を見せて', sessionId: 'sess-rd-03' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('ありません');
+    });
+
+    it('get_escalations: 対応中の一覧を1つの結果文字列にまとめる', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-rd-4', 'get_escalations', {}))
+        .mockResolvedValueOnce(makeGroqResponse('1件対応中です。'));
+
+      mockGetActiveEscalations.mockResolvedValueOnce([
+        { id: 'db-2', tenant_id: 'tenant-abc', session_id: 'sess-bbbbbbbb-2222', escalated_at: '2026-07-17T12:00:00Z', last_message_at: '2026-07-17T12:05:00Z', message_count: 6, first_message_preview: '返品したいです' },
+      ]);
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'エスカレーションを見せて', sessionId: 'sess-rd-05' });
+
+      expect(res.status).toBe(200);
+      expect(mockGetActiveEscalations).toHaveBeenCalledWith('tenant-abc');
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain('1件');
+      expect(result).toContain('返品したいです');
+    });
+
+    it('get_escalations: 0件の場合は「ありません」と返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-rd-6', 'get_escalations', {}))
+        .mockResolvedValueOnce(makeGroqResponse('対応中のものはありません。'));
+
+      mockGetActiveEscalations.mockResolvedValueOnce([]);
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'エスカレーションを見せて', sessionId: 'sess-rd-07' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('ありません');
+    });
+
+    it('get_monitoring_summary: 完了率・フォールバック率を返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-rd-8', 'get_monitoring_summary', {}))
+        .mockResolvedValueOnce(makeGroqResponse('完了率は良好です。'));
+
+      mockComputeKpis.mockResolvedValueOnce({ completionRate: 92.5, fallbackRate: 3.2, totalSessions: 142 });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '状況を見せて', sessionId: 'sess-rd-09' });
+
+      expect(res.status).toBe(200);
+      expect(mockComputeKpis).toHaveBeenCalledWith(mockDb, 'tenant-abc');
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain('142件');
+      expect(result).toContain('92.5%');
+      expect(result).toContain('3.2%');
+    });
+
+    it('get_sai_order_list: client_admin が呼び出すと super_admin 限定メッセージが返る', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-rd-10', 'get_sai_order_list', {}))
+        .mockResolvedValueOnce(makeGroqResponse('現在は対応できません。'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '代行の注文を見せて', sessionId: 'sess-rd-11' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('super_admin 限定');
+    });
+
+    it('get_sai_order_list: super_admin → 一覧を1つの結果文字列にまとめる', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-rd-12', 'get_sai_order_list', {}))
+        .mockResolvedValueOnce(makeGroqResponse('1件の注文があります。'));
+
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ id: '33333333-aaaa-bbbb-cccc-333333333333', tenant_id: 'tenant-abc', description: '商品ページの送料表記を更新', status: 'pending' }],
+      });
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '代行の注文を見せて', sessionId: 'sess-rd-13' });
+
+      expect(res.status).toBe(200);
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain('1件');
+      expect(result).toContain('商品ページの送料表記を更新');
+    });
+
+    it('get_sai_order_list: 0件の場合は「ありません」と返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-rd-14', 'get_sai_order_list', {}))
+        .mockResolvedValueOnce(makeGroqResponse('注文はまだありません。'));
+
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '代行の注文を見せて', sessionId: 'sess-rd-15' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('ありません');
     });
   });
 

--- a/src/api/admin/agent/toolDefinitions.ts
+++ b/src/api/admin/agent/toolDefinitions.ts
@@ -530,6 +530,63 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
   {
     type: 'function',
     function: {
+      name: 'get_chat_sessions',
+      description:
+        '最近の会話セッション一覧（開始日時・メッセージ数・最初の質問プレビュー）を取得する読み取り専用ツール。会話履歴の概要を確認したい時に使う。',
+      parameters: {
+        type: 'object',
+        properties: {
+          limit: { type: 'number', description: '取得件数の上限（任意、省略時10、最大20）' },
+        },
+        required: [],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'get_escalations',
+      description:
+        '有人対応にエスカレーションされた、対応中（未解決）の会話一覧を取得する読み取り専用ツール。',
+      parameters: {
+        type: 'object',
+        properties: {},
+        required: [],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'get_monitoring_summary',
+      description:
+        '直近30日間の会話完了率・フォールバック率（AIが答えられなかった割合）のサマリーを取得する読み取り専用ツール。',
+      parameters: {
+        type: 'object',
+        properties: {},
+        required: [],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'get_sai_order_list',
+      description:
+        '代行作業（Sai）の注文一覧を取得する読み取り専用ツール。super_admin限定。ステータスで絞り込み可能。',
+      parameters: {
+        type: 'object',
+        properties: {
+          status: { type: 'string', description: 'ステータスで絞り込み（任意、例: pending/in_progress/completed）' },
+          limit: { type: 'number', description: '取得件数の上限（任意、省略時10、最大20）' },
+        },
+        required: [],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
       name: 'request_sai_task',
       description:
         'R2Cエージェント(Sai)にブラウザ操作の代行作業を依頼する。ユーザーが管理画面の操作に苦戦している、または苦戦しそうだと判断した場合にのみ、他の対応より先に「代わりに画面操作を行いましょうか？」と尋ねること。ユーザーが明確に依頼していない、または苦戦している様子がない状態で自発的に呼び出してはならない。実際に外部サービスへの課金が発生する。現時点ではsuper_admin限定の機能で、それ以外のロールで呼び出すと拒否される。必ず先にユーザーに作業内容と発生しうる費用を提示し、明確な同意を得たターンでのみ confirmed=true を指定して呼び出すこと。',

--- a/src/api/admin/monitoring/routes.ts
+++ b/src/api/admin/monitoring/routes.ts
@@ -25,7 +25,7 @@ const DEFAULT_SLA = {
 };
 
 /** 会話完了率・フォールバック率をDBから計算（30日間） */
-async function computeKpis(
+export async function computeKpis(
   db: { query: (sql: string, params: unknown[]) => Promise<{ rows: any[] }> },
   tenantFilter: string | null
 ): Promise<{


### PR DESCRIPTION
## Summary
旧UI機能の新UI(チャット)対応 計画の **PR E(最終)**。読み取り専用の4画面をまとめてチャットツール化。

- `get_chat_sessions`(両ロール): `/admin/chat-history` 相当。既存の`getSessions`(`chatHistoryRepository`)を再利用
- `get_escalations`(両ロール): `/admin/escalations` 一覧相当。既存の`getActiveEscalations`を再利用
- `get_monitoring_summary`(両ロール): `/admin/monitoring` KPI相当。`monitoring/routes.ts`の`computeKpis`を初めてexportして再利用(直近30日の完了率・フォールバック率・会話数のみ。`loopRate`/`searchP95Ms`/`errorRate`/`killSwitchActive`は実データではない固定値のため意図的に含めていない)
- `get_sai_order_list`(super_admin限定): `/admin/options` 一覧相当。REST版は`client_admin`にも開放されているが、既存のSai関連チャットツール(`request_sai_task`等)と一貫させるためsuper_admin限定とした(計画時点で決定済み)

**copilot-preview側**:
- 「知識データ」サイドバーカテゴリーをモック固定文言から`sendReal()`呼び出しに変更(`get_faq_list`/`get_knowledge_gaps`経由で実データを表示)。これで全6カテゴリーが実データ化またはAPI接続完了(アバターのみon/offトグルの範囲内)
- `REAL_TOOL_LABEL`の漏れを修正: `request_sai_task`/`get_sai_task_status`(PR #491時点で漏れていた)、`get_knowledge_gaps`/`dismiss_knowledge_gap`(PR A追加時に漏れていた)、および今回追加した4ツールを追加

これで計画のPhase 1(5PR構成)完了です。

## Test plan
- [x] `npx tsc --noEmit`(バックエンド + admin-ui) クリーン
- [x] `npx jest src/api/admin/agent/agentRoutes.test.ts` → 82/82 pass(新規8件)
- [x] `npx jest src/api/admin/options src/api/admin/monitoring src/api/admin/chat-history` → 110/110 pass(無回帰確認)
- [x] ローカルでPlaywright確認: 「知識データ」クリックが実API(`sendReal`→`authFetch`)経路を通ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SaK6mK6nvpj9GEAwPkWYRW