### PR TITLE
feat(analytics): トラフィックソース記録 + 集計をsource='user'に限定

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -10,6 +10,11 @@ export default defineConfig({
     baseURL: process.env.E2E_BASE_URL || 'https://admin.r2c.biz',
     screenshot: 'only-on-failure',
     trace: 'on-first-retry',
+    // GID 1216970103691946: E2Eトラフィックであることをサーバ側(resolveTrafficSource)
+    // が判定できるようにする。本番へのE2E実行がchat_sessions等の集計指標
+    // (継続率・CV率・Judgeスコア)を汚染していた事故の再発防止。
+    // ブラウザコンテキストの全リクエスト(widget.jsのfetch含む)に付与される。
+    extraHTTPHeaders: { 'x-r2c-traffic-source': 'e2e' },
   },
   expect: {
     toHaveScreenshot: { maxDiffPixelRatio: 0.002 },

--- a/src/api/admin/analytics/routes.ts
+++ b/src/api/admin/analytics/routes.ts
@@ -13,6 +13,45 @@ import { isAllowedAdminRole } from "../../middleware/roleAuth";
 import { planHasFeature, queryTenantPlan } from "../../../lib/billing/planFeatures";
 
 // ---------------------------------------------------------------------------
+// GID 1216970103691946: トラフィック汚染対策
+//
+// E2E/chat-test/デモ由来のセッションが chat_sessions.metadata.source に記録されるように
+// なった(src/lib/traffic/trafficSource.ts, src/api/chat/route.ts)。継続率・CV率・
+// Judgeスコアなど「実ユーザーの行動」を表す集計指標は source='user' のセッションのみを
+// 対象にする。過去データ(metadata.source未設定)は自動的に除外される
+// (`metadata->>'source' = 'user'` は NULL に対して常にfalseになるため)。
+//
+// chat_sessions を直接クエリする箇所は USER_SOURCE_CLAUSE(エイリアス指定)を、
+// conversation_evaluations / conversion_attributions など chat_sessions を経由しない
+// テーブルは USER_SOURCE_EXISTS(session_id列, tenant_id列)でEXISTS結合して絞り込む。
+// ---------------------------------------------------------------------------
+
+/** chat_sessions に直接エイリアス `alias` が張られているクエリに追加する条件。 */
+function userSourceClause(alias: string): string {
+  return `AND ${alias}.metadata->>'source' = 'user'`;
+}
+
+/**
+ * chat_sessions を経由しないテーブル(conversation_evaluations / conversion_attributions 等)
+ * から、session_id/tenant_id 経由で実ユーザーのセッションかどうかを判定するEXISTS句。
+ * conversation_evaluations.session_id は chat_sessions.session_id (TEXT) と対応し、
+ * conversion_attributions.session_id は chat_sessions.id (UUID) と対応するため、
+ * どちらの列と突き合わせるかを chatSessionsColumn で指定する。
+ */
+function userSourceExists(
+  sessionIdExpr: string,
+  tenantIdExpr: string,
+  chatSessionsColumn: "session_id" | "id" = "session_id",
+): string {
+  return `AND EXISTS (
+             SELECT 1 FROM chat_sessions cs
+             WHERE cs.${chatSessionsColumn} = ${sessionIdExpr}
+               AND cs.tenant_id = ${tenantIdExpr}
+               AND cs.metadata->>'source' = 'user'
+           )`;
+}
+
+// ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
@@ -206,7 +245,8 @@ export function registerAnalyticsRoutes(app: Express): void {
           `SELECT COUNT(*) AS total_sessions
            FROM chat_sessions s
            WHERE s.started_at >= NOW() - $1::interval
-           ${tenantClause}`,
+           ${tenantClause}
+           ${userSourceClause("s")}`,
           params,
         );
 
@@ -219,11 +259,12 @@ export function registerAnalyticsRoutes(app: Express): void {
            FROM chat_sessions s
            WHERE s.started_at >= NOW() - 2 * ($1::interval)
              AND s.started_at < NOW() - $1::interval
-           ${prevTenantClause}`,
+           ${prevTenantClause}
+           ${userSourceClause("s")}`,
           prevParams,
         );
 
-        // Avg judge score
+        // Avg judge score (GID 1216970103691946: chat_sessions.metadata.source='user' のみ)
         const evalParams: (string | number)[] = [`${interval}`];
         if (tenantId) evalParams.push(tenantId);
         const evalTenantClause = tenantId ? "AND tenant_id = $2" : "";
@@ -232,7 +273,8 @@ export function registerAnalyticsRoutes(app: Express): void {
            FROM conversation_evaluations
            WHERE evaluated_at >= NOW() - $1::interval
              AND score > 0
-           ${evalTenantClause}`,
+           ${evalTenantClause}
+           ${userSourceExists("conversation_evaluations.session_id", "conversation_evaluations.tenant_id")}`,
           evalParams,
         );
 
@@ -259,6 +301,7 @@ export function registerAnalyticsRoutes(app: Express): void {
              LEFT JOIN chat_messages m ON m.session_id = s.id
              WHERE s.started_at >= NOW() - $1::interval
              ${msgTenantClause}
+             ${userSourceClause("s")}
              GROUP BY s.session_id
            ) sub`,
           msgParams,
@@ -274,7 +317,8 @@ export function registerAnalyticsRoutes(app: Express): void {
            JOIN chat_messages m ON m.session_id = s.id
            WHERE s.started_at >= NOW() - $1::interval
              AND (m.content ILIKE '%livekit%' OR m.content ILIKE '%avatar%')
-           ${avatarTenantClause}`,
+           ${avatarTenantClause}
+           ${userSourceClause("s")}`,
           avatarParams,
         );
 
@@ -343,6 +387,18 @@ export function registerAnalyticsRoutes(app: Express): void {
            FROM conversion_attributions
            WHERE created_at > NOW() - INTERVAL '30 days'
            ${cvTenantClause}
+           -- GID 1216970103691946: session_idが無いイベント(セッション紐付けができない
+           -- 旧経路)は誤って除外しないよう温存し、session_idがある場合のみ実ユーザー
+           -- 判定する
+           AND (
+             session_id IS NULL
+             OR EXISTS (
+               SELECT 1 FROM chat_sessions cs
+               WHERE cs.id = conversion_attributions.session_id
+                 AND cs.tenant_id = conversion_attributions.tenant_id
+                 AND cs.metadata->>'source' = 'user'
+             )
+           )
            GROUP BY conversion_type`,
           cvQueryParams,
         );
@@ -481,6 +537,7 @@ export function registerAnalyticsRoutes(app: Express): void {
              FROM chat_sessions s
              WHERE s.started_at >= NOW() - $1::interval
              ${tenantClause}
+             ${userSourceClause("s")}
              GROUP BY day
            ) s_count ON s_count.day = d.date
            LEFT JOIN (
@@ -489,6 +546,7 @@ export function registerAnalyticsRoutes(app: Express): void {
              WHERE e.evaluated_at >= NOW() - $1::interval
                AND e.score > 0
              ${evalTenantClause}
+             ${userSourceExists("e.session_id", "e.tenant_id")}
              GROUP BY day
            ) e_avg ON e_avg.day = d.date
            LEFT JOIN (
@@ -624,6 +682,7 @@ export function registerAnalyticsRoutes(app: Express): void {
            WHERE evaluated_at >= NOW() - $1::interval
              AND score > 0
            ${tenantClause}
+           ${userSourceExists("conversation_evaluations.session_id", "conversation_evaluations.tenant_id")}
            GROUP BY range
            ORDER BY range`,
           params,
@@ -639,7 +698,8 @@ export function registerAnalyticsRoutes(app: Express): void {
            FROM conversation_evaluations
            WHERE evaluated_at >= NOW() - $1::interval
              AND score > 0
-           ${tenantClause}`,
+           ${tenantClause}
+           ${userSourceExists("conversation_evaluations.session_id", "conversation_evaluations.tenant_id")}`,
           params,
         );
 
@@ -665,6 +725,7 @@ export function registerAnalyticsRoutes(app: Express): void {
              AND e.score > 0
              AND e.score < 40
            ${lowTenantClause}
+           ${userSourceExists("e.session_id", "e.tenant_id")}
            ORDER BY e.score ASC
            LIMIT 10`,
           lowScoreParams,
@@ -778,6 +839,7 @@ export function registerAnalyticsRoutes(app: Express): void {
            FROM chat_sessions s
            WHERE s.started_at >= NOW() - $1::interval
            ${tenantClause}
+           ${userSourceClause("s")}
            GROUP BY s.outcome`,
           params,
         );
@@ -786,13 +848,13 @@ export function registerAnalyticsRoutes(app: Express): void {
         // Dedup: get total from a separate count
         const totalCountResult = await pool.query(
           `SELECT COUNT(*) AS total FROM chat_sessions s
-           WHERE s.started_at >= NOW() - $1::interval ${tenantClause}`,
+           WHERE s.started_at >= NOW() - $1::interval ${tenantClause} ${userSourceClause("s")}`,
           params,
         );
         const total = parseInt(totalCountResult.rows[0]?.total ?? "0", 10);
         const recordedResult = await pool.query(
           `SELECT COUNT(*) AS recorded FROM chat_sessions s
-           WHERE s.started_at >= NOW() - $1::interval ${tenantClause} AND s.outcome IS NOT NULL`,
+           WHERE s.started_at >= NOW() - $1::interval ${tenantClause} AND s.outcome IS NOT NULL ${userSourceClause("s")}`,
           params,
         );
         const recorded = parseInt(recordedResult.rows[0]?.recorded ?? "0", 10);
@@ -803,6 +865,7 @@ export function registerAnalyticsRoutes(app: Express): void {
            FROM chat_sessions s
            WHERE s.started_at >= NOW() - $1::interval ${tenantClause}
              AND s.outcome IS NOT NULL
+           ${userSourceClause("s")}
            GROUP BY s.outcome
            ORDER BY cnt DESC`,
           params,
@@ -822,6 +885,7 @@ export function registerAnalyticsRoutes(app: Express): void {
              COUNT(CASE WHEN s.outcome IS NOT NULL AND s.outcome NOT IN ('離脱', '不明') THEN 1 END) AS converted
            FROM chat_sessions s
            WHERE s.started_at >= NOW() - $1::interval ${tenantClause}
+           ${userSourceClause("s")}
            GROUP BY DATE(s.started_at)
            ORDER BY date ASC`,
           params,
@@ -853,7 +917,8 @@ export function registerAnalyticsRoutes(app: Express): void {
            JOIN chat_sessions s ON s.session_id = ce.session_id
            WHERE ce.evaluated_at >= NOW() - $1::interval
              ${techTenantClause}
-             AND ce.feedback IS NOT NULL`,
+             AND ce.feedback IS NOT NULL
+             ${userSourceClause("s")}`,
           techniqueParams,
         );
 
@@ -902,6 +967,7 @@ export function registerAnalyticsRoutes(app: Express): void {
              ${stageTenantClause}
              AND (s.outcome IS NULL OR s.outcome IN ('離脱', '不明'))
              AND cm.metadata->>'state' IS NOT NULL
+             ${userSourceClause("s")}
            GROUP BY cm.metadata->>'state'`,
           stageParams,
         );

--- a/src/api/admin/analytics/trafficSourceFilter.test.ts
+++ b/src/api/admin/analytics/trafficSourceFilter.test.ts
@@ -1,0 +1,113 @@
+// src/api/admin/analytics/trafficSourceFilter.test.ts
+// GID 1216970103691946: 集計クエリが chat_sessions.metadata.source='user' 以外を
+// 除外していることの検証(summary / trends / evaluations / conversions)。
+//
+// SQLの実行結果ではなく、pool.query() に渡された「SQLテキストに絞り込み条件が
+// 含まれているか」を検証する(cvAggregation.test.ts と同じモック手法)。
+
+import express from "express";
+import request from "supertest";
+
+const mockQuery = jest.fn();
+jest.mock("../../../lib/db", () => ({
+  pool: { query: (...args: unknown[]) => mockQuery(...args) },
+  getPool: () => ({ query: (...args: unknown[]) => mockQuery(...args) }),
+}));
+
+jest.mock("../../../lib/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+jest.mock("../../../lib/notifications", () => ({
+  createNotification: jest.fn(),
+  notificationExists: jest.fn().mockResolvedValue(false),
+}));
+
+jest.mock("../../../admin/http/supabaseAuthMiddleware", () => ({
+  supabaseAuthMiddleware: (req: any, _res: any, next: any) => {
+    // super_admin にして plan ゲートのクエリを発生させない(assert対象を絞るため)
+    req.supabaseUser = { app_metadata: { role: "super_admin" } };
+    next();
+  },
+}));
+
+import { registerAnalyticsRoutes } from "./routes";
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  registerAnalyticsRoutes(app);
+  return app;
+}
+
+const USER_SOURCE_SQL = "metadata->>'source' = 'user'";
+
+beforeEach(() => {
+  mockQuery.mockReset();
+  // どのクエリにも安全に応答できる汎用モック(件数0・平均null等)
+  mockQuery.mockImplementation(() => Promise.resolve({ rows: [] }));
+});
+
+describe("GET /v1/admin/analytics/summary — source='user'フィルタ", () => {
+  it("chat_sessions・conversation_evaluations・conversion_attributions のクエリ全てにsource='user'絞り込みが入っている", async () => {
+    const res = await request(makeApp()).get("/v1/admin/analytics/summary");
+    expect(res.status).toBe(200);
+
+    const allSql = mockQuery.mock.calls.map((c) => c[0] as string);
+    const sessionQueries = allSql.filter((sql) => /FROM chat_sessions/.test(sql) && !/tenants t/.test(sql));
+    expect(sessionQueries.length).toBeGreaterThan(0);
+    for (const sql of sessionQueries) {
+      expect(sql).toContain(USER_SOURCE_SQL);
+    }
+
+    const evalQuery = allSql.find((sql) => /FROM conversation_evaluations/.test(sql));
+    expect(evalQuery).toBeDefined();
+    expect(evalQuery).toContain(USER_SOURCE_SQL);
+
+    const cvQuery = allSql.find((sql) => /FROM conversion_attributions/.test(sql));
+    expect(cvQuery).toBeDefined();
+    expect(cvQuery).toContain(USER_SOURCE_SQL);
+    // session_id が無いイベントは誤って除外しない(既存の紐付けできないデータの後方互換)
+    expect(cvQuery).toContain("session_id IS NULL");
+  });
+});
+
+describe("GET /v1/admin/analytics/trends — source='user'フィルタ", () => {
+  it("セッション数・Judgeスコア推移のサブクエリにsource='user'絞り込みが入っている", async () => {
+    const res = await request(makeApp()).get("/v1/admin/analytics/trends");
+    expect(res.status).toBe(200);
+
+    const allSql = mockQuery.mock.calls.map((c) => c[0] as string);
+    const trendSql = allSql.find((sql) => /generate_series/.test(sql));
+    expect(trendSql).toBeDefined();
+    expect(trendSql).toContain(USER_SOURCE_SQL);
+  });
+});
+
+describe("GET /v1/admin/analytics/evaluations — source='user'フィルタ", () => {
+  it("スコア分布・軸平均・低スコアセッション一覧の3クエリ全てにsource='user'絞り込みが入っている", async () => {
+    const res = await request(makeApp()).get("/v1/admin/analytics/evaluations");
+    expect(res.status).toBe(200);
+
+    const allSql = mockQuery.mock.calls.map((c) => c[0] as string);
+    const evalQueries = allSql.filter((sql) => /FROM conversation_evaluations/.test(sql));
+    expect(evalQueries.length).toBe(3);
+    for (const sql of evalQueries) {
+      expect(sql).toContain(USER_SOURCE_SQL);
+    }
+  });
+});
+
+describe("GET /v1/admin/analytics/conversions — source='user'フィルタ", () => {
+  it("chat_sessions直接参照クエリ全てにsource='user'絞り込みが入っている", async () => {
+    const res = await request(makeApp()).get("/v1/admin/analytics/conversions");
+    expect(res.status).toBe(200);
+
+    const allSql = mockQuery.mock.calls.map((c) => c[0] as string);
+    const sessionQueries = allSql.filter((sql) => /chat_sessions/.test(sql));
+    expect(sessionQueries.length).toBeGreaterThan(0);
+    for (const sql of sessionQueries) {
+      expect(sql).toContain(USER_SOURCE_SQL);
+    }
+  });
+});

--- a/src/api/admin/chat-history/chatHistoryRepository.trafficSource.test.ts
+++ b/src/api/admin/chat-history/chatHistoryRepository.trafficSource.test.ts
@@ -1,0 +1,99 @@
+// src/api/admin/chat-history/chatHistoryRepository.trafficSource.test.ts
+// GID 1216970103691946: saveMessage() の chat_sessions.metadata.source 記録の検証
+
+const mockQuery = jest.fn();
+jest.mock("../../../lib/db", () => ({
+  getPool: () => ({ query: (...args: unknown[]) => mockQuery(...args) }),
+}));
+
+import { saveMessage } from "./chatHistoryRepository";
+
+beforeEach(() => {
+  mockQuery.mockReset();
+  // 1回目のquery呼び出し(upsert)は結果を使わないので何でもよい
+  mockQuery.mockResolvedValueOnce({ rows: [] }); // upsert
+  mockQuery.mockResolvedValueOnce({ rows: [{ id: "session-uuid-1" }] }); // SELECT id
+  mockQuery.mockResolvedValueOnce({ rows: [] }); // INSERT chat_messages
+});
+
+describe("saveMessage: chat_sessions.metadata.source", () => {
+  it("trafficSource='e2e' 指定時、upsertのmetadataに{source:'e2e'}を渡す", async () => {
+    await saveMessage({
+      tenantId: "t1",
+      sessionId: "s1",
+      role: "user",
+      content: "hello",
+      trafficSource: "e2e",
+    });
+
+    const upsertCall = mockQuery.mock.calls[0]!;
+    expect(upsertCall[0]).toContain("INSERT INTO chat_sessions");
+    expect(upsertCall[0]).toContain("metadata");
+    const params = upsertCall[1] as unknown[];
+    const metadataParam = params[4] as string;
+    expect(JSON.parse(metadataParam)).toEqual({ source: "e2e" });
+  });
+
+  it("trafficSource未指定時はデフォルトで{source:'user'}(既存呼び出し元との後方互換)", async () => {
+    await saveMessage({
+      tenantId: "t1",
+      sessionId: "s1",
+      role: "user",
+      content: "hello",
+    });
+
+    const upsertCall = mockQuery.mock.calls[0]!;
+    const params = upsertCall[1] as unknown[];
+    const metadataParam = params[4] as string;
+    expect(JSON.parse(metadataParam)).toEqual({ source: "user" });
+  });
+
+  it("ON CONFLICT時、metadataに既にsourceキーがあれば上書きしないSQL(CASE文)になっている", async () => {
+    await saveMessage({
+      tenantId: "t1",
+      sessionId: "s1",
+      role: "assistant",
+      content: "hi",
+      trafficSource: "chat_test",
+    });
+
+    const upsertCall = mockQuery.mock.calls[0]!;
+    const sql = upsertCall[0] as string;
+    // 2回目以降のUPDATEで既存のsourceを保持するCASE文が含まれること
+    expect(sql).toMatch(/CASE\s+WHEN chat_sessions\.metadata \? 'source' THEN chat_sessions\.metadata/);
+    expect(sql).toContain("ON CONFLICT (tenant_id, session_id) DO UPDATE SET");
+  });
+
+  it("trafficSource='demo'を正しく渡す", async () => {
+    await saveMessage({
+      tenantId: "t1",
+      sessionId: "s1",
+      role: "user",
+      content: "hello",
+      trafficSource: "demo",
+    });
+    const params = mockQuery.mock.calls[0]![1] as unknown[];
+    expect(JSON.parse(params[4] as string)).toEqual({ source: "demo" });
+  });
+
+  it("既存の呼び出し(trafficSource無し・metadata/ragSources等の既存パラメータ)が壊れないこと", async () => {
+    await saveMessage({
+      tenantId: "t1",
+      sessionId: "s1",
+      role: "assistant",
+      content: "answer",
+      metadata: { model: "x" },
+      ragSources: [],
+      promptVariantId: "v1",
+      promptVariantName: "variant-A",
+    });
+
+    expect(mockQuery).toHaveBeenCalledTimes(3);
+    const upsertParams = mockQuery.mock.calls[0]![1] as unknown[];
+    expect(upsertParams[0]).toBe("t1");
+    expect(upsertParams[1]).toBe("s1");
+    expect(upsertParams[2]).toBe("v1");
+    expect(upsertParams[3]).toBe("variant-A");
+    expect(JSON.parse(upsertParams[4] as string)).toEqual({ source: "user" });
+  });
+});

--- a/src/api/admin/chat-history/chatHistoryRepository.ts
+++ b/src/api/admin/chat-history/chatHistoryRepository.ts
@@ -3,6 +3,7 @@
 
 import { getPool } from "../../../lib/db";
 import type { RagSource } from "../../../agent/types";
+import type { TrafficSource } from "../../../lib/traffic/trafficSource";
 
 export interface SaveMessageParams {
   tenantId: string;
@@ -20,6 +21,13 @@ export interface SaveMessageParams {
    * 既存テスト互換のため optional。
    */
   ragSources?: RagSource[];
+  /**
+   * GID 1216970103691946: セッション作成経路の判定結果(実ユーザー/E2E/chat-test/デモ)。
+   * chat_sessions.metadata.source に「セッション新規作成時のみ」記録する(2回目以降の
+   * メッセージでは既存値を保持し、上書きしない)。省略時は 'user' 扱い(既存呼び出し元との
+   * 後方互換のため。呼び出し元がトラフィック種別を判定できない場合の安全側デフォルト)。
+   */
+  trafficSource?: TrafficSource;
 }
 
 /**
@@ -30,16 +38,24 @@ export interface SaveMessageParams {
 export async function saveMessage(params: SaveMessageParams): Promise<void> {
   const pool = getPool();
 
-  // 1. chat_sessions を upsert（Phase46: variant情報も記録）
+  // 1. chat_sessions を upsert（Phase46: variant情報も記録 / GID 1216970103691946: source記録）
+  // metadata.source はセッション新規作成時(INSERT)にのみ確定させ、2回目以降のUPDATEでは
+  // 既存値を保持する(CASE ... WHEN metadata ? 'source' THEN 既存値 ELSE 新規値)。
+  // これにより「最初にどの経路でセッションが作られたか」がぶれずに残る。
+  const initialMetadata = JSON.stringify({ source: params.trafficSource ?? "user" });
   await pool.query(
-    `INSERT INTO chat_sessions (tenant_id, session_id, last_message_at, message_count, prompt_variant_id, prompt_variant_name)
-     VALUES ($1, $2, NOW(), 1, $3, $4)
+    `INSERT INTO chat_sessions (tenant_id, session_id, last_message_at, message_count, prompt_variant_id, prompt_variant_name, metadata)
+     VALUES ($1, $2, NOW(), 1, $3, $4, $5::jsonb)
      ON CONFLICT (tenant_id, session_id) DO UPDATE SET
        last_message_at = NOW(),
        message_count = chat_sessions.message_count + 1,
        prompt_variant_id = COALESCE(chat_sessions.prompt_variant_id, EXCLUDED.prompt_variant_id),
-       prompt_variant_name = COALESCE(chat_sessions.prompt_variant_name, EXCLUDED.prompt_variant_name)`,
-    [params.tenantId, params.sessionId, params.promptVariantId ?? null, params.promptVariantName ?? null],
+       prompt_variant_name = COALESCE(chat_sessions.prompt_variant_name, EXCLUDED.prompt_variant_name),
+       metadata = CASE
+         WHEN chat_sessions.metadata ? 'source' THEN chat_sessions.metadata
+         ELSE COALESCE(chat_sessions.metadata, '{}'::jsonb) || EXCLUDED.metadata
+       END`,
+    [params.tenantId, params.sessionId, params.promptVariantId ?? null, params.promptVariantName ?? null, initialMetadata],
   );
 
   // 2. chat_sessions の UUID を取得

--- a/src/api/avatar/anamChatStreamRoutes.ts
+++ b/src/api/avatar/anamChatStreamRoutes.ts
@@ -12,6 +12,7 @@ import type { Express, Request, Response, RequestHandler } from 'express';
 import type { AuthedRequest } from '../../agent/http/authMiddleware';
 import { logger } from '../../lib/logger';
 import { saveMessage } from '../admin/chat-history/chatHistoryRepository';
+import { resolveTrafficSource, TRAFFIC_SOURCE_HEADER } from '../../lib/traffic/trafficSource';
 import { trackUsage } from '../../lib/billing/usageTracker';
 
 const GROQ_API_BASE = 'https://api.groq.com/openai/v1/chat/completions';
@@ -65,6 +66,14 @@ export function registerAnamChatStreamRoutes(app: Express, apiStack: RequestHand
       return res.status(400).json({ error: 'messages array required' });
     }
 
+    // GID 1216970103691946: 実ユーザー/E2E/chat-test/デモの判定（セッション新規作成時のみ記録）
+    const trafficSource = resolveTrafficSource({
+      headerValue: req.header(TRAFFIC_SOURCE_HEADER),
+      userAgent: req.header('user-agent'),
+      referer: req.header('referer'),
+      isChatTestToken: (req as any).isChatTestToken === true,
+    });
+
     // Phase75: 会話ログ永続化。Widgetがsession_idを送ってこない場合、この呼び出し単位を
     // 1セッションとして扱う(継続性は失うが、Hermes MCP等の学習用途には十分な単発Q&Aとして
     // 記録できる)。将来widget.js側でsessionIdを継続送信するよう改修すれば自動的に連続化する。
@@ -80,6 +89,7 @@ export function registerAnamChatStreamRoutes(app: Express, apiStack: RequestHand
         role: 'user',
         content: latestUserMessage.content,
         metadata: { source: 'avatar', channel: 'anam' },
+        trafficSource,
       }).catch((err) => logger.warn('[anamChatStream] saveMessage(user) failed:', err));
     }
 
@@ -219,6 +229,7 @@ export function registerAnamChatStreamRoutes(app: Express, apiStack: RequestHand
           role: 'assistant',
           content: assistantContent,
           metadata: { source: 'avatar', channel: 'anam' },
+          trafficSource,
         }).catch((err) => logger.warn('[anamChatStream] saveMessage(assistant) failed:', err));
       }
 

--- a/src/api/chat/route.trafficSource.test.ts
+++ b/src/api/chat/route.trafficSource.test.ts
@@ -1,0 +1,131 @@
+// src/api/chat/route.trafficSource.test.ts
+// GID 1216970103691946: /api/chat が saveMessage() に渡す trafficSource の判定テスト
+//
+// createChatHandler は多数の依存(agent orchestrator / sentiment / security層)を持つため、
+// トラフィックソース判定に関係しない部分は全てモックし、saveMessage() 呼び出し引数のみを検証する。
+
+import express from "express";
+import request from "supertest";
+import pino from "pino";
+
+const mockSaveMessage = jest.fn().mockResolvedValue(undefined);
+jest.mock("../admin/chat-history/chatHistoryRepository", () => ({
+  saveMessage: (...args: unknown[]) => mockSaveMessage(...args),
+}));
+
+jest.mock("../admin/knowledge/knowledgeGapRepository", () => ({
+  saveKnowledgeGap: jest.fn().mockResolvedValue(undefined),
+}));
+
+jest.mock("../../lib/billing/usageTracker", () => ({
+  trackUsage: jest.fn(),
+}));
+
+jest.mock("../../lib/sentiment/client", () => ({
+  analyzeSentiment: jest.fn().mockResolvedValue(null),
+}));
+
+const mockRunDialogTurn = jest.fn();
+jest.mock("../../agent/dialog/dialogAgent", () => ({
+  runDialogTurn: (...args: unknown[]) => mockRunDialogTurn(...args),
+}));
+
+jest.mock("../../agent/dialog/flowContextStore", () => ({
+  peekFlowSessionMeta: jest.fn().mockReturnValue(undefined),
+}));
+
+jest.mock("../../agent/dialog/salesContextStore", () => ({
+  getSalesSessionMeta: jest.fn().mockReturnValue(undefined),
+}));
+
+import { createChatHandler } from "./route";
+import { requestIdMiddleware } from "../../lib/request-id";
+
+function makeApp(opts: { tenantId?: string; isChatTestToken?: boolean } = {}) {
+  const app = express();
+  app.use(express.json());
+  app.use(requestIdMiddleware);
+  app.use((req: any, _res, next) => {
+    req.tenantId = opts.tenantId ?? "tenant-1";
+    req.lang = "ja";
+    if (opts.isChatTestToken) req.isChatTestToken = true;
+    next();
+  });
+  const logger = pino({ level: "silent" });
+  app.post("/api/chat", createChatHandler(logger));
+  return app;
+}
+
+beforeEach(() => {
+  mockSaveMessage.mockClear();
+  mockRunDialogTurn.mockReset().mockResolvedValue({
+    sessionId: "sess-1",
+    answer: "こんにちは、ご質問ありがとうございます。",
+    needsClarification: false,
+    steps: [],
+    final: true,
+    meta: {},
+  });
+});
+
+describe("POST /api/chat — trafficSource判定", () => {
+  it("x-r2c-traffic-source: e2e ヘッダあり → saveMessageにtrafficSource='e2e'を渡す", async () => {
+    await request(makeApp())
+      .post("/api/chat")
+      .set("x-r2c-traffic-source", "e2e")
+      .send({ message: "こんにちは" });
+
+    expect(mockSaveMessage).toHaveBeenCalled();
+    for (const call of mockSaveMessage.mock.calls) {
+      expect(call[0].trafficSource).toBe("e2e");
+    }
+  });
+
+  it("ヘッダなし・UAがHeadlessChrome → saveMessageにtrafficSource='e2e'を渡す", async () => {
+    await request(makeApp())
+      .post("/api/chat")
+      .set("User-Agent", "Mozilla/5.0 HeadlessChrome/120.0.0.0")
+      .send({ message: "こんにちは" });
+
+    expect(mockSaveMessage).toHaveBeenCalled();
+    for (const call of mockSaveMessage.mock.calls) {
+      expect(call[0].trafficSource).toBe("e2e");
+    }
+  });
+
+  it("chat-test経由(req.isChatTestToken=true) → saveMessageにtrafficSource='chat_test'を渡す", async () => {
+    await request(makeApp({ isChatTestToken: true }))
+      .post("/api/chat")
+      .send({ message: "テスト送信です" });
+
+    expect(mockSaveMessage).toHaveBeenCalled();
+    for (const call of mockSaveMessage.mock.calls) {
+      expect(call[0].trafficSource).toBe("chat_test");
+    }
+  });
+
+  it("通常のブラウザリクエスト(ヘッダ・UAとも通常) → saveMessageにtrafficSource='user'を渡す", async () => {
+    await request(makeApp())
+      .post("/api/chat")
+      .set("User-Agent", "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15")
+      .send({ message: "こんにちは" });
+
+    expect(mockSaveMessage).toHaveBeenCalled();
+    for (const call of mockSaveMessage.mock.calls) {
+      expect(call[0].trafficSource).toBe("user");
+    }
+  });
+
+  it("user/assistant両方のsaveMessage呼び出しに同じtrafficSourceが渡る", async () => {
+    await request(makeApp())
+      .post("/api/chat")
+      .set("x-r2c-traffic-source", "e2e")
+      .send({ message: "こんにちは" });
+
+    // Phase38: user保存(同期) + assistant保存(非同期、レスポンス後) の2回呼ばれる
+    await new Promise((r) => setTimeout(r, 20));
+    expect(mockSaveMessage.mock.calls.length).toBeGreaterThanOrEqual(1);
+    const sources = mockSaveMessage.mock.calls.map((c) => c[0].trafficSource);
+    expect(new Set(sources)).toEqual(new Set(["e2e"]));
+  });
+});

--- a/src/api/chat/route.ts
+++ b/src/api/chat/route.ts
@@ -11,6 +11,7 @@ import type { ApiResponse, ChatAction, ChatMessage } from "../../types/contracts
 import { t } from "../i18n/messages";
 import type { Lang } from "../i18n/messages";
 import { saveMessage } from "../admin/chat-history/chatHistoryRepository";
+import { resolveTrafficSource, TRAFFIC_SOURCE_HEADER } from "../../lib/traffic/trafficSource";
 import { saveKnowledgeGap } from "../admin/knowledge/knowledgeGapRepository";
 import { analyzeSentiment } from "../../lib/sentiment/client";
 import { sanitizeInput, sanitizeOutput, blockReasonToMessage } from "../../lib/security/inputSanitizer";
@@ -91,6 +92,13 @@ export function createChatHandler(logger: Logger) {
     const tenantId = (req as Request & { tenantId?: string }).tenantId ?? "demo-tenant";
     // Phase33: lang は langDetectMiddleware が設定する（フォールバック: "ja"）
     const lang: Lang = (req as any).lang ?? "ja";
+    // GID 1216970103691946: 実ユーザー/E2E/chat-test/デモの判定（セッション新規作成時のみ記録）
+    const trafficSource = resolveTrafficSource({
+      headerValue: req.header(TRAFFIC_SOURCE_HEADER),
+      userAgent: req.header("user-agent"),
+      referer: req.header("referer"),
+      isChatTestToken: (req as any).isChatTestToken === true,
+    });
 
     // Zod バリデーション
     const parsed = ChatRequestSchema.safeParse(req.body);
@@ -176,6 +184,7 @@ export function createChatHandler(logger: Logger) {
       sessionId,
       role: "user",
       content: body.message,
+      trafficSource,
     }).catch((err) =>
       logger.warn({ err }, "[chat-history] save user message failed")
     );
@@ -323,6 +332,7 @@ export function createChatHandler(logger: Logger) {
           knowledge_gap: isKnowledgeGap(gapSignal) || isResponseGap(content),
         },
         ragSources: result.meta?.ragSources,
+        trafficSource,
       }).catch((err) =>
         logger.warn({ err }, "[chat-history] save assistant message failed")
       );

--- a/src/lib/traffic/trafficSource.test.ts
+++ b/src/lib/traffic/trafficSource.test.ts
@@ -1,0 +1,93 @@
+// src/lib/traffic/trafficSource.test.ts
+// GID 1216970103691946
+
+import { resolveTrafficSource, TRAFFIC_SOURCE_HEADER } from "./trafficSource";
+
+describe("resolveTrafficSource", () => {
+  it("ヘッダ名は x-r2c-traffic-source", () => {
+    expect(TRAFFIC_SOURCE_HEADER).toBe("x-r2c-traffic-source");
+  });
+
+  // ---- 必須テストケース(タスク指定) ----
+
+  it("E2Eヘッダあり → 'e2e'", () => {
+    expect(resolveTrafficSource({ headerValue: "e2e" })).toBe("e2e");
+  });
+
+  it("E2Eヘッダなし・UAのみ(HeadlessChrome) → 'e2e'", () => {
+    expect(
+      resolveTrafficSource({
+        userAgent: "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/120.0.0.0 Safari/537.36",
+      }),
+    ).toBe("e2e");
+  });
+
+  it("E2Eヘッダなし・UAのみ(Playwright) → 'e2e'", () => {
+    expect(resolveTrafficSource({ userAgent: "Playwright/1.40.0" })).toBe("e2e");
+  });
+
+  it("chat-test経由(isChatTestToken=true) → 'chat_test'", () => {
+    expect(resolveTrafficSource({ isChatTestToken: true })).toBe("chat_test");
+  });
+
+  it("通常の実ブラウザリクエスト → 'user'", () => {
+    expect(
+      resolveTrafficSource({
+        userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15",
+        referer: "https://example-customer-site.com/shop",
+      }),
+    ).toBe("user");
+  });
+
+  // ---- デモ判定 ----
+
+  it("Refererが/carnation-demo/を含む → 'demo'", () => {
+    expect(resolveTrafficSource({ referer: "https://api.r2c.biz/carnation-demo/index.html" })).toBe("demo");
+  });
+
+  it("Refererが/lp/を含む → 'demo'", () => {
+    expect(resolveTrafficSource({ referer: "https://r2c.biz/lp/" })).toBe("demo");
+  });
+
+  it("Refererが/lp(末尾スラッシュなし) → 'demo'", () => {
+    expect(resolveTrafficSource({ referer: "https://r2c.biz/lp" })).toBe("demo");
+  });
+
+  it("Refererが実顧客サイトのパス(たまたま似た文字列を含まない) → 'user'", () => {
+    expect(resolveTrafficSource({ referer: "https://mystore.example.com/products/lp-gas-heater" })).toBe("user");
+  });
+
+  // ---- 優先順位 ----
+
+  it("isChatTestToken=trueが最優先(E2Eヘッダが同時にあってもchat_test)", () => {
+    expect(
+      resolveTrafficSource({ isChatTestToken: true, headerValue: "e2e", userAgent: "Playwright/1.40.0" }),
+    ).toBe("chat_test");
+  });
+
+  it("明示的なE2Eヘッダはデモrefererより優先される", () => {
+    expect(
+      resolveTrafficSource({ headerValue: "e2e", referer: "https://r2c.biz/lp/" }),
+    ).toBe("e2e");
+  });
+
+  it("UAベースのヘッドレス判定はデモrefererより優先される", () => {
+    expect(
+      resolveTrafficSource({ userAgent: "Playwright/1.40.0", referer: "https://r2c.biz/lp/" }),
+    ).toBe("e2e");
+  });
+
+  // ---- 未設定・空値 ----
+
+  it("何も渡さない場合は 'user'(デフォルト、既存セッションとの後方互換の要)", () => {
+    expect(resolveTrafficSource({})).toBe("user");
+  });
+
+  it("空文字列のヘッダ値は無視される", () => {
+    expect(resolveTrafficSource({ headerValue: "" })).toBe("user");
+  });
+
+  it("大文字小文字を区別しない(E2Eヘッダ)", () => {
+    expect(resolveTrafficSource({ headerValue: "E2E" })).toBe("e2e");
+  });
+});

--- a/src/lib/traffic/trafficSource.ts
+++ b/src/lib/traffic/trafficSource.ts
@@ -1,0 +1,86 @@
+// src/lib/traffic/trafficSource.ts
+// GID 1216970103691946: 実エンドユーザーとテスト/デモトラフィックを区別するための
+// トラフィックソース判定。A/Bテスト実装(lane-plans)を含む全ての集計指標
+// (継続率・CV率・Judgeスコア等)の前提となる。
+//
+// 背景: 本番DBのchat_sessions調査で、7月分292件中82%が集中日(7/17・7/18・7/28)に
+// 偏っており、いずれもE2Eテストを本番に対して大量実行した日と一致した。しかも
+// 該当日は2往復以上の会話が皆無で実ユーザーの振る舞いとは考えにくい。
+// metadataが空でテストと実ユーザーを区別する手がかりが一切なかったため、
+// 全指標(継続率・CV率・Judgeスコア)が汚染されていた。
+//
+// 契約 (lane-plansと共有。変更する場合は必ずteam-leadに相談すること):
+//   chat_sessions.metadata.source に以下のいずれかを記録する:
+//     'user'       = 実エンドユーザー(デフォルト)
+//     'e2e'        = Playwright/CI由来
+//     'chat_test'  = 管理画面のテストチャット
+//     'demo'       = デモページ(carnation-demo・LP埋め込み等)由来
+//     'unknown'    = 判定不能・過去データ(このモジュールが書き込むことはない。
+//                    集計側で `metadata->>'source' = 'user'` フィルタをかければ
+//                    NULL/未設定の過去データは自動的に除外される)
+//   集計は source='user' のみを対象にする。
+
+export type TrafficSource = "user" | "e2e" | "chat_test" | "demo" | "unknown";
+
+/** E2Eテスト(Playwright)が明示的に付与するヘッダ名。 */
+export const TRAFFIC_SOURCE_HEADER = "x-r2c-traffic-source";
+
+/** ヘッダで明示されうる値のうち、判定に使うもの。 */
+const EXPLICIT_E2E_HEADER_VALUE = "e2e";
+
+/** UAベースのE2E判定(ヘッダが付与されなかった場合のフォールバック)。 */
+const HEADLESS_UA_PATTERNS: RegExp[] = [/HeadlessChrome/i, /Playwright/i];
+
+/**
+ * デモページ由来の判定(Referer/Origin ベース)。
+ * carnation-demo (社内デモ用テナント) と LP自体に埋め込まれたウィジェットの両方を対象にする。
+ * 特定タグエントの API キー自体では判定しない(そのテナントが将来実顧客の実サイトから
+ * 同じキーで呼ばれるケースを誤って"demo"扱いしないため。Refererで発生元ページを見る)。
+ */
+const DEMO_REFERER_PATTERNS: RegExp[] = [
+  /\/carnation-demo(?:\/|\.html|$)/i,
+  /\/lp\/?(?:$|[/?#])/i,
+];
+
+export interface TrafficSourceInput {
+  /** x-r2c-traffic-source ヘッダの値 */
+  headerValue?: string | null;
+  /** User-Agent ヘッダ */
+  userAgent?: string | null;
+  /** Referer/Referrer ヘッダ */
+  referer?: string | null;
+  /**
+   * authMiddleware が chat-test JWT (purpose: "chat-test") を検証済みの場合に true。
+   * src/agent/http/authMiddleware.ts が既に req.isChatTestToken として設定している
+   * 既存の仕組みをそのまま利用する(新規実装不要)。
+   */
+  isChatTestToken?: boolean;
+}
+
+/**
+ * リクエストの各種シグナルからトラフィックソースを判定する(純粋関数・副作用なし)。
+ *
+ * 優先順位:
+ *   1. isChatTestToken → 'chat_test' (無条件。管理画面テストチャット由来と確定しているため)
+ *   2. 明示的なE2Eヘッダ → 'e2e'
+ *   3. UAによるヘッドレスブラウザ判定 → 'e2e' (ヘッダ付与漏れのフォールバック)
+ *   4. デモページ由来のReferer → 'demo'
+ *   5. 上記いずれにも該当しない → 'user'
+ */
+export function resolveTrafficSource(input: TrafficSourceInput): TrafficSource {
+  if (input.isChatTestToken) return "chat_test";
+
+  if (input.headerValue && input.headerValue.toLowerCase() === EXPLICIT_E2E_HEADER_VALUE) {
+    return "e2e";
+  }
+
+  if (input.userAgent && HEADLESS_UA_PATTERNS.some((p) => p.test(input.userAgent!))) {
+    return "e2e";
+  }
+
+  if (input.referer && DEMO_REFERER_PATTERNS.some((p) => p.test(input.referer!))) {
+    return "demo";
+  }
+
+  return "user";
+}


### PR DESCRIPTION
## Summary
- GID 1216970103691946: 本番DB調査で `chat_sessions` の7月分292件中82%がE2E集中実行日(7/17・7/18・7/28)に偏り、2往復以上の会話がゼロという実ユーザーとは考えにくい分布であることが判明。`metadata` が空でテストと実ユーザーを区別する手がかりがなく、継続率・CV率・Judgeスコア等の全指標が汚染されていた。
- セッション作成経路(`src/api/chat/route.ts` / `src/api/avatar/anamChatStreamRoutes.ts`)でトラフィックソース(`user` / `e2e` / `chat_test` / `demo`)を判定し、`chat_sessions.metadata.source` に記録する新規モジュール `src/lib/traffic/trafficSource.ts` を追加。
  - E2E: Playwright に `x-r2c-traffic-source: e2e` ヘッダを付与(`playwright.config.ts`)。ヘッダ未送信時は UA の `HeadlessChrome`/`Playwright` 判定にフォールバック
  - chat_test: 管理画面テストチャットが発行する JWT(`purpose: "chat-test"`)を検証済みの `req.isChatTestToken` を最優先で判定(既存の `authMiddleware` の仕組みをそのまま利用)
  - demo: `carnation-demo` / `/lp/` からの Referer
  - 上記いずれにも該当しなければ `user`
- `chatHistoryRepository.saveMessage()` はセッション新規作成時のみ `metadata.source` を確定させ、2回目以降の upsert では既存値を保持する(CASE文)。`trafficSource` 省略時は `user` にフォールバックし、既存呼び出し元との後方互換を維持。
- 集計側(`src/api/admin/analytics/routes.ts`)の summary / trends / evaluations / conversions 系クエリ全てに `metadata->>'source' = 'user'` 絞り込みを追加(`chat_sessions` 直接参照は `userSourceClause`、`conversation_evaluations`/`conversion_attributions` 等の非経由テーブルは `userSourceExists` の EXISTS 結合)。
- 過去データ(`metadata.source` 未設定)は一切書き換えず、上記フィルタで自動的に除外される(推測分類はしていない)。

## Test plan
- [x] `src/lib/traffic/trafficSource.test.ts` — E2Eヘッダ/UAフォールバック/chat_test/demo/user判定、優先順位、大文字小文字・空値ケース
- [x] `src/api/chat/route.trafficSource.test.ts` — `/api/chat` が各シグナルから正しい `trafficSource` を `saveMessage()` に渡すこと(user/assistant両呼び出しで一致すること含む)
- [x] `src/api/admin/chat-history/chatHistoryRepository.trafficSource.test.ts` — upsert SQL への `metadata` 反映、既存セッションの `source` 非上書き(CASE文)、後方互換
- [x] `src/api/admin/analytics/trafficSourceFilter.test.ts` — summary/trends/evaluations/conversions の全クエリに `source='user'` 絞り込みが入っていること
- [x] `npx tsc --noEmit` — エラーなし
- [x] `npx oxlint` (変更ファイルのみ) — 新規警告なし(既存の未使用変数warning 2件は本PR起因ではない)
- [x] 対象ファイル + 直接影響範囲(analytics/avatar/chat-history配下の既存テスト)を個別実行し全てpass。フルスイートはCIに委譲(ローカルでの並行実行によるephemeralポート枯渇を回避するため)

## Notes for reviewer
- `src/api/internal/avatarTranscriptRoutes.ts`(LiveKitアバターのGroq直接フォールバック経路、Python `avatar-agent` からの internal-only 呼び出し)は今回のスコープ外とした。ブラウザ由来のHTTPヘッダ(UA/Referer)を転送する仕組みがなく、`trafficSource` を渡さないため現状は `user` 扱いのまま。E2Eがこの経路を通るケースがあるかは要判断(該当すれば別PRでPython側からのヘッダ転送を検討する必要あり)。
- `src/api/widget/routes.ts` と `src/agent/ab-test/` は別レーン(`feature/avatar-ab-test-sticky-assignment`)の担当のため触れていない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01B1dxH199qQB3diHbsGLNxM