### PR TITLE
fix(lp): デモセクションのアバターショーケースパネルを削除・チャット単一カラム化

### DIFF
--- a/public/lp/index.html
+++ b/public/lp/index.html
@@ -138,49 +138,18 @@
       z-index: 1;
     }
 
-    /* デモセクション 2カラム */
+    /* デモセクション: チャットウィジェット単一カラム、中央寄せ */
     .demo-layout {
-      display: grid;
-      grid-template-columns: 1fr 1fr;
-      gap: 0;
+      display: flex;
+      justify-content: center;
       border-radius: 12px;
       overflow: hidden;
       min-height: 520px;
     }
-    @media (max-width: 767px) {
-      .demo-layout { grid-template-columns: 1fr; }
-      .demo-avatar-panel { display: none; }
-    }
-    .demo-avatar-panel {
-      background: linear-gradient(160deg, #0d0720 0%, #0a0a18 60%, #06060f 100%);
-      border-right: 1px solid rgba(124,58,237,0.15);
-      display: flex;
-      flex-direction: column;
-      align-items: center;
-      justify-content: center;
-      gap: 18px;
-      padding: 32px 24px;
-      position: relative;
-      overflow: hidden;
-    }
-    .demo-avatar-panel::before {
-      content: '';
-      position: absolute;
-      top: -60px; left: -60px;
-      width: 240px; height: 240px;
-      background: radial-gradient(circle, rgba(124,58,237,0.15), transparent 70%);
-      pointer-events: none;
-    }
-    .demo-avatar-panel::after {
-      content: '';
-      position: absolute;
-      bottom: -40px; right: -40px;
-      width: 180px; height: 180px;
-      background: radial-gradient(circle, rgba(6,182,212,0.08), transparent 70%);
-      pointer-events: none;
-    }
     .demo-chat-panel {
       background: #0a0a12;
+      width: 100%;
+      max-width: 480px;
     }
 
     /* Accordion */
@@ -784,59 +753,9 @@
     <button onclick="sendExampleQuestion('人間スタッフとの連携はどうなりますか？')" style="background:rgba(124,58,237,0.12); border:1px solid rgba(124,58,237,0.3); color:#c4b5fd; padding:9px 18px; border-radius:999px; font-size:13px; cursor:pointer; transition:all 0.2s;" onmouseover="this.style.background='rgba(124,58,237,0.25)'" onmouseout="this.style.background='rgba(124,58,237,0.12)'">人間スタッフとの連携はどうなりますか？</button>
   </div>
 
-  <!-- Widget demo area: 2カラム（左=アバター, 右=チャット） -->
+  <!-- Widget demo area: チャットウィジェット単一カラム -->
   <div class="glass-card" style="border-radius:16px; padding:0; position:relative; overflow:hidden;">
     <div class="demo-layout">
-      <!-- 左: アバターショーケース -->
-      <div class="demo-avatar-panel">
-        <!-- アバター本体 -->
-        <div style="position:relative; width:130px; height:130px; flex-shrink:0;">
-          <div class="lp-avatar-ring" style="inset:-12px; animation-delay:0s;"></div>
-          <div class="lp-avatar-ring" style="inset:-24px; border-color:rgba(124,58,237,0.2); animation-delay:0.9s;"></div>
-          <div class="lp-avatar-ring" style="inset:-38px; border-color:rgba(124,58,237,0.1); animation-delay:1.8s;"></div>
-          <div class="lp-avatar-circle" style="width:130px; height:130px; font-size:60px;">🤖</div>
-        </div>
-
-        <!-- ライブバッジ -->
-        <div style="display:flex; align-items:center; gap:6px; background:rgba(34,197,94,0.12); border:1px solid rgba(34,197,94,0.3); border-radius:999px; padding:5px 14px;">
-          <div class="blink" style="width:7px; height:7px; border-radius:50%; background:#22c55e;"></div>
-          <span style="font-size:12px; color:#4ade80; font-weight:600;">LIVE デモ稼働中</span>
-        </div>
-
-        <!-- 名前・役割 -->
-        <div style="text-align:center;">
-          <div id="demo-avatar-name" style="font-size:18px; font-weight:700; color:#fff; margin-bottom:4px;">AIアシスタント</div>
-          <div style="font-size:12px; color:rgba(196,181,253,0.8);">R2C — 24時間自動接客AI</div>
-        </div>
-
-        <!-- プリセット質問 -->
-        <div style="font-size:11px; color:rgba(196,181,253,0.6); text-align:center; line-height:1.6; max-width:200px;">
-          右側のチャットから<br>話しかけてみてください 💬
-        </div>
-
-        <!-- スピーチバブル -->
-        <div
-          id="demo-avatar-bubble"
-          style="background:rgba(124,58,237,0.1); border:1px solid rgba(124,58,237,0.3); border-radius:12px; padding:10px 16px; font-size:12px; color:#e9d5ff; line-height:1.6; max-width:200px; text-align:center; transition:background 0.4s ease, border-color 0.4s ease;"
-        >
-          右のチャットに話しかけてください 💬
-        </div>
-
-        <!-- アバター機能一覧 -->
-        <div style="display:flex; flex-direction:column; gap:8px; width:100%; max-width:200px;">
-          <div style="display:flex; align-items:center; gap:8px; font-size:12px; color:rgba(196,181,253,0.7);">
-            <span style="color:#a78bfa;">🎭</span> リアルタイム映像で接客
-          </div>
-          <div style="display:flex; align-items:center; gap:8px; font-size:12px; color:rgba(196,181,253,0.7);">
-            <span style="color:#a78bfa;">🎤</span> 音声でも話しかけられる
-          </div>
-          <div style="display:flex; align-items:center; gap:8px; font-size:12px; color:rgba(196,181,253,0.7);">
-            <span style="color:#a78bfa;">⚡</span> 3秒以内に即回答
-          </div>
-        </div>
-      </div>
-
-      <!-- 右: チャットウィジェット -->
       <div class="demo-chat-panel">
         <iframe
           id="demo-frame"
@@ -1412,28 +1331,7 @@
   });
 
   // ===== 4. Example Question Buttons =====
