### PR TITLE
feat(admin-ui): /copilot-preview(新UI)をモバイル幅に対応させる

### DIFF
--- a/admin-ui/src/index.css
+++ b/admin-ui/src/index.css
@@ -219,3 +219,71 @@ button {
     background: var(--muted);
   }
 }
+
+/* ── Copilot Preview (新UI) レスポンシブ ────────────────────────────────
+   /copilot-preview 専用のクラス群。旧UI(.app-sidebar 等)とは独立しており、
+   既存セレクタの定義は一切変更しない。ブレークポイントは旧UIに合わせて
+   @media (max-width: 767px) を踏襲する。 ─────────────────────────────── */
+
+.cp-shell {
+  /* previewMode中はPreviewModeBannerの高さ(--cp-banner-h)を差し引く。
+     100dvh未対応ブラウザでは2行目が無効値として無視され、1行目の
+     100vh版にフォールバックする。 */
+  height: calc(100vh - var(--cp-banner-h, 0px));
+  height: calc(100dvh - var(--cp-banner-h, 0px));
+}
+
+.cp-header {
+  padding: 16px 28px;
+}
+
+.cp-thread {
+  padding: 28px 28px;
+}
+
+.cp-composer-wrap {
+  padding: 0 28px 24px;
+}
+
+.cp-rail-backdrop {
+  display: none;
+}
+
+.cp-menu-btn {
+  display: none;
+}
+
+@media (max-width: 767px) {
+  .cp-rail {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    z-index: 50;
+    transform: translateX(-100%);
+    transition: transform 0.2s ease;
+    overflow-y: auto;
+  }
+  .cp-rail.cp-rail-open {
+    transform: translateX(0);
+  }
+  .cp-rail-backdrop {
+    display: block;
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.4);
+    z-index: 45;
+  }
+  .cp-menu-btn {
+    display: inline-flex;
+  }
+  .cp-header {
+    padding: 12px 16px;
+  }
+  .cp-thread {
+    padding: 16px 16px 12px;
+  }
+  .cp-composer-wrap {
+    padding: 0 12px calc(16px + env(safe-area-inset-bottom));
+  }
+}

--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -102,3 +102,114 @@ describe("CopilotPreviewPage — ログアウト", () => {
     await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/login", { replace: true }));
   });
 });
