### PR TITLE
feat(admin-agent): Sai代行注文管理をR2Cエージェント経由で可能に(金額開示の安全設計)

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -68,6 +68,11 @@ const REAL_TOOL_LABEL: Record<string, string> = {
   get_escalations: "エスカレーション一覧の取得",
   get_monitoring_summary: "モニタリングサマリーの取得",
   get_sai_order_list: "代行注文一覧の取得",
+  update_sai_order: "代行注文の更新",
+  complete_sai_order: "代行注文の完了記録",
+  send_sai_schedule_notice: "スケジュール通知の送信",
+  get_sai_rule_proposals: "Saiルール提案一覧の取得",
+  review_sai_rule_proposal: "Saiルール提案の承認/却下",
   request_sai_task: "Saiへの代行依頼",
   get_sai_task_status: "Saiタスク状況の取得",
 };

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -18,6 +18,9 @@ import { checkSaiMonthlyCostCeiling } from '../options/routes';
 import { submitSaiTask, getSaiTask } from '../../../lib/sai/saiClient';
 import { getSessions, getActiveEscalations } from '../chat-history/chatHistoryRepository';
 import { computeKpis } from '../monitoring/routes';
+import { chargeOneOffJpy } from '../../../lib/billing/stripeSync';
+import { createNotification } from '../../../lib/notifications';
+import { listSaiRules, approveSaiRule, rejectSaiRule } from '../../../lib/sai/saiTaskRulesRepository';
 
 // ---------------------------------------------------------------------------
 // Avatar activate（avatar/routes.ts は無改変、ここで再実装）
