### PR TITLE
fix(copilot-preview): super_adminのテナントプレビュー中にtargetTenantIdを送信

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -12,6 +12,7 @@ import { useState, useRef, useEffect, useCallback } from "react";
 import type { Dispatch, SetStateAction } from "react";
 import { authFetch, API_BASE } from "../../lib/api";
 import { isChatFirstDefaultEnabled, setChatFirstDefaultEnabled } from "../../lib/chatFirstDefault";
+import { useAuth } from "../../auth/useAuth";
 
 // ─── モデル ──────────────────────────────────────────────────────────────────
 
@@ -208,6 +209,10 @@ let _uid = 100;
 const nextId = () => ++_uid;
 
 export default function CopilotPreviewPage() {
+  // super_adminがテナントプレビュー中の場合、対象テナントIDをtargetTenantIdとしてAPIに渡す
+  // (他画面のescalations/knowledge-gaps等と同じパターン)。client_adminは自身のJWT由来の
+  // tenantIdがサーバー側で使われるため、previewMode=falseのままで問題ない。
+  const { previewMode, previewTenantId } = useAuth();
   const [active, setActive] = useState("assistant");
   const [input, setInput] = useState("");
   // 起動直後は空。bootstrap()が実データの週次ブリーフィングを積む
@@ -246,11 +251,12 @@ export default function CopilotPreviewPage() {
     if (!opts?.silent) push(me(text));
     setSending(true);
     try {
-      const body: { message: string; sessionId: string; history?: typeof realHistory } = {
+      const body: { message: string; sessionId: string; history?: typeof realHistory; targetTenantId?: string } = {
         message: text,
         sessionId: sessionIdRef.current,
       };
       if (realHistory.length > 0) body.history = realHistory.slice(-20);
+      if (previewMode && previewTenantId) body.targetTenantId = previewTenantId;
 
       const res = await authFetch(`${API_BASE}/v1/admin/agent/chat`, {
         method: "POST",


### PR DESCRIPTION
## Summary
- `/copilot-preview`はテナント(client_admin)専用UIのため、super_adminでテナント未指定のままアクセスすると全ツールが「テナントが特定できません」を返し続けていた(バックエンドの`effectiveTenantId`はsuper_adminの場合`targetTenantId`必須のため)
- 他画面(`escalations`/`knowledge-gaps`等)と同じく、`useAuth()`の`previewMode`/`previewTenantId`(`/admin/tenants/:id`の「🔍 クライアントビューで見る」ボタンで設定される既存の仕組み)を参照し、テナントプレビュー中は`POST /v1/admin/agent/chat`のリクエストボディに`targetTenantId`を含めるよう変更
- client_admin(実際のテナント管理者)は自身のJWT由来の`tenantId`がサーバー側で使われるため、この変更による影響は一切ない

## 変更内容
- `copilot-preview/index.tsx`: `useAuth`から`previewMode`/`previewTenantId`を取得し、`sendReal`のリクエストボディに`targetTenantId`を条件付きで追加

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.app.json`(admin-ui) — copilot-preview/index.tsxにエラーなし
- [x] `npx vite build`(admin-ui) 成功

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01SaK6mK6nvpj9GEAwPkWYRW