### PR TITLE
feat(admin-ui): 旧UIサイドバーに新UI(AIチャット)への復帰導線を追加

### DIFF
--- a/admin-ui/src/components/AppSidebar.test.tsx
+++ b/admin-ui/src/components/AppSidebar.test.tsx
@@ -148,6 +148,57 @@ describe("AppSidebar — ご利用状況・お支払いの可視性", () => {
   });
 });
 
+// GID 1216993321226858: 旧UIから新UI(/copilot-preview)への復帰導線。
+// target="_blank" が効かない環境やチャット・ファースト既定OFFのユーザーが
+// 旧UIで行き止まりにならないことを担保する。
+describe("AppSidebar — AIチャット(新UI)への復帰導線", () => {
+  it("client_admin → /copilot-preview へのリンクが表示される", () => {
+    vi.mocked(useAuth).mockReturnValue(baseAuth({ tenantPlan: "growth" }));
+    renderSidebar();
+
+    const link = screen.getByText("AIチャットに戻る").closest("a");
+    expect(link).toBeTruthy();
+    expect(link?.getAttribute("href")).toBe("/copilot-preview");
+    // 既存navの回帰確認
+    expect(screen.getByText("会話履歴")).toBeTruthy();
+  });
+
+  it("super_adminのプレビュー中(isClientAdmin=true) → 表示される", () => {
+    vi.mocked(useAuth).mockReturnValue(
+      baseAuth({
+        isSuperAdmin: false, // プレビュー中はclient_admin相当にフォールバック
+        isClientAdmin: true,
+        previewMode: true,
+        previewTenantId: "preview-tenant",
+        tenantPlan: "growth",
+      }),
+    );
+    renderSidebar();
+
+    expect(screen.getByText("AIチャットに戻る").closest("a")?.getAttribute("href")).toBe(
+      "/copilot-preview",
+    );
+    expect(screen.getByText("会話履歴")).toBeTruthy();
+  });
+
+  it("プレビューなしのsuper_admin → 非表示(テナント未解決でチャットが機能しないため)", () => {
+    vi.mocked(useAuth).mockReturnValue(
+      baseAuth({
+        isSuperAdmin: true,
+        isClientAdmin: false,
+        previewMode: false,
+        user: { id: "2", email: "admin@example.com", role: "super_admin", tenantId: null, tenantName: null },
+      }),
+    );
+    renderSidebar();
+
+    expect(screen.queryByText("AIチャットに戻る")).toBeNull();
+    // 既存navは従来どおり表示されたまま
+    expect(screen.getByText("会話履歴")).toBeTruthy();
+    expect(screen.getByText("テナント管理")).toBeTruthy();
+  });
+});
+
 // GID: ThemeToggle を common/ThemeToggle.tsx へ切り出した際の回帰テスト。
 // 移設のみでスタイル・ロジックは変更していないため、フッターのテーマ切替
 // (ライト/ダーク/自動の3ボタン)が従来どおり描画されることだけを確認する。

--- a/admin-ui/src/components/AppSidebar.tsx
+++ b/admin-ui/src/components/AppSidebar.tsx
@@ -19,6 +19,7 @@ import {
   GitBranch,
   Headset,
   HelpCircle,
+  Sparkles,
 } from "lucide-react";
 import { useAuth } from "../auth/useAuth";
 import { NotificationBell } from "./common/NotificationBell";
@@ -150,7 +151,7 @@ interface SidebarContentProps {
 }
 
 function SidebarContent({ onClose }: SidebarContentProps) {
-  const { user, isSuperAdmin, previewMode, previewTenantId, tenantPlan, logout } = useAuth();
+  const { user, isSuperAdmin, isClientAdmin, previewMode, previewTenantId, tenantPlan, logout } = useAuth();
   const navigate = useNavigate();
 
   const handleLogout = async () => {
@@ -280,6 +281,41 @@ function SidebarContent({ onClose }: SidebarContentProps) {
           gap: 10,
         }}
       >
+        {/* 新UI(チャット)への復帰導線。
+            target="_blank" を無視する環境(アプリ内ブラウザ等)や、チャット・ファースト
+            既定がOFFのユーザーは旧UIから新UIへ戻る手段が無くなるため、常設リンクを置く。
+            条件は App.tsx の showAIChat と同じ isClientAdmin — テナントが解決できない
+            素のsuper_adminにとってはチャットが機能しないため意図的に非表示にする。 */}
+        {isClientAdmin && (
+          <NavLink
+            to="/copilot-preview"
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 10,
+              padding: "8px 12px",
+              borderRadius: "var(--radius-md)",
+              textDecoration: "none",
+              fontSize: 13.5,
+              fontWeight: 600,
+              color: "var(--sidebar-primary)",
+              background: "var(--sidebar-accent)",
+              transition: "opacity 0.12s",
+            }}
+            onMouseEnter={(e) => {
+              (e.currentTarget as HTMLElement).style.opacity = "0.85";
+            }}
+            onMouseLeave={(e) => {
+              (e.currentTarget as HTMLElement).style.opacity = "1";
+            }}
+          >
+            <Sparkles size={16} style={{ flexShrink: 0 }} />
+            <span style={{ flex: 1, whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis" }}>
+              AIチャットに戻る
+            </span>
+          </NavLink>
+        )}
+
         {/* Theme toggle */}
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
           <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>テーマ</span>


### PR DESCRIPTION
## 概要

PR #569 (旧UIへの案内を行き止まりにしない) のフォローアップ。
旧UI共通サイドバーのフッターに `/copilot-preview`(新UI)への常設リンクを追加する。

## 塞ぐ2つの行き止まり

#569 で新UI→旧UIのリンクを `target="_blank"` 化し「タブを切り替えれば戻れる」形にしたが、これは別タブ遷移が実際に効く場合にしか助けにならない。以下2ケースでは旧UIに入ると戻る手段が消える。

1. **`target="_blank"` が無視される環境** — LINE/Instagram等のアプリ内ブラウザ、一部のPWA/WebView、ポップアップブロック。同一タブで旧UIに遷移してしまう。
2. **チャット・ファースト既定(個人オプトイン)がOFFのユーザー** — `App.tsx` の `isCopilotPreview` は、パスがちょうど `/copilot-preview` の場合か、`/`・`/admin` かつ (`isChatFirstDefaultEnabled()` または `previewMode`) の場合にのみ新UIを出す。オプトインしていないユーザーが `/` や `/admin` に戻っても旧ダッシュボードが表示されるだけ。

旧UI各ページの「← 戻る」は全て `/admin`(旧ダッシュボード)止まりで、新UIへ向かうものは存在しなかった。

## 実装

- `SidebarContent` の `useAuth()` から `isClientAdmin` を取得し、フッターに `NavLink to="/copilot-preview"`(同一タブ)を追加。
- 表示条件は `App.tsx` の `showAIChat` と同一の `isClientAdmin` を再利用。`previewMode`(super_adminのクライアントビュー)中は `isClientAdmin` が true になるため、プレビュー中のsuper_adminにも表示される。
- **テナントが解決できない素のsuper_adminには意図的に非表示** — チャットがテナント無しでは機能しないため。
- `SidebarContent` はデスクトップ `AppSidebar` とモバイルドロワー `MobileHeader` の共有コンポーネントのため、両方に自動的に反映される。既存 `SidebarItem` 同様 `onClose` は呼ばない(`/copilot-preview` へ遷移すると `AppInner` が早期returnし `MobileHeader` ごとアンマウントされる)。

## スコープ外(変更していない)

- `isChatFirstDefaultEnabled()` の既定値、`App.tsx` の `isCopilotPreview` ルーティングロジック
- `/copilot-preview` 自体のコード
- 旧UI各ページ個別の「← 戻る」パンくず(共有サイドバーに一本化)

## テスト

`admin-ui/src/components/AppSidebar.test.tsx` に3ケース追加(既存の `baseAuth`/`vi.mocked(useAuth)` 規約に準拠)。

- client_admin → リンク表示 & href が `/copilot-preview`
- `previewMode: true` のsuper_admin → 表示
- プレビューなしのsuper_admin → 非表示

いずれも既存nav項目(会話履歴/テナント管理)の回帰も併せて確認。

```
Test Files  1 passed (1)
     Tests  13 passed (13)   # 既存10 + 新規3
```

- `npx eslint src/components/AppSidebar.tsx src/components/AppSidebar.test.tsx` → クリーン
- `npm run typecheck` → 変更ファイルにエラーなし(残存13件は全て main 由来の既存エラー: 別テストファイルの auth モックに `tenantPlan` が無い)

## 目視確認

一時的なdev harness(mock auth)+ Playwright でサイドバーを実描画して確認。

- デスクトップ client_admin: テーマ切替の上に配置。既存 active nav item と同じ accent 背景/primary 文字色で、周囲(テーマ行・ユーザー情報・ログアウト)と競合なし。
- デスクトップ super_admin(プレビューなし): 非表示を確認。
- モバイルドロワー(390px幅): 表示・余白とも問題なし。

harnessファイルはコミット前に削除済み(差分は上記2ファイルのみ)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177MCsC7jN3a51F7TdaW9vH