### PR TITLE
fix(admin-ui): copilot-preview(新UI)にログアウトを追加 — 既定画面にすると詰む問題

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -1,0 +1,104 @@
+// GID: 新UI(/copilot-preview)にログアウト手段が無く、Phase4トグルでこの画面を
+// 既定にすると詰む不具合の回帰テスト。左レール下部のログアウトボタンが
+// logout() → navigate("/login") を実行することを検証する。
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import CopilotPreviewPage from "./index";
+import { useAuth } from "../../auth/useAuth";
+
+vi.mock("../../lib/api", () => ({
+  API_BASE: "http://localhost:3100",
+  authFetch: vi.fn(),
+}));
+
+vi.mock("../../auth/useAuth", () => ({
+  useAuth: vi.fn(),
+}));
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
+
+import { authFetch } from "../../lib/api";
+
+const mockOk = (data: unknown): Promise<Response> =>
+  Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(data) } as Response);
+
+function baseAuth(overrides: Partial<ReturnType<typeof useAuth>> = {}) {
+  return {
+    user: { id: "1", email: "a@example.com", role: "client_admin", tenantId: "tenant-a", tenantName: "Tenant A" },
+    isLoading: false,
+    isSuperAdmin: false,
+    isClientAdmin: true,
+    logout: vi.fn().mockResolvedValue(undefined),
+    previewMode: false,
+    previewTenantId: null,
+    previewTenantName: null,
+    enterPreview: vi.fn(),
+    exitPreview: vi.fn(),
+    tenantPlan: null,
+    ...overrides,
+  } as ReturnType<typeof useAuth>;
+}
+
+function renderPage(overrides: Partial<ReturnType<typeof useAuth>> = {}) {
+  vi.mocked(useAuth).mockReturnValue(baseAuth(overrides));
+  return render(
+    <MemoryRouter>
+      <CopilotPreviewPage />
+    </MemoryRouter>,
+  );
+}
+
+describe("CopilotPreviewPage — ログアウト", () => {
+  beforeEach(() => {
+    vi.mocked(authFetch).mockReset();
+    mockNavigate.mockReset();
+    // マウント時のブリーフィング取得(sendReal)・オンボーディング判定を素通りさせる
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (String(url).includes("/v1/admin/my-tenant")) {
+        return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
+      }
+      return mockOk({ reply: "了解しました。", actions: [] });
+    });
+  });
+
+  it("ログアウトボタンが描画されている", async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByRole("button", { name: /ログアウト/ })).toBeTruthy());
+  });
+
+  it("クリックすると logout() が呼ばれ、/login へ遷移する", async () => {
+    const logout = vi.fn().mockResolvedValue(undefined);
+    renderPage({ logout });
+
+    const button = await waitFor(() => screen.getByRole("button", { name: /ログアウト/ }));
+    fireEvent.click(button);
+
+    await waitFor(() => expect(logout).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/login", { replace: true }));
+  });
+
+  it("previewMode中でもログアウトボタンが機能する(super_admin自身がログアウトされる)", async () => {
+    const logout = vi.fn().mockResolvedValue(undefined);
+    renderPage({
+      logout,
+      previewMode: true,
+      previewTenantId: "tenant-preview",
+      previewTenantName: "Preview Tenant",
+      isSuperAdmin: true,
+    });
+
+    const button = await waitFor(() => screen.getByRole("button", { name: /ログアウト/ }));
+    fireEvent.click(button);
+
+    await waitFor(() => expect(logout).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/login", { replace: true }));
+  });
+});

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -10,6 +10,8 @@
 
 import { useState, useRef, useEffect, useCallback } from "react";
 import type { Dispatch, SetStateAction } from "react";
+import { useNavigate } from "react-router-dom";
+import { LogOut } from "lucide-react";
 import { authFetch, API_BASE } from "../../lib/api";
 import { isChatFirstDefaultEnabled, setChatFirstDefaultEnabled } from "../../lib/chatFirstDefault";
 import { useAuth } from "../../auth/useAuth";
