### PR TITLE
fix(app): 「クライアントビューで見る」で新UI(copilot-preview)を表示する

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -118,9 +118,12 @@ function AppInner() {
   // Phase4: このブラウザだけの個人オプトイン(localStorage)で有効化した場合のみ、
   // 従来のランディング(/ , /admin)からもこの画面に入る。既定は無効=従来のダッシュボードのまま。
   // テナント全体・他ユーザーの挙動には一切影響しない。
+  // 追加: super_adminの「クライアントビューで見る」(previewMode)中は、このブラウザの
+  // オプトインフラグに関わらず常に新UI(copilot-preview)を表示する — 動作確認・デモ用途のため。
   const isLandingPath = location.pathname === "/" || location.pathname === "/admin";
   const isCopilotPreview =
-    location.pathname === "/copilot-preview" || (isLandingPath && isChatFirstDefaultEnabled());
+    location.pathname === "/copilot-preview" ||
+    (isLandingPath && (isChatFirstDefaultEnabled() || previewMode));
 
   if (isAuthBridge) {
     return (
@@ -131,7 +134,15 @@ function AppInner() {
   }
 
   if (isCopilotPreview) {
-    return <CopilotPreviewPage />;
+    // previewMode(クライアントビュー)中は「元に戻す」導線を残す必要がある。
+    // 実テナントの通常アクセス(previewMode=false)ではバナーを出さない。
+    return (
+      <>
+        {previewMode && <PreviewModeBanner />}
+        {previewMode && <div style={{ height: PREVIEW_MODE_BANNER_HEIGHT }} />}
+        <CopilotPreviewPage />
+      </>
+    );
   }
 
   if (isLogin) {


### PR DESCRIPTION
## 背景
`/copilot-preview`（R2C新チャットUI、テナント向けチャット・ファースト管理画面）は過去セッションで実装済みだったが、super_adminの「クライアントビューで見る」(previewMode)機能とは連動しておらず、プレビュー中も常に従来のサイドバー型ダッシュボードが表示されていた。

## 変更
- `isCopilotPreview` の条件に `previewMode` を追加。previewMode中はこのブラウザのlocalStorageオプトインフラグに関わらず常に新UIを表示する
- `isCopilotPreview` が true の分岐は早期returnでCopilotPreviewPageのみ描画するため、previewMode中に限り明示的に`PreviewModeBanner`（「元に戻す」導線）を表示し、プレビューから抜けられなくなる事故を防止
- 実テナントの通常アクセス（previewMode=false）はオプトインフラグのみで判定する既存挙動を維持、影響なし

## Test plan
- [x] `npx tsc -b`（admin-ui）: 新規エラーなし
- [x] `npx vitest run`: 118件全通過
- [ ] ステージングで「クライアントビューで見る」→ 新UI(copilot-preview)が表示され、「元に戻す」で通常ダッシュボードに戻れることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014cZaJ8Hz82okDwk5MrZWrx