### PR TITLE
fix(agent): 知識データ登録のtarget指定で他テナントへ越境書き込みできる穴を塞ぐ

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -332,9 +332,15 @@ export default function CopilotPreviewPage() {
         return { id: nextId(), role: "ai", card: { kind: "agentAction", tool: a.tool, result: a.result } };
       });
 
-      // 実際にDBへ書き込んだ操作(確認ブロックで弾かれたものは除く)だけを実進捗としてカウントする
+      // 実際にDBへ書き込んだ操作(確認ブロックで弾かれたものは除く)だけを実進捗としてカウントする。
+      // ブロック理由は2種類あり、どちらも書き込みが起きていないため除外する:
+      //   1. confirmed=false        → 「確認が必要です」
+      //   2. 同一ターン内の連鎖ブロック → 「確認をスキップできません」(agentRoutes.ts:239)
       const writesThisTurn = (data.actions ?? []).filter(
-        (a) => REAL_WRITE_TOOLS.has(a.tool) && !a.result.includes("確認が必要"),
+        (a) =>
+          REAL_WRITE_TOOLS.has(a.tool) &&
+          !a.result.includes("確認が必要") &&
+          !a.result.includes("確認をスキップできません"),
       ).length;
       if (writesThisTurn > 0) setRealActionCount((n) => n + writesThisTurn);
 

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -1090,6 +1090,13 @@ export async function executeToolCall(
       if (target === 'global' && !isSuperAdmin) {
         return truncate('全店舗共通の知識データはSuper Adminのみ登録可能です');
       }
+      // target は toolDefinitions でLLMに公開されているため、client_admin が自然文で
+      // 他テナントIDを指定できてしまう。'global' 以外の越境書き込みもここで塞ぐ
+      // （旧HTTPルート /text/commit の requireKnowledgeTenant は body の target を
+      // 見ないため同じ穴があるが、チャットからは自然文で到達可能なのでここで防ぐ）。
+      if (target !== tenantId && !isSuperAdmin) {
+        return truncate('他のテナントには登録できません');
+      }
 
       try {
         const categoryOverride = staged.categoryOverride ?? undefined;

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -1570,6 +1570,57 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(res2.body.actions[0].result).toContain('Super Adminのみ登録可能');
     });
 
+    it('commit_faq_import: target=他テナントID はSuper Admin以外だと拒否される（越境書き込み防止）', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-fi-13c', 'suggest_faq_import_from_text', { text: '十分な長さの商品説明文です。'.repeat(5) }))
+        .mockResolvedValueOnce(makeGroqResponse('プレビューを作成しました。'));
+      mockGenerateTextFaqPreview.mockResolvedValueOnce([faq1]);
+      await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'FAQを作って', sessionId: 'sess-fi-13c' });
+
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-fi-13d', 'commit_faq_import', { confirmed: true, target: 'tenant-other' }))
+        .mockResolvedValueOnce(makeGroqResponse('拒否されました。'));
+
+      const res2 = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'tenant-otherに登録して', sessionId: 'sess-fi-13c' });
+
+      expect(res2.status).toBe(200);
+      expect(mockCommitTextFaqs).not.toHaveBeenCalled();
+      expect(res2.body.actions[0].result).toContain('他のテナントには登録できません');
+    });
+
+    it('commit_faq_import: super_admin は target=他テナントID を指定して登録できる（越境ガードはclient_admin限定）', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-fi-13e', 'suggest_faq_import_from_text', { text: '十分な長さの商品説明文です。'.repeat(5) }))
+        .mockResolvedValueOnce(makeGroqResponse('プレビューを作成しました。'));
+      mockGenerateTextFaqPreview.mockResolvedValueOnce([faq1]);
+      await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'FAQを作って', sessionId: 'sess-fi-13e', targetTenantId: 'tenant-other' });
+
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-fi-13f', 'commit_faq_import', { confirmed: true, target: 'tenant-other' }))
+        .mockResolvedValueOnce(makeGroqResponse('登録しました。'));
+      mockCommitTextFaqs.mockResolvedValueOnce({ inserted: 1, skipped: 0, insertedIds: [20] });
+
+      const res2 = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '登録して', sessionId: 'sess-fi-13e', targetTenantId: 'tenant-other' });
+
+      expect(res2.status).toBe(200);
+      expect(mockCommitTextFaqs).toHaveBeenCalledWith(
+        expect.anything(),
+        'tenant-other',
+        [faq1],
+        undefined,
+        'admin_agent_text_import',
+      );
+      expect(res2.body.actions[0].result).toContain('FAQを1件登録しました');
+    });
+
     it('別 sessionId のステージングは混ざらない（テナントは同じでもプレビュー無し扱いになる）', async () => {
       mockFetch
         .mockResolvedValueOnce(toolCallResponse('call-fi-14a', 'suggest_faq_import_from_text', { text: '十分な長さの商品説明文です。'.repeat(5) }))


### PR DESCRIPTION
## 背景

PR #562（チャットからFAQのテキスト/URL一括取り込み）の実装中に見つけたフォローアップの穴。

`commit_faq_import` の `target` パラメータは `toolDefinitions` でLLMに公開されているため、client_admin が自然文で「tenant-otherに登録して」のように他テナントIDを指定できてしまう。従来のガードは `target === 'global'` のケースのみを塞いでおり、それ以外の任意の他テナントIDは素通りしていた。

旧HTTPルート `/text/commit` の `requireKnowledgeTenant` も body の `target` を見ないため同じ穴があるが、チャット経由は自然文で到達可能な分リスクが高いため、まずここ（`executeToolCall`）で塞ぐ。

あわせて、`copilot-preview` の実書き込み進捗カウント（`writesThisTurn`）が「同一ターン内の連鎖ブロック」（`確認をスキップできません`、`agentRoutes.ts:239`）で弾かれた操作も実書き込みとしてカウントしてしまっていたバグを修正。既存の「確認が必要」ブロックと同様に除外する。

## 変更

### 1. `src/api/admin/agent/actionExecutor.ts`
`commit_faq_import` に `target !== tenantId && !isSuperAdmin` の明示ガードを追加。`target === 'global'` の既存チェックはそのまま維持（super_adminのみ許可）。super_adminの挙動（任意テナントへの登録）は変更なし。

### 2. `admin-ui/src/pages/copilot-preview/index.tsx`
`writesThisTurn` のフィルタ条件に `!a.result.includes("確認をスキップできません")` を追加し、連鎖ブロックされた操作を実書き込みとしてカウントしないようにした。

## 検証

- `npx tsc --noEmit`（backend）: クリーン
- `admin-ui`: `npx tsc -b` は事前から存在する13件のエラー（本PRの変更ファイルとは無関係、`AuthContextValue.tenantPlan` 不足によるテストファイル側の型不一致）のみで、本PRで新規に増えたエラーはなし
- `npx jest src/api/admin/agent/agentRoutes.test.ts`: 123 passed（新規ガードのテスト2件を含む）
  - client_admin が `target=他テナントID` を指定 → 拒否される
  - super_admin は従来通り `target=他テナントID` で登録できる（ガード対象外）
- `npx vitest run admin-ui/src/pages/copilot-preview/index.test.tsx`: 14 passed（既存テストに回帰なし。進捗カウント修正自体への新規UIテストは未追加）

🤖 Generated with [Claude Code](https://claude.com/claude-code)