### PR TITLE
fix(avatar): Anam会話中のGroqチャットLLM usageを計測してusage_logsに記録

### DIFF
--- a/src/api/avatar/anamChatStreamRoutes.test.ts
+++ b/src/api/avatar/anamChatStreamRoutes.test.ts
@@ -10,31 +10,49 @@ jest.mock('../admin/chat-history/chatHistoryRepository', () => ({
   saveMessage: jest.fn(),
 }));
 
-import { saveMessage } from '../admin/chat-history/chatHistoryRepository';
-const mockSaveMessage = saveMessage as jest.Mock;
+jest.mock('../../lib/billing/usageTracker', () => ({
+  trackUsage: jest.fn(),
+}));
 
-// apiStack: テナントコンテキストをreqに注入するダミーミドルウェア
-function makeTenantStack(tenantId: string | null): RequestHandler[] {
+import { saveMessage } from '../admin/chat-history/chatHistoryRepository';
+import { trackUsage } from '../../lib/billing/usageTracker';
+const mockSaveMessage = saveMessage as jest.Mock;
+const mockTrackUsage = trackUsage as jest.Mock;
+
+// apiStack: テナントコンテキスト + requestId(requestIdMiddleware相当)をreqに注入するダミーミドルウェア
+let requestIdCounter = 0;
+function makeTenantStack(tenantId: string | null, requestId?: string): RequestHandler[] {
   return [
     (req, _res, next) => {
       (req as any).tenantId = tenantId;
+      (req as any).requestId = requestId ?? `req-anam-${++requestIdCounter}`;
       next();
     },
   ];
 }
 
-function makeApp(tenantId: string | null = 'carnation') {
+function makeApp(tenantId: string | null = 'carnation', requestId?: string) {
   const app = express();
   app.use(express.json());
-  registerAnamChatStreamRoutes(app, makeTenantStack(tenantId));
+  registerAnamChatStreamRoutes(app, makeTenantStack(tenantId, requestId));
   return app;
 }
 
-/** Groqのstreaming SSEレスポンスを模したReadableStream風オブジェクトを作る。 */
-function makeGroqStreamResponse(contentChunks: string[]) {
+/**
+ * Groqのstreaming SSEレスポンスを模したReadableStream風オブジェクトを作る。
+ * usage を渡すと、OpenAI互換のstream_options.include_usage同様、最終チャンクとして
+ * choicesなし・usageのみのdataを追加する。
+ */
+function makeGroqStreamResponse(
+  contentChunks: string[],
+  usage?: { prompt_tokens: number; completion_tokens: number },
+) {
   const lines = contentChunks.map(
     (c) => `data: ${JSON.stringify({ choices: [{ delta: { content: c } }] })}\n`,
   );
+  if (usage) {
+    lines.push(`data: ${JSON.stringify({ choices: [], usage })}\n`);
+  }
   lines.push('data: [DONE]\n');
   const fullText = lines.join('');
   const encoder = new TextEncoder();
@@ -55,9 +73,24 @@ function makeGroqStreamResponse(contentChunks: string[]) {
   };
 }
 
+/** ストリーム読み取り中にreader.read()が例外を投げる(接続断)ケースを模す。 */
+function makeGroqStreamInterrupted() {
+  return {
+    ok: true,
+    body: {
+      getReader: () => ({
+        read: async () => {
+          throw new Error('socket hang up');
+        },
+      }),
+    },
+  };
+}
+
 beforeEach(() => {
   mockSaveMessage.mockReset();
   mockSaveMessage.mockResolvedValue(undefined);
+  mockTrackUsage.mockReset();
   process.env.GROQ_API_KEY = 'test-groq-key';
   (global as any).fetch = jest.fn().mockResolvedValue(makeGroqStreamResponse(['こんにちは', '！']));
 });
@@ -137,5 +170,114 @@ describe('POST /api/avatar/chat-stream', () => {
 
     expect(res.status).toBe(400);
     expect(mockSaveMessage).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/avatar/chat-stream — usage計測(trackUsage)', () => {
+  it('usageが返る場合: Groqの最終チャンクのprompt_tokens/completion_tokensでtrackUsageを1回呼ぶ', async () => {
+    (global as any).fetch = jest
+      .fn()
+      .mockResolvedValue(
+        makeGroqStreamResponse(['こんにちは', '！'], { prompt_tokens: 42, completion_tokens: 7 }),
+      );
+
+    const res = await request(makeApp('carnation', 'req-usage-ok'))
+      .post('/api/avatar/chat-stream')
+      .send({ messages: [{ role: 'user', content: '保証はありますか' }], sessionId: 'sess-usage-1' });
+
+    expect(res.status).toBe(200);
+    expect(mockTrackUsage).toHaveBeenCalledTimes(1);
+    expect(mockTrackUsage).toHaveBeenCalledWith({
+      tenantId: 'carnation',
+      requestId: 'req-usage-ok',
+      model: 'llama-3.3-70b-versatile',
+      inputTokens: 42,
+      outputTokens: 7,
+      featureUsed: 'chat',
+    });
+  });
+
+  it('usageが返らない場合: silentに0計上せずlogger.warnを出しつつ0でtrackUsageする', async () => {
+    (global as any).fetch = jest.fn().mockResolvedValue(makeGroqStreamResponse(['こんにちは']));
+    const warnSpy = jest.spyOn(require('../../lib/logger').logger, 'warn').mockImplementation(() => {});
+
+    const res = await request(makeApp('carnation', 'req-usage-missing'))
+      .post('/api/avatar/chat-stream')
+      .send({ messages: [{ role: 'user', content: 'こんにちは' }] });
+
+    expect(res.status).toBe(200);
+    expect(mockTrackUsage).toHaveBeenCalledTimes(1);
+    expect(mockTrackUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: 'carnation',
+        requestId: 'req-usage-missing',
+        inputTokens: 0,
+        outputTokens: 0,
+        featureUsed: 'chat',
+      }),
+    );
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ requestId: 'req-usage-missing', tenantId: 'carnation' }),
+      expect.stringContaining('usage not returned'),
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it('ストリーム中断(接続断)の場合でも0扱いでtrackUsageを1回呼び、warnを出す(例外はレスポンスに変換される)', async () => {
+    (global as any).fetch = jest.fn().mockResolvedValue(makeGroqStreamInterrupted());
+    const warnSpy = jest.spyOn(require('../../lib/logger').logger, 'warn').mockImplementation(() => {});
+
+    const res = await request(makeApp('carnation', 'req-usage-interrupted'))
+      .post('/api/avatar/chat-stream')
+      .send({ messages: [{ role: 'user', content: 'こんにちは' }] });
+
+    // 最初のread()で例外なので、res.write前(headersSent=false)にouterのcatchへ抜け500になる。
+    expect(res.status).toBe(500);
+    expect(mockTrackUsage).toHaveBeenCalledTimes(1);
+    expect(mockTrackUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: 'carnation',
+        requestId: 'req-usage-interrupted',
+        inputTokens: 0,
+        outputTokens: 0,
+        featureUsed: 'chat',
+      }),
+    );
+    expect(warnSpy).toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  it('同一requestIdで再接続されても、trackUsageに渡すrequestIdは常に同じ安定キーになる(重複計上防止はDB側のON CONFLICTに委譲)', async () => {
+    // 各呼び出しごとに独立したstream/readerを返す(closureの使い回しでstate漏れしないように)。
+    (global as any).fetch = jest
+      .fn()
+      .mockImplementation(() =>
+        Promise.resolve(
+          makeGroqStreamResponse(['再送されたテスト応答'], { prompt_tokens: 10, completion_tokens: 5 }),
+        ),
+      );
+
+    const app = makeApp('carnation', 'req-reconnect-stable');
+    await request(app)
+      .post('/api/avatar/chat-stream')
+      .send({ messages: [{ role: 'user', content: '1回目' }], sessionId: 'sess-reconnect' });
+    await request(app)
+      .post('/api/avatar/chat-stream')
+      .send({ messages: [{ role: 'user', content: '2回目(再接続)' }], sessionId: 'sess-reconnect' });
+
+    expect(mockTrackUsage).toHaveBeenCalledTimes(2);
+    for (const call of mockTrackUsage.mock.calls) {
+      expect(call[0]).toEqual(
+        expect.objectContaining({
+          requestId: 'req-reconnect-stable',
+          inputTokens: 10,
+          outputTokens: 5,
+        }),
+      );
+    }
+    // 実際のusage_logsは request_id UNIQUE + ON CONFLICT DO NOTHING (usageTracker.ts) により
+    // 同一requestIdでの複数呼び出しでも1行のみ保存される(usageTracker.test.ts で検証済み)。
   });
 });

--- a/src/api/avatar/anamChatStreamRoutes.ts
+++ b/src/api/avatar/anamChatStreamRoutes.ts
@@ -12,8 +12,41 @@ import type { Express, Request, Response, RequestHandler } from 'express';
 import type { AuthedRequest } from '../../agent/http/authMiddleware';
 import { logger } from '../../lib/logger';
 import { saveMessage } from '../admin/chat-history/chatHistoryRepository';
+import { trackUsage } from '../../lib/billing/usageTracker';
 
 const GROQ_API_BASE = 'https://api.groq.com/openai/v1/chat/completions';
+
+/**
+ * Phase(Anam usage tracking): Groqストリーミング応答のusageをusage_logsへ記録する。
+ * fire-and-forget(trackUsage内部でsetImmediate)、レスポンスをブロックしない。
+ * requestId は req.requestId(requestIdMiddlewareが全リクエストに付与する安定キー)を使う。
+ * usage_logs は request_id UNIQUE + ON CONFLICT DO NOTHING のため、同一requestIdで
+ * 複数回呼ばれても(再接続・エラー後の二重呼び出し等)二重計上されない。
+ */
+function trackAnamChatUsage(params: {
+  tenantId: string;
+  requestId: string;
+  inputTokens: number | undefined;
+  outputTokens: number | undefined;
+}): void {
+  const { tenantId, requestId, inputTokens, outputTokens } = params;
+  if (inputTokens === undefined || outputTokens === undefined) {
+    // Groqがusageチャンクを返さないまま完了/中断した場合。
+    // silentに0計上せず、原価・請求が過少になり得ることを可視化する。
+    logger.warn(
+      { requestId, tenantId },
+      '[anamChatStream] Groq usage not returned — recording as 0 (cost/billing may be understated)',
+    );
+  }
+  trackUsage({
+    tenantId,
+    requestId,
+    model: GROQ_VERSATILE_70B,
+    inputTokens: inputTokens ?? 0,
+    outputTokens: outputTokens ?? 0,
+    featureUsed: 'chat',
+  });
+}
 
 export function registerAnamChatStreamRoutes(app: Express, apiStack: RequestHandler[]): void {
   logger.info('[anamChatStream] POST /api/avatar/chat-stream registered');
@@ -108,6 +141,8 @@ export function registerAnamChatStreamRoutes(app: Express, apiStack: RequestHand
           model: GROQ_VERSATILE_70B,
           messages: groqMessages,
           stream: true,
+          // usage計測: 最終チャンクにusage(prompt_tokens/completion_tokens)を含めてもらう。
+          stream_options: { include_usage: true },
           max_tokens: 150,
           temperature: 0.7,
         }),
@@ -129,34 +164,49 @@ export function registerAnamChatStreamRoutes(app: Express, apiStack: RequestHand
       const decoder = new TextDecoder();
       let buffer = '';
       let assistantContent = '';
+      let inputTokens: number | undefined;
+      let outputTokens: number | undefined;
 
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
+      try {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
 
-        buffer += decoder.decode(value, { stream: true });
-        const lines = buffer.split('\n');
-        buffer = lines.pop() ?? '';
+          buffer += decoder.decode(value, { stream: true });
+          const lines = buffer.split('\n');
+          buffer = lines.pop() ?? '';
 
-        for (const line of lines) {
-          const trimmed = line.trim();
-          if (!trimmed.startsWith('data: ')) continue;
-          const data = trimmed.slice(6);
-          if (data === '[DONE]') continue;
+          for (const line of lines) {
+            const trimmed = line.trim();
+            if (!trimmed.startsWith('data: ')) continue;
+            const data = trimmed.slice(6);
+            if (data === '[DONE]') continue;
 
-          try {
-            const parsed = JSON.parse(data) as {
-              choices?: Array<{ delta?: { content?: string } }>;
-            };
-            const content = parsed.choices?.[0]?.delta?.content ?? '';
-            if (content) {
-              assistantContent += content;
-              res.write(JSON.stringify({ content }) + '\n');
+            try {
+              const parsed = JSON.parse(data) as {
+                choices?: Array<{ delta?: { content?: string } }>;
+                usage?: { prompt_tokens?: number; completion_tokens?: number };
+              };
+              const content = parsed.choices?.[0]?.delta?.content ?? '';
+              if (content) {
+                assistantContent += content;
+                res.write(JSON.stringify({ content }) + '\n');
+              }
+              // stream_options.include_usage時、最終チャンクはchoicesが空でusageのみを含む。
+              if (typeof parsed.usage?.prompt_tokens === 'number' && typeof parsed.usage?.completion_tokens === 'number') {
+                inputTokens = parsed.usage.prompt_tokens;
+                outputTokens = parsed.usage.completion_tokens;
+              }
+            } catch {
+              // JSON parse error — skip malformed chunk
             }
-          } catch {
-            // JSON parse error — skip malformed chunk
           }
         }
+      } finally {
+        // ストリームが正常完了/中断のどちらでも、ここまでに得たusage(未取得ならundefined)で計上する。
+        // requestId(req.requestId)は1リクエストにつき固定なので、再接続で二重にPOSTされない限り
+        // 二重計上は発生しない。二重POST自体はusage_logsのrequest_id UNIQUE制約で防がれる。
+        trackAnamChatUsage({ tenantId, requestId: req.requestId, inputTokens, outputTokens });
       }
 
       res.end();


### PR DESCRIPTION
## Summary
- Asana gid 1216944049266413 (P0): `src/api/avatar/anamChatStreamRoutes.ts` はGroq 70B (`GROQ_VERSATILE_70B`) をstreamで直接fetchしているだけで `trackUsage` を一度も呼んでおらず、Anamリアルタイムアバター会話中の全チャットLLMが `usage_logs` に残らず、原価も請求もゼロだった(END_USER_FEATURESなのに無料提供状態)。
- Groqリクエストに `stream_options: { include_usage: true }` を付与し、最終チャンクの `usage`(prompt_tokens/completion_tokens)を取得。
- ストリームの正常完了/中断のどちらでも `finally` で確実に `trackUsage({ tenantId, requestId, model, inputTokens, outputTokens, featureUsed: 'chat' })` を呼ぶ。
- `usage` が取得できない場合はsilentに0計上せず `logger.warn` を出す(既存パターンに合わせる)。
- `requestId` は `requestIdMiddleware` が全リクエストに付与する `req.requestId`(1リクエストにつき安定なキー)を使用。`usage_logs` は `request_id UNIQUE + ON CONFLICT DO NOTHING`(既存実装、無変更)のため、再接続時に同じ`requestId`で複数回呼ばれても二重計上されない。
- fire-and-forget(`trackUsage`内部で`setImmediate`)でレスポンスをブロックしない既存仕様を踏襲。

## テスト
`src/api/avatar/anamChatStreamRoutes.test.ts` に4件追加(既存5件は無変更):
- usageが返る場合: 最終チャンクのusageで`trackUsage`が正しい引数で1回呼ばれる
- usageが返らない場合: `logger.warn` を出しつつ0で`trackUsage`される
- ストリーム中断(reader.read()が例外)の場合でも0扱いで`trackUsage`が1回呼ばれ、warnが出る
- 同一requestIdでの再接続(2回POST)でも`trackUsage`に渡す`requestId`が常に同じ安定キーになることを確認(実際の重複排除はDB側のON CONFLICT、`usageTracker.test.ts`で別途検証済み)

`npx jest src/api/avatar/anamChatStreamRoutes.test.ts` → 9/9 green。
`npx tsc --noEmit` → clean。
`npx oxlint` (対象2ファイル) → warning無し。

全体`npm test`はこのsandboxed worktree環境で無関係な多数のスイート(auth guard/knowledge-gaps/livekit等)がポートバインド絡み(`EADDRNOTAVAIL`)で非決定的にflakyになる問題が本PRと無関係に既存(変更前のベースラインでも再現、実行毎に失敗するスイートの集合が変わる)。billing/avatar/chat/agent関連スイートのみを`--maxWorkers=1`でまとめて実行した場合は全てgreenであることを確認済み。

## 依存 / 要判断
- なし。`src/lib/billing/costCalculator.ts` / `stripeSync.ts` は編集していない(他レーン作業中のため回避)。

## Test plan
- [x] `npx jest src/api/avatar/anamChatStreamRoutes.test.ts` green (9/9)
- [x] `npx tsc --noEmit` clean
- [x] billing/avatar/chat/agent関連スイートまとめて実行しgreenを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1dxH199qQB3diHbsGLNxM