-  // アバタースピーチバブル: プリセット質問の回答をデモ左パネルに表示
-  var DEMO_AVATAR_REPLIES = {
-    '月いくらかかりますか？': '完全従量課金で1対話あたり5円〜。初月は完全無料です！',
-    '最短で何日で導入できますか？': '最短3日で本番稼働できます！',
-    'うちのECサイトに合いますか？': 'ECサイトに特に強いです。離脱防止・深夜対応を全自動化！',
-    '人間スタッフとの連携はどうなりますか？': 'AIから人間スタッフへシームレスに引き継げます。'
-  };
-  function setDemoAvatarBubble(text) {
-    var bubble = document.getElementById('demo-avatar-bubble');
-    if (!bubble) return;
-    bubble.textContent = text;
-    bubble.style.borderColor = 'rgba(124,58,237,0.6)';
-    bubble.style.background = 'rgba(124,58,237,0.2)';
-    setTimeout(function() {
-      bubble.style.borderColor = 'rgba(124,58,237,0.3)';
-      bubble.style.background = 'rgba(124,58,237,0.1)';
-    }, 2500);
-  }
-
   window.sendExampleQuestion = function(text) {
-    // アバターバブルを更新
-    if (DEMO_AVATAR_REPLIES[text]) setDemoAvatarBubble(DEMO_AVATAR_REPLIES[text]);
     // Scroll to demo section
     var demoSection = document.getElementById('demo');
     if (demoSection) {
@@ -1577,10 +1475,6 @@
         circle.textContent = '';
         circle.appendChild(img);
       });
-
-      // デモセクション左パネルのアバター名も更新
-      var nameEl = document.getElementById('demo-avatar-name');
-      if (nameEl) nameEl.textContent = avatarName;
     })
     .catch(function() { /* フォールバック: 絵文字のまま */ });
   }


### PR DESCRIPTION
## Summary
- 「実際に話しかけてみてください」デモセクションの左パネル（アバター写真・名前・LIVEバッジ・機能一覧・スピーチバブル）を削除
- デモセクションをチャットウィジェット単一カラム（max-width:480px、中央寄せ）に再設計。ヒーローセクションの改修（#518）と同じ方向性
- 削除に伴い不要になったJS（`setDemoAvatarBubble`/`DEMO_AVATAR_REPLIES`、`loadAvatarImage()`内の名前同期処理）を整理

## Test plan
- [x] Playwright でデスクトップ(1440px)・モバイル(390px)のスクリーンショット確認、アバターパネルが消えチャットが中央寄せになっていることを確認
- [ ] 本番/ステージングでのビジュアル確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjefbeEsCmWNdVRwy2rS84