### PR TITLE
feat(agent): チャットから会話セッションの本文を読めるツールを追加

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -69,6 +69,7 @@ const REAL_TOOL_LABEL: Record<string, string> = {
   get_knowledge_gaps: "知識ギャップの取得",
   dismiss_knowledge_gap: "知識ギャップの片付け",
   get_chat_sessions: "会話セッション一覧の取得",
+  get_chat_session_messages: "会話の全文取得",
   get_escalations: "エスカレーション一覧の取得",
   get_monitoring_summary: "モニタリングサマリーの取得",
   get_legacy_ui_link: "旧管理画面への案内",

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -25,7 +25,7 @@ import {
   clearStagedFaqImport,
 } from './knowledgeImportStaging';
 import { suggestEngagementRuleFromText } from './engagementSuggest';
-import { getSessions, getActiveEscalations } from '../chat-history/chatHistoryRepository';
+import { getSessions, getActiveEscalations, getMessages } from '../chat-history/chatHistoryRepository';
 import { computeKpis } from '../monitoring/routes';
 import { checkSaiMonthlyCostCeiling } from '../options/routes';
 import { submitSaiTask, getSaiTask } from '../../../lib/sai/saiClient';
@@ -79,6 +79,55 @@ export async function activateAvatarConfig(
     throw err;
   }
 }
+
+// ---------------------------------------------------------------------------
+// 会話セッションの短縮ID解決（get_chat_sessions が表示する [xxxxxxxx] を受け取る）
+// ---------------------------------------------------------------------------
+
+export type ResolveSessionResult =
+  | { ok: true; session: { id: string; session_id: string } }
+  | { ok: false; message: string };
+
+/** 短縮IDの前方一致でセッションを解決する。tenant_id 条件は省略不可（越境参照防止）。 */
+export async function resolveSessionByShortId(
+  db: Pool,
+  tenantId: string,
+  input: string
+): Promise<ResolveSessionResult> {
+  const shortId = input.trim();
+  if (!shortId) {
+    return { ok: false, message: 'セッションIDを指定してください' };
+  }
+  // LIKE のワイルドカードを無効化し、意図しない広域一致を防ぐ（Postgres の既定エスケープ文字は \）
+  const prefix = shortId.replace(/[\\%_]/g, (c) => `\\${c}`);
+
+  const result = await db.query<{ id: string; session_id: string }>(
+    `SELECT id, session_id FROM chat_sessions
+     WHERE tenant_id = $1 AND session_id LIKE $2 || '%'
+     ORDER BY last_message_at DESC
+     LIMIT 6`,
+    [tenantId, prefix]
+  );
+
+  if (result.rows.length === 0) {
+    return { ok: false, message: `セッション[${shortId}]は見つかりません。get_chat_sessions で表示されたIDをご確認ください` };
+  }
+  if (result.rows.length > 1) {
+    // 8文字だと候補同士が同じ表示になりうるため、区別できるよう長めのIDを提示する
+    const candidates = result.rows.map((r) => `[${r.session_id.slice(0, 16)}]`).join(' ');
+    return {
+      ok: false,
+      message: `セッション[${shortId}]に一致する会話が${result.rows.length}件あります: ${candidates}\nどれか1つのIDをそのまま指定してください`,
+    };
+  }
+  return { ok: true, session: result.rows[0] };
+}
+
+const CHAT_ROLE_LABELS: Record<string, string> = {
+  user: 'お客様',
+  assistant: 'AI',
+  operator: '担当者',
+};
 
 // ---------------------------------------------------------------------------
 // メインエントリ
