### PR TITLE
feat(admin-ui): copilot-preview(新UI)に旧UI共通シェルの残り4機能を追加

### DIFF
--- a/admin-ui/src/components/AppSidebar.test.tsx
+++ b/admin-ui/src/components/AppSidebar.test.tsx
@@ -147,3 +147,17 @@ describe("AppSidebar — ご利用状況・お支払いの可視性", () => {
     expect(screen.getByText("ご利用状況・お支払い")).toBeTruthy();
   });
 });
+
+// GID: ThemeToggle を common/ThemeToggle.tsx へ切り出した際の回帰テスト。
+// 移設のみでスタイル・ロジックは変更していないため、フッターのテーマ切替
+// (ライト/ダーク/自動の3ボタン)が従来どおり描画されることだけを確認する。
+describe("AppSidebar — ThemeToggle切り出し後の回帰テスト", () => {
+  it("フッターにテーマ切替(ライト/ダーク/自動)が描画される", () => {
+    vi.mocked(useAuth).mockReturnValue(baseAuth({ tenantPlan: "growth" }));
+    renderSidebar();
+
+    expect(screen.getByTitle("ライト")).toBeTruthy();
+    expect(screen.getByTitle("ダーク")).toBeTruthy();
+    expect(screen.getByTitle("自動")).toBeTruthy();
+  });
+});

--- a/admin-ui/src/components/AppSidebar.tsx
+++ b/admin-ui/src/components/AppSidebar.tsx
@@ -14,9 +14,6 @@ import {
   FileText,
   CreditCard,
   LogOut,
-  Sun,
-  Moon,
-  Monitor,
   BellRing,
   X,
   GitBranch,
@@ -24,8 +21,8 @@ import {
   HelpCircle,
 } from "lucide-react";
 import { useAuth } from "../auth/useAuth";
-import { useTheme } from "../contexts/ThemeContext";
 import { NotificationBell } from "./common/NotificationBell";
+import { ThemeToggle } from "./common/ThemeToggle";
 import AppSwitcher from "./AppSwitcher";
 import { cn } from "../lib/utils";
 import { planHasFeature, type GatedFeature } from "../lib/planFeatures";
@@ -97,54 +94,6 @@ const SUPER_ADMIN_SECTION: NavSection = {
     { label: "システム稼働状況", path: "/admin/monitoring", icon: BellRing },
   ],
 };
-
-// ─── Theme toggle ─────────────────────────────────────────────────────
-
-function ThemeToggle() {
-  const { theme, setTheme } = useTheme();
-
-  const options: { value: "light" | "dark" | "system"; icon: React.ElementType; label: string }[] = [
-    { value: "light", icon: Sun, label: "ライト" },
-    { value: "dark", icon: Moon, label: "ダーク" },
-    { value: "system", icon: Monitor, label: "自動" },
-  ];
-
-  return (
-    <div
-      style={{
-        display: "flex",
-        gap: 2,
-        background: "var(--sidebar-accent)",
-        borderRadius: "var(--radius-md)",
-        padding: 2,
-      }}
-    >
-      {options.map(({ value, icon: Icon, label }) => (
-        <button
-          key={value}
-          onClick={() => setTheme(value)}
-          title={label}
-          style={{
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "center",
-            width: 28,
-            height: 28,
-            borderRadius: "calc(var(--radius-md) - 2px)",
-            border: "none",
-            background: theme === value ? "var(--background)" : "transparent",
-            color: theme === value ? "var(--foreground)" : "var(--muted-foreground)",
-            cursor: "pointer",
-            boxShadow: theme === value ? "0 1px 3px rgba(0,0,0,0.12)" : "none",
-            transition: "all 0.15s",
-          }}
-        >
-          <Icon size={14} />
-        </button>
-      ))}
-    </div>
-  );
-}
 
 // ─── Sidebar nav item ─────────────────────────────────────────────────
 

