### PR TITLE
feat(widget): アバターA/Bテストの露出計測をwidget.jsに配線する

### DIFF
--- a/public/widget.js
+++ b/public/widget.js
@@ -24,6 +24,15 @@
   var apiKey = currentScript ? currentScript.getAttribute('data-api-key') : '';
   var avatarConfigId = currentScript ? (currentScript.getAttribute('data-avatar-config-id') || '') : '';
   var posthogKey = currentScript ? (currentScript.getAttribute('data-posthog-key') || '') : '';
+
+  // GID 1216978855735482 follow-up: アバターA/Bテストの割当は widgetGenerator.ts が
+  // GET /widget/:tenantSlug.js 生成時に window.__RAJIUCE_TENANT_CFG__ へ注入する
+  // （visitor近似のsticky keyでサーバー側決定済み。widget.js側では割当ロジックを持たない）。
+  // 静的 /widget.js 埋め込み（data-tenant方式）ではこのグローバルは存在しないため両方 null 安全に。
+  var _rajiuceTenantCfg = (typeof window !== 'undefined' && window.__RAJIUCE_TENANT_CFG__) || {};
+  var abExperimentId = _rajiuceTenantCfg.abExperimentId || null;
+  var abVariant = _rajiuceTenantCfg.abVariant || null;
+  var _abExposureSent = false;
   var accentColor = currentScript ? (currentScript.getAttribute('data-accent-color') || '#2563eb') : '#2563eb';
   var greetingText = currentScript ? (currentScript.getAttribute('data-greeting') || 'ご質問はお気軽にどうぞ') : 'ご質問はお気軽にどうぞ';
   var placeholderText = currentScript ? (currentScript.getAttribute('data-placeholder') || 'メッセージを入力…') : 'メッセージを入力…';
@@ -2262,6 +2271,40 @@
     resetAvatarInactivityTimer();
   }
 
+  /**
+   * GID 1216978855735482 follow-up: このセッションが割り当てられたアバターA/B実験の
+   * variantを一度だけサーバーに報告する（POST /v1/ab/avatar-exposure）。
+   * - 実験が無い/割当が無いテナントでは何もしない（abExperimentId/abVariant が null）
+   * - 本番稼働中の埋め込みスクリプトのため、失敗してもチャット機能に一切影響させない
+   *   （non-blocking・サイレントフェイル。トラッキング欠落はexposure記録の欠測に留まる）
+   * - (experiment_id, session_id) はサーバー側でユニーク制約により冪等なので、
+   *   多少の重複呼び出しがあっても実害はないが、_abExposureSent で通常は1回のみ送信する
+   */
+  function recordAbExposure() {
+    if (_abExposureSent || !abExperimentId || !abVariant || !apiKey) return;
+    _abExposureSent = true;
+    try {
+      fetch(apiBase + '/v1/ab/avatar-exposure', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-api-key': apiKey },
+        body: JSON.stringify({
+          experiment_id: abExperimentId,
+          variant: abVariant,
+          session_id: conversationId,
+        }),
+        keepalive: true,
+      }).then(function (res) {
+        if (!res.ok) {
+          console.warn('[R2C] avatar-exposure: server returned ' + res.status);
+        }
+      }).catch(function () {
+        /* silent fail — トラッキング失敗でウィジェット動作を止めない */
+      });
+    } catch (_e) {
+      /* fetch自体が例外を投げる環境でもチャット機能は継続させる */
+    }
+  }
+
   function sendMessage(text) {
     if (!text || !text.trim() || isLoading) return;
 
@@ -2284,6 +2327,9 @@
       timestamp: Date.now(),
     };
     messages.push(userMsg);
+    // 実際にチャットセッションが始まった時点（初回メッセージ送信時）でA/B露出を報告する。
+    // ページ読み込みだけの離脱訪問者はカウントしない（分母を chat_sessions と揃えるため）。
+    recordAbExposure();
     isLoading = true;
     renderMessages();
     scrollToBottom(true);  // ユーザー送信時は強制スクロール