@@ -1360,6 +1409,38 @@ export async function executeToolCall(
       } catch (err) {
         logger.warn('[actionExecutor] get_chat_sessions failed', err);
         return truncate('会話セッション一覧の取得に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    case 'get_chat_session_messages': {
+      if (!tenantId) {
+        return truncate('テナントが特定できません。super_admin の場合は対象テナントを指定してください');
+      }
+      const shortId = String(args['session_id'] ?? '').trim();
+      const limitRaw = Number(args['limit'] ?? 20);
+      const limit = Number.isFinite(limitRaw) ? Math.min(Math.max(limitRaw, 1), 50) : 20;
+
+      try {
+        const resolved = await resolveSessionByShortId(db, tenantId, shortId);
+        if (!resolved.ok) {
+          return truncate(resolved.message);
+        }
+
+        const messages = await getMessages({ sessionDbId: resolved.session.id, tenantId });
+        if (messages.length === 0) {
+          return truncate(`セッション[${resolved.session.session_id.slice(0, 8)}]にメッセージはありません`);
+        }
+
+        const recent = messages.slice(-limit);
+        const lines = recent.map((m) => `${CHAT_ROLE_LABELS[m.role] ?? m.role}: ${m.content}`);
+        return truncate(
+          `セッション[${resolved.session.session_id.slice(0, 8)}]の会話（全${messages.length}件中${recent.length}件）:\n` +
+          lines.join('\n'),
+        );
+      } catch (err) {
+        logger.warn('[actionExecutor] get_chat_session_messages failed', err);
+        return truncate('会話内容の取得に失敗しました');
       }
     }
 

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -114,12 +114,14 @@ jest.mock('../../../lib/sai/saiClient', () => ({
   getSaiTask: (...args: any[]) => mockGetSaiTask(...args),
 }));
 
-// get_chat_sessions / get_escalations が使う依存をモック
+// get_chat_sessions / get_escalations / get_chat_session_messages が使う依存をモック
 const mockGetSessions = jest.fn();
 const mockGetActiveEscalations = jest.fn();
+const mockGetMessages = jest.fn();
 jest.mock('../chat-history/chatHistoryRepository', () => ({
   getSessions: (...args: any[]) => mockGetSessions(...args),
   getActiveEscalations: (...args: any[]) => mockGetActiveEscalations(...args),
+  getMessages: (...args: any[]) => mockGetMessages(...args),
 }));
 
 // get_monitoring_summary が使う依存をモック
@@ -2157,6 +2159,177 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(result).toContain('142件');
       expect(result).toContain('92.5%');
       expect(result).toContain('3.2%');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // get_chat_session_messages（短縮IDでの会話本文取得 / テナント境界）
+  // -------------------------------------------------------------------------
+  describe('get_chat_session_messages', () => {
+    function toolCallResponse(id: string, name: string, args: Record<string, unknown> = {}) {
+      return {
+        ok: true,
+        json: async () => ({
+          choices: [{
+            message: {
+              content: null,
+              tool_calls: [{ id, type: 'function', function: { name, arguments: JSON.stringify(args) } }],
+            },
+          }],
+        }),
+        text: async () => '',
+      };
+    }
+
+    type SessionRow = { id: string; tenant_id: string; session_id: string };
+
+    const OWN_SESSION: SessionRow = {
+      id: 'db-sess-own', tenant_id: 'tenant-abc', session_id: 'a1b2c3d4-1111-4aaa-8000-000000000001',
+    };
+    const OTHER_TENANT_SESSION: SessionRow = {
+      id: 'db-sess-other', tenant_id: 'tenant-zzz', session_id: 'ffeeddcc-9999-4bbb-8000-000000000002',
+    };
+    const DUP_A: SessionRow = {
+      id: 'db-sess-dup-a', tenant_id: 'tenant-abc', session_id: 'dupdup00-1111-4ccc-8000-000000000003',
+    };
+    const DUP_B: SessionRow = {
+      id: 'db-sess-dup-b', tenant_id: 'tenant-abc', session_id: 'dupdup00-2222-4ddd-8000-000000000004',
+    };
+
+    // resolveSessionByShortId の SQL（tenant_id = $1 AND session_id LIKE $2 || '%'）を
+    // 忠実に再現する。テナント越境が「SQLの条件で」防がれていることを検証するため、
+    // 固定の rows を返すのではなく tenant_id + 前方一致でフィルタする。
+    function seedSessions(rows: SessionRow[]) {
+      mockQuery.mockImplementation(async (_sql: string, params?: unknown[]) => {
+        if (!Array.isArray(params)) return { rows: [] };
+        const [tenantId, prefix] = params as [string, string];
+        return {
+          rows: rows
+            .filter((r) => r.tenant_id === tenantId && r.session_id.startsWith(prefix))
+            .map((r) => ({ id: r.id, session_id: r.session_id })),
+        };
+      });
+    }
+
+    it('自テナントのセッションは短縮IDで本文を取得できる', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-cm-1', 'get_chat_session_messages', { session_id: 'a1b2c3d4' }))
+        .mockResolvedValueOnce(makeGroqResponse('会話内容はこちらです。'));
+
+      seedSessions([OWN_SESSION, OTHER_TENANT_SESSION]);
+      mockGetMessages.mockResolvedValueOnce([
+        { id: 1, role: 'user', content: '送料はいくらですか', metadata: {}, created_at: '2026-07-17T10:00:00Z' },
+        { id: 2, role: 'assistant', content: '全国一律500円です', metadata: {}, created_at: '2026-07-17T10:00:10Z' },
+        { id: 3, role: 'operator', content: '担当より補足します', metadata: {}, created_at: '2026-07-17T10:01:00Z' },
+      ]);
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'a1b2c3d4の会話を見せて', sessionId: 'sess-cm-01' });
+
+      expect(res.status).toBe(200);
+      expect(mockGetMessages).toHaveBeenCalledWith({ sessionDbId: 'db-sess-own', tenantId: 'tenant-abc' });
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain('お客様: 送料はいくらですか');
+      expect(result).toContain('AI: 全国一律500円です');
+      expect(result).toContain('担当者: 担当より補足します');
+      expect(result).toContain('全3件中3件');
+    });
+
+    it('limit で新しい方から件数を絞る', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-cm-2', 'get_chat_session_messages', { session_id: 'a1b2c3d4', limit: 2 }))
+        .mockResolvedValueOnce(makeGroqResponse('直近2件です。'));
+
+      seedSessions([OWN_SESSION]);
+      mockGetMessages.mockResolvedValueOnce([
+        { id: 1, role: 'user', content: '古い質問', metadata: {}, created_at: '2026-07-17T10:00:00Z' },
+        { id: 2, role: 'user', content: '新しい質問', metadata: {}, created_at: '2026-07-17T10:01:00Z' },
+        { id: 3, role: 'assistant', content: '新しい回答', metadata: {}, created_at: '2026-07-17T10:01:10Z' },
+      ]);
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '直近だけ見せて', sessionId: 'sess-cm-02' });
+
+      expect(res.status).toBe(200);
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain('全3件中2件');
+      expect(result).toContain('新しい質問');
+      expect(result).not.toContain('古い質問');
+    });
+
+    it('他テナントのセッションIDは「見つかりません」となり本文を漏らさない', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-cm-3', 'get_chat_session_messages', { session_id: 'ffeeddcc' }))
+        .mockResolvedValueOnce(makeGroqResponse('そのセッションは見つかりませんでした。'));
+
+      seedSessions([OWN_SESSION, OTHER_TENANT_SESSION]);
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ffeeddccの会話を見せて', sessionId: 'sess-cm-03' });
+
+      expect(res.status).toBe(200);
+      // 解決クエリは必ず tenant_id で絞られている
+      const [sql, params] = mockQuery.mock.calls[0];
+      expect(sql).toContain('tenant_id = $1');
+      expect(params[0]).toBe('tenant-abc');
+      // 他テナントのメッセージは一切取得しない
+      expect(mockGetMessages).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('見つかりません');
+    });
+
+    it('短縮IDが複数セッションに一致する場合は候補を提示し本文を返さない', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-cm-4', 'get_chat_session_messages', { session_id: 'dupdup00' }))
+        .mockResolvedValueOnce(makeGroqResponse('どちらの会話でしょうか。'));
+
+      seedSessions([OWN_SESSION, DUP_A, DUP_B]);
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'dupdup00の会話を見せて', sessionId: 'sess-cm-04' });
+
+      expect(res.status).toBe(200);
+      expect(mockGetMessages).not.toHaveBeenCalled();
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain('2件あります');
+      expect(result).toContain('[dupdup00-1111-4c]');
+      expect(result).toContain('[dupdup00-2222-4d]');
+    });
+
+    it('存在しない短縮IDは例外を投げずに「見つかりません」を返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-cm-5', 'get_chat_session_messages', { session_id: '00000000' }))
+        .mockResolvedValueOnce(makeGroqResponse('見つかりませんでした。'));
+
+      seedSessions([OWN_SESSION]);
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '00000000の会話を見せて', sessionId: 'sess-cm-05' });
+
+      expect(res.status).toBe(200);
+      expect(mockGetMessages).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('見つかりません');
+    });
+
+    it('session_id が空なら解決クエリを投げずに指定を促す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-cm-6', 'get_chat_session_messages', { session_id: '  ' }))
+        .mockResolvedValueOnce(makeGroqResponse('セッションIDを教えてください。'));
+
+      seedSessions([OWN_SESSION]);
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '会話を見せて', sessionId: 'sess-cm-06' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).not.toHaveBeenCalled();
+      expect(mockGetMessages).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('セッションIDを指定してください');
     });
   });
 

