### PR TITLE
feat(lp): 機能訴求のブラッシュアップ + 学習ループ/信頼性の新設セクション

### DIFF
--- a/public/lp/index.html
+++ b/public/lp/index.html
@@ -655,7 +655,7 @@
               <div style="font-weight:700; font-size:15px; color:#fff; margin-bottom:2px;">AIアバター</div>
               <div style="display:flex; align-items:center; gap:5px;">
                 <div class="blink" style="width:6px; height:6px; border-radius:50%; background:#a78bfa;"></div>
-                <span style="font-size:11px; color:#a78bfa; font-weight:600;">有料オプション</span>
+                <span style="font-size:11px; color:#a78bfa; font-weight:600;">Growth以上</span>
               </div>
             </div>
           </div>

--- a/public/lp/index.html
+++ b/public/lp/index.html
@@ -659,7 +659,7 @@
               </div>
             </div>
           </div>
-          <div style="font-size:13px; color:var(--muted); line-height:1.65;">顔・声のあるAIが親しみやすく接客。テキストボットより<strong style="color:#c4b5fd;">3倍の会話継続率</strong>を実現。</div>
+          <div style="font-size:13px; color:var(--muted); line-height:1.65;">顔・声のあるAIが親しみやすく接客。<strong style="color:#c4b5fd;">リアルタイムの音声対話</strong>にも対応し、テキストだけの応対より離脱されにくく、会話を最後まで届けます。</div>
         </div>
         <div class="glass-card" style="border-radius:14px; padding:26px; transition:border-color 0.2s;" onmouseover="this.style.borderColor='rgba(139,92,246,0.35)'" onmouseout="this.style.borderColor='rgba(255,255,255,0.08)'">
           <div style="font-size:32px; margin-bottom:14px;">🔍</div>
@@ -672,19 +672,91 @@
           <div style="font-size:13px; color:var(--muted); line-height:1.65;">迷っている訪問者を自然にクロージングへ。<strong style="color:#c4b5fd;">購入・予約の転換率を最大化</strong>する対話設計。</div>
         </div>
         <div class="glass-card" style="border-radius:14px; padding:26px; transition:border-color 0.2s;" onmouseover="this.style.borderColor='rgba(139,92,246,0.35)'" onmouseout="this.style.borderColor='rgba(255,255,255,0.08)'">
-          <div style="font-size:32px; margin-bottom:14px;">🚨</div>
-          <div style="font-weight:700; font-size:15px; color:#fff; margin-bottom:8px;">プロアクティブ介入</div>
-          <div style="font-size:13px; color:var(--muted); line-height:1.65;">離脱しそうな訪問者を<strong style="color:#c4b5fd;">先回りで呼び止め</strong>。「何かお手伝いできますか？」で機会損失を防ぐ。</div>
+          <div style="font-size:32px; margin-bottom:14px;">🔮</div>
+          <div style="font-weight:700; font-size:15px; color:#fff; margin-bottom:8px;">行動を読んで、先回りする</div>
+          <div style="font-size:13px; color:var(--muted); line-height:1.65;">滞在時間・回遊・離脱兆候から<strong style="color:#c4b5fd;">購入温度を数値化</strong>。似た行動をした訪問者の成功パターンを参照して、声がけの内容とタイミングを最適化します。</div>
+        </div>
+        <div class="glass-card" style="border-radius:14px; padding:26px; transition:border-color 0.2s;" onmouseover="this.style.borderColor='rgba(139,92,246,0.35)'" onmouseout="this.style.borderColor='rgba(255,255,255,0.08)'">
+          <div style="font-size:32px; margin-bottom:14px;">🤝</div>
+          <div style="font-weight:700; font-size:15px; color:#fff; margin-bottom:8px;">AIで終わらせない、人へ繋ぐ</div>
+          <div style="font-size:13px; color:var(--muted); line-height:1.65;">AIが対応しきれない場面は<strong style="color:#c4b5fd;">ワンタップで有人チャット</strong>へ。会話履歴を引き継ぐので、お客様は最初から説明し直す必要がありません。</div>
         </div>
         <div class="glass-card" style="border-radius:14px; padding:26px; transition:border-color 0.2s;" onmouseover="this.style.borderColor='rgba(139,92,246,0.35)'" onmouseout="this.style.borderColor='rgba(255,255,255,0.08)'">
           <div style="font-size:32px; margin-bottom:14px;">📊</div>
