### PR TITLE
fix(agent): activate_avatarツールのプラン制限バイパスを修正

### DIFF
--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -19,6 +19,7 @@ import { computeKpis } from '../monitoring/routes';
 import { checkSaiMonthlyCostCeiling } from '../options/routes';
 import { submitSaiTask, getSaiTask } from '../../../lib/sai/saiClient';
 import { trackUsage } from '../../../lib/billing/usageTracker';
+import { queryTenantPlan, planHasFeature } from '../../../lib/billing/planFeatures';
 import { isOnboardingIndustry, ONBOARDING_INDUSTRY_LABELS, INDUSTRY_FAQ_TEMPLATES } from './industryFaqTemplates';
 
 // ---------------------------------------------------------------------------
@@ -396,6 +397,16 @@ export async function executeToolCall(
       const id = String(args['id'] ?? '');
       if (!id) {
         return truncate('id は必須です');
+      }
+
+      // GID: LP料金表(Growth〜: AIアバター)に基づくプラン制限。
+      // tenants/routes.ts の features.avatar 更新チェックと同じ基準をここでも適用する
+      // （AIエージェント経由でのチャットからのアクティベートがプラン制限を素通りしないように）。
+      // 注入済みの db を使う（tenantHasFeature 経由だと内部で getPool() の実Poolを
+      // 使ってしまい、テストのモックPoolと食い違って汚染するため queryTenantPlan を直接使う）。
+      const plan = await queryTenantPlan(db, tenantId);
+      if (!planHasFeature(plan, 'avatar')) {
+        return truncate('AIアバター機能はGrowthプラン以上でご利用いただけます');
       }
 
       const client = await db.connect();

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -1990,6 +1990,81 @@ describe('POST /v1/admin/agent/chat', () => {
   });
 
   // -------------------------------------------------------------------------
+  // activate_avatar — プラン制限(Growth〜)がチャット経由でも素通りしないことの回帰テスト
+  // -------------------------------------------------------------------------
+  describe('activate_avatar: プラン制限', () => {
+    function toolCallResponse(id: string, name: string, args: Record<string, unknown> = {}) {
+      return {
+        ok: true,
+        json: async () => ({
+          choices: [{
+            message: {
+              content: null,
+              tool_calls: [{ id, type: 'function', function: { name, arguments: JSON.stringify(args) } }],
+            },
+          }],
+        }),
+        text: async () => '',
+      };
+    }
+
+    it('starterプランは有効化できず、DB更新(db.connect)も発火しない', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-act-1', 'activate_avatar', { id: 'av-1' }))
+        .mockResolvedValueOnce(makeGroqResponse('プラン制限のためお伝えしました。'));
+
+      mockQuery.mockResolvedValueOnce({ rows: [{ plan: 'starter' }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'アバターを有効化して', sessionId: 'sess-act-01' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('Growthプラン以上');
+      expect(mockConnect).not.toHaveBeenCalled();
+    });
+
+    it('growthプランは有効化できる', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-act-2', 'activate_avatar', { id: 'av-1' }))
+        .mockResolvedValueOnce(makeGroqResponse('有効化しました。'));
+
+      mockQuery.mockResolvedValueOnce({ rows: [{ plan: 'growth' }] });
+      const clientQuery = jest.fn()
+        .mockResolvedValueOnce({ rows: [] }) // BEGIN
+        .mockResolvedValueOnce({ rows: [] }) // deactivate all
+        .mockResolvedValueOnce({ rows: [{ id: 'av-1' }] }) // activate target
+        .mockResolvedValueOnce({ rows: [] }) // tenants.features sync
+        .mockResolvedValueOnce({ rows: [] }); // COMMIT
+      mockConnect.mockResolvedValueOnce({ query: clientQuery, release: jest.fn() });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'アバターを有効化して', sessionId: 'sess-act-02' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('有効化しました');
+      expect(mockConnect).toHaveBeenCalledTimes(1);
+    });
+
+    it('planが未設定(null)の場合はfail-safeでstarter扱いとなり有効化できない', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-act-3', 'activate_avatar', { id: 'av-1' }))
+        .mockResolvedValueOnce(makeGroqResponse('プラン制限のためお伝えしました。'));
+
+      mockQuery.mockResolvedValueOnce({ rows: [{ plan: null }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'アバターを有効化して', sessionId: 'sess-act-03' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('Growthプラン以上');
+      expect(mockConnect).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // request_sai_task / get_sai_task_status
   // -------------------------------------------------------------------------
   describe('request_sai_task / get_sai_task_status', () => {


### PR DESCRIPTION
## 背景（ユーザーからの質問がきっかけ）
「新UIの案内も3つの料金体系を対象にした返答をするよね？」という質問を受けて調査したところ、AIエージェント（✨アシスタント / copilot-preview）が`tenantPlan`を一切参照していないことが判明。うち`activate_avatar`ツールは実害のある抜け穴だった。

## 抜け穴の内容
- サイドバー（FE）は`requiresPlan`でstarterプランからアバター設定メニューを非表示
- 対応する`PATCH /v1/admin/tenants/:id`（`features.avatar`更新）もサーバー側で`planHasFeature()`によりGrowth未満を403拒否
- しかしAIエージェントの`activate_avatar`ツールにはこのチェックが一切なく、**starterプランのテナントでもチャットで「アバターを有効化して」と頼めば有効化できてしまう**

analytics/conversion/voice_clone（Enterprise限定）はAIエージェントに対応ツール自体が存在しないため、現状の抜け穴は`activate_avatar`のみ。

## 変更
- `queryTenantPlan(db, tenantId)` + `planHasFeature(plan, 'avatar')` で、`tenants/routes.ts`と同じ基準のプランチェックを追加
- `tenantHasFeature()`はグローバルな`getPool()`を使うため、テストのモックPoolと食い違ってテスト汚染を起こす（PR#4で踏んだのと同じ問題）ことを避け、`executeToolCall`に既に注入済みの`db: Pool`で完結する`queryTenantPlan()`を直接使用

## Test plan
- [x] `npx tsc --noEmit`: エラーなし
- [x] `agentRoutes.test.ts`: 95件通過（新規3件: starterブロック/growth許可/plan未設定はfail-safeでブロック）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014cZaJ8Hz82okDwk5MrZWrx