@@ -1278,6 +1281,250 @@ export async function executeToolCall(
         }
         logger.warn('[actionExecutor] get_sai_order_list failed', err);
         return truncate('注文一覧の取得に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    case 'update_sai_order': {
+      if (!isSuperAdmin) {
+        return truncate('この操作は現在 super_admin 限定です');
+      }
+
+      const id = String(args['id'] ?? '').trim();
+      const confirmed = Boolean(args['confirmed']);
+
+      if (!confirmed) {
+        return truncate(`代行注文（ID: ${id.slice(0, 8)}）の更新には確認が必要です。confirmed=true を指定して再度実行してください`);
+      }
+      if (!id) {
+        return truncate('id が不正です');
+      }
+
+      const VALID_STATUS = new Set(['pending', 'in_progress', 'completed']);
+      const statusRaw = args['status'];
+      if (statusRaw !== undefined && !VALID_STATUS.has(String(statusRaw))) {
+        return truncate('status が不正です（pending/in_progress/completed のいずれか）');
+      }
+      const status = typeof statusRaw === 'string' ? statusRaw : undefined;
+      const finalAmountRaw = args['final_amount'];
+      const finalAmount =
+        typeof finalAmountRaw === 'number' && Number.isFinite(finalAmountRaw) ? Math.round(finalAmountRaw) : undefined;
+
+      if (status === undefined && finalAmount === undefined) {
+        return truncate('変更する内容がありません（status・final_amount のいずれかを指定してください）');
+      }
+
+      try {
+        const result = await db.query(
+          `UPDATE option_orders SET
+             status       = COALESCE($1, status),
+             final_amount = COALESCE($2, final_amount),
+             updated_at   = NOW()
+           WHERE id = $3
+           RETURNING id, status, final_amount`,
+          [status ?? null, finalAmount ?? null, id],
+        );
+        if (result.rows.length === 0) {
+          return truncate(`代行注文（ID: ${id.slice(0, 8)}）が見つかりません`);
+        }
+        const row = result.rows[0] as { id: string; status: string; final_amount: number | null };
+        return truncate(
+          `代行注文（ID: ${id.slice(0, 8)}）を更新しました: status=${row.status}` +
+          (row.final_amount != null ? `, final_amount=¥${row.final_amount.toLocaleString('ja-JP')}` : ''),
+        );
+      } catch (err) {
+        logger.warn('[actionExecutor] update_sai_order failed', err);
+        return truncate('代行注文の更新に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    case 'complete_sai_order': {
+      if (!isSuperAdmin) {
+        return truncate('この操作は現在 super_admin 限定です');
+      }
+
+      const id = String(args['id'] ?? '').trim();
+      const confirmed = Boolean(args['confirmed']);
+
+      if (!id) {
+        return truncate('id が不正です');
+      }
+
+      try {
+        const orderRes = await db.query(
+          `SELECT id, tenant_id, description, type, final_amount, llm_estimate_amount, status
+           FROM option_orders WHERE id = $1`,
+          [id],
+        );
+        if (orderRes.rows.length === 0) {
+          return truncate(`代行注文（ID: ${id.slice(0, 8)}）が見つかりません`);
+        }
+        const order = orderRes.rows[0] as {
+          id: string; tenant_id: string; description: string; type: string | null;
+          final_amount: number | null; llm_estimate_amount: number | null; status: string;
+        };
+
+        if (order.status === 'completed') {
+          return truncate(`代行注文（ID: ${id.slice(0, 8)}）は既に完了済みです`);
+        }
+
+        const amount = order.final_amount ?? order.llm_estimate_amount ?? 0;
+
+        if (!confirmed) {
+          return truncate(
+            `この代行作業を完了記録すると、テナント（${order.tenant_id}）に¥${amount.toLocaleString('ja-JP')}が請求されます（Stripe決済）。` +
+            'よろしければ confirmed=true を指定して再度実行してください',
+          );
+        }
+
+        // 二重完了防止(status != 'completed'のWHERE句がアトミックなガード)
+        const completeRes = await db.query(
+          `UPDATE option_orders SET status = 'completed', completed_at = NOW(), updated_at = NOW()
+           WHERE id = $1 AND status != 'completed'
+           RETURNING tenant_id, description, type`,
+          [id],
+        );
+        if (completeRes.rows.length === 0) {
+          return truncate(`代行注文（ID: ${id.slice(0, 8)}）は既に完了済みです`);
+        }
+        const completed = completeRes.rows[0] as { tenant_id: string; description: string; type: string | null };
+        const isPremiumAvatar = completed.type === 'premium_avatar';
+
+        await createNotification({
+          recipientRole: 'client_admin',
+          recipientTenantId: completed.tenant_id,
+          type: isPremiumAvatar ? 'premium_avatar_completed' : 'option_completed',
+          title: isPremiumAvatar ? 'プレミアムアバターが完成しました' : 'オプションサービスが完了しました',
+          message: completed.description.slice(0, 100),
+          link: isPremiumAvatar ? '/admin/avatar' : '/admin/options',
+        });
+
+        const charged = await chargeOneOffJpy(db, logger, {
+          tenantId: completed.tenant_id,
+          amountJpy: amount,
+          description: `代行作業: ${completed.description.slice(0, 80)}`,
+          idempotencyKey: `option-complete:${id}`,
+        });
+        if (charged) {
+          await db
+            .query('UPDATE option_orders SET stripe_usage_recorded = true WHERE id = $1', [id])
+            .catch((err) => logger.warn('[actionExecutor] complete_sai_order stripe_usage_recorded update failed', err));
+        }
+
+        return truncate(
+          `代行注文（ID: ${id.slice(0, 8)}）を完了にしました。テナントへの請求: ¥${amount.toLocaleString('ja-JP')}` +
+          `（${charged ? 'Stripe決済実行済み' : '課金スキップ（無料期間等）'}）`,
+        );
+      } catch (err) {
+        logger.warn('[actionExecutor] complete_sai_order failed', err);
+        return truncate('代行注文の完了処理に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    case 'send_sai_schedule_notice': {
+      if (!isSuperAdmin) {
+        return truncate('この操作は現在 super_admin 限定です');
+      }
+
+      const orderId = String(args['order_id'] ?? '').trim();
+      const messageTemplate = String(args['message'] ?? '').trim().slice(0, 2000);
+      const confirmed = Boolean(args['confirmed']);
+
+      if (!confirmed) {
+        return truncate('通知の送信には確認が必要です。内容をユーザーに提示し、同意を得てから confirmed=true で再度呼び出してください');
+      }
+      if (!orderId || !messageTemplate) {
+        return truncate('order_id・message は必須です');
+      }
+
+      try {
+        const orderRes = await db.query('SELECT tenant_id FROM option_orders WHERE id = $1', [orderId]);
+        if (orderRes.rows.length === 0) {
+          return truncate(`代行注文（ID: ${orderId.slice(0, 8)}）が見つかりません`);
+        }
+        const tenantIdForOrder = (orderRes.rows[0] as { tenant_id: string }).tenant_id;
+
+        const scheduledAtRaw = args['scheduled_at'];
+        const scheduledAt = typeof scheduledAtRaw === 'string' ? new Date(scheduledAtRaw) : undefined;
+        const dateText =
+          scheduledAt && !Number.isNaN(scheduledAt.getTime())
+            ? scheduledAt.toLocaleString('ja-JP', { year: 'numeric', month: '2-digit', day: '2-digit', hour: '2-digit', minute: '2-digit' })
+            : '後日ご連絡';
+        const resolvedMessage = messageTemplate.replace('{日時}', dateText);
+
+        await createNotification({
+          recipientRole: 'client_admin',
+          recipientTenantId: tenantIdForOrder,
+          type: 'option_scheduled',
+          title: '代行作業のスケジュールについて',
+          message: resolvedMessage,
+          link: '/admin/options',
+        });
+
+        return truncate(`テナント（${tenantIdForOrder}）にスケジュール通知を送信しました: 「${resolvedMessage.slice(0, 100)}」`);
+      } catch (err) {
+        logger.warn('[actionExecutor] send_sai_schedule_notice failed', err);
+        return truncate('通知の送信に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    case 'get_sai_rule_proposals': {
+      if (!isSuperAdmin) {
+        return truncate('この操作は現在 super_admin 限定です');
+      }
+
+      const status = typeof args['status'] === 'string' ? args['status'] : 'pending';
+
+      try {
+        const rules = await listSaiRules(undefined, { status });
+        if (rules.length === 0) {
+          return truncate(`${status}状態のSaiルール提案はありません`);
+        }
+        const lines = rules
+          .slice(0, 15)
+          .map((r) => `[${r.id}] (${r.tenant_id}) 「${r.trigger_pattern.slice(0, 60)}」→ ${r.expected_behavior.slice(0, 100)}`);
+        return truncate(`Saiルール提案一覧（${status}、${rules.length}件）:\n` + lines.join('\n'));
+      } catch (err: any) {
+        if (err?.code === '42P01') {
+          return truncate('Saiルール提案はありません');
+        }
+        logger.warn('[actionExecutor] get_sai_rule_proposals failed', err);
+        return truncate('Saiルール提案一覧の取得に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    case 'review_sai_rule_proposal': {
+      if (!isSuperAdmin) {
+        return truncate('この操作は現在 super_admin 限定です');
+      }
+
+      const id = Number(args['id']);
+      const action = String(args['action'] ?? '');
+      const confirmed = Boolean(args['confirmed']);
+
+      if (!confirmed) {
+        return truncate(`Saiルール提案（ID: ${id}）の${action === 'reject' ? '却下' : '承認'}には確認が必要です。confirmed=true を指定して再度実行してください`);
+      }
+      if (!Number.isFinite(id)) {
+        return truncate('id が不正です');
+      }
+      if (action !== 'approve' && action !== 'reject') {
+        return truncate('action が不正です（approve/reject のいずれか）');
+      }
+
+      try {
+        const updated = action === 'approve' ? await approveSaiRule(id) : await rejectSaiRule(id);
+        if (!updated) {
+          return truncate(`Saiルール提案（ID: ${id}）が見つかりません`);
+        }
+        return truncate(`Saiルール提案（ID: ${id}）を${action === 'approve' ? '承認' : '却下'}しました: 「${updated.trigger_pattern.slice(0, 60)}」`);
+      } catch (err) {
+        logger.warn('[actionExecutor] review_sai_rule_proposal failed', err);
+        return truncate('Saiルール提案の処理に失敗しました');
       }
     }
 

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -114,6 +114,27 @@ jest.mock('../monitoring/routes', () => ({
   computeKpis: (...args: any[]) => mockComputeKpis(...args),
 }));
 
+// complete_sai_order / send_sai_schedule_notice が使う依存をモック(実課金・実通知は厳禁のため必ずモック)
+const mockChargeOneOffJpy = jest.fn();
+jest.mock('../../../lib/billing/stripeSync', () => ({
+  chargeOneOffJpy: (...args: any[]) => mockChargeOneOffJpy(...args),
+}));
+
+const mockCreateNotification = jest.fn();
+jest.mock('../../../lib/notifications', () => ({
+  createNotification: (...args: any[]) => mockCreateNotification(...args),
+}));
+
+// get_sai_rule_proposals / review_sai_rule_proposal が使う依存をモック
+const mockListSaiRules = jest.fn();
+const mockApproveSaiRule = jest.fn();
+const mockRejectSaiRule = jest.fn();
+jest.mock('../../../lib/sai/saiTaskRulesRepository', () => ({
+  listSaiRules: (...args: any[]) => mockListSaiRules(...args),
+  approveSaiRule: (...args: any[]) => mockApproveSaiRule(...args),
+  rejectSaiRule: (...args: any[]) => mockRejectSaiRule(...args),
+}));
+
 // logger モック
 jest.mock('../../../lib/logger', () => ({
   logger: { warn: jest.fn(), info: jest.fn(), error: jest.fn() },
@@ -2032,6 +2053,279 @@ describe('POST /v1/admin/agent/chat', () => {
 
       expect(res.status).toBe(200);
       expect(res.body.actions[0].result).toContain('ありません');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // update_sai_order / complete_sai_order / send_sai_schedule_notice /
+  // get_sai_rule_proposals / review_sai_rule_proposal（全てsuper_admin限定）
+  // -------------------------------------------------------------------------
+  describe('update_sai_order / complete_sai_order / send_sai_schedule_notice / get_sai_rule_proposals / review_sai_rule_proposal', () => {
+    function toolCallResponse(id: string, name: string, args: Record<string, unknown> = {}) {
+      return {
+        ok: true,
+        json: async () => ({
+          choices: [{
+            message: {
+              content: null,
+              tool_calls: [{ id, type: 'function', function: { name, arguments: JSON.stringify(args) } }],
+            },
+          }],
+        }),
+        text: async () => '',
+      };
+    }
+    const ORDER_ID = '33333333-aaaa-bbbb-cccc-333333333333';
+
+    // ── update_sai_order ──────────────────────────────────────────────────
+    it('update_sai_order: client_admin が呼び出すと super_admin 限定メッセージが返る', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-so-1', 'update_sai_order', { id: ORDER_ID, status: 'in_progress', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('現在は対応できません。'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '注文を進行中にして', sessionId: 'sess-so-01' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('super_admin 限定');
+    });
+
+    it('update_sai_order: super_admin・confirmed=true → status/final_amountがCOALESCE更新される', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-so-2', 'update_sai_order', { id: ORDER_ID, status: 'in_progress', final_amount: 5000, confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('更新しました。'));
+
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: ORDER_ID, status: 'in_progress', final_amount: 5000 }] });
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '注文を進行中・5000円にして', sessionId: 'sess-so-03' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE option_orders'),
+        ['in_progress', 5000, ORDER_ID],
+      );
+      expect(res.body.actions[0].result).toContain('¥5,000');
+    });
+
+    // ── complete_sai_order: 金額開示・課金・二重完了防止の3点を明示確認 ────────
+    it('complete_sai_order: confirmed=false → 実行されず正確な金額（final_amount優先）が開示される', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-so-4', 'complete_sai_order', { id: ORDER_ID }))
+        .mockResolvedValueOnce(makeGroqResponse('確認してから完了します。'));
+
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ id: ORDER_ID, tenant_id: 'tenant-abc', description: '送料表記の更新', type: null, final_amount: 3000, llm_estimate_amount: 2500, status: 'in_progress' }],
+      });
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'この注文を完了にして', sessionId: 'sess-so-05' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).toHaveBeenCalledTimes(1); // SELECTのみ、UPDATE/課金は発火しない
+      expect(mockChargeOneOffJpy).not.toHaveBeenCalled();
+      expect(mockCreateNotification).not.toHaveBeenCalled();
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain('¥3,000'); // final_amount優先(llm_estimate_amountの2500ではない)
+      expect(result).toContain('請求されます');
+    });
+
+    it('complete_sai_order: llm_estimate_amountのみの場合はそちらが開示金額になる', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-so-6', 'complete_sai_order', { id: ORDER_ID }))
+        .mockResolvedValueOnce(makeGroqResponse('確認してから完了します。'));
+
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ id: ORDER_ID, tenant_id: 'tenant-abc', description: '送料表記の更新', type: null, final_amount: null, llm_estimate_amount: 2500, status: 'in_progress' }],
+      });
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'この注文を完了にして', sessionId: 'sess-so-07' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('¥2,500');
+    });
+
+    it('complete_sai_order: confirmed=true → 完了更新・通知・課金の順で実行される', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-so-8', 'complete_sai_order', { id: ORDER_ID, confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('完了しました。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ id: ORDER_ID, tenant_id: 'tenant-abc', description: '送料表記の更新', type: null, final_amount: 3000, llm_estimate_amount: 2500, status: 'in_progress' }] }) // SELECT
+        .mockResolvedValueOnce({ rows: [{ tenant_id: 'tenant-abc', description: '送料表記の更新', type: null }] }) // UPDATE (二重完了防止WHERE付き)
+        .mockResolvedValueOnce({ rows: [] }); // stripe_usage_recorded更新
+      mockCreateNotification.mockResolvedValueOnce(undefined);
+      mockChargeOneOffJpy.mockResolvedValueOnce(true);
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'この注文を完了にして', sessionId: 'sess-so-09' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).toHaveBeenNthCalledWith(2, expect.stringContaining("WHERE id = $1 AND status != 'completed'"), [ORDER_ID]);
+      expect(mockCreateNotification).toHaveBeenCalledWith(
+        expect.objectContaining({ recipientRole: 'client_admin', recipientTenantId: 'tenant-abc', type: 'option_completed' }),
+      );
+      expect(mockChargeOneOffJpy).toHaveBeenCalledWith(
+        mockDb,
+        expect.anything(),
+        expect.objectContaining({ tenantId: 'tenant-abc', amountJpy: 3000, idempotencyKey: `option-complete:${ORDER_ID}` }),
+      );
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain('¥3,000');
+      expect(result).toContain('Stripe決済実行済み');
+    });
+
+    it('complete_sai_order: 既にstatus=completedの場合、confirmed有無に関わらず課金せず「既に完了済み」を返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-so-10', 'complete_sai_order', { id: ORDER_ID, confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('既に完了しています。'));
+
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ id: ORDER_ID, tenant_id: 'tenant-abc', description: 'x', type: null, final_amount: 3000, llm_estimate_amount: null, status: 'completed' }],
+      });
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'この注文を完了にして', sessionId: 'sess-so-11' });
+
+      expect(res.status).toBe(200);
+      expect(mockChargeOneOffJpy).not.toHaveBeenCalled();
+      expect(mockCreateNotification).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('既に完了済み');
+    });
+
+    it('complete_sai_order: 二重完了防止WHERE句が0件返す競合ケース → 課金せず「既に完了済み」を返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-so-12', 'complete_sai_order', { id: ORDER_ID, confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('既に完了しています。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ id: ORDER_ID, tenant_id: 'tenant-abc', description: 'x', type: null, final_amount: 3000, llm_estimate_amount: null, status: 'in_progress' }] }) // SELECT時点ではまだin_progress
+        .mockResolvedValueOnce({ rows: [] }); // 直後に他プロセスが完了させ、UPDATEのWHERE句が0件ヒット
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'この注文を完了にして', sessionId: 'sess-so-13' });
+
+      expect(res.status).toBe(200);
+      expect(mockChargeOneOffJpy).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('既に完了済み');
+    });
+
+    // ── send_sai_schedule_notice ─────────────────────────────────────────
+    it('send_sai_schedule_notice: confirmed=false → 送信されずブロックされる', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-so-14', 'send_sai_schedule_notice', { order_id: ORDER_ID, message: '対応は{日時}を予定しています', confirmed: false }))
+        .mockResolvedValueOnce(makeGroqResponse('確認してから送信します。'));
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '通知を送って', sessionId: 'sess-so-15' });
+
+      expect(res.status).toBe(200);
+      expect(mockCreateNotification).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('確認が必要');
+    });
+
+    it('send_sai_schedule_notice: scheduled_at指定時は{日時}が日本語日時に置換される', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-so-16', 'send_sai_schedule_notice', {
+          order_id: ORDER_ID, message: '対応は{日時}を予定しています', scheduled_at: '2026-08-01T10:00:00+09:00', confirmed: true,
+        }))
+        .mockResolvedValueOnce(makeGroqResponse('送信しました。'));
+
+      mockQuery.mockResolvedValueOnce({ rows: [{ tenant_id: 'tenant-abc' }] });
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '通知を送って', sessionId: 'sess-so-17' });
+
+      expect(res.status).toBe(200);
+      expect(mockCreateNotification).toHaveBeenCalledWith(
+        expect.objectContaining({
+          recipientTenantId: 'tenant-abc',
+          type: 'option_scheduled',
+          title: '代行作業のスケジュールについて',
+          message: expect.stringContaining('2026'),
+        }),
+      );
+      expect(mockCreateNotification.mock.calls[0][0].message).not.toContain('{日時}');
+    });
+
+    it('send_sai_schedule_notice: scheduled_at未指定時は「後日ご連絡」に置換される', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-so-18', 'send_sai_schedule_notice', {
+          order_id: ORDER_ID, message: '対応は{日時}を予定しています', confirmed: true,
+        }))
+        .mockResolvedValueOnce(makeGroqResponse('送信しました。'));
+
+      mockQuery.mockResolvedValueOnce({ rows: [{ tenant_id: 'tenant-abc' }] });
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '通知を送って', sessionId: 'sess-so-19' });
+
+      expect(res.status).toBe(200);
+      expect(mockCreateNotification.mock.calls[0][0].message).toContain('後日ご連絡');
+    });
+
+    // ── get_sai_rule_proposals / review_sai_rule_proposal ───────────────
+    it('get_sai_rule_proposals: pending一覧を1つの結果文字列にまとめる', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-so-20', 'get_sai_rule_proposals', {}))
+        .mockResolvedValueOnce(makeGroqResponse('1件あります。'));
+
+      mockListSaiRules.mockResolvedValueOnce([
+        { id: 1, tenant_id: 'tenant-abc', trigger_pattern: '送料', expected_behavior: '一律550円と案内', priority: 0, is_active: false, status: 'pending', source: 'sai_judge', evidence: null, created_by: null, approved_at: null, rejected_at: null, created_at: '', updated_at: '' },
+      ]);
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'Saiのルール提案を見せて', sessionId: 'sess-so-21' });
+
+      expect(res.status).toBe(200);
+      expect(mockListSaiRules).toHaveBeenCalledWith(undefined, { status: 'pending' });
+      expect(res.body.actions[0].result).toContain('送料');
+    });
+
+    it('review_sai_rule_proposal: confirmed=true・action=approve → approveSaiRuleが呼ばれる', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-so-22', 'review_sai_rule_proposal', { id: 1, action: 'approve', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('承認しました。'));
+
+      mockApproveSaiRule.mockResolvedValueOnce({ id: 1, trigger_pattern: '送料', tenant_id: 'tenant-abc' });
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルール1を承認して', sessionId: 'sess-so-23' });
+
+      expect(res.status).toBe(200);
+      expect(mockApproveSaiRule).toHaveBeenCalledWith(1);
+      expect(mockRejectSaiRule).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('承認しました');
+    });
+
+    it('review_sai_rule_proposal: confirmed=true・action=reject → rejectSaiRuleが呼ばれる', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-so-24', 'review_sai_rule_proposal', { id: 1, action: 'reject', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('却下しました。'));
+
+      mockRejectSaiRule.mockResolvedValueOnce({ id: 1, trigger_pattern: '送料', tenant_id: 'tenant-abc' });
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルール1を却下して', sessionId: 'sess-so-25' });
+
+      expect(res.status).toBe(200);
+      expect(mockRejectSaiRule).toHaveBeenCalledWith(1);
+      expect(res.body.actions[0].result).toContain('却下しました');
     });
   });
 

