### PR TITLE
feat(feedback): 担当者側モーダルにテナントへの返信欄を追加

### DIFF
--- a/admin-ui/src/pages/admin/feedback/DetailModal.test.tsx
+++ b/admin-ui/src/pages/admin/feedback/DetailModal.test.tsx
@@ -1,0 +1,133 @@
+// Phase: 相談窓口(返信)機能 — DetailModal 返信欄の回帰テスト
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { DetailModal, type AdminFeedback } from "./index";
+
+vi.mock("../../../lib/api", () => ({
+  API_BASE: "http://localhost:3100",
+  authFetch: vi.fn(),
+}));
+
+import { authFetch } from "../../../lib/api";
+
+const BASE_ITEM: AdminFeedback = {
+  id: "fb-1",
+  tenant_id: "tenant-abc",
+  user_email: "owner@example.com",
+  message: "送料の設定はどこから変えますか",
+  ai_response: null,
+  ai_answered: false,
+  status: "new",
+  category: "operation_guide",
+  priority: "normal",
+  admin_notes: null,
+  linked_knowledge_gap_id: null,
+  reply_body: null,
+  replied_at: null,
+  replied_by_email: null,
+  reply_read_at: null,
+  parent_feedback_id: null,
+  created_at: "2026-07-28T00:00:00Z",
+  updated_at: "2026-07-28T00:00:00Z",
+};
+
+function renderModal(item: Partial<AdminFeedback> = {}, isSuperAdmin = true) {
+  const onSaved = vi.fn();
+  const onClose = vi.fn();
+  const onDeleted = vi.fn();
+  render(
+    <DetailModal
+      item={{ ...BASE_ITEM, ...item }}
+      lang="ja"
+      isSuperAdmin={isSuperAdmin}
+      onClose={onClose}
+      onSaved={onSaved}
+      onDeleted={onDeleted}
+    />
+  );
+  return { onSaved, onClose, onDeleted };
+}
+
+const mockOk = (data: unknown): Promise<Response> =>
+  Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(data) } as Response);
+
+const mockErr = (status: number): Promise<Response> =>
+  Promise.resolve({ ok: false, status, json: () => Promise.resolve({ error: "err" }) } as Response);
+
+describe("DetailModal — テナントへの返信", () => {
+  beforeEach(() => {
+    vi.mocked(authFetch).mockReset();
+  });
+
+  it("client_admin(super_admin以外)には返信欄が表示されない", () => {
+    renderModal({}, false);
+    expect(screen.queryByText("── テナントへの返信 ──")).toBeNull();
+  });
+
+  it("super_admin には返信欄が表示され、未入力ではボタンが無効", () => {
+    renderModal({}, true);
+    expect(screen.getByText("── テナントへの返信 ──")).toBeTruthy();
+    const btn = screen.getByRole("button", { name: "返信を送る" }) as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
+
+  it("返信を送ると POST /:id/reply が呼ばれ、送信済みの返信として表示される", async () => {
+    vi.mocked(authFetch).mockReturnValue(
+      mockOk({ ...BASE_ITEM, reply_body: "設定ページから変更できます", replied_at: "2026-07-28T01:00:00Z" })
+    );
+    const { onSaved } = renderModal();
+
+    const textarea = screen.getByPlaceholderText("テナントへの返信を入力...");
+    fireEvent.change(textarea, { target: { value: "設定ページから変更できます" } });
+
+    const btn = screen.getByRole("button", { name: "返信を送る" });
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      expect(vi.mocked(authFetch)).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/admin/feedback/fb-1/reply",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ reply_body: "設定ページから変更できます" }),
+        })
+      );
+    });
+
+    expect(await screen.findByText("✅ 送信済みの返信")).toBeTruthy();
+    expect(screen.getByText("設定ページから変更できます")).toBeTruthy();
+    expect(onSaved).toHaveBeenCalled();
+  });
+
+  it("送信失敗時はエラーメッセージを表示し、送信済み表示にはならない", async () => {
+    vi.mocked(authFetch).mockReturnValue(mockErr(500));
+    renderModal();
+
+    fireEvent.change(screen.getByPlaceholderText("テナントへの返信を入力..."), {
+      target: { value: "テスト返信" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: "返信を送る" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("返信の送信に失敗しました")).toBeTruthy();
+    });
+    expect(screen.queryByText("✅ 送信済みの返信")).toBeNull();
+  });
+
+  it("既に返信済みの相談は「送信済みの返信」を初期表示し、続けて返信するプレースホルダーになる", () => {
+    renderModal({ reply_body: "既存の返信です", replied_at: "2026-07-27T00:00:00Z" });
+
+    expect(screen.getByText("✅ 送信済みの返信")).toBeTruthy();
+    expect(screen.getByText("既存の返信です")).toBeTruthy();
+    expect(screen.getByPlaceholderText("続けて返信する場合はこちらに...")).toBeTruthy();
+  });
+
+  it("parent_feedback_id がある相談には「前回の続き」バッジが出る", () => {
+    renderModal({ parent_feedback_id: "fb-0" });
+    expect(screen.getByText("🔗 前回の続き")).toBeTruthy();
+  });
+
+  it("parent_feedback_id が無い相談にはバッジが出ない", () => {
+    renderModal({});
+    expect(screen.queryByText("🔗 前回の続き")).toBeNull();
+  });
+});

