### PR TITLE
feat(agent-panel): アシスタントに相談ボタン・お返事カード・FABバッジを追加

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -25,6 +25,7 @@ import TuningPage from "./pages/admin/tuning/index";
 import FeedbackPage from "./pages/admin/feedback/index";
 import AdminAgentButton from "./components/AdminAgent/AdminAgentButton";
 import AdminAgentPanel from "./components/AdminAgent/AdminAgentPanel";
+import { useFeedbackReplies } from "./components/AdminAgent/useFeedbackReplies";
 import AvatarListPage from "./pages/admin/avatar/index";
 import AvatarStudioPage from "./pages/admin/avatar/studio";
 import AvatarWizardPage from "./pages/admin/avatar/wizard";
@@ -100,6 +101,14 @@ function AppInner() {
   const { isOpen: agentOpen, seedQuery, toggle: toggleAgent, close: closeAgent } = useAdminAgentUI();
   const location = useLocation();
   const showAIChat = isClientAdmin && location.pathname !== "/admin/chat-test";
+  // previewMode中は isClientAdmin が true になり showAIChat が表示されるが、
+  // 実ログインユーザー(super_admin)の user?.tenantId は常にnullのため
+  // previewTenantId を優先しないとAIアシスタントがテナント無しで動作してしまう
+  const effectiveTenantId = previewMode ? (previewTenantId ?? null) : (user?.tenantId ?? null);
+  const { replies: feedbackReplies, markRead: markReplyRead } = useFeedbackReplies(
+    showAIChat ? effectiveTenantId : null,
+    isSuperAdmin
+  );
   const isAdmin = location.pathname.startsWith("/admin") || location.pathname === "/";
   const isLogin =
     location.pathname === "/login" || location.pathname === "/reset-password";
@@ -237,16 +246,16 @@ function AppInner() {
           <AdminAgentButton
             onClick={toggleAgent}
             isOpen={agentOpen}
+            hasUnread={feedbackReplies.length > 0}
           />
-          {/* previewMode中は isClientAdmin が true になり showAIChat が表示されるが、
-              実ログインユーザー(super_admin)の user?.tenantId は常にnullのため
-              previewTenantId を優先しないとAIアシスタントがテナント無しで動作してしまう */}
           <AdminAgentPanel
             isOpen={agentOpen}
             onClose={closeAgent}
-            tenantId={previewMode ? (previewTenantId ?? null) : (user?.tenantId ?? null)}
+            tenantId={effectiveTenantId}
             isSuperAdmin={isSuperAdmin}
             initialQuery={seedQuery}
+            replies={feedbackReplies}
+            onMarkReplyRead={markReplyRead}
           />
         </>
       )}

--- a/admin-ui/src/components/AdminAgent/AdminAgentButton.test.tsx
+++ b/admin-ui/src/components/AdminAgent/AdminAgentButton.test.tsx
@@ -1,0 +1,23 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import AdminAgentButton from "./AdminAgentButton";
+
+describe("AdminAgentButton — 未読バッジ", () => {
+  it("hasUnread=false ではバッジを表示しない", () => {
+    render(<AdminAgentButton onClick={vi.fn()} isOpen={false} hasUnread={false} />);
+    const button = screen.getByRole("button");
+    expect(button.querySelector("span")).toBeNull();
+  });
+
+  it("hasUnread=true かつ閉じている場合はバッジを表示する", () => {
+    render(<AdminAgentButton onClick={vi.fn()} isOpen={false} hasUnread={true} />);
+    const button = screen.getByRole("button");
+    expect(button.querySelector("span")).not.toBeNull();
+  });
+
+  it("パネルが開いている間はバッジを表示しない", () => {
+    render(<AdminAgentButton onClick={vi.fn()} isOpen={true} hasUnread={true} />);
+    const button = screen.getByRole("button");
+    expect(button.querySelector("span")).toBeNull();
+  });
+});

