### PR TITLE
fix(knowledge): 公開/非公開トグルの反転バグを修正

### DIFF
--- a/src/api/admin/knowledge/routes.ts
+++ b/src/api/admin/knowledge/routes.ts
@@ -401,6 +401,7 @@ export function registerKnowledgeAdminRoutes(app: Express): void {
     const user = (req as KnowledgeReq).user;
     const category = req.query.category as string | undefined;
     const isGlobalParam = req.query.is_global as string | undefined;
+    const isPublishedParam = req.query.is_published as string | undefined;
 
     if (!tenantId && user?.role !== "super_admin") {
       return res.status(400).json({ error: "tenant クエリパラメータが必要です" });
@@ -408,7 +409,7 @@ export function registerKnowledgeAdminRoutes(app: Express): void {
 
     try {
       const params: unknown[] = [];
-      let sql = `SELECT id, tenant_id, question, answer, category, tags, is_global, created_at FROM faq_docs`;
+      let sql = `SELECT id, tenant_id, question, answer, category, tags, is_global, is_published, created_at FROM faq_docs`;
       const conditions: string[] = [];
 
       if (tenantId) {
@@ -423,6 +424,11 @@ export function registerKnowledgeAdminRoutes(app: Express): void {
         conditions.push(`is_global = true`);
       } else if (isGlobalParam === "false") {
         conditions.push(`is_global = false OR is_global IS NULL`);
+      }
+      if (isPublishedParam === "true") {
+        conditions.push(`is_published = true`);
+      } else if (isPublishedParam === "false") {
+        conditions.push(`is_published = false`);
       }
       if (conditions.length > 0) {
         sql += ` WHERE ${conditions.join(" AND ")}`;


### PR DESCRIPTION
## 概要
- `GET /v1/admin/knowledge` が `is_published` カラムをSELECTしておらず、`item.is_published` が常に `undefined` になっていた
- `KnowledgeListTab.tsx:127` の `!item.is_published` によりトグルが反転し、「非公開にする」ボタンを押すと実際には公開される事故が発生していた
- 公開中/非公開バッジも常に「公開中」表示、公開状態フィルタも無反応だった

## 修正
- SELECT に `is_published` を追加
- 既存の `is_published` クエリパラメータでのフィルタも有効化（`/faq` エンドポイントと同じシンプルな等価比較で統一）

## Test plan
- [x] `npx tsc --noEmit` 通過
- [x] `knowledgeRoutesAuthGuard.test.ts` 通過（9件）
- [ ] ステージング環境で「非公開にする」→バッジが即座に非公開表示に変わることを確認
- [ ] 公開状態フィルタ（公開中/非公開）が実データで反応することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014cZaJ8Hz82okDwk5MrZWrx