### PR TITLE
feat(admin-agent): フィードバックの拒否ルール一発作成をR2Cエージェント経由で可能に

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -61,6 +61,7 @@ const REAL_TOOL_LABEL: Record<string, string> = {
   delete_engagement_rule: "声がけルールの削除",
   get_feedback_list: "フィードバック一覧の取得",
   triage_feedback: "フィードバックの更新",
+  create_deny_rule_from_feedback: "拒否ルールの一発作成",
   get_knowledge_gaps: "知識ギャップの取得",
   dismiss_knowledge_gap: "知識ギャップの片付け",
   get_chat_sessions: "会話セッション一覧の取得",

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -1131,6 +1131,62 @@ export async function executeToolCall(
     }
 
     // -----------------------------------------------------------------------
+    case 'create_deny_rule_from_feedback': {
+      if (!isSuperAdmin) {
+        return truncate('この操作は現在 super_admin 限定です');
+      }
+
+      const feedbackId = String(args['feedback_id'] ?? '').trim();
+      const confirmed = Boolean(args['confirmed']);
+
+      if (!confirmed) {
+        return truncate(`拒否ルールの作成には確認が必要です。confirmed=true を指定して再度実行してください`);
+      }
+      if (!feedbackId) {
+        return truncate('feedback_id が不正です');
+      }
+
+      const DEFAULT_DENY_BEHAVIOR =
+        'この種の質問には『申し訳ございませんが、当店ではお答えできかねます。ご了承ください。』と丁寧に断ってください';
+
+      try {
+        const feedbackRes = await db.query('SELECT tenant_id, message FROM admin_feedback WHERE id = $1', [feedbackId]);
+        if (feedbackRes.rows.length === 0) {
+          return truncate(`フィードバック（ID: ${feedbackId.slice(0, 8)}）が見つかりません`);
+        }
+        const feedbackRow = feedbackRes.rows[0] as { tenant_id: string; message: string };
+
+        const triggerPatternArg = args['trigger_pattern'];
+        const triggerPattern =
+          typeof triggerPatternArg === 'string' && triggerPatternArg.trim()
+            ? triggerPatternArg.trim().slice(0, 1000)
+            : feedbackRow.message.slice(0, 1000);
+        const expectedBehaviorArg = args['expected_behavior'];
+        const expectedBehavior =
+          typeof expectedBehaviorArg === 'string' && expectedBehaviorArg.trim()
+            ? expectedBehaviorArg.trim().slice(0, 4000)
+            : DEFAULT_DENY_BEHAVIOR;
+
+        const rule = await createRule({
+          tenant_id: feedbackRow.tenant_id,
+          trigger_pattern: triggerPattern,
+          expected_behavior: expectedBehavior,
+          priority: 8,
+          created_by: 'admin_agent',
+        });
+
+        await db.query('UPDATE admin_feedback SET status = $1 WHERE id = $2', ['resolved', feedbackId]);
+
+        return truncate(
+          `拒否ルールを作成しました（ルールID: ${rule.id}）: 「${rule.trigger_pattern.slice(0, 60)}」→ 丁寧に断る対応を設定しました。フィードバック（ID: ${feedbackId.slice(0, 8)}）はresolvedにしました`,
+        );
+      } catch (err) {
+        logger.warn('[actionExecutor] create_deny_rule_from_feedback failed', err);
+        return truncate('拒否ルールの作成に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
     case 'get_chat_sessions': {
       if (!tenantId) {
         return truncate('テナントが特定できません。super_admin の場合は対象テナントを指定してください');

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -1756,6 +1756,126 @@ describe('POST /v1/admin/agent/chat', () => {
   });
 
   // -------------------------------------------------------------------------
+  // create_deny_rule_from_feedback（super_admin限定）
+  // -------------------------------------------------------------------------
+  describe('create_deny_rule_from_feedback', () => {
+    function toolCallResponse(id: string, name: string, args: Record<string, unknown> = {}) {
+      return {
+        ok: true,
+        json: async () => ({
+          choices: [{
+            message: {
+              content: null,
+              tool_calls: [{ id, type: 'function', function: { name, arguments: JSON.stringify(args) } }],
+            },
+          }],
+        }),
+        text: async () => '',
+      };
+    }
+    const FEEDBACK_ID = '11111111-aaaa-bbbb-cccc-111111111111';
+
+    it('client_admin が呼び出すと super_admin 限定メッセージが返る', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-dr-1', 'create_deny_rule_from_feedback', { feedback_id: FEEDBACK_ID, confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('現在は対応できません。'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '拒否ルールを作って', sessionId: 'sess-dr-01' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).not.toHaveBeenCalled();
+      expect(mockCreateRule).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('super_admin 限定');
+    });
+
+    it('super_admin・confirmed=false → 作成されずブロックされる', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-dr-2', 'create_deny_rule_from_feedback', { feedback_id: FEEDBACK_ID, confirmed: false }))
+        .mockResolvedValueOnce(makeGroqResponse('確認してから作成します。'));
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '拒否ルールを作って', sessionId: 'sess-dr-03' });
+
+      expect(res.status).toBe(200);
+      expect(mockCreateRule).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('確認が必要');
+    });
+
+    it('super_admin・confirmed=true・引数省略 → フィードバック本文と標準文言でルール作成しresolvedに更新', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-dr-4', 'create_deny_rule_from_feedback', { feedback_id: FEEDBACK_ID, confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('作成しました。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ tenant_id: 'tenant-abc', message: '返品ポリシーを教えてください' }] }) // SELECT feedback
+        .mockResolvedValueOnce({ rows: [] }); // UPDATE admin_feedback
+      mockCreateRule.mockResolvedValueOnce({
+        id: 55, tenant_id: 'tenant-abc', trigger_pattern: '返品ポリシーを教えてください', expected_behavior: 'x', priority: 8, is_active: true, created_by: 'admin_agent', source_message_id: null, created_at: '', updated_at: '',
+      });
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '拒否ルールを作って', sessionId: 'sess-dr-05' });
+
+      expect(res.status).toBe(200);
+      expect(mockCreateRule).toHaveBeenCalledWith(
+        expect.objectContaining({
+          tenant_id: 'tenant-abc',
+          trigger_pattern: '返品ポリシーを教えてください',
+          expected_behavior: expect.stringContaining('お答えできかねます'),
+          priority: 8,
+        }),
+      );
+      expect(mockQuery).toHaveBeenLastCalledWith('UPDATE admin_feedback SET status = $1 WHERE id = $2', ['resolved', FEEDBACK_ID]);
+      expect(res.body.actions[0].result).toContain('ID: 55');
+      expect(res.body.actions[0].result).toContain('resolved');
+    });
+
+    it('super_admin・trigger_pattern/expected_behaviorを明示指定 → その内容でルール作成される', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-dr-6', 'create_deny_rule_from_feedback', {
+          feedback_id: FEEDBACK_ID, trigger_pattern: 'カスタムトリガー', expected_behavior: 'カスタム対応方針', confirmed: true,
+        }))
+        .mockResolvedValueOnce(makeGroqResponse('作成しました。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ tenant_id: 'tenant-abc', message: '元の質問' }] })
+        .mockResolvedValueOnce({ rows: [] });
+      mockCreateRule.mockResolvedValueOnce({
+        id: 56, tenant_id: 'tenant-abc', trigger_pattern: 'カスタムトリガー', expected_behavior: 'カスタム対応方針', priority: 8, is_active: true, created_by: 'admin_agent', source_message_id: null, created_at: '', updated_at: '',
+      });
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '拒否ルールを作って', sessionId: 'sess-dr-07' });
+
+      expect(res.status).toBe(200);
+      expect(mockCreateRule).toHaveBeenCalledWith(
+        expect.objectContaining({ trigger_pattern: 'カスタムトリガー', expected_behavior: 'カスタム対応方針' }),
+      );
+    });
+
+    it('対象のフィードバックが見つからない場合はその旨を返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-dr-8', 'create_deny_rule_from_feedback', { feedback_id: '99999999-aaaa-bbbb-cccc-999999999999', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('見つかりませんでした。'));
+
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '拒否ルールを作って', sessionId: 'sess-dr-09' });
+
+      expect(res.status).toBe(200);
+      expect(mockCreateRule).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('見つかりません');
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // get_chat_sessions / get_escalations / get_monitoring_summary / get_sai_order_list
   // -------------------------------------------------------------------------
   describe('get_chat_sessions / get_escalations / get_monitoring_summary / get_sai_order_list', () => {

--- a/src/api/admin/agent/toolDefinitions.ts
+++ b/src/api/admin/agent/toolDefinitions.ts
@@ -581,6 +581,24 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
   {
     type: 'function',
     function: {
+      name: 'create_deny_rule_from_feedback',
+      description:
+        '選択したフィードバックの内容をもとに、AIがその種の質問を丁寧に断るための指示ルールを作成し、フィードバックのステータスをresolvedにする（旧UIの「拒否ルールを作成」ボタンと同じ一発ショートカット）。super_admin限定。必ず先に作成するルール内容を提示し、明確な同意を得たターンでのみ confirmed=true で呼び出すこと。',
+      parameters: {
+        type: 'object',
+        properties: {
+          feedback_id: { type: 'string', description: 'get_feedback_listの結果に含まれるフィードバックID' },
+          trigger_pattern: { type: 'string', description: 'トリガー内容（省略時はフィードバックの本文をそのまま使う）' },
+          expected_behavior: { type: 'string', description: 'AIへの対応方針（省略時は標準の丁寧な拒否文言を使う）' },
+          confirmed: { type: 'boolean', description: '確認フラグ（true でのみ実行される）' },
+        },
+        required: ['feedback_id', 'confirmed'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
       name: 'get_chat_sessions',
       description:
         '最近の会話セッション一覧（開始日時・メッセージ数・最初の質問プレビュー）を取得する読み取り専用ツール。会話履歴の概要を確認したい時に使う。',


### PR DESCRIPTION
## Summary
旧UI機能の新UI(チャット)対応 計画(Phase 2)の **PR G**。旧UIの「拒否ルールを作成」ボタン(`admin-ui/src/pages/admin/feedback/index.tsx:149-181`)と同じ一発ショートカットをチャットツール化。

- `create_deny_rule_from_feedback`(confirmed必須、super_admin限定): フィードバック本文を`trigger_pattern`、標準の丁寧な拒否文言を`expected_behavior`として`createRule`(既存import済み)で`tuning_rule`作成(`priority=8`固定、旧UIと同じ)、続けて`admin_feedback`を`status='resolved'`に更新。旧UIはカスタマイズ不可の一発ボタンだが、チャットの対話性を活かし`trigger_pattern`/`expected_behavior`を任意で上書き指定できるようにした(省略時は旧UIと完全に同じ挙動)

**copilot-preview側**: `REAL_TOOL_LABEL`に1ツールのラベルを追加。

## Test plan
- [x] `npx tsc --noEmit`(バックエンド + admin-ui) クリーン
- [x] `npx jest src/api/admin/agent/agentRoutes.test.ts` → 95/95 pass(新規5件: client_admin拒否/confirmed=false/引数省略時の既定挙動/明示指定での上書き/対象なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SaK6mK6nvpj9GEAwPkWYRW