--- a/admin-ui/src/components/common/ThemeToggle.tsx
+++ b/admin-ui/src/components/common/ThemeToggle.tsx
@@ -1,0 +1,53 @@
+// admin-ui/src/components/common/ThemeToggle.tsx
+// 元々 AppSidebar.tsx にインライン定義されていたテーマ切替を共有コンポーネント化。
+// 旧UI(AppSidebar)・新UI(/copilot-preview)の両方から使う。移設のみでスタイル・
+// ロジックは一切変更していない(旧UIの見た目・挙動を変えないため)。
+
+import { Sun, Moon, Monitor } from "lucide-react";
+import { useTheme } from "../../contexts/ThemeContext";
+
+export function ThemeToggle() {
+  const { theme, setTheme } = useTheme();
+
+  const options: { value: "light" | "dark" | "system"; icon: React.ElementType; label: string }[] = [
+    { value: "light", icon: Sun, label: "ライト" },
+    { value: "dark", icon: Moon, label: "ダーク" },
+    { value: "system", icon: Monitor, label: "自動" },
+  ];
+
+  return (
+    <div
+      style={{
+        display: "flex",
+        gap: 2,
+        background: "var(--sidebar-accent)",
+        borderRadius: "var(--radius-md)",
+        padding: 2,
+      }}
+    >
+      {options.map(({ value, icon: Icon, label }) => (
+        <button
+          key={value}
+          onClick={() => setTheme(value)}
+          title={label}
+          style={{
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "center",
+            width: 28,
+            height: 28,
+            borderRadius: "calc(var(--radius-md) - 2px)",
+            border: "none",
+            background: theme === value ? "var(--background)" : "transparent",
+            color: theme === value ? "var(--foreground)" : "var(--muted-foreground)",
+            cursor: "pointer",
+            boxShadow: theme === value ? "0 1px 3px rgba(0,0,0,0.12)" : "none",
+            transition: "all 0.15s",
+          }}
+        >
+          <Icon size={14} />
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -16,6 +16,19 @@ vi.mock("../../auth/useAuth", () => ({
   useAuth: vi.fn(),
 }));
 
+// GID: 旧UI(AppSidebar)との共通シェルパリティ(通知ベル/AppSwitcher)の回帰テスト用。
+// AppSidebar.test.tsx と同じくスタブ化する — NotificationBell は実APIポーリングを、
+// AppSwitcher は useAdminAgentUI(AdminAgentUIProviderが必要)を持つため、ページ単体の
+// テストでは実体を必要としない。ThemeToggle/LangSwitcher は Context にデフォルト値が
+// あり Provider 無しで安全に描画できるため、実コンポーネントのまま検証する。
+vi.mock("../../components/common/NotificationBell", () => ({
+  NotificationBell: () => <div data-testid="notification-bell-stub" />,
+}));
+
+vi.mock("../../components/AppSwitcher", () => ({
+  default: () => <div data-testid="app-switcher-stub" />,
+}));
+
 const mockNavigate = vi.fn();
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
@@ -211,5 +224,59 @@ describe("CopilotPreviewPage — モバイル左レールのドロワー化", ()
     // 後片付け: pendingのfetchを解決し、タイマー等が残らないようにする
     resolveFetch({ ok: true, status: 200, json: () => Promise.resolve({ reply: "ok", actions: [] }) } as unknown as Response);
     await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
+  });
+});
+
+// GID: 新UI(/copilot-preview)には旧UI(AppSidebar)の共通シェル機能が丸ごと落ちていた
+// (App.tsx がAppSidebarより手前で早期returnするため)。ログアウト・モバイル対応に続き、
+// 残る4機能(テーマ切替/言語切替/通知ベル/AppSwitcher)の回帰テスト。
+describe("CopilotPreviewPage — 共通シェル機能パリティ(テーマ/言語/通知/AppSwitcher)", () => {
+  beforeEach(() => {
+    vi.mocked(authFetch).mockReset();
+    mockNavigate.mockReset();
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (String(url).includes("/v1/admin/my-tenant")) {
+        return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
+      }
+      return mockOk({ reply: "了解しました。", actions: [] });
+    });
+  });
+
+  it("テーマ切替(ライト/ダーク/自動)が描画されている", async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByRole("button", { name: /ログアウト/ })).toBeTruthy());
+
+    expect(screen.getByTitle("ライト")).toBeTruthy();
+    expect(screen.getByTitle("ダーク")).toBeTruthy();
+    expect(screen.getByTitle("自動")).toBeTruthy();
+  });
+
+  it("テーマ切替ボタンをクリックしてもエラーにならない(Provider無し=デフォルト値でも安全)", async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByRole("button", { name: /ログアウト/ })).toBeTruthy());
+
+    expect(() => fireEvent.click(screen.getByTitle("ダーク"))).not.toThrow();
+  });
+
+  it("言語切替(日本語/English)が描画されている", async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByRole("button", { name: /ログアウト/ })).toBeTruthy());
+
+    expect(screen.getByRole("button", { name: /日本語/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /English/ })).toBeTruthy();
+  });
+
+  it("通知ベルが描画されている", async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByRole("button", { name: /ログアウト/ })).toBeTruthy());
+
+    expect(screen.getByTestId("notification-bell-stub")).toBeTruthy();
+  });
+
+  it("AppSwitcher(R2C⇄R2C2)が描画されている", async () => {
+    renderPage();
+    await waitFor(() => expect(screen.getByRole("button", { name: /ログアウト/ })).toBeTruthy());
+
+    expect(screen.getByTestId("app-switcher-stub")).toBeTruthy();
   });
 });

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -17,6 +17,13 @@ import { isChatFirstDefaultEnabled, setChatFirstDefaultEnabled } from "../../lib
 import { useAuth } from "../../auth/useAuth";
 import { ONBOARDING_INDUSTRIES } from "../../components/onboarding/industryFaqTemplates";
 import { PREVIEW_MODE_BANNER_HEIGHT } from "../../components/PreviewModeBanner";