-          <div style="font-weight:700; font-size:15px; color:#fff; margin-bottom:8px;">CV計測</div>
-          <div style="font-size:13px; color:var(--muted); line-height:1.65;">購入・予約・問い合わせへの<strong style="color:#c4b5fd;">AI貢献を数値化</strong>。ROIが一目でわかる。</div>
+          <div style="font-weight:700; font-size:15px; color:#fff; margin-bottom:8px;">成果の可視化</div>
+          <div style="font-size:13px; color:var(--muted); line-height:1.65;">購入・予約・問い合わせへの<strong style="color:#c4b5fd;">AI貢献を数値化</strong>。Judgeエンジンが全会話を4軸評価し、品質を可視化します。</div>
         </div>
-        <div class="glass-card" style="border-radius:14px; padding:26px; transition:border-color 0.2s;" onmouseover="this.style.borderColor='rgba(139,92,246,0.35)'" onmouseout="this.style.borderColor='rgba(255,255,255,0.08)'">
-          <div style="font-size:32px; margin-bottom:14px;">📈</div>
-          <div style="font-weight:700; font-size:15px; color:#fff; margin-bottom:8px;">Analytics Dashboard</div>
-          <div style="font-size:13px; color:var(--muted); line-height:1.65;">会話品質・CVRを<strong style="color:#c4b5fd;">リアルタイムに改善</strong>。Judgeエンジンがトークスクリプトを自動チューニング。</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ===================== LEARNING LOOP (使うほど賢くなる) ===================== -->
+<section style="background:rgba(255,255,255,0.015); border-top:1px solid rgba(255,255,255,0.06); border-bottom:1px solid rgba(255,255,255,0.06); padding:80px 20px;">
+  <div style="max-width:1100px; margin:0 auto;">
+    <div style="text-align:center; margin-bottom:20px;">
+      <h2 style="font-size:clamp(22px,3vw,34px); font-weight:800; margin:0 0 12px; line-height:1.4;">使うほど賢くなる。<br>それが、作りっぱなしのチャットボットとの違いです</h2>
+      <p style="color:var(--muted); font-size:15px; max-width:520px; margin:0 auto; line-height:1.7;">多くのチャットボットは、設置した日が一番賢い日です。R2Cは逆で、会話が増えるほど精度が上がります。</p>
+    </div>
+
+    <div class="learn-grid" style="display:grid; grid-template-columns:repeat(4,1fr); gap:20px; margin-top:44px;">
+      <style>
+        @media (max-width: 900px) { .learn-grid { grid-template-columns: repeat(2,1fr) !important; } }
+        @media (max-width: 560px) { .learn-grid { grid-template-columns: 1fr !important; } }
+      </style>
+      <div style="display:contents;">
+        <div class="glass-card" style="border-radius:14px; padding:24px;">
+          <div style="font-size:28px; margin-bottom:12px;">🔎</div>
+          <div style="font-weight:700; font-size:15px; color:#fff; margin-bottom:8px;">未回答質問を自動で集める</div>
+          <div style="font-size:13px; color:var(--muted); line-height:1.65;">AIが答えられなかった質問は自動で抽出され、管理画面に一覧されます。何を追加すべきかを探す手間がありません。</div>
+        </div>
+        <div class="glass-card" style="border-radius:14px; padding:24px;">
+          <div style="font-size:28px; margin-bottom:12px;">⚖️</div>
+          <div style="font-weight:700; font-size:15px; color:#fff; margin-bottom:8px;">全会話をAIが採点</div>
+          <div style="font-size:13px; color:var(--muted); line-height:1.65;">Judgeエンジンが4軸で評価。どの応対が良く、どこで失敗したかが数字で見えます。</div>
+        </div>
+        <div class="glass-card" style="border-radius:14px; padding:24px;">
+          <div style="font-size:28px; margin-bottom:12px;">🌱</div>
+          <div style="font-weight:700; font-size:15px; color:#fff; margin-bottom:8px;">良かった会話から学習</div>
+          <div style="font-size:13px; color:var(--muted); line-height:1.65;">高評価だった会話は要点が蒸留され、次回以降の応対に反映されます。</div>
+        </div>
+        <div class="glass-card" style="border-radius:14px; padding:24px;">
+          <div style="font-size:28px; margin-bottom:12px;">🗣️</div>
+          <div style="font-weight:700; font-size:15px; color:#fff; margin-bottom:8px;">反論パターンが貯まる</div>
+          <div style="font-size:13px; color:var(--muted); line-height:1.65;">「高い」「今じゃない」といった反応への切り返しが蓄積され、営業トークが磨かれます。</div>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ===================== TRUST (AIが答えられない時こそ、差が出る) ===================== -->
+<section style="background:rgba(255,255,255,0.015); border-top:1px solid rgba(255,255,255,0.06); border-bottom:1px solid rgba(255,255,255,0.06); padding:80px 20px;">
+  <div style="max-width:1100px; margin:0 auto;">
+    <div style="text-align:center; margin-bottom:44px;">
+      <h2 style="font-size:clamp(22px,3vw,34px); font-weight:800; margin:0 0 12px;">「AIが変なことを言ったら困る」への答え</h2>
+      <p style="color:var(--muted); font-size:15px; margin:0;">AI接客で最も多い懸念です。R2Cは3段構えで対応します。</p>
+    </div>
+
+    <div class="trust-grid" style="display:grid; grid-template-columns:repeat(3,1fr); gap:20px;">
+      <style>
+        @media (max-width: 767px) { .trust-grid { grid-template-columns: 1fr !important; } }
+      </style>
+      <div style="display:contents;">
+        <div class="glass-card" style="border-radius:14px; padding:26px;">
+          <div style="font-size:32px; margin-bottom:14px;">🔒</div>
+          <div style="font-weight:700; font-size:15px; color:#fff; margin-bottom:8px;">でたらめを言わせない</div>
+          <div style="font-size:13px; color:var(--muted); line-height:1.65;">登録された知識に基づいてのみ回答。根拠がない質問には正直に「わかりません」と答えます。</div>
+        </div>
+        <div class="glass-card" style="border-radius:14px; padding:26px;">
+          <div style="font-size:32px; margin-bottom:14px;">🤝</div>
+          <div style="font-weight:700; font-size:15px; color:#fff; margin-bottom:8px;">その場で人に繋ぐ</div>
+          <div style="font-size:13px; color:var(--muted); line-height:1.65;">お客様を待たせず有人チャットへ。会話の文脈ごと引き継ぎます。</div>
+        </div>
+        <div class="glass-card" style="border-radius:14px; padding:26px;">
+          <div style="font-size:32px; margin-bottom:14px;">🔄</div>
+          <div style="font-weight:700; font-size:15px; color:#fff; margin-bottom:8px;">同じ失敗を繰り返さない</div>
+          <div style="font-size:13px; color:var(--muted); line-height:1.65;">答えられなかった質問は自動で記録され、次はAIが答えられるようになります。</div>
         </div>
       </div>
     </div>
