### PR TITLE
fix(auth): テナントプレビュー状態をsessionStorageに永続化

### DIFF
--- a/admin-ui/src/auth/useAuth.test.tsx
+++ b/admin-ui/src/auth/useAuth.test.tsx
@@ -62,6 +62,18 @@ function Probe() {
   return <div data-testid="probe">plan={String(tenantPlan)} preview={String(previewMode)}</div>;
 }
 
+function PreviewProbe() {
+  const { isLoading, previewMode, previewTenantId, enterPreview, exitPreview } = useAuth();
+  if (isLoading) return <div>loading</div>;
+  return (
+    <div>
+      <div data-testid="preview-probe">preview={String(previewMode)} tenantId={String(previewTenantId)}</div>
+      <button onClick={() => enterPreview("tenant-b", "テナントB")}>enter</button>
+      <button onClick={() => exitPreview()}>exit</button>
+    </div>
+  );
+}
+
 describe("useAuth — tenantPlan", () => {
   beforeEach(() => {
     vi.mocked(authFetch).mockReset();
@@ -125,6 +137,89 @@ describe("useAuth — tenantPlan", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("probe").textContent).toContain("plan=null");
+    });
+  });
+});
+
+describe("useAuth — previewMode の sessionStorage永続化", () => {
+  beforeEach(() => {
+    vi.mocked(authFetch).mockReset();
+    window.sessionStorage.clear();
+    mockGetSession.mockResolvedValue(SUPER_ADMIN_SESSION());
+  });
+
+  it("enterPreview() でsessionStorageに保存され、ページ再読み込み(再マウント)後も復元される", async () => {
+    const { unmount } = render(
+      <AuthProvider>
+        <PreviewProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("preview-probe").textContent).toContain("preview=false");
+    });
+
+    screen.getByText("enter").click();
+    await waitFor(() => {
+      expect(screen.getByTestId("preview-probe").textContent).toContain("preview=true tenantId=tenant-b");
+    });
+    expect(window.sessionStorage.getItem("r2c_admin_preview_tenant")).toContain("tenant-b");
+
+    // ページ再読み込みを模擬(AuthProviderを再マウント)
+    unmount();
+    render(
+      <AuthProvider>
+        <PreviewProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("preview-probe").textContent).toContain("preview=true tenantId=tenant-b");
+    });
+  });
+
+  it("exitPreview() でsessionStorageからも消え、再マウント後もプレビューなしのまま", async () => {
+    window.sessionStorage.setItem("r2c_admin_preview_tenant", JSON.stringify({ tenantId: "tenant-b", tenantName: "テナントB" }));
+
+    const { unmount } = render(
+      <AuthProvider>
+        <PreviewProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("preview-probe").textContent).toContain("preview=true tenantId=tenant-b");
+    });
+
+    screen.getByText("exit").click();
+    await waitFor(() => {
+      expect(screen.getByTestId("preview-probe").textContent).toContain("preview=false tenantId=null");
+    });
+    expect(window.sessionStorage.getItem("r2c_admin_preview_tenant")).toBeNull();
+
+    unmount();
+    render(
+      <AuthProvider>
+        <PreviewProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("preview-probe").textContent).toContain("preview=false tenantId=null");
+    });
+  });
+
+  it("sessionStorageの内容が壊れている場合は無視してプレビューなしで起動する", async () => {
+    window.sessionStorage.setItem("r2c_admin_preview_tenant", "not-json");
+
+    render(
+      <AuthProvider>
+        <PreviewProbe />
+      </AuthProvider>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("preview-probe").textContent).toContain("preview=false tenantId=null");
     });
   });
 });

--- a/admin-ui/src/auth/useAuth.tsx
+++ b/admin-ui/src/auth/useAuth.tsx
@@ -54,12 +54,49 @@ function parseRole(meta: Record<string, unknown>): AuthUser["role"] {
   return "anonymous";
 }
 