+// 旧UI(AppSidebar)の共通シェル機能パリティ(残り4件)。既に独立コンポーネント化
+// 済みのものはそのままimportし、テーマ切替だけ common/ThemeToggle として新規に
+// 切り出した(旧UIとの共有コンポーネント。詳細は common/ThemeToggle.tsx 参照)。
+import { NotificationBell } from "../../components/common/NotificationBell";
+import { ThemeToggle } from "../../components/common/ThemeToggle";
+import LangSwitcher from "../../components/LangSwitcher";
+import AppSwitcher from "../../components/AppSwitcher";
 
 // ─── モデル ──────────────────────────────────────────────────────────────────
 
@@ -497,6 +504,10 @@ export default function CopilotPreviewPage() {
             ✕
           </button>
         </div>
+        {/* AppSwitcher (R2C ⇄ R2C2)。旧UI(AppSidebar)と同じくヘッダー直下に配置 */}
+        <div style={{ padding: "0 2px" }}>
+          <AppSwitcher />
+        </div>
         <PreviewBadge />
         {CATEGORIES.map((c) => {
           const locked = busy && c.key !== active;
@@ -524,6 +535,14 @@ export default function CopilotPreviewPage() {
           <Phase4DefaultToggle />
           <div style={{ fontSize: 12, color: "var(--muted-foreground)", lineHeight: 1.55, padding: "10px" }}>
             「くわしい設定」は従来画面のまま。会話UIは<strong style={{ color: "var(--foreground)" }}>追加</strong>で、既存は消していません。
+          </div>
+          {/* テーマ切替・言語切替。旧UI(AppSidebar)フッターと同じ並び(設定行→ログアウト) */}
+          <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "0 8px", marginBottom: 8 }}>
+            <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>テーマ</span>
+            <ThemeToggle />
+          </div>
+          <div style={{ padding: "0 8px", marginBottom: 10 }}>
+            <LangSwitcher />
           </div>
           <button
             onClick={() => void handleLogout()}
@@ -561,6 +580,9 @@ export default function CopilotPreviewPage() {
               <span style={{ width: 8, height: 8, borderRadius: "50%", background: "#22c55e", boxShadow: "0 0 0 3px rgba(34,197,94,0.15)" }} />オンライン
             </div>
           </div>
+          {/* 通知ベル: モバイルではcp-railがドロワー化しoverflow-y:autoでポップオーバーが
+              見切れうるため、常時表示のcp-header側に置く(cp-railのoverflow影響を受けない) */}
+          <NotificationBell />
           <div style={{ display: "flex", flexDirection: "column", alignItems: "flex-end", gap: 5 }}>
             <RealActionBadge count={realActionCount} />
           </div>


### PR DESCRIPTION
## 背景

`App.tsx:135-147` のとおり新UI(`/copilot-preview`)は `AppSidebar` より手前で早期 return されるため、旧UIの共通シェル機能が丸ごと落ちている。ログアウト(#558)とモバイル対応(#559)は対応済みで、**本PRで残り4件を揃える**。

| 機能 | 対応方法 |
|---|---|
| 通知ベル | `NotificationBell` をimport（既に独立エクスポート済み） |
| 言語切替 | `LangSwitcher` をimport（同上） |
| AppSwitcher | `AppSwitcher` をimport（同上） |
| テーマ切替 | **`AppSidebar.tsx` にインライン定義されていたため共有コンポーネントへ切り出し** |

## ThemeToggle の切り出し

`AppSidebar.tsx:103-147` の `function ThemeToggle()` を `components/common/ThemeToggle.tsx` へ**スタイル・ロジックを一字一句変えずに移設**し、旧UI・新UIの両方から使う形にした。

旧UIは全画面で使われる共通シェルのためリグレッションの影響範囲が大きい。そのため:
- `AppSidebar.tsx` 側の差分は**削除 + import 追加のみ**で、JSX呼び出し行 `<ThemeToggle />` は無変更
- `AppSidebar.test.tsx` に回帰テストを追加し、`{false && <ThemeToggle />}` に一時的に壊して RED になることを確認 → 復元して GREEN
- 既存9件の `AppSidebar.test.tsx`（plan制限・Starterプラン等）も全通過

## 配置

- **AppSwitcher**: 左レールのブランド行直下。旧UIと同じ位置
- **ThemeToggle / LangSwitcher**: 左レール下部、説明文とログアウトの間。旧UIのフッター順（設定系 → ログアウト）に倣う
- **NotificationBell**: **左レールではなく `cp-header`（常時表示のヘッダー）に配置**

### NotificationBell だけ配置を変えた理由

モバイル(#559)で `.cp-rail` はドロワー化され `overflow-y: auto` を持つ。CSS仕様上「overflow-x が visible で overflow-y がそれ以外」の場合、**overflow-x も実質 auto として計算される**ため、幅320pxのポップオーバーを248px幅のレール内に置くと横方向にclipされ見切れる恐れがある。

旧UIのモバイル実装を確認したところ、ベルは「常時表示の mobile-header」と「ドロワー内」の両方にあるが、**旧UIのドロワーは overflow を nav 要素だけに限定**しており新UIと同じ構造ではなかった。

そのため見切れリスクを避け、overflow指定の無い `cp-header` 側に置いた。他3要素はポップオーバーを持たない固定サイズのボタン列なのでレール内で問題ない。

## 検証

- `npx tsc --noEmit`: クリーン
- `npm run test:ui`: **154/154 passed**（基準148 + 新規6）
- `npm run build`: 成功
- 新規テスト6件すべてで「わざと壊す → RED確認 → 復元 → GREEN確認」を実施

### 実機確認をお願いしたい点

happy-dom ではレイアウト計算がされないため、以下は**静的分析のみで実機未確認**です:

- NotificationBell のポップオーバーの実際の描画位置・見切れの有無
- 248px幅レール内での LangSwitcher（2ボタン）の横収まり

## 補足（スコープの正確性について）

`LangSwitcher` は**旧UIでは `AppSidebar` に無く、各ページのヘッダーに個別配置**されている（`pages/admin/index.tsx:307` 等）。厳密には「共通シェル」の定義に含まれない可能性があるが、新UIには各ページヘッダーに相当するものが無く、レールに置くのが最も自然と判断した。不要であれば外せる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011g5MZqwhh8xiPCPFr554qm