--- a/admin-ui/src/pages/admin/feedback/index.tsx
+++ b/admin-ui/src/pages/admin/feedback/index.tsx
@@ -14,7 +14,7 @@ import { SearchBox } from "../../../components/common/SearchBox";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
-interface AdminFeedback {
+export interface AdminFeedback {
   id: string;
   tenant_id: string;
   user_email: string | null;
@@ -26,6 +26,11 @@ interface AdminFeedback {
   priority: "low" | "normal" | "high";
   admin_notes: string | null;
   linked_knowledge_gap_id: string | null;
+  reply_body: string | null;
+  replied_at: string | null;
+  replied_by_email: string | null;
+  reply_read_at: string | null;
+  parent_feedback_id: string | null;
   created_at: string;
   updated_at: string;
 }
@@ -120,7 +125,7 @@ const selectStyle: React.CSSProperties = {
 
 // ─── Detail Modal ─────────────────────────────────────────────────────────────
 
-interface DetailModalProps {
+export interface DetailModalProps {
   item: AdminFeedback;
   lang: string;
   isSuperAdmin: boolean;
@@ -129,7 +134,7 @@ interface DetailModalProps {
   onDeleted: (id: string) => void;
 }
 
-function DetailModal({ item, lang, isSuperAdmin, onClose, onSaved, onDeleted }: DetailModalProps) {
+export function DetailModal({ item, lang, isSuperAdmin, onClose, onSaved, onDeleted }: DetailModalProps) {
   const locale = lang === "en" ? "en-US" : "ja-JP";
   const [status, setStatus] = useState<AdminFeedback["status"]>(item.status);
   const [priority, setPriority] = useState<AdminFeedback["priority"]>(item.priority);
@@ -140,6 +145,12 @@ function DetailModal({ item, lang, isSuperAdmin, onClose, onSaved, onDeleted }: 
   const [error, setError] = useState<string | null>(null);
   const [creatingRule, setCreatingRule] = useState(false);
   const [toast, setToast] = useState<{ text: string; ok: boolean } | null>(null);
+  const [replyBody, setReplyBody] = useState("");
+  const [sendingReply, setSendingReply] = useState(false);
+  const [replyError, setReplyError] = useState<string | null>(null);
+  const [sentReply, setSentReply] = useState<{ body: string; repliedAt: string } | null>(
+    item.reply_body ? { body: item.reply_body, repliedAt: item.replied_at ?? "" } : null
+  );
 
   const showToast = (text: string, ok: boolean) => {
     setToast({ text, ok });
@@ -203,6 +214,32 @@ function DetailModal({ item, lang, isSuperAdmin, onClose, onSaved, onDeleted }: 
     }
   };
 
+  const handleSendReply = async () => {
+    if (!replyBody.trim()) return;
+    setSendingReply(true);
+    setReplyError(null);
+    try {
+      const res = await authFetch(`${API_BASE}/v1/admin/feedback/${item.id}/reply`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ reply_body: replyBody.trim() }),
+      });
+      if (!res.ok) {
+        setReplyError(lang === "ja" ? "返信の送信に失敗しました" : "Failed to send reply");
+        return;
+      }
+      const updated = (await res.json()) as AdminFeedback;
+      setSentReply({ body: updated.reply_body ?? replyBody.trim(), repliedAt: updated.replied_at ?? "" });
+      setReplyBody("");
+      showToast(lang === "ja" ? "返信を送りました" : "Reply sent", true);
+      onSaved({ ...item, reply_body: updated.reply_body, replied_at: updated.replied_at });
+    } catch {
+      setReplyError(lang === "ja" ? "ネットワークエラー" : "Network error");
+    } finally {
+      setSendingReply(false);
+    }
+  };
+
   const handleDelete = async () => {
     if (!confirmDelete) { setConfirmDelete(true); return; }
     setDeleting(true);
@@ -262,6 +299,21 @@ function DetailModal({ item, lang, isSuperAdmin, onClose, onSaved, onDeleted }: 
             <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>
               {lang === "ja" ? catLabel.ja : catLabel.en}
             </span>
+            {item.parent_feedback_id && (
+              <span style={{
+                display: "inline-block",
+                padding: "2px 8px",
+                borderRadius: 999,
+                fontSize: 11,
+                fontWeight: 700,
+                background: "rgba(139,92,246,0.12)",
+                border: "1px solid rgba(139,92,246,0.35)",
+                color: "#a78bfa",
+                whiteSpace: "nowrap",
+              }}>
+                {lang === "ja" ? "🔗 前回の続き" : "🔗 Follow-up"}
+              </span>
+            )}
           </div>
           <button
             onClick={onClose}
@@ -446,6 +498,98 @@ function DetailModal({ item, lang, isSuperAdmin, onClose, onSaved, onDeleted }: 
             }}
           />
         </div>
+
+        {/* テナントへの返信 — super_admin限定(BE authz と一致)。管理者メモとは視覚的に明確に分離する（誤送信事故防止） */}
+        {isSuperAdmin && (
+        <div style={{
+          padding: "14px 16px",
+          borderRadius: 10,
+          border: "1px solid rgba(59,130,246,0.35)",
+          background: "rgba(59,130,246,0.06)",
+        }}>
+          <p style={{ fontSize: 12, fontWeight: 700, color: "#93c5fd", marginBottom: 4 }}>
+            {lang === "ja" ? "── テナントへの返信 ──" : "── Reply to Tenant ──"}
+          </p>
+          <p style={{ fontSize: 11, color: "#93c5fd", opacity: 0.85, marginBottom: 10 }}>
+            {lang === "ja"
+              ? "⚠️ ここに書いた内容はテナントに届きます"
+              : "⚠️ This will be sent directly to the tenant"}
+          </p>
+
+          {sentReply && (
+            <div style={{
+              padding: "10px 12px",
+              borderRadius: 8,
+              border: "1px solid rgba(74,222,128,0.3)",
+              background: "rgba(5,46,22,0.4)",
+              marginBottom: 10,
+            }}>
+              <p style={{ fontSize: 11, fontWeight: 600, color: "#86efac", marginBottom: 4 }}>
+                {lang === "ja" ? "✅ 送信済みの返信" : "✅ Sent Reply"}
+                {sentReply.repliedAt && (
+                  <span style={{ marginLeft: 8, fontWeight: 400, opacity: 0.8 }}>
+                    {new Date(sentReply.repliedAt).toLocaleString(locale, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })}
+                  </span>
+                )}
+              </p>
+              <p style={{ fontSize: 13, color: "#d1fae5", lineHeight: 1.6, whiteSpace: "pre-wrap", wordBreak: "break-word", margin: 0 }}>
+                {sentReply.body}
+              </p>
+            </div>
+          )}
+
+          <textarea
+            value={replyBody}
+            onChange={(e) => setReplyBody(e.target.value)}
+            placeholder={
+              sentReply
+                ? (lang === "ja" ? "続けて返信する場合はこちらに..." : "Send a follow-up reply...")
+                : (lang === "ja" ? "テナントへの返信を入力..." : "Write a reply to the tenant...")
+            }
+            rows={3}
+            style={{
+              width: "100%",
+              padding: "10px 12px",
+              borderRadius: 8,
+              border: "1px solid rgba(59,130,246,0.3)",
+              background: "rgba(0,0,0,0.3)",
+              color: "var(--foreground)",
+              fontSize: 14,
+              fontFamily: "inherit",
+              lineHeight: 1.6,
+              resize: "vertical",
+              outline: "none",
+              boxSizing: "border-box",
+              marginBottom: 8,
+            }}
+          />
+
+          {replyError && (
+            <p style={{ fontSize: 12, color: "#fca5a5", marginBottom: 8 }}>{replyError}</p>
+          )}
+
+          <button
+            onClick={() => void handleSendReply()}
+            disabled={sendingReply || !replyBody.trim()}
+            style={{
+              padding: "10px 20px",
+              minHeight: 44,
+              borderRadius: 8,
+              border: "none",
+              background: sendingReply || !replyBody.trim()
+                ? "rgba(59,130,246,0.3)"
+                : "linear-gradient(135deg, #1d4ed8, #3b82f6)",
+              color: "#fff",
+              fontSize: 14,
+              fontWeight: 700,
+              cursor: sendingReply || !replyBody.trim() ? "not-allowed" : "pointer",
+              opacity: sendingReply || !replyBody.trim() ? 0.7 : 1,
+            }}
+          >
+            {sendingReply ? (lang === "ja" ? "送信中..." : "Sending...") : (lang === "ja" ? "返信を送る" : "Send Reply")}
+          </button>
+        </div>
+        )}
 
         {/* Error */}
         {error && (


### PR DESCRIPTION
## 概要
PR #521（相談窓口API: POST /:id/reply, PATCH /:id/read, migration）の上に積んだPRです。base branch は `feat/feedback-reply-thread`。#521がmainにマージされたらbaseが自動でmainへ付け替わります。

## 変更
- `DetailModal` に「テナントへの返信」セクションを追加。`POST /v1/admin/feedback/:id/reply` を呼び、送信済みの返信をカード表示
- 管理者メモ（内部専用）とは枠線・背景色・警告文言(「⚠️ ここに書いた内容はテナントに届きます」)で視覚的に明確分離し、誤って内部メモを送ってしまう事故を防止
- `parent_feedback_id` がある相談には「🔗 前回の続き」バッジを表示
- 返信済みの相談は既存の返信を表示し、テキストエリアのプレースホルダーが「続けて返信する場合は...」に変わる
- 返信欄は `isSuperAdmin` の場合のみ表示（BEの認可 — super_adminのみreply可 — と一致）
- テスト用に `DetailModal` / `AdminFeedback` 型を export（振る舞い変更なし）

## Test plan
- [x] `npx tsc -b`（admin-ui）: 新規エラーなし
- [x] `npx vitest run`: 89件全通過（新規 `DetailModal.test.tsx` 7件含む）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014cZaJ8Hz82okDwk5MrZWrx