### PR TITLE
feat(billing): deep_research/premium_avatar/Sai代行にプランゲート追加

### DIFF
--- a/admin-ui/src/lib/planFeatures.test.ts
+++ b/admin-ui/src/lib/planFeatures.test.ts
@@ -13,6 +13,15 @@ describe("planHasFeature", () => {
     ["growth", "analytics", true],
     ["starter", "conversion", false],
     ["growth", "conversion", true],
+    ["starter", "deep_research", false],
+    ["growth", "deep_research", false],
+    ["enterprise", "deep_research", true],
+    ["starter", "premium_avatar", false],
+    ["growth", "premium_avatar", true],
+    ["enterprise", "premium_avatar", true],
+    ["starter", "sai_task", false],
+    ["growth", "sai_task", false],
+    ["enterprise", "sai_task", true],
   ] as const)("%s プランで %s = %s", (plan, feature, expected) => {
     expect(planHasFeature(plan, feature)).toBe(expected);
   });

--- a/admin-ui/src/lib/planFeatures.ts
+++ b/admin-ui/src/lib/planFeatures.ts
@@ -10,13 +10,24 @@ const PLAN_RANK: Record<TenantPlan, number> = {
   enterprise: 2,
 };
 
-export type GatedFeature = "avatar" | "voice_clone" | "analytics" | "conversion";
+export type GatedFeature =
+  | "avatar"
+  | "voice_clone"
+  | "analytics"
+  | "conversion"
+  | "deep_research"
+  | "premium_avatar"
+  | "sai_task";
 
 const FEATURE_MIN_PLAN: Record<GatedFeature, TenantPlan> = {
   avatar: "growth",
   voice_clone: "enterprise",
   analytics: "growth",
   conversion: "growth",
+  // GID 1216944249525907: 原価が跳ねる機能への新規プランゲート
+  deep_research: "enterprise",
+  premium_avatar: "growth",
+  sai_task: "enterprise",
 };
 
 /**

--- a/admin-ui/src/pages/admin/tenants/DeepResearchTab.test.tsx
+++ b/admin-ui/src/pages/admin/tenants/DeepResearchTab.test.tsx
@@ -1,0 +1,57 @@
+// GID 1216944249525907: ディープリサーチはEnterpriseプラン以上限定の回帰テスト
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import DeepResearchTab from "./DeepResearchTab";
+import type { TenantDetail } from "./types";
+
+vi.mock("../../../lib/api", () => ({
+  API_BASE: "http://localhost:3100",
+  authFetch: vi.fn(),
+}));
+
+function makeTenant(overrides: Partial<TenantDetail> = {}): TenantDetail {
+  return {
+    id: "tenant-a",
+    name: "Tenant A",
+    slug: "tenant-a",
+    plan: "starter",
+    status: "active",
+    createdAt: "2026-01-01T00:00:00Z",
+    widgetTitle: "",
+    widgetColor: "#000",
+    allowed_origins: [],
+    billing_enabled: false,
+    billing_free_from: null,
+    billing_free_until: null,
+    features: { avatar: false, voice: false, rag: true, deep_research: false },
+    lemonslice_agent_id: null,
+    conversion_types: [],
+    ...overrides,
+  };
+}
+
+describe("DeepResearchTab — プラン制限による表示切替", () => {
+  it("plan=starter → トグルが無効化され、理由が表示される", () => {
+    render(<DeepResearchTab tenant={makeTenant({ plan: "starter" })} onUpdate={vi.fn()} showToast={vi.fn()} />);
+
+    const toggle = screen.getByLabelText("ディープリサーチ切り替え") as HTMLButtonElement;
+    expect(toggle.disabled).toBe(true);
+    expect(screen.getByText(/Enterpriseプラン以上でご利用いただけます/)).toBeTruthy();
+  });
+
+  it("plan=growth → まだEnterprise未達のためトグルは無効", () => {
+    render(<DeepResearchTab tenant={makeTenant({ plan: "growth" })} onUpdate={vi.fn()} showToast={vi.fn()} />);
+
+    const toggle = screen.getByLabelText("ディープリサーチ切り替え") as HTMLButtonElement;
+    expect(toggle.disabled).toBe(true);
+    expect(screen.getByText(/Enterpriseプラン以上でご利用いただけます/)).toBeTruthy();
+  });
+
+  it("plan=enterprise → トグルが有効化され、理由メッセージは表示されない", () => {
+    render(<DeepResearchTab tenant={makeTenant({ plan: "enterprise" })} onUpdate={vi.fn()} showToast={vi.fn()} />);
+
+    const toggle = screen.getByLabelText("ディープリサーチ切り替え") as HTMLButtonElement;
+    expect(toggle.disabled).toBe(false);
+    expect(screen.queryByText(/Enterpriseプラン以上でご利用いただけます/)).toBeNull();
+  });
+});

--- a/admin-ui/src/pages/admin/tenants/DeepResearchTab.tsx
+++ b/admin-ui/src/pages/admin/tenants/DeepResearchTab.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
 import { authFetch, API_BASE } from "../../../lib/api";
 import type { TenantDetail, TenantFeatures } from "./types";
-import { CARD_STYLE } from "./types";
+import { CARD_STYLE, PLAN_OPTIONS } from "./types";
+import { planHasFeature } from "../../../lib/planFeatures";
 
 async function updateDeepResearchSettings(
   tenantId: string,
@@ -42,7 +43,12 @@ export default function DeepResearchTab({
   const [saving, setSaving] = useState(false);
   const [confirmPending, setConfirmPending] = useState(false);
 
+  // GID 1216944249525907: ディープリサーチはEnterpriseプラン以上限定。
+  // 対象テナントのプランが未達の場合はトグルを無効化し理由を表示する。
+  const planAllowsDeepResearch = planHasFeature(tenant.plan, "deep_research");
+
   const handleToggle = async () => {
+    if (!planAllowsDeepResearch) return;
     const next = !deepResearch;
     if (next) {
       // ON切り替え → 確認ダイアログ
@@ -142,17 +148,18 @@ export default function DeepResearchTab({
         <button
           type="button"
           onClick={handleToggle}
-          disabled={saving}
+          disabled={saving || !planAllowsDeepResearch}
           aria-label="ディープリサーチ切り替え"
+          title={planAllowsDeepResearch ? undefined : "ディープリサーチはEnterpriseプラン以上でご利用いただけます"}
           style={{
             position: "relative",
             display: "inline-flex", alignItems: "center",
             width: 56, height: 32, borderRadius: 16,
             border: "none",
             background: deepResearch ? "#2563eb" : "#374151",
-            cursor: saving ? "not-allowed" : "pointer",
+            cursor: saving || !planAllowsDeepResearch ? "not-allowed" : "pointer",
             transition: "background 0.2s", flexShrink: 0,
-            opacity: saving ? 0.6 : 1,
+            opacity: saving || !planAllowsDeepResearch ? 0.6 : 1,
           }}
         >
           <span
@@ -165,6 +172,22 @@ export default function DeepResearchTab({
           />
         </button>
       </div>
+
+      {/* プラン未達の理由表示 */}
+      {!planAllowsDeepResearch && (
+        <div
+          style={{
+            borderRadius: 10,
+            border: "1px solid rgba(234,179,8,0.3)",
+            background: "rgba(234,179,8,0.08)",
+            padding: "12px 16px",
+            fontSize: 13, color: "#fbbf24", lineHeight: 1.6,
+          }}
+        >
+          🔒 ディープリサーチはEnterpriseプラン以上でご利用いただけます
+          （現在のプラン: {PLAN_OPTIONS.find((p) => p.value === tenant.plan)?.label ?? tenant.plan}）
+        </div>
+      )}
 
       {/* ONにすると何が実現できるか */}
       <div

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -1216,6 +1216,15 @@ export async function executeToolCall(
         return truncate('テナントが特定できません。super_admin の場合は対象テナントを指定してください');
       }
 