--- a/admin-ui/src/components/AdminAgent/AdminAgentButton.tsx
+++ b/admin-ui/src/components/AdminAgent/AdminAgentButton.tsx
@@ -5,9 +5,10 @@
 interface AdminAgentButtonProps {
   onClick: () => void;
   isOpen: boolean;
+  hasUnread?: boolean;
 }
 
-export default function AdminAgentButton({ onClick, isOpen }: AdminAgentButtonProps) {
+export default function AdminAgentButton({ onClick, isOpen, hasUnread }: AdminAgentButtonProps) {
   return (
     <button
       onClick={onClick}
@@ -43,6 +44,20 @@ export default function AdminAgentButton({ onClick, isOpen }: AdminAgentButtonPr
       }}
     >
       {isOpen ? "✕" : "✨"}
+      {hasUnread && !isOpen && (
+        <span
+          style={{
+            position: "absolute",
+            top: 2,
+            right: 2,
+            width: 12,
+            height: 12,
+            borderRadius: "50%",
+            background: "#ef4444",
+            border: "2px solid #0f172a",
+          }}
+        />
+      )}
     </button>
   );
 }

--- a/admin-ui/src/components/AdminAgent/AdminAgentPanel.test.tsx
+++ b/admin-ui/src/components/AdminAgent/AdminAgentPanel.test.tsx
@@ -1,0 +1,179 @@
+// Phase: 相談窓口(お返事カード・解決確認プロンプト)の回帰テスト
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import AdminAgentPanel from "./AdminAgentPanel";
+
+vi.mock("../../lib/api", () => ({
+  API_BASE: "http://localhost:3100",
+  authFetch: vi.fn(),
+}));
+
+const mockSendMessage = vi.fn();
+let mockMessages: Array<{ role: "user" | "assistant"; content: string; actions?: unknown[]; answeredFrom?: string }> = [];
+let mockIsLoading = false;
+
+vi.mock("./useAdminAgent", () => ({
+  useAdminAgent: () => ({
+    messages: mockMessages,
+    isLoading: mockIsLoading,
+    sendMessage: mockSendMessage,
+  }),
+}));
+
+import { authFetch } from "../../lib/api";
+
+const mockOk = (data: unknown): Promise<Response> =>
+  Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(data) } as Response);
+
+const REPLY = {
+  id: "fb-1",
+  message: "送料の設定はどこから変えますか",
+  reply_body: "設定ページから変更できます",
+  replied_at: "2026-07-28T01:00:00Z",
+};
+
+function renderPanel(overrides: Partial<Parameters<typeof AdminAgentPanel>[0]> = {}) {
+  const onMarkReplyRead = vi.fn().mockResolvedValue(undefined);
+  render(
+    <AdminAgentPanel
+      isOpen={true}
+      onClose={vi.fn()}
+      tenantId="tenant-abc"
+      isSuperAdmin={false}
+      replies={[]}
+      onMarkReplyRead={onMarkReplyRead}
+      {...overrides}
+    />
+  );
+  return { onMarkReplyRead };
+}
+
+describe("AdminAgentPanel — お返事カード", () => {
+  beforeEach(() => {
+    mockMessages = [];
+    mockIsLoading = false;
+    mockSendMessage.mockReset();
+    vi.mocked(authFetch).mockReset();
+  });
+
+  it("replies が空なら「担当者からお返事」カードは表示されない", () => {
+    renderPanel({ replies: [] });
+    expect(screen.queryByText("💬 担当者からお返事が届きました")).toBeNull();
+  });
+
+  it("replies があると質問と返事が表示される", () => {
+    renderPanel({ replies: [REPLY] });
+    expect(screen.getByText("💬 担当者からお返事が届きました")).toBeTruthy();
+    expect(screen.getByText("送料の設定はどこから変えますか")).toBeTruthy();
+    expect(screen.getByText("設定ページから変更できます")).toBeTruthy();
+  });
+
+  it("2件以上あると「＋あと{n}件」を表示する", () => {
+    renderPanel({ replies: [REPLY, { ...REPLY, id: "fb-2" }] });
+    expect(screen.getByText("＋あと1件")).toBeTruthy();
+  });
+
+  it("「解決しました」クリックで onMarkReplyRead が呼ばれる", async () => {
+    const { onMarkReplyRead } = renderPanel({ replies: [REPLY] });
+    fireEvent.click(screen.getByText("解決しました"));
+    await waitFor(() => {
+      expect(onMarkReplyRead).toHaveBeenCalledWith("fb-1");
+    });
+  });
+
+  it("「まだ解決しません」クリックで既読化 + parent_feedback_id 付きで新規相談が送信される", async () => {
+    vi.mocked(authFetch).mockReturnValue(mockOk({ id: "fb-3" }));
+    const { onMarkReplyRead } = renderPanel({ replies: [REPLY] });
+
+    fireEvent.click(screen.getByText("まだ解決しません"));
+
+    await waitFor(() => {
+      expect(onMarkReplyRead).toHaveBeenCalledWith("fb-1");
+      expect(vi.mocked(authFetch)).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/admin/feedback",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            message: "送料の設定はどこから変えますか",
+            category: "other",
+            parent_feedback_id: "fb-1",
+          }),
+        })
+      );
+    });
+  });
+});
+
+describe("AdminAgentPanel — 解決確認プロンプト", () => {
+  beforeEach(() => {
+    mockSendMessage.mockReset();
+    vi.mocked(authFetch).mockReset();
+  });
+
+  it("ローディング中は解決確認プロンプトを表示しない", () => {
+    mockMessages = [
+      { role: "user", content: "設定を教えて" },
+      { role: "assistant", content: "確認しました。" },
+    ];
+    mockIsLoading = true;
+    renderPanel();
+    expect(screen.queryByText("このお返事で解決しましたか？")).toBeNull();
+  });
+
+  it("直近のAI回答の下にのみ解決確認プロンプトを表示する", () => {
+    mockMessages = [
+      { role: "user", content: "1つ目の質問" },
+      { role: "assistant", content: "1つ目の回答" },
+      { role: "user", content: "2つ目の質問" },
+      { role: "assistant", content: "2つ目の回答" },
+    ];
+    mockIsLoading = false;
+    renderPanel();
+    expect(screen.getAllByText("このお返事で解決しましたか？").length).toBe(1);
+  });
+
+  it("answeredFrom が faq_list の場合、出どころ表示が出る", () => {
+    mockMessages = [
+      { role: "user", content: "送料は？" },
+      { role: "assistant", content: "550円です。", answeredFrom: "faq_list" },
+    ];
+    renderPanel();
+    expect(screen.getByText("📚 登録した知識データから回答しました")).toBeTruthy();
+  });
+
+  it("「うまく解決しなかった」クリックで質問文が feedback として送信され、確認文言に変わる", async () => {
+    mockMessages = [
+      { role: "user", content: "割引クーポンはありますか" },
+      { role: "assistant", content: "申し訳ございません、その情報は登録されていません。" },
+    ];
+    vi.mocked(authFetch).mockReturnValue(mockOk({ id: "fb-9" }));
+    renderPanel();
+
+    fireEvent.click(screen.getByText("うまく解決しなかった"));
+
+    await waitFor(() => {
+      expect(vi.mocked(authFetch)).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/admin/feedback",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ message: "割引クーポンはありますか", category: "other" }),
+        })
+      );
+    });
+
+    expect(await screen.findByText("✅ 担当者に伝えました。お返事はこの画面に届きます。")).toBeTruthy();
+  });
+
+  it("「はい」クリックでプロンプトは消え、APIは呼ばれない", () => {
+    mockMessages = [
+      { role: "user", content: "設定を教えて" },
+      { role: "assistant", content: "確認しました。" },
+    ];
+    renderPanel();
+
+    fireEvent.click(screen.getByText("はい"));
+
+    expect(screen.queryByText("このお返事で解決しましたか？")).toBeNull();
+    expect(authFetch).not.toHaveBeenCalled();
+  });
+});

