### PR TITLE
feat(agent): エージェント挙動メトリクスの計測基盤を配線(旧UI受け渡し/確認ブロック/ホップ数)

### DIFF
--- a/docs/AGENT_METRICS.md
+++ b/docs/AGENT_METRICS.md
@@ -1,0 +1,115 @@
+# AGENT_METRICS — 管理AIエージェントの挙動メトリクス命名契約
+
+`/copilot-preview`（チャットファーストの管理UI）とそのバックエンド
+`src/api/admin/agent/` の**エージェント自身の挙動**を計測するためのメトリクス定義。
+
+計測の目的は「将来のチャットUIに関する製品判断を数値で行えるようにする」こと。
+たとえば「旧UIへの案内（handoff）がどれくらい起きているか」が分かれば、
+旧ダッシュボードのページを畳めるかどうかを勘ではなく数字で判断できる。
+
+**このドキュメントは命名契約である。** 実装（`src/lib/metrics/agentMetrics.ts` /
+`src/api/admin/agent/agentRoutes.ts`）とダッシュボード/分析クエリの双方が
+ここに書かれた `metric_name` / `labels` / `value` の意味に依存する。
+値を増やす・意味を変える場合は必ずこのファイルを先に更新する。
+
+## 保存先
+
+既存の汎用シンクテーブル `metrics_snapshots`（`src/migrations/phase72d_metrics_snapshots.sql`、
+本番適用済み）をそのまま再利用する。**このメトリクスのために新しいテーブルやマイグレーションは作らない。**
+
+```sql
+CREATE TABLE IF NOT EXISTS metrics_snapshots (
+  id          BIGSERIAL    PRIMARY KEY,
+  metric_name TEXT         NOT NULL,
+  tenant_id   TEXT,
+  labels      JSONB        NOT NULL DEFAULT '{}',
+  value       NUMERIC      NOT NULL,
+  snapshot_at TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+```
+
+- `tenant_id`: リクエストの `effectiveTenantId`。テナント未特定の super_admin
+  （`targetTenantId` 未指定でプレビュー対象がない状態）では `NULL`。
+- `labels`: 下表のキーのみ。**PII を入れない**（ユーザーの自由入力文、FAQ本文、
+  顧客名、セッション本文などは一切ラベルに含めない）。入るのは下表で定義した
+  enum 値と、ツール名のような固定語彙だけ。
+- `snapshot_at`: DB 既定値（`NOW()`）に任せる。
+
+## メトリクス一覧（この5つのみ）
+
+| metric_name | labels | value | 発火タイミング |
+| --- | --- | --- | --- |
+| `agent_tool_invoked` | `{ tool: string, outcome: "ok" \| "blocked" \| "error" }` | 常に `1`（イベント件数） | ツール呼び出しの結果が `actions` に積まれるたび（1ツール呼び出し=1行） |
+| `agent_write_blocked` | `{ tool: string, reason: "unconfirmed" \| "chain" }` | 常に `1` | 書き込み系ツールが確認ゲートでブロックされたとき（`agent_tool_invoked` の `outcome="blocked"` と同時に発火する） |
+| `agent_turn_hops` | `{ hit_limit: boolean }` | そのターンで実際に消費したツール呼び出しホップ数（`0` 以上） | ターン完了時（1ターン1行） |
+| `agent_legacy_handoff` | `{ feature: string }` | 常に `1` | `get_legacy_ui_link` が呼ばれたとき。「チャットがまだ旧UIへ何回受け渡しているか」の**分子** |
+| `agent_turn_completed` | `{ answered_from: string }` | 常に `1` | 結果に関わらずターンが完了したとき。handoff率の**分母** |
+
+### `agent_tool_invoked`
+
+- `tool`: ツール名（`ADMIN_AGENT_TOOLS` の `name`。例 `get_faq_list`, `save_faq`）。
+- `outcome`:
+  - `ok` — ツールが結果文字列を返した（＝ブロックされなかった）
+  - `blocked` — 確認ゲートでブロックされた（下記「ブロック判定」参照）
+  - `error` — ツール実行が例外を投げた（`actionExecutor` の各 case は基本的に
+    内部で catch して文字列を返すため通常は発生しない。ここに数字が出るのは
+    実行系そのものの異常を意味する）
+- 1ツール呼び出しにつき必ず1行。同一ターンで複数ツールが呼ばれれば複数行になる。
+
+**ブロック判定**は結果文字列の部分一致で行う（フロントエンドの
+`admin-ui/src/pages/copilot-preview/index.tsx` が確認待ちUIの出し分けに使っているのと
+同じ規約）。
+
+| 部分文字列 | outcome | reason |
+| --- | --- | --- |
+| `確認が必要です` | `blocked` | `unconfirmed` |
+| `確認をスキップできません` | `blocked` | `chain` |
+| 上記以外 | `ok` | — |
+
+`unconfirmed` の判定にフロントと同じ `確認が必要` ではなく **`確認が必要です`** を使う点に注意。
+`get_embed_code` の**成功**メッセージが「再確認が必要な場合は新しいキーを発行してください」を
+含むため、`確認が必要` だと正常応答をブロックとして数えてしまう。実際のブロック文言
+（`actionExecutor.ts` の各確認ゲート、および `agentRoutes.ts` の同一ターン連鎖ブロック）は
+すべて「〜には確認が必要です」の形なので、`です` まで含めれば誤検出しない。
+
+### `agent_write_blocked`
+
+`outcome="blocked"` の内訳を単独で引けるようにするための派生メトリクス。
+`reason` の意味:
+
+- `unconfirmed` — `confirmed=true` が付いていない書き込み（`actionExecutor` の確認ゲート）
+- `chain` — 同一ターン内で `suggest_* → save_*` を連鎖実行しようとした
+  （`agentRoutes.ts` の `SUGGEST_TO_SAVE_TOOL` ガード。人間の確認を経ない書き込みを防ぐ）
+
+### `agent_turn_hops`
+
+- `value` = そのターンで「ツール呼び出しを含む Groq 呼び出し」が実際に走った回数。
+  ツールを一度も使わなかったターンは `0`。
+- `hit_limit` = `MAX_TOOL_HOPS` に達しても収束せず、tools 無しの強制まとめ呼び出しに
+  落ちたかどうか。`true` が増えているならモデルが1ターンで解決しきれていない兆候。
+- ストリーミング（SSE）経路・非ストリーミング（JSON）経路の両方で発火する。
+
+### `agent_legacy_handoff`
+
+- `feature`: `get_legacy_ui_link` に渡された `feature` 引数。想定値は
+  `billing` / `avatar_studio` / `escalation_reply` / `session_deletion` /
+  `analytics` / `conversion` / `chat_test` / `avatar_wizard` / `knowledge_pdf`。
+  モデルが未定義の値を渡した場合はラベルの語彙を有界に保つため `unknown` に丸める。
+- `agent_tool_invoked{tool="get_legacy_ui_link"}` とは**重複して**発火する
+  （前者はツール実行の記録、こちらは製品指標としての handoff 記録）。
+
+### `agent_turn_completed`
+
+- `answered_from`: レスポンスで返している `answered_from` と同じ値
+  （`faq_list` / `tool_action` / `general`）。
+- ツールを使ったか・ブロックされたかに関わらず、ターンが完了すれば必ず1行。
+  handoff 率は `count(agent_legacy_handoff) / count(agent_turn_completed)` で出す。
+- 500エラーや SSE の `event: error` で終わったターンは「完了」ではないので発火しない。
+
+## 実装上の制約
+
+- 記録は **fire-and-forget**。`recordAgentMetric` は内部で try/catch し、失敗は
+  `logger.warn` に落とすだけで例外を投げない。呼び出し側も戻り値を待たない。
+  **計測の失敗がチャット応答のステータスコードや本文を変えてはならない。**
+- 計測は `agentRoutes.ts` にのみ実装する。`actionExecutor.ts` の 45 個の `case`
+  分岐には手を入れない（1箇所で横断的に取れる形を保つ）。