+// previewMode/previewTenantId は元々メモリ上のReact stateのみで管理していたため、
+// ページの再読み込みや直接URL入力(フルページ遷移)のたびにリセットされていた
+// (例: /copilot-previewはブックマーク/URL直打ちで開く前提のページのため、テナント
+// 詳細画面でプレビューに入ってもそこへ移動すると毎回プレビューが外れてしまっていた)。
+// sessionStorageに永続化することで、同一ブラウザタブのセッション内は再読み込みしても
+// 保持されるようにする(タブを閉じれば消える点はlocalStorageと差別化)。
+const PREVIEW_STORAGE_KEY = "r2c_admin_preview_tenant";
+
+interface StoredPreview {
+  tenantId: string;
+  tenantName: string;
+}
+
+function loadStoredPreview(): StoredPreview | null {
+  try {
+    if (typeof window === "undefined") return null;
+    const raw = window.sessionStorage.getItem(PREVIEW_STORAGE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<StoredPreview>;
+    if (typeof parsed.tenantId !== "string" || typeof parsed.tenantName !== "string") return null;
+    return { tenantId: parsed.tenantId, tenantName: parsed.tenantName };
+  } catch {
+    return null;
+  }
+}
+
+function saveStoredPreview(preview: StoredPreview | null): void {
+  try {
+    if (typeof window === "undefined") return;
+    if (preview) window.sessionStorage.setItem(PREVIEW_STORAGE_KEY, JSON.stringify(preview));
+    else window.sessionStorage.removeItem(PREVIEW_STORAGE_KEY);
+  } catch {
+    // sessionStorage無効環境(プライベートブラウズ等)では静かに無視
+  }
+}
+
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<AuthUser | null>(null);
   const [isLoading, setIsLoading] = useState(true);
-  const [previewMode, setPreviewMode] = useState(false);
-  const [previewTenantId, setPreviewTenantId] = useState<string | null>(null);
-  const [previewTenantName, setPreviewTenantName] = useState<string | null>(null);
+  const storedPreview = loadStoredPreview();
+  const [previewMode, setPreviewMode] = useState(storedPreview !== null);
+  const [previewTenantId, setPreviewTenantId] = useState<string | null>(storedPreview?.tenantId ?? null);
+  const [previewTenantName, setPreviewTenantName] = useState<string | null>(storedPreview?.tenantName ?? null);
   const [tenantPlan, setTenantPlan] = useState<TenantPlan | null>(null);
 
   const loadUser = useCallback(async () => {
@@ -147,18 +184,21 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     setPreviewMode(false);
     setPreviewTenantId(null);
     setPreviewTenantName(null);
+    saveStoredPreview(null);
   }, []);
 
   const enterPreview = useCallback((tenantId: string, tenantName: string) => {
     setPreviewMode(true);
     setPreviewTenantId(tenantId);
     setPreviewTenantName(tenantName);
+    saveStoredPreview({ tenantId, tenantName });
   }, []);
 
   const exitPreview = useCallback(() => {
     setPreviewMode(false);
     setPreviewTenantId(null);
     setPreviewTenantName(null);
+    saveStoredPreview(null);
   }, []);
 
   const effectiveRole = previewMode ? "client_admin" : (user?.role ?? "anonymous");


### PR DESCRIPTION
## Summary
- `previewMode`/`previewTenantId`/`previewTenantName`がメモリ上のReact stateのみで管理されており、ページ再読み込みや直接URL入力(フルページ遷移)のたびにプレビュー状態がリセットされていた
- `/copilot-preview`はURLを直接開く前提の隔離ルートのため、テナント詳細画面(`/admin/tenants/:id`)の「🔍 クライアントビューで見る」でプレビューに入った直後にそこへ移動すると、毎回プレビューが外れて「テナントが特定できません」が発生していた
- PR #511で`targetTenantId`送信自体は正しく実装していたが、`previewMode`自体がページ遷移で保持されていなかったため効果が出ていなかった

## 変更内容
- `useAuth.tsx`: `previewMode`/`previewTenantId`/`previewTenantName`を`sessionStorage`(タブを閉じれば消える。localStorageより安全な永続化範囲)に保存
  - `AuthProvider`初期化時にsessionStorageから復元
  - `enterPreview`/`exitPreview`/`logout`の各操作でsessionStorageも同期
  - 破損データ(JSON parse失敗等)はプレビューなし扱いに安全にフォールバック

## Test plan
- [x] `npx tsc --noEmit -p tsconfig.app.json` — 新規エラーなし(pre-existingのuseAuth.test.tsx:13エラーは本PR無関係・未変更)
- [x] `npx vitest run --config vitest.config.ts src/auth/useAuth.test.tsx` — 新規3件(永続化・復元/exitPreviewでのクリア/破損データのフォールバック)含め計7件全パス
- [x] `npx vitest run --config vitest.config.ts`(admin-ui全体) — 82件全パス
- [x] `npx vite build` 成功

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01SaK6mK6nvpj9GEAwPkWYRW