### PR TITLE
fix(admin): Sai月次コスト上限をテナント横断からテナント単位に修正

### DIFF
--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -1217,9 +1217,14 @@ export async function executeToolCall(
       }
 
       try {
-        const ceilingCheck = await checkSaiMonthlyCostCeiling(db);
+        const ceilingCheck = await checkSaiMonthlyCostCeiling(db, tenantId);
         if (!ceilingCheck.ok) {
-          return truncate('Saiの月次コスト上限に達しているため、今回は依頼できません。管理者に確認してください');
+          logger.warn({ event: 'sai_cost_ceiling_blocked', tenantId, ...ceilingCheck }, 'request_sai_task blocked: monthly cost ceiling reached');
+          const msg =
+            ceilingCheck.reason === 'global'
+              ? 'Saiの全体月次コスト上限に達しているため、今回は依頼できません。管理者に確認してください'
+              : 'Saiの月次コスト上限に達しているため、今回は依頼できません。管理者に確認してください';
+          return truncate(msg);
         }
 
         const { task_id } = await submitSaiTask({ description });

--- a/src/api/admin/options/routes.ts
+++ b/src/api/admin/options/routes.ts
@@ -69,20 +69,45 @@ function denyInsufficient(req: Request, res: Response, su: Record<string, any> |
 // Phase5 (Saiセキュリティ強化): 支出上限ガードレール
 // Sai VPS側の日次タスク数上限(SAI_MAX_TASKS_PER_DAY)とは独立した、
 // R2C本体側での月次コスト上限チェック(多層防御)。デフォルトOFF(未設定なら無制限)。
+//
+// バグ修正: 従来は usage_logs を feature_used='sai_agent' のみでテナント横断集計しており、
+// 1テナントが使い込むと他の全テナントのSaiが止まっていた。テナント単位の上限を主とし、
+// 自社防衛用の全体上限(任意・別env)を2段構えで持つ。どちらで止まったかを reason で区別する。
 // ---------------------------------------------------------------------------
-export async function checkSaiMonthlyCostCeiling(pool: any): Promise<{ ok: true } | { ok: false; spentCents: number; ceilingCents: number }> {
-  const ceilingCents = Number(process.env.SAI_MONTHLY_COST_CEILING_CENTS ?? '0');
-  if (!ceilingCents || ceilingCents <= 0) return { ok: true };
+export type SaiCeilingCheckResult =
+  | { ok: true }
+  | { ok: false; reason: 'tenant' | 'global'; spentCents: number; ceilingCents: number };
 
-  const result = await pool.query(
-    `SELECT COALESCE(SUM(cost_total_cents), 0) AS total
-     FROM usage_logs
-     WHERE feature_used = 'sai_agent' AND created_at >= date_trunc('month', NOW())`,
-  );
-  const spentCents = parseInt(result.rows[0]?.total ?? '0', 10);
-  if (spentCents >= ceilingCents) {
-    return { ok: false, spentCents, ceilingCents };
+export async function checkSaiMonthlyCostCeiling(pool: any, tenantId: string): Promise<SaiCeilingCheckResult> {
+  // テナント単位の上限(主)。未設定(0)なら従来どおり無制限。
+  const tenantCeilingCents = Number(process.env.SAI_MONTHLY_COST_CEILING_CENTS ?? '0');
+  if (tenantCeilingCents > 0) {
+    const tenantResult = await pool.query(
+      `SELECT COALESCE(SUM(cost_total_cents), 0) AS total
+       FROM usage_logs
+       WHERE feature_used = 'sai_agent' AND tenant_id = $1 AND created_at >= date_trunc('month', NOW())`,
+      [tenantId],
+    );
+    const tenantSpentCents = parseInt(tenantResult.rows[0]?.total ?? '0', 10);
+    if (tenantSpentCents >= tenantCeilingCents) {
+      return { ok: false, reason: 'tenant', spentCents: tenantSpentCents, ceilingCents: tenantCeilingCents };
+    }
   }
+
+  // 全体(自社防衛)上限(任意・2段構えの補強)。未設定(0)ならスキップ。
+  const globalCeilingCents = Number(process.env.SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS ?? '0');
+  if (globalCeilingCents > 0) {
+    const globalResult = await pool.query(
+      `SELECT COALESCE(SUM(cost_total_cents), 0) AS total
+       FROM usage_logs
+       WHERE feature_used = 'sai_agent' AND created_at >= date_trunc('month', NOW())`,
+    );
+    const globalSpentCents = parseInt(globalResult.rows[0]?.total ?? '0', 10);
+    if (globalSpentCents >= globalCeilingCents) {
+      return { ok: false, reason: 'global', spentCents: globalSpentCents, ceilingCents: globalCeilingCents };
+    }
+  }
+
   return { ok: true };
 }
 
@@ -100,10 +125,17 @@ async function attemptSaiForOrder(
   order: { id: string; tenant_id: string; description: string },
   maxSteps?: number,
 ): Promise<SaiAttemptResult> {
-  const ceilingCheck = await checkSaiMonthlyCostCeiling(pool);
+  const ceilingCheck = await checkSaiMonthlyCostCeiling(pool, order.tenant_id);
   if (!ceilingCheck.ok) {
-    logger.warn({ event: 'sai_cost_ceiling_blocked', ...ceilingCheck }, 'Sai attempt blocked: monthly cost ceiling reached');
-    return { ok: false, reason: 'ceiling', error: 'R2Cエージェント利用の月次コスト上限に達しています。管理者に確認してください。' };
+    logger.warn(
+      { event: 'sai_cost_ceiling_blocked', tenantId: order.tenant_id, ...ceilingCheck },
+      'Sai attempt blocked: monthly cost ceiling reached',
+    );
+    const error =
+      ceilingCheck.reason === 'global'
+        ? 'R2Cエージェント利用の全体月次コスト上限に達しています。管理者に確認してください。'
+        : 'R2Cエージェント利用の月次コスト上限に達しています。管理者に確認してください。';
+    return { ok: false, reason: 'ceiling', error };
   }
 
   // Phase6 (Sai Judge学習ループ): 承認済みルールがあれば作業内容に注入する。

--- a/src/api/admin/options/saiBridge.test.ts
+++ b/src/api/admin/options/saiBridge.test.ts
@@ -3,7 +3,7 @@
 
 import express from 'express';
 import request from 'supertest';
-import { registerOptionRoutes } from './routes';
+import { registerOptionRoutes, checkSaiMonthlyCostCeiling } from './routes';
 
 jest.mock('../../../admin/http/supabaseAuthMiddleware', () => ({
   supabaseAuthMiddleware: (_req: any, _res: any, next: any) => next(),
@@ -170,6 +170,41 @@ describe('POST /v1/admin/options/:id/try-sai', () => {
     expect(mockSubmitSaiTask).toHaveBeenCalled();
   });
 
+  it('バグ修正の回帰確認: 上限チェックSELECTはテナント単位(tenant_id条件)でフィルタする', async () => {
+    process.env.SAI_MONTHLY_COST_CEILING_CENTS = '1000';
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'order-1', tenant_id: 'tenant-x', description: 'x' }] });
+    mockQuery.mockResolvedValueOnce({ rows: [{ total: '500' }] });
+    mockSubmitSaiTask.mockResolvedValueOnce({ task_id: 'sai-task-1', status: 'queued' });
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [] });
+
+    await request(superAdminApp()).post('/v1/admin/options/order-1/try-sai').send({});
+
+    const ceilingCall = mockQuery.mock.calls[1]!;
+    expect(ceilingCall[0]).toContain('tenant_id = $1');
+    expect(ceilingCall[1]).toEqual(['tenant-x']);
+  });
+
+  it('テナント横断バグの回帰確認: テナントAが上限超過していてもテナントBは依頼できる', async () => {
+    process.env.SAI_MONTHLY_COST_CEILING_CENTS = '1000';
+
+    // 1回目: テナントAの発注 → 上限超過(429、依頼しない)
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'order-a', tenant_id: 'tenant-a', description: 'x' }] });
+    mockQuery.mockResolvedValueOnce({ rows: [{ total: '1000' }] });
+    const resA = await request(superAdminApp()).post('/v1/admin/options/order-a/try-sai').send({});
+    expect(resA.status).toBe(429);
+    expect(mockSubmitSaiTask).not.toHaveBeenCalled();
+
+    // 2回目: テナントBの発注 → 未使用(0円)なので依頼できる
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'order-b', tenant_id: 'tenant-b', description: 'y' }] });
+    mockQuery.mockResolvedValueOnce({ rows: [{ total: '0' }] });
+    mockSubmitSaiTask.mockResolvedValueOnce({ task_id: 'sai-task-b', status: 'queued' });
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [] });
+    const resB = await request(superAdminApp()).post('/v1/admin/options/order-b/try-sai').send({});
+
+    expect(resB.status).toBe(202);
+    expect(mockSubmitSaiTask).toHaveBeenCalledWith(expect.objectContaining({ description: 'y' }));
+  });
+
   it('SAI_API_KEY未設定時は503', async () => {
     mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'order-1', description: 'x' }] });
     mockSubmitSaiTask.mockRejectedValueOnce(new Error('SAI_API_KEY not set'));
@@ -298,5 +333,73 @@ describe('Phase6 (Sai Judge学習ループ): /v1/admin/sai-rules', () => {
     expect(res.status).toBe(200);
     expect(res.body.item.status).toBe('rejected');
     expect(mockRejectSaiRule).toHaveBeenCalledWith(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkSaiMonthlyCostCeiling: バグ修正(テナント横断集計 → テナント単位 + 任意の全体上限)の直接検証
+// ---------------------------------------------------------------------------
+describe('checkSaiMonthlyCostCeiling', () => {
+  const savedTenantCeiling = process.env.SAI_MONTHLY_COST_CEILING_CENTS;
+  const savedGlobalCeiling = process.env.SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS;
+
+  beforeEach(() => {
+    mockQuery.mockReset();
+    delete process.env.SAI_MONTHLY_COST_CEILING_CENTS;
+    delete process.env.SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS;
+  });
+
+  afterAll(() => {
+    if (savedTenantCeiling === undefined) delete process.env.SAI_MONTHLY_COST_CEILING_CENTS;
+    else process.env.SAI_MONTHLY_COST_CEILING_CENTS = savedTenantCeiling;
+    if (savedGlobalCeiling === undefined) delete process.env.SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS;
+    else process.env.SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS = savedGlobalCeiling;
+  });
+
+  it('両方未設定(0)なら従来どおり無制限で、DBクエリは一切発行しない(後方互換)', async () => {
+    const pool = { query: mockQuery };
+    const result = await checkSaiMonthlyCostCeiling(pool, 'tenant-a');
+
+    expect(result).toEqual({ ok: true });
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it('テナントAが上限超過していてもテナントBの判定には影響しない(テナント単位)', async () => {
+    process.env.SAI_MONTHLY_COST_CEILING_CENTS = '1000';
+    const pool = { query: mockQuery };
+
+    mockQuery.mockResolvedValueOnce({ rows: [{ total: '1500' }] });
+    const resultA = await checkSaiMonthlyCostCeiling(pool, 'tenant-a');
+    expect(resultA).toEqual({ ok: false, reason: 'tenant', spentCents: 1500, ceilingCents: 1000 });
+
+    mockQuery.mockResolvedValueOnce({ rows: [{ total: '0' }] });
+    const resultB = await checkSaiMonthlyCostCeiling(pool, 'tenant-b');
+    expect(resultB).toEqual({ ok: true });
+
+    expect(mockQuery.mock.calls[0]![1]).toEqual(['tenant-a']);
+    expect(mockQuery.mock.calls[1]![1]).toEqual(['tenant-b']);
+  });
+
+  it('テナント上限は未満だが全体(自社防衛)上限に達している場合は reason=global で拒否する', async () => {
+    process.env.SAI_MONTHLY_COST_CEILING_CENTS = '10000';
+    process.env.SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS = '5000';
+    const pool = { query: mockQuery };
+
+    mockQuery.mockResolvedValueOnce({ rows: [{ total: '100' }] }); // テナント単位: 余裕あり
+    mockQuery.mockResolvedValueOnce({ rows: [{ total: '5000' }] }); // 全体: 上限到達
+
+    const result = await checkSaiMonthlyCostCeiling(pool, 'tenant-a');
+    expect(result).toEqual({ ok: false, reason: 'global', spentCents: 5000, ceilingCents: 5000 });
+  });
+
+  it('テナント上限のみ設定(全体上限は未設定)なら全体集計クエリは発行しない', async () => {
+    process.env.SAI_MONTHLY_COST_CEILING_CENTS = '1000';
+    const pool = { query: mockQuery };
+
+    mockQuery.mockResolvedValueOnce({ rows: [{ total: '0' }] });
+    const result = await checkSaiMonthlyCostCeiling(pool, 'tenant-a');
+
+    expect(result).toEqual({ ok: true });
+    expect(mockQuery).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
## Summary
- Asana gid 1216944050151626 (バグ): `src/api/admin/options/routes.ts:73-87` の `checkSaiMonthlyCostCeiling` は `usage_logs` を `WHERE feature_used='sai_agent'` のみで集計しており **tenant_id 条件がなかった**。テナント横断の合計で上限判定していたため、あるテナントが使い込むと他の全テナントのSaiが一律停止していた。
- `checkSaiMonthlyCostCeiling(pool, tenantId)` に `tenantId` を必須化し、`WHERE tenant_id = $1` でテナント単位判定に修正。
- 自社防衛用の全体上限は別env `SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS` として2段構えで維持(テナント単位判定 → 全体判定の順)。どちらで止まったかを `reason: 'tenant' | 'global'` で区別し、ログ・ユーザー向けメッセージの両方に反映。
- 呼び出し元2箇所を更新:
  - `src/api/admin/agent/actionExecutor.ts` の `request_sai_task`
  - `src/api/admin/options/routes.ts` の `attemptSaiForOrder`(手動try-sai・発注時の自動試行の両方から呼ばれる共通処理)

## 要判断
- `SAI_MONTHLY_COST_CEILING_CENTS`(テナント単位)/ `SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS`(全体・新設)とも、デフォルトは引き続き `'0'`(無制限)のままにしている。テナント単位に直した上で妥当なデフォルト上限値を入れるかどうかは本PRでは判断せず未決定のまま残した。運用側で必要な値を決めてenv設定してほしい。

## テスト
`src/api/admin/options/saiBridge.test.ts`:
- `checkSaiMonthlyCostCeiling` を直接呼ぶ新規describeを追加:
  - テナントAが上限超過していてもテナントBの判定には影響しない(テナント単位)
  - テナント上限は未満だが全体上限に達している場合は `reason: 'global'`
  - 両方未設定(0)なら従来どおり無制限で、DBクエリすら発行しない(後方互換)
  - テナント上限のみ設定なら全体集計クエリは発行しない
- 既存HTTPレイヤーのテスト群に回帰テストを追加:
  - 上限チェックSELECTが `tenant_id = $1` でフィルタされていることの確認
  - テナントAが上限超過(429)していてもテナントBは依頼できる(202)ことの確認
- 既存 `saiBridge.test.ts`(未設定時スキップ / 上限到達時429 / 上限未満時202 など)は無変更のまま green。
- 既存 `agentRoutes.test.ts` の `request_sai_task` / `get_sai_task_status` 関連テスト(`checkSaiMonthlyCostCeiling` をモック)は無変更のまま green。

`npx tsc --noEmit` → clean。
`npx oxlint`(対象3ファイル) → warning無し。

全体`npm test`はこのsandboxed worktree環境で無関係な多数のスイートがポートバインド絡み(`EADDRNOTAVAIL`)で非決定的にflakyになる問題が本PRと無関係に既存(Task1のPR #535でも同様に確認済み)。`src/api/admin/options` / `src/api/admin/agent` / `src/lib/billing` / `src/api/avatar` をまとめて`--maxWorkers=1`で実行し、フレーキーな1スイートは再実行すると単独で確実にgreenになることを確認済み。

## 依存
- なし。`src/lib/billing/costCalculator.ts` / `stripeSync.ts` は編集していない(他レーン作業中のため回避)。

## Test plan
- [x] `npx jest src/api/admin/options/saiBridge.test.ts` green (26/26、既存分含む)
- [x] `npx jest src/api/admin/agent/agentRoutes.test.ts` green (95/95、既存分含む、request_sai_task系も含む)
- [x] `npx tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1dxH199qQB3diHbsGLNxM