### PR TITLE
copilot-preview: 新規テナント向けチャットオンボーディングを追加

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -13,6 +13,7 @@ import type { Dispatch, SetStateAction } from "react";
 import { authFetch, API_BASE } from "../../lib/api";
 import { isChatFirstDefaultEnabled, setChatFirstDefaultEnabled } from "../../lib/chatFirstDefault";
 import { useAuth } from "../../auth/useAuth";
+import { ONBOARDING_INDUSTRIES } from "../../components/onboarding/industryFaqTemplates";
 
 // ─── モデル ──────────────────────────────────────────────────────────────────
 
@@ -64,6 +65,7 @@ const REAL_TOOL_LABEL: Record<string, string> = {
   get_avatar_status: "アバター稼働状況の取得",
   request_sai_task: "Saiへの代行依頼",
   get_sai_task_status: "Saiタスク状況の取得",
+  import_industry_faq_templates: "業種別FAQたたき台の登録",
 };
 
 // 実際にDBを書き換える(=「進捗」としてカウントしてよい)ツール名
@@ -78,11 +80,20 @@ const REAL_WRITE_TOOLS = new Set([
   "set_posthog",
   "set_widget_theme",
   "activate_avatar",
+  "import_industry_faq_templates",
 ]);
 
 // Phase2 (P7): ログイン直後に能動的に状況を尋ねる自動キックオフメッセージ
 const BOOTSTRAP_PROMPT =
   "ログインしたところです。今週の状況を教えてください。要点と次にやるべきことを最大3つまで、簡潔に教えてください。";
+
+// GID 1216274591838389 チャット版: 新規テナント(onboarding_completed_at未設定)の初回起動時、
+// 業種選択チップを添えた案内を出す(AIを介さないローカル表示。選択後の提案・登録は実API接続)。
+const INDUSTRY_CHIPS: Chip[] = ONBOARDING_INDUSTRIES.map((ind) => ({
+  label: `${ind.icon} ${ind.label}`,
+  action: `__real:業種は「${ind.label}」です。この業種のFAQテンプレートを提案してください。`,
+  tone: "ghost",
+}));
 
 // ─── 実APIのツール結果 → 見た目の良いカードへの変換 ────────────────────────────
 // actionExecutor.ts が返す日本語の定型文字列を軽くパースする。想定外の形式なら
