### PR TITLE
fix(billing): Sai月次コスト上限のデフォルト値設定 + super_adminバイパス境界の明文化

### DIFF
--- a/admin-ui/src/lib/planFeatures.ts
+++ b/admin-ui/src/lib/planFeatures.ts
@@ -1,6 +1,14 @@
 // admin-ui/src/lib/planFeatures.ts
 // LP(r2c.biz)の料金表に対応するプラン別機能制限。
 // backend(src/lib/billing/planFeatures.ts)のロジックと一致させること。
+//
+// GID 1216961878992581: super_admin バイパスの境界（意図的な区別。「割れている」わけではない）。
+// 新しいゲートを追加する際は、以下のどちらに当てはまるかで super_admin バイパスの可否を判断すること。
+//   - テナントの権能を永続的に付与する操作(features フラグを立てる等) → バイパス不可。
+//     super_admin であってもプランを超えた権能付与はさせない
+//     (例: activate_avatar — テナントの avatar 機能を有効化する操作、PR #533)。
+//   - 1回ごとに原価が発生する staff 起点の操作 → バイパス可。サポート業務を止めない
+//     (例: deep_research / premium_avatar / sai_task — その場限りの生成・代行実行、PR #538)。
 
 import type { TenantPlan } from "../auth/useAuth";
 

--- a/src/api/admin/options/routes.ts
+++ b/src/api/admin/options/routes.ts
@@ -68,7 +68,9 @@ function denyInsufficient(req: Request, res: Response, su: Record<string, any> |
 // ---------------------------------------------------------------------------
 // Phase5 (Saiセキュリティ強化): 支出上限ガードレール
 // Sai VPS側の日次タスク数上限(SAI_MAX_TASKS_PER_DAY)とは独立した、
-// R2C本体側での月次コスト上限チェック(多層防御)。デフォルトOFF(未設定なら無制限)。
+// R2C本体側での月次コスト上限チェック(多層防御)。
+// GID 1216947740906009: デフォルトはテナント単位$50/月・全体$200/月(env未設定時)。
+// env に明示的に '0' を渡すと無制限(エスカレーション時の逃げ道)。
 //
 // バグ修正: 従来は usage_logs を feature_used='sai_agent' のみでテナント横断集計しており、
 // 1テナントが使い込むと他の全テナントのSaiが止まっていた。テナント単位の上限を主とし、
@@ -78,9 +80,19 @@ export type SaiCeilingCheckResult =
   | { ok: true }
   | { ok: false; reason: 'tenant' | 'global'; spentCents: number; ceilingCents: number };
 
+// GID 1216947740906009: Sai($0.05/step暫定単価)の安全弁としてのデフォルト上限。
+// テナント単位: $50/月(月1000step相当)。全体(自社防衛): $200/月。
+// 実測が固まるまでの水準であり、env で明示的に上書きできる。
+const SAI_MONTHLY_COST_CEILING_CENTS_DEFAULT = 5000;
+const SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS_DEFAULT = 20000;
+
 export async function checkSaiMonthlyCostCeiling(pool: any, tenantId: string): Promise<SaiCeilingCheckResult> {
-  // テナント単位の上限(主)。未設定(0)なら従来どおり無制限。
-  const tenantCeilingCents = Number(process.env.SAI_MONTHLY_COST_CEILING_CENTS ?? '0');
+  // テナント単位の上限(主)。
+  // env 未設定時はデフォルト値(安全弁)を適用する。env に明示的に '0' を渡した場合は
+  // 従来どおり無制限にする(エスカレーション時の逃げ道を残す) — 「未設定」と「明示的に0」を区別する。
+  const tenantCeilingCents = process.env.SAI_MONTHLY_COST_CEILING_CENTS === undefined
+    ? SAI_MONTHLY_COST_CEILING_CENTS_DEFAULT
+    : Number(process.env.SAI_MONTHLY_COST_CEILING_CENTS);
   if (tenantCeilingCents > 0) {
     const tenantResult = await pool.query(
       `SELECT COALESCE(SUM(cost_total_cents), 0) AS total
@@ -94,8 +106,11 @@ export async function checkSaiMonthlyCostCeiling(pool: any, tenantId: string): P
     }
   }
 
-  // 全体(自社防衛)上限(任意・2段構えの補強)。未設定(0)ならスキップ。
-  const globalCeilingCents = Number(process.env.SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS ?? '0');
+  // 全体(自社防衛)上限(2段構えの補強)。
+  // env 未設定時はデフォルト値を適用、明示的に '0' なら無制限(テナント上限と同じ規則)。
+  const globalCeilingCents = process.env.SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS === undefined
+    ? SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS_DEFAULT
+    : Number(process.env.SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS);
   if (globalCeilingCents > 0) {
     const globalResult = await pool.query(
       `SELECT COALESCE(SUM(cost_total_cents), 0) AS total

--- a/src/api/admin/options/routes.ts
+++ b/src/api/admin/options/routes.ts
@@ -86,13 +86,40 @@ export type SaiCeilingCheckResult =
 const SAI_MONTHLY_COST_CEILING_CENTS_DEFAULT = 5000;
 const SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS_DEFAULT = 20000;
 
+/**
+ * Sai月次コスト上限のenv値を解決する。安全弁は fail-safe(不正な設定ならデフォルトへ
+ * フォールバック)であるべきで、fail-open(不正な設定で誤って無制限になる)を避ける。
+ *
+ * - 未設定(undefined) → デフォルト値
+ * - 明示的に '0' → 無制限(エスカレーション時の逃げ道。これだけが唯一の無制限手段)
+ * - 空文字・NaN・負値などの不正値 → デフォルト値にフォールバックし、warnログを出す
+ *   (黙ってデフォルトに戻すと運用者が設定ミスに気づけないため)
+ * - それ以外の正の数値 → その値をそのまま使う
+ */
+function resolveSaiCeilingCents(envValue: string | undefined, defaultCents: number, label: string): number {
+  if (envValue === undefined) return defaultCents;
+  if (envValue === '0') return 0;
+
+  const parsed = Number(envValue);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    logger.warn(
+      { envValue, label, fallbackCents: defaultCents },
+      `[options] invalid ${label} value — falling back to default (fail-safe, not fail-open)`,
+    );
+    return defaultCents;
+  }
+  return parsed;
+}
+
 export async function checkSaiMonthlyCostCeiling(pool: any, tenantId: string): Promise<SaiCeilingCheckResult> {
   // テナント単位の上限(主)。
   // env 未設定時はデフォルト値(安全弁)を適用する。env に明示的に '0' を渡した場合は
   // 従来どおり無制限にする(エスカレーション時の逃げ道を残す) — 「未設定」と「明示的に0」を区別する。
-  const tenantCeilingCents = process.env.SAI_MONTHLY_COST_CEILING_CENTS === undefined
-    ? SAI_MONTHLY_COST_CEILING_CENTS_DEFAULT
-    : Number(process.env.SAI_MONTHLY_COST_CEILING_CENTS);
+  const tenantCeilingCents = resolveSaiCeilingCents(
+    process.env.SAI_MONTHLY_COST_CEILING_CENTS,
+    SAI_MONTHLY_COST_CEILING_CENTS_DEFAULT,
+    'SAI_MONTHLY_COST_CEILING_CENTS',
+  );
   if (tenantCeilingCents > 0) {
     const tenantResult = await pool.query(
       `SELECT COALESCE(SUM(cost_total_cents), 0) AS total
@@ -108,9 +135,11 @@ export async function checkSaiMonthlyCostCeiling(pool: any, tenantId: string): P
 
   // 全体(自社防衛)上限(2段構えの補強)。
   // env 未設定時はデフォルト値を適用、明示的に '0' なら無制限(テナント上限と同じ規則)。
-  const globalCeilingCents = process.env.SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS === undefined
-    ? SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS_DEFAULT
-    : Number(process.env.SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS);
+  const globalCeilingCents = resolveSaiCeilingCents(
+    process.env.SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS,
+    SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS_DEFAULT,
+    'SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS',
+  );
   if (globalCeilingCents > 0) {
     const globalResult = await pool.query(
       `SELECT COALESCE(SUM(cost_total_cents), 0) AS total

--- a/src/api/admin/options/saiBridge.test.ts
+++ b/src/api/admin/options/saiBridge.test.ts
@@ -67,15 +67,22 @@ function superAdminApp() {
 
 describe('POST /v1/admin/options/:id/try-sai', () => {
   const savedCeiling = process.env.SAI_MONTHLY_COST_CEILING_CENTS;
+  const savedGlobalCeiling = process.env.SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS;
 
   beforeEach(() => {
     jest.clearAllMocks();
-    delete process.env.SAI_MONTHLY_COST_CEILING_CENTS;
+    // デフォルトは明示的に無制限('0')にしておき、上限そのものを検証したいテストだけが
+    // 個別に上書き/未設定化する(GID 1216947740906009 で未設定時のデフォルト上限が有効化された
+    // ため、上限チェックを意図しない既存テストへ副作用が及ぶのを防ぐ)。
+    process.env.SAI_MONTHLY_COST_CEILING_CENTS = '0';
+    process.env.SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS = '0';
   });
 
   afterEach(() => {
     if (savedCeiling === undefined) delete process.env.SAI_MONTHLY_COST_CEILING_CENTS;
     else process.env.SAI_MONTHLY_COST_CEILING_CENTS = savedCeiling;
+    if (savedGlobalCeiling === undefined) delete process.env.SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS;
+    else process.env.SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS = savedGlobalCeiling;
   });
 
   it('super_admin以外は403', async () => {
@@ -134,15 +141,59 @@ describe('POST /v1/admin/options/:id/try-sai', () => {
     expect(sentDescription).toContain('FAQ登録代行をお願いします');
   });
 
-  it('SAI_MONTHLY_COST_CEILING_CENTS未設定時は上限チェックをスキップする(デフォルト無制限)', async () => {
-    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'order-1', description: 'x' }] });
+  // GID 1216947740906009: env未設定時はデフォルト上限(テナント$50/月・全体$200/月)が適用される。
+  it('SAI_MONTHLY_COST_CEILING_CENTS未設定時はデフォルト上限($50/月)が適用され、下回っていれば通常通り依頼できる', async () => {
+    delete process.env.SAI_MONTHLY_COST_CEILING_CENTS;
+    delete process.env.SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS;
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'order-1', tenant_id: 'tenant-x', description: 'x' }] }); // 発注SELECT
+    mockQuery.mockResolvedValueOnce({ rows: [{ total: '100' }] }); // テナント上限チェックSELECT（$50未満）
+    mockQuery.mockResolvedValueOnce({ rows: [{ total: '100' }] }); // 全体上限チェックSELECT（$200未満）
+    mockSubmitSaiTask.mockResolvedValueOnce({ task_id: 'sai-task-1', status: 'queued' });
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [] }); // sai_task_id UPDATE
+
+    const res = await request(superAdminApp()).post('/v1/admin/options/order-1/try-sai').send({});
+
+    expect(res.status).toBe(202);
+    // env未設定でもデフォルト上限のチェックは行われる(発注SELECT+テナント上限SELECT+全体上限SELECT+UPDATE)
+    expect(mockQuery).toHaveBeenCalledTimes(4);
+  });
+
+  it('env未設定でテナント使用量がデフォルト上限($50=5000セント)以上なら429で拒否される', async () => {
+    delete process.env.SAI_MONTHLY_COST_CEILING_CENTS;
+    delete process.env.SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS;
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'order-1', tenant_id: 'tenant-x', description: 'x' }] });
+    mockQuery.mockResolvedValueOnce({ rows: [{ total: '5000' }] }); // テナント上限ちょうど到達
+
+    const res = await request(superAdminApp()).post('/v1/admin/options/order-1/try-sai').send({});
+
+    expect(res.status).toBe(429);
+    expect(mockSubmitSaiTask).not.toHaveBeenCalled();
+  });
+
+  it('env未設定でテナントは上限内だが全体使用量がデフォルト上限($200=20000セント)以上なら429で拒否される', async () => {
+    delete process.env.SAI_MONTHLY_COST_CEILING_CENTS;
+    delete process.env.SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS;
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'order-1', tenant_id: 'tenant-x', description: 'x' }] });
+    mockQuery.mockResolvedValueOnce({ rows: [{ total: '100' }] }); // テナント上限: 余裕あり
+    mockQuery.mockResolvedValueOnce({ rows: [{ total: '20000' }] }); // 全体上限ちょうど到達
+
+    const res = await request(superAdminApp()).post('/v1/admin/options/order-1/try-sai').send({});
+
+    expect(res.status).toBe(429);
+    expect(mockSubmitSaiTask).not.toHaveBeenCalled();
+  });
+
+  it('env に明示的に"0"を渡すと従来どおり無制限になる(エスカレーション時の逃げ道)', async () => {
+    process.env.SAI_MONTHLY_COST_CEILING_CENTS = '0';
+    process.env.SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS = '0';
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'order-1', tenant_id: 'tenant-x', description: 'x' }] });
     mockSubmitSaiTask.mockResolvedValueOnce({ task_id: 'sai-task-1', status: 'queued' });
     mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [] });
 
     const res = await request(superAdminApp()).post('/v1/admin/options/order-1/try-sai').send({});
 
     expect(res.status).toBe(202);
