### PR TITLE
feat(admin-ui): LP未記載機能の正式プラン組み入れ + 事前ディスパッチをEnterprise限定に

### DIFF
--- a/admin-ui/src/components/AppSidebar.test.tsx
+++ b/admin-ui/src/components/AppSidebar.test.tsx
@@ -104,6 +104,28 @@ describe("AppSidebar — plan制限によるnav非表示", () => {
   });
 });
 
+// GID 1216944004404664: LP未記載機能の正式プラン組み入れ。
+// Starterから提供する機能に誤ってゲートをかけていないことの回帰テスト。
+describe("AppSidebar — Starterプランでも使える機能(誤ゲート防止の回帰テスト)", () => {
+  it("client_admin + plan=starter → 対応中の会話/未回答質問/お客様への声がけ設定が表示される", () => {
+    vi.mocked(useAuth).mockReturnValue(baseAuth({ tenantPlan: "starter" }));
+    renderSidebar();
+
+    expect(screen.getByText("対応中の会話")).toBeTruthy();
+    expect(screen.getByText("未回答質問")).toBeTruthy();
+    expect(screen.getByText("お客様への声がけ設定")).toBeTruthy();
+  });
+
+  it("client_admin + plan未取得(null) → 対応中の会話/未回答質問/お客様への声がけ設定は非ゲートのため表示される", () => {
+    vi.mocked(useAuth).mockReturnValue(baseAuth({ tenantPlan: null }));
+    renderSidebar();
+
+    expect(screen.getByText("対応中の会話")).toBeTruthy();
+    expect(screen.getByText("未回答質問")).toBeTruthy();
+    expect(screen.getByText("お客様への声がけ設定")).toBeTruthy();
+  });
+});
+
 describe("AppSidebar — ご利用状況・お支払いの可視性", () => {
   it("client_adminにも「ご利用状況・お支払い」が表示される（旧UIはsuper_admin限定表示ではなかった）", () => {
     vi.mocked(useAuth).mockReturnValue(baseAuth({ tenantPlan: "growth" }));

--- a/admin-ui/src/lib/planFeatures.test.ts
+++ b/admin-ui/src/lib/planFeatures.test.ts
@@ -22,6 +22,9 @@ describe("planHasFeature", () => {
     ["starter", "sai_task", false],
     ["growth", "sai_task", false],
     ["enterprise", "sai_task", true],
+    ["starter", "pre_dispatch", false],
+    ["growth", "pre_dispatch", false],
+    ["enterprise", "pre_dispatch", true],
   ] as const)("%s プランで %s = %s", (plan, feature, expected) => {
     expect(planHasFeature(plan, feature)).toBe(expected);
   });

--- a/admin-ui/src/lib/planFeatures.ts
+++ b/admin-ui/src/lib/planFeatures.ts
@@ -17,7 +17,8 @@ export type GatedFeature =
   | "conversion"
   | "deep_research"
   | "premium_avatar"
-  | "sai_task";
+  | "sai_task"
+  | "pre_dispatch";
 
 const FEATURE_MIN_PLAN: Record<GatedFeature, TenantPlan> = {
   avatar: "growth",
@@ -28,6 +29,8 @@ const FEATURE_MIN_PLAN: Record<GatedFeature, TenantPlan> = {
   deep_research: "enterprise",
   premium_avatar: "growth",
   sai_task: "enterprise",
+  // GID 1216944004404664: 事前ディスパッチ(アバター高速表示)はLP表記どおりEnterprise限定
+  pre_dispatch: "enterprise",
 };
 
 /**

--- a/admin-ui/src/pages/admin/tenants/AvatarTab.test.tsx
+++ b/admin-ui/src/pages/admin/tenants/AvatarTab.test.tsx
@@ -1,0 +1,71 @@
+// GID 1216944004404664: 事前ディスパッチ(pre_dispatch)はEnterpriseプラン限定の回帰テスト
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, within } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { AvatarTab } from "./AvatarTab";
+import type { TenantDetail } from "./types";
+
+function makeTenant(overrides: Partial<TenantDetail> = {}): TenantDetail {
+  return {
+    id: "tenant-a",
+    name: "Tenant A",
+    slug: "tenant-a",
+    plan: "starter",
+    status: "active",
+    createdAt: "2026-01-01T00:00:00Z",
+    widgetTitle: "",
+    widgetColor: "#000",
+    allowed_origins: [],
+    billing_enabled: false,
+    billing_free_from: null,
+    billing_free_until: null,
+    features: { avatar: true, voice: false, rag: true },
+    lemonslice_agent_id: null,
+    conversion_types: [],
+    ...overrides,
+  };
+}
+
+function renderTab(tenant: TenantDetail) {
+  return render(
+    <MemoryRouter>
+      <AvatarTab tenant={tenant} onUpdate={vi.fn()} updateAvatarSettings={vi.fn()} />
+    </MemoryRouter>,
+  );
+}
+
+// 「アバター事前起動」カードの2つ上の親(カード全体)からトグルボタンを取得する。
+// 「⏸️ 無効」は音声会話トグルにも同じ文言があるため、カード単位で絞り込む必要がある。
+function getPreDispatchToggle(): HTMLButtonElement {
+  const heading = screen.getByText("アバター事前起動（高速表示）");
+  const card = heading.parentElement?.parentElement as HTMLElement;
+  return within(card).getByRole("button") as HTMLButtonElement;
+}
+
+describe("AvatarTab — 事前ディスパッチのプラン制限", () => {
+  it("plan=starter かつ未設定 → トグルが無効化され、理由が表示される", () => {
+    renderTab(makeTenant({ plan: "starter", features: { avatar: true, voice: false, rag: true, pre_dispatch: false } }));
+
+    expect(getPreDispatchToggle().disabled).toBe(true);
+    expect(screen.getByText(/事前ディスパッチはEnterpriseプラン以上でご利用いただけます/)).toBeTruthy();
+  });
+
+  it("plan=growth → まだEnterprise未達のためトグルは無効", () => {
+    renderTab(makeTenant({ plan: "growth", features: { avatar: true, voice: false, rag: true, pre_dispatch: false } }));
+
+    expect(getPreDispatchToggle().disabled).toBe(true);
+  });
+
+  it("plan=enterprise → トグルが有効化され、理由メッセージは表示されない", () => {
+    renderTab(makeTenant({ plan: "enterprise", features: { avatar: true, voice: false, rag: true, pre_dispatch: false } }));
+
+    expect(getPreDispatchToggle().disabled).toBe(false);
+    expect(screen.queryByText(/事前ディスパッチはEnterpriseプラン以上でご利用いただけます/)).toBeNull();
+  });
+
+  it("plan=starter でも既にON(ダウングレード後)ならOFFへの切り替えは許可される", () => {
+    renderTab(makeTenant({ plan: "starter", features: { avatar: true, voice: false, rag: true, pre_dispatch: true } }));
+
+    expect(getPreDispatchToggle().disabled).toBe(false);
+  });
+});

--- a/admin-ui/src/pages/admin/tenants/AvatarTab.tsx
+++ b/admin-ui/src/pages/admin/tenants/AvatarTab.tsx
@@ -2,7 +2,8 @@ import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { useLang } from "../../../i18n/LangContext";
 import type { TenantFeatures, TenantDetail } from "./types";
-import { CARD_STYLE, INPUT_STYLE, LABEL_STYLE } from "./types";
+import { CARD_STYLE, INPUT_STYLE, LABEL_STYLE, PLAN_OPTIONS } from "./types";
+import { planHasFeature } from "../../../lib/planFeatures";
 
 // ─── タブ: アバター設定 ────────────────────────────────────────────────────────
 
@@ -27,6 +28,10 @@ export function AvatarTab({
   const [agentId, setAgentId] = useState(tenant.lemonslice_agent_id ?? "");
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
+
+  // GID 1216944004404664: 事前ディスパッチはLP表記どおりEnterpriseプラン限定。
+  // 対象テナントのプランが未達の場合はトグルを無効化し理由を表示する。
+  const planAllowsPreDispatch = planHasFeature(tenant.plan, "pre_dispatch");
 
   const handleSave = async () => {
     setSaving(true);
@@ -205,12 +210,35 @@ export function AvatarTab({
               </>
             )}
           </div>
+          {!planAllowsPreDispatch && (
+            <div
+              style={{
+                marginTop: 8,
+                padding: "10px 12px",
+                borderRadius: 8,
+                background: "rgba(234,179,8,0.08)",
+                border: "1px solid rgba(234,179,8,0.3)",
+                fontSize: 12,
+                color: "#fbbf24",
+                lineHeight: 1.6,
+              }}
+            >
+              🔒 事前ディスパッチはEnterpriseプラン以上でご利用いただけます
+              （現在のプラン: {PLAN_OPTIONS.find((p) => p.value === tenant.plan)?.label ?? tenant.plan}）
+            </div>
+          )}
         </div>
         <button
           type="button"
-          onClick={() => { if (avatarEnabled) setPreDispatchEnabled((v) => !v); }}
-          disabled={!avatarEnabled}
-          style={toggleStyle(preDispatchEnabled, !avatarEnabled)}
+          onClick={() => {
+            if (!avatarEnabled) return;
+            // プラン未達でも「ON→OFF」は常に許可する（ダウングレード後に無効化できなくなるのを防ぐ）
+            if (!preDispatchEnabled && !planAllowsPreDispatch) return;
+            setPreDispatchEnabled((v) => !v);
+          }}
+          disabled={!avatarEnabled || (!preDispatchEnabled && !planAllowsPreDispatch)}
+          title={planAllowsPreDispatch ? undefined : "事前ディスパッチはEnterpriseプラン以上でご利用いただけます"}
+          style={toggleStyle(preDispatchEnabled, !avatarEnabled || (!preDispatchEnabled && !planAllowsPreDispatch))}
         >
           {preDispatchEnabled ? "⚡ 有効" : "⏸️ 無効"}
         </button>

--- a/admin-ui/src/pages/admin/tenants/types.ts
+++ b/admin-ui/src/pages/admin/tenants/types.ts
@@ -4,10 +4,12 @@ import type { CSSProperties } from "react";
 // プラン定義（バックエンド planValues と一致: starter/growth/enterprise）
 export type TenantPlan = "starter" | "growth" | "enterprise";
 
+// GID 1216944004404664: LP未記載機能の正式プラン組み入れに合わせてdescを更新。
+// Starterは有人エスカレーション/未回答質問/お客様への声がけ/心理学Sales AI/API連携が無ゲートで含まれる。
 export const PLAN_OPTIONS: { value: TenantPlan; label: string; multiplier: number; desc: string }[] = [
   { value: "starter",    label: "Starter",    multiplier: 1.0, desc: "小規模サイト向け（〜500対話/月）" },
-  { value: "growth",     label: "Growth",     multiplier: 1.5, desc: "成長期のビジネス向け（〜3,000対話/月）" },
-  { value: "enterprise", label: "Enterprise", multiplier: 2.5, desc: "大規模・高品質要求向け（無制限）" },
+  { value: "growth",     label: "Growth",     multiplier: 1.5, desc: "成長期のビジネス向け（〜3,000対話/月・AIアバター/Analytics/A-Bテスト/プレミアムアバター生成）" },
+  { value: "enterprise", label: "Enterprise", multiplier: 2.5, desc: "大規模・高品質要求向け（無制限・音声クローン/ディープリサーチ/Sai代行/事前ディスパッチ）" },
 ];
 
 export interface TenantFeatures {

--- a/src/lib/billing/planFeatures.test.ts
+++ b/src/lib/billing/planFeatures.test.ts
@@ -29,6 +29,9 @@ describe("planHasFeature", () => {
     ["starter", "sai_task", false],
     ["growth", "sai_task", false],
     ["enterprise", "sai_task", true],
+    ["starter", "pre_dispatch", false],
+    ["growth", "pre_dispatch", false],
+    ["enterprise", "pre_dispatch", true],
   ] as const)("%s プランで %s = %s", (plan, feature, expected) => {
     expect(planHasFeature(plan, feature)).toBe(expected);
   });

--- a/src/lib/billing/planFeatures.ts
+++ b/src/lib/billing/planFeatures.ts
@@ -26,7 +26,8 @@ export type GatedFeature =
   | "conversion"
   | "deep_research"
   | "premium_avatar"
-  | "sai_task";
+  | "sai_task"
+  | "pre_dispatch";
 
 const FEATURE_MIN_PLAN: Record<GatedFeature, TenantPlan> = {
   avatar: "growth",
@@ -37,6 +38,8 @@ const FEATURE_MIN_PLAN: Record<GatedFeature, TenantPlan> = {
   deep_research: "enterprise",
   premium_avatar: "growth",
   sai_task: "enterprise",
+  // GID 1216944004404664: 事前ディスパッチ(アバター高速表示)はLP表記どおりEnterprise限定
+  pre_dispatch: "enterprise",
 };
 
 function rank(plan: string | null | undefined): number {


### PR DESCRIPTION
## Summary
Asana gid 1216944004404664。既に実装済みだがLPにもプラン表にも記載がなかった機能の割当を整理し、admin-uiの表示・ガードを実装に整合させるタスク(表示側のみ担当)。

**Base branch について**: このPRは #538 (タスク1: deep_research/premium_avatar/Sai代行のプランゲート追加) の上に積んでいます。`admin-ui/src/lib/planFeatures.ts` / `src/lib/billing/planFeatures.ts` の `GatedFeature` 型を両タスクで共有しているためです。**#538がmainにマージされたら、このPRのbaseをmainに retarget してください。**

## 実装
- **事前ディスパッチ**(`features.pre_dispatch`, `AvatarTab.tsx`)を新規にEnterprise限定としてゲート — LP記載の3項目のうち唯一未ゲートだった項目
  - ダウングレード後もON→OFFの切り替えは常に許可(Enterprise未満で「無効化すらできない」状態を防止)
- `src/lib/billing/planFeatures.ts` / `admin-ui/src/lib/planFeatures.ts` の `GatedFeature`/`FEATURE_MIN_PLAN` に `pre_dispatch` を追加(両ファイル一致を維持。ヘッダコメントで明記された不変条件)
- `admin-ui/src/pages/admin/tenants/types.ts` の `PLAN_OPTIONS` の `desc` を実際の機能割当に合わせて更新
- Starter提供機能(有人エスカレーション/未回答質問/お客様への声がけ設定/心理学Sales AI/APIキー・許可ドメイン・埋め込みコード)は現状どおり無ゲートを維持 — 回帰テストで確認
- A/Bテスト・GA4連携・PostHog連携は super_admin のテナント管理画面内の設定タブであり、client_admin向けの直接ゲートは存在しない(既存の conversion/analytics ゲート越しにしか効果を持たない導線)。コード変更は不要と判断し、表記の整合のみ

## Test plan
- [x] `admin-ui/src/pages/admin/tenants/AvatarTab.test.tsx`(新規): pre_dispatchのプラン制限4ケース(starter無効化+理由表示、growth無効化、enterprise有効化、ダウングレード後OFF許可)
- [x] `admin-ui/src/components/AppSidebar.test.tsx`: Starter機能の誤ゲート防止回帰テストを追加(対応中の会話/未回答質問/お客様への声がけ設定がstarter/plan未取得でも表示されること)
- [x] `admin-ui/src/lib/planFeatures.test.ts` / `src/lib/billing/planFeatures.test.ts`: pre_dispatchのケースを追加
- [x] 変更した全テストファイルを個別実行しグリーン確認済み(admin-uiは `npm run test:ui` フルスイートも実行し139件全グリーン)
- [x] バックエンド`npm test`のフルスイートは、複数レーン同時実行によるephemeralポート枯渇(`EADDRNOTAVAIL`)で環境要因のflakinessがあり(#538で報告済み)、本PRの変更ファイル(`src/lib/billing/planFeatures.test.ts`)は個別実行でグリーン確認

## 要判断として残した項目
- なし。A/Bテスト等のGrowthゲートは既存の導線どおりで実装変更不要と判断しました。

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

https://claude.ai/code/session_01B1dxH199qQB3diHbsGLNxM