--- a/docs/AGENT_METRICS.md
+++ b/docs/AGENT_METRICS.md
@@ -99,6 +99,9 @@ CREATE TABLE IF NOT EXISTS metrics_snapshots (
   `billing` / `avatar_studio` / `escalation_reply` / `session_deletion` /
   `analytics` / `conversion` / `chat_test` / `avatar_wizard` / `knowledge_pdf`。
   モデルが未定義の値を渡した場合はラベルの語彙を有界に保つため `unknown` に丸める。
+  この語彙は `toolDefinitions.ts` の `LEGACY_UI_FEATURES`（`get_legacy_ui_link` の
+  feature enum の実体）を import して導出しており、計測側に写しを持たない。
+  したがって enum から値を削除すれば、その feature は自動的に `unknown` へ丸まる。
 - `agent_tool_invoked{tool="get_legacy_ui_link"}` とは**重複して**発火する
   （前者はツール実行の記録、こちらは製品指標としての handoff 記録）。
 

--- a/docs/AGENT_METRICS.md
+++ b/docs/AGENT_METRICS.md
@@ -88,6 +88,10 @@ CREATE TABLE IF NOT EXISTS metrics_snapshots (
 - `hit_limit` = `MAX_TOOL_HOPS` に達しても収束せず、tools 無しの強制まとめ呼び出しに
   落ちたかどうか。`true` が増えているならモデルが1ターンで解決しきれていない兆候。
 - ストリーミング（SSE）経路・非ストリーミング（JSON）経路の両方で発火する。
+- ラベルは `hit_limit` のみ。`tool` もターン/セッションIDも**意図的に持たせていない**ため、
+  ホップ数をページや個別ツールに帰属させることはできない。この指標は全体のveto
+  （エージェント全体が1ターンで解決できているか）専用で、機能単位の労力は別指標で見る。
+  行数とプライバシーのコストに見合わないので、消費側の要望があっても安易に追加しない。
 
 ### `agent_legacy_handoff`
 
@@ -98,13 +102,37 @@ CREATE TABLE IF NOT EXISTS metrics_snapshots (
 - `agent_tool_invoked{tool="get_legacy_ui_link"}` とは**重複して**発火する
   （前者はツール実行の記録、こちらは製品指標としての handoff 記録）。
 
+#### `feature="unknown"` は捨てバケツではなく調査シグナル
+
+`unknown` に落ちる行は「異常値をまとめて捨てる先」ではない。**恒常的に集計し、
+ゼロでなければ理由を突き止めるべき signal** として扱う。`unknown` が出る経路は2つあり、
+どちらも情報を持っている。
+
+1. **enum に無い feature をモデルが渡した** — チャットから案内したい機能があるのに
+   案内先のキーが存在しない、という兆候。実例として、テナントに見えているのに
+   対応ツールも handoff キューも無い機能が `unknown` の調査から見つかっている
+   （`agent_tool_invoked` と `agent_legacy_handoff` の両方から不可視だった）。
+   次の取りこぼしを検出する手段がこのカウントである。
+2. **旧UIページの閉鎖に伴い `toolDefinitions.ts` の feature enum から値が削除された** —
+   閉鎖済みページ宛の残存 handoff は消えるのではなく `unknown` に着地する。
+   `docs/LEGACY_UI_SUNSET.md` はこれを閉鎖後のトリップワイヤーとして使う。
+
+つまり `unknown` は時間が経つほど「純粋なエラーバケツ」ではなくなる。
+**この行を「ノイズだから」と落とす形での“修正”をしてはならない**（閉鎖済みページへの
+残存アクセスを観測する唯一の経路が消える）。増加時は上記1と2のどちらなのかを切り分ける。
+
 ### `agent_turn_completed`
 
 - `answered_from`: レスポンスで返している `answered_from` と同じ値
   （`faq_list` / `tool_action` / `general`）。
 - ツールを使ったか・ブロックされたかに関わらず、ターンが完了すれば必ず1行。
   handoff 率は `count(agent_legacy_handoff) / count(agent_turn_completed)` で出す。
-- 500エラーや SSE の `event: error` で終わったターンは「完了」ではないので発火しない。
+- 500エラーや SSE の `event: error` で終わったターンは「完了」ではないので発火しない
+  （分母は「完了したターン」だけ）。
+- 行にターン/セッションIDが無いため、1ターン中に `get_legacy_ui_link` が2回呼ばれれば
+  handoff 行も2行になり重複排除できない。したがって上記の比は
+  **「完了ターンあたりの handoff 回数」であって「handoff を含んだターンの割合」ではない**
+  （原理的に 1.0 を超えうる）。指標名や文書でこの2つを混同しないこと。
 
 ## 実装上の制約
 

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -154,6 +154,19 @@ jest.mock('../../../lib/billing/usageTracker', () => ({
   trackUsage: (...args: any[]) => mockTrackUsage(...args),
 }));
 
+// agentMetrics モック（挙動メトリクス。実DBへのINSERTを避けつつ発火内容を検証する）
+const mockRecordAgentMetric = jest.fn();
+jest.mock('../../../lib/metrics/agentMetrics', () => ({
+  recordAgentMetric: (...args: any[]) => mockRecordAgentMetric(...args),
+}));
+
+/** mockRecordAgentMetric に記録された指定 metric_name の入力だけを取り出す */
+function recordedMetrics(metricName: string): Array<Record<string, any>> {
+  return mockRecordAgentMetric.mock.calls
+    .map(([, input]) => input as Record<string, any>)
+    .filter((input) => input?.metricName === metricName);
+}
+
 // ---------------------------------------------------------------------------
 // テスト対象を import
 // ---------------------------------------------------------------------------
@@ -294,6 +307,90 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(res.body.actions[0].tool).toBe('get_tenant_settings');
       expect(typeof res.body.actions[0].result).toBe('string');
       expect(res.body).toHaveProperty('reply');
+
+      // 挙動メトリクス: 成功したツール呼び出しは outcome=ok、ターン完了で hops/completed も記録される
+      expect(recordedMetrics('agent_tool_invoked')).toEqual([
+        {
+          metricName: 'agent_tool_invoked',
+          tenantId: 'tenant-abc',
+          labels: { tool: 'get_tenant_settings', outcome: 'ok' },
+          value: 1,
+        },
+      ]);
+      expect(recordedMetrics('agent_write_blocked')).toEqual([]);
+      expect(recordedMetrics('agent_turn_hops')).toEqual([
+        {
+          metricName: 'agent_turn_hops',
+          tenantId: 'tenant-abc',
+          labels: { hit_limit: false },
+          value: 1,
+        },
+      ]);
+      expect(recordedMetrics('agent_turn_completed')).toEqual([
+        {
+          metricName: 'agent_turn_completed',
+          tenantId: 'tenant-abc',
+          labels: { answered_from: 'tool_action' },
+          value: 1,
+        },
+      ]);
+    });
+
+    it('ツール未使用のターンでも agent_turn_hops(0) と agent_turn_completed が記録される', async () => {
+      mockFetch.mockResolvedValueOnce(makeGroqResponse('設定を確認しました。'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'GA4の設定を教えて', sessionId: 'sess-metrics-01' });
+
+      expect(res.status).toBe(200);
+      expect(recordedMetrics('agent_tool_invoked')).toEqual([]);
+      expect(recordedMetrics('agent_turn_hops')).toEqual([
+        { metricName: 'agent_turn_hops', tenantId: 'tenant-abc', labels: { hit_limit: false }, value: 0 },
+      ]);
+      expect(recordedMetrics('agent_turn_completed')).toEqual([
+        { metricName: 'agent_turn_completed', tenantId: 'tenant-abc', labels: { answered_from: 'general' }, value: 1 },
+      ]);
+    });
+
+    it('recordAgentMetric が throw / reject しても 200 と reply を返す（計測失敗は応答を壊さない）', async () => {
+      mockRecordAgentMetric
+        .mockImplementationOnce(() => {
+          throw new Error('metrics sync boom');
+        })
+        .mockImplementation(() => Promise.reject(new Error('metrics async boom')));
+
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            choices: [{
+              message: {
+                content: null,
+                tool_calls: [{
+                  id: 'call-metrics-err',
+                  type: 'function',
+                  function: { name: 'get_tenant_settings', arguments: '{}' },
+                }],
+              },
+            }],
+          }),
+          text: async () => '',
+        })
+        .mockResolvedValueOnce(makeGroqResponse('GA4は未設定です。'));
+
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ ga4_measurement_id: null, posthog_host: null, widget_theme: {} }],
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '設定を確認して', sessionId: 'sess-metrics-02' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.reply).toBe('GA4は未設定です。');
+      expect(res.body.actions[0].tool).toBe('get_tenant_settings');
+      expect(res.body.answered_from).toBe('tool_action');
     });
   });
 
