### PR TITLE
fix(ci): スタックPR再発防止 — base≠main declineの明示テスト + 親merge済み検出

### DIFF
--- a/.github/workflows/auto-merge-tier-b.yml
+++ b/.github/workflows/auto-merge-tier-b.yml
@@ -9,11 +9,19 @@
 #   - high-risk / do-not-merge / needs-review ラベルで人間が即停止可能
 #   - 必須チェック (Gate 1 / security-scan / gitleaks) が全 green のときのみ merge
 #   - GITHUB_TOKEN で merge (branch protection の必須チェックは GitHub 側でも二重に強制される)
+#   - base≠main の PR は ci-auto-merge.sh 側で常に decline (スタックPRは対象外)
 #
 # トリガー:
 #   - check_suite completed: CI 完了時に該当 PR を評価
-#   - schedule (2時間毎): イベント取りこぼしの backstop sweep (check_suite が主経路)
+#   - schedule (2時間毎): イベント取りこぼしの backstop sweep (check_suite が主経路) +
+#     スタックPR再発防止スイープ (SCRIPTS/stacked-pr-guard.sh, GID 1216945618304983)
 #   - workflow_dispatch: 手動実行 (任意で pr 指定)
+#
+# スタックPR再発防止 (#528/#540/#539 事故の再発防止):
+#   base≠main の open PR のうち、base ブランチ自身が既に別PRとして main へ
+#   マージ済みのもの (= このPRをmergeしても実体がmainに届かない状態) を検出し、
+#   needs-review ラベル + 警告コメントを自動付与する。schedule sweep のみで実行
+#   (check_suite の度に走らせるとAPIコール過多になるため)。
 
 name: Auto-merge Tier B
 
@@ -32,6 +40,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  issues: write
   checks: read
   statuses: read
 
@@ -84,3 +93,11 @@ jobs:
             bash SCRIPTS/ci-auto-merge.sh "$pr" || echo "  (#$pr は merge せず or エラー — 続行)"
             echo "::endgroup::"
           done
+
+      - name: スタックPR再発防止スイープ (base≠mainで親が既にmain入りのPRを警告)
+        if: github.event_name == 'schedule'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          bash SCRIPTS/stacked-pr-guard.sh || echo "  (stacked-pr-guard でエラー — 次回sweepで再試行)"

--- a/SCRIPTS/ci-auto-merge.sh
+++ b/SCRIPTS/ci-auto-merge.sh
@@ -76,6 +76,15 @@ night_frozen() {
   return 1
 }
 
+# スタックPR再発防止 (GID 1216945618304983): base が main 以外の PR は
+# 自動マージ対象外にする(状態を持たない確実な判定)。0=main(通過)、1=main以外(decline対象)。
+# 実際の事故(#528/#540/#539)は本スクリプト経由ではなく人力mergeが原因だったが、
+# 自前automationが同じ轍を踏まないことを保証するための最終防御として明示テストする。
+is_base_main() {
+  local base="$1"
+  [[ "$base" == "main" ]]
+}
+
 # ─── self-test ───────────────────────────────────────────────────────────────
 if [[ "${1:-}" == "--self-test" ]]; then
   fail=0
@@ -88,6 +97,9 @@ if [[ "${1:-}" == "--self-test" ]]; then
   if all_required_green "$ROLLUP_GREEN" "$DEFAULT_REQUIRED" 2>/dev/null; then echo "PASS green: 全 green 検出"; else echo "FAIL green all"; fail=1; fi
   if all_required_green "$ROLLUP_RED" "$DEFAULT_REQUIRED" 2>/dev/null; then echo "FAIL: red を green 判定"; fail=1; else echo "PASS green: red を検出"; fi
   if all_required_green "$ROLLUP_MISSING" "$DEFAULT_REQUIRED" 2>/dev/null; then echo "FAIL: 欠落 check を green 判定"; fail=1; else echo "PASS green: 欠落 check を検出"; fi
+  if is_base_main "main"; then echo "PASS base: base=main は通過"; else echo "FAIL base: base=main を誤ってdecline"; fail=1; fi
+  if is_base_main "feature/some-parent-branch"; then echo "FAIL base: base≠main を誤って通過"; fail=1; else echo "PASS base: base≠main(スタックPR)を検出してdecline"; fi
+  if is_base_main "feat/parent-of-parent"; then echo "FAIL base: 多段スタックのbase≠mainを誤って通過"; fail=1; else echo "PASS base: 多段スタックのbase≠mainを検出してdecline"; fi
   echo "---"; [[ "$fail" == 0 ]] && { echo "✅ self-test PASS"; exit 0; } || { echo "❌ self-test FAIL"; exit 1; }
 fi
 