+
+// GID: /copilot-preview のモバイル対応(左レールのドロワー化)の回帰テスト。
+// happy-dom ではレイアウトの実際の見た目(幅・position:fixed の描画結果等)は検証できないため、
+// ドロワーの開閉状態(className)・オーバーレイの有無・会話中ロックが維持されることを
+// 状態遷移として検証する。タイプライター演出は matchMedia で reduce-motion を強制して無効化し、
+// テストを決定的にしている。
+function getRail(): HTMLElement {
+  return document.querySelector(".cp-rail") as HTMLElement;
+}
+
+function getBackdrop(): HTMLElement | null {
+  return document.querySelector(".cp-rail-backdrop");
+}
+
+describe("CopilotPreviewPage — モバイル左レールのドロワー化", () => {
+  beforeEach(() => {
+    vi.mocked(authFetch).mockReset();
+    mockNavigate.mockReset();
+    vi.mocked(authFetch).mockImplementation(() => mockOk({ reply: "今週も順調です", actions: [] }));
+    // タイプライター演出(setInterval)を無効化し、応答を同期的に確定させてテストを決定的にする
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: true,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  });
+
+  it("初期状態ではドロワーは閉じており、オーバーレイも存在しない", async () => {
+    // super_admin(client_admin以外)は my-tenant 判定をスキップして直接ブリーフィングへ進む
+    renderPage({ isSuperAdmin: true, isClientAdmin: false, user: { id: "2", email: "admin@example.com", role: "super_admin", tenantId: null, tenantName: null } });
+    await waitFor(() => expect(authFetch).toHaveBeenCalledTimes(1));
+
+    expect(getRail().className).not.toContain("cp-rail-open");
+    expect(getBackdrop()).toBeNull();
+  });
+
+  it("ハンバーガーボタンでドロワーが開き、背景オーバーレイが表示される", async () => {
+    renderPage({ isSuperAdmin: true, isClientAdmin: false, user: { id: "2", email: "admin@example.com", role: "super_admin", tenantId: null, tenantName: null } });
+    await waitFor(() => expect(authFetch).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole("button", { name: "メニューを開く" }));
+
+    expect(getRail().className).toContain("cp-rail-open");
+    expect(getBackdrop()).not.toBeNull();
+  });
+
+  it("オーバーレイをタップするとドロワーが閉じる", async () => {
+    renderPage({ isSuperAdmin: true, isClientAdmin: false, user: { id: "2", email: "admin@example.com", role: "super_admin", tenantId: null, tenantName: null } });
+    await waitFor(() => expect(authFetch).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole("button", { name: "メニューを開く" }));
+    expect(getBackdrop()).not.toBeNull();
+
+    fireEvent.click(getBackdrop()!);
+
+    expect(getBackdrop()).toBeNull();
+    expect(getRail().className).not.toContain("cp-rail-open");
+  });
+
+  it("レール内の閉じるボタン(✕)でもドロワーが閉じる", async () => {
+    renderPage({ isSuperAdmin: true, isClientAdmin: false, user: { id: "2", email: "admin@example.com", role: "super_admin", tenantId: null, tenantName: null } });
+    await waitFor(() => expect(authFetch).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole("button", { name: "メニューを開く" }));
+    expect(getRail().className).toContain("cp-rail-open");
+
+    fireEvent.click(screen.getByRole("button", { name: "メニューを閉じる" }));
+    expect(getRail().className).not.toContain("cp-rail-open");
+  });
+
+  it("会話中でない状態でカテゴリーを選択するとドロワーが閉じる", async () => {
+    renderPage({ isSuperAdmin: true, isClientAdmin: false, user: { id: "2", email: "admin@example.com", role: "super_admin", tenantId: null, tenantName: null } });
+    // bootstrap完了(送信ボタンのdisabled解除)を待ってから操作する
+    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
+
+    fireEvent.click(screen.getByRole("button", { name: "メニューを開く" }));
+    expect(getRail().className).toContain("cp-rail-open");
+
+    fireEvent.click(screen.getByRole("button", { name: /今週のまとめ/ }));
+    expect(getRail().className).not.toContain("cp-rail-open");
+  });
+
+  it("会話中(busy)は他カテゴリーへの切り替えロックがドロワー化後も維持される", async () => {
+    let resolveFetch: (v: Response) => void = () => {};
+    vi.mocked(authFetch).mockImplementation(
+      () => new Promise<Response>((resolve) => { resolveFetch = resolve; }),
+    );
+    renderPage({ isSuperAdmin: true, isClientAdmin: false, user: { id: "2", email: "admin@example.com", role: "super_admin", tenantId: null, tenantName: null } });
+    await waitFor(() => expect(authFetch).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole("button", { name: "メニューを開く" }));
+    expect(getRail().className).toContain("cp-rail-open");
+
+    // sending中は現在アクティブでないカテゴリーのボタンがdisabledのまま(ドロワー化前と同じロック)
+    const weeklyBtn = screen.getByRole("button", { name: /今週のまとめ/ }) as HTMLButtonElement;
+    expect(weeklyBtn.disabled).toBe(true);
+
+    // disabledボタンはクリックしても何も起きない(active・ドロワー状態とも変化しない)
+    fireEvent.click(weeklyBtn);
+    expect(getRail().className).toContain("cp-rail-open");
+
+    // 後片付け: pendingのfetchを解決し、タイマー等が残らないようにする
+    resolveFetch({ ok: true, status: 200, json: () => Promise.resolve({ reply: "ok", actions: [] }) } as unknown as Response);
+    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
+  });
+});

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -16,6 +16,7 @@ import { authFetch, API_BASE } from "../../lib/api";
 import { isChatFirstDefaultEnabled, setChatFirstDefaultEnabled } from "../../lib/chatFirstDefault";
 import { useAuth } from "../../auth/useAuth";
 import { ONBOARDING_INDUSTRIES } from "../../components/onboarding/industryFaqTemplates";
