### PR TITLE
fix(ci): E2Eワークフローを直列化し本番へのレート制限誤爆を防ぐ

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,6 +10,16 @@ on:
       - 'tests/e2e/**'
       - 'playwright.config.ts'
 
+# E2E は playwright.config.ts の baseURL(https://admin.r2c.biz)経由で本番環境を直接叩く
+# (専用のstaging環境やサーバ起動ステップが無いため)。並行PRが同時にE2Eを走らせると
+# 本番へのリクエストがレート制限(429)に達し、PRの内容と無関係にCIが赤くなる事象が
+# 確認された(GID 1216947610263309)。E2Eジョブを1本ずつ直列実行させることで回避する。
+# cancel-in-progress は必ず false — 後から来たPRのE2Eが先行PRの実行中E2Eをキャンセルして
+# しまうと、先行PRの結果が失われるため。
+concurrency:
+  group: e2e-production
+  cancel-in-progress: false
+
 jobs:
   e2e:
     name: E2E — Playwright (authenticated)


### PR DESCRIPTION
## Summary
Asana gid 1216947610263309。`playwright.config.ts` の `baseURL` は `https://admin.r2c.biz`(本番)で、`.github/workflows/e2e.yml` にサーバ起動ステップが無いため、CIのE2Eは本番環境を直接叩いている。並行PRが同時にE2Eを走らせると本番へのリクエストがレート制限(429)に達し、PRの内容と無関係にCIが赤くなる事象が発生していた(実測: `Expected: 401 / Received: 429`。PR #545はLPのHTMLしか変えていないのに同じテストが落ち、コード変更なしの再実行だけで #542/#545 ともgreenになったことで原因を確定)。

## 実装(最小対策)
`.github/workflows/e2e.yml` に `auto-merge-tier-b.yml` と同じ concurrency group パターンを追加し、E2Eジョブを1本ずつ直列実行させる。

```yaml
concurrency:
  group: e2e-production
  cancel-in-progress: false
```

`cancel-in-progress: false` を明示。後発PRのE2Eが先行PRの実行中E2Eをキャンセルしてしまうと、先行PRの結果が失われるため。

IPホワイトリストの導入やstaging環境の新設は今回のスコープ外(別途検討推奨)。

## 確認
- YAML構文は `python3 -c "import yaml; yaml.safe_load(...)"` で検証済み。concurrency groupのキー構造は既に本番で稼働実績のある `auto-merge-tier-b.yml` と同一パターン。
- **実地での直列化確認について**: `.github/workflows/e2e.yml` はE2Eのトリガーpath(`src/**` / `admin-ui/src/**` / `public/**` / `tests/e2e/**` / `playwright.config.ts`)に含まれていないため、本PR自体はE2Eを起動しません。そのため「複数PRが同時にE2Eを開始してもgroup単位で直列化される」という実地確認は、本PRがmainにmergeされた後、実際にE2Eをトリガーする複数PRが並行した際に初めて観測できます(GitHub Actionsのconcurrency機能自体は枯れた機能のため、設定ミスがなければ動作は保証されると考えます)。
- **直列化によるCI待ち時間**: 直近のE2E実行時間を計測したところ、PR #538/#541/#542 いずれも約2分40秒(09:18:46→09:21:25、09:32:04→09:34:46、09:53:39→09:56:18)。今日は10本以上のPRが並行して開かれる日もあるため、直列化により列の末尾のPRは理論上最大 `(同時に待機中のPR数-1) × 約2.7分` 待たされる可能性がある。ただし現状はレース条件で誤ってCIが赤くなり手動で再実行が必要になっているため、待ち時間が増えても「再現性のある結果が得られる」方が総コストは低いと判断する。根本解決(staging環境の新設)は別タスクとして推奨。

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

https://claude.ai/code/session_01B1dxH199qQB3diHbsGLNxM