+      // GID 1216944249525907: LP料金表(Enterprise〜: Sai代行)に基づくプラン制限。
+      // super_adminは従来どおりバイパス。fail-safe: plan取得失敗時はstarter扱い(=拒否)。
+      if (!isSuperAdmin) {
+        const plan = await queryTenantPlan(db, tenantId);
+        if (!planHasFeature(plan, 'sai_task')) {
+          return truncate('Saiへの代行依頼はEnterpriseプラン以上でご利用いただけます');
+        }
+      }
+
       try {
         const ceilingCheck = await checkSaiMonthlyCostCeiling(db);
         if (!ceilingCheck.ok) {

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -2098,6 +2098,7 @@ describe('POST /v1/admin/agent/chat', () => {
     });
 
     it('client_admin: 月次コスト上限に達している場合は依頼されない', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [{ plan: 'enterprise' }] });
       mockCheckSaiMonthlyCostCeiling.mockResolvedValueOnce({ ok: false, spentCents: 100000, ceilingCents: 100000 });
       mockFetch
         .mockResolvedValueOnce(toolCallResponse('request_sai_task', { description: '送料表記を直して', confirmed: true }))
@@ -2113,6 +2114,7 @@ describe('POST /v1/admin/agent/chat', () => {
     });
 
     it('client_admin: confirmed=true かつ上限内 → Saiに依頼されタスクIDが返る', async () => {
+      mockQuery.mockResolvedValueOnce({ rows: [{ plan: 'enterprise' }] });
       mockFetch
         .mockResolvedValueOnce(toolCallResponse('request_sai_task', { description: '送料表記を新しい内容に更新', confirmed: true }))
         .mockResolvedValueOnce(makeGroqResponse('依頼しました。'));
@@ -2128,6 +2130,74 @@ describe('POST /v1/admin/agent/chat', () => {
         expect.objectContaining({ description: '送料表記を新しい内容に更新' }),
       );
       expect(res.body.actions[0].result).toContain('sai-task-99');
+    });
+
+    // -----------------------------------------------------------------------
+    // GID 1216944249525907: request_sai_task はEnterpriseプラン以上限定
+    // -----------------------------------------------------------------------
+    describe('request_sai_task: プラン制限', () => {
+      it('starterプランは依頼できず、Saiにも上限チェックにも到達しない', async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [{ plan: 'starter' }] });
+        mockFetch
+          .mockResolvedValueOnce(toolCallResponse('request_sai_task', { description: '送料表記を直して', confirmed: true }))
+          .mockResolvedValueOnce(makeGroqResponse('プラン制限のためお伝えしました。'));
+
+        const res = await request(makeApp(CLIENT_ADMIN_USER))
+          .post('/v1/admin/agent/chat')
+          .send({ message: '送料表記を直して', sessionId: 'sess-sai-plan-01' });
+
+        expect(res.status).toBe(200);
+        expect(res.body.actions[0].result).toContain('Enterpriseプラン以上');
+        expect(mockCheckSaiMonthlyCostCeiling).not.toHaveBeenCalled();
+        expect(mockSubmitSaiTask).not.toHaveBeenCalled();
+      });
+
+      it('growthプランはまだEnterprise未達のため依頼できない', async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [{ plan: 'growth' }] });
+        mockFetch
+          .mockResolvedValueOnce(toolCallResponse('request_sai_task', { description: '送料表記を直して', confirmed: true }))
+          .mockResolvedValueOnce(makeGroqResponse('プラン制限のためお伝えしました。'));
+
+        const res = await request(makeApp(CLIENT_ADMIN_USER))
+          .post('/v1/admin/agent/chat')
+          .send({ message: '送料表記を直して', sessionId: 'sess-sai-plan-02' });
+
+        expect(res.status).toBe(200);
+        expect(res.body.actions[0].result).toContain('Enterpriseプラン以上');
+        expect(mockSubmitSaiTask).not.toHaveBeenCalled();
+      });
+
+      it('planが未設定(null)の場合はfail-safeでstarter扱いとなり依頼できない', async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [{ plan: null }] });
+        mockFetch
+          .mockResolvedValueOnce(toolCallResponse('request_sai_task', { description: '送料表記を直して', confirmed: true }))
+          .mockResolvedValueOnce(makeGroqResponse('プラン制限のためお伝えしました。'));
+
+        const res = await request(makeApp(CLIENT_ADMIN_USER))
+          .post('/v1/admin/agent/chat')
+          .send({ message: '送料表記を直して', sessionId: 'sess-sai-plan-03' });
+
+        expect(res.status).toBe(200);
+        expect(res.body.actions[0].result).toContain('Enterpriseプラン以上');
+        expect(mockSubmitSaiTask).not.toHaveBeenCalled();
+      });
+
+      it('super_adminはプラン(starter)に関わらずバイパスできる', async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [{ plan: 'starter' }] });
+        mockFetch
+          .mockResolvedValueOnce(toolCallResponse('request_sai_task', { description: '送料表記を直して', confirmed: true }))
+          .mockResolvedValueOnce(makeGroqResponse('依頼しました。'));
+
+        mockSubmitSaiTask.mockResolvedValueOnce({ task_id: 'sai-task-200', status: 'queued' });
+
+        const res = await request(makeApp(SUPER_ADMIN_USER))
+          .post('/v1/admin/agent/chat')
+          .send({ message: '送料表記を直して', sessionId: 'sess-sai-plan-04', targetTenantId: 'tenant-abc' });
+
+        expect(res.status).toBe(200);
+        expect(mockSubmitSaiTask).toHaveBeenCalled();
+        expect(res.body.actions[0].result).toContain('sai-task-200');
+      });
     });
 
     it('client_admin: get_sai_task_status で状態と自己申告非信用の注記を返す', async () => {

--- a/src/api/admin/avatar/premiumGenerationRoutes.test.ts
+++ b/src/api/admin/avatar/premiumGenerationRoutes.test.ts
@@ -22,6 +22,11 @@ jest.mock("../../../lib/magnific", () => ({
   upscaleWithMagnific: jest.fn(),
 }));
 
+const mockQuery = jest.fn();
+jest.mock("../../../lib/db", () => ({
+  getPool: () => ({ query: mockQuery }),
+}));
+
 const mockFetch = jest.fn();
 global.fetch = mockFetch;
 
@@ -30,11 +35,11 @@ const mockUpscale = upscaleWithMagnific as jest.Mock;
 
 // ── ヘルパー ──────────────────────────────────────────────────────────────────
 
-function makeApp(tenantId = "tenant-a") {
+function makeApp(tenantId = "tenant-a", role: "client_admin" | "super_admin" = "client_admin") {
   const app = express();
   app.use(express.json());
   app.use((req: any, _res: any, next: any) => {
-    req.supabaseUser = { app_metadata: { tenant_id: tenantId, role: 'client_admin' } };
+    req.supabaseUser = { app_metadata: { tenant_id: tenantId, role } };
     req.requestId = "req-premium-001";
     next();
   });
@@ -56,6 +61,9 @@ describe("POST /v1/admin/avatar/generate-premium", () => {
     jest.clearAllMocks();
     process.env.FAL_KEY = "test-fal-key";
     delete process.env.FREEPIK_API_KEY;
+    // デフォルトはgrowthプラン（プラン制限に無関係な既存テストを壊さないため）。
+    // プラン制限そのものをテストするケースはmockResolvedValueOnceで上書きする。
+    mockQuery.mockResolvedValue({ rows: [{ plan: "growth" }] });
   });
 
   afterEach(() => {
@@ -199,5 +207,78 @@ describe("POST /v1/admin/avatar/generate-premium", () => {
     expect(res.body).toHaveProperty("imageUrl");
     expect(res.body).toHaveProperty("originalUrl");
     expect(res.body).toHaveProperty("enhancedUrl");
+  });
+});
+
+// GID 1216944249525907: LP料金表(Growth〜: プレミアムアバター生成)に基づくプラン制限の回帰テスト
+describe("POST /v1/admin/avatar/generate-premium — プラン制限", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.FAL_KEY = "test-fal-key";
+    delete process.env.FREEPIK_API_KEY;
+  });
+
+  afterEach(() => {
+    delete process.env.FAL_KEY;
+    delete process.env.FREEPIK_API_KEY;
+  });
+
+  it("starterプランは403(plan_upgrade_required)で拒否され、FAL APIも呼ばれない", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ plan: "starter" }] });
+
+    const res = await request(makeApp("tenant-a", "client_admin"))
+      .post("/v1/admin/avatar/generate-premium")
+      .send({ prompt: VALID_PROMPT });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("plan_upgrade_required");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("growthプランは生成できる", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ plan: "growth" }] });
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => FAL_OK });
+
+    const res = await request(makeApp("tenant-a", "client_admin"))
+      .post("/v1/admin/avatar/generate-premium")
+      .send({ prompt: VALID_PROMPT });
+
+    expect(res.status).toBe(200);
+  });
+
+  it("enterpriseプランは生成できる", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ plan: "enterprise" }] });
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => FAL_OK });
+
+    const res = await request(makeApp("tenant-a", "client_admin"))
+      .post("/v1/admin/avatar/generate-premium")
+      .send({ prompt: VALID_PROMPT });
+
+    expect(res.status).toBe(200);
+  });
+
+  it("plan取得失敗時はfail-safeでstarter扱いとなり403", async () => {
+    mockQuery.mockRejectedValueOnce(new Error("db down"));
+
+    const res = await request(makeApp("tenant-a", "client_admin"))
+      .post("/v1/admin/avatar/generate-premium")
+      .send({ prompt: VALID_PROMPT });
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("plan_upgrade_required");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("super_adminはプラン(starter)に関わらずバイパスできる", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ plan: "starter" }] });
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => FAL_OK });
+
+    const res = await request(makeApp("tenant-a", "super_admin"))
+      .post("/v1/admin/avatar/generate-premium")
+      .send({ prompt: VALID_PROMPT });
+
+    expect(res.status).toBe(200);
+    // super_adminはプラン照会をバイパスするため、queryTenantPlan自体を呼ばない
+    expect(mockQuery).not.toHaveBeenCalled();
   });
 });