--- a/admin-ui/src/components/AdminAgent/AdminAgentPanel.tsx
+++ b/admin-ui/src/components/AdminAgent/AdminAgentPanel.tsx
@@ -2,6 +2,9 @@
 import { useRef, useEffect, useState, useCallback } from "react";
 import { useAdminAgent } from "./useAdminAgent";
 import AdminAgentMessage from "./AdminAgentMessage";
+import FeedbackPrompt from "./FeedbackPrompt";
+import ReplyCard from "./ReplyCard";
+import { submitConsultation, type FeedbackReply } from "./useFeedbackReplies";
 
 interface AdminAgentPanelProps {
   isOpen: boolean;
@@ -9,9 +12,17 @@ interface AdminAgentPanelProps {
   tenantId: string | null;
   isSuperAdmin: boolean;
   initialQuery?: string | null;
+  replies: FeedbackReply[];
+  onMarkReplyRead: (id: string) => Promise<void>;
 }
 
 const INITIAL_MESSAGE = "こんにちは！設定の変更やFAQの追加など、何でもお手伝いします。";
+
+const ANSWERED_FROM_LABEL: Record<string, string> = {
+  faq_list: "📚 登録した知識データから回答しました",
+  tool_action: "⚙️ 操作を実行しました",
+  general: "💡 R2Cの使い方ガイドから回答しました",
+};
 
 export default function AdminAgentPanel({
   isOpen,
@@ -19,6 +30,8 @@ export default function AdminAgentPanel({
   tenantId,
   isSuperAdmin,
   initialQuery,
+  replies,
+  onMarkReplyRead,
 }: AdminAgentPanelProps) {
   const { messages, isLoading, sendMessage } = useAdminAgent();
   const [input, setInput] = useState("");
@@ -57,6 +70,15 @@ export default function AdminAgentPanel({
     await sendMessage(text, targetTenantId);
     setTimeout(() => inputRef.current?.focus(), 50);
   }, [input, isLoading, isSuperAdmin, tenantId, sendMessage]);
+
+  const handleReplyResolved = useCallback(async (reply: FeedbackReply) => {
+    await onMarkReplyRead(reply.id);
+  }, [onMarkReplyRead]);
+
+  const handleReplyNotResolved = useCallback(async (reply: FeedbackReply) => {
+    await onMarkReplyRead(reply.id);
+    await submitConsultation({ message: reply.message, parentFeedbackId: reply.id });
+  }, [onMarkReplyRead]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     if (
@@ -144,14 +166,40 @@ export default function AdminAgentPanel({
           gap: 10,
         }}
       >
+        {/* 担当者からのお返事（最新の未読1件のみ表示、他は件数バッジで案内） */}
+        {replies.length > 0 && (
+          <ReplyCard
+            reply={replies[0]}
+            extraCount={replies.length - 1}
+            onResolved={() => handleReplyResolved(replies[0])}
+            onNotResolved={() => handleReplyNotResolved(replies[0])}
+          />
+        )}
+
         {/* 初期メッセージ */}
         <AdminAgentMessage
           message={{ role: "assistant", content: INITIAL_MESSAGE }}
         />
 
-        {messages.map((msg, i) => (
-          <AdminAgentMessage key={i} message={msg} />
-        ))}
+        {messages.map((msg, i) => {
+          const isLastAssistantMessage =
+            !isLoading && i === messages.length - 1 && msg.role === "assistant";
+          return (
+            <div key={i}>
+              <AdminAgentMessage message={msg} />
+              {isLastAssistantMessage && msg.answeredFrom && (
+                <div style={{ fontSize: 11, color: "#6b7280", marginTop: 2, padding: "0 4px" }}>
+                  {ANSWERED_FROM_LABEL[msg.answeredFrom]}
+                </div>
+              )}
+              {isLastAssistantMessage && (
+                <div style={{ marginTop: 6 }}>
+                  <FeedbackPrompt question={messages[i - 1]?.content ?? msg.content} />
+                </div>
+              )}
+            </div>
+          );
+        })}
 
         {isLoading && (
           <div style={{ display: "flex", justifyContent: "flex-start" }}>

--- a/admin-ui/src/components/AdminAgent/FeedbackPrompt.tsx
+++ b/admin-ui/src/components/AdminAgent/FeedbackPrompt.tsx
@@ -1,0 +1,69 @@
+// admin-ui/src/components/AdminAgent/FeedbackPrompt.tsx
+// 直近のAI回答の下に出す「解決しましたか？」の確認導線。
+import { useState } from "react";
+import { submitConsultation } from "./useFeedbackReplies";
+
+interface FeedbackPromptProps {
+  question: string;
+}
+
+type PromptState = "idle" | "sending" | "sent" | "dismissed";
+
+export default function FeedbackPrompt({ question }: FeedbackPromptProps) {
+  const [state, setState] = useState<PromptState>("idle");
+
+  if (state === "dismissed") return null;
+
+  if (state === "sent") {
+    return (
+      <div style={{ fontSize: 12, color: "#86efac", padding: "2px 4px" }}>
+        {"✅ 担当者に伝えました。お返事はこの画面に届きます。"}
+      </div>
+    );
+  }
+
+  const handleNotResolved = async () => {
+    setState("sending");
+    const ok = await submitConsultation({ message: question });
+    setState(ok ? "sent" : "idle");
+  };
+
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 8, padding: "2px 4px", flexWrap: "wrap" }}>
+      <span style={{ fontSize: 12, color: "#6b7280" }}>このお返事で解決しましたか？</span>
+      <button
+        onClick={() => setState("dismissed")}
+        style={{
+          padding: "4px 10px",
+          minHeight: 28,
+          borderRadius: 999,
+          border: "1px solid rgba(74,222,128,0.35)",
+          background: "rgba(34,197,94,0.1)",
+          color: "#86efac",
+          fontSize: 11,
+          fontWeight: 600,
+          cursor: "pointer",
+        }}
+      >
+        はい
+      </button>
+      <button
+        onClick={() => void handleNotResolved()}
+        disabled={state === "sending"}
+        style={{
+          padding: "4px 10px",
+          minHeight: 28,
+          borderRadius: 999,
+          border: "1px solid rgba(255,255,255,0.15)",
+          background: "transparent",
+          color: "#9ca3af",
+          fontSize: 11,
+          fontWeight: 600,
+          cursor: state === "sending" ? "not-allowed" : "pointer",
+        }}
+      >
+        {state === "sending" ? "送信中..." : "うまく解決しなかった"}
+      </button>
+    </div>
+  );
+}

--- a/admin-ui/src/components/AdminAgent/ReplyCard.tsx
+++ b/admin-ui/src/components/AdminAgent/ReplyCard.tsx
@@ -1,0 +1,111 @@
+// admin-ui/src/components/AdminAgent/ReplyCard.tsx
+import { useState } from "react";
+import type { FeedbackReply } from "./useFeedbackReplies";
+
+interface ReplyCardProps {
+  reply: FeedbackReply;
+  extraCount: number;
+  onResolved: () => Promise<void>;
+  onNotResolved: () => Promise<void>;
+}
+
+export default function ReplyCard({ reply, extraCount, onResolved, onNotResolved }: ReplyCardProps) {
+  const [busy, setBusy] = useState(false);
+
+  const handleResolved = async () => {
+    setBusy(true);
+    await onResolved();
+  };
+
+  const handleNotResolved = async () => {
+    setBusy(true);
+    await onNotResolved();
+  };
+
+  return (
+    <div
+      style={{
+        borderRadius: 12,
+        border: "1px solid rgba(99,102,241,0.35)",
+        background: "rgba(99,102,241,0.08)",
+        padding: "12px 14px",
+        marginBottom: 4,
+        display: "flex",
+        flexDirection: "column",
+        gap: 8,
+      }}
+    >
+      <div style={{ fontSize: 13, fontWeight: 700, color: "#a5b4fc" }}>
+        {"💬 担当者からお返事が届きました"}
+        {extraCount > 0 && (
+          <span style={{ marginLeft: 6, fontWeight: 400, color: "#818cf8", fontSize: 11 }}>
+            {`＋あと${extraCount}件`}
+          </span>
+        )}
+      </div>
+
+      <div>
+        <div style={{ fontSize: 11, color: "#9ca3af", marginBottom: 2 }}>あなたの質問</div>
+        <div style={{ fontSize: 13, color: "#e5e7eb", lineHeight: 1.5, whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
+          {reply.message}
+        </div>
+      </div>
+
+      <div>
+        <div style={{ fontSize: 11, color: "#9ca3af", marginBottom: 2 }}>お返事</div>
+        <div style={{ fontSize: 13, color: "#f9fafb", lineHeight: 1.5, whiteSpace: "pre-wrap", wordBreak: "break-word" }}>
+          {reply.reply_body}
+        </div>
+        {reply.replied_at && (
+          <div style={{ fontSize: 11, color: "#6b7280", marginTop: 4 }}>
+            {new Date(reply.replied_at).toLocaleString("ja-JP", {
+              month: "short",
+              day: "numeric",
+              hour: "2-digit",
+              minute: "2-digit",
+            })}
+          </div>
+        )}
+      </div>
+
+      <div style={{ display: "flex", gap: 8, marginTop: 2 }}>
+        <button
+          onClick={() => void handleResolved()}
+          disabled={busy}
+          style={{
+            flex: 1,
+            padding: "9px 12px",
+            minHeight: 40,
+            borderRadius: 8,
+            border: "none",
+            background: busy ? "rgba(34,197,94,0.3)" : "linear-gradient(135deg, #16a34a, #22c55e)",
+            color: "#f0fdf4",
+            fontSize: 13,
+            fontWeight: 700,
+            cursor: busy ? "not-allowed" : "pointer",
+          }}
+        >
+          解決しました
+        </button>
+        <button
+          onClick={() => void handleNotResolved()}
+          disabled={busy}
+          style={{
+            flex: 1,
+            padding: "9px 12px",
+            minHeight: 40,
+            borderRadius: 8,
+            border: "1px solid rgba(255,255,255,0.15)",
+            background: "transparent",
+            color: "#d1d5db",
+            fontSize: 13,
+            fontWeight: 600,
+            cursor: busy ? "not-allowed" : "pointer",
+          }}
+        >
+          まだ解決しません
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/admin-ui/src/components/AdminAgent/useAdminAgent.ts
+++ b/admin-ui/src/components/AdminAgent/useAdminAgent.ts
@@ -2,11 +2,14 @@
 import { useState, useCallback } from "react";
 import { authFetch, API_BASE } from "../../lib/api";
 
+export type AnsweredFrom = "faq_list" | "tool_action" | "general";
+
 export interface AgentMessage {
   role: "user" | "assistant";
   content: string;
   actions?: { tool: string; result: string }[];
   needsConfirmation?: boolean;
+  answeredFrom?: AnsweredFrom;
 }
 
 interface UseAdminAgentResult {
@@ -71,6 +74,7 @@ export function useAdminAgent(): UseAdminAgentResult {
       const data = (await res.json()) as {
         reply: string;
         actions: { tool: string; result: string }[];
+        answered_from?: AnsweredFrom;
       };
 
       setMessages((prev) => [
@@ -79,6 +83,7 @@ export function useAdminAgent(): UseAdminAgentResult {
           role: "assistant",
           content: data.reply,
           actions: data.actions,
+          answeredFrom: data.answered_from,
         },
       ]);
     } catch {

--- a/admin-ui/src/components/AdminAgent/useFeedbackReplies.ts
+++ b/admin-ui/src/components/AdminAgent/useFeedbackReplies.ts
@@ -1,0 +1,74 @@
+// admin-ui/src/components/AdminAgent/useFeedbackReplies.ts
+// テナントの「相談窓口」: 担当者からの未読返信をポーリングし、
+// FABバッジ・お返事カードの両方が同じ状態を参照できるようにする。
+import { useCallback, useEffect, useState } from "react";
+import { authFetch, API_BASE } from "../../lib/api";
+
+export interface FeedbackReply {
+  id: string;
+  message: string;
+  reply_body: string;
+  replied_at: string | null;
+}
+
+const POLL_INTERVAL_MS = 60_000;
+
+export function useFeedbackReplies(tenantId: string | null, isSuperAdmin: boolean) {
+  const [replies, setReplies] = useState<FeedbackReply[]>([]);
+
+  const fetchReplies = useCallback(async () => {
+    if (!tenantId) {
+      setReplies([]);
+      return;
+    }
+    try {
+      const params = new URLSearchParams({ unread: "true", limit: "5" });
+      // super_admin のJWTにはtenant_idが無いため、プレビュー中も明示的に指定する
+      if (isSuperAdmin) params.set("tenant_id", tenantId);
+      const res = await authFetch(`${API_BASE}/v1/admin/feedback?${params}`);
+      if (!res.ok) return;
+      const data = (await res.json()) as { items: FeedbackReply[] };
+      setReplies(data.items ?? []);
+    } catch {
+      // best-effort: バッジ更新は失敗しても致命的ではない
+    }
+  }, [tenantId, isSuperAdmin]);
+
+  useEffect(() => {
+    void fetchReplies();
+    const timer = setInterval(() => void fetchReplies(), POLL_INTERVAL_MS);
+    return () => clearInterval(timer);
+  }, [fetchReplies]);
+
+  const markRead = useCallback(async (id: string) => {
+    // 楽観的に即座にリストから消す
+    setReplies((prev) => prev.filter((r) => r.id !== id));
+    try {
+      await authFetch(`${API_BASE}/v1/admin/feedback/${id}/read`, { method: "PATCH" });
+    } catch {
+      // best-effort: 既読化に失敗しても次回ポーリングで再取得されるだけ
+    }
+  }, []);
+
+  return { replies, markRead, refetch: fetchReplies };
+}
+
+/** 「うまく解決しなかった」「まだ解決しません」共通の相談投稿ヘルパー */
+export async function submitConsultation(params: {
+  message: string;
+  parentFeedbackId?: string;
+}): Promise<boolean> {
+  try {
+    const res = await authFetch(`${API_BASE}/v1/admin/feedback`, {
+      method: "POST",
+      body: JSON.stringify({
+        message: params.message,
+        category: "other",
+        ...(params.parentFeedbackId ? { parent_feedback_id: params.parentFeedbackId } : {}),
+      }),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## 概要
PR #521（相談窓口API群、base branch）の上に積んだPRです。base branch は `feat/feedback-reply-thread`。#521がmainにマージされたらbaseが自動でmainへ付け替わります。

**追加の依存**: PR #516（`answered_from`フィールド追加）にも依存します。ファイルの重なりが無いため別ブランチのまま独立していますが、`answered_from`は`msg.answeredFrom && ...`で存在チェックしているため、#516が未マージでもこのPR単体は壊れません（出どころ表示が出ないだけ）。

## 変更
- **FeedbackPrompt**: 直近のAI回答の下に「このお返事で解決しましたか？」。「うまく解決しなかった」で直前の質問文をそのまま`POST /v1/admin/feedback`へ送信し、フォーム入力なしで相談完了
- **ReplyCard**: 担当者からの未読返信をパネル上部に固定表示。「解決しました」で既読化、「まだ解決しません」で既読化 + `parent_feedback_id`付きの続きの相談を自動作成
- **useFeedbackReplies**: `GET /v1/admin/feedback?unread=true`を60秒間隔でポーリングする共有フック。App.tsxで一度だけ呼び出し、FABバッジとお返事カードの両方に配線（重複ポーリングを回避）
- **出どころ表示**: `answered_from`を元に「📚 登録した知識データから回答しました」等を直近のAI回答の下に表示
- super_adminのpreviewMode中はJWTにtenant_idが無いため、`tenant_id`クエリを明示的に付与

## Test plan
- [x] `npx tsc -b`（admin-ui）: 新規エラーなし
- [x] `npx vitest run`: 95件全通過（新規 `AdminAgentPanel.test.tsx` 10件 + `AdminAgentButton.test.tsx` 3件）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014cZaJ8Hz82okDwk5MrZWrx