--- a/src/api/admin/agent/toolDefinitions.ts
+++ b/src/api/admin/agent/toolDefinitions.ts
@@ -671,6 +671,27 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
   {
     type: 'function',
     function: {
+      name: 'get_chat_session_messages',
+      description:
+        '指定した会話セッションの本文（お客様とAI・担当者のやり取り）を取得する読み取り専用ツール。' +
+        'get_chat_sessions が返した [xxxxxxxx] の短縮IDをそのまま session_id に渡せる。' +
+        '「この会話の中身を見せて」「どんなやり取りだったか」と聞かれた時に使う。',
+      parameters: {
+        type: 'object',
+        properties: {
+          session_id: {
+            type: 'string',
+            description: 'セッションID。get_chat_sessions の [xxxxxxxx] 表記の短縮ID（8文字）をそのまま指定してよい',
+          },
+          limit: { type: 'number', description: '取得するメッセージ数の上限（任意、省略時20、最大50。新しい方から取得）' },
+        },
+        required: ['session_id'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
       name: 'get_escalations',
       description:
         '有人対応にエスカレーションされた、対応中（未解決）の会話一覧を取得する読み取り専用ツール。',


### PR DESCRIPTION
## 背景

新UI(`/copilot-preview`)のチャットエージェントは `get_chat_sessions` で会話セッション一覧を取れるが、返るのは短縮ID(`session_id.slice(0,8)`)と最初の質問プレビューだけで、**会話の中身を読む手段がなかった**。旧UI `/admin/chat-history/:sessionId` にある機能が新UIから欠落していたギャップを埋める。

Asana GID 1216986395368701

## 変更内容

### `src/api/admin/agent/toolDefinitions.ts`
- 読み取り専用ツール `get_chat_session_messages` を追加
  - `session_id`(必須): `get_chat_sessions` が表示する `[xxxxxxxx]` の短縮IDをそのまま渡せる旨を description に明記
  - `limit`(任意): 既定20・最大50、新しい方から取得

### `src/api/admin/agent/actionExecutor.ts`
- ヘルパー `resolveSessionByShortId(db, tenantId, input)` を追加
  - `WHERE tenant_id = $1 AND session_id LIKE $2 || '%'` — **tenant_id 条件はバイパス経路なし**
  - LIKE ワイルドカード(`% _ \`)をエスケープし、意図しない広域一致を防止
  - 0件 → 「見つかりません」/ 複数件 → 候補ID(16文字)を提示するのみで本文は返さない / 1件 → 解決
- `case 'get_chat_session_messages'`: 既存の tenantId ガード文言を踏襲し、解決後は**既存の** `getMessages({ sessionDbId, tenantId })` を再利用(新規SQLは追加していない)
- 整形は お客様 / AI / 担当者 の日本語ラベル、他caseと同じ `truncate()` を通す

### `admin-ui/src/pages/copilot-preview/index.tsx`
- `REAL_TOOL_LABEL` に `get_chat_session_messages: "会話の全文取得"` を追加
- 読み取り専用のため `REAL_WRITE_TOOLS` には**入れていない**

## セキュリティ

`8c895fdf` と同種のテナント越境参照を作らないよう、解決クエリのtenant_id条件を必須にし、`getMessages()` にも tenantId を渡して二重に検証している(リポジトリ側も不一致なら空配列を返す)。越境ケースは例外ではなく「見つかりません」を返す。

## テスト

`src/api/admin/agent/agentRoutes.test.ts` に `describe('get_chat_session_messages')` を追加(6件)。解決クエリのモックは固定行ではなく **tenant_id + 前方一致で実際にフィルタする実装**にして、越境がSQL条件で防がれていることを検証している。

- 自テナントのセッションは短縮IDで本文を取得できる
- `limit` で新しい方から件数を絞る
- 他テナントのセッションIDは「見つかりません」となり本文を漏らさない(`getMessages` 未呼び出し)
- 短縮IDが複数一致 → 候補提示のみで本文を返さない
- 存在しない短縮ID → 例外を投げず「見つかりません」
- `session_id` が空 → 解決クエリすら投げずに指定を促す

### 検証結果
- `npx tsc --noEmit` — パス(エラーなし)
- `npm run lint` — パス(exit 0 / 変更ファイルに新規警告なし)
- `npx jest src/api/admin/agent` — 142 passed(うち新規6件)
- `admin-ui`: `vitest run src/pages/copilot-preview` — 14 passed / `tsc -b` の既存エラーは無関係な他テストファイルのみ(copilot-preview は0件)

## 触っていないもの
- 旧UI(`/admin/chat-history*`)は無改変
- `chat-history/routes.ts` / `chatHistoryRepository.ts` は `getMessages` の import のみ(新規リポジトリ関数なし)
- super_admin 限定機能の追加なし(#507 の轍を踏まない)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177MCsC7jN3a51F7TdaW9vH