### PR TITLE
fix(logger): logger.warn('msg', err)形式でerrが握りつぶされるバグを修正

### DIFF
--- a/src/lib/logger.test.ts
+++ b/src/lib/logger.test.ts
@@ -1,0 +1,60 @@
+// src/lib/logger.test.ts
+// logger.ts の console互換シム(logger.warn('msg', err) 形式)が
+// pinoの出力に正しくマージされることを検証する。
+// 修正前は logger.warn('msg', err) の err が握りつぶされ、本番ログから
+// エラー詳細が一切見えなくなっていた(実際に発生した観測不能バグ)。
+
+import { Writable } from 'stream';
+import { createLogger } from './logger';
+
+function captureWrites(fn: (logger: ReturnType<typeof createLogger>) => void): Record<string, unknown>[] {
+  const chunks: string[] = [];
+  const stream = new Writable({
+    write(chunk, _enc, cb) {
+      chunks.push(chunk.toString());
+      cb();
+    },
+  });
+  const logger = createLogger(undefined, stream);
+  fn(logger);
+  return chunks.map((c) => JSON.parse(c));
+}
+
+describe('logger console互換シム', () => {
+  it('logger.warn(msg, error) → err がstack付きでログに出る', () => {
+    const [line] = captureWrites((logger) => {
+      logger.warn('[test]', new Error('boom'));
+    });
+
+    expect(line?.['msg']).toBe('[test]');
+    expect(line?.['err']).toMatchObject({ type: 'Error', message: 'boom' });
+    expect((line?.['err'] as { stack?: string })?.stack).toContain('boom');
+  });
+
+  it('logger.warn(msg, 非Error値) → argフィールドに保持される', () => {
+    const [line] = captureWrites((logger) => {
+      logger.warn('[test]', { orderId: 'abc' });
+    });
+
+    expect(line?.['msg']).toBe('[test]');
+    expect(line?.['arg']).toEqual({ orderId: 'abc' });
+  });
+
+  it('logger.warn(obj, msg) → pinoネイティブ形式はそのまま透過する', () => {
+    const [line] = captureWrites((logger) => {
+      logger.warn({ foo: 'bar' }, '[test-obj]');
+    });
+
+    expect(line?.['msg']).toBe('[test-obj]');
+    expect(line?.['foo']).toBe('bar');
+  });
+
+  it('logger.warn(msg) 単独呼び出しは従来通り動作する', () => {
+    const [line] = captureWrites((logger) => {
+      logger.warn('[test-plain]');
+    });
+
+    expect(line?.['msg']).toBe('[test-plain]');
+    expect(line?.['err']).toBeUndefined();
+  });
+});

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -17,11 +17,54 @@ export interface AppLogger {
   child(bindings: Record<string, unknown>): AppLogger;
 }
 