@@ -897,9 +969,19 @@
             <td class="r2c-col" style="text-align:center; padding:14px 16px; border-bottom:1px solid rgba(124,58,237,0.15);">💰 完全従量課金</td>
           </tr>
           <tr>
-            <td style="font-size:14px; color:var(--muted); padding:14px 16px;">データ活用</td>
-            <td style="font-size:14px; color:var(--muted); text-align:center; padding:14px 16px;">ログ閲覧のみ</td>
-            <td class="r2c-col" style="text-align:center; padding:14px 16px;">📊 Judge自動チューニング</td>
+            <td style="font-size:14px; color:var(--muted); padding:14px 16px; border-bottom:1px solid rgba(255,255,255,0.06);">データ活用</td>
+            <td style="font-size:14px; color:var(--muted); text-align:center; padding:14px 16px; border-bottom:1px solid rgba(255,255,255,0.06);">ログ閲覧のみ</td>
+            <td class="r2c-col" style="text-align:center; padding:14px 16px; border-bottom:1px solid rgba(124,58,237,0.15);">📊 未回答質問の自動抽出＋自己学習</td>
+          </tr>
+          <tr>
+            <td style="font-size:14px; color:var(--muted); padding:14px 16px; border-bottom:1px solid rgba(255,255,255,0.06);">有人対応</td>
+            <td style="font-size:14px; color:var(--muted); text-align:center; padding:14px 16px; border-bottom:1px solid rgba(255,255,255,0.06);">なし／別システム</td>
+            <td class="r2c-col" style="text-align:center; padding:14px 16px; border-bottom:1px solid rgba(124,58,237,0.15);">🤝 文脈を引き継いで即エスカレーション</td>
+          </tr>
+          <tr>
+            <td style="font-size:14px; color:var(--muted); padding:14px 16px;">既存ツール連携</td>
+            <td style="font-size:14px; color:var(--muted); text-align:center; padding:14px 16px;">なし</td>
+            <td class="r2c-col" style="text-align:center; padding:14px 16px;">🔗 GA4・PostHog連携</td>
           </tr>
         </tbody>
       </table>
