### PR TITLE
feat(experiments): アバター効果A/Bテスト基盤(sticky assignment + 露出/継続率計測)

### DIFF
--- a/src/agent/ab-test/variantSelector.test.ts
+++ b/src/agent/ab-test/variantSelector.test.ts
@@ -1,5 +1,6 @@
 // src/agent/ab-test/variantSelector.test.ts
 
+import { randomUUID } from 'node:crypto';
 import { selectVariant } from './variantSelector';
 import type { PromptVariant } from './variantSelector';
 
@@ -62,5 +63,50 @@ describe('selectVariant', () => {
     // variantId が variants のいずれかの id と一致すること
     const validIds = [variantA.id, variantB.id];
     expect(validIds).toContain(result.variantId);
+  });
+
+  // GID 1216978855735482: sticky assignment（同一セッション内でvariantが揺れないこと）
+  describe('stickyKey指定時のsticky assignment', () => {
+    it('同一のstickyKeyは常に同じvariantを返す（100回連続呼び出しでも一致）', () => {
+      const sessionId = 'session-sticky-001';
+      const first = selectVariant([variantA, variantB], 'fallback', sessionId);
+      for (let i = 0; i < 100; i++) {
+        const result = selectVariant([variantA, variantB], 'fallback', sessionId);
+        expect(result.variantId).toBe(first.variantId);
+      }
+    });
+
+    it('異なるstickyKeyであれば分布として両方のvariantが選ばれ得る（統計的検証、実運用同様UUID形式のセッションIDを使用）', () => {
+      // "session-0", "session-1"... のような連番に近い文字列は先頭が共通し
+      // ハッシュ分布が偏るため、実運用のsession_idに近いUUID形式で検証する。
+      const counts: Record<string, number> = { variant_a: 0, variant_b: 0 };
+      for (let i = 0; i < 500; i++) {
+        const result = selectVariant([variantA, variantB], 'fallback', randomUUID());
+        if (result.variantId) counts[result.variantId] = (counts[result.variantId] ?? 0) + 1;
+      }
+      // weight[70,30]の分布に統計的に近いこと（ハッシュ由来なので緩めの範囲で確認）
+      const ratioA = counts['variant_a']! / 500;
+      expect(ratioA).toBeGreaterThan(0.5);
+      expect(ratioA).toBeLessThan(0.9);
+      expect(counts['variant_b']).toBeGreaterThan(0);
+    });
+
+    it('stickyKey省略時は従来どおりMath.random()ベースの後方互換動作のまま（既存呼び出し元を壊さない）', () => {
+      // stickyKeyを渡さない呼び出しが既存テスト(このファイル冒頭)と同じ統計的挙動を保つことを再確認
+      const counts: Record<string, number> = { variant_a: 0, variant_b: 0 };
+      for (let i = 0; i < 1000; i++) {
+        const result = selectVariant([variantA, variantB], 'fallback');
+        if (result.variantId) counts[result.variantId] = (counts[result.variantId] ?? 0) + 1;
+      }
+      const ratioA = counts['variant_a']! / 1000;
+      expect(ratioA).toBeGreaterThan(0.60);
+      expect(ratioA).toBeLessThan(0.80);
+    });
+
+    it('variantsが1つだけの場合はstickyKeyの有無に関わらず常にそのvariantを返す', () => {
+      const single: PromptVariant = { id: 'only_variant', name: '唯一版', prompt: '唯一プロンプト', weight: 100 };
+      const result = selectVariant([single], 'fallback', 'any-session-id');
+      expect(result.variantId).toBe('only_variant');
+    });
   });
 });

