### PR TITLE
fix(billing): anam_sessionの請求数量を秒数から分換算する

### DIFF
--- a/src/lib/billing/stripeSync.test.ts
+++ b/src/lib/billing/stripeSync.test.ts
@@ -10,7 +10,7 @@ jest.mock('stripe', () => {
   }));
 }, { virtual: true });
 
-import { PLAN_MULTIPLIERS, planMultiplier, lemonsliceShareJpy, monthlyShareJpy, getLemonsliceMonthlyFeeJpy, getLivekitMonthlyFeeJpy, getPlatformMonthlyFeeJpy, chargeOneOffJpy } from './stripeSync';
+import { PLAN_MULTIPLIERS, planMultiplier, lemonsliceShareJpy, monthlyShareJpy, getLemonsliceMonthlyFeeJpy, getLivekitMonthlyFeeJpy, getPlatformMonthlyFeeJpy, chargeOneOffJpy, anamSessionBillableUnits } from './stripeSync';
 
 describe('planMultiplier', () => {
   it('プラン別の倍率を返す（Starter 1.0 / Growth 1.5 / Enterprise 2.5）', () => {
@@ -46,6 +46,67 @@ describe('billedQuantity 算出（Math.ceil(totalRequests * multiplier)）', () 
   it('Enterprise は 2.5 倍', () => {
     expect(billed(100, 'enterprise')).toBe(250);
     expect(billed(3, 'enterprise')).toBe(8); // 7.5 → 8
+  });
+});
+
+// GID 1216944002701788: Anam.aiは$0.16/分の時間課金だが、Stripe報告数量は他機能と同じ
+// 「1行=1リクエスト」のままだと3分セッションが1リクエスト分の単価でしか請求されず赤字になる。
+// anam_session行のみ秒→分に換算して billable units に加算する（案A: 行数ベースは維持）。
+describe('anamSessionBillableUnits（anam_session行の秒→分換算・切り上げ）', () => {
+  it('0秒は0（対象外）', () => {
+    expect(anamSessionBillableUnits(0)).toBe(0);
+  });
+
+  it('59秒は1分に切り上げ', () => {
+    expect(anamSessionBillableUnits(59)).toBe(1);
+  });
+
+  it('60秒はちょうど1分', () => {
+    expect(anamSessionBillableUnits(60)).toBe(1);
+  });
+
+  it('61秒は2分に切り上げ', () => {
+    expect(anamSessionBillableUnits(61)).toBe(2);
+  });
+
+  it('3分(180秒)はちょうど3分', () => {
+    expect(anamSessionBillableUnits(180)).toBe(3);
+  });
+
+  it('null / undefined / 負値は0', () => {
+    expect(anamSessionBillableUnits(null)).toBe(0);
+    expect(anamSessionBillableUnits(undefined)).toBe(0);
+    expect(anamSessionBillableUnits(-5)).toBe(0);
+  });
+});
+
+describe('billedQuantity（anam_session混在時の分数換算を加算・後方互換）', () => {
+  // stripeSync._reportTenantUsage の集計SQL（billable_units）と同じ規則:
+  // billableUnits = 非anam行のCOUNT(*) + anam_session行のΣanamSessionBillableUnits(seconds)
+  const billed = (billableUnits: number, plan: string) =>
+    Math.ceil(billableUnits * planMultiplier(plan));
+
+  it('テキストのみのテナントは billableUnits === totalRequests のまま（現行と変わらない）', () => {
+    const billableUnits = 100; // anam_session行が無いのでCOUNT(*)と一致
+    expect(billed(billableUnits, 'starter')).toBe(100);
+    expect(billed(billableUnits, 'growth')).toBe(150);
+  });
+
+  it('chat 10件 + Anam 3分セッション1件（Starter）: 10 + 3 = 13', () => {
+    const billableUnits = 10 + anamSessionBillableUnits(180);
+    expect(billed(billableUnits, 'starter')).toBe(13);
+  });
+
+  it('chat 0件 + Anam 59秒セッション1件（Growth 1.5倍）: ceil(1 * 1.5) = 2', () => {
+    const billableUnits = anamSessionBillableUnits(59);
+    expect(billed(billableUnits, 'growth')).toBe(2);
+  });
+
+  it('Anam複数セッション(59秒+61秒+180秒)は行ごとに切り上げてから合算: 1+2+3=6', () => {
+    const billableUnits =
+      anamSessionBillableUnits(59) + anamSessionBillableUnits(61) + anamSessionBillableUnits(180);
+    expect(billableUnits).toBe(6);
+    expect(billed(billableUnits, 'enterprise')).toBe(15); // 6 * 2.5 = 15
   });
 });
 

--- a/src/lib/billing/stripeSync.ts
+++ b/src/lib/billing/stripeSync.ts
@@ -258,6 +258,22 @@ async function getSubscriptionItemId(
 }
 
 /**
+ * anam_session 1行分の請求数量（分単位、切り上げ）を返す。
+ *
+ * Anam.ai は $0.16/分の時間課金だが、Stripe報告数量は他機能と同じ「1行=1リクエスト」の
+ * まま合算すると、3分セッション(原価 約$0.16×3)が「1リクエスト」分の単価でしか請求されず
+ * 赤字になる（GID 1216944002701788）。anam_session行のみ秒→分に換算して数量に加算する。
+ *
+ * 切り上げ規則: 0秒は0（対象外）。1秒でも経過すれば1分として計上する
+ * （例: 59秒→1分、60秒→1分、61秒→2分、180秒→3分）。負値は0を返す。
+ */
+export function anamSessionBillableUnits(sessionSeconds: number | null | undefined): number {
+  const seconds = sessionSeconds ?? 0;
+  if (seconds <= 0) return 0;
+  return Math.ceil(seconds / 60);
+}
+
+/**
  * 指定期間のテナント使用量を集計してStripeに報告する（冪等）。
  *
  * @param db  pg.Pool インスタンス
@@ -325,7 +341,13 @@ async function _reportTenantUsage(
   const aggResult = await db.query(
     `SELECT
        COUNT(*)::integer           AS total_requests,
-       COALESCE(SUM(cost_total_cents), 0)::integer AS total_cost_cents
+       COALESCE(SUM(cost_total_cents), 0)::integer AS total_cost_cents,
+       COALESCE(SUM(
+         CASE WHEN feature_used = 'anam_session'
+              THEN CEIL(COALESCE(anam_session_seconds, 0) / 60.0)
+              ELSE 1
+         END
+       ), 0)::integer AS billable_units
      FROM usage_logs
      WHERE tenant_id = $1
        AND created_at >= $2
@@ -336,6 +358,9 @@ async function _reportTenantUsage(
 
   const totalRequests: number = aggResult.rows[0].total_requests;
   const totalCostCents: number = aggResult.rows[0].total_cost_cents;
+  // anam_session行は秒→分換算（anamSessionBillableUnits と同じ切り上げ規則をSQL側でも適用）、
+  // それ以外は従来通り1行=1単位。テキストのみのテナントは billableUnits === totalRequests。
+  const billableUnits: number = aggResult.rows[0].billable_units;
 
   if (totalRequests === 0) {
     logger.debug({ tenantId, periodYyyyMm }, '[stripeSync] no pending usage');
@@ -345,7 +370,7 @@ async function _reportTenantUsage(
   // プラン倍率を Stripe 報告数量に適用（リクエスト課金 × プラン別単価）。
   // 実リクエスト数は stripe_usage_reports.total_requests に保持し、請求数量のみ倍率適用する。
   const multiplier = planMultiplier(plan);
-  const billedQuantity = Math.ceil(totalRequests * multiplier);
+  const billedQuantity = Math.ceil(billableUnits * multiplier);
 
   const idempotencyKey = `billing:${tenantId}:${periodYyyyMm}`;
 
@@ -406,7 +431,7 @@ async function _reportTenantUsage(
       );
 
       logger.info(
-        { tenantId, periodYyyyMm, totalRequests, billedQuantity, plan, multiplier, totalCostCents },
+        { tenantId, periodYyyyMm, totalRequests, billableUnits, billedQuantity, plan, multiplier, totalCostCents },
         '[stripeSync] usage reported to Stripe'
       );
 


### PR DESCRIPTION
## 背景 (Asana gid 1216944002701788)
`src/lib/billing/stripeSync.ts` の Stripe 報告数量 (`billedQuantity`) は usage_logs の**行数**ベースで、`anam_session` 行の実時間 (`anam_session_seconds`) を一切考慮していませんでした。Anam.ai は $0.16/分の時間課金のため、3分セッション (原価 約$0.16×3 ≒ ¥72) が「1リクエスト」分の単価 (例: ¥5) でしか請求されず、1セッションあたり約¥69の赤字が発生していました。

## 実装内容 (案A: 行数ベースを維持しアバターのみ数量換算)
- `anamSessionBillableUnits(seconds)` を新設: `anam_session` 1行分の請求数量を秒→分（切り上げ）で返す純粋関数。
  - 切り上げ規則: 0秒→0（対象外）、1秒でも経過すれば1分計上 (59秒→1分、60秒→1分、61秒→2分、180秒→3分)。負値/null/undefinedは0。
- `_reportTenantUsage` の集計SQLに `billable_units` 列を追加:
  - `feature_used = 'anam_session'` の行は `CEIL(anam_session_seconds / 60.0)`
  - それ以外は従来通り1行=1単位
- `billedQuantity = Math.ceil(billableUnits * multiplier)` に変更。
  - `totalRequests`（実リクエスト数、`stripe_usage_reports.total_requests` 用）は変更なし。
  - `anam_session` 行が無いテナント（テキストのみ）は `billableUnits === totalRequests` となり、**請求数量は現行と完全に一致**（後方互換）。

## テスト
`src/lib/billing/stripeSync.test.ts` に追加:
- `anamSessionBillableUnits`: 0秒/59秒/60秒/61秒/180秒(3分)/負値・null・undefinedの境界値
- `billedQuantity`（anam_session混在時）: テキストのみテナントの後方互換確認、chat+anam混在時の加算、プラン倍率(Growth/Enterprise)適用、複数anamセッションの行ごと切り上げ合算

既存の `billedQuantity 算出`・冪等性 (`chargeOneOffJpy`) 系テストは変更なし（回帰確認済み）。

## npm test 結果
`src/lib/billing/*.test.ts` (billing関連スイート全6件) は全てPASS。
リポジトリ全体の `npm test` は、このサンドボックス環境固有の `EADDRNOTAVAIL`／タイムアウトによる supertest 系テストの断続的な失敗があります（billing と無関係のファイル: avatar routes, hermes, notifications, conversion tracking 等）。これは本PRの変更を含まない `origin/main` 側の未修正ブランチでも同様に再現するサンドボックス起因の既知の環境フラークネスであり、本変更による回帰ではないことを確認済みです。billing関連テストは安定してPASSしています。

## 要判断
特になし。