### PR TITLE
fix(lp): ヒーローセクションの余白を整理して読みやすく

### DIFF
--- a/public/lp/index.html
+++ b/public/lp/index.html
@@ -297,10 +297,10 @@
 </nav>
 
 <!-- ===================== HERO ===================== -->
-<section id="hero" style="max-width:720px; margin:0 auto; padding:80px 20px 60px; text-align:center;">
+<section id="hero" style="max-width:800px; margin:0 auto; padding:104px 20px 96px; text-align:center;">
   <div>
     <!-- Live badge -->
-    <div style="display:inline-flex; align-items:center; gap:8px; background:rgba(34,197,94,0.1); border:1px solid rgba(34,197,94,0.25); border-radius:999px; padding:6px 14px; margin-bottom:28px;">
+    <div style="display:inline-flex; align-items:center; gap:8px; background:rgba(34,197,94,0.1); border:1px solid rgba(34,197,94,0.25); border-radius:999px; padding:6px 14px; margin-bottom:32px;">
       <div style="position:relative; width:8px; height:8px;">
         <span class="pulse-ring" style="position:absolute; inset:0; border-radius:50%; background:#22c55e; display:block;"></span>
         <span class="blink" style="position:absolute; inset:0; border-radius:50%; background:#22c55e; display:block;"></span>
@@ -309,37 +309,34 @@
     </div>
 
     <!-- H1 -->
-    <h1 style="font-size:clamp(28px,4vw,48px); font-weight:800; line-height:1.15; letter-spacing:-1px; margin:0 0 20px;">
+    <h1 style="font-size:clamp(30px,4.4vw,52px); font-weight:800; line-height:1.25; letter-spacing:-1px; margin:0 0 28px;">
       あなたのサイトに、<br>
       <span class="gradient-text">24時間365日</span><br>
       休まず働くAIを。
     </h1>
 
     <!-- Sub copy -->
-    <p style="font-size:16px; color:var(--muted); line-height:1.75; margin:0 auto 32px; max-width:520px;">
+    <p style="font-size:17px; color:var(--muted); line-height:1.85; margin:0 auto 44px; max-width:600px;">
       1行の埋め込みだけ。訪問者の「わからない」を3秒で解決し、購入・予約・問い合わせまで自動誘導。夜中の離脱を防ぎ、売上を逃さない。
     </p>
 
     <!-- CTA buttons -->
-    <div style="display:flex; flex-wrap:wrap; justify-content:center; gap:12px; margin-bottom:28px;">
-      <a href="#" onclick="if (window.FaqWidget) window.FaqWidget.open(); return false;" style="background:linear-gradient(135deg,#7c3aed,#8b5cf6); color:#fff; text-decoration:none; font-weight:700; font-size:15px; padding:13px 28px; border-radius:10px; display:inline-block; transition:opacity 0.2s;" onmouseover="this.style.opacity='0.85'" onmouseout="this.style.opacity='1'">AIに話しかける</a>
-      <a href="#contact" style="color:#c4b5fd; text-decoration:none; font-weight:600; font-size:15px; padding:13px 24px; border-radius:10px; border:1px solid rgba(139,92,246,0.35); display:inline-block; transition:all 0.2s;" onmouseover="this.style.borderColor='rgba(139,92,246,0.7)'" onmouseout="this.style.borderColor='rgba(139,92,246,0.35)'">無料で導入相談 →</a>
+    <div style="display:flex; flex-wrap:wrap; justify-content:center; gap:14px; margin-bottom:20px;">
+      <a href="#" onclick="if (window.FaqWidget) window.FaqWidget.open(); return false;" style="background:linear-gradient(135deg,#7c3aed,#8b5cf6); color:#fff; text-decoration:none; font-weight:700; font-size:15px; padding:14px 30px; border-radius:10px; display:inline-block; transition:opacity 0.2s;" onmouseover="this.style.opacity='0.85'" onmouseout="this.style.opacity='1'">AIに話しかける</a>
+      <a href="#contact" style="color:#c4b5fd; text-decoration:none; font-weight:600; font-size:15px; padding:14px 26px; border-radius:10px; border:1px solid rgba(139,92,246,0.35); display:inline-block; transition:all 0.2s;" onmouseover="this.style.borderColor='rgba(139,92,246,0.7)'" onmouseout="this.style.borderColor='rgba(139,92,246,0.35)'">無料で導入相談 →</a>
+    </div>
+
+    <!-- Widget hint (secondary, lightweight caption) -->
+    <div style="display:flex; align-items:center; justify-content:center; gap:8px; margin-bottom:48px;">
+      <span style="font-size:15px;">💬</span>
+      <span style="font-size:13px; color:var(--muted);">画面右下のアイコンからもAIアシスタントに話しかけられます</span>
     </div>
 
     <!-- Badges -->
