### PR TITLE
refactor(agent): 書き込みツールのリスク階層表を confirmPolicy.ts に一元化(挙動不変)

### DIFF
--- a/src/api/admin/agent/agentRoutes.ts
+++ b/src/api/admin/agent/agentRoutes.ts
@@ -8,6 +8,7 @@ import { supabaseAuthMiddleware } from '../../../admin/http/supabaseAuthMiddlewa
 import { logger } from '../../../lib/logger';
 import { ADMIN_AGENT_TOOLS } from './toolDefinitions';
 import { executeToolCall } from './actionExecutor';
+import { requiresConfirmation } from './confirmPolicy';
 import { trackUsage } from '../../../lib/billing/usageTracker';
 import { GROQ_VERSATILE_70B } from '../../../config/groqModels';
 import { isUnanswered } from '../ai-assist/systemPrompt';
@@ -233,8 +234,15 @@ async function executeHopToolCalls(
       .map(([suggest]) => suggest);
     const alreadySuggestedThisTurn = suggestCounterparts.some((s) => suggestedThisTurn.has(s));
 
+    // 同一ターン連鎖のブロックは「確認ゲートの対象ツール」にのみ効かせる。
+    // 対象かどうかの判定は confirmPolicy.ts に集約する（リスク階層の単一の情報源）。
+    // requiresConfirmation は分類済みの書き込みツールすべてに対して true を返すため、
+    // ここでの判定結果は従来と完全に同一（挙動不変）。未分類ツールでは例外を投げるが、
+    // 短絡評価により連鎖を検出した save 側ツールしか渡らない。
+    const blockSameTurnChain = alreadySuggestedThisTurn && requiresConfirmation(name);
+
     let result: string;
-    if (alreadySuggestedThisTurn) {
+    if (blockSameTurnChain) {
       // 同一ターン内で suggest → save が連鎖しようとしている: 人間の確認を経ていないためブロック
       result = 'この保存は同一ターン内での連続実行のため確認をスキップできません。提案内容を確認のうえ、あらためて「保存して」等のメッセージを送ってください。';
     } else {

--- a/src/api/admin/agent/confirmPolicy.test.ts
+++ b/src/api/admin/agent/confirmPolicy.test.ts
@@ -1,0 +1,170 @@
+// src/api/admin/agent/confirmPolicy.test.ts
+//
+// 主眼は「登録漏れの検出」。toolDefinitions.ts に新しいツールが増えたのに
+// confirmPolicy.ts で分類されていない、という取りこぼしで落ちるようにする。
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { ADMIN_AGENT_TOOLS } from './toolDefinitions';
+import { WRITE_TOOL_RISK_TIERS, NON_WRITE_TOOLS, requiresConfirmation, type RiskTier } from './confirmPolicy';
+
+const ALL_TOOL_NAMES = ADMIN_AGENT_TOOLS.map((t) => t.function.name);
+
+describe('confirmPolicy: リスク階層表の網羅性', () => {
+  it('toolDefinitions.ts の全ツールが「書き込み(階層付き)」か「非書き込み」のどちらかに分類されている', () => {
+    const classified = new Set([...Object.keys(WRITE_TOOL_RISK_TIERS), ...NON_WRITE_TOOLS]);
+    const unclassified = ALL_TOOL_NAMES.filter((name) => !classified.has(name));
+    expect(unclassified).toEqual([]);
+  });
+
+  it('分類表に、存在しないツール名が残っていない', () => {
+    const known = new Set(ALL_TOOL_NAMES);
+    const stale = [...Object.keys(WRITE_TOOL_RISK_TIERS), ...NON_WRITE_TOOLS].filter((name) => !known.has(name));
+    expect(stale).toEqual([]);
+  });
+
+  it('同じツールが書き込み表と非書き込み表の両方に入っていない', () => {
+    const both = NON_WRITE_TOOLS.filter((name) => name in WRITE_TOOL_RISK_TIERS);
+    expect(both).toEqual([]);
+  });
+
+  it('全ツールが分類表のいずれか一方だけで数え上げられる', () => {
+    expect(Object.keys(WRITE_TOOL_RISK_TIERS).length + NON_WRITE_TOOLS.length).toBe(ALL_TOOL_NAMES.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// actionExecutor.ts のソースを機械的に読み、書き込みを行っている case を検出する。
+// 手で写した一覧は必ず腐るため、実装側の変化（読み取り専用ツールが書き込みを
+// 始めた等）をここで拾えるようにしておく。
+// ---------------------------------------------------------------------------
+
+const EXECUTOR_SOURCE = readFileSync(join(__dirname, 'actionExecutor.ts'), 'utf8');
+
+// 行コメントを落とす。コメント内の "INSERT経路" のような記述を書き込みとして
+// 誤検出しないため（文字列内の "https://" も潰れるが、キーワード検出には無害）。
+const EXECUTOR_CODE = EXECUTOR_SOURCE.split('\n')
+  .map((line) => line.replace(/\/\/.*$/, ''))
+  .join('\n');
+
+// 書き込みの目印: 生SQLと、書き込みを担う既知のヘルパ関数。
+const MUTATION_PATTERNS: RegExp[] = [
+  /\bINSERT\s+INTO\b/i,
+  /\bUPDATE\s+[a-z_]+\s+SET\b/i,
+  /\bDELETE\s+FROM\b/i,
+  /\bcreateRule\(/,
+  /\bupdateRule\(/,
+  /\bdeleteRule\(/,
+  /\bupdateGapStatus\(/,
+  /\bsaveMessage\(/,
+  /\bresolveEscalation\(/,
+  /\bsubmitSaiTask\(/,
+  /\bactivateAvatarConfig\(/,
+  /\bcommitTextFaqs\(/,
+  /\bcommitScrapeFaqs\(/,
+];
+
+/** executeToolCall の switch を case ごとに切り、書き込みを行っているツール名を返す。 */
+function detectMutatingToolsFromExecutor(): Set<string> {
+  const toolNames = new Set(ALL_TOOL_NAMES);
+  const caseRe = /case '([a-z_0-9]+)':/g;
+  const boundaries: Array<{ name: string; start: number }> = [];
+
+  for (let m = caseRe.exec(EXECUTOR_CODE); m !== null; m = caseRe.exec(EXECUTOR_CODE)) {
+    boundaries.push({ name: m[1]!, start: m.index });
+  }
+
+  const mutating = new Set<string>();
+  // switch 内には result.reason に対する入れ子の case もあるため、
+  // ツール名の case を見つけたときだけ帰属先を更新する。
+  let owner: string | null = null;
+
+  for (let i = 0; i < boundaries.length; i++) {
+    const { name, start } = boundaries[i]!;
+    if (toolNames.has(name)) owner = name;
+    if (owner === null) continue;
+
+    const end = i + 1 < boundaries.length ? boundaries[i + 1]!.start : EXECUTOR_CODE.length;
+    const body = EXECUTOR_CODE.slice(start, end);
+    if (MUTATION_PATTERNS.some((re) => re.test(body))) mutating.add(owner);
+  }
+
+  return mutating;
+}
+
+describe('confirmPolicy: actionExecutor.ts の実装との突き合わせ', () => {
+  const mutating = detectMutatingToolsFromExecutor();
+
+  it('書き込みを行っている case はすべてリスク階層表に登録されている', () => {
+    const missing = [...mutating].filter((name) => !(name in WRITE_TOOL_RISK_TIERS));
+    expect(missing).toEqual([]);
+  });
+
+  it('リスク階層表と実装側の書き込み一覧が完全に一致する', () => {
+    // 片側に寄せた subset ではなく厳密一致で見る。ここが落ちる場合は
+    // (a) 表に古いエントリが残っている、または
+    // (b) 新しい書き込みヘルパを使い始めたので MUTATION_PATTERNS に追加が必要、のどちらか。
+    expect([...mutating].sort()).toEqual(Object.keys(WRITE_TOOL_RISK_TIERS).sort());
+  });
+
+  it('非書き込みとして分類したツールが実際には書き込んでいない', () => {
+    const contradictions = NON_WRITE_TOOLS.filter((name) => mutating.has(name));
+    expect(contradictions).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// フロントの REAL_WRITE_TOOLS（実書き込み回数のカウント対象）との突き合わせ。
+// 双方が独立に「書き込みツール一覧」を持っているため、片方だけ増えるのを防ぐ。
+// ---------------------------------------------------------------------------
+
+function readFrontendRealWriteTools(): string[] {
+  const path = join(__dirname, '../../../../admin-ui/src/pages/copilot-preview/index.tsx');
+  const source = readFileSync(path, 'utf8');
+  const block = source.match(/const REAL_WRITE_TOOLS = new Set\(\[([\s\S]*?)\]\)/);
+  if (!block) {
+    throw new Error(`REAL_WRITE_TOOLS not found in ${path} — 名称かファイル位置が変わった場合はこのテストも更新する`);
+  }
+  return [...block[1]!.matchAll(/["']([a-z_0-9]+)["']/g)].map((m) => m[1]!);
+}
+
+describe('confirmPolicy: フロントの REAL_WRITE_TOOLS との突き合わせ', () => {
+  it('フロントが書き込みと見なしているツールはすべてリスク階層表に登録されている', () => {
+    const missing = readFrontendRealWriteTools().filter((name) => !(name in WRITE_TOOL_RISK_TIERS));
+    expect(missing).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// requiresConfirmation の挙動（本タスクの時点では階層によらず一律 true）
+// ---------------------------------------------------------------------------
+
+describe('requiresConfirmation', () => {
+  const samples: Array<[RiskTier, string]> = [
+    ['low', 'set_ga4_id'],
+    ['low', 'dismiss_knowledge_gap'],
+    ['medium', 'save_faq'],
+    ['medium', 'update_engagement_rule'],
+    ['high', 'delete_faq'],
+    ['high', 'request_sai_task'],
+  ];
+
+  it.each(samples)('%s の %s も確認ゲートの対象（階層による緩和はしない）', (tier, tool) => {
+    expect(WRITE_TOOL_RISK_TIERS[tool]).toBe(tier);
+    expect(requiresConfirmation(tool)).toBe(true);
+  });
+
+  it('分類済みの書き込みツールすべてで true を返す', () => {
+    for (const tool of Object.keys(WRITE_TOOL_RISK_TIERS)) {
+      expect(requiresConfirmation(tool)).toBe(true);
+    }
+  });
+
+  it('未分類のツール名は黙って false にせず例外を投げる', () => {
+    expect(() => requiresConfirmation('brand_new_write_tool')).toThrow('Unclassified write tool: brand_new_write_tool');
+  });
+
+  it('読み取り専用ツールも階層表には無いため例外になる（誤用の検出）', () => {
+    expect(() => requiresConfirmation('get_faq_list')).toThrow('Unclassified write tool: get_faq_list');
+  });
+});

--- a/src/api/admin/agent/confirmPolicy.ts
+++ b/src/api/admin/agent/confirmPolicy.ts
@@ -1,0 +1,112 @@
+// src/api/admin/agent/confirmPolicy.ts
+//
+// 書き込み系ツールのリスク階層表（単一の情報源）。
+//
+// 【現時点での役割】
+// このモジュールは「分類」だけを行い、確認（confirmed）ゲートの挙動は一切変えない。
+// requiresConfirmation() は階層に関わらず常に true を返す。低リスクなら確認を省く、
+// といった緩和はプロダクト判断が済んでいないため実装しない（将来の別タスク）。
+//
+// 【いま置く理由】
+// 1. リスク階層の判断を1か所に集約し、レビュー可能な形で残す。
+// 2. toolDefinitions.ts に新しいツールが追加されたのに未分類のまま、という
+//    取りこぼしを confirmPolicy.test.ts が機械的に検出できるようにする。
+//    （この表は「網羅」が価値なので、読み取り専用ツールも NON_WRITE_TOOLS に
+//    明示列挙し、全ツールがどちらかに属することをテストで保証する）
+
+export type RiskTier = 'low' | 'medium' | 'high';
+
+// 階層の定義:
+//   low    … 単一の設定値/フラグの切り替え。コンテンツの生成も破棄もせず、
+//            元の値を入れ直せば完全に元の状態へ戻る。
+//   medium … 永続コンテンツ（顧客が目にしうる実体）を作成・変更する。
+//            原理的には戻せるが、内容を作り直す必要がある。
+//   high   … 永続データを不可逆に破棄する / 課金が発生する /
+//            エンドユーザーや外部システムへ何かを送出する。
+export const WRITE_TOOL_RISK_TIERS: Record<string, RiskTier> = {
+  // --- low: 設定値・フラグの切り替え ---
+  set_ga4_id: 'low',
+  set_posthog: 'low',
+  set_widget_theme: 'low',
+  activate_avatar: 'low',
+  // 社内向け分析レコードのステータス変更のみ。顧客影響なし・再度拾い直せる。
+  dismiss_knowledge_gap: 'low',
+
+  // --- medium: 永続コンテンツの作成・変更 ---
+  add_faq: 'medium',
+  update_faq: 'medium',
+  save_faq: 'medium',
+  commit_faq_import: 'medium',
+  import_industry_faq_templates: 'medium',
+  save_tuning_rule: 'medium',
+  update_tuning_rule: 'medium',
+  save_engagement_rule: 'medium',
+  update_engagement_rule: 'medium',
+  // 名前からは設定変更に見えるが、採用した文面はそのまま顧客への回答に使われる。
+  // remove_approved_response で戻せるものの、文面の作り直しが必要なため medium。
+  approve_tuning_rule_response: 'medium',
+  // 採用済み文面の削除。対象は配列の1要素で approve_ し直せるが、
+  // 元の文面自体は失われるため low ではなく medium に置く。
+  remove_approved_response: 'medium',
+
+  // --- high: 不可逆な破棄 / 課金 / 外部送出 ---
+  delete_faq: 'high',
+  delete_tuning_rule: 'high',
+  delete_engagement_rule: 'high',
+  // 顧客の画面に有人返信として表示される（取り消し手段がない）。
+  reply_to_escalation: 'high',
+  // 返信待ちの顧客対応を打ち切りエスカレーション一覧から外す。状態変更ではあるが
+  // 待たせている顧客が取りこぼされる影響が大きいため保守的に high。
+  resolve_escalation: 'high',
+  // 外部エージェント(Sai)へのタスク投入 + 従量課金が発生する。
+  request_sai_task: 'high',
+};
+
+// 書き込みを伴わないツール。DBへの書き込みも外部への副作用のある送出も行わない。
+// （網羅性テストのために明示列挙する。新規ツールはここか上の表のどちらかへ必ず追加する）
+export const NON_WRITE_TOOLS: readonly string[] = [
+  'get_tenant_settings',
+  'get_faq_list',
+  'get_avatar_status',
+  'get_embed_code',
+  'get_tuning_rules',
+  'get_weekly_briefing',
+  'get_knowledge_gaps',
+  'get_engagement_rules',
+  'get_chat_sessions',
+  'get_chat_session_messages',
+  'get_escalations',
+  'get_monitoring_summary',
+  'get_sai_task_status',
+  'get_legacy_ui_link',
+  'get_analytics_summary',
+  'get_conversion_summary',
+  // suggest_* / generate_* はLLMを呼ぶため課金は発生するが、永続化はしない下書き生成。
+  'suggest_tuning_rule',
+  'suggest_faq',
+  'suggest_engagement_rule',
+  'generate_tuning_rule_test_responses',
+  // 一括取り込みのプレビュー。結果は knowledgeImportStaging のプロセス内Mapに
+  // 一時保存されるだけで、DBへは commit_faq_import まで何も書かない。
+  // from_urls は外部URLへGETするが、相手側を変更しない読み取りアクセス。
+  'suggest_faq_import_from_text',
+  'suggest_faq_import_from_urls',
+  // 上記プレビューのプロセス内Mapを消すだけ（DBは触らない）。
+  'discard_faq_import',
+];
+
+/**
+ * このツールが確認（confirmed）ゲートの対象かどうか。
+ *
+ * 現時点では分類済みの書き込みツールすべてに対して階層を問わず true を返す
+ * （挙動不変が本モジュール導入時の要件）。tier を参照した緩和は意図的に未実装。
+ *
+ * 未分類のツール名は黙って false に倒さず例外にする。これにより
+ * 「新しい書き込みツールを追加したが分類し忘れた」を実行時・テスト時に検出できる。
+ */
+export function requiresConfirmation(toolName: string): boolean {
+  if (!(toolName in WRITE_TOOL_RISK_TIERS)) {
+    throw new Error(`Unclassified write tool: ${toolName}`);
+  }
+  return true;
+}


### PR DESCRIPTION
## 目的（Asana GID 1217007387468193）

チャットエージェントの書き込みツールは現在すべて同じ重みで確認（confirmed）ゲートにかかる。将来「本当に低リスクな操作は確認を省く」を検討できるようにするため、**リスク階層の分類だけ**を先に一元化する。

**このPRは挙動完全不変**。緩和は一切実装していない（プロダクト判断が未了のため）。`requiresConfirmation()` は分類済みの書き込みツールすべてに対して、階層を問わず `true` を返す。

得られるもの:
- (a) リスク階層を人間がレビューできる形で1か所に置く
- (b) `toolDefinitions.ts` に新しい書き込みツールが増えたのに未分類、という取りこぼしでテストが落ちる安全網

## リスク階層表

階層の定義（`confirmPolicy.ts` 冒頭にも記載）:

| 階層 | 定義 |
|---|---|
| `low` | 単一の設定値/フラグの切り替え。コンテンツの生成も破棄もせず、元の値を入れ直せば完全に元の状態へ戻る |
| `medium` | 永続コンテンツ（顧客が目にしうる実体）を作成・変更する。原理的には戻せるが内容の作り直しが必要 |
| `high` | 永続データを不可逆に破棄する / 課金が発生する / エンドユーザーや外部システムへ何かを送出する |

書き込みツール **22件**:

| ツール | 階層 | 書き込み内容 | confirmedゲート(既存) |
|---|---|---|---|
| `set_ga4_id` | low | `UPDATE tenants.ga4_measurement_id` | なし |
| `set_posthog` | low | `UPDATE tenants.posthog_host` | なし |
| `set_widget_theme` | low | `UPDATE tenants.widget_theme` | なし |
| `activate_avatar` | low | `UPDATE avatar_configs.is_active` + `tenants.features` | なし |
| `dismiss_knowledge_gap` | low | `updateGapStatus(dismissed)` | あり |
| `add_faq` | medium | `INSERT faq_docs` | なし |
| `update_faq` | medium | `UPDATE faq_docs` + embeddings削除 | なし |
| `save_faq` | medium | `INSERT faq_docs` | あり |
| `commit_faq_import` | medium | `commitTextFaqs` / `commitScrapeFaqs`（最大20件一括INSERT） | あり |
| `import_industry_faq_templates` | medium | 業種テンプレ一括`INSERT` + `tenants.onboarding_*` | あり |
| `save_tuning_rule` | medium | `createRule` | あり |
| `update_tuning_rule` | medium | `updateRule` | あり |
| `save_engagement_rule` | medium | `INSERT trigger_rules` | あり |
| `update_engagement_rule` | medium | `UPDATE trigger_rules` | あり |
| `approve_tuning_rule_response` | medium | `updateRule(approved_responses)` | あり |
| `remove_approved_response` | medium | `updateRule(approved_responses)` | あり |
| `delete_faq` | high | `DELETE faq_docs` + embeddings | あり |
| `delete_tuning_rule` | high | `deleteRule` | あり |
| `delete_engagement_rule` | high | `DELETE trigger_rules` | あり |
| `reply_to_escalation` | high | `saveMessage(role=operator)` | あり |
| `resolve_escalation` | high | `resolveEscalation` | あり |
| `request_sai_task` | high | `submitSaiTask`（外部 + 従量課金） | あり |

### 名前から自明でない判断（レビューしてほしい点）

- **`approve_tuning_rule_response` → medium**（タスク文の想定は low）。名前は「承認」だが、採用した文面はそのまま顧客への回答に使われる。`remove_approved_response` で戻せるものの文面の作り直しが必要なので、`low`（値を入れ直せば完全復旧）の定義に当てはまらない。
- **`remove_approved_response` → medium**（タスク文の想定は low）。`remove_*` だが実質は永続コンテンツの削除。対象が配列1要素で再approveできるため `high` ではないが、元の文面自体は失われる。
- **`resolve_escalation` → high**。DB上は状態変更だけで `dismiss_knowledge_gap`（low）と似るが、返信待ちの顧客対応を打ち切って一覧から外すため、取りこぼしの影響を重く見て保守的に high。
- **`dismiss_knowledge_gap` → low**。社内向け分析レコードのステータス変更のみ。顧客影響なし。
- **`activate_avatar` → low**。プラン制限チェックは通るが、実体は `is_active` フラグ。

### 非書き込みとして分類したもの（23件）

`get_*` 16件のほか、以下を非書き込みに置いた（`NON_WRITE_TOOLS` に明示列挙し、全45ツールがどちらかに属することをテストで保証）:

- `suggest_tuning_rule` / `suggest_faq` / `suggest_engagement_rule` / `generate_tuning_rule_test_responses` — LLMを呼ぶため課金は発生するが永続化しない下書き生成
- `suggest_faq_import_from_text` / `suggest_faq_import_from_urls` — 結果は `knowledgeImportStaging` のプロセス内Mapに一時保存されるだけで、DBへは `commit_faq_import` まで何も書かない。`from_urls` は外部URLへGETするが相手側を変更しない読み取りアクセス
- `discard_faq_import` — 上記プレビューのプロセス内Mapを消すだけ（既存実装も「DBへの書き込みは何もしていない」ため意図的にconfirmedゲート無し）

## `REAL_WRITE_TOOLS`（フロント）との差分

`admin-ui/src/pages/copilot-preview/index.tsx` の `REAL_WRITE_TOOLS` は **14件**で、本PRの階層表 **22件**の真部分集合。**矛盾はない**（フロントが書き込みと見なすものは全て階層表にある）が、フロント側に **8件の取りこぼし**がある:

`update_tuning_rule` / `delete_tuning_rule` / `approve_tuning_rule_response` / `remove_approved_response` / `dismiss_knowledge_gap` / `update_engagement_rule` / `delete_engagement_rule` / `request_sai_task`

これらは実際にDBを書き換える（`request_sai_task` は外部+課金）が、`REAL_WRITE_TOOLS` に無いため `/copilot-preview` の「実アクション回数」カウンタに計上されていない。**本PRのスコープ外なので修正していない**（挙動不変が要件）。カウンタ表示の精度の問題であり、確認ゲート自体には影響しない。別タスクで拾う候補。

## 実装

- **新規** `src/api/admin/agent/confirmPolicy.ts` — `RiskTier` / `WRITE_TOOL_RISK_TIERS` / `NON_WRITE_TOOLS` / `requiresConfirmation()`。未分類のツール名は黙って `false` に倒さず `Unclassified write tool: ${toolName}` を投げる（これが登録漏れ検出を意味あるものにしている）。階層を参照した緩和ロジックは意図的に未実装。
- **新規** `src/api/admin/agent/confirmPolicy.test.ts` — 17件。
  - `actionExecutor.ts` のソースを読み、`case` ごとに書き込みSQL／既知の書き込みヘルパ（`createRule` `updateRule` `deleteRule` `updateGapStatus` `saveMessage` `resolveEscalation` `submitSaiTask` `activateAvatarConfig` `commitTextFaqs` `commitScrapeFaqs`）を機械的に検出し、階層表と**厳密一致**することを検証。手で写した一覧ではないので腐らない。行コメントは除去してから判定（`add_faqと同じINSERT経路` のようなコメントの誤検出を避けるため）。
  - `toolDefinitions.ts` の全45ツールが「書き込み(階層付き)」「非書き込み」のいずれか一方に必ず属することを検証 → **新規ツールを分類し忘れると落ちる**
  - フロントの `REAL_WRITE_TOOLS` を正規表現で抽出し、階層表の部分集合であることを検証
  - `requiresConfirmation` が3階層すべてで `true`、未分類名で例外
- **変更** `src/api/admin/agent/agentRoutes.ts`（+9/-1）— `executeHopToolCalls` の suggest→save 同一ターン連鎖ブロックで、「このツールは確認ゲートの対象か」の判定を `requiresConfirmation(name)` 経由にした。

```ts
const blockSameTurnChain = alreadySuggestedThisTurn && requiresConfirmation(name);
```

`confirmed` の実チェックは既存どおり `actionExecutor.ts` の各 `case` 内にあり（45個のcase本体は未変更）、agentRoutes側にツール単位の確認判定は元々存在しなかったため、論理的に対応する既存の判定点＝連鎖ブロックに配線した。短絡評価により `requiresConfirmation` は連鎖を検出した save 側ツール（すべて分類済み）にしか到達せず、未分類例外が本番経路に出ることはない。**ブロック時の応答文面は一切変更していない**（フロントが「確認が必要」「確認をスキップできません」の部分一致に依存）。

## 検証

| 項目 | 結果 |
|---|---|
| `npm run lint` | exit 0（新規ファイル由来の警告 0件、既存の警告予算 63 も未変更） |
| `npx tsc --noEmit` | pass |
| `npx jest src/api/admin/agent/agentRoutes.test.ts` | **変更前 150 passed → 変更後 150 passed**。既存アサーションの変更は **0件**（`agentRoutes.test.ts` は1行も触っていない） |
| `npx jest src/api/admin/agent/confirmPolicy.test.ts` | 17 passed |
| `git diff --stat origin/main -- '*.sql' '.env*' 'package.json'` | 空 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177MCsC7jN3a51F7TdaW9vH