+import { PREVIEW_MODE_BANNER_HEIGHT } from "../../components/PreviewModeBanner";
 
 // ─── モデル ──────────────────────────────────────────────────────────────────
 
@@ -229,6 +230,8 @@ export default function CopilotPreviewPage() {
   const navigate = useNavigate();
   const [active, setActive] = useState("assistant");
   const [input, setInput] = useState("");
+  // モバイル用: 左レール(ドロワー)の開閉状態。デスクトップでは未使用(CSSで常時表示)。
+  const [railOpen, setRailOpen] = useState(false);
   // 起動直後は空。bootstrap()が実データの週次ブリーフィングを積む
   const [msgs, setMsgs] = useState<Msg[]>([]);
 
@@ -437,6 +440,7 @@ export default function CopilotPreviewPage() {
   const handleCategory = (key: string) => {
     if (busy && key !== active) return;
     setActive(key);
+    setRailOpen(false); // モバイル: カテゴリー選択でドロワーを閉じる(デスクトップでは無害)
     if (key === "weekly") {
       void sendReal("今週の状況を教えてください。要点と次にやるべきことを最大3つまで、簡潔に教えてください。");
     } else if (key === "history") {
@@ -461,12 +465,37 @@ export default function CopilotPreviewPage() {
 
   // ─── レイアウト ───────────────────────────────────────────────────────────
   return (
-    <div style={{ display: "flex", height: "100vh", background: "var(--background)", color: "var(--foreground)", fontFamily: "var(--font-sans, system-ui, sans-serif)", overflow: "hidden" }}>
-      {/* 左レール(=各カテゴリはAIブリーフィングの窓口) */}
-      <aside style={{ width: 248, flexShrink: 0, background: "var(--sidebar, var(--card))", borderRight: "1px solid var(--border)", padding: "20px 14px", display: "flex", flexDirection: "column", gap: 5 }}>
-        <div style={{ fontWeight: 900, fontSize: 18, letterSpacing: "-0.03em", padding: "4px 8px 6px" }}>
-          R2C
-          <span style={{ fontSize: 11, fontWeight: 700, color: AGENT, background: AGENT_SOFT, padding: "2px 8px", borderRadius: 6, marginLeft: 7, letterSpacing: "0.04em" }}>店主モード</span>
+    <div
+      className="cp-shell"
+      style={{
+        display: "flex",
+        background: "var(--background)",
+        color: "var(--foreground)",
+        fontFamily: "var(--font-sans, system-ui, sans-serif)",
+        overflow: "hidden",
+        // previewMode中はPreviewModeBanner分の高さをcp-shellのheight計算から差し引く(index.css参照)
+        ["--cp-banner-h" as string]: previewMode ? `${PREVIEW_MODE_BANNER_HEIGHT}px` : "0px",
+      } as React.CSSProperties}
+    >
+      {/* モバイル: ドロワーが開いている間の背景オーバーレイ。外側タップで閉じる */}
+      {railOpen && (
+        <div className="cp-rail-backdrop" onClick={() => setRailOpen(false)} aria-hidden="true" />
+      )}
+      {/* 左レール(=各カテゴリはAIブリーフィングの窓口)。モバイルではドロワー化(index.css参照) */}
+      <aside className={`cp-rail${railOpen ? " cp-rail-open" : ""}`} style={{ width: 248, flexShrink: 0, background: "var(--sidebar, var(--card))", borderRight: "1px solid var(--border)", padding: "20px 14px", display: "flex", flexDirection: "column", gap: 5 }}>
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 8 }}>
+          <div style={{ fontWeight: 900, fontSize: 18, letterSpacing: "-0.03em", padding: "4px 8px 6px" }}>
+            R2C
+            <span style={{ fontSize: 11, fontWeight: 700, color: AGENT, background: AGENT_SOFT, padding: "2px 8px", borderRadius: 6, marginLeft: 7, letterSpacing: "0.04em" }}>店主モード</span>
+          </div>
+          <button
+            className="cp-menu-btn"
+            onClick={() => setRailOpen(false)}
+            aria-label="メニューを閉じる"
+            style={{ border: "none", background: "transparent", color: "var(--muted-foreground)", cursor: "pointer", minWidth: 44, minHeight: 44, alignItems: "center", justifyContent: "center", fontSize: 18, borderRadius: 10, flexShrink: 0 }}
+          >
+            ✕
+          </button>
         </div>
         <PreviewBadge />
         {CATEGORIES.map((c) => {
@@ -515,7 +544,16 @@ export default function CopilotPreviewPage() {
       {/* チャット本体 */}
       <main style={{ flex: 1, display: "flex", flexDirection: "column", minWidth: 0 }}>
         {/* ヘッダー */}
-        <header style={{ display: "flex", alignItems: "center", gap: 14, padding: "16px 28px", borderBottom: "1px solid var(--border)", flexShrink: 0 }}>
+        <header className="cp-header" style={{ display: "flex", alignItems: "center", gap: 14, borderBottom: "1px solid var(--border)", flexShrink: 0 }}>
+          <button
+            className="cp-menu-btn"
+            onClick={() => setRailOpen(true)}
+            aria-label="メニューを開く"
+            aria-expanded={railOpen}
+            style={{ border: "none", background: "transparent", color: "var(--foreground)", cursor: "pointer", minWidth: 44, minHeight: 44, alignItems: "center", justifyContent: "center", fontSize: 20, borderRadius: 10, flexShrink: 0 }}
+          >
+            ☰
+          </button>
           <AgentMark />
           <div style={{ flex: 1 }}>
             <div style={{ fontWeight: 700, fontSize: 17 }}>R2Cエージェント</div>
@@ -529,7 +567,7 @@ export default function CopilotPreviewPage() {
         </header>
 
         {/* スレッド */}
-        <div ref={threadRef} style={{ flex: 1, overflowY: "auto", padding: "28px 28px", display: "flex", flexDirection: "column", gap: 18 }}>
+        <div ref={threadRef} className="cp-thread" style={{ flex: 1, overflowY: "auto", display: "flex", flexDirection: "column", gap: 18 }}>
           <div style={{ width: "100%", maxWidth: 820, margin: "0 auto", display: "flex", flexDirection: "column", gap: 18 }}>
             {msgs.map((m) => (
               <MessageRow key={m.id} m={m} onChip={runAction} />
@@ -538,7 +576,7 @@ export default function CopilotPreviewPage() {
         </div>
 
         {/* コンポーザ（実API接続） */}
-        <div style={{ padding: "0 28px 24px", flexShrink: 0 }}>
+        <div className="cp-composer-wrap" style={{ flexShrink: 0 }}>
           <div style={{ maxWidth: 820, margin: "0 auto" }}>
             <div style={{ display: "flex", alignItems: "center", gap: 12, padding: "12px 12px 12px 20px", border: `1px solid ${sending ? AGENT_BORDER : "var(--border)"}`, borderRadius: 16, background: "var(--input, var(--card))" }}>
               <input


### PR DESCRIPTION
## 問題

`/copilot-preview`（新UI）が**モバイルを一切考慮していない**。

`App.tsx:135-147` のとおり新UIは `AppSidebar` より手前で早期 return されるため、旧UIの `MobileHeader` / `MobileBottomBar` が適用されない。新UI自体も:

- ルートが `display: flex; height: 100vh`
- 左レールが `width: 248, flexShrink: 0` の固定幅
- **メディアクエリが1つも無い**

結果、狭い画面では248pxのレールが常に居座り、チャット領域が潰れる。

## 変更

### ドロワー化

左レールに `.cp-rail` / 開時 `.cp-rail-open` を付与。**デスクトップにはCSSルールを一切置かず**、従来どおり静的な flex 子要素のまま。モバイル（`max-width: 767px`）のみ `position: fixed` + `transform: translateX(-100%)` でドロワー化する。

開閉トリガーは4つ: ヘッダーのハンバーガー（☰）/ レール内の ✕ / 背景オーバーレイのタップ / カテゴリー選択時の自動クローズ。

オーバーレイは旧UIの `box-shadow: 0 0 0 100vw` トリックではなく、`MobileHeader` が実際に使っている**実 backdrop div** 方式を採用した。前者はクリック判定を持てず「外側タップで閉じる」が実装できないため（なお `.app-sidebar.open` の box-shadow ルールは現状JS側から使われていない死んだルール）。

### メディアクエリの実現方法

新UIはインラインstyle中心で書かれているが、**インラインstyleは外部CSSのメディアクエリより常に優先される**ため、レスポンシブ切り替えが必要なプロパティは物理的にCSS側へ出す必要がある。

そこで height / header・thread・composer の padding / ドロワーの position・transform **だけ**を `.cp-*` クラスへ退避し、それ以外は元のインラインstyleのまま残して diff を最小化した。`index.css` には `.cp-*` 名前空間で追記し、**旧UIの既存セレクタ（`.app-sidebar` 等）は一切変更していない**。

### 100dvh・セーフエリア・previewMode の高さ

```css
height: calc(100vh  - var(--cp-banner-h, 0px));
height: calc(100dvh - var(--cp-banner-h, 0px));  /* 非対応ブラウザは無効値として無視 */
```

`height: 100vh` は iOS Safari のURLバーで実表示領域とズレ、コンポーザが画面外に出る。`100dvh` を使い、2行宣言でフォールバックする。

`--cp-banner-h` はCSSカスタムプロパティとして注入し、`previewMode` 時のみ `PREVIEW_MODE_BANNER_HEIGHT` を差し引く。**これによりpreviewMode中に元々あった潜在的なオーバーフローも解消される**（この修正のみモバイル限定ではなくデスクトップにも適用。挙動が変わるのは previewMode 中だけで、非previewMode時は不変）。

コンポーザは `position: fixed` にせず、flex-column 最終要素のままとした。`100dvh` と組み合わせる方がモバイルキーボード表示時に堅牢なため。下部セーフエリアは `calc(16px + env(safe-area-inset-bottom))` で確保。

### 会話中ロックの維持

`handleCategory` の `busy` ガードと各ボタンの `disabled={locked}` は**一切変更していない**。ドロワー化は `<aside>` に position/transform を足しただけでロック判定のコードパスに影響しない。テストでも、`sending=true` を人工的に作った状態でドロワーを開き、他カテゴリーボタンが disabled のままであることを確認している。

## 検証

- `npx tsc --noEmit`: クリーン
- `npm run test:ui`: **148/148 passed**（既存142 + 新規6）
- `npm run build`: 成功
- テストの実効性確認: (a) カテゴリー選択時のドロワー閉じ処理を削除 → 該当テストが赤 (b) `locked` を無効化 → 該当テストが赤。いずれも復元後 green を確認

### テストで担保できていないこと

happy-dom の制約上、**実際のCSS適用結果は検証できない**（ドロワー幅、`translateX` アニメーション、`100dvh` の計算、`safe-area-inset-bottom` の実測、視覚的なレイアウト崩れ）。これらは実機/ブラウザでの目視確認が必要。

担保できているのは状態遷移のみ: ドロワーの開閉（className）、オーバーレイ要素の有無、カテゴリー選択での自動クローズ、busy中のロック維持。

## スコープ

モバイル対応のみ。同じく新UIから欠落しているテーマ切替 / 言語切替 / 通知ベル / AppSwitcher は別途。機能の追加・削除はしておらず、レイアウトの適応のみ。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011g5MZqwhh8xiPCPFr554qm