### PR TITLE
feat(admin-ui): ご利用状況・お支払いをclient_adminにも表示 + ページ説明文補完

### DIFF
--- a/admin-ui/src/components/AppSidebar.test.tsx
+++ b/admin-ui/src/components/AppSidebar.test.tsx
@@ -103,3 +103,25 @@ describe("AppSidebar — plan制限によるnav非表示", () => {
     expect(screen.queryByText("成約・効果分析")).toBeNull();
   });
 });
+
+describe("AppSidebar — ご利用状況・お支払いの可視性", () => {
+  it("client_adminにも「ご利用状況・お支払い」が表示される（旧UIはsuper_admin限定表示ではなかった）", () => {
+    vi.mocked(useAuth).mockReturnValue(baseAuth({ tenantPlan: "growth" }));
+    renderSidebar();
+
+    expect(screen.getByText("ご利用状況・お支払い")).toBeTruthy();
+  });
+
+  it("super_adminにも表示される", () => {
+    vi.mocked(useAuth).mockReturnValue(
+      baseAuth({
+        isSuperAdmin: true,
+        isClientAdmin: false,
+        user: { id: "2", email: "admin@example.com", role: "super_admin", tenantId: null, tenantName: null },
+      }),
+    );
+    renderSidebar();
+
+    expect(screen.getByText("ご利用状況・お支払い")).toBeTruthy();
+  });
+});

--- a/admin-ui/src/components/AppSidebar.tsx
+++ b/admin-ui/src/components/AppSidebar.tsx
@@ -79,6 +79,10 @@ const MAIN_SECTIONS: NavSection[] = [
       { label: "アバター設定", path: "/admin/avatar", icon: Palette },
       { label: "AIへの指示ルール", path: "/admin/tuning", icon: SlidersHorizontal },
       { label: "テストチャット", path: "/admin/chat-test", icon: FlaskConical },
+      // GID: 旧UIでは全admin可視だったご利用状況・お支払いを復元。
+      // ルート自体は元々 AdminRoute (super/client 両方許可) だったが、
+      // サイドバーからはsuper_admin専用セクションに置かれていたためclient_adminから辿れなかった
+      { label: "ご利用状況・お支払い", path: "/admin/billing", icon: CreditCard },
     ],
   },
 ];
@@ -90,7 +94,6 @@ const SUPER_ADMIN_SECTION: NavSection = {
     { label: "テナント管理", path: "/admin/tenants", icon: Building2 },
     { label: "お客様の声", path: "/admin/feedback", icon: MessageCircleHeart },
     { label: "代行作業管理", path: "/admin/options", icon: FileText },
-    { label: "請求・使用量", path: "/admin/billing", icon: CreditCard },
     { label: "システム稼働状況", path: "/admin/monitoring", icon: BellRing },
   ],
 };

--- a/admin-ui/src/pages/admin/avatar/AvatarListHeader.tsx
+++ b/admin-ui/src/pages/admin/avatar/AvatarListHeader.tsx
@@ -32,6 +32,11 @@ export function AvatarListHeader({
           <h1 style={{ fontSize: 24, fontWeight: 700, margin: 0, color: "var(--foreground)", display: "flex", alignItems: "center", gap: 8 }}>
             🎭 {lang === "ja" ? "アバター設定" : "Avatar Configs"}
           </h1>
+          <p style={{ fontSize: 13, color: "var(--muted-foreground)", margin: "4px 0 0" }}>
+            {lang === "ja"
+              ? "接客アバターの見た目・声・性格を作成・管理できます"
+              : "Create and manage your chat avatar's appearance, voice, and personality"}
+          </p>
           {!loading && (
             <p style={{ fontSize: 13, color: "var(--muted-foreground)", margin: "4px 0 0" }}>
               {isSuperAdmin

--- a/admin-ui/src/pages/admin/knowledge/[tenantId].tsx
+++ b/admin-ui/src/pages/admin/knowledge/[tenantId].tsx
@@ -119,6 +119,9 @@ export default function TenantKnowledgePage() {
         <h1 style={{ fontSize: 26, fontWeight: 700, margin: 0, color: "var(--foreground)" }}>
           {t("knowledge.title")}
         </h1>
+        <p style={{ fontSize: 14, color: "var(--muted-foreground)", marginTop: 4, marginBottom: 0 }}>
+          {t("knowledge.subtitle")}
+        </p>
         {isSuperAdmin ? (
           <div style={{ display: "flex", gap: 8, alignItems: "center", marginTop: 10 }}>
             <select


### PR DESCRIPTION
## 概要
main直下からの独立PR（他ブランチへの依存なし）。

## 変更
1. **請求画面の可視化**: 「ご利用状況・お支払い」を `SUPER_ADMIN_SECTION` から `MAIN_SECTIONS`「設定」セクションへ移動。旧UI（AdminNavBar）では `superAdminOnly` 指定なしで全adminに見えていたが、現行UIではsuper_admin専用セクションに置かれていたためclient_adminのサイドバーから消えていた。ルート自体は元々 `AdminRoute`（super/client両方許可）なので表示箇所を移すだけで復元できる
2. **ページ説明文の抜け漏れ補完**: 全管理画面ページを確認し、`knowledge/[tenantId].tsx` と `avatar/index.tsx`（`AvatarListHeader`）の2ページのみ冒頭の1行説明が欠けていたため追加。他の全ページ（escalations/knowledge-gaps/chat-history/tuning/billing/tenants/monitoring/options/engagement/analytics/chat-test/avatar-defaults/dashboard）は既に説明文があることを確認済み

## 判断が必要な点
請求画面をテナントに見せる方針は事前に確認済み（「1. 良い」）。

## Test plan
- [x] `npx tsc -b`（admin-ui）: 新規エラーなし
- [x] `npx vitest run`: 84件全通過（`AppSidebar.test.tsx` に新規2件: client_admin/super_adminどちらにも「ご利用状況・お支払い」が表示されること）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014cZaJ8Hz82okDwk5MrZWrx