@@ -948,7 +1030,31 @@
       </button>
       <div class="accordion-content">
         <div style="padding:0 20px 18px; font-size:14px; color:var(--muted); line-height:1.75;">
-          RAG（検索拡張生成）技術により、登録した知識ベースの情報のみを使って回答します。根拠のない回答（ハルシネーション）を大幅に抑制。さらにJudgeエンジンが全会話を4軸評価し、品質が下がった場合は自動でアラートを発します。
+          RAG（検索拡張生成）技術により、登録した知識ベースの情報のみを使って回答します。根拠のない回答（ハルシネーション）を大幅に抑制。さらにJudgeエンジンが全会話を4軸評価して品質を可視化し、会話完了率やエラー率など運用指標が悪化した場合は管理側へ自動アラートが届きます。
+        </div>
+      </div>
+    </div>
+
+    <div class="glass-card accordion-item" style="border-radius:12px; overflow:hidden; margin-bottom:2px;">
+      <button onclick="toggleAccordion(this)" style="width:100%; background:none; border:none; padding:18px 20px; display:flex; justify-content:space-between; align-items:center; cursor:pointer; text-align:left; gap:12px;">
+        <span style="font-size:15px; font-weight:600; color:#fff; line-height:1.4;">音声で話せますか？</span>
+        <svg class="accordion-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" style="flex-shrink:0; color:var(--muted);"><path d="M6 9l6 6 6-6"/></svg>
+      </button>
+      <div class="accordion-content">
+        <div style="padding:0 20px 18px; font-size:14px; color:var(--muted); line-height:1.75;">
+          はい。Growthプラン以上でAIアバターの音声入力・音声応答に対応しています。テキストと音声、どちらでも自然に会話いただけます。
+        </div>
+      </div>
+    </div>
+
+    <div class="glass-card accordion-item" style="border-radius:12px; overflow:hidden; margin-bottom:2px;">
+      <button onclick="toggleAccordion(this)" style="width:100%; background:none; border:none; padding:18px 20px; display:flex; justify-content:space-between; align-items:center; cursor:pointer; text-align:left; gap:12px;">
+        <span style="font-size:15px; font-weight:600; color:#fff; line-height:1.4;">英語のお客様にも対応できますか？</span>
+        <svg class="accordion-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" style="flex-shrink:0; color:var(--muted);"><path d="M6 9l6 6 6-6"/></svg>
+      </button>
+      <div class="accordion-content">
+        <div style="padding:0 20px 18px; font-size:14px; color:var(--muted); line-height:1.75;">
+          日本語・英語に対応しています。訪問者の言語に応じてAIが自動で切り替えて応答します。
         </div>
       </div>
     </div>
@@ -1009,6 +1115,30 @@
       <div class="accordion-content">
         <div style="padding:0 20px 18px; font-size:14px; color:var(--muted); line-height:1.75;">
           管理画面から知識ベースをいつでも更新できます。FAQの追加・修正・削除はリアルタイムで反映され、次の会話から正しく回答します。Judgeエンジンが誤回答パターンを検出した場合は管理画面に改善提案が届きます。
+        </div>
+      </div>
+    </div>
+
+    <div class="glass-card accordion-item" style="border-radius:12px; overflow:hidden; margin-bottom:2px;">
+      <button onclick="toggleAccordion(this)" style="width:100%; background:none; border:none; padding:18px 20px; display:flex; justify-content:space-between; align-items:center; cursor:pointer; text-align:left; gap:12px;">
+        <span style="font-size:15px; font-weight:600; color:#fff; line-height:1.4;">既存のGA4やPostHogと繋がりますか？</span>
+        <svg class="accordion-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" style="flex-shrink:0; color:var(--muted);"><path d="M6 9l6 6 6-6"/></svg>
+      </button>
+      <div class="accordion-content">
+        <div style="padding:0 20px 18px; font-size:14px; color:var(--muted); line-height:1.75;">
+          Growthプラン以上でGA4・PostHog連携に対応しています。AI経由のコンバージョンを既存の分析基盤でも確認できます。
+        </div>
+      </div>
+    </div>
+
+    <div class="glass-card accordion-item" style="border-radius:12px; overflow:hidden; margin-bottom:2px;">
+      <button onclick="toggleAccordion(this)" style="width:100%; background:none; border:none; padding:18px 20px; display:flex; justify-content:space-between; align-items:center; cursor:pointer; text-align:left; gap:12px;">
+        <span style="font-size:15px; font-weight:600; color:#fff; line-height:1.4;">設定は自分でやるんですか？</span>
+        <svg class="accordion-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" style="flex-shrink:0; color:var(--muted);"><path d="M6 9l6 6 6-6"/></svg>
+      </button>
+      <div class="accordion-content">
+        <div style="padding:0 20px 18px; font-size:14px; color:var(--muted); line-height:1.75;">
+          管理画面でAIエージェントに話しかけるだけで、FAQ登録や接客ルールの調整が完結します。複雑な設定変更が必要な場合は、Enterpriseプランで「R2Cエージェント」に代行を依頼することも可能です。
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
Asana gid 1216980922207019。構成案は小林さん承認済みのため方向性確認なしでそのまま実装。対象は `public/lp/index.html` のみ。