@@ -212,7 +223,7 @@ export default function CopilotPreviewPage() {
   // super_adminがテナントプレビュー中の場合、対象テナントIDをtargetTenantIdとしてAPIに渡す
   // (他画面のescalations/knowledge-gaps等と同じパターン)。client_adminは自身のJWT由来の
   // tenantIdがサーバー側で使われるため、previewMode=falseのままで問題ない。
-  const { previewMode, previewTenantId } = useAuth();
+  const { user, previewMode, previewTenantId } = useAuth();
   const [active, setActive] = useState("assistant");
   const [input, setInput] = useState("");
   // 起動直後は空。bootstrap()が実データの週次ブリーフィングを積む
@@ -316,6 +327,10 @@ export default function CopilotPreviewPage() {
       const saiPendingConfirm = data.actions?.some(
         (a) => a.tool === "request_sai_task" && a.result.includes("確認が必要"),
       );
+      // オンボーディングのFAQテンプレート提案がconfirmed待ちでブロックされた場合も同様
+      const industryTemplatePendingConfirm = data.actions?.some(
+        (a) => a.tool === "import_industry_faq_templates" && a.result.includes("よろしければ登録しますか"),
+      );
       const chips: Chip[] | undefined = suggested
         ? [
             { label: "保存して", action: "__real:保存してください", tone: "primary" },
@@ -325,6 +340,11 @@ export default function CopilotPreviewPage() {
         ? [
             { label: "お願いする", action: "__real:はい、お願いします", tone: "primary" },
             { label: "やめておく", action: "__real:やめておきます", tone: "ghost" },
+          ]
+        : industryTemplatePendingConfirm
+        ? [
+            { label: "登録して", action: "__real:登録してください", tone: "primary" },
+            { label: "あとで", action: "__real:あとでにします", tone: "ghost" },
           ]
         : undefined;
 
@@ -348,15 +368,37 @@ export default function CopilotPreviewPage() {
     setSending(false);
   };
 
-  // マウント時に実データの週次ブリーフィングを自動取得
+  // マウント時、新規テナント(onboarding_completed_at未設定)なら業種選択オンボーディングを、
+  // 既存テナントなら実データの週次ブリーフィングを自動取得する。
+  // super_admin(プレビュー中含む)はオンボーディング判定の対象外(常に週次ブリーフィング側)。
   const bootstrapped = useRef(false);
   useEffect(() => {
     if (bootstrapped.current) return;
     bootstrapped.current = true;
 
     void (async () => {
-      push({ id: nextId(), role: "ai", text: "ログイン、お疲れさまです。今週の実データを確認しています…" });
-      await sendReal(BOOTSTRAP_PROMPT, { silent: true });
+      let isNewTenant = false;
+      if (!previewMode && user?.role === "client_admin") {
+        try {
+          const res = await authFetch(`${API_BASE}/v1/admin/my-tenant`);
+          if (res.ok) {
+            const data = (await res.json()) as { onboarding_completed_at?: string | null };
+            isNewTenant = !data.onboarding_completed_at;
+          }
+        } catch {
+          // 取得失敗時は通常の週次ブリーフィング側にフォールバック
+        }
+      }
+
+      if (isNewTenant) {
+        push(say(
+          "初めまして！まず1つだけ教えてください。どんな業種ですか？\nお答えに合わせて、すぐ使えるFAQのたたき台をご提案します。",
+          INDUSTRY_CHIPS,
+        ));
+      } else {
+        push({ id: nextId(), role: "ai", text: "ログイン、お疲れさまです。今週の実データを確認しています…" });
+        await sendReal(BOOTSTRAP_PROMPT, { silent: true });
+      }
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -19,6 +19,7 @@ import { computeKpis } from '../monitoring/routes';
 import { checkSaiMonthlyCostCeiling } from '../options/routes';
 import { submitSaiTask, getSaiTask } from '../../../lib/sai/saiClient';
 import { trackUsage } from '../../../lib/billing/usageTracker';
+import { isOnboardingIndustry, ONBOARDING_INDUSTRY_LABELS, INDUSTRY_FAQ_TEMPLATES } from './industryFaqTemplates';
 
 // ---------------------------------------------------------------------------
 // Avatar activate（avatar/routes.ts は無改変、ここで再実装）
@@ -296,6 +297,67 @@ export async function executeToolCall(
       } catch (err) {
         logger.warn('[actionExecutor] delete_faq failed', err);
         return truncate('FAQ の削除に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    // 新規テナントのオンボーディング(GID 1216274591838389のチャット版):
+    // 業種別FAQたたき台を一括登録し、旧UI(OnboardingModal)と同じ条件で
+    // onboarding_completed_at を更新する(業種選択のみで完了扱いになる仕様を踏襲)。
+    case 'import_industry_faq_templates': {
+      const industryRaw = args['industry'];
+      if (!isOnboardingIndustry(industryRaw)) {
+        return truncate(`不明な業種です: ${String(industryRaw)}`);
+      }
+      const confirmed = Boolean(args['confirmed']);
+      const templates = INDUSTRY_FAQ_TEMPLATES[industryRaw];
+      const label = ONBOARDING_INDUSTRY_LABELS[industryRaw];
+
+      if (!confirmed) {
+        const lines = templates.map((t, i) => `${i + 1}. Q: ${t.question} / A: ${t.answer}`);
+        return truncate(
+          `「${label}」向けのFAQたたき台を${templates.length}件ご用意しました:\n` +
+          lines.join('\n') +
+          `\nよろしければ登録しますか？（登録後も自由に編集・削除できます）`,
+        );
+      }
+      if (!tenantId) {
+        return truncate('テナントが特定できません。super_admin の場合は対象テナントを指定してください');
+      }
+
+      try {
+        let inserted = 0;
+        for (const t of templates) {
+          try {
+            const result = await db.query(
+              `INSERT INTO faq_docs (tenant_id, question, answer, category, is_published)
+               VALUES ($1, $2, $3, $4, true)
+               RETURNING id, question, answer, is_published`,
+              [tenantId, t.question, t.answer, t.category ?? 'general'],
+            );
+            const row = result.rows[0] as { id: number; question: string; answer: string; is_published: boolean };
+            insertEmbeddingAsync(db, tenantId, `${row.question}\n${row.answer}`, row.id, {
+              source: 'admin_agent_onboarding',
+              faq_id: row.id,
+            });
+            upsertToEsAsync(tenantId, row.id, row.question, row.answer, row.is_published);
+            inserted++;
+          } catch (err) {
+            logger.warn('[actionExecutor] import_industry_faq_templates insert failed', err);
+          }
+        }
+
+        await db.query(
+          `UPDATE tenants SET onboarding_industry = $1, onboarding_completed_at = NOW() WHERE id = $2`,
+          [industryRaw, tenantId],
+        ).catch((err) => {
+          logger.warn('[actionExecutor] import_industry_faq_templates onboarding update failed', err);
+        });
+
+        return truncate(`「${label}」向けのFAQを${inserted}件登録しました`);
+      } catch (err) {
+        logger.warn('[actionExecutor] import_industry_faq_templates failed', err);
+        return truncate('FAQテンプレートの登録に失敗しました');
       }
     }
 

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -1771,6 +1771,81 @@ describe('POST /v1/admin/agent/chat', () => {
   });
 
   // -------------------------------------------------------------------------
+  // import_industry_faq_templates
+  // -------------------------------------------------------------------------
+  describe('import_industry_faq_templates', () => {
+    function toolCallResponse(id: string, name: string, args: Record<string, unknown> = {}) {
+      return {
+        ok: true,
+        json: async () => ({
+          choices: [{
+            message: {
+              content: null,
+              tool_calls: [{ id, type: 'function', function: { name, arguments: JSON.stringify(args) } }],
+            },
+          }],
+        }),
+        text: async () => '',
+      };
+    }
+
+    it('confirmed=false → テンプレート一覧を提示するのみで登録されない', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-ind-1', 'import_industry_faq_templates', { industry: 'beauty', confirmed: false }))
+        .mockResolvedValueOnce(makeGroqResponse('こちらでよろしいですか？'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '美容室です', sessionId: 'sess-ind-01' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).not.toHaveBeenCalled();
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain('美容・サロン');
+      expect(result).toContain('予約は必要ですか？');
+    });
+
+    it('不明な業種の場合はその旨を返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-ind-2', 'import_industry_faq_templates', { industry: 'space_travel', confirmed: false }))
+        .mockResolvedValueOnce(makeGroqResponse('確認できませんでした。'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '宇宙旅行業です', sessionId: 'sess-ind-02' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('不明な業種');
+    });
+
+    it('confirmed=true → 全テンプレートがINSERTされ、テナントのonboarding項目が更新される', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-ind-3', 'import_industry_faq_templates', { industry: 'beauty', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('登録しました。'));
+
+      for (let i = 0; i < 5; i++) {
+        mockQuery.mockResolvedValueOnce({
+          rows: [{ id: 100 + i, question: `q${i}`, answer: `a${i}`, is_published: true }],
+        });
+      }
+      mockQuery.mockResolvedValueOnce({ rows: [] }); // UPDATE tenants
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '登録して', sessionId: 'sess-ind-03' });
+
+      expect(res.status).toBe(200);
+      const insertCalls = mockQuery.mock.calls.filter(([sql]) => String(sql).includes('INSERT INTO faq_docs'));
+      expect(insertCalls).toHaveLength(5);
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE tenants SET onboarding_industry'),
+        ['beauty', 'tenant-abc'],
+      );
+      expect(res.body.actions[0].result).toContain('5件登録しました');
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // get_avatar_status
   // -------------------------------------------------------------------------
   describe('get_avatar_status', () => {

--- a/src/api/admin/agent/agentRoutes.ts
+++ b/src/api/admin/agent/agentRoutes.ts
@@ -393,6 +393,10 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
         `ユーザーが管理画面の操作を代わりにやってほしいと頼んできた場合（例:「送料表記を直して」）は、` +
         `request_sai_task が使えます。他のLLM機能と同じ従量課金が発生するため、必ず先に依頼内容を要約提示し、` +
         `同意を得たターンでのみ confirmed=true で呼び出してください。進捗は get_sai_task_status で確認できます。` +
+        `新規テナントのオンボーディング中でユーザーが業種を答えてくれた場合は import_industry_faq_templates を` +
+        `使ってFAQのたたき台を提案・登録してください（confirmedゲート必須）。登録が完了したら、続けて` +
+        `get_avatar_status でアバターの状況を確認し、無効であれば有効化(activate_avatar)を提案し、最後に` +
+        `get_embed_code でウィジェットの埋め込みコードを案内する、という3ステップを自然な会話で順に進めてください。` +
         `セッションID: ${sessionId}`;
 
       // G2: 直近の会話履歴をそのままシステムプロンプトの後に差し込み、マルチターンの文脈を持たせる

--- a/src/api/admin/agent/industryFaqTemplates.ts
+++ b/src/api/admin/agent/industryFaqTemplates.ts
@@ -1,0 +1,75 @@
+// src/api/admin/agent/industryFaqTemplates.ts
+// admin-ui/src/components/onboarding/industryFaqTemplates.ts のバックエンド版。
+// admin-uiとbackendは別TSプロジェクトのため直接import共有できず、同一内容をここに複製している。
+// 内容を変更する場合は両ファイルを同時に更新すること。
+// GID 1216274591838389: 初回ログインオンボーディングで提案する業種別FAQテンプレート
+
+export type OnboardingIndustry = 'auto' | 'beauty' | 'food' | 'realestate' | 'retail' | 'other';
+
+export const ONBOARDING_INDUSTRY_VALUES: readonly OnboardingIndustry[] = [
+  'auto', 'beauty', 'food', 'realestate', 'retail', 'other',
+];
+
+export const ONBOARDING_INDUSTRY_LABELS: Record<OnboardingIndustry, string> = {
+  auto: '自動車販売・整備',
+  beauty: '美容・サロン',
+  food: '飲食',
+  realestate: '不動産',
+  retail: '小売・EC',
+  other: 'その他',
+};
+
+export interface IndustryFaqTemplate {
+  question: string;
+  answer: string;
+  category?: string;
+}
+
+export const INDUSTRY_FAQ_TEMPLATES: Record<OnboardingIndustry, IndustryFaqTemplate[]> = {
+  auto: [
+    { question: '営業時間を教えてください', answer: '営業時間は平日・土日ともに10:00〜19:00です。定休日は水曜日です。', category: 'store_info' },
+    { question: '車検の費用はいくらですか？', answer: '車種により異なりますが、目安は5万円〜です。事前にお見積もりも可能です。', category: 'inventory' },
+    { question: '試乗はできますか？', answer: 'はい、事前にご連絡いただければ試乗車をご用意いたします。', category: 'inventory' },
+    { question: '下取り・買取もお願いできますか？', answer: 'はい、査定を無料で承っております。お車の情報をお伝えください。', category: 'inventory' },
+    { question: 'ローンでの購入はできますか？', answer: 'はい、各種オートローンに対応しております。お気軽にご相談ください。', category: 'inventory' },
+  ],
+  beauty: [
+    { question: '営業時間を教えてください', answer: '営業時間は10:00〜20:00です。最終受付は19:00となります。', category: 'store_info' },
+    { question: '予約は必要ですか？', answer: 'はい、ご来店前のご予約をお願いしております。当日予約も空きがあれば承れます。', category: 'store_info' },
+    { question: '初めてでも大丈夫ですか？', answer: 'はい、初めてのお客様も安心してご利用いただけます。カウンセリングから丁寧にご案内します。', category: 'coupon' },
+    { question: 'クーポンや割引はありますか？', answer: '初回限定クーポンをご用意しております。詳しくは店舗までお問い合わせください。', category: 'coupon' },
+    { question: '駐車場はありますか？', answer: '近隣に提携駐車場がございます。ご来店の際はスタッフにお申し付けください。', category: 'store_info' },
+  ],
+  food: [
+    { question: '営業時間を教えてください', answer: 'ランチ11:00〜15:00、ディナー17:00〜23:00で営業しております。', category: 'store_info' },
+    { question: '予約はできますか？', answer: 'はい、お電話またはWebから予約を承っております。', category: 'store_info' },
+    { question: '個室はありますか？', answer: 'はい、少人数〜大人数まで対応できる個室をご用意しております。', category: 'store_info' },
+    { question: 'アレルギー対応はしていますか？', answer: 'はい、アレルギー品目に応じてメニューを調整いたします。ご予約時にお申し付けください。', category: 'product_info' },
+    { question: 'テイクアウトはできますか？', answer: 'はい、一部メニューでテイクアウトに対応しております。', category: 'product_info' },
+  ],
+  realestate: [
+    { question: '営業時間を教えてください', answer: '営業時間は9:30〜18:30です。定休日は火曜日です。', category: 'store_info' },
+    { question: '内見は無料ですか？', answer: 'はい、内見は無料でご案内しております。事前予約をお願いします。', category: 'store_info' },
+    { question: '仲介手数料はいくらですか？', answer: '原則として賃料の1ヶ月分(税別)を上限としております。詳細は物件ごとにご案内します。', category: 'pricing' },
+    { question: 'ペット可の物件はありますか？', answer: 'はい、ペット可物件も多数取り扱っております。条件はお気軽にご相談ください。', category: 'inventory' },
+    { question: 'オンラインでの内見は可能ですか？', answer: 'はい、ビデオ通話でのオンライン内見にも対応しております。', category: 'store_info' },
+  ],
+  retail: [
+    { question: '営業時間を教えてください', answer: '営業時間は10:00〜20:00です。年中無休で営業しております。', category: 'store_info' },
+    { question: '送料はいくらですか？', answer: '5,000円以上のご購入で送料無料です。それ未満は一律600円です。', category: 'pricing' },
+    { question: '返品・交換はできますか？', answer: '商品到着後7日以内であれば、未使用品に限り返品・交換を承ります。', category: 'product_info' },
+    { question: '在庫はどのくらいありますか？', answer: '商品ページに在庫状況を掲載しております。お問い合わせいただければ最新状況もご案内します。', category: 'inventory' },
+    { question: 'クーポンや割引はありますか？', answer: '会員登録で使える初回クーポンをご用意しております。', category: 'coupon' },
+  ],
+  other: [
+    { question: '営業時間を教えてください', answer: '営業時間は平日10:00〜18:00です。土日祝はお休みをいただいております。', category: 'store_info' },
+    { question: '料金はいくらですか？', answer: '内容により異なります。お気軽にお問い合わせください。', category: 'pricing' },
+    { question: '予約は必要ですか？', answer: 'はい、事前のご予約をお願いしております。', category: 'store_info' },
+    { question: '対応エリアを教えてください', answer: '対応エリアの詳細はお問い合わせください。', category: 'store_info' },
+    { question: '問い合わせ方法を教えてください', answer: 'お電話またはお問い合わせフォームからご連絡ください。', category: 'store_info' },
+  ],
+};
+
+export function isOnboardingIndustry(value: unknown): value is OnboardingIndustry {
+  return typeof value === 'string' && (ONBOARDING_INDUSTRY_VALUES as readonly string[]).includes(value);
+}

--- a/src/api/admin/agent/toolDefinitions.ts
+++ b/src/api/admin/agent/toolDefinitions.ts
@@ -158,6 +158,32 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
   {
     type: 'function',
     function: {
+      name: 'import_industry_faq_templates',
+      description:
+        '新規テナントのオンボーディングで、ユーザーが答えた業種に合わせたFAQのたたき台を一括登録する。' +
+        'ユーザーが業種（自動車販売・整備／美容・サロン／飲食／不動産／小売・EC／その他）を教えてくれた' +
+        '直後にのみ使用すること。confirmed=falseで呼ぶとテンプレート内容を提示するだけで登録はしない。' +
+        '内容をユーザーに提示し、同意を得たターンでのみ confirmed=true で呼び出すこと。',
+      parameters: {
+        type: 'object',
+        properties: {
+          industry: {
+            type: 'string',
+            description: 'ユーザーが答えた業種',
+            enum: ['auto', 'beauty', 'food', 'realestate', 'retail', 'other'],
+          },
+          confirmed: {
+            type: 'boolean',
+            description: 'ユーザーの明確な同意を得た場合のみ true',
+          },
+        },
+        required: ['industry'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
       name: 'get_avatar_status',
       description: 'アバターの稼働状況（有効/無効、稼働中の設定名）を取得する読み取り専用ツール。',
       parameters: {


### PR DESCRIPTION
## Summary
- 新規テナント(`tenants.onboarding_completed_at`未設定)と既存テナントでオンボーディング体験が分岐していなかった問題に対応。従来は新規テナントも「会話数0件、成約0件・¥0…」と実績ゼロの数字をそのまま告げられるだけで、次にやるべきことへの導線が無かった
- 調査の結果、旧UI(`OnboardingModal`)の業種→FAQテンプレート一括インポート以外に必須の初期セットアップは無いと判明(アバターはテナント作成時に18種のデフォルトが自動生成済みで`activate_avatar`一回で有効化でき、GA4/PostHog/指示ルール/声がけルール/オリジン制限は運用中のチューニング項目で無くても動作する)
- これを踏まえ、新UIのオンボーディングを**業種選択→FAQ一括登録→アバター有効化→ウィジェット埋め込みコード案内**の3ステップに設計・実装

## 変更内容
- `src/api/admin/agent/industryFaqTemplates.ts`(新規): 旧UIの業種別FAQテンプレート(6業種×5件)をミラー(admin-uiとbackendは別TSプロジェクトのため直接共有できず複製。変更時は両ファイルの同期が必要)
- `toolDefinitions.ts`/`actionExecutor.ts`: 新ツール`import_industry_faq_templates(industry, confirmed)`を追加。confirmed=falseでテンプレート内容を提示、confirmed=trueで一括INSERT + 旧UIと同じ条件(`onboarding_industry`設定時に`onboarding_completed_at = NOW()`)でオンボーディング完了扱いに更新
- `agentRoutes.ts`: systemPromptに3ステップの継続案内を追記(FAQ登録完了後、既存の`get_avatar_status`→`activate_avatar`→`get_embed_code`へ自然に繋げるようAIに指示。新規ツールはFAQ登録のみで、アバター/ウィジェット案内は既存ツールを流用)
- `copilot-preview/index.tsx`: 起動時に`GET /v1/admin/my-tenant`で`onboarding_completed_at`を確認し、新規テナント(client_admin・プレビュー中でない場合のみ判定)なら業種選択チップ付きの案内を、既存テナントなら従来通り週次ブリーフィングを表示する分岐を追加

## Test plan
- [x] `npx tsc --noEmit`(バックエンド) クリーン
- [x] `npx tsc --noEmit -p tsconfig.app.json`(admin-ui) — copilot-preview/index.tsxにエラーなし
- [x] `npx jest src/api/admin/agent/agentRoutes.test.ts` — 新規3件(confirmed=false時のプレビュー・不明業種・confirmed=true時の一括INSERT+onboarding更新)含め計88件全パス
- [x] `npx vitest run --config vitest.config.ts`(admin-ui全体) — 82件全パス
- [x] `npx vite build` 成功

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01SaK6mK6nvpj9GEAwPkWYRW