-export function createLogger(options?: pino.LoggerOptions): AppLogger {
-  return pino({
-    level: process.env.LOG_LEVEL ?? 'info',
-    ...options,
-  }) as unknown as AppLogger;
+type PinoLevel = 'info' | 'error' | 'warn' | 'debug' | 'trace' | 'fatal';
+
+// pinoの本来のシグネチャは (mergingObject, msg?, ...) で、第一引数が文字列の場合
+// 後続の引数はprintf形式の埋め込み値としてしか扱われない。そのため
+// logger.warn('message', err) のようなconsole互換の呼び出しではerrが
+// ログに一切出力されず握りつぶされていた。ここで第一引数が文字列かつ
+// 第二引数以降がある場合は { err } または { arg } に包んでマージオブジェクト
+// 化し、pinoのerrシリアライザ(スタックトレース等)が効くようにする。
+function wrapLevel(base: pino.Logger, level: PinoLevel): LogFn {
+  return (msgOrObj: unknown, msgOrArg?: unknown, ...rest: unknown[]) => {
+    if (typeof msgOrObj === 'object' && msgOrObj !== null) {
+      (base[level] as LogFn)(msgOrObj, msgOrArg, ...rest);
+      return;
+    }
+    if (msgOrArg === undefined) {
+      (base[level] as LogFn)(msgOrObj);
+      return;
+    }
+    const extras = rest.length > 0 ? [msgOrArg, ...rest] : msgOrArg;
+    const mergingObject = extras instanceof Error ? { err: extras } : { arg: extras };
+    (base[level] as LogFn)(mergingObject, msgOrObj as string);
+  };
+}
+
+function wrapPinoInstance(base: pino.Logger): AppLogger {
+  return {
+    info: wrapLevel(base, 'info'),
+    error: wrapLevel(base, 'error'),
+    warn: wrapLevel(base, 'warn'),
+    debug: wrapLevel(base, 'debug'),
+    trace: wrapLevel(base, 'trace'),
+    fatal: wrapLevel(base, 'fatal'),
+    child: (bindings: Record<string, unknown>) => wrapPinoInstance(base.child(bindings)),
+  };
+}
+
+// destination はテストで同期的な収集用ストリームを注入するためのみに使用する
+// (pino のデフォルトはstdoutへの非同期書き込みのため、テストでの出力検証に向かない)
+export function createLogger(options?: pino.LoggerOptions, destination?: pino.DestinationStream): AppLogger {
+  const base = pino(
+    {
+      level: process.env.LOG_LEVEL ?? 'info',
+      serializers: { err: pino.stdSerializers.err },
+      ...options,
+    },
+    destination,
+  );
+  return wrapPinoInstance(base);
 }
 
 export const logger: AppLogger = createLogger();


### PR DESCRIPTION
## Summary
- 本番の`/copilot-preview`で「エラー: AIエージェントの応答生成に失敗しました」の実際の原因調査中に発見
- `src/lib/logger.ts`のコメントは「console互換 (msg, ...args) 形式に対応」と謳っていたが、実装は素のpinoインスタンスをそのまま返すだけで互換シムが存在しなかった
- pinoネイティブの`logger.warn(msg, ...)`は第一引数が文字列の場合、後続引数をprintf埋め込み値としてしか扱わない仕様のため、`logger.warn('...', err)`のerrが常にログから消えていた(コードベース全体で同パターン64箇所)
- `agentRoutes.ts`の`logger.warn('[POST /v1/admin/agent/chat]', err)`もこのバグの影響を受けており、本番ログにエラー内容が一切出力されず原因調査ができない状態だった

## 変更内容
- `logger.ts`: 第一引数が文字列で第二引数以降がある場合、Errorインスタンスは`{err}`、それ以外は`{arg}`に包んでpinoのマージオブジェクト形式に変換するシムを実装。`pino.stdSerializers.err`も設定しスタックトレース付きで出力されるように修正。第一引数がオブジェクトのpinoネイティブ形式(`logger.warn(obj, msg)`)はそのまま透過
- `createLogger()`にテスト用のdestinationストリーム引数を追加(pinoのデフォルトstdout書き込みは非同期でjestでの出力検証に向かないため)
- 呼び出し側(64箇所)は無変更 — 修正はlogger.ts一箇所のみ

## Test plan
- [x] `npx tsc --noEmit` クリーン
- [x] `npx jest src/lib/logger.test.ts` — 新規4件全パス(err付き/非Error値/pinoネイティブ形式透過/単独呼び出しの4パターン)
- [x] `npx jest --runInBand`(バックエンド全体)を複数回実行し、失敗するテストが毎回異なることを確認(ローカル既知のEADDRNOTAVAILポート枯渇フレークであり本修正と無関係と判断)。個別に再実行した疑わしいスイート(tuningAuthGuard, feedbackAuthGuard, notifications, knowledgeGap, evaluations)は全てクリーン。唯一残る`avatar/routes.test.ts`の失敗は`global.fetch`モック関連の既存問題で本PR無関係

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01SaK6mK6nvpj9GEAwPkWYRW