### PR TITLE
feat(billing): 管理系LLM呼び出しの原価可視化 + usage_logs.billableフラグ追加

### DIFF
--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -941,7 +941,7 @@ export async function executeToolCall(
       }
 
       try {
-        const suggestion = await suggestEngagementRuleFromText(freeText);
+        const suggestion = await suggestEngagementRuleFromText(freeText, tenantId);
         if (!suggestion.message_template) {
           return truncate('声がけの下書き生成に失敗しました。もう少し具体的に教えてください');
         }

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -1406,7 +1406,8 @@ describe('POST /v1/admin/agent/chat', () => {
         .send({ message: '商品ページを長く見てる人にランキングを勧めたい', sessionId: 'sess-060' });
 
       expect(res.status).toBe(200);
-      expect(mockSuggestEngagementRuleFromText).toHaveBeenCalledWith('商品ページを長く見てる人にランキングを勧めたい');
+      // GID 1216944003337186: trackUsage計測のためtenantIdも渡すようになった
+      expect(mockSuggestEngagementRuleFromText).toHaveBeenCalledWith('商品ページを長く見てる人にランキングを勧めたい', 'tenant-abc');
       expect(mockQuery).not.toHaveBeenCalled();
       const result = res.body.actions[0].result as string;
       expect(result).toContain('idle_time');

--- a/src/api/admin/agent/engagementSuggest.test.ts
+++ b/src/api/admin/agent/engagementSuggest.test.ts
@@ -1,0 +1,82 @@
+// src/api/admin/agent/engagementSuggest.test.ts
+// GID 1216944003337186: suggestEngagementRuleFromText のtrackUsage計測を検証。
+
+const mockTrackUsage = jest.fn();
+jest.mock('../../../lib/billing/usageTracker', () => ({
+  trackUsage: (...args: unknown[]) => mockTrackUsage(...args),
+}));
+
+import { suggestEngagementRuleFromText } from './engagementSuggest';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+const GROQ_OK_BODY = {
+  choices: [{ message: { content: JSON.stringify({
+    trigger_type: 'exit_intent',
+    trigger_config: {},
+    message_template: 'お待ちください！',
+    priority: 50,
+    reason: '離脱防止のため',
+  }) } }],
+  usage: { prompt_tokens: 90, completion_tokens: 40 },
+};
+
+describe('suggestEngagementRuleFromText', () => {
+  let savedEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    savedEnv = { ...process.env };
+    process.env.GROQ_API_KEY = 'test-groq-key';
+    mockTrackUsage.mockReset();
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    process.env = savedEnv;
+  });
+
+  it('tenantId指定・正常系: trackUsage(admin_engagement_suggest)を実トークン数で記録する', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => GROQ_OK_BODY });
+
+    const result = await suggestEngagementRuleFromText('離脱しそうな人に声をかけたい', 'tenant-a');
+
+    expect(result.message_template).toBe('お待ちください！');
+    expect(mockTrackUsage).toHaveBeenCalledTimes(1);
+    expect(mockTrackUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: 'tenant-a',
+        featureUsed: 'admin_engagement_suggest',
+        inputTokens: 90,
+        outputTokens: 40,
+      })
+    );
+  });
+
+  it('tenantId未指定はtrackUsageを呼ばない（原価を誰にも帰属できないため）', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => GROQ_OK_BODY });
+
+    await suggestEngagementRuleFromText('離脱しそうな人に声をかけたい');
+
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
+
+  it('GROQ_API_KEY未設定はtrackUsageを呼ばない', async () => {
+    delete process.env.GROQ_API_KEY;
+
+    const result = await suggestEngagementRuleFromText('声がけしたい', 'tenant-a');
+
+    expect(result.message_template).toBe('');
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
+
+  it('Groq APIエラー時はtrackUsageを呼ばない', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500 });
+
+    const result = await suggestEngagementRuleFromText('声がけしたい', 'tenant-a');
+
+    expect(result.message_template).toBe('');
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
+});

--- a/src/api/admin/agent/engagementSuggest.ts
+++ b/src/api/admin/agent/engagementSuggest.ts
@@ -3,6 +3,7 @@
 // tuning/routes.ts の callGroq8bSuggestFromText と同型のパターン。
 
 import { GROQ_INSTANT_8B } from '../../../config/groqModels';
+import { trackUsage } from '../../../lib/billing/usageTracker';
 
 export type EngagementTriggerType = 'scroll_depth' | 'idle_time' | 'exit_intent' | 'page_url_match';
 