--- a/tests/widget/recordAbExposure.test.ts
+++ b/tests/widget/recordAbExposure.test.ts
@@ -1,0 +1,193 @@
+// tests/widget/recordAbExposure.test.ts
+// widget.js の recordAbExposure() のユニットテスト
+// GID 1216978855735482 follow-up: PR #561 が意図的に含めなかった widget.js 配線
+
+/**
+ * widget.js が持つ recordAbExposure 関数を再現するファクトリ。
+ * trackConversion.test.ts と同じ方針で、実際の widget.js を eval するのではなく
+ * 同等のロジックを抽出して検証する。
+ */
+function makeRecordAbExposure(opts: {
+  apiBase: string;
+  apiKey: string | null;
+  abExperimentId: number | null;
+  abVariant: 'a' | 'b' | null;
+  conversationId: string;
+  fetchImpl: typeof fetch;
+}) {
+  const { apiBase, apiKey, abExperimentId, abVariant, conversationId, fetchImpl } = opts;
+  let sent = false;
+
+  return function recordAbExposure(): void {
+    if (sent || !abExperimentId || !abVariant || !apiKey) return;
+    sent = true;
+    try {
+      fetchImpl(apiBase + '/v1/ab/avatar-exposure', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'x-api-key': apiKey },
+        body: JSON.stringify({
+          experiment_id: abExperimentId,
+          variant: abVariant,
+          session_id: conversationId,
+        }),
+        keepalive: true,
+      }).then(function (res: Response) {
+        if (!res.ok) {
+          console.warn('[R2C] avatar-exposure: server returned ' + res.status);
+        }
+      }).catch(function () {
+        /* silent fail */
+      });
+    } catch (_e) {
+      /* silent fail */
+    }
+  };
+}
+
+describe('widget.js recordAbExposure', () => {
+  const API_BASE = 'https://api.r2c.biz';
+  const API_KEY = 'test-key-abc123';
+  const SESSION_ID = '11111111-1111-4111-8111-111111111111';
+
+  let mockFetch: jest.Mock;
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    mockFetch = jest.fn().mockResolvedValue({ ok: true } as Response);
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('abExperimentId が無いテナントでは fetch しない', () => {
+    const fn = makeRecordAbExposure({
+      apiBase: API_BASE,
+      apiKey: API_KEY,
+      abExperimentId: null,
+      abVariant: null,
+      conversationId: SESSION_ID,
+      fetchImpl: mockFetch,
+    });
+    fn();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('abVariant が無い場合は fetch しない（実験IDのみ注入され割当が無いケース）', () => {
+    const fn = makeRecordAbExposure({
+      apiBase: API_BASE,
+      apiKey: API_KEY,
+      abExperimentId: 42,
+      abVariant: null,
+      conversationId: SESSION_ID,
+      fetchImpl: mockFetch,
+    });
+    fn();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('apiKey が無い場合は fetch しない（未認証埋め込みは対象外）', () => {
+    const fn = makeRecordAbExposure({
+      apiBase: API_BASE,
+      apiKey: null,
+      abExperimentId: 42,
+      abVariant: 'a',
+      conversationId: SESSION_ID,
+      fetchImpl: mockFetch,
+    });
+    fn();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it('実験に割り当てられている場合 /v1/ab/avatar-exposure に POST する', () => {
+    const fn = makeRecordAbExposure({
+      apiBase: API_BASE,
+      apiKey: API_KEY,
+      abExperimentId: 42,
+      abVariant: 'b',
+      conversationId: SESSION_ID,
+      fetchImpl: mockFetch,
+    });
+    fn();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${API_BASE}/v1/ab/avatar-exposure`);
+    expect(init.method).toBe('POST');
+    const headers = init.headers as Record<string, string>;
+    expect(headers['x-api-key']).toBe(API_KEY);
+    expect(headers['Content-Type']).toBe('application/json');
+  });
+
+  it('payload に experiment_id / variant / session_id が正しく含まれる', () => {
+    const fn = makeRecordAbExposure({
+      apiBase: API_BASE,
+      apiKey: API_KEY,
+      abExperimentId: 42,
+      abVariant: 'a',
+      conversationId: SESSION_ID,
+      fetchImpl: mockFetch,
+    });
+    fn();
+    const body = JSON.parse((mockFetch.mock.calls[0][1] as RequestInit).body as string);
+    expect(body).toEqual({ experiment_id: 42, variant: 'a', session_id: SESSION_ID });
+  });
+
+  it('keepalive: true が設定されている（ページ離脱時の送信欠落を防ぐ）', () => {
+    const fn = makeRecordAbExposure({
+      apiBase: API_BASE,
+      apiKey: API_KEY,
+      abExperimentId: 42,
+      abVariant: 'a',
+      conversationId: SESSION_ID,
+      fetchImpl: mockFetch,
+    });
+    fn();
+    const init = mockFetch.mock.calls[0][1] as RequestInit;
+    expect(init.keepalive).toBe(true);
+  });
+
+  it('2回目以降の呼び出しでは再送しない（1セッション1回のみ）', () => {
+    const fn = makeRecordAbExposure({
+      apiBase: API_BASE,
+      apiKey: API_KEY,
+      abExperimentId: 42,
+      abVariant: 'a',
+      conversationId: SESSION_ID,
+      fetchImpl: mockFetch,
+    });
+    fn();
+    fn();
+    fn();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('fetch が reject しても例外が throw されない（silent fail）', async () => {
+    const failFetch = jest.fn().mockRejectedValue(new Error('network error'));
+    const fn = makeRecordAbExposure({
+      apiBase: API_BASE,
+      apiKey: API_KEY,
+      abExperimentId: 42,
+      abVariant: 'a',
+      conversationId: SESSION_ID,
+      fetchImpl: failFetch as unknown as typeof fetch,
+    });
+    expect(() => fn()).not.toThrow();
+    await new Promise((r) => setTimeout(r, 0));
+  });
+
+  it('非2xxレスポンスで console.warn を呼ぶがチャット動作は継続する', async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 404 } as Response);
+    const fn = makeRecordAbExposure({
+      apiBase: API_BASE,
+      apiKey: API_KEY,
+      abExperimentId: 42,
+      abVariant: 'a',
+      conversationId: SESSION_ID,
+      fetchImpl: mockFetch,
+    });
+    fn();
+    await new Promise((r) => setTimeout(r, 0));
+    expect(warnSpy).toHaveBeenCalledWith('[R2C] avatar-exposure: server returned 404');
+  });
+});


### PR DESCRIPTION
## 背景

PR #561（GID 1216978855735482「アバター効果のA/Bテスト基盤」）は、意図的に `public/widget.js` への配線を含めずに完了した。バックエンド側は `widgetGenerator.ts` が `GET /widget/:tenantSlug.js` 生成時に `window.__RAJIUCE_TENANT_CFG__` へ `abExperimentId`/`abVariant` を注入するところまで実装・テスト済みだったが、widget.js側でそれを読み取って `POST /v1/ab/avatar-exposure` を呼ぶ処理が無く、実際には露出が一切記録されない状態だった（PR #561本文「意図的にこのPRに含めなかったもの」より、本番稼働中の全テナント配信スクリプトへの変更はレビュー・確認を分けるべきと判断されたため）。本PRはその追随PR。

## 変更

- `public/widget.js`
  - 初期化時に `window.__RAJIUCE_TENANT_CFG__.abExperimentId` / `.abVariant` を読み取る（動的配信 `/widget/:tenantSlug.js` 以外の静的埋め込みではこのグローバルが存在しないため null 安全）
  - `recordAbExposure()` を追加: `sendMessage()` の初回メッセージ送信時（＝実際にチャットセッションが始まった時点）に一度だけ `POST /v1/ab/avatar-exposure` を発火する。ページを開いただけで離脱した訪問者は対象にしない（分母を `chat_sessions` 側の集計と揃えるため）。
  - 本番稼働中の全テナント配信スクリプトである点を踏まえ、`keepalive: true` + 非ブロッキング + サイレントフェイル（fetch失敗・非2xxいずれもチャット機能を止めない）を徹底。`(experiment_id, session_id)` はサーバー側でユニーク制約により冪等だが、`_abExposureSent` フラグで通常は1回のみ送信するようにした。
- `tests/widget/recordAbExposure.test.ts`（新規）: 既存の `tests/widget/trackConversion.test.ts` と同じ方針で、widget.js を eval せず同等ロジックを抽出してユニットテスト。ガード条件（実験なし/割当なし/APIキーなし/2重送信防止）、payload形状、keepalive、silent fail、非2xx時のwarnログを検証（9件）。

## 検証

- `npx tsc --noEmit`: クリーン（新規エラーなし）
- `npx jest tests/widget/ src/api/conversion/abExposureRoutes.test.ts`: 3 suites / 29 tests 全green（新規9件 + 既存 trackConversion 12件 + abExposureRoutes 8件）
- `node --check public/widget.js`: 構文エラーなし
- widget.js の他フィールド（tenantId/apiKey/avatarEnabled等）は引き続き `data-*` 属性経由で読まれており、本PRでは `abExperimentId`/`abVariant` の読み取りのみを追加した（既存の設定読み込みフローには触れていない）

## 未検証・要判断として残した項目

- Playwright E2E（`tests/e2e/widget.spec.ts` 等）は未実行・未追加。ライブサーバ起動が前提のため今回はユニットテストのみで検証した
- widget.js が `window.__RAJIUCE_TENANT_CFG__` を参照するのは本PRが最初のケース。他フィールド（tenantId/apiKey/avatarEnabled）は今も `data-*` 属性から読まれており、動的配信ルートとこのグローバルの位置づけ自体は本PRのスコープ外

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>