--- a/src/api/admin/agent/toolDefinitions.ts
+++ b/src/api/admin/agent/toolDefinitions.ts
@@ -656,6 +656,94 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
   {
     type: 'function',
     function: {
+      name: 'update_sai_order',
+      description:
+        '代行作業（Sai）注文のステータスや確定金額を編集する。super_admin限定。変更したい項目だけを指定すればよい。必ず先に変更内容をユーザーに提示し、明確な同意を得たターンでのみ confirmed=true で呼び出すこと。',
+      parameters: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', description: 'get_sai_order_listの結果に含まれる注文ID' },
+          status: {
+            type: 'string',
+            enum: ['pending', 'in_progress', 'completed'],
+            description: '新しいステータス（変更する場合のみ指定。完了記録はcomplete_sai_orderの使用を推奨）',
+          },
+          final_amount: { type: 'number', description: '確定金額（円、変更する場合のみ指定）' },
+          confirmed: { type: 'boolean', description: '確認フラグ（true でのみ実行される）' },
+        },
+        required: ['id', 'confirmed'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'complete_sai_order',
+      description:
+        '代行作業（Sai）注文を完了として記録する。super_admin限定。完了記録すると、テナントへの完了通知送信と、確定金額（final_amount、未設定ならllm_estimate_amount）のStripe単発請求が実行される（実際にお金が動く）。confirmed=falseまたは未指定で呼び出すと、実行はせず正確な請求予定金額だけを返すので、必ずその金額をユーザーに提示し、明確な同意を得たターンでのみ confirmed=true を指定して呼び出すこと。',
+      parameters: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', description: 'get_sai_order_listの結果に含まれる注文ID' },
+          confirmed: { type: 'boolean', description: '確認フラグ（true でのみ実際に完了処理と請求が実行される）' },
+        },
+        required: ['id', 'confirmed'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'send_sai_schedule_notice',
+      description:
+        '代行作業（Sai）注文のテナントに、作業予定についてのお知らせ通知を送る。super_admin限定。必ず先に通知内容をユーザーに提示し、明確な同意を得たターンでのみ confirmed=true で呼び出すこと。',
+      parameters: {
+        type: 'object',
+        properties: {
+          order_id: { type: 'string', description: 'get_sai_order_listの結果に含まれる注文ID' },
+          message: { type: 'string', description: '通知本文。日時を入れたい箇所には literal な文字列 "{日時}" を含めること（scheduled_atがあれば自動的に日本語日時表記に置換され、なければ「後日ご連絡」に置換される）' },
+          scheduled_at: { type: 'string', description: '予定日時のISO 8601文字列（任意。指定しない場合は「後日ご連絡」という文言になる）' },
+          confirmed: { type: 'boolean', description: '確認フラグ（true でのみ実行される）' },
+        },
+        required: ['order_id', 'message', 'confirmed'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'get_sai_rule_proposals',
+      description:
+        'Saiの自己改善ルール提案（承認待ち）の一覧を取得する読み取り専用ツール。super_admin限定。',
+      parameters: {
+        type: 'object',
+        properties: {
+          status: { type: 'string', description: 'ステータスで絞り込み（任意、省略時は"pending"）' },
+        },
+        required: [],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'review_sai_rule_proposal',
+      description:
+        'Saiの自己改善ルール提案を承認または却下する。super_admin限定。必ず先にどのルールをどうするか提示し、明確な同意を得たターンでのみ confirmed=true で呼び出すこと。',
+      parameters: {
+        type: 'object',
+        properties: {
+          id: { type: 'number', description: 'get_sai_rule_proposalsの結果に含まれるルールID' },
+          action: { type: 'string', enum: ['approve', 'reject'], description: '承認するか却下するか' },
+          confirmed: { type: 'boolean', description: '確認フラグ（true でのみ実行される）' },
+        },
+        required: ['id', 'action', 'confirmed'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
       name: 'request_sai_task',
       description:
         'R2Cエージェント(Sai)にブラウザ操作の代行作業を依頼する。ユーザーが管理画面の操作に苦戦している、または苦戦しそうだと判断した場合にのみ、他の対応より先に「代わりに画面操作を行いましょうか？」と尋ねること。ユーザーが明確に依頼していない、または苦戦している様子がない状態で自発的に呼び出してはならない。実際に外部サービスへの課金が発生する。現時点ではsuper_admin限定の機能で、それ以外のロールで呼び出すと拒否される。必ず先にユーザーに作業内容と発生しうる費用を提示し、明確な同意を得たターンでのみ confirmed=true を指定して呼び出すこと。',


### PR DESCRIPTION
## Summary
旧UI機能の新UI(チャット)対応 計画(Phase 2)の **PR H(最終)**。`/admin/options` 画面が持つ注文レベルの管理機能をチャットツール化。全てsuper_admin限定・confirmed必須。

ユーザー判断: 「Saiも他のLLM APIと同じく従量課金に含める。使用前におおよその課金額をリアルタイムで試算・提示し、同意を得る」を反映。

- `update_sai_order`: `PUT /v1/admin/options/:id`相当。status/final_amountのCOALESCE更新
- `complete_sai_order`: `PUT /v1/admin/options/:id/complete`相当。**金額開示の安全設計**: `confirmed=false`(未指定)で呼ぶと、実際の`final_amount`(未設定なら`llm_estimate_amount`)を含めて「¥Xが請求されます」と返すのみで一切実行しない(モデルが金額を捏造できない)。`confirmed=true`で初めて`createNotification`→`chargeOneOffJpy`→`stripe_usage_recorded`更新を実行(既存route実装と同じ順序)。`status!='completed'`のWHERE句によるアトミックな二重完了防止もそのまま踏襲(SELECT時点では未完了でもUPDATE時点で他プロセスが先に完了させていた場合、課金せず「既に完了済み」を返すことをテストで確認済み)
- `send_sai_schedule_notice`: `POST /v1/admin/notifications`相当。フロント側の`{日時}`プレースホルダ置換ロジック(scheduled_at指定時は日本語日時表記、未指定時は「後日ご連絡」)を移植
- `get_sai_rule_proposals`/`review_sai_rule_proposal`: 既存export済みの`listSaiRules`/`approveSaiRule`/`rejectSaiRule`(`saiTaskRulesRepository.ts`)をそのまま再利用

**copilot-preview側**: `REAL_TOOL_LABEL`に5ツールのラベルを追加。

これで計画の**Phase 1・Phase 2ともに完了**です。

## Test plan
- [x] `npx tsc --noEmit`(バックエンド + admin-ui) クリーン
- [x] `npx jest src/api/admin/agent/agentRoutes.test.ts` → 108/108 pass(新規13件、うち`complete_sai_order`は金額開示×2・実行成功・既完了済み・競合時二重完了防止の5件を明示テスト)
- [x] `npx jest src/api/admin/options src/lib/sai` → 79/79 pass(無回帰確認)
- [x] 実際のStripe呼び出し・通知送信は全てモック(実課金・実送信は一切なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SaK6mK6nvpj9GEAwPkWYRW