--- a/src/api/admin/avatar/premiumGenerationRoutes.ts
+++ b/src/api/admin/avatar/premiumGenerationRoutes.ts
@@ -8,6 +8,8 @@ import { supabaseAdmin } from "../../../auth/supabaseClient";
 import { logger } from "../../../lib/logger";
 import { upscaleWithMagnific } from "../../../lib/magnific";
 import { trackUsage } from "../../../lib/billing/usageTracker";
+import { getPool } from "../../../lib/db";
+import { queryTenantPlan, planHasFeature } from "../../../lib/billing/planFeatures";
 import { roleAuthMiddleware, requireRole, type AuthedReq } from "../../middleware/roleAuth";
 
 type AuthReq = Request & { supabaseUser?: Record<string, unknown>; requestId?: string };
@@ -117,6 +119,20 @@ export function registerPremiumGenerationRoutes(app: Express): void {
     const suMeta = su?.app_metadata as Record<string, unknown> | undefined;
     const tenantId = (suMeta?.tenant_id as string) ?? "";
     const requestId = (req as AuthReq).requestId ?? crypto.randomUUID();
+
+    // GID 1216944249525907: LP料金表(Growth〜: プレミアムアバター生成)に基づくプラン制限。
+    // super_adminは従来どおりバイパス。
+    // fail-safe: plan取得失敗時はqueryTenantPlanの既定挙動どおりstarter扱い(=拒否)。
+    const isSuperAdmin = (req as AuthedReq).user?.role === "super_admin";
+    if (!isSuperAdmin) {
+      const plan = await queryTenantPlan(getPool(), tenantId);
+      if (!planHasFeature(plan, "premium_avatar")) {
+        return res.status(403).json({
+          error: "plan_upgrade_required",
+          message: "プレミアムアバター生成はGrowthプラン以上でご利用いただけます",
+        });
+      }
+    }
 
     const falKey = process.env.FAL_KEY?.trim();
     if (!falKey) {

--- a/src/lib/billing/planFeatures.test.ts
+++ b/src/lib/billing/planFeatures.test.ts
@@ -20,6 +20,15 @@ describe("planHasFeature", () => {
     ["growth", "analytics", true],
     ["starter", "conversion", false],
     ["growth", "conversion", true],
+    ["starter", "deep_research", false],
+    ["growth", "deep_research", false],
+    ["enterprise", "deep_research", true],
+    ["starter", "premium_avatar", false],
+    ["growth", "premium_avatar", true],
+    ["enterprise", "premium_avatar", true],
+    ["starter", "sai_task", false],
+    ["growth", "sai_task", false],
+    ["enterprise", "sai_task", true],
   ] as const)("%s プランで %s = %s", (plan, feature, expected) => {
     expect(planHasFeature(plan, feature)).toBe(expected);
   });

--- a/src/lib/billing/planFeatures.ts
+++ b/src/lib/billing/planFeatures.ts
@@ -1,10 +1,11 @@
 // src/lib/billing/planFeatures.ts
 // LP(r2c.biz)の料金表に対応するプラン別機能制限。
-// 表示側(admin-ui/src/pages/admin/tenants/types.ts の PLAN_OPTIONS)と一致させること。
+// 表示側(admin-ui/src/lib/planFeatures.ts と admin-ui/src/pages/admin/tenants/types.ts の
+// PLAN_OPTIONS)と一致させること。
 //
 // LPの機能マッピング:
-//   Growth〜: AIアバター（顔・声）、高度なAnalytics、CV計測
-//   Enterprise〜: カスタムアバター（Fish Audio Voice Cloning）
+//   Growth〜: AIアバター（顔・声）、高度なAnalytics、CV計測、プレミアムアバター生成
+//   Enterprise〜: カスタムアバター（Fish Audio Voice Cloning）、ディープリサーチ、Sai代行（R2Cエージェント）
 // 「心理学Sales AI」は現状すべてのプランで提供するため、ここでは制限しない。
 
 import type { Pool } from "pg";
@@ -18,13 +19,24 @@ const PLAN_RANK: Record<TenantPlan, number> = {
   enterprise: 2,
 };
 
-export type GatedFeature = "avatar" | "voice_clone" | "analytics" | "conversion";
+export type GatedFeature =
+  | "avatar"
+  | "voice_clone"
+  | "analytics"
+  | "conversion"
+  | "deep_research"
+  | "premium_avatar"
+  | "sai_task";
 
 const FEATURE_MIN_PLAN: Record<GatedFeature, TenantPlan> = {
   avatar: "growth",
   voice_clone: "enterprise",
   analytics: "growth",
   conversion: "growth",
+  // GID 1216944249525907: 原価が跳ねる機能への新規プランゲート
+  deep_research: "enterprise",
+  premium_avatar: "growth",
+  sai_task: "enterprise",
 };
 
 function rank(plan: string | null | undefined): number {

--- a/src/lib/research/featureCheck.test.ts
+++ b/src/lib/research/featureCheck.test.ts
@@ -1,0 +1,71 @@
+// src/lib/research/featureCheck.test.ts
+// GID 1216944249525907: deep_research は features フラグ ON に加えて
+// プランが Enterprise 以上であることも要求する（原価が跳ねるため）。
+
+const mockQuery = jest.fn();
+jest.mock("../db", () => ({
+  getPool: () => ({ query: mockQuery }),
+}));
+
+import { isDeepResearchEnabled } from "./featureCheck";
+
+describe("isDeepResearchEnabled", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it("tenantId が空なら false", async () => {
+    expect(await isDeepResearchEnabled("")).toBe(false);
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  it("フラグOFFならプランに関係なくfalse", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ features: { deep_research: false }, plan: "enterprise" }],
+    });
+    expect(await isDeepResearchEnabled("tenant-a")).toBe(false);
+  });
+
+  it("フラグONでもstarterプランならfalse", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ features: { deep_research: true }, plan: "starter" }],
+    });
+    expect(await isDeepResearchEnabled("tenant-a")).toBe(false);
+  });
+
+  it("フラグONでもgrowthプランならfalse（Enterprise専用）", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ features: { deep_research: true }, plan: "growth" }],
+    });
+    expect(await isDeepResearchEnabled("tenant-a")).toBe(false);
+  });
+
+  it("フラグONかつenterpriseプランならtrue", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ features: { deep_research: true }, plan: "enterprise" }],
+    });
+    expect(await isDeepResearchEnabled("tenant-a")).toBe(true);
+  });
+
+  it("plan未設定(null)はfail-safeでstarter扱いとなりfalse", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{ features: { deep_research: true }, plan: null }],
+    });
+    expect(await isDeepResearchEnabled("tenant-a")).toBe(false);
+  });
+
+  it("テナント不在なら false", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    expect(await isDeepResearchEnabled("nonexistent")).toBe(false);
+  });
+
+  it("features未設定なら false", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ features: null, plan: "enterprise" }] });
+    expect(await isDeepResearchEnabled("tenant-a")).toBe(false);
+  });
+
+  it("DB障害時はfail-safeでfalse", async () => {
+    mockQuery.mockRejectedValueOnce(new Error("db down"));
+    expect(await isDeepResearchEnabled("tenant-a")).toBe(false);
+  });
+});

