### PR TITLE
feat(agent): 未回答質問の自動記録 + answered_from フィールド

### DIFF
--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -261,6 +261,96 @@ describe('POST /v1/admin/agent/chat', () => {
     });
   });
 
+  describe('answered_from / 未回答質問の自動記録', () => {
+    it('ツール未使用の通常回答 → answered_from は general、admin_feedback は記録されない', async () => {
+      mockFetch.mockResolvedValueOnce(makeGroqResponse('設定を確認しました。'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'GA4の設定を教えて', sessionId: 'sess-af-01' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.answered_from).toBe('general');
+      expect(mockQuery).not.toHaveBeenCalled();
+    });
+
+    it('ツール未使用かつ回答が未回答フレーズを含む → answered_from は general、admin_feedback に knowledge_gap で記録される', async () => {
+      mockFetch.mockResolvedValueOnce(makeGroqResponse('申し訳ございません、その情報は登録されていません。'));
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '割引クーポンはありますか', sessionId: 'sess-af-02' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.answered_from).toBe('general');
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+      const [sql, params] = mockQuery.mock.calls[0];
+      expect(sql).toContain('INSERT INTO admin_feedback');
+      expect(sql).toContain('knowledge_gap');
+      expect(params).toEqual([
+        'tenant-abc',
+        null,
+        '割引クーポンはありますか',
+        '申し訳ございません、その情報は登録されていません。',
+      ]);
+    });
+
+    it('get_faq_list を使って回答 → answered_from は faq_list', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            choices: [{
+              message: {
+                content: null,
+                tool_calls: [{ id: 'call-1', type: 'function', function: { name: 'get_faq_list', arguments: '{}' } }],
+              },
+            }],
+          }),
+          text: async () => '',
+        })
+        .mockResolvedValueOnce(makeGroqResponse('送料についてのFAQが見つかりました。'));
+
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 1, question: 'q', answer: 'a' }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '送料について教えて', sessionId: 'sess-af-03' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.answered_from).toBe('faq_list');
+    });
+
+    it('get_faq_list 以外のツールを使用 → answered_from は tool_action、回答が未回答フレーズでも記録されない', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            choices: [{
+              message: {
+                content: null,
+                tool_calls: [{ id: 'call-1', type: 'function', function: { name: 'get_tenant_settings', arguments: '{}' } }],
+              },
+            }],
+          }),
+          text: async () => '',
+        })
+        .mockResolvedValueOnce(makeGroqResponse('申し訳ございません、確認できませんでした。'));
+
+      mockQuery.mockResolvedValueOnce({ rows: [{ ga4_measurement_id: null, posthog_host: null, widget_theme: {} }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '設定を確認して', sessionId: 'sess-af-04' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.answered_from).toBe('tool_action');
+      // get_tenant_settings の SELECT 1回のみ。admin_feedback への INSERT は発火しない
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+    });
+  });
+
   // -------------------------------------------------------------------------
   // 認証エラー: supabaseUser なし → 403
   // -------------------------------------------------------------------------

--- a/src/api/admin/agent/agentRoutes.ts
+++ b/src/api/admin/agent/agentRoutes.ts
@@ -10,6 +10,51 @@ import { ADMIN_AGENT_TOOLS } from './toolDefinitions';
 import { executeToolCall } from './actionExecutor';
 import { trackUsage } from '../../../lib/billing/usageTracker';
 import { GROQ_VERSATILE_70B } from '../../../config/groqModels';