@@ -223,7 +225,8 @@ export default function CopilotPreviewPage() {
   // super_adminがテナントプレビュー中の場合、対象テナントIDをtargetTenantIdとしてAPIに渡す
   // (他画面のescalations/knowledge-gaps等と同じパターン)。client_adminは自身のJWT由来の
   // tenantIdがサーバー側で使われるため、previewMode=falseのままで問題ない。
-  const { user, previewMode, previewTenantId } = useAuth();
+  const { user, previewMode, previewTenantId, logout } = useAuth();
+  const navigate = useNavigate();
   const [active, setActive] = useState("assistant");
   const [input, setInput] = useState("");
   // 起動直後は空。bootstrap()が実データの週次ブリーフィングを積む
@@ -403,6 +406,15 @@ export default function CopilotPreviewPage() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  // 新UI(サイドバー型ではないため)にはログアウト手段が無く、Phase4トグルで
+  // このブラウザの既定画面にすると詰む(GID: 新UI常用時にログアウトできない)。
+  // previewMode(super_adminのクライアントビュー)中も、実ログインユーザーは
+  // super_adminのため、ここでのログアウトは正しくsuper_admin自身を退出させる。
+  const handleLogout = async () => {
+    await logout();
+    navigate("/login", { replace: true });
+  };
+
   const runAction = (action: string, fromMsgId: number) => {
     consumeChips(fromMsgId);
     // チップは全て実APIへの返信（sendReal 側で me() を積むため、ここでは積まない）
@@ -484,6 +496,19 @@ export default function CopilotPreviewPage() {
           <div style={{ fontSize: 12, color: "var(--muted-foreground)", lineHeight: 1.55, padding: "10px" }}>
             「くわしい設定」は従来画面のまま。会話UIは<strong style={{ color: "var(--foreground)" }}>追加</strong>で、既存は消していません。
           </div>
+          <button
+            onClick={() => void handleLogout()}
+            title={previewMode ? "Super Adminとしてログアウトします（クライアントビューの「元に戻す」とは別の操作です）" : "ログアウト"}
+            style={{
+              display: "flex", alignItems: "center", gap: 10, width: "calc(100% - 16px)", margin: "2px 8px 0",
+              padding: "11px 12px", borderRadius: 10, border: "1px solid var(--border)",
+              background: "transparent", cursor: "pointer", textAlign: "left",
+              fontSize: 13, color: "var(--muted-foreground)", minHeight: 44,
+            }}
+          >
+            <LogOut size={16} />
+            ログアウト
+          </button>
         </div>
       </aside>
 


### PR DESCRIPTION
## 問題

`/copilot-preview`（新UI）に**ログアウト手段が無い**。

`App.tsx:135-147` を見ると分かるとおり、新UIは `AppSidebar` より**手前で早期 return** される構造のため、旧UIの共通シェル（ログアウト・テーマ切替・通知ベル・AppSwitcher・モバイルナビ）が丸ごと落ちている。

このうちログアウトの欠落は実害がある。新UIのサイドバーには `Phase4DefaultToggle`（「これを既定の画面にする」localStorage オプトイン）があり、**ONにすると `/` と `/admin` を開いた時に新UIが表示されるようになるため、そのブラウザからログアウトする手段が完全に失われる**。

## 変更

`admin-ui/src/pages/copilot-preview/index.tsx` の左レール下部（`Phase4DefaultToggle` と説明文の続き）にログアウトボタンを追加。

- 実装は `AppSidebar.tsx` の `handleLogout` と同一パターン（`await logout()` → `navigate("/login", { replace: true })`）
- `lucide-react` の `LogOut` アイコン、`minHeight: 44` で既存のサイドバーボタンとタップ領域を統一
- `previewMode`（super_admin の「クライアントビューで見る」）中は、上部の `PreviewModeBanner`（「元に戻す」）と紛らわしくならないよう、`title` 属性で「Super Admin としてログアウトします（クライアントビューの『元に戻す』とは別の操作です）」と明示

`previewMode` 中の実ログインユーザーは super_admin なので、ここでのログアウトが super_admin 自身を退出させるのは正しい挙動。特別扱いはしていない。

## 検証

- `npx tsc --noEmit`: クリーン
- `npm run test:ui`: **142/142 passed**（従来139 + 新規3）
- `npm run build`: 成功
- `CopilotPreviewPage` が `BrowserRouter` の内側でレンダリングされることを確認済み（`App.tsx:287` の `<BrowserRouter>` → `AuthProvider` → `AdminAgentUIProvider` → `AppInner` 内の早期return）。`useNavigate` は正常に動作する
- テストの実効性確認: `navigate("/login")` を一時削除するとクリック系2テストが赤くなることを確認（描画確認テストのみ緑のまま）

## スコープ

ログアウトのみ。同じく新UIから欠落している**テーマ切替 / 言語切替 / 通知ベル / AppSwitcher / モバイル対応**は別PRで扱う（モバイル対応は着手済み）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011g5MZqwhh8xiPCPFr554qm