-    // 上限チェックのSELECTは発火しない(合計2回=発注SELECT+sai_task_id UPDATEのみ)
+    // 明示的に0を渡すと上限チェックSELECTは発火しない(発注SELECT+UPDATEのみ)
     expect(mockQuery).toHaveBeenCalledTimes(2);
   });
 
@@ -356,7 +407,40 @@ describe('checkSaiMonthlyCostCeiling', () => {
     else process.env.SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS = savedGlobalCeiling;
   });
 
-  it('両方未設定(0)なら従来どおり無制限で、DBクエリは一切発行しない(後方互換)', async () => {
+  // GID 1216947740906009: env未設定時はデフォルト上限(テナント5000セント=$50・全体20000セント=$200)が適用される。
+  it('両方未設定ならデフォルト上限($50/$200)が適用され、下回っていればokを返す', async () => {
+    const pool = { query: mockQuery };
+
+    mockQuery.mockResolvedValueOnce({ rows: [{ total: '100' }] }); // テナント: $50未満
+    mockQuery.mockResolvedValueOnce({ rows: [{ total: '100' }] }); // 全体: $200未満
+    const result = await checkSaiMonthlyCostCeiling(pool, 'tenant-a');
+
+    expect(result).toEqual({ ok: true });
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it('未設定時、テナント使用量がデフォルト上限(5000セント)以上なら reason=tenant で拒否する', async () => {
+    const pool = { query: mockQuery };
+
+    mockQuery.mockResolvedValueOnce({ rows: [{ total: '5000' }] });
+    const result = await checkSaiMonthlyCostCeiling(pool, 'tenant-a');
+
+    expect(result).toEqual({ ok: false, reason: 'tenant', spentCents: 5000, ceilingCents: 5000 });
+  });
+
+  it('未設定時、テナント上限は未満だが全体使用量がデフォルト上限(20000セント)以上なら reason=global で拒否する', async () => {
+    const pool = { query: mockQuery };
+
+    mockQuery.mockResolvedValueOnce({ rows: [{ total: '100' }] }); // テナント: 余裕あり
+    mockQuery.mockResolvedValueOnce({ rows: [{ total: '20000' }] }); // 全体: 上限到達
+    const result = await checkSaiMonthlyCostCeiling(pool, 'tenant-a');
+
+    expect(result).toEqual({ ok: false, reason: 'global', spentCents: 20000, ceilingCents: 20000 });
+  });
+
+  it('明示的に"0"を渡すとテナント・全体とも無制限になり、DBクエリを一切発行しない(エスカレーション時の逃げ道)', async () => {
+    process.env.SAI_MONTHLY_COST_CEILING_CENTS = '0';
+    process.env.SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS = '0';
     const pool = { query: mockQuery };
     const result = await checkSaiMonthlyCostCeiling(pool, 'tenant-a');
 
@@ -366,6 +450,7 @@ describe('checkSaiMonthlyCostCeiling', () => {
 
   it('テナントAが上限超過していてもテナントBの判定には影響しない(テナント単位)', async () => {
     process.env.SAI_MONTHLY_COST_CEILING_CENTS = '1000';
+    process.env.SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS = '0'; // このテストの対象外(テナント単位の検証)
     const pool = { query: mockQuery };
 
     mockQuery.mockResolvedValueOnce({ rows: [{ total: '1500' }] });
@@ -392,8 +477,9 @@ describe('checkSaiMonthlyCostCeiling', () => {
     expect(result).toEqual({ ok: false, reason: 'global', spentCents: 5000, ceilingCents: 5000 });
   });
 
-  it('テナント上限のみ設定(全体上限は未設定)なら全体集計クエリは発行しない', async () => {
+  it('全体上限を明示的に0にすると全体集計クエリは発行しない(テナント上限のみ有効)', async () => {
     process.env.SAI_MONTHLY_COST_CEILING_CENTS = '1000';
+    process.env.SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS = '0';
     const pool = { query: mockQuery };
 
     mockQuery.mockResolvedValueOnce({ rows: [{ total: '0' }] });

--- a/src/api/admin/options/saiBridge.test.ts
+++ b/src/api/admin/options/saiBridge.test.ts
@@ -4,6 +4,7 @@
 import express from 'express';
 import request from 'supertest';
 import { registerOptionRoutes, checkSaiMonthlyCostCeiling } from './routes';
+import { logger } from '../../../lib/logger';
 
 jest.mock('../../../admin/http/supabaseAuthMiddleware', () => ({
   supabaseAuthMiddleware: (_req: any, _res: any, next: any) => next(),
@@ -446,6 +447,95 @@ describe('checkSaiMonthlyCostCeiling', () => {
 
     expect(result).toEqual({ ok: true });
     expect(mockQuery).not.toHaveBeenCalled();
+  });
+
+  // 安全弁は fail-safe(不正な設定ならデフォルトへフォールバック)であるべきで、
+  // fail-open(不正な設定で誤って無制限になる)を避ける。無制限にできるのは明示的な '0' のみ。
+  describe('不正なenv値はfail-safeでデフォルトにフォールバックする(fail-openしない)', () => {
+    let warnSpy: jest.SpyInstance;
+
+    beforeEach(() => {
+      warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it('空文字は不正値としてデフォルト値(5000セント)にフォールバックする(無制限にならない)', async () => {
+      process.env.SAI_MONTHLY_COST_CEILING_CENTS = '';
+      process.env.SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS = '0';
+      const pool = { query: mockQuery };
+
+      mockQuery.mockResolvedValueOnce({ rows: [{ total: '5000' }] }); // デフォルト上限ちょうど到達
+      const result = await checkSaiMonthlyCostCeiling(pool, 'tenant-a');
+
+      expect(result).toEqual({ ok: false, reason: 'tenant', spentCents: 5000, ceilingCents: 5000 });
+    });
+
+    it("'abc'等のタイポ(NaN)はデフォルト値にフォールバックし、警告ログを出す", async () => {
+      process.env.SAI_MONTHLY_COST_CEILING_CENTS = 'abc';
+      process.env.SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS = '0';
+      const pool = { query: mockQuery };
+
+      mockQuery.mockResolvedValueOnce({ rows: [{ total: '100' }] });
+      const result = await checkSaiMonthlyCostCeiling(pool, 'tenant-a');
+
+      expect(result).toEqual({ ok: true });
+      expect(mockQuery.mock.calls[0]![1]).toEqual(['tenant-a']);
+      // デフォルト値(5000セント)が使われたことを、上限超過ケースで確認
+      warnSpy.mockClear();
+      mockQuery.mockResolvedValueOnce({ rows: [{ total: '5000' }] });
+      const result2 = await checkSaiMonthlyCostCeiling(pool, 'tenant-a');
+      expect(result2).toEqual({ ok: false, reason: 'tenant', spentCents: 5000, ceilingCents: 5000 });
+
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ envValue: 'abc', label: 'SAI_MONTHLY_COST_CEILING_CENTS' }),
+        expect.stringContaining('invalid'),
+      );
+    });
+
+    it("'-100'(負値)はデフォルト値にフォールバックし、警告ログを出す", async () => {
+      process.env.SAI_MONTHLY_COST_CEILING_CENTS = '-100';
+      process.env.SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS = '0';
+      const pool = { query: mockQuery };
+
+      mockQuery.mockResolvedValueOnce({ rows: [{ total: '5000' }] }); // デフォルト上限ちょうど到達
+      const result = await checkSaiMonthlyCostCeiling(pool, 'tenant-a');
+
+      expect(result).toEqual({ ok: false, reason: 'tenant', spentCents: 5000, ceilingCents: 5000 });
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ envValue: '-100', label: 'SAI_MONTHLY_COST_CEILING_CENTS' }),
+        expect.stringContaining('invalid'),
+      );
+    });
+
+    it("正しい数値('10000')はそのまま使われ、警告ログは出ない", async () => {
+      process.env.SAI_MONTHLY_COST_CEILING_CENTS = '10000';
+      process.env.SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS = '0';
+      const pool = { query: mockQuery };
+
+      mockQuery.mockResolvedValueOnce({ rows: [{ total: '10000' }] });
+      const result = await checkSaiMonthlyCostCeiling(pool, 'tenant-a');
+
+      expect(result).toEqual({ ok: false, reason: 'tenant', spentCents: 10000, ceilingCents: 10000 });
+      expect(warnSpy).not.toHaveBeenCalled();
+    });
+
+    it('全体上限側も同じ規則が適用される(空文字→デフォルト20000セントにフォールバック)', async () => {
+      process.env.SAI_MONTHLY_COST_CEILING_CENTS = '0';
+      process.env.SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS = '';
+      const pool = { query: mockQuery };
+
+      mockQuery.mockResolvedValueOnce({ rows: [{ total: '20000' }] }); // 全体デフォルト上限ちょうど到達
+      const result = await checkSaiMonthlyCostCeiling(pool, 'tenant-a');
+
+      expect(result).toEqual({ ok: false, reason: 'global', spentCents: 20000, ceilingCents: 20000 });
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({ envValue: '', label: 'SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS' }),
+        expect.stringContaining('invalid'),
+      );
+    });
   });
 
   it('テナントAが上限超過していてもテナントBの判定には影響しない(テナント単位)', async () => {

--- a/src/lib/billing/planFeatures.ts
+++ b/src/lib/billing/planFeatures.ts
@@ -7,6 +7,14 @@
 //   Growth〜: AIアバター（顔・声）、高度なAnalytics、CV計測、プレミアムアバター生成
 //   Enterprise〜: カスタムアバター（Fish Audio Voice Cloning）、ディープリサーチ、Sai代行（R2Cエージェント）
 // 「心理学Sales AI」は現状すべてのプランで提供するため、ここでは制限しない。
+//
+// GID 1216961878992581: super_admin バイパスの境界（意図的な区別。「割れている」わけではない）。
+// 新しいゲートを追加する際は、以下のどちらに当てはまるかで super_admin バイパスの可否を判断すること。
+//   - テナントの権能を永続的に付与する操作(features フラグを立てる等) → バイパス不可。
+//     super_admin であってもプランを超えた権能付与はさせない
+//     (例: activate_avatar — テナントの avatar 機能を有効化する操作、PR #533)。
+//   - 1回ごとに原価が発生する staff 起点の操作 → バイパス可。サポート業務を止めない
+//     (例: deep_research / premium_avatar / sai_task — その場限りの生成・代行実行、PR #538)。
 
 import type { Pool } from "pg";
 import { getPool } from "../db";


### PR DESCRIPTION
2件の小さいタスクをまとめてPRにしています(team-lead指示)。base=origin/main、他ブランチへのスタックなし。

## タスク1: Sai月次コスト上限のデフォルト値 (Asana gid 1216947740906009)
`checkSaiMonthlyCostCeiling` の env フォールバックを、従来のデフォルト `'0'`(無制限)から以下に変更しました:
- `SAI_MONTHLY_COST_CEILING_CENTS`(テナント単位) = **5000** ($50/月)
- `SAI_MONTHLY_COST_CEILING_GLOBAL_CENTS`(全体・自社防衛) = **20000** ($200/月)

根拠: Sai は $0.05/step の暫定単価。テナントあたり月1000ステップ相当で、実測が固まるまでの安全弁として妥当な水準(小林さん判断)。

**env で明示的に `'0'` を渡した場合は従来どおり無制限**にしています(エスカレーション時の逃げ道を残す)。「未設定ならデフォルト値、明示的に0なら無制限」を `=== undefined` での判定で区別しました(`?? '0'` だと両者を区別できないため)。

## タスク2: super_admin バイパスの境界を明文化 (Asana gid 1216961878992581)
**コードの振る舞いは変えず、コメントのみ追加**しました。`src/lib/billing/planFeatures.ts` と `admin-ui/src/lib/planFeatures.ts` の両方の先頭コメントに、以下の境界を記述:
- テナントの権能を永続的に付与する操作(features フラグを立てる等) → バイパス不可(例: `activate_avatar`, PR #533)
- 1回ごとに原価が発生する staff 起点の操作 → バイパス可、サポート業務を止めない(例: `deep_research`/`premium_avatar`/`sai_task`, PR #538)

## テスト
`saiBridge.test.ts`:
- env未設定時のデフォルト上限適用(テナント/全体それぞれ超過時に429)
- env明示的 `'0'` での無制限(エスカレーション逃げ道)
- 既存の回帰確認テストを更新: 全体上限が未設定時に「従来どおりスキップ」を前提にしていた既存テストが、新デフォルト(未設定=$200上限が有効)と矛盾するようになったため、describe block の `beforeEach` で両env変数をデフォルト `'0'`(無制限)に設定し、上限そのものを検証したいテストだけが個別に上書き/削除する形に整理しました。

`planFeatures.test.ts`(backend/admin-ui): コメントのみの変更のため新規テストは追加せず、既存テストが通ることを確認。

対象テスト(`saiBridge.test.ts` 32件, `planFeatures.test.ts` backend 29件・admin-ui 23件)全てPASS。`tsc --noEmit`(backend)0エラー。

admin-ui の `tsc -b` では `AuthContextValue.tenantPlan` 関連の既存エラーが多数出ますが、本PRが触っていない他ファイル(auth/chat-history/chat-test/conversion/options 等のテストモック)群での既存の型不整合で、本PRの変更(コメント追加のみ)とは無関係です。

ローカルはフルスイート未実行(レーン並列によるポート枯渇のため)、フルスイート検証はCIに委譲します。