### PR TITLE
fix(billing): premiumGenerationRoutesのmarginOverride誤用を修正

### DIFF
--- a/src/api/admin/avatar/premiumGenerationRoutes.test.ts
+++ b/src/api/admin/avatar/premiumGenerationRoutes.test.ts
@@ -33,6 +33,12 @@ global.fetch = mockFetch;
 import { upscaleWithMagnific } from "../../../lib/magnific";
 const mockUpscale = upscaleWithMagnific as jest.Mock;
 
+import { trackUsage } from "../../../lib/billing/usageTracker";
+const mockTrackUsage = trackUsage as jest.Mock;
+
+// costCalculatorはモックしない（実際のcost_total_cents計算を検証するため）
+import { calculateBillingAmountCents } from "../../../lib/billing/costCalculator";
+
 // ── ヘルパー ──────────────────────────────────────────────────────────────────
 
 function makeApp(tenantId = "tenant-a", role: "client_admin" | "super_admin" = "client_admin") {
@@ -88,6 +94,15 @@ describe("POST /v1/admin/avatar/generate-premium", () => {
     // Magnificスキップ時はoriginal === enhanced
     expect(res.body.originalUrl).toBe(res.body.enhancedUrl);
     expect(mockUpscale).not.toHaveBeenCalled();
+
+    // GID 1216944003337122: Magnific未実行時はfluxImageCountのみでcost_total_centsが
+    // 意図額(PREMIUM_AVATAR_PRICE_CENTS デフォルト100セント=$1.00相当)になる
+    expect(mockTrackUsage).toHaveBeenCalledTimes(1);
+    const call = mockTrackUsage.mock.calls[0][0];
+    expect(call.featureUsed).toBe("premium_avatar_generation");
+    expect(call.fluxImageCount).toBe(1);
+    expect(call.magnificUpscaleCount).toBe(0);
+    expect(calculateBillingAmountCents(call)).toBe(100);
   });
 
   it("正常系（Magnific設定済み）: アップスケール結果を返す", async () => {
@@ -121,6 +136,15 @@ describe("POST /v1/admin/avatar/generate-premium", () => {
     expect(mockUpscale).toHaveBeenCalledWith(
       expect.objectContaining({ scaleFactor: 2, style: "portrait" })
     );
+
+    // GID 1216944003337122: Magnific実行時はflux+magnific両方のコストが積み上がっても
+    // marginOverrideの逆算により、意図額(PREMIUM_AVATAR_PRICE_CENTS デフォルト100セント)
+    // ちょうどが計上される
+    expect(mockTrackUsage).toHaveBeenCalledTimes(1);
+    const call = mockTrackUsage.mock.calls[0][0];
+    expect(call.fluxImageCount).toBe(1);
+    expect(call.magnificUpscaleCount).toBe(1);
+    expect(calculateBillingAmountCents(call)).toBe(100);
   });
 
   it("Magnificエラー時はoriginalUrlにフォールバック", async () => {
@@ -142,6 +166,11 @@ describe("POST /v1/admin/avatar/generate-premium", () => {
     // Magnificがエラーでも200でoriginalを返す
     expect(res.status).toBe(200);
     expect(res.body.imageUrl).toBeTruthy();
+
+    // GID 1216944003337122: Magnificが失敗した回はmagnificUpscaleCount=0（課金しない）
+    const call = mockTrackUsage.mock.calls[0][0];
+    expect(call.magnificUpscaleCount).toBe(0);
+    expect(calculateBillingAmountCents(call)).toBe(100);
   });
 
   it("バリデーションエラー: prompt短すぎ", async () => {

--- a/src/api/admin/avatar/premiumGenerationRoutes.ts
+++ b/src/api/admin/avatar/premiumGenerationRoutes.ts
@@ -10,6 +10,11 @@ import { upscaleWithMagnific } from "../../../lib/magnific";
 import { trackUsage } from "../../../lib/billing/usageTracker";
 import { getPool } from "../../../lib/db";
 import { queryTenantPlan, planHasFeature } from "../../../lib/billing/planFeatures";
+import {
+  FLUX_PRO_COST_PER_IMAGE_USD,
+  MAGNIFIC_UPSCALE_COST_USD,
+  SERVER_COST_PER_REQUEST_USD,
+} from "../../../lib/billing/costCalculator";
 import { roleAuthMiddleware, requireRole, type AuthedReq } from "../../middleware/roleAuth";
 
 type AuthReq = Request & { supabaseUser?: Record<string, unknown>; requestId?: string };
@@ -198,6 +203,7 @@ export function registerPremiumGenerationRoutes(app: Express): void {
 
       // ── ステップ2: Magnific AI アップスケール（FREEPIK_API_KEY設定時のみ） ─
       let enhancedUrl = originalUrl;
+      let magnificRan = false; // GID 1216944003337122: 実際にMagnificで課金対象の処理が成功したか
       const freepikKey = process.env.FREEPIK_API_KEY?.trim();
 
       if (freepikKey) {
@@ -221,13 +227,14 @@ export function registerPremiumGenerationRoutes(app: Express): void {
               `premium-enhanced-${requestId}-${ts}`
             );
             enhancedUrl = savedUrl ?? originalUrl;
+            magnificRan = true;
             logger.info("[premium/generate] magnific done", {
               requestId,
               taskId: magnResult.taskId,
             });
           }
         } catch (magnErr) {
-          // Magnificエラーはフォールバック（オリジナル画像を使用）
+          // Magnificエラーはフォールバック（オリジナル画像を使用、課金もしない）
           logger.warn("[premium/generate] magnific failed, using original", { magnErr });
           enhancedUrl = originalUrl;
         }
@@ -236,7 +243,22 @@ export function registerPremiumGenerationRoutes(app: Express): void {
       }
 
       // ── 課金記録 ──────────────────────────────────────────────────────────
+      // GID 1216944003337122: marginOverrideは倍率であり金額(USD/セント)ではない。
+      // 従来は `PREMIUM_AVATAR_PRICE_CENTS / 100` (=1.0) をそのまま渡していたため
+      // 「マージン×1.0=原価のみ」を意味してしまい、しかも原価自体もDALL-E単価
+      // ($0.04固定, imageCount)で計算されておりFlux/Magnificの実単価と乖離していた
+      // (意図の1/20程度しか計上されない不具合)。
+      // 実際に使ったAPI(Flux 2 Pro / Magnific)の実単価を積み上げて原価を算出し、
+      // 「原価 × marginOverride = 意図した請求額(PREMIUM_AVATAR_PRICE_CENTS)」となるよう
+      // marginOverrideを逆算する。marginOverrideの「倍率」という意味自体は変えない。
       if (tenantId) {
+        const actualCostUSD =
+          FLUX_PRO_COST_PER_IMAGE_USD +
+          (magnificRan ? MAGNIFIC_UPSCALE_COST_USD : 0) +
+          SERVER_COST_PER_REQUEST_USD;
+        const targetChargeUSD = PREMIUM_AVATAR_PRICE_CENTS / 100;
+        const marginOverride = actualCostUSD > 0 ? targetChargeUSD / actualCostUSD : 1;
+
         trackUsage({
           tenantId,
           requestId,
@@ -244,8 +266,9 @@ export function registerPremiumGenerationRoutes(app: Express): void {
           inputTokens: 0,
           outputTokens: 0,
           featureUsed: "premium_avatar_generation",
-          imageCount: 1,
-          marginOverride: PREMIUM_AVATAR_PRICE_CENTS / 100, // $1.00相当
+          fluxImageCount: 1,
+          magnificUpscaleCount: magnificRan ? 1 : 0,
+          marginOverride,
         });
       }
 

--- a/src/api/admin/avatar/routes.ts
+++ b/src/api/admin/avatar/routes.ts
@@ -856,6 +856,10 @@ export function registerAvatarConfigRoutes(app: Express, db: any): void {
             .json({ error: "設定が見つからないかアクセス権限がありません" });
         }
 
+        // GID 1216944003337122: marginOverride: 1 は「倍率×1=原価のみ」の意図で正しい
+        // （avatar_config_voiceは管理機能でEND_USER_FEATURESにも含まれないため、本来
+        // marginOverrideを省略しても同じ結果になるが、意図を明示するため残す）。
+        // premiumGenerationRoutes.tsのように「金額を倍率として渡す」誤用ではない。
         trackUsage({
           tenantId: tenantId ?? 'unknown',
           requestId: (req as any).requestId ?? `vc-${id}-${Date.now()}`,

--- a/src/api/admin/feedback/feedbackAI.ts
+++ b/src/api/admin/feedback/feedbackAI.ts
@@ -248,6 +248,9 @@ export async function generateFeedbackReply(
     // ------------------------------------------------------------------
     const safe = sanitizeOutput(reply);
 
+    // GID 1216944003337122: marginOverride: 1 は「倍率×1=原価のみ」の意図で正しい
+    // （社内向けフィードバックAIの原価可視化が目的。featureUsed='chat'はEND_USER_FEATURES
+    // に含まれ本来MARGIN_MULTIPLIERが適用されるため、意図的にmarginOverrideで打ち消している）。
     trackUsage({
       tenantId,
       requestId: 'feedback-ai',

--- a/src/api/admin/options/routes.ts
+++ b/src/api/admin/options/routes.ts
@@ -542,6 +542,9 @@ export function registerOptionRoutes(app: Express): void {
 
         // 社内原価集計のみ(テナント請求は既存の /complete → chargeOneOffJpy で完結)。
         // requestIdをsai_task_idで固定し、再ポーリングでも二重計上しない(ON CONFLICT DO NOTHING)。
+        // GID 1216944003337122: marginOverride: 1 は「倍率×1=原価のみ」の意図で正しい
+        // （sai_agentはEND_USER_FEATURESに含まれず、テナント請求は上記の通り別経路で完結する
+        // ため、ここでのcost_total_centsは社内原価可視化のみが目的）。
         if (orderRow?.tenant_id) {
           trackUsage({
             tenantId: orderRow.tenant_id,

--- a/src/lib/research/perplexityProvider.ts
+++ b/src/lib/research/perplexityProvider.ts
@@ -77,6 +77,9 @@ export class PerplexityProvider implements ExternalResearchProvider {
       const rawCitations = (data['citations'] as string[] | undefined) ?? [];
       const usage = data['usage'] as { prompt_tokens?: number; completion_tokens?: number } | undefined;
 
+      // GID 1216944003337122: marginOverride: 1 は「倍率×1=原価のみ」の意図で正しい
+      // （option_serviceはEND_USER_FEATURESに含まれず、代行作業原価の可視化が目的。
+      // premiumGenerationRoutes.tsのように「金額を倍率として渡す」誤用ではない）。
       if (billingContext) {
         trackUsage({
           tenantId: billingContext.tenantId,


### PR DESCRIPTION
これは #539 の内容をmainに直接反映するための再送PRです。#539(base: feature/billing-untracked-external-apis)は当該ブランチへのマージには成功しましたが、そのブランチ自体が#536としてmainへ先にマージされたため、#539の変更自体はmainに反映されていませんでした（スタックPRの統合漏れ、#546で報告済み）。本PRはmain最新（#538のプランゲート追加を含む）の上に3fe1e979をcherry-pickし、コンフリクト（import文の統合のみ）を解消したものです。

## 背景 (Asana gid 1216944003337122)
`src/api/admin/avatar/premiumGenerationRoutes.ts:232` が `marginOverride: PREMIUM_AVATAR_PRICE_CENTS / 100` (=1.0) を渡し、コメントに「$1.00相当」とありましたが、`marginOverride` は costCalculator.ts の `calculateBillingAmountCents` における**倍率**であり、USD/セントの金額ではありません。

さらに、原価自体もDALL-E単価（`imageCount` × `IMAGE_GENERATION_COST_USD` = $0.04固定）で計算されており、実際に使っているFlux 2 Pro / Magnificの実単価と乖離していました。結果として「マージン×1.0=原価のみ」を意味してしまい、かつ原価自体も不正確だったため、意図した$1.00に対して約5セントしか計上されておらず、意図の1/20程度でした。

## 実装内容
#536で`costCalculator.ts`に追加された実単価を使用:
- `FLUX_PRO_COST_PER_IMAGE_USD`（Flux 2 Pro 1枚生成、常に発生）
- `MAGNIFIC_UPSCALE_COST_USD`（Magnificアップスケール、成功時のみ）

これらを積み上げて実原価(`actualCostUSD`)を算出し、

```
marginOverride = targetChargeUSD(PREMIUM_AVATAR_PRICE_CENTS/100) / actualCostUSD
```

としてmarginOverrideを逆算します。`marginOverride`本来の「倍率」という意味は崩さず、「原価 × marginOverride = 意図した請求額」となるようにしました。Magnificが実際に成功した回のみ `magnificUpscaleCount: 1` を計上し、未設定/失敗時は課金しません。

trackUsageの `imageCount: 1`（DALL-E単価だった）を `fluxImageCount: 1` に置き換えました。

## 他のmarginOverride:1箇所について
`avatar/routes.ts`、`options/routes.ts`、`feedbackAI.ts`、`perplexityProvider.ts`は、いずれも意図通り「原価のみ計上」が目的で誤用ではないため**動作は変更していません**。誤用と誤解されないよう、意図を明示するコメントを追加しました。

## テスト
`premiumGenerationRoutes.test.ts`に以下を追加（#538のプランゲート追加で増えた「プラン制限」テストとも共存確認済み）:
- Magnific未実行（FREEPIK_API_KEY未設定）: `fluxImageCount=1, magnificUpscaleCount=0` → cost_total_cents = 100（$1.00ちょうど）
- Magnific実行成功: `fluxImageCount=1, magnificUpscaleCount=1` → cost_total_cents = 100（$1.00ちょうど、marginOverrideの逆算で吸収）
- Magnific失敗（フォールバック）: `magnificUpscaleCount=0`（課金しない）→ cost_total_cents = 100

`premiumGenerationRoutes.test.ts`(13件、プラン制限テスト含む)、`options`、`feedback`、`research`、`billing`配下、計321件全てPASS。tsc --noEmit も0エラー。