@@ -56,7 +57,10 @@ function normalizeTriggerConfig(triggerType: EngagementTriggerType, raw: unknown
  * 自然文の指示から、お客様への声がけ(trigger_rules)を構造化提案する。
  * GROQ_API_KEY未設定・LLM応答が不正な場合は空の提案(message_templateが空文字)を返す。
  */
-export async function suggestEngagementRuleFromText(freeText: string): Promise<EngagementSuggestion> {
+export async function suggestEngagementRuleFromText(
+  freeText: string,
+  tenantId?: string,
+): Promise<EngagementSuggestion> {
   const apiKey = process.env.GROQ_API_KEY?.trim();
   if (!apiKey) return { ...EMPTY_SUGGESTION };
 
@@ -98,8 +102,24 @@ trigger_type は次の4種類から最も適切なものを1つ選んでくだ�
 
     if (!res.ok) return { ...EMPTY_SUGGESTION };
 
-    const data = (await res.json()) as { choices?: Array<{ message?: { content?: string } }> };
+    const data = (await res.json()) as {
+      choices?: Array<{ message?: { content?: string } }>;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
+    };
     const raw: string = data.choices?.[0]?.message?.content?.trim() ?? '';
+
+    // GID 1216944003337186: featureUsed='admin_engagement_suggest'はNON_BILLABLE_FEATURES
+    // のためStripe請求数量には含まれない（原価可視化のみ）。
+    if (tenantId) {
+      trackUsage({
+        tenantId,
+        requestId: `admin-engagement-suggest:${tenantId}:${Date.now()}`,
+        model: process.env.GROQ_MODEL_8B ?? GROQ_INSTANT_8B,
+        inputTokens: data.usage?.prompt_tokens ?? 0,
+        outputTokens: data.usage?.completion_tokens ?? 0,
+        featureUsed: 'admin_engagement_suggest',
+      });
+    }
 
     const jsonMatch = raw.match(/\{[\s\S]*\}/);
     if (!jsonMatch) return { ...EMPTY_SUGGESTION };

--- a/src/api/admin/ai-assist/routes.test.ts
+++ b/src/api/admin/ai-assist/routes.test.ts
@@ -1,0 +1,139 @@
+// src/api/admin/ai-assist/routes.test.ts
+// GID 1216944003337186: POST /v1/admin/ai-assist/chat のtrackUsage計測を検証。
+// admin_guideモード（detectIntent + callGroq8b）とbusiness_faqモード（detectIntent + callGroq70b）
+// のそれぞれでtrackUsage(featureUsed='admin_ai_assist')が記録されることを確認する。
+
+jest.mock('../../../admin/http/supabaseAuthMiddleware', () => ({
+  supabaseAuthMiddleware: (req: any, _res: any, next: any) => {
+    req.supabaseUser = req._mockUser ?? null;
+    next();
+  },
+}));
+jest.mock('../../../lib/db', () => ({
+  getPool: () => ({ query: jest.fn().mockResolvedValue({ rows: [{ id: 'fb-1' }] }) }),
+}));
+jest.mock('../../../lib/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock('../../../lib/knowledgeSearchUtil', () => ({
+  searchKnowledgeForSuggestion: jest.fn().mockResolvedValue({ results: [] }),
+  formatKnowledgeContext: jest.fn().mockReturnValue(''),
+}));
+jest.mock('../../../lib/crossTenantContext', () => ({
+  getCrossTenantContext: jest.fn().mockResolvedValue({
+    avgScores: null,
+    topPsychologyPrinciples: [],
+    commonGapPatterns: [],
+    effectiveRulePatterns: [],
+    totalTenants: 0,
+    dataAsOf: new Date().toISOString(),
+  }),
+  formatCrossTenantContext: jest.fn().mockReturnValue(''),
+}));
+jest.mock('../../../lib/research', () => ({
+  getResearchProvider: jest.fn().mockReturnValue(null),
+}));
+jest.mock('../../../lib/research/featureCheck', () => ({
+  isDeepResearchEnabled: jest.fn().mockResolvedValue(false),
+}));
+jest.mock('../../../lib/research/queryBuilder', () => ({
+  buildResearchQuery: jest.fn().mockReturnValue(''),
+}));
+
+const mockTrackUsage = jest.fn();
+jest.mock('../../../lib/billing/usageTracker', () => ({
+  trackUsage: (...args: unknown[]) => mockTrackUsage(...args),
+}));
+
+import express from 'express';
+import request from 'supertest';
+import { registerAdminAiAssistRoutes } from './routes';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+/** tenantId: null は「未認証」、'' は「認証済みだがテナント未特定（super_admin想定）」 */
+function makeApp(tenantId: string | null = 'tenant-a') {
+  const app = express();
+  app.use(express.json());
+  app.use((req: any, _res: any, next: any) => {
+    req._mockUser =
+      tenantId === null ? null : { app_metadata: { tenant_id: tenantId }, email: 'test@test.com' };
+    next();
+  });
+  app.use((req: any, _res: any, next: any) => {
+    req.supabaseUser = req._mockUser;
+    next();
+  });
+  registerAdminAiAssistRoutes(app);
+  return app;
+}
+
+function groqBody(content: string, usage = { prompt_tokens: 50, completion_tokens: 20 }) {
+  return { choices: [{ message: { content } }], usage };
+}
+
+describe('POST /v1/admin/ai-assist/chat — trackUsage計測', () => {
+  let savedEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    savedEnv = { ...process.env };
+    process.env.GROQ_API_KEY = 'test-groq-key';
+    mockTrackUsage.mockReset();
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    process.env = savedEnv;
+  });
+
+  it('admin_guideモード: intent判定 + 回答生成で計2回trackUsage(admin_ai_assist)が記録される', async () => {
+    // 1回目: detectIntent（admin_guideのまま） / 2回目: callGroq8b
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => groqBody('admin_guide', { prompt_tokens: 10, completion_tokens: 5 }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => groqBody('管理画面の使い方はこちらです', { prompt_tokens: 40, completion_tokens: 15 }) });
+
+    const res = await request(makeApp('tenant-a'))
+      .post('/v1/admin/ai-assist/chat')
+      .send({ message: 'FAQの登録方法は？' });
+
+    expect(res.status).toBe(200);
+    expect(mockTrackUsage).toHaveBeenCalledTimes(2);
+    for (const call of mockTrackUsage.mock.calls) {
+      expect(call[0]).toMatchObject({ tenantId: 'tenant-a', featureUsed: 'admin_ai_assist' });
+    }
+  });
+
+  it('business_faqモード: intent判定 + RAG回答生成で計2回trackUsage(admin_ai_assist)が記録される', async () => {
+    mockFetch
+      .mockResolvedValueOnce({ ok: true, json: async () => groqBody('business_faq', { prompt_tokens: 10, completion_tokens: 5 }) })
+      .mockResolvedValueOnce({ ok: true, json: async () => groqBody('営業時間は10時〜19時です', { prompt_tokens: 60, completion_tokens: 25 }) });
+
+    const res = await request(makeApp('tenant-a'))
+      .post('/v1/admin/ai-assist/chat')
+      .send({ message: '営業時間は？' });
+
+    expect(res.status).toBe(200);
+    expect(mockTrackUsage).toHaveBeenCalledTimes(2);
+  });
+
+  it('tenantIdなし（super_adminでテナント未特定）はtrackUsageを呼ばない', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => groqBody('管理画面の使い方はこちらです') });
+
+    const res = await request(makeApp(''))
+      .post('/v1/admin/ai-assist/chat')
+      .send({ message: 'FAQの登録方法は？' });
+
+    expect(res.status).toBe(200);
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
+
+  it('認証なしは403でtrackUsageを呼ばない', async () => {
+    const res = await request(makeApp(null))
+      .post('/v1/admin/ai-assist/chat')
+      .send({ message: 'FAQの登録方法は？' });
+
+    expect(res.status).toBe(403);
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
+});