### 1. 「6つの機能」を刷新
- AIアバター: リアルタイム音声対話の訴求に差し替え(根拠のない「3倍の会話継続率」は削除)
- RAG FAQ検索 / 心理学Sales AI: 現行文言のまま
- プロアクティブ介入 → **「行動を読んで、先回りする」**に置換
- **「AIで終わらせない、人へ繋ぐ」**を新規追加
- CV計測 + Analytics Dashboard → **「成果の可視化」**に統合(「トークスクリプトを自動チューニング」は未配線のためこちらも削除)

### 2. 新設セクション「使うほど賢くなる」
配置: 6つの機能 → **使うほど賢くなる(新設)** → AIが答えられない時こそ差が出る(新設) → 料金表。カード4枚(未回答質問の自動抽出/Judge採点/学習/反論パターン蓄積)。

### 3. 新設セクション「AIが答えられない時こそ、差が出る」
見出し「『AIが変なことを言ったら困る』への答え」。3項目(でたらめを言わせない/その場で人に繋ぐ/同じ失敗を繰り返さない)。

### 4. 比較表「なぜR2Cが選ばれるのか」
- データ活用行: 「Judge自動チューニング」→「未回答質問の自動抽出＋自己学習」
- 「有人対応」「既存ツール連携」の2行を追加

### 5. FAQに4問追加
音声対応(Growth+) / 英語対応 / GA4・PostHog連携(Growth+) / 設定代行(R2Cエージェント、Enterprise)。日英対応は `src/api/i18n/messages.ts` の `Lang` 型(`"ja"|"en"`)と一致することをコードで確認済み。

### 6. 根拠のない主張の削除(最重要)
- 「テキストボットより3倍の会話継続率」: リポジトリ全体を検索したが根拠・出典が存在しないため削除
- 「Judgeエンジンがトークスクリプトを自動チューニング」: `src/api/conversion/autoTuning.ts` の関数群を検索した結果、外部参照ゼロで未配線と確認したため削除
- FAQ「品質が下がった場合は自動でアラートを発します」: `src/lib/alerts/alertRules.ts` の実装(6ルール: 会話完了率/ループ検出率/アバターフォールバック率/検索レイテンシ/エラー率/Kill Switch)を確認したところ **Judgeスコア低下のルールは存在しない** ため、実装に合わせて「会話完了率やエラー率など運用指標が悪化した場合は自動アラート」に修正

## 壊さないよう配慮した点
- 料金表(PR #541/#545で確定済み)の内容・**モバイル1カラム化修正には一切触れていない**
- 新設2セクションのグリッドは `pricing-grid` と同じ方式(実際にグリッドを形成する外側divへクラスを付与)。`display:contents` な内側divにmedia queryを当てる旧パターンは再現していない
- 「1対話 = ユーザー発言1往復」の注記はそのまま維持(小林さん判断のため無変更)

## 確認
- Playwrightでデスクトップ(1440px)・モバイル(390px)双方、6箇所(features/learn/trust/pricing/compare/faq)をスクリーンショット確認
- 新設FAQ項目のアコーディオン開閉、`#contact`/`#features`/`#pricing`/`#faq` などnavリンクをheadlessブラウザで実クリックして動作確認(JSエラーなし。baseline mainと同一の既存リソース読み込みエラーのみで新規回帰なし)
- タグバランス確認(`<section>` / `</section>` ともに14個で一致)

**検証(視覚レビュー・テスト)は team-lead(Opus 5)側で実施予定**のため、本PRではスクリーンショットの添付・報告のみ行います。

## Merge
自分ではmergeしません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1dxH199qQB3diHbsGLNxM