+import { isUnanswered } from '../ai-assist/systemPrompt';
+
+// ---------------------------------------------------------------------------
+// answered_from: このターンの回答がどこから来たかをUIに伝える
+// ---------------------------------------------------------------------------
+
+type AnsweredFrom = 'faq_list' | 'tool_action' | 'general';
+
+function determineAnsweredFrom(actions: Array<{ tool: string; result: string }>): AnsweredFrom {
+  if (actions.some((a) => a.tool === 'get_faq_list')) return 'faq_list';
+  if (actions.length > 0) return 'tool_action';
+  return 'general';
+}
+
+// ---------------------------------------------------------------------------
+// 未回答質問の自動記録: ツール未使用かつ回答が「わかりません」系の場合のみ、
+// admin_feedback に knowledge_gap として記録する（ai-assist/routes.ts の
+// recordFeedback と同パターン）。失敗しても本処理は継続する。
+// ---------------------------------------------------------------------------
+
+async function recordUnansweredFeedback(
+  db: Pool,
+  params: {
+    tenantId: string;
+    email: string;
+    message: string;
+    reply: string;
+  }
+): Promise<void> {
+  const safeTenantId = params.tenantId || 'unknown';
+  try {
+    await db.query(
+      `INSERT INTO admin_feedback
+         (tenant_id, user_email, message, ai_response, ai_answered, category)
+       VALUES ($1, $2, $3, $4, false, 'knowledge_gap')`,
+      [safeTenantId, params.email || null, params.message, params.reply]
+    );
+  } catch (err: any) {
+    if (err?.code === '42P01') {
+      logger.warn('[admin-agent] admin_feedback table not found — run migration_admin_feedback.sql');
+    } else {
+      logger.error('[admin-agent] feedback INSERT failed:', err?.code, err?.message);
+    }
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Auth helper（options/routes.ts と同パターンのローカル定義）
@@ -348,7 +393,8 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
   app.use('/v1/admin/agent', supabaseAuthMiddleware);
 
   app.post('/v1/admin/agent/chat', async (req: Request, res: Response) => {
-    const { role, tenantId, isSuperAdmin } = extractAuth(req);
+    const { su, role, tenantId, isSuperAdmin } = extractAuth(req);
+    const email: string = su?.email ?? '';
 
     // ロールチェック
     if (role !== 'super_admin' && role !== 'client_admin') {
@@ -479,7 +525,12 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
             });
           }
 
-          res.write(`event: done\ndata: ${JSON.stringify({ reply: finalReply, actions })}\n\n`);
+          const answeredFrom = determineAnsweredFrom(actions);
+          if (effectiveTenantId && actions.length === 0 && isUnanswered(finalReply)) {
+            await recordUnansweredFeedback(db, { tenantId: effectiveTenantId, email, message, reply: finalReply });
+          }
+
+          res.write(`event: done\ndata: ${JSON.stringify({ reply: finalReply, actions, answered_from: answeredFrom })}\n\n`);
           res.end();
         } catch (err) {
           logger.warn('[POST /v1/admin/agent/chat stream]', err);
@@ -547,7 +598,13 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
       }
 
       reportUsage();
-      return res.json({ reply: finalReply, actions });
+
+      const answeredFrom = determineAnsweredFrom(actions);
+      if (effectiveTenantId && actions.length === 0 && isUnanswered(finalReply)) {
+        await recordUnansweredFeedback(db, { tenantId: effectiveTenantId, email, message, reply: finalReply });
+      }
+
+      return res.json({ reply: finalReply, actions, answered_from: answeredFrom });
     } catch (err) {
       logger.warn('[POST /v1/admin/agent/chat]', err);
       return res.status(500).json({ error: 'AIエージェントの応答生成に失敗しました' });


### PR DESCRIPTION
## 概要
テナントが✨アシスタントに送った質問のうち、AIがツールを使わず「わかりません」系の回答をしたものを `admin_feedback` に `knowledge_gap` として自動記録する。現状この経路は誰も呼んでおらず、テナントの声が一切蓄積されていなかった（`ai-assist/routes.ts` の同等ロジックは孤立UIからしか呼ばれていない）。

後続PR（相談窓口・出どころ表示）が使う `answered_from`（`faq_list` / `tool_action` / `general`）もレスポンスに追加。

## 変更
- `determineAnsweredFrom()`: `get_faq_list` 呼び出しの有無で `faq_list` / `tool_action` / `general` を判定
- `recordUnansweredFeedback()`: ツール未使用 + `isUnanswered()`（`ai-assist/systemPrompt.ts` の既存ヘルパーを再利用）が true の場合のみ `admin_feedback` にINSERT。失敗してもリクエスト自体は継続
- ストリーミング・非ストリーミング両経路に適用
- DB書き込みは新規に `getPool()` を呼ばず、既存の `registerAdminAgentRoutes(app, db)` の `db: Pool` をそのまま再利用（このテストファイルは実DB接続を避ける設計のため。一度 `getPool()` で実装し、テスト全体を実行すると無関係なテストが落ちる問題に気づいて修正した）

## Test plan
- [x] `npx tsc --noEmit` 通過
- [x] `agentRoutes.test.ts` 92件通過（新規4件: general/knowledge_gap記録/faq_list/tool_action）
- [ ] ステージングで✨アシスタントに未登録の質問を投げ、`admin_feedback` にレコードが増えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014cZaJ8Hz82okDwk5MrZWrx