@@ -118,7 +130,7 @@ decline() { log "SKIP #$PR_NUMBER ($1): $TITLE"; exit 0; }
 
 [[ "$STATE" == "OPEN" ]]   || decline "state=$STATE"
 [[ "$DRAFT" == "false" ]]  || decline "draft"
-[[ "$BASE" == "main" ]]    || decline "base=$BASE"
+is_base_main "$BASE"       || decline "base=$BASE (stacked PR — not main)"
 has_block_label "$LABELS"  && decline "block-label ($LABELS)"
 night_frozen               && decline "night-freeze (22:00-07:00 JST)"
 

--- a/SCRIPTS/stacked-pr-guard.sh
+++ b/SCRIPTS/stacked-pr-guard.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# stacked-pr-guard.sh — スタックPR(base≠main)のうち、親ブランチが既にmainへ
+# マージ済みのものを検出し、needs-reviewラベル + 警告コメントで人間に気付かせる。
+# (GID 1216945618304983)
+#
+# 背景 (実際に3回起きた事故): #519/#522/#523/#524 (→#528で事後回収),
+# #540 (→#542でリカバリ), #539 (→#547でリカバリ)。
+#
+# 根本原因 (実際のPRデータをgh apiで検証済み):
+#   子PR(base=親featureブランチ)を作成 → 親PR(base=main)が先にmerge →
+#   しかし親ブランチが削除されなかった(またはretargetのタイミング前)ため、
+#   子PRのbaseは親featureブランチのままGitHub側で自動retargetされない →
+#   その状態で子PRをmergeすると、squash commitは親ブランチに着地し、mainには
+#   一切届かない(親ブランチのtipはsquash mergeによりmainの祖先にならないため
+#   `git merge-base --is-ancestor` では検知できない — 実際に検証済み)。
+#   GitHub上はどちらもMERGED表示になるため、誰も気づけない。
+#
+# 検知方法:
+#   open PRのうちbase≠mainのものについて、「そのbaseブランチ名を headRefName とし
+#   base=main でMERGED済みのPRが存在するか」をgh pr listで調べる。存在すれば、
+#   「親は既にmainへ入っている」ことが確定するので警告する。
+#   (git ancestor判定はsquash mergeで壊れるため使わない。GitHub PR履歴ベースの
+#   判定のみが確実)
+#
+# 正当なスタック作業中(親のPRがまだmainへmergeされていない)は検知対象外。
+# ラベル付与・コメント投稿は冪等(重複しない)。
+#
+# 使い方:
+#   bash SCRIPTS/stacked-pr-guard.sh                # open PR全件を走査して警告
+#   bash SCRIPTS/stacked-pr-guard.sh --dry-run       # 判定のみ(ラベル付与・コメントしない)
+#   bash SCRIPTS/stacked-pr-guard.sh --self-test     # 純粋判定ロジックの単体確認
+#
+# 環境変数:
+#   GH_REPO   owner/repo (default: milechy/commerce-faq-tasks)
+#   WARN_LABEL 警告ラベル名 (default: needs-review。リポジトリに既存のラベルを再利用)
+#
+# 依存: gh, jq
+
+set -euo pipefail
+
+GH_REPO="${GH_REPO:-milechy/commerce-faq-tasks}"
+WARN_LABEL="${WARN_LABEL:-needs-review}"
+WARN_MARKER='<!-- stacked-pr-guard: stale-base-warning -->'
+
+log() { printf '[stacked-pr-guard] %s\n' "$*" >&2; }
+
+# ─── 純粋判定ヘルパー (self-test 対象) ───────────────────────────────────────
+
+# 引数1: PRのbaseRefName。引数2: `gh pr list --head <base> --state merged
+#   --json baseRefName,state` 相当のJSON配列文字列。
+# 0=stale(親は既にmainへmerge済み。警告すべき)、1=正常(スタック作業中、または該当PRなし)
+is_stale_stacked_base() {
+  local matches_json="$1"
+  local hit
+  hit="$(printf '%s' "$matches_json" | jq -r \
+    '[.[] | select(.baseRefName=="main" and .state=="MERGED")] | length')"
+  [[ "$hit" -gt 0 ]]
+}
+
+# 既存ラベル一覧(改行区切り)に WARN_LABEL が含まれるか。0=含まれる(付与不要)。
+has_warn_label() {
+  local labels_csv="$1"
+  printf '%s' "$labels_csv" | tr ',' '\n' | grep -qx "$WARN_LABEL"
+}
+
+# 既存コメント本文の配列(JSON, [{"body":"..."}]) に WARN_MARKER を含むものがあるか。
+# 0=既に警告済み(再投稿不要)
+has_warned_comment() {
+  local comments_json="$1"
+  printf '%s' "$comments_json" | jq -e --arg m "$WARN_MARKER" \
+    '[.[] | select(.body | contains($m))] | length > 0' >/dev/null 2>&1
+}
+
+# ─── self-test ───────────────────────────────────────────────────────────────
+if [[ "${1:-}" == "--self-test" ]]; then
+  fail=0
+
+  MERGED_TO_MAIN='[{"baseRefName":"main","state":"MERGED"}]'
+  if is_stale_stacked_base "$MERGED_TO_MAIN"; then
+    echo "PASS stale: 親がmainへmerge済み(headRefName一致)を検出"
+  else
+    echo "FAIL stale: 親merge済みを見逃した"; fail=1
+  fi
+
+  STILL_OPEN='[]'
+  if is_stale_stacked_base "$STILL_OPEN"; then
+    echo "FAIL stale: 該当PRなし(正当なスタック中)を誤検知"; fail=1
+  else
+    echo "PASS stale: 正当なスタック作業中(親未マージ)は誤検知しない"
+  fi
+
+  MERGED_ELSEWHERE='[{"baseRefName":"feature/parent-of-parent","state":"MERGED"}]'
+  if is_stale_stacked_base "$MERGED_ELSEWHERE"; then
+    echo "FAIL stale: main以外へのmergeを誤検知"; fail=1
+  else
+    echo "PASS stale: 親がさらに別ブランチへmerge済み(main未到達)は誤検知しない"
+  fi
+
+  STILL_OPEN_PR='[{"baseRefName":"main","state":"OPEN"}]'
+  if is_stale_stacked_base "$STILL_OPEN_PR"; then
+    echo "FAIL stale: 親PRがOPENのままなのに誤検知"; fail=1
+  else
+    echo "PASS stale: 親PRがOPEN(未merge)は誤検知しない"
+  fi
+
+  if has_warn_label "needs-review,foo"; then
+    echo "PASS label: 既存ラベルを検出(重複付与しない判定)"
+  else
+    echo "FAIL label: 既存ラベルを見逃した"; fail=1
+  fi
+  if has_warn_label "bug,enhancement"; then
+    echo "FAIL label: 無関係ラベルを誤検出"; fail=1
+  else
+    echo "PASS label: 未付与を正しく検出"
+  fi
+
+  COMMENTS_WARNED='[{"body":"some text"},{"body":"prefix <!-- stacked-pr-guard: stale-base-warning --> suffix"}]'
+  if has_warned_comment "$COMMENTS_WARNED"; then
+    echo "PASS comment: 既存警告コメントを検出(重複投稿しない判定)"
+  else
+    echo "FAIL comment: 既存警告コメントを見逃した"; fail=1
+  fi
+  COMMENTS_NONE='[{"body":"unrelated comment"}]'
+  if has_warned_comment "$COMMENTS_NONE"; then
+    echo "FAIL comment: 無関係コメントを誤検出"; fail=1
+  else
+    echo "PASS comment: 未投稿を正しく検出"
+  fi
+
+  echo "---"; [[ "$fail" == 0 ]] && { echo "✅ self-test PASS"; exit 0; } || { echo "❌ self-test FAIL"; exit 1; }
+fi
+
+# ─── 実行本体 ──────────────────────────────────────────────────────────────
+for cmd in gh jq; do command -v "$cmd" >/dev/null 2>&1 || { log "missing: $cmd"; exit 2; }; done
+
+DRY_RUN=0
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=1
+
+# base≠main の open PR 一覧を取得
+CANDIDATES_JSON="$(gh pr list --repo "$GH_REPO" --state open --json number,baseRefName,labels \
+  --jq '[.[] | select(.baseRefName != "main")]' 2>/dev/null || echo '[]')"
+
+COUNT="$(printf '%s' "$CANDIDATES_JSON" | jq 'length')"
+log "base≠main の open PR: ${COUNT}件"
+
+if [[ "$COUNT" == "0" ]]; then
+  log "対象なし。終了。"
+  exit 0
+fi
+
+# 1件分の処理。失敗しても呼び出し側で継続できるよう、ここでは exit させず return で返す。
+process_one_pr() {
+  local pr="$1"
+  local PR_NUM BASE LABELS_CSV MATCHES_JSON COMMENTS_JSON BODY
+  PR_NUM="$(jq -r '.number' <<<"$pr")"
+  BASE="$(jq -r '.baseRefName' <<<"$pr")"
+  LABELS_CSV="$(jq -r '[.labels[].name] | join(",")' <<<"$pr")"
+
+  MATCHES_JSON="$(gh pr list --repo "$GH_REPO" --head "$BASE" --state merged \
+    --json baseRefName,state 2>/dev/null || echo '[]')"
+
+  if ! is_stale_stacked_base "$MATCHES_JSON"; then
+    log "PR #${PR_NUM} (base=${BASE}): 親は未mainマージ — 正当なスタック作業中、スキップ"
+    return 0
+  fi
+
+  log "PR #${PR_NUM} (base=${BASE}): ⚠️ 親ブランチは既にmainへmerge済み。base差し替えが必要"
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    log "  DRY-RUN: ラベル付与・コメント投稿はスキップ"
+    return 0
+  fi
+
+  if has_warn_label "$LABELS_CSV"; then
+    log "  ラベル '${WARN_LABEL}' は付与済み — スキップ"
+  else
+    if gh pr edit "$PR_NUM" --repo "$GH_REPO" --add-label "$WARN_LABEL" 2>&1 | sed 's/^/[stacked-pr-guard]   /' >&2; then
+      log "  ✓ ラベル '${WARN_LABEL}' を付与"
+    else
+      log "  ⚠ ラベル付与に失敗 (権限/API制限の可能性) — 次回sweepで再試行"
+    fi
+  fi
+
+  COMMENTS_JSON="$(gh api "repos/${GH_REPO}/issues/${PR_NUM}/comments" --jq '[.[] | {body: .body}]' 2>/dev/null || echo '[]')"
+  if has_warned_comment "$COMMENTS_JSON"; then
+    log "  警告コメントは投稿済み — スキップ"
+    return 0
+  fi
+
+  BODY="$(cat <<EOF
+${WARN_MARKER}
+⚠️ **スタックPRの base が古くなっています**
+
+このPRの base (\`${BASE}\`) は、既に \`main\` へマージ済みの別PRの head です。
+このまま merge すると squash commit が \`${BASE}\` に着地し、**main には届きません**
+(実際に #528 / #540 / #539 で同じ事故が発生しています)。
+
+対応: base を \`main\` に retarget するか、\`main\` から新しいブランチを切って
+このPRの差分を作り直し、\`base=main\` の新しいPRとして出し直してください
+(過去の復旧例: #542, #547)。
+
+このコメントは \`SCRIPTS/stacked-pr-guard.sh\` による自動警告です。
+EOF
+)"
+  if gh pr comment "$PR_NUM" --repo "$GH_REPO" --body "$BODY" 2>&1 | sed 's/^/[stacked-pr-guard]   /' >&2; then
+    log "  ✓ 警告コメントを投稿"
+  else
+    log "  ⚠ コメント投稿に失敗 (権限/API制限の可能性) — 次回sweepで再試行"
+  fi
+  return 0
+}
+
+printf '%s' "$CANDIDATES_JSON" | jq -c '.[]' | while IFS= read -r pr; do
+  process_one_pr "$pr" || log "  ⚠ このPRの処理中にエラー — 次のPRへ続行"
+done
+
+log "done"


### PR DESCRIPTION
## Summary
Asana gid 1216945618304983。スタックPR(base≠main)で親ブランチが先にmainへmergeされた後、子PRをmergeしても実体がmainに届かない事故が3回発生していた:
- PR #528: #519/#522/#523/#524 の4件がこの状態になり事後回収
- PR #540: 同事故。#542でリカバリ
- PR #539: 同事故。#547でリカバリ

## 根本原因(実データで検証済み)
`gh pr view` と `git merge-base --is-ancestor` で #519/#522/#523/#524/#539/#540 の実際のPRデータを調べた結果:

- これらの子PRは **MERGED表示のまま `baseRefName` が親featureブランチ名のまま**(mainに retarget されていない)
- 各PRの `mergeCommit` は `origin/main` の祖先ではない(=main未到達を実データで確認)
- 親ブランチは **削除されずリモートに現存**していた(`git ls-remote` で確認) — GitHubは base ブランチが**削除された時のみ**PRのbaseをmainへ自動retargetする仕様のため、削除されなかったこれらのケースでは子PRのbaseが親ブランチのまま固定されていた
- 親のPRが実際にmainへmergeされたタイムスタンプの数十秒後に子PRがmergeされている(例: #517→#519は27秒後)。人力での短時間の連続mergeが直接の引き金
- 親ブランチのtipはsquash mergeで祖先関係が切れるため、`git merge-base --is-ancestor` では「親が既にmainへ入っている」ことを検知できない。**GitHub PR履歴(headRefNameベース)でのみ確実に検知できる**

## 対応

### 1. `SCRIPTS/ci-auto-merge.sh`
既存のbase==main decline判定(元々存在していたが、実際の事故は本スクリプトを経由しない人力mergeが原因だったため機能していなかった)を `is_base_main()` として純粋関数に切り出し、`--self-test` に明示テストを3件追加:
- base=mainは通過
- base≠main(スタックPR)はdecline
- 多段スタックのbase≠mainもdecline

自前automationが同じ轍を踏まないことを保証する最終防御として明文化。

### 2. `SCRIPTS/stacked-pr-guard.sh`(新規)
open PRのうちbase≠mainのものについて、**「そのbaseブランチ名を headRefName として base=main で既にMERGED済みのPRが存在するか」** を `gh pr list` で検出する。存在すれば「親は既にmainへ入っている」ことが確定するため、`needs-review` ラベル + 警告コメントを冪等に付与する(ラベル付与により `ci-auto-merge.sh` の `BLOCK_LABELS` にも二重に引っかかるようになる副次効果もあり)。

**正当なスタック作業中(親のPRがまだmainへmergeされていない)は誤検知しない**(親未merge/親が別ブランチへmerge済み/親PRがOPENのままの3パターンをself-testで確認)。

### 3. `.github/workflows/auto-merge-tier-b.yml`
schedule sweep(2時間毎)の後段で `stacked-pr-guard.sh` を実行するステップを追加。**`check_suite` の度には走らせず**、API呼び出し過多を回避(schedule実行時のみ)。PRコメント投稿のため `issues: write` をpermissionsに追加。

## テスト
- `bash SCRIPTS/ci-auto-merge.sh --self-test` → 全9ケースPASS(既存6 + 新規3)
- `bash SCRIPTS/stacked-pr-guard.sh --self-test` → 全8ケースPASS(stale検出4 + ラベル冪等性2 + コメント冪等性2)
- `bash SCRIPTS/stacked-pr-guard.sh --dry-run`(実リポジトリ)→ エラーなく動作、現状該当PR 0件
- `bash SCRIPTS/ci-auto-merge.sh 549 --dry-run`(実リポジトリ、base=main PR)→ 従来どおりeligible判定、回帰なし
- YAML構文チェック(`python3 -c "import yaml; yaml.safe_load(...)"`) → OK
- shellcheck → info-level(SC2015)のみ、既存コードと同水準

ローカルではフルスイート(`npm test`)は実行していません(レーン並列によるポート枯渇のため、対象範囲のみ個別実行)。フルスイート検証はCIに委譲します。本PRは `.github/workflows/` と `SCRIPTS/*.sh` のみの変更のためnpm testの対象外です。

## 注意点・スコープ外
- 実際の3事故は `ci-auto-merge.sh` を経由しない人力(または他の直接 `gh pr merge` 呼び出し)が原因だった。本PRは (a) 自前automationが同じミスをしないことの保証、(b) 危険な状態を人間が見落とさないようにする警告の自動化、の2点に対応するもので、**人間が直接 `gh pr merge` を実行すること自体は止められない**(branch protectionでの強制ブロックはより踏み込んだ変更のため今回のスコープ外。必要なら別途相談させてください)。
- `high-risk` / `do-not-merge` ラベルは現状リポジトリに未登録(`needs-review` のみ登録済み)だったため、`stacked-pr-guard.sh` の警告ラベルは既存の `needs-review` を再利用した。

## Merge
自分ではmergeしません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1dxH199qQB3diHbsGLNxM