--- a/src/lib/research/featureCheck.ts
+++ b/src/lib/research/featureCheck.ts
@@ -2,22 +2,29 @@
 // Phase60-C: テナントのdeep_researchフラグ読み取り
 
 import { getPool } from '../db';
+import { planHasFeature } from '../billing/planFeatures';
 
 /**
  * テナントのdeep_researchフィーチャーフラグを読み取る。
  * DB未接続・テナント不在・features未設定の場合は false を返す（safe default）。
+ *
+ * GID 1216944249525907: features.deep_research がONでも、プランがEnterprise未満なら
+ * 利用不可とする（Perplexity Sonar ProはGroq系の30-50倍の原価がかかるため）。
+ * fail-safe: DB取得失敗時は false（=最も制限の強いstarter相当）を返す。
  */
 export async function isDeepResearchEnabled(tenantId: string): Promise<boolean> {
   if (!tenantId) return false;
   try {
     const pool = getPool();
-    const result = await pool.query<{ features: Record<string, unknown> | null }>(
-      'SELECT features FROM tenants WHERE id = $1 LIMIT 1',
+    const result = await pool.query<{ features: Record<string, unknown> | null; plan: string | null }>(
+      'SELECT features, plan FROM tenants WHERE id = $1 LIMIT 1',
       [tenantId],
     );
     if (result.rows.length === 0) return false;
-    const features = result.rows[0]!.features ?? {};
-    return features['deep_research'] === true;
+    const row = result.rows[0]!;
+    const features = row.features ?? {};
+    if (features['deep_research'] !== true) return false;
+    return planHasFeature(row.plan, 'deep_research');
   } catch {
     return false; // silent fail — DB unavailable or テナント未登録
   }

--- a/tests/phase60/featureCheck.test.ts
+++ b/tests/phase60/featureCheck.test.ts
@@ -17,23 +17,32 @@ beforeEach(() => {
   jest.clearAllMocks();
 });
 
-// 10. features.deep_research=true → true
-it('10. features.deep_research=true → true', async () => {
-  mockDbQuery.mockResolvedValueOnce({ rows: [{ features: { deep_research: true } }] });
+// 10. features.deep_research=true かつ enterpriseプラン → true
+// GID 1216944249525907: deep_researchはEnterpriseプラン以上限定になったため、
+// フラグONだけでなくplan=enterpriseもモックする必要がある。
+it('10. features.deep_research=true かつ enterpriseプラン → true', async () => {
+  mockDbQuery.mockResolvedValueOnce({ rows: [{ features: { deep_research: true }, plan: 'enterprise' }] });
   const result = await isDeepResearchEnabled('tenant-test');
   expect(result).toBe(true);
 });
 
+// 10b. features.deep_research=true でもプランがEnterprise未満 → false
+it('10b. features.deep_research=true でもgrowthプラン → false', async () => {
+  mockDbQuery.mockResolvedValueOnce({ rows: [{ features: { deep_research: true }, plan: 'growth' }] });
+  const result = await isDeepResearchEnabled('tenant-test');
+  expect(result).toBe(false);
+});
+
 // 11. features.deep_research=false → false
 it('11. features.deep_research=false → false', async () => {
-  mockDbQuery.mockResolvedValueOnce({ rows: [{ features: { deep_research: false } }] });
+  mockDbQuery.mockResolvedValueOnce({ rows: [{ features: { deep_research: false }, plan: 'enterprise' }] });
   const result = await isDeepResearchEnabled('tenant-test');
   expect(result).toBe(false);
 });
 
 // 12. features未設定 → false（デフォルト）
 it('12. features=null → false（デフォルト）', async () => {
-  mockDbQuery.mockResolvedValueOnce({ rows: [{ features: null }] });
+  mockDbQuery.mockResolvedValueOnce({ rows: [{ features: null, plan: 'enterprise' }] });
   const result = await isDeepResearchEnabled('tenant-test');
   expect(result).toBe(false);
 });


### PR DESCRIPTION
## Summary
Asana gid 1216944249525907。プラン制限が `avatar`/`voice_clone`/`analytics`/`conversion` の4つしかなく、原価が跳ねる以下3機能が無ゲートだった問題を修正。

- **deep_research**（Perplexity Sonar Pro、Groq系の30-50倍原価）: Enterpriseプラン限定
- **premium_avatar生成**（Flux 2 Pro + Magnific、LP表記はGrowth以上）: Growth以上限定
- **Sai代行**（`request_sai_task`、$0.05/step）: Enterpriseプラン限定

## 実装
- `src/lib/billing/planFeatures.ts` / `admin-ui/src/lib/planFeatures.ts` の `GatedFeature`/`FEATURE_MIN_PLAN` に3機能を追加（両ファイル一致）
- `src/lib/research/featureCheck.ts`: `isDeepResearchEnabled` にプラン判定を追加（`features.deep_research` フラグONでもEnterprise未満なら利用不可）
- `src/api/admin/avatar/premiumGenerationRoutes.ts`: `queryTenantPlan` + `planHasFeature` でGrowth未満を403 `plan_upgrade_required`
- `src/api/admin/agent/actionExecutor.ts`: `request_sai_task` にEnterprise未満を弾くチェックを追加（`activate_avatar` の既存パターンを踏襲）
- いずれも super_admin はバイパス、DB取得失敗時は starter 扱い（fail-safe、503を隠蔽しない）
- `admin-ui/.../DeepResearchTab.tsx`: 対象テナントがEnterprise未満の場合トグルを無効化し理由を表示

## Test plan
- [x] `src/lib/billing/planFeatures.test.ts` / `admin-ui/src/lib/planFeatures.test.ts` に3機能分のケース追加
- [x] `src/lib/research/featureCheck.test.ts`（新規）+ `tests/phase60/featureCheck.test.ts`（既存、plan列モック追加で修正）
- [x] `src/api/admin/avatar/premiumGenerationRoutes.test.ts`: starter/growth/enterprise/plan取得失敗/super_adminバイパスの5ケース追加
- [x] `src/api/admin/agent/agentRoutes.test.ts`: request_sai_taskのプラン制限マトリクス（starter/growth/null/super_adminバイパス）追加
- [x] `admin-ui/.../DeepResearchTab.test.tsx`（新規）: plan別のトグル無効化表示テスト
- [x] 変更した全テストファイルを個別実行しグリーン確認済み（他レーンと同時実行時はephemeralポート枯渇でnpm testのフルスイートがflakyになる環境要因あり、team-leadへ報告済み）

## 要判断として残した項目
- `actionExecutor.ts` の `activate_avatar`（既存, PR #533）はsuper_adminをバイパスしない設計になっており、本PRの3機能（super_adminバイパスあり）と方針が異なります。指示どおりsuper_adminバイパスで実装しましたが、一貫性を取るなら要検討です。

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

https://claude.ai/code/session_01B1dxH199qQB3diHbsGLNxM