### PR TITLE
fix(avatar): pre_dispatchのプラン制限をバックエンドで強制

### DIFF
--- a/src/api/avatar/livekitTokenRoutes.test.ts
+++ b/src/api/avatar/livekitTokenRoutes.test.ts
@@ -329,13 +329,14 @@ describe("POST /api/avatar/room-token", () => {
   });
 
   describe("pre_dispatch フラグ分岐", () => {
-    it("pre_dispatch=true かつ connect=false → dispatchAgentToRoom が呼ばれ preDispatchEnabled=true", async () => {
+    it("pre_dispatch=true かつ connect=false かつ enterprise プラン → dispatchAgentToRoom が呼ばれ preDispatchEnabled=true", async () => {
       mockQuery
         .mockResolvedValueOnce({
           rows: [{ ...TENANT_ROW, features: { avatar: true, pre_dispatch: true } }],
           rowCount: 1,
         })
-        .mockResolvedValueOnce({ rows: [] }); // Q3: avatarConfigId 未指定 → fallback
+        .mockResolvedValueOnce({ rows: [] }) // Q3: avatarConfigId 未指定 → fallback
+        .mockResolvedValueOnce({ rows: [{ plan: "enterprise" }] }); // queryTenantPlan
 
       const app = makeApp("tenant-a");
       const res = await request(app)
@@ -352,7 +353,7 @@ describe("POST /api/avatar/room-token", () => {
       expect(mockCreateDispatch).toHaveBeenCalledTimes(1);
     });
 
-    it("pre_dispatch=false かつ connect=false → dispatch 呼ばれず preDispatchEnabled=false", async () => {
+    it("pre_dispatch=false かつ connect=false → dispatch 呼ばれず preDispatchEnabled=false（プラン確認自体スキップ）", async () => {
       mockQuery
         .mockResolvedValueOnce({
           rows: [{ ...TENANT_ROW, features: { avatar: true, pre_dispatch: false } }],
@@ -371,6 +372,8 @@ describe("POST /api/avatar/room-token", () => {
       // dispatch が呼ばれていないことを確認
       await new Promise(resolve => setImmediate(resolve));
       expect(mockCreateDispatch).toHaveBeenCalledTimes(0);
+      // フラグが既にfalseならプラン確認クエリ(3回目のquery)自体が発生しない
+      expect(mockQuery).toHaveBeenCalledTimes(2);
     });
 
     it("features に pre_dispatch キー無し → dispatch スキップ、preDispatchEnabled=false（コスト発生なし）", async () => {
@@ -392,6 +395,124 @@ describe("POST /api/avatar/room-token", () => {
       // pre_dispatch キーが存在しない場合は dispatch を呼ばない（デフォルト安全）
       await new Promise(resolve => setImmediate(resolve));
       expect(mockCreateDispatch).toHaveBeenCalledTimes(0);
+    });
+  });
+
+  // GID 1216945619969548: pre_dispatch はfeaturesフラグに加えバックエンドでもEnterprise限定を強制する。
+  // admin-ui のトグル表示制御だけでは、既にfeatures.pre_dispatch=trueが立っているStarter/Growth
+  // テナントでサーバ側の事前ディスパッチ(LiveKitセッション時間の先行発生=原価)が動き続けてしまう不具合の修正。
+  describe("pre_dispatch バックエンドプランゲート強制", () => {
+    it.each(["starter", "growth"] as const)(
+      "%sプラン + features.pre_dispatch=true でも事前ディスパッチされない（バックエンド強制）",
+      async (plan) => {
+        mockQuery
+          .mockResolvedValueOnce({
+            rows: [{ ...TENANT_ROW, features: { avatar: true, pre_dispatch: true } }],
+            rowCount: 1,
+          })
+          .mockResolvedValueOnce({ rows: [] }) // Q3 fallback
+          .mockResolvedValueOnce({ rows: [{ plan }] }); // queryTenantPlan
+
+        const app = makeApp("tenant-a");
+        const res = await request(app)
+          .post("/api/avatar/room-token")
+          .send({ connect: false });
+
+        expect(res.status).toBe(200);
+        expect(res.body.preDispatchEnabled).toBe(false);
+
+        await new Promise(resolve => setImmediate(resolve));
+        expect(mockCreateDispatch).toHaveBeenCalledTimes(0);
+      }
+    );
+
+    it("enterprise プラン + features.pre_dispatch=true では従来どおり事前ディスパッチされる", async () => {
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [{ ...TENANT_ROW, features: { avatar: true, pre_dispatch: true } }],
+          rowCount: 1,
+        })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [{ plan: "enterprise" }] });
+
+      const app = makeApp("tenant-a");
+      const res = await request(app)
+        .post("/api/avatar/room-token")
+        .send({ connect: false });
+
+      expect(res.status).toBe(200);
+      expect(res.body.preDispatchEnabled).toBe(true);
+
+      await new Promise(resolve => setImmediate(resolve));
+      expect(mockCreateDispatch).toHaveBeenCalledTimes(1);
+    });
+
+    it("plan取得失敗時はfail-safeでstarter扱いとなり事前ディスパッチされない", async () => {
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [{ ...TENANT_ROW, features: { avatar: true, pre_dispatch: true } }],
+          rowCount: 1,
+        })
+        .mockResolvedValueOnce({ rows: [] }) // Q3 fallback
+        .mockRejectedValueOnce(new Error("db down")); // queryTenantPlan内部でcatchされstarter扱いになる
+
+      const app = makeApp("tenant-a");
+      const res = await request(app)
+        .post("/api/avatar/room-token")
+        .send({ connect: false });
+
+      expect(res.status).toBe(200);
+      expect(res.body.preDispatchEnabled).toBe(false);
+
+      await new Promise(resolve => setImmediate(resolve));
+      expect(mockCreateDispatch).toHaveBeenCalledTimes(0);
+    });
+
+    it.each(["starter", "growth", "enterprise"] as const)(
+      "%sプランでもconnect=trueのオンデマンド起動は従来どおり動作する（回帰、pre_dispatchプラン制限の対象外）",
+      async (plan) => {
+        mockQuery
+          .mockResolvedValueOnce({
+            rows: [{ ...TENANT_ROW, features: { avatar: true, pre_dispatch: false } }],
+            rowCount: 1,
+          })
+          .mockResolvedValueOnce({ rows: [] }); // Q3 fallback
+        // pre_dispatch=false なので queryTenantPlan は呼ばれない(connect=trueの経路はplan判定を経由しない)
+
+        const app = makeApp("tenant-a");
+        const res = await request(app)
+          .post("/api/avatar/room-token")
+          .send({ connect: true });
+
+        expect(res.status).toBe(200);
+        expect(res.body.enabled).toBe(true);
+
+        await new Promise(resolve => setImmediate(resolve));
+        expect(mockCreateDispatch).toHaveBeenCalledTimes(1);
+      }
+    );
+
+    it("connect=true はfeatures.pre_dispatch=trueかつプラン制限に引っかかる場合でも従来どおり動作する", async () => {
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [{ ...TENANT_ROW, features: { avatar: true, pre_dispatch: true } }],
+          rowCount: 1,
+        })
+        .mockResolvedValueOnce({ rows: [] }) // Q3 fallback
+        .mockResolvedValueOnce({ rows: [{ plan: "starter" }] }); // queryTenantPlan → starterなのでpreDispatchEnabled=false
+
+      const app = makeApp("tenant-a");
+      const res = await request(app)
+        .post("/api/avatar/room-token")
+        .send({ connect: true });
+
+      expect(res.status).toBe(200);
+      expect(res.body.enabled).toBe(true);
+      // preDispatchEnabled自体はプラン制限でfalseだが、connect=trueなのでdispatchは実行される
+      expect(res.body.preDispatchEnabled).toBe(false);
+
+      await new Promise(resolve => setImmediate(resolve));
+      expect(mockCreateDispatch).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/api/avatar/livekitTokenRoutes.ts
+++ b/src/api/avatar/livekitTokenRoutes.ts
@@ -17,6 +17,7 @@ import { pool } from "../../lib/db";
 import { RoomServiceClient, AgentDispatchClient } from "livekit-server-sdk";
 import type { AuthedRequest } from "../../agent/http/authMiddleware";
 import { logger } from '../../lib/logger';
+import { queryTenantPlan, planHasFeature } from "../../lib/billing/planFeatures";
 
 // ─── LiveKit JWT 生成 ─────────────────────────────────────────────────────────
 
@@ -195,8 +196,26 @@ export function registerLiveKitTokenRoutes(
         }
       }
 
-      const preDispatchEnabled = row.features?.pre_dispatch === true;
+      // GID 1216945619969548: features.pre_dispatch はテナント側フラグに過ぎず、
+      // プラン制限(Enterprise限定, GID 1216944004404664)はバックエンドで強制する。
+      // admin-ui のトグル表示制御だけでは、既に features.pre_dispatch=true が立っている
+      // Starter/Growth テナントでサーバ側の事前ディスパッチが動き続けてしまう
+      // （LiveKitセッション時間が先行発生する原価ゲート漏れ）。
+      // フラグが false の場合はプラン確認自体が不要なのでDBクエリをスキップする。
+      const preDispatchFeatureFlag = row.features?.pre_dispatch === true;
+      let preDispatchEnabled = false;
+      if (preDispatchFeatureFlag) {
+        // fail-safe: plan取得失敗時は queryTenantPlan が starter を返す(=事前ディスパッチしない)
+        const plan = await queryTenantPlan(pool, tenantId);
+        preDispatchEnabled = planHasFeature(plan, "pre_dispatch");
+        if (!preDispatchEnabled) {
+          logger.info(
+            `[livekitTokenRoutes] pre_dispatch feature flag is true but plan=${plan} does not include pre_dispatch — enforcing backend gate for tenant: ${tenantId}`
+          );
+        }
+      }
       // connect=true はウィジェットがパネルを開いた瞬間の呼び出しを示す（pre_dispatch=false 時のオンデマンド起動）
+      // オンデマンド起動はプラン制限の対象外 — 全プランで従来どおり動作させる。
       const connectRequested = req.body?.connect === true;
       const shouldDispatch = preDispatchEnabled || connectRequested;
 


### PR DESCRIPTION
## 背景 (Asana gid 1216945619969548)
#542 で pre_dispatch を Enterprise 限定にしましたが、実装は admin-ui のトグル表示制御のみでした。バックエンドの `src/api/avatar/livekitTokenRoutes.ts:198` は

```js
const preDispatchEnabled = row.features?.pre_dispatch === true;
```

と features フラグを直読みしているだけでプラン判定が無く、既に `features.pre_dispatch=true` が立っている Starter/Growth テナントは、UI でトグルが無効化されても**サーバ側では事前ディスパッチが動き続けていました**。事前ディスパッチは LiveKit セッション時間が先行発生するため、原価目的のゲートが実質機能していませんでした。

他の4ゲート(avatar/analytics/conversion/voice_clone)と #538 で追加した3ゲート(deep_research/premium_avatar/sai_task)はバックエンドで強制されており、pre_dispatch だけが例外状態でした。

## 実装
- `features.pre_dispatch === true` の場合のみ `queryTenantPlan` + `planHasFeature(plan, 'pre_dispatch')` で Enterprise 以上か確認するようにしました。フラグが既に false の場合はプラン確認クエリ自体をスキップし、既存の低レイテンシ経路を維持します。
- fail-safe: plan 取得失敗時は `queryTenantPlan` が既に starter を返す実装になっているため、そのまま利用（事前ディスパッチしない）。
- `connect=true` のオンデマンド起動経路はプラン制限の対象外とし、全プランで従来どおり動作させています（アバター自体を止めるタスクではないため）。

パターンは `src/api/admin/analytics/routes.ts` の `queryTenantPlan` + `planHasFeature` 使用箇所を参考にしました。

## テスト
`livekitTokenRoutes.test.ts` に8件追加:
- starter/growth は `features.pre_dispatch=true` でも事前ディスパッチされない
- enterprise は従来どおり事前ディスパッチされる
- plan 取得失敗時は fail-safe で事前ディスパッチしない
- `connect=true` は starter/growth/enterprise 全プランで従来どおり動作する（回帰）
- `connect=true` はプラン制限に引っかかっていても従来どおり動作する

既存3件も新しいクエリ順序（プラン確認クエリが追加された分）に合わせて更新しました。

対象テスト(`livekitTokenRoutes.test.ts`, `planFeatures.test.ts`)計60件PASS。`tsc --noEmit` 0エラー。

ローカルはフルスイート未実行(レーン並列によるポート枯渇のため)、フルスイート検証はCIに委譲します。