--- a/src/agent/ab-test/variantSelector.ts
+++ b/src/agent/ab-test/variantSelector.ts
@@ -14,14 +14,35 @@ export interface VariantSelectionResult {
 }
 
 /**
+ * 文字列キーを [0, 1) の決定的な擬似乱数値にハッシュする。
+ * 同じキーからは常に同じ値が得られる（sticky assignment用）。
+ * src/api/conversion/abTestRoutes.ts の assignVariant と同じ hash*31+charCode パターンを
+ * 採用しつつ、2値分岐ではなく連続値 [0,1) が必要なためこちらは独自に実装する
+ * （assignVariant自体は既存の呼び出し元・テストへの影響を避けるため変更しない）。
+ */
+function hashToUnitInterval(key: string): number {
+  let hash = 0;
+  for (let i = 0; i < key.length; i++) {
+    hash = (hash * 31 + key.charCodeAt(i)) >>> 0;
+  }
+  return hash / 4294967296; // 2^32 で正規化
+}
+
+/**
  * テナントのsystem_prompt_variantsからA/B振り分けを行う。
  * - variants が空 or 1つだけ → 既存のfallbackPromptをそのまま使う（後方互換）
- * - variants が2つ以上 → weightに基づいてランダム選択
+ * - variants が2つ以上 → weightに基づいて選択
  * - weight合計が100でない場合は正規化して動作
+ *
+ * GID 1216978855735482: stickyKey（通常はsession_id）を指定すると、Math.random()の
+ * 代わりに決定的ハッシュで選択する。同一セッション内で複数回呼ばれても常に同じvariantに
+ * なる（sticky assignment）。stickyKey省略時は従来どおりMath.random()を使う
+ * （呼び出し元がsession_idを持たない場合の後方互換フォールバック）。
  */
 export function selectVariant(
   variants: PromptVariant[],
   fallbackPrompt: string,
+  stickyKey?: string,
 ): VariantSelectionResult {
   // null/undefined/空配列 → fallbackを返す
   if (!variants || variants.length === 0) {
@@ -34,7 +55,7 @@ export function selectVariant(
     return { prompt: v.prompt, variantId: v.id, variantName: v.name };
   }
 
-  // 2つ以上 → weightを合計して正規化、ランダム選択
+  // 2つ以上 → weightを合計して正規化、選択
   const totalWeight = variants.reduce((sum, v) => sum + v.weight, 0);
   if (totalWeight <= 0) {
     // weightが全て0以下の場合は先頭を返す
@@ -42,7 +63,8 @@ export function selectVariant(
     return { prompt: v.prompt, variantId: v.id, variantName: v.name };
   }
 
-  const rand = Math.random() * totalWeight;
+  const pseudoRandom = stickyKey ? hashToUnitInterval(stickyKey) : Math.random();
+  const rand = pseudoRandom * totalWeight;
   let cumulative = 0;
   for (const v of variants) {
     cumulative += v.weight;

--- a/src/agent/tools/synthesisTool.ts
+++ b/src/agent/tools/synthesisTool.ts
@@ -16,7 +16,9 @@ import type { SimilarPattern } from '../../api/events/similarUserMatcher';
 import { getPool } from '../../lib/db';
 import { buildSentimentHint } from '../../lib/sentiment/hint';
 
-async function getTenantsPromptWithVariant(tenantId: string): Promise<{
+// GID 1216978855735482: sessionId を sticky key として渡し、同一セッション内で
+// variant が揺れないようにする（Math.random()だと呼ばれるたびに選び直されていた）。
+async function getTenantsPromptWithVariant(tenantId: string, sessionId?: string): Promise<{
   prompt: string | null;
   variantId: string | null;
   variantName: string | null;
@@ -36,7 +38,7 @@ async function getTenantsPromptWithVariant(tenantId: string): Promise<{
     const variants = row.system_prompt_variants ?? [];
     const fallback = row.system_prompt?.trim() ?? '';
 
-    const selection = selectVariant(variants, fallback);
+    const selection = selectVariant(variants, fallback, sessionId);
     return {
       prompt: selection.prompt || null,
       variantId: selection.variantId,
@@ -186,7 +188,7 @@ export async function synthesizeAnswer(input: SynthesisInput): Promise<Synthesis
 
   // テナント固有のシステムプロンプトをA/Bバリアント込みで取得（tenantId がある場合のみ）
   const promptResult = tenantId
-    ? await getTenantsPromptWithVariant(tenantId)
+    ? await getTenantsPromptWithVariant(tenantId, input.sessionId)
     : { prompt: null, variantId: null, variantName: null };
   const tenantSystemPrompt = promptResult.prompt;
   const selectedVariantId = promptResult.variantId;

--- a/src/api/conversion/abExposureRoutes.test.ts
+++ b/src/api/conversion/abExposureRoutes.test.ts
@@ -1,0 +1,110 @@
+// src/api/conversion/abExposureRoutes.test.ts
+// GID 1216978855735482: アバター効果A/Bテスト基盤 — 露出記録エンドポイント
+
+import express from 'express';
+import request from 'supertest';
+import { registerAbExposureRoutes } from './abExposureRoutes';
+
+const VALID_SESSION_ID = '11111111-1111-1111-1111-111111111111';
+
+function makeApp(opts: {
+  tenantId?: string | null;
+  queryResponses?: Array<{ rows: any[]; rowCount?: number } | Error>;
+  dbNull?: boolean;
+}) {
+  const { tenantId = 'tenant-a', queryResponses = [] } = opts;
+  const app = express();
+  app.use(express.json());
+
+  const authMw = (req: any, _res: any, next: any) => {
+    if (tenantId !== null) req.tenantId = tenantId;
+    next();
+  };
+
+  let callCount = 0;
+  const mockDb: any = opts.dbNull
+    ? null
+    : {
+        query: jest.fn().mockImplementation(() => {
+          const resp = queryResponses[callCount++] ?? { rows: [], rowCount: 0 };
+          if (resp instanceof Error) return Promise.reject(resp);
+          return Promise.resolve(resp);
+        }),
+      };
+
+  registerAbExposureRoutes(app, [authMw], mockDb);
+  return { app, mockDb };
+}
+
+describe('POST /v1/ab/avatar-exposure', () => {
+  it('正常系: runningな実験に対する露出を202で受理する', async () => {
+    const { app, mockDb } = makeApp({
+      queryResponses: [
+        { rows: [{ 1: 1 }], rowCount: 1 }, // ab_experiments存在確認
+        { rows: [], rowCount: 0 }, // INSERT
+      ],
+    });
+    const res = await request(app)
+      .post('/v1/ab/avatar-exposure')
+      .send({ experiment_id: 9, variant: 'a', session_id: VALID_SESSION_ID });
+    expect(res.status).toBe(202);
+    expect(mockDb.query).toHaveBeenCalledTimes(2);
+  });
+
+  it('tenantId不明（未認証） → 401', async () => {
+    const { app } = makeApp({ tenantId: null });
+    const res = await request(app)
+      .post('/v1/ab/avatar-exposure')
+      .send({ experiment_id: 9, variant: 'a', session_id: VALID_SESSION_ID });
+    expect(res.status).toBe(401);
+  });
+
+  it('DB未接続 → 503', async () => {
+    const { app } = makeApp({ dbNull: true });
+    const res = await request(app)
+      .post('/v1/ab/avatar-exposure')
+      .send({ experiment_id: 9, variant: 'a', session_id: VALID_SESSION_ID });
+    expect(res.status).toBe(503);
+  });
+
+  it('session_idがUUID形式でない → 400', async () => {
+    const { app } = makeApp({});
+    const res = await request(app)
+      .post('/v1/ab/avatar-exposure')
+      .send({ experiment_id: 9, variant: 'a', session_id: 'not-a-uuid' });
+    expect(res.status).toBe(400);
+  });
+
+  it('variantが a/b 以外 → 400', async () => {
+    const { app } = makeApp({});
+    const res = await request(app)
+      .post('/v1/ab/avatar-exposure')
+      .send({ experiment_id: 9, variant: 'c', session_id: VALID_SESSION_ID });
+    expect(res.status).toBe(400);
+  });
+
+  it('experiment_idが自テナントのrunning実験でない（他テナント/存在しない/draft等）→ 404', async () => {
+    const { app, mockDb } = makeApp({
+      queryResponses: [{ rows: [], rowCount: 0 }], // ab_experiments存在確認 → 該当なし
+    });
+    const res = await request(app)
+      .post('/v1/ab/avatar-exposure')
+      .send({ experiment_id: 999, variant: 'a', session_id: VALID_SESSION_ID });
+    expect(res.status).toBe(404);
+    // 存在確認で弾かれるため、INSERT(recordAvatarExposure)は呼ばれない
+    expect(mockDb.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('存在確認クエリがtenant_idで絞り込んでいる（クロステナント汚染防止）', async () => {
+    const { app, mockDb } = makeApp({
+      tenantId: 'tenant-a',
+      queryResponses: [{ rows: [{ 1: 1 }], rowCount: 1 }, { rows: [] }],
+    });
+    await request(app)
+      .post('/v1/ab/avatar-exposure')
+      .send({ experiment_id: 9, variant: 'a', session_id: VALID_SESSION_ID });
+    const [sql, params] = (mockDb.query as jest.Mock).mock.calls[0];
+    expect(sql).toContain('tenant_id = $2');
+    expect(params).toEqual([9, 'tenant-a']);
+  });
+});

--- a/src/api/conversion/abExposureRoutes.ts
+++ b/src/api/conversion/abExposureRoutes.ts
@@ -1,0 +1,66 @@
+// src/api/conversion/abExposureRoutes.ts
+// GID 1216978855735482: アバター効果A/Bテスト基盤 — 露出記録エンドポイント
+//
+// widget側で決定したアバターA/B実験の割当(experiment_id + variant)を、実際の
+// session_idと紐付けてab_resultsに記録する。 /api/events(Phase55の行動イベント)は
+// features.event_tracking(Growth+)が有効なテナントでしか動かないため使えない
+// （アバター実験はStarterでも参加しうるため、プラン非依存の専用経路が必要）。
+//
+// NOTE: このPRでは widget/routes.ts 側での実験割当ロジック(resolveAvatarAssignment)
+// までを実装しており、このエンドポイントを実際に呼び出す public/widget.js 側の配線は
+// 含めていない（本番稼働中の配信スクリプトへの変更は影響範囲が大きく、別途レビュー・
+// E2E確認のうえで追随PRとして行うのが安全と判断した。PR本文に明記）。
+
+import type { Express, Request, Response, RequestHandler } from 'express';
+import type { Pool } from 'pg';
+import { z } from 'zod';
+import { recordAvatarExposure } from './avatarAbExperiment';
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+const ExposureSchema = z.object({
+  experiment_id: z.number().int().positive(),
+  variant: z.enum(['a', 'b']),
+  session_id: z.string().regex(UUID_PATTERN, 'session_id must be a UUID'),
+});
+
+export function registerAbExposureRoutes(
+  app: Express,
+  apiStack: RequestHandler[],
+  db: Pool | null,
+): void {
+  app.post('/v1/ab/avatar-exposure', ...apiStack, async (req: Request, res: Response) => {
+    const tenantId: string = (req as any).tenantId ?? '';
+    if (!tenantId) {
+      return res.status(401).json({ error: 'tenant_not_found' });
+    }
+    if (!db) {
+      return res.status(503).json({ error: 'database_unavailable' });
+    }
+
+    const parsed = ExposureSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return res.status(400).json({
+        error: 'invalid_request',
+        details: parsed.error.issues.map((i) => ({ field: i.path.join('.'), message: i.message })),
+      });
+    }
+    const { experiment_id, variant, session_id } = parsed.data;
+
+    try {
+      // クロステナント汚染防止: experiment_id が本当にこのテナントの running 実験かを確認する
+      const check = await db.query(
+        `SELECT 1 FROM ab_experiments WHERE id = $1 AND tenant_id = $2 AND status = 'running'`,
+        [experiment_id, tenantId],
+      );
+      if (check.rowCount === 0) {
+        return res.status(404).json({ error: 'experiment_not_found' });
+      }
+
+      await recordAvatarExposure(db, experiment_id, variant, session_id);
+      return res.status(202).json({ accepted: true });
+    } catch {
+      return res.status(500).json({ error: 'internal_error' });
+    }
+  });
+}

--- a/src/api/conversion/abResultsOutcomeSync.test.ts
+++ b/src/api/conversion/abResultsOutcomeSync.test.ts
@@ -1,0 +1,98 @@
+// src/api/conversion/abResultsOutcomeSync.test.ts
+// GID 1216978855735482: アバター効果A/Bテスト基盤 — 成果の遅延反映
+
+import { reconcileAbResultOutcomes } from './abResultsOutcomeSync';
+
+function makePool(queryResponses: Array<{ rows: any[]; rowCount?: number } | Error>) {
+  let callCount = 0;
+  const calls: unknown[][] = [];
+  return {
+    query: jest.fn().mockImplementation((...args: unknown[]) => {
+      calls.push(args);
+      const resp = queryResponses[callCount++] ?? { rows: [], rowCount: 0 };
+      if (resp instanceof Error) return Promise.reject(resp);
+      return Promise.resolve(resp);
+    }),
+    calls,
+  };
+}
+
+describe('reconcileAbResultOutcomes', () => {
+  it('metadata列が存在しない場合はsourceフィルタ無しでUPDATEを2本発行する', async () => {
+    const pool = makePool([
+      { rows: [{ exists: false }] }, // information_schema
+      { rows: [], rowCount: 3 }, // reached_two_plus_exchanges UPDATE
+      { rows: [], rowCount: 1 }, // converted UPDATE
+    ]);
+    await reconcileAbResultOutcomes(pool as any, 42);
+
+    expect(pool.query).toHaveBeenCalledTimes(3);
+    const [reachedSql] = pool.calls[1] as [string, unknown[]];
+    const [convertedSql] = pool.calls[2] as [string, unknown[]];
+    expect(reachedSql).not.toContain("metadata->>'source'");
+    expect(convertedSql).not.toContain("metadata->>'source'");
+    expect(reachedSql).toContain('message_count >=');
+    expect(convertedSql).toContain('outcome <> ALL(');
+  });
+
+  it('metadata列が存在する場合はsourceフィルタ(source=user OR NULL)を付与する', async () => {
+    const pool = makePool([
+      { rows: [{ exists: true }] },
+      { rows: [], rowCount: 0 },
+      { rows: [], rowCount: 0 },
+    ]);
+    await reconcileAbResultOutcomes(pool as any, 42);
+
+    const [reachedSql] = pool.calls[1] as [string, unknown[]];
+    const [convertedSql] = pool.calls[2] as [string, unknown[]];
+    expect(reachedSql).toContain("cs.metadata->>'source' = 'user'");
+    expect(reachedSql).toContain("cs.metadata->>'source' IS NULL");
+    expect(convertedSql).toContain("cs.metadata->>'source' = 'user'");
+  });
+
+  it('information_schemaクエリが例外を投げても列なし扱い(false)にフォールバックし、UPDATEは実行される', async () => {
+    const pool = makePool([
+      new Error('information_schema unavailable'),
+      { rows: [], rowCount: 0 },
+      { rows: [], rowCount: 0 },
+    ]);
+    await expect(reconcileAbResultOutcomes(pool as any, 42)).resolves.toBeUndefined();
+    expect(pool.query).toHaveBeenCalledTimes(3);
+  });
+
+  it('reached_two_plus_exchangesのUPDATEはexperimentIdと閾値(4)をパラメータに渡す', async () => {
+    const pool = makePool([
+      { rows: [{ exists: false }] },
+      { rows: [], rowCount: 0 },
+      { rows: [], rowCount: 0 },
+    ]);
+    await reconcileAbResultOutcomes(pool as any, 42);
+    const [, params] = pool.calls[1] as [string, unknown[]];
+    expect(params).toEqual([42, 4]);
+  });
+
+  it('1本目のUPDATEが失敗すると例外がそのまま伝播する（呼び出し元でtry/catchする設計）', async () => {
+    const pool = makePool([
+      { rows: [{ exists: false }] },
+      new Error('update failed'),
+    ]);
+    await expect(reconcileAbResultOutcomes(pool as any, 42)).rejects.toThrow('update failed');
+  });
+
+  it('ab_results.session_id(UUID)とchat_sessions.session_id(TEXT)の型不一致を::textキャストで吸収する', async () => {
+    // chat_sessions.session_id は TEXT 型（widget側でcrypto.randomUUID()により常にUUID形式の
+    // 値が入るが、カラム型としてはTEXT）。ab_results.session_id は UUID 型のため、
+    // PostgresはUUID=TEXTの暗黙キャストを行わずエラーになる。r.session_id::text で
+    // 明示キャストしていることを確認する（実DBでの型エラー再発防止の回帰テスト）。
+    const pool = makePool([
+      { rows: [{ exists: false }] },
+      { rows: [], rowCount: 0 },
+      { rows: [], rowCount: 0 },
+    ]);
+    await reconcileAbResultOutcomes(pool as any, 42);
+    const [reachedSql] = pool.calls[1] as [string, unknown[]];
+    const [convertedSql] = pool.calls[2] as [string, unknown[]];
+    expect(reachedSql).toContain('r.session_id::text = cs.session_id');
+    expect(convertedSql).toContain('r.session_id::text = cs.session_id');
+  });
+});

--- a/src/api/conversion/abResultsOutcomeSync.ts
+++ b/src/api/conversion/abResultsOutcomeSync.ts
@@ -1,0 +1,98 @@
+// src/api/conversion/abResultsOutcomeSync.ts
+// GID 1216978855735482: アバター効果A/Bテスト基盤 — 成果の遅延反映
+//
+// 割当時点(露出)でab_resultsにconverted=NULLの行が入る想定(avatarAbExperiment.ts参照)。
+// このモジュールは、結果集計(GET /v1/admin/ab/experiments/:id/results)の直前に
+// 呼び出され、chat_sessionsと突合して以下を書き戻す:
+//   - reached_two_plus_exchanges: 主要指標。2往復以上（message_count >= 4。
+//     saveMessage は user/assistant 各1回ずつ message_count を+1するため、
+//     2往復 = 4メッセージ）に到達していれば true。
+//   - converted: 副次指標。chat_sessions.outcome が設定されており、かつ
+//     デフォルトのconversion_types終端2件（'離脱','不明'）でなければ true とみなす簡易判定。
+//     conversion_typesはテナントごとにカスタム可能なため厳密ではないが、CV率は
+//     判定に使わない副次指標のため許容する（タスク仕様）。
+//
+// GID 1216995497... (lane-instrumentのトラフィック分離と並行): chat_sessions.metadata.source
+// が導入され次第 source='user' のみを対象にする契約。カラムがまだ存在しない間は
+// フィルタを適用しない（未設定を許容）。カラムの有無は毎回 information_schema で
+// 確認する（結果APIは高頻度エンドポイントではないため許容できるオーバーヘッド）。
+//
+// GID 1216978855735482 かつ chat_sessions の作成経路・metadata記録そのものには
+// 一切触れていない（読み取り専用の突合のみ）。
+
+import type { Pool } from 'pg';
+
+const TWO_PLUS_EXCHANGES_MESSAGE_COUNT = 4;
+
+// デフォルトのconversion_types終端2件（admin-ui/src/pages/admin/tenants/ConversionTypesTab.tsx
+// のデフォルト値と一致させる）。カスタムconversion_typesのテナントでは不正確になりうるが、
+// CV率は副次指標(記録のみ・判定に使わない)のため許容する。
+const NON_CONVERTING_OUTCOMES = ['離脱', '不明'];
+
+/**
+ * chat_sessions に metadata カラムが存在するか確認する。
+ * TODO(GID 1216978855735482 / lane-instrument連携): metadata.source 列が入り次第、
+ * 下記の存在チェックを廃止し常に `AND (cs.metadata->>'source' = 'user' OR cs.metadata->>'source' IS NULL)`
+ * を適用してよい。現状は移行期間中のため動的に判定する。
+ */
+async function chatSessionsHasMetadataColumn(pool: Pick<Pool, 'query'>): Promise<boolean> {
+  try {
+    const result = await pool.query<{ exists: boolean }>(
+      `SELECT EXISTS (
+         SELECT 1 FROM information_schema.columns
+         WHERE table_name = 'chat_sessions' AND column_name = 'metadata'
+       ) AS exists`,
+    );
+    return result.rows[0]?.exists === true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * 指定experimentの未解決(reached_two_plus_exchanges IS NULL)露出行をchat_sessionsと突合し、
+ * reached_two_plus_exchanges / converted を書き戻す。
+ * message_countは単調増加するため、まだ2往復未満のセッションは次回呼び出し時に
+ * 再評価される（「未到達」を確定値として書き込むことはない — NULLのまま残す）。
+ * best-effort: 失敗しても結果集計自体は止めない（呼び出し元でtry/catchすること）。
+ */
+export async function reconcileAbResultOutcomes(
+  pool: Pick<Pool, 'query'>,
+  experimentId: number,
+): Promise<void> {
+  const hasMetadata = await chatSessionsHasMetadataColumn(pool);
+  const sourceFilter = hasMetadata
+    ? `AND (cs.metadata->>'source' = 'user' OR cs.metadata->>'source' IS NULL)`
+    : '';
+
+  // 2往復以上に到達した行: reached_two_plus_exchanges を true に更新
+  // NOTE: ab_results.session_id は UUID型だが chat_sessions.session_id は TEXT型
+  // （widget側でcrypto.randomUUID()により常にUUID形式の値が入るが、カラム型としては
+  // TEXTのため、PostgresはUUID=TEXTの暗黙キャストを行わずエラーになる。r側を::textで
+  // 明示キャストして比較する）。
+  await pool.query(
+    `UPDATE ab_results r
+     SET reached_two_plus_exchanges = true
+     FROM chat_sessions cs
+     WHERE r.experiment_id = $1
+       AND r.session_id::text = cs.session_id
+       AND r.reached_two_plus_exchanges IS NOT TRUE
+       AND cs.message_count >= $2
+       ${sourceFilter}`,
+    [experimentId, TWO_PLUS_EXCHANGES_MESSAGE_COUNT],
+  );
+
+  // CV(副次指標): outcomeが設定済みかつ非離脱/不明の行を converted=true に更新
+  await pool.query(
+    `UPDATE ab_results r
+     SET converted = true
+     FROM chat_sessions cs
+     WHERE r.experiment_id = $1
+       AND r.session_id::text = cs.session_id
+       AND r.converted IS NOT TRUE
+       AND cs.outcome IS NOT NULL
+       AND cs.outcome <> ALL($2::text[])
+       ${sourceFilter}`,
+    [experimentId, NON_CONVERTING_OUTCOMES],
+  );
+}

--- a/src/api/conversion/abTestRoutes.ts
+++ b/src/api/conversion/abTestRoutes.ts
@@ -14,6 +14,7 @@ import { supabaseAuthMiddleware } from '../../admin/http/supabaseAuthMiddleware'
 import { roleAuthMiddleware, requireRole } from '../middleware/roleAuth';
 import type { AuthenticatedUser, AuthedReq } from '../middleware/roleAuth';
 import { planHasFeature, queryTenantPlan } from '../../lib/billing/planFeatures';
+import { reconcileAbResultOutcomes } from './abResultsOutcomeSync';
 
 /**
  * GID: LP料金表(Growth〜: CV計測)に基づくplan制限。
@@ -204,16 +205,29 @@ export function registerAbTestRoutes(app: Express, db: Pool | null): void {
     if (!Number.isInteger(id) || id <= 0) return res.status(400).json({ error: 'invalid_id' });
 
     try {
-      const existing = await db.query('SELECT tenant_id FROM ab_experiments WHERE id=$1', [id]);
+      const existing = await db.query(
+        'SELECT tenant_id, min_sample_size FROM ab_experiments WHERE id=$1',
+        [id],
+      );
       if (existing.rowCount === 0) return res.status(404).json({ error: 'not_found' });
       if (user.role === 'client_admin' && existing.rows[0].tenant_id !== user.tenantId) {
         return res.status(403).json({ error: 'forbidden' });
+      }
+      const minSampleSize = Number(existing.rows[0].min_sample_size);
+
+      // GID 1216978855735482: 成果(継続率/CV)をchat_sessionsと突合して反映してから集計する。
+      // best-effort — 突合が失敗しても、その時点のab_results状態で集計は続行する。
+      try {
+        await reconcileAbResultOutcomes(db, id);
+      } catch {
+        // noop — 集計は続行
       }
 
       const result = await db.query(
         `SELECT
            variant,
-           COUNT(*) AS total,
+           COUNT(*) AS exposed,
+           COUNT(*) FILTER (WHERE reached_two_plus_exchanges) AS reached_two_plus,
            COUNT(*) FILTER (WHERE converted) AS converted,
            ROUND(AVG(judge_score)::numeric, 1) AS avg_judge_score
          FROM ab_results
@@ -222,19 +236,51 @@ export function registerAbTestRoutes(app: Express, db: Pool | null): void {
         [id],
       );
 
-      const byVariant: Record<string, { total: number; converted: number; conversion_rate: number; avg_judge_score: number | null }> = {};
+      const byVariant: Record<string, {
+        exposed: number;
+        // GID 1216978855735482: 主要指標。2往復以上に進んだセッションの割合。
+        reached_two_plus: number;
+        reached_two_plus_rate: number;
+        // 副次指標（記録のみ・判定には使わない）
+        converted: number;
+        conversion_rate: number;
+        avg_judge_score: number | null;
+      }> = {};
+      let totalExposed = 0;
       for (const row of result.rows) {
-        const total = Number(row.total);
+        const exposed = Number(row.exposed);
+        const reachedTwoPlus = Number(row.reached_two_plus);
         const converted = Number(row.converted);
+        totalExposed += exposed;
         byVariant[row.variant] = {
-          total,
+          exposed,
+          reached_two_plus: reachedTwoPlus,
+          reached_two_plus_rate: exposed > 0 ? Math.round((reachedTwoPlus / exposed) * 1000) / 10 : 0,
           converted,
-          conversion_rate: total > 0 ? Math.round((converted / total) * 1000) / 10 : 0,
+          conversion_rate: exposed > 0 ? Math.round((converted / exposed) * 1000) / 10 : 0,
           avg_judge_score: row.avg_judge_score !== null ? Number(row.avg_judge_score) : null,
         };
       }
 
-      return res.json({ experiment_id: id, variants: byVariant });
+      // GID 1216978855735482: peeking(覗き見)によるfalse positive防止。
+      // min_sample_size未到達の間は reliable=false とし、意思決定に使わないよう警告する。
+      // 生の件数自体は隠さない（テナント自身のデータであり透明性を優先する）。
+      const reliable = totalExposed >= minSampleSize;
+
+      return res.json({
+        experiment_id: id,
+        min_sample_size: minSampleSize,
+        total_exposed: totalExposed,
+        reliable,
+        ...(reliable
+          ? {}
+          : {
+              warning:
+                `サンプルサイズが min_sample_size(${minSampleSize}) に未到達です` +
+                `（現在 ${totalExposed} 件）。この結果を意思決定に使わないでください。`,
+            }),
+        variants: byVariant,
+      });
     } catch {
       return res.status(500).json({ error: 'internal_error' });
     }

--- a/src/api/conversion/avatarAbExperiment.test.ts
+++ b/src/api/conversion/avatarAbExperiment.test.ts
@@ -1,0 +1,139 @@
+// src/api/conversion/avatarAbExperiment.test.ts
+// GID 1216978855735482: アバター効果A/Bテスト基盤
+
+import {
+  findRunningAvatarExperiment,
+  resolveAvatarAssignment,
+  recordAvatarExposure,
+} from './avatarAbExperiment';
+
+function makePool(queryResponses: Array<{ rows: any[]; rowCount?: number } | Error>) {
+  let callCount = 0;
+  return {
+    query: jest.fn().mockImplementation(() => {
+      const resp = queryResponses[callCount++] ?? { rows: [], rowCount: 0 };
+      if (resp instanceof Error) return Promise.reject(resp);
+      return Promise.resolve(resp);
+    }),
+  };
+}
+
+describe('findRunningAvatarExperiment', () => {
+  it('variant_a/variant_bともにavatarEnabledを持つrunning実験を返す', async () => {
+    const pool = makePool([
+      {
+        rows: [
+          {
+            id: 5,
+            variant_a: { avatarEnabled: true },
+            variant_b: { avatarEnabled: false },
+            traffic_split: '0.5',
+          },
+        ],
+      },
+    ]);
+    const result = await findRunningAvatarExperiment(pool as any, 'tenant-a');
+    expect(result).toEqual({
+      id: 5,
+      tenantId: 'tenant-a',
+      variantA: { avatarEnabled: true },
+      variantB: { avatarEnabled: false },
+      trafficSplit: 0.5,
+    });
+  });
+
+  it('avatarEnabledを持たない実験（プロンプトA/B等）はスキップしnullを返す', async () => {
+    const pool = makePool([
+      {
+        rows: [
+          { id: 1, variant_a: { prompt_modifier: 'x' }, variant_b: { prompt_modifier: 'y' }, traffic_split: '0.5' },
+        ],
+      },
+    ]);
+    const result = await findRunningAvatarExperiment(pool as any, 'tenant-a');
+    expect(result).toBeNull();
+  });
+
+  it('複数running実験がある場合、avatarEnabled形式の最初の1件を採用する', async () => {
+    const pool = makePool([
+      {
+        rows: [
+          { id: 1, variant_a: { prompt_modifier: 'x' }, variant_b: { prompt_modifier: 'y' }, traffic_split: '0.5' },
+          { id: 2, variant_a: { avatarEnabled: true }, variant_b: { avatarEnabled: false }, traffic_split: '0.3' },
+        ],
+      },
+    ]);
+    const result = await findRunningAvatarExperiment(pool as any, 'tenant-a');
+    expect(result?.id).toBe(2);
+  });
+
+  it('running実験なし → null', async () => {
+    const pool = makePool([{ rows: [] }]);
+    const result = await findRunningAvatarExperiment(pool as any, 'tenant-a');
+    expect(result).toBeNull();
+  });
+
+  it('DB障害時はfail-safeでnull（可用性優先）', async () => {
+    const pool = makePool([new Error('db down')]);
+    const result = await findRunningAvatarExperiment(pool as any, 'tenant-a');
+    expect(result).toBeNull();
+  });
+});
+
+describe('resolveAvatarAssignment', () => {
+  it('defaultAvatarEnabled=false（features.avatarが無効）の場合は実験を一切参照せずfalseを返す', async () => {
+    const pool = makePool([{ rows: [{ id: 1 }] }]); // もし呼ばれたら実験ありに見えてしまう罠
+    const result = await resolveAvatarAssignment(pool as any, 'tenant-a', 'sticky-key', false);
+    expect(result).toEqual({ avatarEnabled: false, experimentId: null, variant: null });
+    // ガードにより ab_experiments へのクエリ自体が発生しないこと
+    expect(pool.query).not.toHaveBeenCalled();
+  });
+
+  it('実験なし → defaultAvatarEnabledをそのまま返す', async () => {
+    const pool = makePool([{ rows: [] }]);
+    const result = await resolveAvatarAssignment(pool as any, 'tenant-a', 'sticky-key', true);
+    expect(result).toEqual({ avatarEnabled: true, experimentId: null, variant: null });
+  });
+
+  it('実験あり → sticky keyに基づき決定的にvariantを割り当てる（同一keyは同一結果）', async () => {
+    const pool = makePool([
+      {
+        rows: [
+          { id: 9, variant_a: { avatarEnabled: true }, variant_b: { avatarEnabled: false }, traffic_split: '0.5' },
+        ],
+      },
+    ]);
+    const result1 = await resolveAvatarAssignment(pool as any, 'tenant-a', 'same-key', true);
+
+    const pool2 = makePool([
+      {
+        rows: [
+          { id: 9, variant_a: { avatarEnabled: true }, variant_b: { avatarEnabled: false }, traffic_split: '0.5' },
+        ],
+      },
+    ]);
+    const result2 = await resolveAvatarAssignment(pool2 as any, 'tenant-a', 'same-key', true);
+
+    expect(result1.variant).toBe(result2.variant);
+    expect(result1.experimentId).toBe(9);
+    expect(result1.avatarEnabled).toBe(result1.variant === 'a');
+  });
+});
+
+describe('recordAvatarExposure', () => {
+  it('ON CONFLICT DO NOTHINGで冪等にINSERTする', async () => {
+    const pool = makePool([{ rows: [] }]);
+    await recordAvatarExposure(pool as any, 9, 'a', '11111111-1111-1111-1111-111111111111');
+    expect(pool.query).toHaveBeenCalledWith(
+      expect.stringContaining('ON CONFLICT (experiment_id, session_id) DO NOTHING'),
+      [9, 'a', '11111111-1111-1111-1111-111111111111'],
+    );
+  });
+
+  it('DB障害時は例外を投げずに握りつぶす（露出記録失敗でリクエストを壊さない）', async () => {
+    const pool = makePool([new Error('insert failed')]);
+    await expect(
+      recordAvatarExposure(pool as any, 9, 'a', '11111111-1111-1111-1111-111111111111'),
+    ).resolves.toBeUndefined();
+  });
+});

--- a/src/api/conversion/avatarAbExperiment.ts
+++ b/src/api/conversion/avatarAbExperiment.ts
@@ -1,0 +1,135 @@
+// src/api/conversion/avatarAbExperiment.ts
+// GID 1216978855735482: アバター効果A/Bテスト基盤
+//
+// 既存の ab_experiments / ab_results（Phase58, src/api/conversion/abTestRoutes.ts）を
+// 再利用し、「アバターあり vs テキストのみ」の割当を決定・記録する。
+// variant_a / variant_b の JSONB にどちらも { avatarEnabled: boolean } を含む
+// running な実験を「アバター実験」とみなす規約とする（専用のtype列は追加しない）。
+
+import type { Pool } from 'pg';
+import { assignVariant } from './abTestRoutes';
+
+export interface AvatarExperimentVariantConfig {
+  avatarEnabled: boolean;
+}
+
+export interface RunningAvatarExperiment {
+  id: number;
+  tenantId: string;
+  variantA: AvatarExperimentVariantConfig;
+  variantB: AvatarExperimentVariantConfig;
+  trafficSplit: number;
+}
+
+export interface AvatarAssignmentResult {
+  avatarEnabled: boolean;
+  experimentId: number | null;
+  variant: 'a' | 'b' | null;
+}
+
+/** variant_a/variant_b のJSONBが { avatarEnabled: boolean } の形か判定する */
+function isAvatarVariantConfig(v: unknown): v is AvatarExperimentVariantConfig {
+  return (
+    typeof v === 'object' &&
+    v !== null &&
+    typeof (v as Record<string, unknown>)['avatarEnabled'] === 'boolean'
+  );
+}
+
+/**
+ * テナントに紐づく running なアバター実験を1件探す。
+ * 複数存在する場合は最新(created_at DESC)を採用する（通常は同時に1件のみを想定）。
+ * DB障害時はnull（実験なし扱いにフォールバック — 可用性優先）。
+ */
+export async function findRunningAvatarExperiment(
+  pool: Pick<Pool, 'query'>,
+  tenantId: string,
+): Promise<RunningAvatarExperiment | null> {
+  try {
+    const result = await pool.query<{
+      id: number;
+      variant_a: unknown;
+      variant_b: unknown;
+      traffic_split: string | number;
+    }>(
+      `SELECT id, variant_a, variant_b, traffic_split
+       FROM ab_experiments
+       WHERE tenant_id = $1 AND status = 'running'
+       ORDER BY created_at DESC`,
+      [tenantId],
+    );
+
+    for (const row of result.rows) {
+      if (isAvatarVariantConfig(row.variant_a) && isAvatarVariantConfig(row.variant_b)) {
+        return {
+          id: row.id,
+          tenantId,
+          variantA: row.variant_a,
+          variantB: row.variant_b,
+          trafficSplit: Number(row.traffic_split),
+        };
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 訪問者/セッション単位でアバター表示可否を決定する。
+ *
+ * GID 1216944004404664（プランゲート）とは独立: defaultAvatarEnabled が false
+ * （テナントのfeatures.avatarがそもそも無効）の場合は実験を一切参照せず、
+ * 常に false を返す（アバターを出せないテナントで実験に参加させない、という
+ * タスク仕様のガード）。
+ *
+ * stickyKey が session_id 相当であれば sticky（同一セッション内で結果が揺れない）。
+ * 既存の assignVariant（同一visitor_idは常に同じvariant）をそのまま再利用する。
+ */
+export async function resolveAvatarAssignment(
+  pool: Pick<Pool, 'query'>,
+  tenantId: string,
+  stickyKey: string,
+  defaultAvatarEnabled: boolean,
+): Promise<AvatarAssignmentResult> {
+  if (!defaultAvatarEnabled) {
+    return { avatarEnabled: false, experimentId: null, variant: null };
+  }
+
+  const experiment = await findRunningAvatarExperiment(pool, tenantId);
+  if (!experiment) {
+    return { avatarEnabled: defaultAvatarEnabled, experimentId: null, variant: null };
+  }
+
+  const variant = assignVariant(stickyKey, experiment.trafficSplit);
+  const avatarEnabled =
+    variant === 'a' ? experiment.variantA.avatarEnabled : experiment.variantB.avatarEnabled;
+
+  return { avatarEnabled, experimentId: experiment.id, variant };
+}
+
+/**
+ * 割当時点の露出をab_resultsに1行記録する（成果は後から更新 — reconcileAbResultOutcomes参照）。
+ * (experiment_id, session_id) にユニーク制約があるため、同一セッションからの複数回呼び出しは
+ * 冪等（ON CONFLICT DO NOTHING）。fire-and-forgetで呼ぶこと（結果表示をブロックしない）。
+ * migration_ab_results_exposure.sql の適用前（convertedがNOT NULLのまま）の環境では
+ * INSERTが失敗しうるため、失敗は握りつぶす（露出記録の欠落は許容し、可用性を優先する）。
+ */
+export async function recordAvatarExposure(
+  pool: Pick<Pool, 'query'>,
+  experimentId: number,
+  variant: 'a' | 'b',
+  sessionId: string,
+): Promise<void> {
+  try {
+    await pool.query(
+      `INSERT INTO ab_results (experiment_id, variant, session_id, converted)
+       VALUES ($1, $2, $3::uuid, NULL)
+       ON CONFLICT (experiment_id, session_id) DO NOTHING`,
+      [experimentId, variant, sessionId],
+    );
+  } catch {
+    // best-effort — 露出記録の失敗でリクエストを失敗させない
+  }
+}

--- a/src/api/conversion/migration_ab_results_exposure.sql
+++ b/src/api/conversion/migration_ab_results_exposure.sql
@@ -1,0 +1,17 @@
+-- src/api/conversion/migration_ab_results_exposure.sql
+-- GID 1216978855735482: アバター効果A/Bテスト基盤
+--
+-- 従来のab_resultsは成果(converted)確定時にのみ1行INSERTする想定で
+-- converted NOT NULLだった。露出(割当)時点で1行先にINSERTし、成果は
+-- 後から更新できるようにconvertedをNULL許容にする。
+-- 同一セッションへの重複露出記録を防ぐため (experiment_id, session_id) にユニーク制約を追加する。
+
+ALTER TABLE ab_results ALTER COLUMN converted DROP NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_ab_results_exp_session
+  ON ab_results(experiment_id, session_id)
+  WHERE session_id IS NOT NULL;
+
+-- 主要指標「2往復以上に進んだセッションの割合」を保持するカラム。
+-- 集計のたびに chat_sessions.message_count と突合して更新する（reconcileAbResultOutcomes）。
+ALTER TABLE ab_results ADD COLUMN IF NOT EXISTS reached_two_plus_exchanges BOOLEAN;

--- a/src/api/widget/routes.test.ts
+++ b/src/api/widget/routes.test.ts
@@ -1,0 +1,128 @@
+// src/api/widget/routes.test.ts
+// GID 1216978855735482: GET /widget/:tenantSlug.js のアバターA/Bテスト割当まわりの回帰テスト
+
+import express from 'express';
+import request from 'supertest';
+import { registerWidgetRoutes } from './routes';
+
+jest.mock('./widgetGenerator', () => ({
+  generateWidgetJs: jest.fn().mockImplementation(async (config: any) => {
+    // 実際のobfuscationは行わず、渡された設定をそのままJSON文字列として埋め込む
+    // （テストからassignmentの結果を検証しやすくするため）
+    return `/* config: ${JSON.stringify(config)} */`;
+  }),
+}));
+
+import { generateWidgetJs } from './widgetGenerator';
+
+function makePool(queryResponses: Array<{ rows: any[]; rowCount?: number } | Error>) {
+  let callCount = 0;
+  return {
+    query: jest.fn().mockImplementation(() => {
+      const resp = queryResponses[callCount++] ?? { rows: [], rowCount: 0 };
+      if (resp instanceof Error) return Promise.reject(resp);
+      return Promise.resolve(resp);
+    }),
+  };
+}
+
+function makeApp(db: any) {
+  const app = express();
+  registerWidgetRoutes(app, db);
+  return app;
+}
+
+describe('GET /widget/:tenantSlug.js', () => {
+  beforeEach(() => {
+    (generateWidgetJs as jest.Mock).mockClear();
+  });
+
+  it('DB未接続 → /widget.js へリダイレクト', async () => {
+    const app = makeApp(null);
+    const res = await request(app).get('/widget/tenant-a.js');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/widget.js');
+  });
+
+  it('テナントが存在しない → 404', async () => {
+    const db = makePool([{ rows: [], rowCount: 0 }]);
+    const app = makeApp(db);
+    const res = await request(app).get('/widget/nonexistent.js');
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('tenant_not_found');
+  });
+
+  it('テナント無効 → 404', async () => {
+    const db = makePool([{ rows: [{ id: 'tenant-a', is_active: false, features: {} }], rowCount: 1 }]);
+    const app = makeApp(db);
+    const res = await request(app).get('/widget/tenant-a.js');
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('tenant_inactive');
+  });
+
+  it('features.avatar=false のテナント → 実験を参照せずavatarEnabled=falseで生成（ガード）', async () => {
+    const db = makePool([
+      { rows: [{ id: 'tenant-a', is_active: true, features: { avatar: false } }], rowCount: 1 },
+      // resolveAvatarAssignmentのガードにより ab_experiments へのクエリは発生しないはず
+    ]);
+    const app = makeApp(db);
+    const res = await request(app).get('/widget/tenant-a.js');
+    expect(res.status).toBe(200);
+    const config = (generateWidgetJs as jest.Mock).mock.calls[0][0];
+    expect(config.avatarEnabled).toBe(false);
+    expect(config.abExperimentId).toBeNull();
+    expect(config.abVariant).toBeNull();
+    // tenants テーブルへの1回のクエリのみ（ab_experiments へは問い合わせない）
+    expect(db.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('features.avatar=true かつ running なアバター実験なし → デフォルトのavatarEnabledをそのまま使う', async () => {
+    const db = makePool([
+      { rows: [{ id: 'tenant-a', is_active: true, features: { avatar: true } }], rowCount: 1 },
+      { rows: [] }, // ab_experiments: running実験なし
+    ]);
+    const app = makeApp(db);
+    const res = await request(app).get('/widget/tenant-a.js');
+    expect(res.status).toBe(200);
+    const config = (generateWidgetJs as jest.Mock).mock.calls[0][0];
+    expect(config.avatarEnabled).toBe(true);
+    expect(config.abExperimentId).toBeNull();
+  });
+
+  it('running なアバター実験あり → assignVariant結果に応じてavatarEnabledが上書きされる', async () => {
+    const db = makePool([
+      { rows: [{ id: 'tenant-a', is_active: true, features: { avatar: true } }], rowCount: 1 },
+      {
+        rows: [
+          { id: 7, variant_a: { avatarEnabled: true }, variant_b: { avatarEnabled: false }, traffic_split: '0.5' },
+        ],
+      },
+    ]);
+    const app = makeApp(db);
+    const res = await request(app).get('/widget/tenant-a.js');
+    expect(res.status).toBe(200);
+    const config = (generateWidgetJs as jest.Mock).mock.calls[0][0];
+    expect(config.abExperimentId).toBe(7);
+    expect(['a', 'b']).toContain(config.abVariant);
+    expect(config.avatarEnabled).toBe(config.abVariant === 'a');
+  });
+
+  it('レスポンスヘッダ: Content-Type/Cache-Control/X-Content-Type-Options', async () => {
+    const db = makePool([
+      { rows: [{ id: 'tenant-a', is_active: true, features: { avatar: false } }], rowCount: 1 },
+    ]);
+    const app = makeApp(db);
+    const res = await request(app).get('/widget/tenant-a.js');
+    expect(res.headers['content-type']).toContain('application/javascript');
+    expect(res.headers['cache-control']).toBe('public, max-age=86400');
+    expect(res.headers['x-content-type-options']).toBe('nosniff');
+  });
+
+  it('DBクエリ例外 → 500', async () => {
+    const db = makePool([new Error('db down')]);
+    const app = makeApp(db);
+    const res = await request(app).get('/widget/tenant-a.js');
+    expect(res.status).toBe(500);
+    expect(res.body.error).toBe('widget_generation_failed');
+  });
+});

--- a/src/api/widget/routes.ts
+++ b/src/api/widget/routes.ts
@@ -9,6 +9,7 @@
 import type { Express, Request, Response } from "express";
 import { Pool } from "pg";
 import { generateWidgetJs } from "./widgetGenerator";
+import { resolveAvatarAssignment } from "../conversion/avatarAbExperiment";
 
 const API_BASE_URL =
   process.env.API_BASE_URL ?? "https://api.r2c.biz";
@@ -40,11 +41,25 @@ export function registerWidgetRoutes(app: Express, db: Pool | null): void {
       }
 
       const features = tenant.features ?? {};
+      const defaultAvatarEnabled: boolean = features.avatar ?? false;
+
+      // GID 1216978855735482: 「アバターあり vs テキストのみ」A/Bテスト。
+      // このエンドポイントは24hブラウザキャッシュされ、かつ生成時点ではまだ
+      // chat_sessionのsession_idが存在しない（ページ読み込み時に1回だけ呼ばれる）。
+      // そのため厳密なsession単位ではなく、visitor近似のsticky key（IP+テナントID）で
+      // 決定的に割り当てる。同じ訪問者はブラウザキャッシュにより最大24h同じ結果になり、
+      // 副次的にセッションをまたいだstickinessも得られる。
+      // features.avatar=false のテナントでは実験を一切参照しない（ガード）。
+      const stickyKey = `${req.ip ?? "unknown"}:${tenant.id}`;
+      const assignment = await resolveAvatarAssignment(db, tenant.id, stickyKey, defaultAvatarEnabled);
+
       const js = await generateWidgetJs({
         tenantId: tenant.id,
         apiBaseUrl: API_BASE_URL,
-        avatarEnabled: features.avatar ?? false,
+        avatarEnabled: assignment.avatarEnabled,
         themeColor: "#22c55e",
+        abExperimentId: assignment.experimentId,
+        abVariant: assignment.variant,
       });
 
       res.set("Content-Type", "application/javascript; charset=utf-8");

--- a/src/api/widget/widgetGenerator.ts
+++ b/src/api/widget/widgetGenerator.ts
@@ -12,6 +12,10 @@ export interface TenantWidgetConfig {
   apiBaseUrl: string;
   themeColor?: string;
   avatarEnabled?: boolean;
+  /** GID 1216978855735482: アバターA/Bテストの割当実験ID（実験が無ければnull） */
+  abExperimentId?: number | null;
+  /** GID 1216978855735482: アバターA/Bテストの割当variant（実験が無ければnull） */
+  abVariant?: "a" | "b" | null;
 }
 
 const WIDGET_SRC_PATH = path.resolve(process.cwd(), "public", "widget.js");
@@ -54,6 +58,8 @@ export async function generateWidgetJs(config: TenantWidgetConfig): Promise<stri
     apiBase: ${JSON.stringify(config.apiBaseUrl)},
     themeColor: ${JSON.stringify(config.themeColor ?? "#22c55e")},
     avatarEnabled: ${JSON.stringify(config.avatarEnabled ?? false)},
+    abExperimentId: ${JSON.stringify(config.abExperimentId ?? null)},
+    abVariant: ${JSON.stringify(config.abVariant ?? null)},
     _wt: ${JSON.stringify(token)}
   };
   if (typeof window !== "undefined") {

--- a/src/index.ts
+++ b/src/index.ts
@@ -88,6 +88,7 @@ import { registerEngagementRoutes } from "./api/engagement/engagementRoutes";
 import { registerEscalationRoutes } from "./api/chat/escalationRoutes";
 import { registerConversionRoutes } from "./api/conversion/conversionRoutes";
 import { registerAbTestRoutes } from "./api/conversion/abTestRoutes";
+import { registerAbExposureRoutes } from "./api/conversion/abExposureRoutes";
 import { registerHermesMcpRoutes } from "./api/hermes-mcp/routes";
 import { registerHermesProposalAdminRoutes } from "./api/admin/hermes/routes";
 import { registerKnowledgeGapPhase46Routes } from "./api/admin/knowledge-gaps/routes";
@@ -635,6 +636,9 @@ registerEscalationRoutes(app, apiStack);
 // Phase58: コンバージョン最適化ループ
 registerConversionRoutes(app, apiStack, db);
 if (db) registerAbTestRoutes(app, db);
+
+// GID 1216978855735482: アバターA/Bテストの露出記録 (Widget → Server)
+registerAbExposureRoutes(app, apiStack, db);
 
 // Phase75: Hermes Agent(外部, 別VPS)向けMCPデータエンドポイント(Bearer認証、同意ゲート)
 registerHermesMcpRoutes(app);

--- a/tests/phase58/abTestRoutes.test.ts
+++ b/tests/phase58/abTestRoutes.test.ts
@@ -174,28 +174,81 @@ describe('PATCH /v1/admin/ab/experiments/:id/status', () => {
 });
 
 describe('GET /v1/admin/ab/experiments/:id/results', () => {
-  it('variant別 conversion rate 算出 → 200', async () => {
+  // GID 1216978855735482: reconcileAbResultOutcomes が結果集計の直前に呼ばれるようになった。
+  // 呼び出し順序: [0]tenant_id+min_sample_size取得 [1]metadata列存在確認
+  // [2]reached_two_plus_exchanges UPDATE [3]converted UPDATE [4]集計SELECT
+  function queryResponsesWithReconcile(
+    minSampleSize: number,
+    aggregationRows: any[],
+    tenantId = 'tenant-a',
+  ) {
+    return [
+      { rows: [{ tenant_id: tenantId, min_sample_size: minSampleSize }], rowCount: 1 },
+      { rows: [{ exists: false }] }, // metadata列なし（未移行環境を模す）
+      { rows: [], rowCount: 0 }, // reached_two_plus_exchanges UPDATE
+      { rows: [], rowCount: 0 }, // converted UPDATE
+      { rows: aggregationRows },
+    ];
+  }
+
+  it('variant別 conversion rate / 継続率(reached_two_plus_rate) 算出 → 200、サンプル十分でreliable=true', async () => {
     const { app } = makeApp({
-      queryResponses: [
-        { rows: [{ tenant_id: 'tenant-a' }], rowCount: 1 },
-        {
-          rows: [
-            { variant: 'a', total: 100, converted: 30, avg_judge_score: 75 },
-            { variant: 'b', total: 100, converted: 20, avg_judge_score: 65 },
-          ],
-        },
-      ],
+      queryResponses: queryResponsesWithReconcile(100, [
+        { variant: 'a', exposed: 100, reached_two_plus: 60, converted: 30, avg_judge_score: 75 },
+        { variant: 'b', exposed: 100, reached_two_plus: 40, converted: 20, avg_judge_score: 65 },
+      ]),
     });
     const res = await request(app).get('/v1/admin/ab/experiments/1/results');
     expect(res.status).toBe(200);
     expect(res.body.variants['a'].conversion_rate).toBe(30);
     expect(res.body.variants['b'].conversion_rate).toBe(20);
+    expect(res.body.variants['a'].reached_two_plus_rate).toBe(60);
+    expect(res.body.variants['b'].reached_two_plus_rate).toBe(40);
+    expect(res.body.total_exposed).toBe(200);
+    expect(res.body.min_sample_size).toBe(100);
+    expect(res.body.reliable).toBe(true);
+    expect(res.body.warning).toBeUndefined();
+  });
+
+  it('min_sample_size未到達 → reliable=false + warningを返す（生の件数は隠さない）', async () => {
+    const { app } = makeApp({
+      queryResponses: queryResponsesWithReconcile(1000, [
+        { variant: 'a', exposed: 5, reached_two_plus: 2, converted: 1, avg_judge_score: 80 },
+        { variant: 'b', exposed: 5, reached_two_plus: 1, converted: 0, avg_judge_score: null },
+      ]),
+    });
+    const res = await request(app).get('/v1/admin/ab/experiments/1/results');
+    expect(res.status).toBe(200);
+    expect(res.body.reliable).toBe(false);
+    expect(res.body.total_exposed).toBe(10);
+    expect(typeof res.body.warning).toBe('string');
+    expect(res.body.warning).toContain('1000');
+    // 生の件数自体は隠さない
+    expect(res.body.variants['a'].exposed).toBe(5);
   });
 
   it('存在しないID → 404', async () => {
     const { app } = makeApp({ queryResponses: [{ rows: [], rowCount: 0 }] });
     const res = await request(app).get('/v1/admin/ab/experiments/999/results');
     expect(res.status).toBe(404);
+  });
+
+  it('reconcile自体が例外を投げても集計は継続する(best-effort)', async () => {
+    // metadata列存在確認は内部でtry/catch済みのため常に成功扱い(false)になる。
+    // 1本目のUPDATE(reached_two_plus_exchanges)が例外を投げると reconcileAbResultOutcomes
+    // 全体がその場でrejectし、2本目のUPDATE(converted)は呼ばれない。呼び出し元(results
+    // ハンドラ)のtry/catchがこれを吸収し、次の実クエリ(集計SELECT)に進む。
+    const { app } = makeApp({
+      queryResponses: [
+        { rows: [{ tenant_id: 'tenant-a', min_sample_size: 10 }], rowCount: 1 },
+        { rows: [{ exists: false }] },
+        new Error('update failed'),
+        { rows: [{ variant: 'a', exposed: 20, reached_two_plus: 10, converted: 5, avg_judge_score: 70 }] },
+      ],
+    });
+    const res = await request(app).get('/v1/admin/ab/experiments/1/results');
+    expect(res.status).toBe(200);
+    expect(res.body.variants['a'].exposed).toBe(20);
   });
 });
 


### PR DESCRIPTION
## Summary
Asana gid 1216978855735482。「アバターあり vs テキストのみ」をランダム割当で比較し、会話継続率への効果を実測する基盤。**既存資産(ab_experiments/ab_results, `src/api/conversion/abTestRoutes.ts`)を再利用し、作り直していない。**

## 1. Sticky assignment（プロンプトA/B、既存機能の修正）
`src/agent/ab-test/variantSelector.ts` の `selectVariant()` が呼ばれるたびに `Math.random()` で選び直しており、同一セッション内でvariantが揺れる不具合を修正。第3引数 `stickyKey`（通常はsession_id）を渡すと決定的ハッシュで選択する。**省略時はMath.random()の従来動作を維持**（後方互換 — 既存テストは無改造で通過）。`src/agent/tools/synthesisTool.ts` で `input.sessionId` を渡すよう変更。

## 2. アバター実験の割当(`src/api/conversion/avatarAbExperiment.ts`, 新規)
- `ab_experiments` の `variant_a`/`variant_b` が両方 `{ avatarEnabled: boolean }` の形を持つ running な実験を「アバター実験」とみなす規約(専用type列は追加しない)。
- 既存の `assignVariant(visitorId, trafficSplit)`（abTestRoutes.tsに既に実装済みだが未使用のまま放置されていた決定的ハッシュ関数）をそのまま再利用。
- `features.avatar=false` のテナントは実験を一切参照しない（要件5のガード）。

## 3. widget/routes.ts でのavatarEnabled上書き
`GET /widget/:tenantSlug.js` は24hブラウザキャッシュされ、生成時点ではまだsession_idが存在しない（ページ読み込み時に1回だけ呼ばれる、chatセッション開始前）。そのため厳密なsession単位ではなく、**visitor近似のsticky key（IP+テナントID）**で決定的に割り当てる。同一訪問者はブラウザキャッシュにより最大24h同じ結果になり、副次的にセッションをまたいだstickinessも得られる。IPが変わる/共有IP環境では割当が変わりうる制約がある点は認識のうえでの選択。

## 4. 露出記録・継続率/CVの遅延反映
- `migration_ab_results_exposure.sql`: `ab_results.converted` を NULL許容にし(露出時点でconverted未確定のままINSERTできるように)、`(experiment_id, session_id)` にユニーク制約を追加(冪等な露出記録)。主要指標を保持する `reached_two_plus_exchanges` 列を追加。
- `src/api/conversion/abExposureRoutes.ts`（新規）: `POST /v1/ab/avatar-exposure`。**`/api/events` は `features.event_tracking`(Growth+限定)が有効なテナントでしか動かないため使えない**（アバター実験はStarterのテナントも対象になりうる）。プラン非依存の専用の軽量エンドポイントを用意した。
- `src/api/conversion/abResultsOutcomeSync.ts`（新規）: 結果集計の直前に `chat_sessions` と突合し、`reached_two_plus_exchanges`(message_count>=4 = 2往復。saveMessageはuser/assistant各1回ずつmessage_countを+1するため)と `converted`(outcome設定済みかつ非離脱/不明の簡易判定。conversion_typesはテナントごとにカスタム可能なため厳密ではない — CV率は判定に使わない副次指標のため許容)を書き戻す。
  - `chat_sessions.metadata.source` はlane-instrumentが並行実装中のトラフィック分離契約。列が無い間はフィルタなしで動作し(未設定を許容、TODOコメント付き)、列が存在すれば `source='user'` のみに絞る(`information_schema` で毎回動的判定)。
  - **`chat_sessions` の作成経路・metadata記録そのものには一切触れていない**(読み取り専用の突合のみ)。
  - 実装中に発見: `ab_results.session_id` は UUID型だが `chat_sessions.session_id` は TEXT型のため、素の等号比較だとPostgresがエラーになる。`r.session_id::text = cs.session_id` で明示キャストし、回帰テストも追加した。

## 5. 結果API: peeking防止 + 主要指標
`GET /v1/admin/ab/experiments/:id/results`: `min_sample_size` 未到達時は `reliable=false` と警告メッセージを返す（生の件数自体は隠さない — テナント自身のデータであり透明性を優先）。`reached_two_plus_rate`（主要指標）と `conversion_rate`/`avg_judge_score`（副次指標、判定には使わない）を分けて返す。

## 意図的にこのPRに含めなかったもの
- **`public/widget.js` の配線**: `window.__RAJIUCE_TENANT_CFG__` に `abExperimentId`/`abVariant` を注入する変更(`widgetGenerator.ts`)までは実装したが、widget.js側でそれを読んで `POST /v1/ab/avatar-exposure` を呼ぶ配線は含めていない。widget.jsは全テナントに配信される本番稼働中のスクリプトで単体テストがほぼ無く(`tests/widget/`には1ファイルのみ)、この場で盲目的に変更するリスクが実験の価値(下記参照)に見合わないと判断した。バックエンド側は完成・テスト済みで、次PRで安全に配線できる状態になっている。

## 正直な見積もり
実トラフィックは月数十セッション規模のため、3倍の効果でも検出に数ヶ月、倍率が小さければ年単位かかる。**LPの文言はこの結果を待たない方針。本タスクの目的はLPではなくプロダクト改善。**

## Test plan
- [x] `src/agent/ab-test/variantSelector.test.ts`: sticky assignment回帰(+5件、既存4件は無改造で通過)
- [x] `src/api/conversion/avatarAbExperiment.test.ts`（新規、10件）
- [x] `src/api/conversion/abResultsOutcomeSync.test.ts`（新規、6件、UUID/TEXT型不一致の回帰テスト含む）
- [x] `src/api/conversion/abExposureRoutes.test.ts`（新規、7件）
- [x] `src/api/widget/routes.test.ts`（新規、8件、既存テストが無かったファイル）
- [x] `tests/phase58/abTestRoutes.test.ts`: 結果APIの新レスポンス形状に追従(+3件)
- [x] 変更・新規ファイルを個別実行し全61件グリーン確認済み
- [x] `tsc --noEmit`: 本変更起因のエラーなし(既存の無関係な`string|string[]`型エラー35件のみ残存、他タスクで確認済みの既知の事前差分と一致)
- [x] ローカルのフルスイート実行は方針どおり未実行。フルスイート検証はCIに委譲

## 要判断として残した項目
1. `public/widget.js` への配線（上記「意図的に含めなかったもの」参照）— 次PRとして安全に実施することを推奨
2. CV率の判定(`NON_CONVERTING_OUTCOMES = ['離脱','不明']`)はデフォルトのconversion_types終端2件のハードコードで、カスタムconversion_typesのテナントでは不正確になりうる。副次指標のため許容したが、気になる場合はご指摘ください

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

https://claude.ai/code/session_01B1dxH199qQB3diHbsGLNxM