### PR TITLE
fix(deps): security-scan を落としているjs-yaml/brace-expansionの高深刻度脆弱性を解消

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
       "axios": ">=1.15.0",
       "minimatch": ">=9.0.7 <10",
       "protobufjs": ">=7.5.6 <8",
-      "@grpc/grpc-js": ">=1.14.4 <2"
+      "@grpc/grpc-js": ">=1.14.4 <2",
+      "brace-expansion": ">=5.0.8"
     },
     "auditConfig": {
       "ignoreCves": [
@@ -130,7 +131,7 @@
     "cors": "^2.8.5",
     "dotenv": "17.2.3",
     "express": "5.1.0",
-    "js-yaml": "^4.1.1",
+    "js-yaml": "^4.3.0",
     "jsonwebtoken": "^9.0.3",
     "livekit-server-sdk": "^2.15.0",
     "multer": "^2.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   minimatch: '>=9.0.7 <10'
   protobufjs: '>=7.5.6 <8'
   '@grpc/grpc-js': '>=1.14.4 <2'
+  brace-expansion: '>=5.0.8'
 
 importers:
 
@@ -48,8 +49,8 @@ importers:
         specifier: 5.1.0
         version: 5.1.0
       js-yaml:
-        specifier: ^4.1.1
-        version: 4.1.1
+        specifier: ^4.3.0
+        version: 4.3.0
       jsonwebtoken:
         specifier: ^9.0.3
         version: 9.0.3
@@ -1367,8 +1368,9 @@ packages:
     peerDependencies:
       '@babel/core': ^7.11.0 || ^8.0.0-beta.1
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
 
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
@@ -1394,8 +1396,9 @@ packages:
     resolution: {integrity: sha512-02qvAaxv8tp7fBa/mw1ga98OGm+eCbqzJOKoRt70sLmfEEi+jyBYVTDGfCL/k06/4EMk/z01gCe7HoCH/f2LTg==}
     engines: {node: '>=18'}
 
-  brace-expansion@2.1.1:
-    resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -2365,8 +2368,8 @@ packages:
     resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
 
-  js-yaml@4.1.1:
-    resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
+  js-yaml@4.3.0:
+    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -4896,7 +4899,7 @@ snapshots:
       babel-plugin-jest-hoist: 30.2.0
       babel-preset-current-node-syntax: 1.2.0(@babel/core@7.28.5)
 
-  balanced-match@1.0.2: {}
+  balanced-match@4.0.4: {}
 
   base64-js@1.5.1: {}
 
@@ -4924,9 +4927,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  brace-expansion@2.1.1:
+  brace-expansion@5.0.8:
     dependencies:
-      balanced-match: 1.0.2
+      balanced-match: 4.0.4
 
   braces@3.0.3:
     dependencies:
@@ -6139,7 +6142,7 @@ snapshots:
       argparse: 1.0.10
       esprima: 4.0.1
 
-  js-yaml@4.1.1:
+  js-yaml@4.3.0:
     dependencies:
       argparse: 2.0.1
 
@@ -6308,7 +6311,7 @@ snapshots:
 
   minimatch@9.0.9:
     dependencies:
-      brace-expansion: 2.1.1
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 


### PR DESCRIPTION
## Summary
開いているPRのほぼ全て（#515,#516,#517,#518,#520,#521 等）で `security-scan` チェックが `pnpm audit --audit-level=high` で落ちていた。原因は `main` のロックファイルに既に含まれていた2件の高深刻度脆弱性で、個々のPRの変更内容とは無関係。

- `js-yaml` 4.1.1（直接依存）→ `^4.3.0` に更新。[GHSA-52cp-r559-cp3m](https://github.com/advisories/GHSA-52cp-r559-cp3m)（YAML merge-key連鎖によるCPU二次消費）を修正。
- `brace-expansion`（`@google-analytics/data > google-gax > rimraf > glob > minimatch` 経由の推移依存、および `jest`/`javascript-obfuscator` の devDependencies経由）→ 既存の `pnpm.overrides`（`minimatch`/`protobufjs`/`@grpc/grpc-js` と同じ仕組み）で `>=5.0.8` に固定。[GHSA-3jxr-9vmj-r5cp](https://github.com/advisories/GHSA-3jxr-9vmj-r5cp) と [GHSA-mh99-v99m-4gvg](https://github.com/advisories/GHSA-mh99-v99m-4gvg)（brace展開によるDoS）を修正。`brace-expansion` は自コードから直接参照されておらず（minimatch/glob内部でのみ使用）、メジャーバージョン跨ぎのoverrideによるAPI互換性リスクはなし。

## Test plan
- [x] `SCRIPTS/security-scan.sh` ローカル実行 → `CRITICAL/HIGH (FAIL): 0` / `Result: PASS`
- [x] `tsc --noEmit` クリーン
- [x] `pnpm run lint` exit 0（既存warningのみ、新規warningなし）
- [x] `pnpm run test` 実行 → 本マシン上でポート競合による既存のflaky失敗あり（*AuthGuard/routes系）だが、素の`main`チェックアウトでも同種・同程度のflaky失敗が再現することを確認済み。今回の依存変更による新規リグレッションではない。

このPRがマージされ次第、他の未マージPRは `main` を取り込めば `security-scan` が揃ってPASSするはず。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjefbeEsCmWNdVRwy2rS84