### PR TITLE
feat(lp): 料金表・機能一覧を実装に合わせて改訂しR2Cエージェントを追加

### DIFF
--- a/public/lp/index.html
+++ b/public/lp/index.html
@@ -613,6 +613,9 @@
         <div style="display:flex; align-items:center; gap:10px; font-size:14px; color:#e5e7eb;">
           <span style="color:#4ade80;">✓</span> マニュアル不要。迷ったらAIに聞くだけ
         </div>
+        <div style="display:flex; align-items:center; gap:10px; font-size:14px; color:#e5e7eb;">
+          <span style="color:#4ade80;">✓</span> 複雑な設定変更は「R2Cエージェント」に依頼すれば管理画面のGUI操作まで代行（Enterprise）
+        </div>
       </div>
     </div>
 
@@ -709,11 +712,13 @@
       </div>
     </div>
 
-    <div style="display:grid; grid-template-columns:repeat(3,1fr); gap:20px;">
+    <div class="pricing-grid" style="display:grid; grid-template-columns:repeat(3,1fr); gap:20px;">
       <style>
+        /* 既存バグ修正: display:contents な内側divにmedia queryが当たっていて767px以下で1カラム化されていなかった。
+           グリッドを実際に形成している外側divに .pricing-grid を付け替えて修正する。 */
         @media (max-width: 767px) { .pricing-grid { grid-template-columns: 1fr !important; } }
       </style>
-      <div class="pricing-grid" style="display:contents;">
+      <div style="display:contents;">
         <!-- Starter -->
         <div class="glass-card" style="border-radius:16px; padding:28px;">
           <div style="font-weight:700; font-size:18px; margin-bottom:6px;">Starter</div>
@@ -724,6 +729,10 @@
             <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> ウィジェット埋め込み</li>
             <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> FAQ RAG（PDF/URL）</li>
             <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> テキスト接客</li>
+            <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> 心理学Sales AI</li>
+            <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> 有人エスカレーション</li>
+            <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> 未回答質問の自動抽出</li>
+            <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> プロアクティブ声がけ</li>
             <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> 基本ダッシュボード</li>
           </ul>
           <a href="#contact" style="display:block; text-align:center; background:rgba(124,58,237,0.15); border:1px solid rgba(124,58,237,0.35); color:#c4b5fd; text-decoration:none; font-weight:600; font-size:14px; padding:12px; border-radius:10px; transition:all 0.2s;" onmouseover="this.style.background='rgba(124,58,237,0.25)'" onmouseout="this.style.background='rgba(124,58,237,0.15)'">無料で始める</a>
@@ -738,9 +747,11 @@
           <ul style="list-style:none; padding:0; margin:0 0 24px; display:flex; flex-direction:column; gap:10px;">
             <li style="font-size:13px; color:#fff; display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> Starterの全機能</li>
             <li style="font-size:13px; color:#fff; display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> AIアバター（顔・声）</li>
-            <li style="font-size:13px; color:#fff; display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> 心理学Sales AI</li>
             <li style="font-size:13px; color:#fff; display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> 高度なAnalytics</li>
             <li style="font-size:13px; color:#fff; display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> CV計測</li>
+            <li style="font-size:13px; color:#fff; display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> A/Bテスト</li>
+            <li style="font-size:13px; color:#fff; display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> GA4・PostHog連携</li>
+            <li style="font-size:13px; color:#fff; display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> プレミアムアバター生成（従量オプション）</li>
           </ul>
           <a href="#contact" style="display:block; text-align:center; background:linear-gradient(135deg,#7c3aed,#8b5cf6); color:#fff; text-decoration:none; font-weight:700; font-size:14px; padding:12px; border-radius:10px; transition:opacity 0.2s;" onmouseover="this.style.opacity='0.85'" onmouseout="this.style.opacity='1'">無料で始める</a>
         </div>
@@ -757,9 +768,20 @@
             <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> 専任サポート</li>
             <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> SLA保証</li>
             <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> カスタム開発対応</li>
+            <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> ディープリサーチ</li>
+            <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> 事前ディスパッチ（低レイテンシ）</li>
+            <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> R2Cエージェントによる設定代行</li>
           </ul>
           <a href="#contact" style="display:block; text-align:center; background:rgba(124,58,237,0.15); border:1px solid rgba(124,58,237,0.35); color:#c4b5fd; text-decoration:none; font-weight:600; font-size:14px; padding:12px; border-radius:10px; transition:all 0.2s;" onmouseover="this.style.background='rgba(124,58,237,0.25)'" onmouseout="this.style.background='rgba(124,58,237,0.15)'">お問い合わせ</a>
         </div>
+      </div>
+    </div>
+
+    <!-- 個別発注オプション(option_orders: Stripe別建て請求) -->
+    <div style="max-width:760px; margin:28px auto 0;">
+      <div class="glass-card" style="border-radius:12px; padding:18px 24px; font-size:13px; color:var(--muted); line-height:1.7; text-align:center;">
+        <strong style="color:#e5e7eb;">🎨 個別発注オプション（従量課金とは別建て）</strong><br>
+        プレミアムアバターの制作代行や、R2Cエージェントによる各種設定代行など、管理画面でAIと会話しながら依頼できる個別サービスがあります。これらは上記の対話課金とは別に、発注ごとにStripeで都度請求されます（金額は発注時にご案内）。
       </div>
     </div>
 


### PR DESCRIPTION
## Summary
Asana gid 1216944050906932。r2c.biz LP(`public/lp/index.html`)の3プラン機能行が実装と乖離していたため改訂。

- **Starter**: 心理学Sales AI(Growth欄から移動。`src/lib/billing/planFeatures.ts:8` のコメント通り現状全プラン提供のため) / 有人エスカレーション(`src/api/chat/escalationRoutes.ts`) / 未回答質問の自動抽出(knowledge-gaps) / プロアクティブ声がけ(engagement) を追加
- **Growth**: A/Bテスト(`src/api/conversion/abTestRoutes.ts`) / GA4・PostHog連携 / プレミアムアバター生成（従量オプション） を追加
- **Enterprise**: ディープリサーチ / 事前ディスパッチ（低レイテンシ） / R2Cエージェントによる設定代行 を追加
- 料金表グリッドの直下に「🎨 個別発注オプション（従量課金とは別建て）」カードを新設。プレミアムアバター制作代行・R2Cエージェント代行(`option_orders`)がStripeで都度請求される旨を明示(金額は記載せず、既存の「固定費ゼロ・従量のみ」という説明文との不整合を解消)
- 管理画面セクションのチェックリストにR2Cエージェントの記載を追加。**対外名称は「R2Cエージェント」で統一し「Sai」は一切出していない**(`src/api/admin/options/routes.ts:96` の実装コメントと同方針)。単価は未確定($0.05/stepは暫定値)のため金額は記載せずEnterprise限定機能として記載

## 既存バグ修正(pricing-grid のみ、本PRに同梱)
**pricing-grid のモバイル1カラム化が既存バグで効いていなかったため最小修正を同梱した。baseline再現スクショあり(team-leadに共有済み)。**

料金表グリッドが767px以下でも1カラム化されず、3カラムが潰れたまま表示される既存バグ(本PRの変更前=baselineから再現)。原因はCSSの`display:contents`な内側divにmedia queryが当たっており、実際にグリッドを形成している外側divには当たっていなかったこと。media query自体は既に存在し当たる要素が間違っていただけで、新しいデザイン判断ではなく意図された挙動への復元。今回追加した機能行でカードが縦に伸びるため、この修正なしでは「モバイルでレイアウトが崩れないこと」という完了条件を満たせない。**グリッドを形成する外側divへクラスを付け替える1行規模の最小修正**で `pricing-grid` のみ対応(pricingセクション内に閉じており他セクションに影響しない)。

同一パターンが `stats-grid` / `prob-sol-grid` / `uc-cards`(×3) / `feat-grid` / `form-2col` にも存在するが、**これらは本PRに含めていない**。team-lead側でAsanaに別タスクとして起票予定。

## 意図的に変更していない点
「1対話」の定義(699-702行目、767行目付近)は変更していない。実際の請求単位(`usage_logs`の行数)との整合は **lane-billingの管理系原価可視化タスク(gid 1216944003337186)の結果待ちのため今回は保留**。断定的な数値表現・定義の書き換えは行っていない。

## 依存関係
- プランゲート実装PR #538(`feature/plan-gates-deep-research-avatar-sai`)は**既にmerge済みであることを確認済み**。本PRはそれとは独立(静的HTMLのみ)なので、merge順序の制約はない。
- 「1対話」定義の整合は上記の通りlane-billing側のタスク完了待ち。本PRでは触れていない。

## 確認
Playwrightでデスクトップ(1440px)・モバイル(390px、767px以下のブレークポイント)双方をスクリーンショットで確認:
- [x] 料金表3カラムの高さが揃っている(CSS Gridのstretchで自動的に揃う。Starter 8項目・Growth 7項目・Enterprise 8項目)
- [x] モバイルで料金表が正しく1カラムに積み上がる(修正後)
- [x] `#contact` リンクが生きている
- [x] 管理画面セクションのR2Cエージェント行がデスクトップ/モバイルとも崩れずに表示される

## Merge
自分ではmergeしません。レビュー後、team-lead側でmergeしてください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1dxH199qQB3diHbsGLNxM