### PR TITLE
chore: 一時スクラッチ2件を削除し .claude/tmp_* を gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,6 @@ docs/postmortem/2026-05-28-oauth-fail/r2c-queue.db.pre-clean
 # 2026-05-28 LFS untrack: CE_MODEL_PATH env でVPS実体(/opt/rajiuce/models/...)を参照
 # git管理不要、LFS帯域超過(9.1GB/月)の根治
 models/ce-export/model.onnx
+
+# 一時スクラッチ(Playwright REPL 等)
+.claude/tmp_*


### PR DESCRIPTION
## 削除したもの

**`tests/e2e/zz-real-audio-asr-check.spec.ts`**
- `expect` を import しているがアサーションが1件も無く、全て `console.log` の手動診断スクリプト
- 対象が `https://admin.r2c.biz` = 本番。E2Eが本番を叩く問題(PR #548で直列化した件)をさらに増やす
- 音声ファイルが別セッションのスクラッチパッドの絶対パス参照で、他環境では動作しない
- `tests/e2e/` に置いたままだと Playwright の glob に拾われてCIで実行される

**`.claude/tmp_pw_repl.mjs`**
- Playwright 対話デバッグ用のスクラッチ(62行)。成果物ではない

## 追加
`.gitignore` に `.claude/tmp_*` を追加。同種の一時ファイルが今後コミット候補に出てこないようにする。

## 補足
ASRの回帰テストが必要な場合は、小さなWAVをリポジトリ内に置いて相対パス化し、実際のアサーションを書いた上で本番以外を対象にする別タスクとすべきです。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1dxH199qQB3diHbsGLNxM