-    <div style="display:flex; flex-wrap:wrap; justify-content:center; gap:10px; margin-bottom:36px;">
-      <span style="font-size:12px; color:#86efac; background:rgba(34,197,94,0.08); border:1px solid rgba(34,197,94,0.2); border-radius:6px; padding:4px 10px;">✓ 初月無料</span>
-      <span style="font-size:12px; color:#86efac; background:rgba(34,197,94,0.08); border:1px solid rgba(34,197,94,0.2); border-radius:6px; padding:4px 10px;">✓ 固定費ゼロ・従量課金</span>
-      <span style="font-size:12px; color:#86efac; background:rgba(34,197,94,0.08); border:1px solid rgba(34,197,94,0.2); border-radius:6px; padding:4px 10px;">✓ 最短3日で本番稼働</span>
-    </div>
-
-    <!-- Widget hint (all breakpoints) -->
-    <div style="display:flex; align-items:center; justify-content:center; gap:12px; padding:16px 20px; border-radius:12px; background:rgba(124,58,237,0.08); border:1px solid rgba(124,58,237,0.2);">
-      <div style="font-size:24px;">💬</div>
-      <div style="text-align:left;">
-        <div style="font-size:14px; color:#c4b5fd; font-weight:600; margin-bottom:2px;">AIアシスタントが右下に起動しています</div>
-        <div style="font-size:12px; color:var(--muted);">画面右下のアイコンをクリックして話しかけてみてください</div>
-      </div>
+    <div style="display:flex; flex-wrap:wrap; justify-content:center; gap:12px;">
+      <span style="font-size:12px; color:#86efac; background:rgba(34,197,94,0.08); border:1px solid rgba(34,197,94,0.2); border-radius:6px; padding:5px 12px;">✓ 初月無料</span>
+      <span style="font-size:12px; color:#86efac; background:rgba(34,197,94,0.08); border:1px solid rgba(34,197,94,0.2); border-radius:6px; padding:5px 12px;">✓ 固定費ゼロ・従量課金</span>
+      <span style="font-size:12px; color:#86efac; background:rgba(34,197,94,0.08); border:1px solid rgba(34,197,94,0.2); border-radius:6px; padding:5px 12px;">✓ 最短3日で本番稼働</span>
     </div>
   </div>
 </section>


### PR DESCRIPTION
## Summary
ヒーローセクションの各要素（バッジ・H1・サブコピー・CTA・信頼バッジ・ウィジェット案内）の余白がほぼ同じ狭さ（20〜36px）で並んでおり、視覚的な階層がなく詰まって見えていた問題を修正。

- ヒーローの`max-width`を720→800px、サブコピーの`max-width`を520→600pxに拡大（不自然な折り返しを解消）
- セクションの上下`padding`を拡大（固定ナビ・次のセクションとの区切りを明確化）
- 読む流れ（バッジ→H1→サブコピー→CTA）の余白を拡大しつつ、CTAボタン同士など関連要素はタイトにグルーピング
- 「AIアシスタントが右下に〜」のカード（背景・枠線付きで主張が強かった）を、CTA直下の控えめな1行キャプションに変更。信頼バッジはセクション末尾の軽いフッター行として再配置

## Test plan
- [x] Playwright でデスクトップ(1440px)・モバイル(390px)のスクリーンショットを確認、ユーザーに事前共有して方向性承認済み
- [x] コンソールエラーなし（CORS由来を除く）
- [x] #529（デモセクション削除）マージ後のmainにrebaseし、ヒーローCTAの`window.FaqWidget.open()`配線を維持したままマージコンフリクトを解消

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BjefbeEsCmWNdVRwy2rS84