@@ -825,6 +922,24 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(res.status).toBe(200);
       expect(mockUpdateRule).not.toHaveBeenCalled();
       expect(res.body.actions[0].result).toContain('確認が必要');
+
+      // 挙動メトリクス: 確認ゲートでのブロックは outcome=blocked + reason=unconfirmed
+      expect(recordedMetrics('agent_tool_invoked')).toEqual([
+        {
+          metricName: 'agent_tool_invoked',
+          tenantId: 'tenant-abc',
+          labels: { tool: 'update_tuning_rule', outcome: 'blocked' },
+          value: 1,
+        },
+      ]);
+      expect(recordedMetrics('agent_write_blocked')).toEqual([
+        {
+          metricName: 'agent_write_blocked',
+          tenantId: 'tenant-abc',
+          labels: { tool: 'update_tuning_rule', reason: 'unconfirmed' },
+          value: 1,
+        },
+      ]);
     });
 
     it('update_tuning_rule: client_admin・confirmed=true → tenant_idスコープ(super_admin以外はundefined渡さない)で更新される', async () => {
@@ -2608,6 +2723,16 @@ describe('POST /v1/admin/agent/chat', () => {
       // toContain(path) だけだと `/admin/chat-test` に対する `/admin/chat-tests` のような
       // 末尾追加型のtypoを検出できないため、行末(\n)まで含めて厳密に検証する
       expect(result).toContain(`URL: ${path}\n`);
+
+      // 挙動メトリクス: 旧UIへの受け渡しは agent_legacy_handoff として feature 付きで記録される
+      expect(recordedMetrics('agent_legacy_handoff')).toEqual([
+        {
+          metricName: 'agent_legacy_handoff',
+          tenantId: 'tenant-abc',
+          labels: { feature },
+          value: 1,
+        },
+      ]);
     });
 
     it('不明なfeatureの場合はその旨を返す', async () => {
@@ -2621,6 +2746,16 @@ describe('POST /v1/admin/agent/chat', () => {
 
       expect(res.status).toBe(200);
       expect(res.body.actions[0].result).toContain('不明な案内先');
+
+      // ラベルの語彙を有界に保つため、未定義の feature は 'unknown' に丸めて記録する
+      expect(recordedMetrics('agent_legacy_handoff')).toEqual([
+        {
+          metricName: 'agent_legacy_handoff',
+          tenantId: 'tenant-abc',
+          labels: { feature: 'unknown' },
+          value: 1,
+        },
+      ]);
     });
 
     // analytics / conversion はLP料金表上Growth〜の機能（AppSidebar.tsxのrequiresPlanと同じ基準）。
@@ -3493,6 +3628,19 @@ describe('POST /v1/admin/agent/chat', () => {
 
       const saveAction = res.body.actions.find((a: any) => a.tool === 'save_faq');
       expect(saveAction.result).toContain('同一ターン内での連続実行');
+
+      // 挙動メトリクス: 連鎖ブロックは reason=chain として記録される
+      expect(recordedMetrics('agent_write_blocked')).toEqual([
+        {
+          metricName: 'agent_write_blocked',
+          tenantId: 'tenant-abc',
+          labels: { tool: 'save_faq', reason: 'chain' },
+          value: 1,
+        },
+      ]);
+      expect(recordedMetrics('agent_turn_hops')).toEqual([
+        { metricName: 'agent_turn_hops', tenantId: 'tenant-abc', labels: { hit_limit: false }, value: 2 },
+      ]);
     });
 
     it('同一ホップ内で suggest_tuning_rule と save_tuning_rule(confirmed=true) が同時に来ても後者はブロックされる', async () => {
@@ -3600,6 +3748,22 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(res.text).toContain('"tool":"get_tenant_settings"');
       expect(res.text.indexOf('event: action')).toBeLessThan(res.text.indexOf('event: done'));
       expect(res.text).toContain('設定を確認しました。');
+
+      // 挙動メトリクス: SSE経路でも JSON経路と同じくツール呼び出しとターン完了が記録される
+      expect(recordedMetrics('agent_tool_invoked')).toEqual([
+        {
+          metricName: 'agent_tool_invoked',
+          tenantId: 'tenant-abc',
+          labels: { tool: 'get_tenant_settings', outcome: 'ok' },
+          value: 1,
+        },
+      ]);
+      expect(recordedMetrics('agent_turn_hops')).toEqual([
+        { metricName: 'agent_turn_hops', tenantId: 'tenant-abc', labels: { hit_limit: false }, value: 1 },
+      ]);
+      expect(recordedMetrics('agent_turn_completed')).toEqual([
+        { metricName: 'agent_turn_completed', tenantId: 'tenant-abc', labels: { answered_from: 'tool_action' }, value: 1 },
+      ]);
     });
 
     it('stream:true でも suggest_faq→save_faq の同一ターン連鎖はブロックされ、DBに書き込まれない', async () => {

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -172,6 +172,7 @@ function recordedMetrics(metricName: string): Array<Record<string, any>> {
 // ---------------------------------------------------------------------------
 
 import { registerAdminAgentRoutes } from './agentRoutes';
+import { ADMIN_AGENT_TOOLS, LEGACY_UI_FEATURES } from './toolDefinitions';
 // ステージング(knowledgeImportStaging.ts)はモックせず実物を使う。
 // suggest_faq_import_from_text/urls → commit_faq_import の2ターン検証、
 // TTL/上限とは独立にテスト間の状態リークを防ぐためのリセット関数として使う。
@@ -2685,6 +2686,18 @@ describe('POST /v1/admin/agent/chat', () => {
   // get_legacy_ui_link
   // -------------------------------------------------------------------------
   describe('get_legacy_ui_link', () => {
+    // 計測ラベルの語彙(agentRoutes の LEGACY_HANDOFF_FEATURES)は toolDefinitions の
+    // feature enum から導出している。ここに写しが復活すると、旧UIページ閉鎖でenumから
+    // 値を消しても閉鎖済みページ宛の handoff が 'unknown' に落ちず自分の名前で記録され続け、
+    // docs/LEGACY_UI_SUNSET.md のトリップワイヤーが無言で作動しなくなる。
+    // 同一参照であることを検証して、リテラル配列への差し戻しを失敗させる。
+    it('feature enum は LEGACY_UI_FEATURES から導出されている（写しを作らない）', () => {
+      const tool = ADMIN_AGENT_TOOLS.find((t) => t.function.name === 'get_legacy_ui_link');
+      expect(tool).toBeDefined();
+      const featureProp = tool!.function.parameters.properties['feature'] as { enum: unknown };
+      expect(featureProp.enum).toBe(LEGACY_UI_FEATURES);
+    });
+
     function toolCallResponse(id: string, name: string, args: Record<string, unknown> = {}) {
       return {
         ok: true,

--- a/src/api/admin/agent/agentRoutes.ts
+++ b/src/api/admin/agent/agentRoutes.ts
@@ -9,8 +9,68 @@ import { logger } from '../../../lib/logger';
 import { ADMIN_AGENT_TOOLS } from './toolDefinitions';
 import { executeToolCall } from './actionExecutor';
 import { trackUsage } from '../../../lib/billing/usageTracker';
+import { recordAgentMetric, type AgentMetricInput } from '../../../lib/metrics/agentMetrics';
 import { GROQ_VERSATILE_70B } from '../../../config/groqModels';
 import { isUnanswered } from '../ai-assist/systemPrompt';
+
+// ---------------------------------------------------------------------------
+// 挙動メトリクス（metric_name / labels / value の契約は docs/AGENT_METRICS.md）
+// ---------------------------------------------------------------------------
+
+// ブロック判定の部分一致。フロント(copilot-preview)が確認待ちUIの出し分けに使うのと同じ規約だが、
+// get_embed_code の成功文「再確認が必要な場合は〜」を誤ってブロックと数えないよう「です」まで含める。
+const BLOCKED_UNCONFIRMED_MARKER = '確認が必要です';
+const BLOCKED_CHAIN_MARKER = '確認をスキップできません';
+
+// ラベルの語彙を有界に保つためのホワイトリスト（toolDefinitions の feature enum と対応）。
+// モデルが未定義の値を渡した場合は 'unknown' に丸める。
+const LEGACY_HANDOFF_FEATURES = new Set([
+  'billing',
+  'avatar_studio',
+  'escalation_reply',
+  'session_deletion',
+  'analytics',
+  'conversion',
+  'chat_test',
+  'avatar_wizard',
+  'knowledge_pdf',
+]);
+
+/** 計測は fire-and-forget。記録の失敗をチャット応答に一切影響させない。 */
+function fireAgentMetric(db: Pool, input: AgentMetricInput): void {
+  try {
+    void Promise.resolve(recordAgentMetric(db, input)).catch(() => undefined);
+  } catch {
+    // 計測失敗は応答に影響させない
+  }
+}
+
+function classifyToolResult(result: string): {
+  outcome: 'ok' | 'blocked';
+  reason?: 'unconfirmed' | 'chain';
+} {
+  if (result.includes(BLOCKED_CHAIN_MARKER)) return { outcome: 'blocked', reason: 'chain' };
+  if (result.includes(BLOCKED_UNCONFIRMED_MARKER)) return { outcome: 'blocked', reason: 'unconfirmed' };
+  return { outcome: 'ok' };
+}
+
+function recordTurnCompleted(
+  db: Pool,
+  params: { tenantId: string | null; toolHops: number; hitHopLimit: boolean; answeredFrom: AnsweredFrom },
+): void {
+  fireAgentMetric(db, {
+    metricName: 'agent_turn_hops',
+    tenantId: params.tenantId,
+    labels: { hit_limit: params.hitHopLimit },
+    value: params.toolHops,
+  });
+  fireAgentMetric(db, {
+    metricName: 'agent_turn_completed',
+    tenantId: params.tenantId,
+    labels: { answered_from: params.answeredFrom },
+    value: 1,
+  });
+}
 
 // ---------------------------------------------------------------------------
 // answered_from: このターンの回答がどこから来たかをUIに伝える
@@ -238,12 +298,48 @@ async function executeHopToolCalls(
       // 同一ターン内で suggest → save が連鎖しようとしている: 人間の確認を経ていないためブロック
       result = 'この保存は同一ターン内での連続実行のため確認をスキップできません。提案内容を確認のうえ、あらためて「保存して」等のメッセージを送ってください。';
     } else {
-      result = await executeToolCall(name, args, effectiveTenantId, db, sessionId, isSuperAdmin);
+      try {
+        result = await executeToolCall(name, args, effectiveTenantId, db, sessionId, isSuperAdmin);
+      } catch (err) {
+        fireAgentMetric(db, {
+          metricName: 'agent_tool_invoked',
+          tenantId: effectiveTenantId || null,
+          labels: { tool: name, outcome: 'error' },
+          value: 1,
+        });
+        throw err;
+      }
       if (name in SUGGEST_TO_SAVE_TOOL) suggestedThisTurn.add(name);
     }
 
     actions.push({ tool: name, result });
     messages.push({ role: 'tool', tool_call_id: id, name, content: result });
+
+    const metricTenantId = effectiveTenantId || null;
+    const { outcome, reason } = classifyToolResult(result);
+    fireAgentMetric(db, {
+      metricName: 'agent_tool_invoked',
+      tenantId: metricTenantId,
+      labels: { tool: name, outcome },
+      value: 1,
+    });
+    if (reason) {
+      fireAgentMetric(db, {
+        metricName: 'agent_write_blocked',
+        tenantId: metricTenantId,
+        labels: { tool: name, reason },
+        value: 1,
+      });
+    }
+    if (name === 'get_legacy_ui_link') {
+      const feature = String(args['feature'] ?? '');
+      fireAgentMetric(db, {
+        metricName: 'agent_legacy_handoff',
+        tenantId: metricTenantId,
+        labels: { feature: LEGACY_HANDOFF_FEATURES.has(feature) ? feature : 'unknown' },
+        value: 1,
+      });
+    }
   }
 }
 
@@ -496,8 +592,10 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
 
         try {
           let finalReply: string | null = null;
+          // ループを抜けた時点で「ツール呼び出しを含むホップを何回消費したか」になる（agent_turn_hops の value）
+          let toolHops = 0;
 
-          for (let hop = 0; hop < MAX_TOOL_HOPS; hop++) {
+          for (; toolHops < MAX_TOOL_HOPS; toolHops++) {
             const hopResult = await runStreamingHop(messages, ADMIN_AGENT_TOOLS, res);
             totalPromptTokens += hopResult.usage.promptTokens;
             totalCompletionTokens += hopResult.usage.completionTokens;
@@ -521,6 +619,8 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
               res.write(`event: action\ndata: ${JSON.stringify(action)}\n\n`);
             }
           }
+
+          const hitHopLimit = finalReply === null;
 
           if (finalReply === null) {
             // MAX_TOOL_HOPS に達しても収束しなかった場合、tools無しで強制的にまとめさせる(これもストリーミング)。
@@ -549,6 +649,13 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
             await recordUnansweredFeedback(db, { tenantId: effectiveTenantId, email, message, reply: finalReply });
           }
 
+          recordTurnCompleted(db, {
+            tenantId: effectiveTenantId || null,
+            toolHops,
+            hitHopLimit,
+            answeredFrom,
+          });
+
           res.write(`event: done\ndata: ${JSON.stringify({ reply: finalReply, actions, answered_from: answeredFrom })}\n\n`);
           res.end();
         } catch (err) {
@@ -576,11 +683,13 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
       };
 
       let finalReply: string | null = null;
+      // ループを抜けた時点で「ツール呼び出しを含むホップを何回消費したか」になる（agent_turn_hops の value）
+      let toolHops = 0;
 
       // G1: tools付きGroq呼び出しを最大 MAX_TOOL_HOPS 回まで繰り返す。
       // モデルがツール結果を見て追加のツールを呼ぶ「多段推論」を許容しつつ、
       // 上限に達しても収束しない場合は必ず自然文の reply で終了させる。
-      for (let hop = 0; hop < MAX_TOOL_HOPS; hop++) {
+      for (; toolHops < MAX_TOOL_HOPS; toolHops++) {
         const hopResponse = await callGroqWithTools(messages, ADMIN_AGENT_TOOLS);
         totalPromptTokens += hopResponse.usage.promptTokens;
         totalCompletionTokens += hopResponse.usage.completionTokens;
@@ -605,6 +714,8 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
         await executeHopToolCalls(parsedToolCalls, effectiveTenantId, db, suggestedThisTurn, actions, messages, isSuperAdmin, sessionId);
       }
 
+      const hitHopLimit = finalReply === null;
+
       if (finalReply === null) {
         // MAX_TOOL_HOPS に達しても収束しなかった場合、tools無しで強制的にまとめさせる。
         // 実測: toolsを外しただけだと、まだ呼びたいツールがある場合にモデルが
@@ -622,6 +733,13 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
       if (effectiveTenantId && actions.length === 0 && isUnanswered(finalReply)) {
         await recordUnansweredFeedback(db, { tenantId: effectiveTenantId, email, message, reply: finalReply });
       }
+
+      recordTurnCompleted(db, {
+        tenantId: effectiveTenantId || null,
+        toolHops,
+        hitHopLimit,
+        answeredFrom,
+      });
 
       return res.json({ reply: finalReply, actions, answered_from: answeredFrom });
     } catch (err) {

--- a/src/api/admin/agent/agentRoutes.ts
+++ b/src/api/admin/agent/agentRoutes.ts
@@ -6,7 +6,7 @@ import { Pool } from 'pg';
 import { z } from 'zod';
 import { supabaseAuthMiddleware } from '../../../admin/http/supabaseAuthMiddleware';
 import { logger } from '../../../lib/logger';
-import { ADMIN_AGENT_TOOLS } from './toolDefinitions';
+import { ADMIN_AGENT_TOOLS, LEGACY_UI_FEATURES } from './toolDefinitions';
 import { executeToolCall } from './actionExecutor';
 import { trackUsage } from '../../../lib/billing/usageTracker';
 import { recordAgentMetric, type AgentMetricInput } from '../../../lib/metrics/agentMetrics';
@@ -22,19 +22,11 @@ import { isUnanswered } from '../ai-assist/systemPrompt';
 const BLOCKED_UNCONFIRMED_MARKER = '確認が必要です';
 const BLOCKED_CHAIN_MARKER = '確認をスキップできません';
 
-// ラベルの語彙を有界に保つためのホワイトリスト（toolDefinitions の feature enum と対応）。
-// モデルが未定義の値を渡した場合は 'unknown' に丸める。
-const LEGACY_HANDOFF_FEATURES = new Set([
-  'billing',
-  'avatar_studio',
-  'escalation_reply',
-  'session_deletion',
-  'analytics',
-  'conversion',
-  'chat_test',
-  'avatar_wizard',
-  'knowledge_pdf',
-]);
+// ラベルの語彙を有界に保つためのホワイトリスト。値は列挙し直さず toolDefinitions の
+// feature enum から導出する（ここに写しを持つと、旧UIページ閉鎖でenumから値を消しても
+// 閉鎖済みページ宛の handoff が 'unknown' に落ちず自分の名前で記録され続け、
+// docs/LEGACY_UI_SUNSET.md のトリップワイヤーが無言で作動しなくなる）。
+const LEGACY_HANDOFF_FEATURES = new Set<string>(LEGACY_UI_FEATURES);
 
 /** 計測は fire-and-forget。記録の失敗をチャット応答に一切影響させない。 */
 function fireAgentMetric(db: Pool, input: AgentMetricInput): void {

--- a/src/api/admin/agent/toolDefinitions.ts
+++ b/src/api/admin/agent/toolDefinitions.ts
@@ -14,6 +14,27 @@ export interface GroqTool {
   };
 }
 
+/**
+ * get_legacy_ui_link が案内できる旧管理画面の機能キー。
+ *
+ * 下の get_legacy_ui_link 定義の enum から参照し、計測側
+ * （agentRoutes.ts の agent_legacy_handoff ラベル語彙）もこの配列を import する。
+ * 旧UIページの閉鎖でここから値を削除すると、モデルがその feature を渡せなくなり、
+ * 万一渡しても計測側は自動的に 'unknown' へ丸める（docs/LEGACY_UI_SUNSET.md が
+ * 閉鎖後のトリップワイヤーとして依存している挙動）。値を二重管理しないこと。
+ */
+export const LEGACY_UI_FEATURES = [
+  'billing',
+  'avatar_studio',
+  'escalation_reply',
+  'session_deletion',
+  'analytics',
+  'conversion',
+  'chat_test',
+  'avatar_wizard',
+  'knowledge_pdf',
+] as const;
+
 export const ADMIN_AGENT_TOOLS: GroqTool[] = [
   {
     type: 'function',
@@ -836,17 +857,7 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
           feature: {
             type: 'string',
             description: '案内先の機能',
-            enum: [
-              'billing',
-              'avatar_studio',
-              'escalation_reply',
-              'session_deletion',
-              'analytics',
-              'conversion',
-              'chat_test',
-              'avatar_wizard',
-              'knowledge_pdf',
-            ],
+            enum: LEGACY_UI_FEATURES,
           },
           session_id: {
             type: 'string',

--- a/src/lib/metrics/agentMetrics.test.ts
+++ b/src/lib/metrics/agentMetrics.test.ts
@@ -1,0 +1,90 @@
+/**
+ * agentMetrics ユニットテスト
+ *
+ * - 正常系: metrics_snapshots へ期待した行形状で INSERT する
+ * - DB エラーは握りつぶす（throw せず logger.warn する）
+ * - tenantId=null（テナント未特定の super_admin）でも記録できる
+ */
+
+jest.mock('../logger', () => ({
+  logger: { warn: jest.fn(), info: jest.fn(), error: jest.fn(), debug: jest.fn() },
+}));
+
+import { recordAgentMetric } from './agentMetrics';
+import { logger } from '../logger';
+
+const mockQuery = jest.fn();
+const mockDb = { query: mockQuery } as unknown as import('pg').Pool;
+
+describe('recordAgentMetric', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('metrics_snapshots へ metric_name / tenant_id / labels / value を INSERT する', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    await recordAgentMetric(mockDb, {
+      metricName: 'agent_tool_invoked',
+      tenantId: 'tenant-abc',
+      labels: { tool: 'get_faq_list', outcome: 'ok' },
+      value: 1,
+    });
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const [sql, values] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).toContain('INSERT INTO metrics_snapshots');
+    expect(sql).toContain('(metric_name, tenant_id, labels, value)');
+    expect(values).toEqual([
+      'agent_tool_invoked',
+      'tenant-abc',
+      JSON.stringify({ tool: 'get_faq_list', outcome: 'ok' }),
+      1,
+    ]);
+  });
+
+  it('value にカウント以外の数値（ホップ数）も記録できる', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    await recordAgentMetric(mockDb, {
+      metricName: 'agent_turn_hops',
+      tenantId: 'tenant-abc',
+      labels: { hit_limit: false },
+      value: 3,
+    });
+
+    const [, values] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(values[2]).toBe(JSON.stringify({ hit_limit: false }));
+    expect(values[3]).toBe(3);
+  });
+
+  it('DB エラーは throw せず logger.warn に落とす', async () => {
+    mockQuery.mockRejectedValueOnce(new Error('relation "metrics_snapshots" does not exist'));
+
+    await expect(
+      recordAgentMetric(mockDb, {
+        metricName: 'agent_turn_completed',
+        tenantId: 'tenant-abc',
+        labels: { answered_from: 'general' },
+        value: 1,
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(logger.warn).toHaveBeenCalled();
+  });
+
+  it('tenantId が null（テナント未特定の super_admin）でも記録する', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    await recordAgentMetric(mockDb, {
+      metricName: 'agent_legacy_handoff',
+      tenantId: null,
+      labels: { feature: 'billing' },
+      value: 1,
+    });
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const [, values] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(values[1]).toBeNull();
+  });
+});

--- a/src/lib/metrics/agentMetrics.ts
+++ b/src/lib/metrics/agentMetrics.ts
@@ -1,0 +1,33 @@
+/**
+ * 管理AIエージェント（/copilot-preview）の挙動メトリクスを metrics_snapshots へ記録する。
+ *
+ * metric_name / labels / value の意味は docs/AGENT_METRICS.md が唯一の契約。
+ * 新しいテーブルは作らず、Phase72-D の汎用シンク metrics_snapshots を再利用する。
+ *
+ * 制約:
+ *   - fire-and-forget。失敗は logger.warn に落とすだけで呼び出し側へ投げない
+ *     （計測の失敗がチャット応答を壊してはならない）
+ *   - labels に PII を入れない（ユーザー自由入力・FAQ本文・顧客名などは渡さない）
+ */
+
+import type { Pool } from 'pg';
+import { logger } from '../logger';
+
+export interface AgentMetricInput {
+  metricName: string;
+  tenantId: string | null;
+  labels: Record<string, unknown>;
+  value: number;
+}
+
+export async function recordAgentMetric(db: Pool, input: AgentMetricInput): Promise<void> {
+  try {
+    await db.query(
+      `INSERT INTO metrics_snapshots (metric_name, tenant_id, labels, value)
+       VALUES ($1, $2, $3::jsonb, $4)`,
+      [input.metricName, input.tenantId, JSON.stringify(input.labels), input.value],
+    );
+  } catch (err) {
+    logger.warn('[agentMetrics] INSERT failed', err);
+  }
+}


### PR DESCRIPTION
Asana GID 1217007364382183

## なぜ

チャットファーストの管理UI(`/copilot-preview` / バックエンド `src/api/admin/agent/`)には、
**自身の挙動を測る仕組みが一切なかった**。そのため

- 旧UIへの案内(handoff)が何回起きているか
- 書き込みの確認ゲートで何回ブロックされているか
- 1ターンに何ホップのツール呼び出しを消費しているか

が分からず、チャットUIに関する製品判断(例:「この旧ダッシュボードのページは畳めるか」)を
数値ではなく勘で行うしかなかった。本PRは**計測の配線のみ**で、ダッシュボードや分析は含まない。

## 何をしたか

### 1. `docs/AGENT_METRICS.md`（命名契約・先に定義）

`metric_name` / `labels` / `value` の意味を確定させた。定義は以下の5つのみ。

| metric_name | labels | value |
| --- | --- | --- |
| `agent_tool_invoked` | `{ tool, outcome: ok\|blocked\|error }` | `1` |
| `agent_write_blocked` | `{ tool, reason: unconfirmed\|chain }` | `1` |
| `agent_turn_hops` | `{ hit_limit: boolean }` | そのターンで消費したホップ数 |
| `agent_legacy_handoff` | `{ feature }` | `1`（handoff率の**分子**) |
| `agent_turn_completed` | `{ answered_from }` | `1`（handoff率の**分母**) |

### 2. `src/lib/metrics/agentMetrics.ts`

既存の汎用シンク `metrics_snapshots`（Phase72-D、本番適用済み）へ1行INSERTするだけの
`recordAgentMetric(db, {...})`。**fire-and-forget**で、DB失敗は `logger.warn` に落とすのみ。
`labels` にPIIを入れない（ユーザー自由入力・FAQ本文・顧客名は渡さない。入るのは
ツール名とドキュメントで定義したenum値だけ）。

### 3. `src/api/admin/agent/agentRoutes.ts` に計測を追加

- ツール結果が `actions` に積まれる箇所で `agent_tool_invoked` を記録
- ターン完了の2箇所（JSON `res.json` と SSE `event: done`）で `agent_turn_hops` /
  `agent_turn_completed` を記録。ホップ数は既存のループ変数を巻き上げて再利用（新カウンタ追加なし）
- `get_legacy_ui_link` では追加で `agent_legacy_handoff` を記録

`actionExecutor.ts` の45個の `case` 分岐には**一切触っていない**。ブロック判定は結果文字列の
部分一致（フロントの `copilot-preview` が確認待ちUIの出し分けに使っているのと同じ規約）。

## レビューで見てほしい点

**ブロック判定の部分一致にフロントと同じ `確認が必要` ではなく `確認が必要です` を使っている。**
`get_embed_code` の**成功**メッセージが「再確認が必要な場合は新しいキーを発行してください」を
含むため（`actionExecutor.ts:513`）、`確認が必要` だと正常応答をブロックとして数えてしまう。
実際のブロック文言はすべて「〜には確認が必要です」の形なので `です` まで含めれば誤検出しない。
（フロント側の既存判定は今回のスコープ外のため変更していない）

## テスト

- `src/lib/metrics/agentMetrics.test.ts`（新規4件）: 行形状 / DBエラーの握りつぶし / `tenantId=null`
- `src/api/admin/agent/agentRoutes.test.ts`（既存スイートに追加）: `outcome=ok` / `blocked`+`unconfirmed` /
  `chain` / `legacy_handoff` の feature ラベル（未定義値は `unknown` に丸め） / JSON・SSE両経路の
  ターン完了 / **`recordAgentMetric` が throw・reject しても 200 と reply を返す**
- 既存の約3600行のアサーションは**1行も変更していない**（挙動変更ゼロの純粋な追加計測）

```
npx jest src/api/admin/agent/agentRoutes.test.ts  → 152 passed
npx jest src/lib/metrics                          → 10 passed
npm run lint                                      → exit 0（警告59件、変更ファイルからの新規警告0）
npx tsc --noEmit                                  → clean
git diff origin/main -- '*.sql' '.env*' 'package.json' → 空（マイグレーション/環境変数/依存の追加なし）
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177MCsC7jN3a51F7TdaW9vH