--- a/src/api/admin/ai-assist/routes.ts
+++ b/src/api/admin/ai-assist/routes.ts
@@ -21,6 +21,7 @@ import {
 import { getResearchProvider } from '../../../lib/research';
 import { isDeepResearchEnabled } from '../../../lib/research/featureCheck';
 import { buildResearchQuery } from '../../../lib/research/queryBuilder';
+import { trackUsage } from '../../../lib/billing/usageTracker';
 
 
 // ---------------------------------------------------------------------------
@@ -46,7 +47,7 @@ function extractAuth(req: Request) {
 // インテント判定（Groq 8b — 軽量）
 // ---------------------------------------------------------------------------
 
-async function detectIntent(message: string): Promise<Intent> {
+async function detectIntent(message: string, tenantId: string): Promise<Intent> {
   const apiKey = process.env.GROQ_API_KEY?.trim();
   if (!apiKey) return "admin_guide";
 
@@ -73,6 +74,20 @@ async function detectIntent(message: string): Promise<Intent> {
     if (!res.ok) return "admin_guide";
     const data = (await res.json()) as any;
     const raw: string = data.choices?.[0]?.message?.content?.trim() ?? "";
+
+    // GID 1216944003337186: featureUsed='admin_ai_assist'はNON_BILLABLE_FEATURESのため
+    // Stripe請求数量には含まれない（原価可視化のみ）。
+    if (tenantId) {
+      trackUsage({
+        tenantId,
+        requestId: `admin-ai-assist-intent:${tenantId}:${Date.now()}`,
+        model: GROQ_INSTANT_8B,
+        inputTokens: data.usage?.prompt_tokens ?? 0,
+        outputTokens: data.usage?.completion_tokens ?? 0,
+        featureUsed: "admin_ai_assist",
+      });
+    }
+
     return raw.includes("business_faq") ? "business_faq" : "admin_guide";
   } catch {
     return "admin_guide"; // fail-safe
@@ -83,7 +98,7 @@ async function detectIntent(message: string): Promise<Intent> {
 // Groq LLM 呼び出し（llama-3.1-8b-instant）— admin_guide モード
 // ---------------------------------------------------------------------------
 
-async function callGroq8b(userMessage: string): Promise<string> {
+async function callGroq8b(userMessage: string, tenantId: string): Promise<string> {
   const apiKey = process.env.GROQ_API_KEY?.trim();
   if (!apiKey) throw new Error("GROQ_API_KEY not configured");
 
@@ -110,6 +125,18 @@ async function callGroq8b(userMessage: string): Promise<string> {
   }
 
   const data = (await res.json()) as any;
+
+  if (tenantId) {
+    trackUsage({
+      tenantId,
+      requestId: `admin-ai-assist-guide:${tenantId}:${Date.now()}`,
+      model: GROQ_INSTANT_8B,
+      inputTokens: data.usage?.prompt_tokens ?? 0,
+      outputTokens: data.usage?.completion_tokens ?? 0,
+      featureUsed: "admin_ai_assist",
+    });
+  }
+
   return data.choices?.[0]?.message?.content?.trim() ?? "";
 }
 
@@ -117,7 +144,7 @@ async function callGroq8b(userMessage: string): Promise<string> {
 // Groq LLM 呼び出し（llama-3.3-70b-versatile）— business_faq モード
 // ---------------------------------------------------------------------------
 
-async function callGroq70b(userMessage: string, ragContext: string): Promise<string> {
+async function callGroq70b(userMessage: string, ragContext: string, tenantId: string): Promise<string> {
   const apiKey = process.env.GROQ_API_KEY?.trim();
   if (!apiKey) throw new Error("GROQ_API_KEY not configured");
 
@@ -158,6 +185,18 @@ ${ragContext}`
   }
 
   const data = (await res.json()) as any;
+
+  if (tenantId) {
+    trackUsage({
+      tenantId,
+      requestId: `admin-ai-assist-faq:${tenantId}:${Date.now()}`,
+      model: GROQ_VERSATILE_70B,
+      inputTokens: data.usage?.prompt_tokens ?? 0,
+      outputTokens: data.usage?.completion_tokens ?? 0,
+      featureUsed: "admin_ai_assist",
+    });
+  }
+
   return data.choices?.[0]?.message?.content?.trim() ?? "";
 }
 
@@ -197,7 +236,7 @@ async function buildBusinessFaqAnswer(
 
     logger.info(`[ai-assist] pgvector search: ${knowledgeCtx.results.length} hits for tenant=${tenantId}`);
 
-    const answer = await callGroq70b(message, ragContext);
+    const answer = await callGroq70b(message, ragContext, tenantId);
     const aiAnswered = knowledgeCtx.results.length > 0 && !isUnanswered(answer);
     return { answer, aiAnswered };
   } catch (e) {
@@ -295,7 +334,7 @@ export function registerAdminAiAssistRoutes(app: Express): void {
       try {
         // 1. インテント判定（tenantId がある場合のみ business_faq を試みる）
         const intent: Intent =
-          tenantId ? await detectIntent(message) : "admin_guide";
+          tenantId ? await detectIntent(message, tenantId) : "admin_guide";
 
         // 2. インテント別回答生成
         let answer: string;
@@ -304,7 +343,7 @@ export function registerAdminAiAssistRoutes(app: Express): void {
         if (intent === "business_faq") {
           ({ answer, aiAnswered } = await buildBusinessFaqAnswer(message, tenantId));
         } else {
-          answer = await callGroq8b(message);
+          answer = await callGroq8b(message, tenantId);
           aiAnswered = answer ? !isUnanswered(answer) : false;
         }
 

--- a/src/api/admin/feedback/feedbackAI.ts
+++ b/src/api/admin/feedback/feedbackAI.ts
@@ -232,7 +232,7 @@ export async function generateFeedbackReply(
     // ------------------------------------------------------------------
     const optionAction = parseOptionAction(reply);
     if (optionAction) {
-      const estimate = await estimateOptionPrice(optionAction.task_description);
+      const estimate = await estimateOptionPrice(optionAction.task_description, { tenantId });
       const amountFormatted = estimate.estimated_amount.toLocaleString('ja-JP');
       return (
         `作業内容: ${optionAction.task_description}\n` +

--- a/src/api/admin/feedback/optionEstimator.test.ts
+++ b/src/api/admin/feedback/optionEstimator.test.ts
@@ -1,0 +1,95 @@
+// src/api/admin/feedback/optionEstimator.test.ts
+// GID 1216944003337186: estimateOptionPrice のtrackUsage計測を検証。
+
+const mockTrackUsage = jest.fn();
+jest.mock('../../../lib/billing/usageTracker', () => ({
+  trackUsage: (...args: unknown[]) => mockTrackUsage(...args),
+}));
+
+jest.mock('../../../lib/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { estimateOptionPrice } from './optionEstimator';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+const GROQ_OK_BODY = {
+  choices: [{ message: { content: JSON.stringify({
+    estimated_amount: 8000,
+    breakdown: 'アバター画像生成・声設定',
+    estimated_hours: 1.5,
+  }) } }],
+  usage: { prompt_tokens: 200, completion_tokens: 60 },
+};
+
+describe('estimateOptionPrice', () => {
+  let savedEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    savedEnv = { ...process.env };
+    process.env.GROQ_API_KEY = 'test-groq-key';
+    mockTrackUsage.mockReset();
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    process.env = savedEnv;
+  });
+
+  it('tenantId指定・正常系: trackUsage(admin_option_estimator)を実トークン数で記録する', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => GROQ_OK_BODY });
+
+    const result = await estimateOptionPrice('アバターのカスタマイズ', { tenantId: 'tenant-a' });
+
+    expect(result.estimated_amount).toBe(8000);
+    expect(mockTrackUsage).toHaveBeenCalledTimes(1);
+    expect(mockTrackUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: 'tenant-a',
+        featureUsed: 'admin_option_estimator',
+        inputTokens: 200,
+        outputTokens: 60,
+      })
+    );
+  });
+
+  it('tenantId未指定はtrackUsageを呼ばない', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => GROQ_OK_BODY });
+
+    await estimateOptionPrice('アバターのカスタマイズ');
+
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
+
+  it('GROQ_API_KEY未設定はフォールバックを返しtrackUsageを呼ばない', async () => {
+    delete process.env.GROQ_API_KEY;
+
+    const result = await estimateOptionPrice('アバターのカスタマイズ', { tenantId: 'tenant-a' });
+
+    expect(result.estimated_amount).toBe(10000); // fallback()
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
+
+  it('Groq APIエラー時はフォールバックを返しtrackUsageを呼ばない', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 503 });
+
+    const result = await estimateOptionPrice('アバターのカスタマイズ', { tenantId: 'tenant-a' });
+
+    expect(result.estimated_amount).toBe(10000);
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
+
+  it('tenantContextも同時に渡せる（tenantIdとの併用）', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => GROQ_OK_BODY });
+
+    await estimateOptionPrice('アバターのカスタマイズ', { tenantContext: 'Growthプラン', tenantId: 'tenant-a' });
+
+    const [, opts] = mockFetch.mock.calls[0];
+    const body = JSON.parse(opts.body as string);
+    expect(body.messages[1].content).toContain('Growthプラン');
+    expect(mockTrackUsage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/api/admin/feedback/optionEstimator.ts
+++ b/src/api/admin/feedback/optionEstimator.ts
@@ -3,6 +3,7 @@
 
 import { GROQ_VERSATILE_70B } from '../../../config/groqModels';
 import { logger } from '../../../lib/logger';
+import { trackUsage } from '../../../lib/billing/usageTracker';
 
 const GROQ_API_BASE = 'https://api.groq.com/openai/v1/chat/completions';
 
@@ -30,13 +31,16 @@ const ESTIMATE_SYSTEM_PROMPT = `あなたはIT業務の料金見積もり専門�
 /** 作業内容の説明から料金を試算する */
 export async function estimateOptionPrice(
   taskDescription: string,
-  tenantContext?: string,
+  opts?: { tenantContext?: string; tenantId?: string },
 ): Promise<EstimateResult> {
   const apiKey = process.env.GROQ_API_KEY;
   if (!apiKey) {
     logger.warn('[estimateOptionPrice] GROQ_API_KEY not set, using fallback');
     return fallback();
   }
+
+  const tenantContext = opts?.tenantContext;
+  const tenantId = opts?.tenantId;
 
   const userPrompt =
     `## 作業内容\n${taskDescription}` +
@@ -67,7 +71,21 @@ export async function estimateOptionPrice(
 
     const data = (await response.json()) as {
       choices?: Array<{ message?: { content?: string } }>;
+      usage?: { prompt_tokens?: number; completion_tokens?: number };
     };
+
+    // GID 1216944003337186: featureUsed='admin_option_estimator'はNON_BILLABLE_FEATURES
+    // のためStripe請求数量には含まれない（原価可視化のみ）。
+    if (tenantId) {
+      trackUsage({
+        tenantId,
+        requestId: `admin-option-estimator:${tenantId}:${Date.now()}`,
+        model: process.env.GROQ_MODEL_70B ?? GROQ_VERSATILE_70B,
+        inputTokens: data.usage?.prompt_tokens ?? 0,
+        outputTokens: data.usage?.completion_tokens ?? 0,
+        featureUsed: 'admin_option_estimator',
+      });
+    }
 
     const content = data.choices?.[0]?.message?.content?.trim() ?? '';
     const jsonMatch = content.match(/\{[\s\S]*"estimated_amount"[\s\S]*\}/);

--- a/src/api/admin/tuning/routes.ts
+++ b/src/api/admin/tuning/routes.ts
@@ -25,6 +25,7 @@ import {
 import { getResearchProvider } from '../../../lib/research';
 import { isDeepResearchEnabled } from '../../../lib/research/featureCheck';
 import { buildResearchQuery } from '../../../lib/research/queryBuilder';
+import { trackUsage } from '../../../lib/billing/usageTracker';
 
 // ---------------------------------------------------------------------------
 // ALLOWED_ROLES whitelist
@@ -333,6 +334,25 @@ export function registerTuningRoutes(app: Express): void {
             crossTenantSection,
             researchSection,
           );
+
+      // GID 1216944003337186: callGroq8bSuggest/FromTextはactionExecutor.tsからも
+      // 共有呼び出しされる純粋関数のためtenantIdを持たない。Groqは実トークン数を返すが、
+      // ここでは呼び出し元(このハンドラ)でのみ計測し、文字数からの概算トークン数を使う。
+      // featureUsed='admin_tuning'はNON_BILLABLE_FEATURESのためStripe請求数量には含まれない
+      // （原価可視化のみ）。
+      if (tenantId) {
+        const promptChars = anchorText.length + knowledgeSection.length + existingRulesSection.length;
+        const outputChars = JSON.stringify(suggestion).length;
+        trackUsage({
+          tenantId,
+          requestId: `admin-tuning-suggest:${Date.now()}`,
+          model: process.env.GROQ_MODEL_8B ?? GROQ_INSTANT_8B,
+          inputTokens: Math.ceil(promptChars / 4),
+          outputTokens: Math.ceil(outputChars / 4),
+          featureUsed: 'admin_tuning',
+        });
+      }
+
       return res.json(suggestion);
     },
   );

--- a/src/api/admin/tuning/suggestRuleTrackUsage.test.ts
+++ b/src/api/admin/tuning/suggestRuleTrackUsage.test.ts
@@ -1,0 +1,125 @@
+// src/api/admin/tuning/suggestRuleTrackUsage.test.ts
+// GID 1216944003337186: POST /v1/admin/tuning/suggest-rule のtrackUsage計測を検証。
+// モック構成はtuningAuthGuard.test.tsに準拠。
+
+jest.mock('../../../lib/db', () => ({
+  pool: null,
+  getPool: () => null,
+}));
+jest.mock('../../../lib/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock('../../../admin/http/supabaseAuthMiddleware', () => ({
+  supabaseAuthMiddleware: (req: any, _res: any, next: any) => {
+    req.supabaseUser = req._mockUser ?? null;
+    next();
+  },
+}));
+jest.mock('./tuningRulesRepository', () => ({
+  listRules: jest.fn().mockResolvedValue([]),
+  createRule: jest.fn().mockResolvedValue({ id: 1 }),
+  updateRule: jest.fn().mockResolvedValue({ id: 1 }),
+  deleteRule: jest.fn().mockResolvedValue({ id: 1 }),
+}));
+jest.mock('../../../lib/knowledgeSearchUtil', () => ({
+  searchKnowledgeForSuggestion: jest.fn().mockResolvedValue({ results: [] }),
+  formatKnowledgeContext: jest.fn().mockReturnValue(''),
+}));
+jest.mock('../../../lib/crossTenantContext', () => ({
+  getCrossTenantContext: jest.fn().mockResolvedValue({
+    avgScores: null,
+    topPsychologyPrinciples: [],
+    commonGapPatterns: [],
+    effectiveRulePatterns: [],
+    totalTenants: 0,
+    dataAsOf: new Date().toISOString(),
+  }),
+  formatCrossTenantContext: jest.fn().mockReturnValue(''),
+}));
+jest.mock('../../../lib/research', () => ({
+  getResearchProvider: jest.fn().mockReturnValue(null),
+}));
+jest.mock('../../../lib/research/featureCheck', () => ({
+  isDeepResearchEnabled: jest.fn().mockResolvedValue(false),
+}));
+jest.mock('../../../lib/research/queryBuilder', () => ({
+  buildResearchQuery: jest.fn().mockReturnValue(''),
+}));
+
+const mockTrackUsage = jest.fn();
+jest.mock('../../../lib/billing/usageTracker', () => ({
+  trackUsage: (...args: unknown[]) => mockTrackUsage(...args),
+}));
+
+import express from 'express';
+import request from 'supertest';
+import { registerTuningRoutes } from './routes';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+function makeApp(appMetadata: Record<string, unknown> | null) {
+  const app = express();
+  app.use(express.json());
+  app.use((req: any, _res: any, next: any) => {
+    req._mockUser = appMetadata
+      ? { app_metadata: appMetadata, email: 'test@test.com' }
+      : null;
+    next();
+  });
+  registerTuningRoutes(app);
+  return app;
+}
+
+const GROQ_SUGGEST_BODY = {
+  choices: [{ message: { content: JSON.stringify({
+    trigger_pattern: '価格について聞かれた場合',
+    instruction: '料金プランの詳細を案内する',
+    priority: 5,
+    reason: '価格への関心が高いため',
+  }) } }],
+};
+
+describe('POST /v1/admin/tuning/suggest-rule — trackUsage計測', () => {
+  beforeEach(() => {
+    process.env.GROQ_API_KEY = 'test-groq-key';
+    mockTrackUsage.mockReset();
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    delete process.env.GROQ_API_KEY;
+  });
+
+  it('正常系: trackUsage(admin_tuning)を1回記録する', async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => GROQ_SUGGEST_BODY });
+
+    const res = await request(makeApp({ role: 'client_admin', tenant_id: 'tenant-a' }))
+      .post('/v1/admin/tuning/suggest-rule')
+      .send({ userMessage: '料金を教えて', aiMessage: 'プランをご案内します' });
+
+    expect(res.status).toBe(200);
+    expect(mockTrackUsage).toHaveBeenCalledTimes(1);
+    expect(mockTrackUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ tenantId: 'tenant-a', featureUsed: 'admin_tuning' })
+    );
+  });
+
+  it('権限なし（viewer等）は403でtrackUsageを呼ばない', async () => {
+    const res = await request(makeApp({ role: 'viewer', tenant_id: 'tenant-a' }))
+      .post('/v1/admin/tuning/suggest-rule')
+      .send({ userMessage: '料金を教えて', aiMessage: 'プランをご案内します' });
+
+    expect(res.status).toBe(403);
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
+
+  it('バリデーションエラー時はtrackUsageを呼ばない', async () => {
+    const res = await request(makeApp({ role: 'client_admin', tenant_id: 'tenant-a' }))
+      .post('/v1/admin/tuning/suggest-rule')
+      .send({});
+
+    expect(res.status).toBe(400);
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
+});

--- a/src/api/admin/tuning/testResponseRoutes.test.ts
+++ b/src/api/admin/tuning/testResponseRoutes.test.ts
@@ -1,0 +1,128 @@
+// src/api/admin/tuning/testResponseRoutes.test.ts
+// GID 1216944003337186: generateTestResponses（tuning-rules test-response生成、
+// ルートとactionExecutor.tsの両方から呼ばれる共通ロジック）のtrackUsage計測を検証。
+
+const mockPoolQuery = jest.fn();
+jest.mock('../../../lib/db', () => ({
+  getPool: () => ({ query: mockPoolQuery }),
+}));
+
+const mockTrackUsage = jest.fn();
+jest.mock('../../../lib/billing/usageTracker', () => ({
+  trackUsage: (...args: unknown[]) => mockTrackUsage(...args),
+}));
+
+jest.mock('../../../lib/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+import { generateTestResponses } from './testResponseRoutes';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+describe('generateTestResponses', () => {
+  let savedEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    savedEnv = { ...process.env };
+    process.env.GROQ_API_KEY = 'test-groq-key';
+    mockPoolQuery.mockReset();
+    mockTrackUsage.mockReset();
+    mockFetch.mockReset();
+  });
+
+  afterEach(() => {
+    process.env = savedEnv;
+  });
+
+  const RULE_ROW = { trigger_pattern: '価格について', expected_behavior: '料金プランを案内する', tenant_id: 'tenant-a' };
+  const TENANT_ROW = { system_prompt: 'あなたは丁寧な接客AIです' };
+  const GROQ_OK_BODY = {
+    choices: [{ message: { content: JSON.stringify([
+      { style: '丁寧版', text: 'こちらです' },
+      { style: '簡潔版', text: 'こちら' },
+      { style: '提案型', text: 'いかがですか' },
+    ]) } }],
+    usage: { prompt_tokens: 120, completion_tokens: 80 },
+  };
+
+  it('正常系: trackUsage(admin_tuning)を実トークン数で1回記録する', async () => {
+    mockPoolQuery
+      .mockResolvedValueOnce({ rows: [RULE_ROW] })
+      .mockResolvedValueOnce({ rows: [TENANT_ROW] });
+    mockFetch.mockResolvedValueOnce({ ok: true, json: async () => GROQ_OK_BODY });
+
+    const result = await generateTestResponses(1, 'tenant-a', false);
+
+    expect(result.ok).toBe(true);
+    expect(mockTrackUsage).toHaveBeenCalledTimes(1);
+    expect(mockTrackUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: 'tenant-a',
+        featureUsed: 'admin_tuning',
+        inputTokens: 120,
+        outputTokens: 80,
+      })
+    );
+  });
+
+  it('ルールが見つからない場合はtrackUsageを呼ばない', async () => {
+    mockPoolQuery.mockResolvedValueOnce({ rows: [] });
+
+    const result = await generateTestResponses(999, 'tenant-a', false);
+
+    expect(result.ok).toBe(false);
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
+
+  it('テナント越境（forbidden）はGroqを呼ばずtrackUsageも呼ばない', async () => {
+    mockPoolQuery.mockResolvedValueOnce({ rows: [RULE_ROW] });
+
+    const result = await generateTestResponses(1, 'other-tenant', false);
+
+    expect(result).toEqual({ ok: false, reason: 'forbidden' });
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
+
+  it('GROQ_API_KEY未設定はtrackUsageを呼ばない', async () => {
+    delete process.env.GROQ_API_KEY;
+    mockPoolQuery
+      .mockResolvedValueOnce({ rows: [RULE_ROW] })
+      .mockResolvedValueOnce({ rows: [TENANT_ROW] });
+
+    const result = await generateTestResponses(1, 'tenant-a', false);
+
+    expect(result).toEqual({ ok: false, reason: 'no_api_key' });
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
+
+  it('Groq APIエラー時はtrackUsageを呼ばない（失敗した呼び出しを課金しない）', async () => {
+    mockPoolQuery
+      .mockResolvedValueOnce({ rows: [RULE_ROW] })
+      .mockResolvedValueOnce({ rows: [TENANT_ROW] });
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 503 });
+
+    const result = await generateTestResponses(1, 'tenant-a', false);
+
+    expect(result).toEqual({ ok: false, reason: 'llm_error' });
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
+
+  it('LLM出力がJSON配列でない場合でも、Groq呼び出し自体は成功しているのでtrackUsageは記録する', async () => {
+    mockPoolQuery
+      .mockResolvedValueOnce({ rows: [RULE_ROW] })
+      .mockResolvedValueOnce({ rows: [TENANT_ROW] });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ choices: [{ message: { content: '不正な出力' } }], usage: { prompt_tokens: 50, completion_tokens: 10 } }),
+    });
+
+    const result = await generateTestResponses(1, 'tenant-a', false);
+
+    expect(result).toEqual({ ok: false, reason: 'invalid_output' });
+    // Groq呼び出し自体には実コストが発生しているため計測する
+    expect(mockTrackUsage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/api/admin/tuning/testResponseRoutes.ts
+++ b/src/api/admin/tuning/testResponseRoutes.ts
@@ -7,6 +7,7 @@ import type { AuthedReq } from "../../middleware/roleAuth";
 import { supabaseAuthMiddleware } from "../../../admin/http/supabaseAuthMiddleware";
 import { getPool } from "../../../lib/db";
 import { logger } from "../../../lib/logger";
+import { trackUsage } from "../../../lib/billing/usageTracker";
 
 const GROQ_MODEL_70B = GROQ_VERSATILE_70B;
 
@@ -115,8 +116,21 @@ ${systemPrompt || "(未設定)"}
 
   const groqData = await groqRes.json() as {
     choices?: Array<{ message?: { content?: string } }>;
+    usage?: { prompt_tokens?: number; completion_tokens?: number };
   };
   const raw = groqData.choices?.[0]?.message?.content?.trim() ?? "";
+
+  // GID 1216944003337186: このルートとactionExecutor.ts(チャットツール)の両方から呼ばれる
+  // 共通ロジックのため、ここで計測すれば両方の呼び出し元をカバーできる。
+  // featureUsed='admin_tuning'はNON_BILLABLE_FEATURESのためStripe請求数量には含まれない。
+  trackUsage({
+    tenantId: rule.tenant_id,
+    requestId: `admin-tuning-test-response:${id}:${Date.now()}`,
+    model: GROQ_MODEL_70B,
+    inputTokens: groqData.usage?.prompt_tokens ?? 0,
+    outputTokens: groqData.usage?.completion_tokens ?? 0,
+    featureUsed: 'admin_tuning',
+  });
 
   // JSON配列を抽出（markdown code block 対応）
   const jsonMatch = raw.match(/\[[\s\S]*\]/);

--- a/src/lib/billing/costCalculator.test.ts
+++ b/src/lib/billing/costCalculator.test.ts
@@ -19,6 +19,7 @@ import {
   MAGNIFIC_UPSCALE_COST_USD,
   FLUX_PRO_COST_PER_IMAGE_USD,
   LEMONSLICE_AVATAR_REGISTRATION_COST_USD,
+  NON_BILLABLE_FEATURES,
 } from './costCalculator';
 
 // ---------------------------------------------------------------------------
@@ -747,6 +748,31 @@ describe('END_USER_FEATURES', () => {
     expect(END_USER_FEATURES.has('feedback_ai')).toBe(false);
     expect(END_USER_FEATURES.has('avatar_config_image')).toBe(false);
     expect(END_USER_FEATURES.has('book_structurize')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GID 1216944003337186: NON_BILLABLE_FEATURES 定数チェック
+// ---------------------------------------------------------------------------
+describe('NON_BILLABLE_FEATURES', () => {
+  it('管理系LLM機能(tuning/ai-assist/engagement-suggest/option-estimator)が含まれる', () => {
+    expect(NON_BILLABLE_FEATURES.has('admin_tuning')).toBe(true);
+    expect(NON_BILLABLE_FEATURES.has('admin_ai_assist')).toBe(true);
+    expect(NON_BILLABLE_FEATURES.has('admin_engagement_suggest')).toBe(true);
+    expect(NON_BILLABLE_FEATURES.has('admin_option_estimator')).toBe(true);
+  });
+
+  it('sai_agentが含まれる（chargeOneOffJpyで既に請求済みのため二重計上防止）', () => {
+    expect(NON_BILLABLE_FEATURES.has('sai_agent')).toBe(true);
+  });
+
+  it('エンドユーザー向け機能・課金対象の管理機能は含まれない', () => {
+    expect(NON_BILLABLE_FEATURES.has('chat')).toBe(false);
+    expect(NON_BILLABLE_FEATURES.has('avatar')).toBe(false);
+    expect(NON_BILLABLE_FEATURES.has('voice')).toBe(false);
+    expect(NON_BILLABLE_FEATURES.has('admin_agent')).toBe(false);
+    expect(NON_BILLABLE_FEATURES.has('avatar_config_image')).toBe(false);
+    expect(NON_BILLABLE_FEATURES.has('premium_avatar_generation')).toBe(false);
   });
 });
 

--- a/src/lib/billing/costCalculator.ts
+++ b/src/lib/billing/costCalculator.ts
@@ -34,6 +34,26 @@ export const MARGIN_MULTIPLIER = Number(process.env.MARGIN_RATE ?? '5') || 5;
  */
 export const END_USER_FEATURES: ReadonlySet<string> = new Set(['chat', 'avatar', 'voice']);
 
+/**
+ * GID 1216944003337186: usage_logs の行として記録はする（cost_total_centsで原価は可視化する）が、
+ * stripeSync.ts の集計（Stripe請求数量 billedQuantity）からは除外する機能。
+ * usage_logs.billable カラムで制御する（デフォルトtrue、ここに含まれる機能のみfalseになる）。
+ *
+ * - admin_tuning / admin_ai_assist / admin_engagement_suggest / admin_option_estimator:
+ *   いずれもmooores社内の運用・チューニングツールで、テナントの直接操作によるリクエストではない。
+ *   請求リクエスト数を水増ししないよう非課金とする。
+ * - sai_agent: テナント請求は既に chargeOneOffJpy（代行作業完了時の単発JPY請求、
+ *   options/routes.ts の /complete エンドポイント）で完結している。ここでも
+ *   billedQuantityのCOUNT(*)に含めると二重計上になるため非課金とする。
+ */
+export const NON_BILLABLE_FEATURES: ReadonlySet<string> = new Set([
+  'admin_tuning',
+  'admin_ai_assist',
+  'admin_engagement_suggest',
+  'admin_option_estimator',
+  'sai_agent',
+]);
+
 /** Phase40: Fish Audio TTS単価: $15.00 / 1M UTF-8バイト */
 export const FISH_AUDIO_COST_PER_BYTE_USD = 15.0 / 1_000_000;
 

--- a/src/lib/billing/migration_admin_tooling_feature.sql
+++ b/src/lib/billing/migration_admin_tooling_feature.sql
@@ -1,0 +1,29 @@
+-- GID 1216944003337186: usage_logs.feature_used の CHECK 制約を拡張
+-- 追加: admin_tuning, admin_ai_assist, admin_engagement_suggest, admin_option_estimator
+-- （いずれも管理系LLM機能。billable=false で原価可視化のみ、Stripe請求数量には含めない）
+
+ALTER TABLE usage_logs DROP CONSTRAINT IF EXISTS usage_logs_feature_used_check;
+
+ALTER TABLE usage_logs ADD CONSTRAINT usage_logs_feature_used_check
+  CHECK (feature_used IN (
+    'chat',
+    'avatar',
+    'voice',
+    'admin_guide',
+    'avatar_config_image',
+    'avatar_config_voice',
+    'avatar_config_prompt',
+    'avatar_config_test',
+    'anam_session',
+    'feedback_ai',
+    'book_analysis',
+    'book_structurize',
+    'option_service',
+    'premium_avatar_generation',
+    'admin_agent',
+    'sai_agent',
+    'admin_tuning',
+    'admin_ai_assist',
+    'admin_engagement_suggest',
+    'admin_option_estimator'
+  ));

--- a/src/lib/billing/migration_usage_logs_billable_flag.sql
+++ b/src/lib/billing/migration_usage_logs_billable_flag.sql
@@ -1,0 +1,14 @@
+-- GID 1216944003337186: usage_logs.billable フラグ追加
+--
+-- 管理系LLM機能（admin_tuning / admin_ai_assist / admin_engagement_suggest /
+-- admin_option_estimator）や、既にchargeOneOffJpyで請求が完結しているsai_agentは、
+-- 原価(cost_total_cents)はusage_logsに記録するが、Stripe請求数量
+-- (stripeSync.ts の billedQuantity = usage_logs の行数ベース集計)には含めたくない。
+--
+-- billable=false の行は原価可視化のみに使い、stripeSync.ts の集計クエリから除外する。
+-- 既存行は全て billable=true 相当として扱う（デフォルトtrue、既存の課金挙動を変えない）。
+
+ALTER TABLE usage_logs
+  ADD COLUMN IF NOT EXISTS billable BOOLEAN NOT NULL DEFAULT true;
+
+CREATE INDEX IF NOT EXISTS idx_usage_logs_billable ON usage_logs(billable);

--- a/src/lib/billing/stripeSync.test.ts
+++ b/src/lib/billing/stripeSync.test.ts
@@ -110,6 +110,83 @@ describe('billedQuantity（anam_session混在時の分数換算を加算・後�
   });
 });
 
+// GID 1216944003337186: usage_logs.billable=false（管理系LLM機能・chargeOneOffJpyで
+// 既に請求済みのsai_agent）の行はstripeSync._reportTenantUsageの集計SQL
+// (`AND billable = true`) で除外される。ここではその集計ロジックをJS側で再現して検証する
+// （_reportTenantUsageは非exportのため、SQLと同じ集計規則を純粋関数として再現する）。
+describe('billedQuantity（billable=falseの行を除外）', () => {
+  interface FakeUsageLogRow {
+    feature_used: string;
+    anam_session_seconds?: number;
+    billable: boolean;
+  }
+
+  /** stripeSync._reportTenantUsage の集計SQL（`AND billable = true` + billable_units CASE）と同じ規則 */
+  function simulateBillableUnits(rows: FakeUsageLogRow[]): number {
+    return rows
+      .filter((r) => r.billable)
+      .reduce(
+        (sum, r) =>
+          sum +
+          (r.feature_used === 'anam_session'
+            ? anamSessionBillableUnits(r.anam_session_seconds ?? 0)
+            : 1),
+        0,
+      );
+  }
+
+  it('billable=falseの管理系行(admin_tuning等)・sai_agentはbillableUnitsに含まれない', () => {
+    const rows: FakeUsageLogRow[] = [
+      { feature_used: 'chat', billable: true },
+      { feature_used: 'chat', billable: true },
+      { feature_used: 'admin_tuning', billable: false },
+      { feature_used: 'admin_ai_assist', billable: false },
+      { feature_used: 'sai_agent', billable: false },
+    ];
+    expect(simulateBillableUnits(rows)).toBe(2);
+  });
+
+  it('billable=trueのみのテナントは従来通り全行カウントされる（後方互換）', () => {
+    const rows: FakeUsageLogRow[] = [
+      { feature_used: 'chat', billable: true },
+      { feature_used: 'avatar', billable: true },
+      { feature_used: 'premium_avatar_generation', billable: true },
+    ];
+    expect(simulateBillableUnits(rows)).toBe(3);
+  });
+
+  it('billable=false行にanam_session混在時も、非billable分は0として扱われる', () => {
+    const rows: FakeUsageLogRow[] = [
+      { feature_used: 'anam_session', anam_session_seconds: 180, billable: true }, // 3分
+      { feature_used: 'anam_session', anam_session_seconds: 180, billable: false }, // 除外される3分
+      { feature_used: 'chat', billable: true },
+    ];
+    expect(simulateBillableUnits(rows)).toBe(4); // 3(billable anam) + 1(chat)、非billable分は含まれない
+  });
+
+  it('全行がbillable=falseなら0（Stripeに何も報告されない）', () => {
+    const rows: FakeUsageLogRow[] = [
+      { feature_used: 'admin_tuning', billable: false },
+      { feature_used: 'admin_option_estimator', billable: false },
+    ];
+    expect(simulateBillableUnits(rows)).toBe(0);
+  });
+});
+
+// GID 1216944003337186: マイグレーション後の既存行のデフォルト値検証
+// （生SQLテキストの検証。実際のDB適用結果はステージング/本番マイグレーション実行時に確認する）
+describe('migration_usage_logs_billable_flag.sql', () => {
+  it('billableカラムはNOT NULL DEFAULT trueで追加される（既存行は全てbillable=true扱い）', () => {
+    const fs = require('fs') as typeof import('fs');
+    const path = require('path') as typeof import('path');
+    const sql = fs.readFileSync(
+      path.join(__dirname, 'migration_usage_logs_billable_flag.sql'),
+      'utf-8',
+    );
+    expect(sql).toMatch(/ADD COLUMN IF NOT EXISTS billable BOOLEAN NOT NULL DEFAULT true/);
+  });
+});
+
 describe('lemonsliceShareJpy（月額固定費の均等割り・切り上げ）', () => {
   it('テナント数で均等割り（切り上げ）', () => {
     expect(lemonsliceShareJpy(1200, 1)).toBe(1200);

--- a/src/lib/billing/stripeSync.ts
+++ b/src/lib/billing/stripeSync.ts
@@ -338,6 +338,8 @@ async function _reportTenantUsage(
 
   const { startDate, endDate } = periodToDateRange(periodYyyyMm);
 
+  // GID 1216944003337186: billable=false（管理系LLM機能・chargeOneOffJpyで別途請求済みの
+  // sai_agent等）は原価がusage_logsに記録されていてもStripe請求数量の集計対象から除外する。
   const aggResult = await db.query(
     `SELECT
        COUNT(*)::integer           AS total_requests,
@@ -352,7 +354,8 @@ async function _reportTenantUsage(
      WHERE tenant_id = $1
        AND created_at >= $2
        AND created_at <  $3
-       AND billing_status = 'pending'`,
+       AND billing_status = 'pending'
+       AND billable = true`,
     [tenantId, startDate, endDate]
   );
 
@@ -420,13 +423,17 @@ async function _reportTenantUsage(
         [usageRecord.id, idempotencyKey]
       );
 
+      // billable=false の行はこの集計・報告に含まれていないため 'reported' にはしない
+      // （'pending' のまま維持。原価可視化のための行であり、Stripeに送信済みという意味を
+      // 持たせない）。
       await db.query(
         `UPDATE usage_logs
          SET billing_status = 'reported'
          WHERE tenant_id = $1
            AND created_at >= $2
            AND created_at <  $3
-           AND billing_status = 'pending'`,
+           AND billing_status = 'pending'
+           AND billable = true`,
         [tenantId, startDate, endDate]
       );
 

--- a/src/lib/billing/usageTracker.test.ts
+++ b/src/lib/billing/usageTracker.test.ts
@@ -185,6 +185,111 @@ describe('usageTracker', () => {
     });
   });
 
+  // GID 1216944003337186: usage_logs.billable フラグ（NON_BILLABLE_FEATURESから自動判定）
+  describe('billableフラグの自動判定・pass-through', () => {
+    it('featureUsed=chat（課金対象）はbillable=trueでINSERTされる', async () => {
+      const mockQuery = jest.fn().mockResolvedValue({ rowCount: 1 });
+      const mockLogger = { warn: jest.fn(), error: jest.fn(), debug: jest.fn(), info: jest.fn() } as any;
+      initUsageTracker({ query: mockQuery } as any, mockLogger);
+
+      trackUsage({
+        tenantId: 'test-tenant',
+        requestId: 'req-billable-chat',
+        model: 'llama-3.1-8b-instant',
+        inputTokens: 100,
+        outputTokens: 50,
+        featureUsed: 'chat',
+      });
+
+      await flushSetImmediate();
+      await flushSetImmediate();
+
+      const insertCall = mockQuery.mock.calls.find(
+        ([, p]: [string, any[]]) => p?.[1] === 'req-billable-chat'
+      );
+      expect(insertCall).toBeDefined();
+      const [sql, params] = insertCall!;
+      expect(sql).toContain('billable');
+      expect(params[params.length - 1]).toBe(true);
+    });
+
+    it('featureUsed=admin_tuning（NON_BILLABLE_FEATURES）はbillable=falseでINSERTされ、costは0にならない', async () => {
+      const mockQuery = jest.fn().mockResolvedValue({ rowCount: 1 });
+      const mockLogger = { warn: jest.fn(), error: jest.fn(), debug: jest.fn(), info: jest.fn() } as any;
+      initUsageTracker({ query: mockQuery } as any, mockLogger);
+
+      trackUsage({
+        tenantId: 'test-tenant',
+        requestId: 'req-non-billable-tuning',
+        model: 'llama-3.1-8b-instant',
+        inputTokens: 1000,
+        outputTokens: 500,
+        featureUsed: 'admin_tuning',
+      });
+
+      await flushSetImmediate();
+      await flushSetImmediate();
+
+      const insertCall = mockQuery.mock.calls.find(
+        ([, p]: [string, any[]]) => p?.[1] === 'req-non-billable-tuning'
+      );
+      expect(insertCall).toBeDefined();
+      const [, params] = insertCall!;
+      expect(params[params.length - 1]).toBe(false); // billable=false
+      expect(params[7]).toBeGreaterThan(0); // cost_total_centsは原価可視化のため0にならない
+    });
+
+    it('featureUsed=sai_agent（NON_BILLABLE_FEATURES）もbillable=falseになる', async () => {
+      const mockQuery = jest.fn().mockResolvedValue({ rowCount: 1 });
+      const mockLogger = { warn: jest.fn(), error: jest.fn(), debug: jest.fn(), info: jest.fn() } as any;
+      initUsageTracker({ query: mockQuery } as any, mockLogger);
+
+      trackUsage({
+        tenantId: 'test-tenant',
+        requestId: 'req-sai-agent-non-billable',
+        model: 'agent-s',
+        inputTokens: 0,
+        outputTokens: 0,
+        featureUsed: 'sai_agent',
+        saiAgentSteps: 3,
+      });
+
+      await flushSetImmediate();
+      await flushSetImmediate();
+
+      const insertCall = mockQuery.mock.calls.find(
+        ([, p]: [string, any[]]) => p?.[1] === 'req-sai-agent-non-billable'
+      );
+      const [, params] = insertCall!;
+      expect(params[params.length - 1]).toBe(false);
+    });
+
+    it('billableを明示指定すると自動判定より優先される（オーバーライド）', async () => {
+      const mockQuery = jest.fn().mockResolvedValue({ rowCount: 1 });
+      const mockLogger = { warn: jest.fn(), error: jest.fn(), debug: jest.fn(), info: jest.fn() } as any;
+      initUsageTracker({ query: mockQuery } as any, mockLogger);
+
+      trackUsage({
+        tenantId: 'test-tenant',
+        requestId: 'req-explicit-billable-override',
+        model: 'llama-3.1-8b-instant',
+        inputTokens: 10,
+        outputTokens: 10,
+        featureUsed: 'chat', // 通常はbillable=trueになる機能
+        billable: false,     // 明示的にfalseを指定
+      });
+
+      await flushSetImmediate();
+      await flushSetImmediate();
+
+      const insertCall = mockQuery.mock.calls.find(
+        ([, p]: [string, any[]]) => p?.[1] === 'req-explicit-billable-override'
+      );
+      const [, params] = insertCall!;
+      expect(params[params.length - 1]).toBe(false);
+    });
+  });
+
   describe('pool 未初期化時', () => {
     it('pool が null の場合は warn ログを出してクラッシュしない', async () => {
       // pool を null にリセット

--- a/src/lib/billing/usageTracker.ts
+++ b/src/lib/billing/usageTracker.ts
@@ -2,12 +2,15 @@
 // Phase32: API使用量の非同期記録（fire-and-forget）
 
 import type pino from 'pino';
-import { calculateLLMCostCents, calculateBillingAmountCents, normalizeModelKey } from './costCalculator';
+import { calculateLLMCostCents, calculateBillingAmountCents, normalizeModelKey, NON_BILLABLE_FEATURES } from './costCalculator';
 
-// DBのusage_logs_feature_used_check制約(migration_sai_agent_feature.sql)と一致させる。
+// DBのusage_logs_feature_used_check制約(migration_sai_agent_feature.sql /
+// migration_admin_tooling_feature.sql)と一致させる。
 // admin_guide / feedback_ai / book_analysis / book_structurize はDB側の制約には既に
-// 含まれていたがTS型に無く未使用だった値（GID 1216944049264977 / 1216944003337186 で配線）。
-export type FeatureUsed = 'chat' | 'avatar' | 'voice' | 'admin_guide' | 'avatar_config_image' | 'avatar_config_voice' | 'avatar_config_prompt' | 'avatar_config_test' | 'anam_session' | 'feedback_ai' | 'book_analysis' | 'book_structurize' | 'option_service' | 'premium_avatar_generation' | 'admin_agent' | 'sai_agent';
+// 含まれていたがTS型に無く未使用だった値（GID 1216944049264977 で配線）。
+// admin_tuning / admin_ai_assist / admin_engagement_suggest / admin_option_estimator は
+// GID 1216944003337186 で新設（いずれもNON_BILLABLE_FEATURES、原価可視化のみが目的）。
+export type FeatureUsed = 'chat' | 'avatar' | 'voice' | 'admin_guide' | 'avatar_config_image' | 'avatar_config_voice' | 'avatar_config_prompt' | 'avatar_config_test' | 'anam_session' | 'feedback_ai' | 'book_analysis' | 'book_structurize' | 'option_service' | 'premium_avatar_generation' | 'admin_agent' | 'sai_agent' | 'admin_tuning' | 'admin_ai_assist' | 'admin_engagement_suggest' | 'admin_option_estimator';
 
 export interface TrackUsageParams {
   tenantId: string;
@@ -45,6 +48,13 @@ export interface TrackUsageParams {
   fluxImageCount?: number;
   /** GID 1216944049264977: LemonSliceアバター登録（プロビジョニング）回数 */
   lemonsliceRegistrationCount?: number;
+  /**
+   * GID 1216944003337186: この行をStripe請求数量（billedQuantity）の対象にするか。
+   * 省略時は featureUsed が NON_BILLABLE_FEATURES に含まれるかどうかで自動判定する
+   * （明示的に渡した場合はそちらが優先される）。cost_total_cents は billable に関わらず
+   * 常に計算・記録される（原価の可視化自体は billable=false でも行う）。
+   */
+  billable?: boolean;
 }
 
 let _pool: any | null = null;
@@ -76,7 +86,11 @@ async function _insertUsageLog(params: TrackUsageParams): Promise<void> {
     featureUsed, marginOverride, ttsTextBytes, avatarCredits, avatarSessionMs, imageCount,
     anam_session_seconds, extraLlmUsages, saiAgentSteps,
     ocrPages, asrRequestCount, magnificUpscaleCount, fluxImageCount, lemonsliceRegistrationCount,
+    billable,
   } = params;
+
+  // GID 1216944003337186: billable未指定時はfeatureUsedから自動判定する。
+  const isBillable = billable ?? !NON_BILLABLE_FEATURES.has(featureUsed);
 
   // Subtask 3: 追加 LLM（planner 等）に価格表に無いモデルが来た場合、コストは 0 計上になる。
   // env override 等で発生しうるため、サイレント未課金を避けるべく可視化ログを出す。
@@ -118,16 +132,16 @@ async function _insertUsageLog(params: TrackUsageParams): Promise<void> {
       `INSERT INTO usage_logs
          (tenant_id, request_id, model, input_tokens, output_tokens,
           feature_used, cost_llm_cents, cost_total_cents,
-          tts_text_bytes, avatar_credits, avatar_session_ms, anam_session_seconds)
-       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
+          tts_text_bytes, avatar_credits, avatar_session_ms, anam_session_seconds, billable)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
        ON CONFLICT (request_id) DO NOTHING`,
       [tenantId, requestId, model, totalInputTokens, totalOutputTokens,
        featureUsed, costLlmCents, costTotalCents,
        ttsTextBytes ?? null, avatarCredits ?? null, avatarSessionMs ?? null,
-       anam_session_seconds ?? null]
+       anam_session_seconds ?? null, isBillable]
     );
     _logger?.debug(
-      { tenantId, requestId, costLlmCents, costTotalCents },
+      { tenantId, requestId, costLlmCents, costTotalCents, billable: isBillable },
       '[usageTracker] logged'
     );
   } catch (err) {


### PR DESCRIPTION
Rebase onto main済み（#534, #536含む最新mainの上に構築）。

## 背景 (Asana gid 1216944003337186)
以下は外部LLMを叩くが trackUsage 未呼び出しで自社負担の原価が不可視でした:
`src/api/admin/tuning/routes.ts`、`tuning/testResponseRoutes.ts`、`admin/ai-assist/routes.ts`、`admin/analytics/routes.ts`、`admin/agent/engagementSuggest.ts`、`admin/feedback/optionEstimator.ts`

## billableフラグ（重要な設計判断）
請求は usage_logs の行数ベースのため、単純にtrackUsageを追加すると管理系機能の呼び出しがテナントの請求リクエスト数を水増ししてしまいます。「原価は記録するが請求数量には入れない」を usage_logs.billable カラムで実現しました。

- `migration_usage_logs_billable_flag.sql`: `billable BOOLEAN NOT NULL DEFAULT true` を追加（既存行は全てbillable=true相当、既存の課金挙動を変えない）
- `migration_admin_tooling_feature.sql`: `feature_used` CHECK制約に `admin_tuning` / `admin_ai_assist` / `admin_engagement_suggest` / `admin_option_estimator` を追加
- `costCalculator.ts`: `NON_BILLABLE_FEATURES` 定数を新設（上記4機能 + `sai_agent`）
- `usageTracker.ts`: `billable` 省略時は `featureUsed` から `NON_BILLABLE_FEATURES` で自動判定（明示指定で上書き可）。`cost_total_cents` は billable に関わらず常に計算・記録します（原価可視化自体は行う）。
- `stripeSync.ts`: `_reportTenantUsage` の集計SQLに `AND billable = true` を追加し、非課金行を `total_requests` / `billable_units` / Stripe報告から除外

## trackUsage配線
- `tuning/routes.ts`: `POST /v1/admin/tuning/suggest-rule` ハンドラで計測（トークン数は文字数からの概算、`featureUsed='admin_tuning'`）
- `tuning/testResponseRoutes.ts`: `generateTestResponses` 内で計測（このルートと `actionExecutor.ts` チャットツールの両方の呼び出し元をカバー、実トークン数）
- `ai-assist/routes.ts`: `detectIntent` / `callGroq8b` / `callGroq70b` に `tenantId` 引数を追加し各Groq呼び出し内で計測（実トークン数、`featureUsed='admin_ai_assist'`）
- `agent/engagementSuggest.ts`: `suggestEngagementRuleFromText` に `tenantId` 引数を追加（呼び出し元 `actionExecutor.ts` も更新）
- `feedback/optionEstimator.ts`: `estimateOptionPrice` の第2引数を `{ tenantContext?, tenantId? }` に変更（呼び出し元 `feedbackAI.ts` も更新）

## admin/analytics/routes.ts について
タスク指示にありましたが、調査の結果 `admin/analytics` 配下（`routes.ts` / `eventAnalyticsRoutes.ts` 含む）には現状LLM呼び出しが存在しませんでした（`GROQ_API_KEY` / `OPENAI_API_KEY` / 外部 `fetch` 呼び出しが一切なし）。対象外としています。もし別の場所にLLM呼び出しがある想定でしたらパスをご確認いただけますでしょうか。

## 要判断
既存の `admin_agent` / `avatar_config_*` / `sai_agent` / `premium_avatar_generation` の billable 扱いについて、以下のように判断しましたが確認をお願いします。

| feature_used | billable | 理由 |
|---|---|---|
| `admin_agent` | true（現行維持） | テナント管理者が使う管理画面内チャットアシスタント。tenant起点の実費なので課金対象が妥当 |
| `avatar_config_*` | true（現行維持） | テナント管理者が明示的にアバター設定（音声クローン等）を実行した結果の実費 |
| `premium_avatar_generation` | true（現行維持） | テナントが明示的に購入するプレミアム機能 |
| `sai_agent` | **false に変更** | テナント請求は `options/routes.ts` の `/complete` → `chargeOneOffJpy`（単発JPY請求）で既に完結している。ここでも`billedQuantity`のCOUNT(*)に含めると**二重計上**になるため非課金が妥当と判断 |

`sai_agent` の変更は実質的な請求額の修正（減額方向）を伴うため、特にご確認をお願いします。

## テスト
`costCalculator.test.ts` / `usageTracker.test.ts` / `stripeSync.test.ts` / `testResponseRoutes.test.ts`（新規）/ `engagementSuggest.test.ts`（新規）/ `optionEstimator.test.ts`（新規）/ `suggestRuleTrackUsage.test.ts`（新規）/ `ai-assist/routes.test.ts`（新規）に計45件超のテストを追加。既存 `agentRoutes.test.ts` の1件（`suggestEngagementRuleFromText` の呼び出し引数）は `tenantId` 引数追加に合わせて更新しました。

billing関連 + 影響範囲（tuning/ai-assist/agent/feedback/options/avatar配下、ocrPipeline/fishAsr/lemonsliceAvatarApi/premiumGenerationRoutes含む）500件、全てPASS。tsc --noEmit も0エラー。

## 補足: PR #536 → #539 のスタック統合漏れについて
作業中に発見したのですが、#536(タスク2)にスタックした#539(タスク3: premiumGenerationRoutesのmarginOverride修正)は「#536のブランチにマージ」された状態のまま、#536ブランチがmainに先にマージされたため、**#539の変更自体はまだmainに反映されていません**（`premiumGenerationRoutes.ts`は現在も旧バグ挙動のままです）。#539は別途mainへの反映が必要になりますので、ご確認をお願いします。