### PR TITLE
feat(knowledge): /faq に is_global + 一括公開切替 + category自由化

### DIFF
--- a/src/api/admin/knowledge/faqCrudEsIndex.test.ts
+++ b/src/api/admin/knowledge/faqCrudEsIndex.test.ts
@@ -166,6 +166,62 @@ describe("FAQ CRUD ES write path — index 統一 (Phase69-2-E)", () => {
     expect(esDeletes[0].url).toContain(`/_doc/7_${TENANT}`);
   });
 
+  it("PATCH /faq/bulk-publish: 所有IDを一括更新し、faq_${tenantId}/_doc/ へES同期する", async () => {
+    const { pool } = makeMockPool();
+    (pool.query as jest.Mock).mockImplementation(async (sql: string) => {
+      if (/SELECT id FROM faq_docs WHERE id = ANY/.test(sql)) {
+        return { rows: [{ id: 1 }, { id: 2 }], rowCount: 2 };
+      }
+      if (/UPDATE faq_docs SET is_published/.test(sql)) {
+        return {
+          rows: [
+            { id: 1, question: "q1", answer: "a1", is_excluded_from_search: false },
+            { id: 2, question: "q2", answer: "a2", is_excluded_from_search: false },
+          ],
+          rowCount: 2,
+        };
+      }
+      return { rows: [], rowCount: 0 };
+    });
+    const app = makeApp(pool);
+
+    const res = await request(app)
+      .patch(`/v1/admin/knowledge/faq/bulk-publish?tenant=${TENANT}`)
+      .send({ ids: [1, 2], is_published: false });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ updated: 2 });
+    await new Promise((r) => setImmediate(r));
+
+    const esWrites = captured.filter((c) => c.method === "PUT");
+    expect(esWrites.length).toBe(2);
+    const expectedIndex = resolveFaqWriteIndex(TENANT);
+    expect(esWrites[0].url).toContain(`/${expectedIndex}/_doc/1_${TENANT}`);
+    expect(esWrites[1].url).toContain(`/${expectedIndex}/_doc/2_${TENANT}`);
+  });
+
+  it("PATCH /faq/bulk-publish: 他テナントのIDが混じっている場合は400で拒否しUPDATEしない", async () => {
+    const { pool } = makeMockPool();
+    (pool.query as jest.Mock).mockImplementation(async (sql: string) => {
+      if (/SELECT id FROM faq_docs WHERE id = ANY/.test(sql)) {
+        return { rows: [{ id: 1 }], rowCount: 1 }; // id:2 は他テナント所有
+      }
+      return { rows: [], rowCount: 0 };
+    });
+    const app = makeApp(pool);
+
+    const res = await request(app)
+      .patch(`/v1/admin/knowledge/faq/bulk-publish?tenant=${TENANT}`)
+      .send({ ids: [1, 2], is_published: true });
+
+    expect(res.status).toBe(400);
+    expect(res.body.foreign_ids).toEqual([2]);
+    const updateCalls = (pool.query as jest.Mock).mock.calls.filter(([sql]) =>
+      /UPDATE faq_docs SET is_published/.test(sql)
+    );
+    expect(updateCalls.length).toBe(0);
+  });
+
   it("PATCH /exclude 後、同じ index に対する hybrid 読み取りパスと write index が一致する", () => {
     // write は faq_${tenantId}、read fallback の旧形式も faq_${tenantId}。
     // 両者が一致しないと exclude 同期が検索 index に届かない（Phase33-c バグ）。

--- a/src/api/admin/knowledge/faqCrudRoutes.ts
+++ b/src/api/admin/knowledge/faqCrudRoutes.ts
@@ -8,8 +8,6 @@ import { embedText } from "../../../agent/llm/openaiEmbeddingClient";
 import { logger } from '../../../lib/logger';
 import { resolveFaqWriteIndex } from "../../../search/langIndex";
 
-const CATEGORIES = ["inventory", "campaign", "coupon", "store_info"] as const;
-
 /** query/header からテナントIDを解決（bodyから取得禁止 — CLAUDE.md） */
 function resolveTenantId(req: Request): string | null {
   const fromQuery = (req.query.tenant || req.query.tenant_id) as string | undefined;
@@ -103,10 +101,15 @@ const bulkDeleteSchema = z.object({
   ids: z.array(z.coerce.number().int().positive()).min(1).max(100),
 });
 
+const bulkPublishSchema = z.object({
+  ids: z.array(z.coerce.number().int().positive()).min(1).max(100),
+  is_published: z.boolean(),
+});
+
 const createSchema = z.object({
   question: z.string().min(1).max(500),
   answer: z.string().min(1).max(2000),
-  category: z.enum(CATEGORIES).optional(),
+  category: z.string().min(1).max(50).optional(),
   tags: z.array(z.string()).optional().default([]),
   is_published: z.boolean().optional().default(true),
 });
@@ -114,7 +117,7 @@ const createSchema = z.object({
 const updateSchema = z.object({
   question: z.string().min(1).max(500),
   answer: z.string().min(1).max(2000),
-  category: z.enum(CATEGORIES).optional(),
+  category: z.string().min(1).max(50).optional(),
   tags: z.array(z.string()).optional(),
   is_published: z.boolean().optional(),
   /** Phase69-2: 検索除外フラグ */
@@ -152,6 +155,7 @@ export function registerFaqCrudRoutes(
 
     const { limit, offset, search, sort, order, category } = parsed.data;
     const isPublishedRaw = req.query.is_published as string | undefined;
+    const isGlobalRaw = req.query.is_global as string | undefined;
 
     // ORDER BY — Zodのenum検証済み値を明示的なマッピングで二重保護
     const SORT_COLUMN_MAP: Record<string, string> = {
@@ -181,6 +185,12 @@ export function registerFaqCrudRoutes(
         whereClause += ` AND is_published = $${params.length}`;
       }
 
+      if (isGlobalRaw === "true") {
+        whereClause += ` AND is_global = true`;
+      } else if (isGlobalRaw === "false") {
+        whereClause += ` AND (is_global = false OR is_global IS NULL)`;
+      }
+
       const countResult = await db.query(
         `SELECT COUNT(*)::int AS total FROM faq_docs ${whereClause}`,
         params
@@ -190,7 +200,7 @@ export function registerFaqCrudRoutes(
       params.push(limit);
       params.push(offset);
       const itemsResult = await db.query(
-        `SELECT id, tenant_id, question, answer, category, tags, is_published, is_excluded_from_search, created_at, updated_at
+        `SELECT id, tenant_id, question, answer, category, tags, is_published, is_excluded_from_search, is_global, created_at, updated_at
          FROM faq_docs
          ${whereClause}
          ORDER BY ${safeSortCol} ${safeOrder}
@@ -222,7 +232,7 @@ export function registerFaqCrudRoutes(
 
     try {
       const result = await db.query(
-        `SELECT id, tenant_id, question, answer, category, tags, is_published, is_excluded_from_search, created_at, updated_at
+        `SELECT id, tenant_id, question, answer, category, tags, is_published, is_excluded_from_search, is_global, created_at, updated_at
          FROM faq_docs
          WHERE id = $1`,
         [id]
@@ -556,6 +566,65 @@ export function registerFaqCrudRoutes(
     } catch (err) {
       logger.warn("[DELETE /v1/admin/knowledge/faq/bulk]", err);
       return res.status(500).json({ error: "一括削除に失敗しました" });
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // PATCH /v1/admin/knowledge/faq/bulk-publish
+  // FAQ一括公開状態切替（最大100件）
+  // -------------------------------------------------------------------------
+  app.patch("/v1/admin/knowledge/faq/bulk-publish", knowledgeAuth, requireKnowledgeRole, requireKnowledgeTenant, async (req: Request, res: Response) => {
+    const tenantId = resolveTenantId(req);
+    if (!tenantId) {
+      return res.status(400).json({ error: "tenant クエリパラメータが必要です" });
+    }
+
+    const parsed = bulkPublishSchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      return res.status(400).json({ error: "invalid_request", details: parsed.error.issues });
+    }
+
+    const { ids, is_published } = parsed.data;
+
+    try {
+      // 全IDが指定テナントに属することを確認
+      const checkResult = await db.query(
+        `SELECT id FROM faq_docs WHERE id = ANY($1::int[]) AND tenant_id = $2`,
+        [ids, tenantId]
+      );
+      // BIGINT列はpgが文字列で返すため Number() で正規化して比較
+      const ownedIds = (checkResult.rows as { id: number | string }[]).map((r) => Number(r.id));
+      const foreignIds = ids.filter((id) => !ownedIds.includes(id));
+      if (foreignIds.length > 0) {
+        return res.status(400).json({
+          error: "指定されたIDの一部がテナントに属していません",
+          foreign_ids: foreignIds,
+        });
+      }
+
+      const updateResult = await db.query(
+        `UPDATE faq_docs SET is_published = $1, updated_at = NOW()
+         WHERE id = ANY($2::int[]) AND tenant_id = $3
+         RETURNING id, question, answer, is_excluded_from_search`,
+        [is_published, ids, tenantId]
+      );
+
+      const updatedRows = updateResult.rows as {
+        id: number;
+        question: string;
+        answer: string;
+        is_excluded_from_search: boolean | null;
+      }[];
+
+      // ES同期（best-effort、fire-and-forget — DB が source-of-truth）
+      for (const row of updatedRows) {
+        upsertToEsAsync(tenantId, row.id, row.question, row.answer, is_published, row.is_excluded_from_search ?? false);
+      }
+
+      return res.json({ updated: updatedRows.length });
+    } catch (err) {
+      logger.warn("[PATCH /v1/admin/knowledge/faq/bulk-publish]", err);
+      return res.status(500).json({ error: "一括更新に失敗しました" });
     }
   });
 


### PR DESCRIPTION
## 概要
次PR（ナレッジ画面の検索・並び替え・一括操作UI）の前提となるBE変更。

## 変更
1. **is_global 追加**: `GET /v1/admin/knowledge/faq`（一覧・単体）のSELECTとフィルタに `is_global` を追加。super_adminのグローバルナレッジ絞り込みに使用
2. **PATCH /v1/admin/knowledge/faq/bulk-publish 新設**: 最大100件を一括で公開/非公開切替。既存の `DELETE /faq/bulk` と同じテナント越境チェックパターン。更新後 `upsertToEsAsync` でES同期
3. **category バリデーション自由化**: `z.enum(["inventory","campaign","coupon","store_info"])` → `z.string().min(1).max(50)`。PDF/URL取込・AIエージェントの `add_faq` は `general`/`product_info`/`pricing`等、この4値enumに無いカテゴリを書き込んでおり、該当FAQを `PUT` で編集すると常に400エラーになっていた（サイレントに保存できないバグ）

## Test plan
- [x] `npx tsc --noEmit` 通過
- [x] `faqCrudEsIndex.test.ts` 6件通過（bulk-publish成功/他テナントID拒否の新規2件含む）
- [x] `src/api/admin/knowledge/` 配下の既存テスト40件通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014cZaJ8Hz82okDwk5MrZWrx