### PR TITLE
fix(admin-ui): 新UIコンポーザのIME誤送信と保留チップの取り残しを直す

### DIFF
--- a/admin-ui/src/components/AdminAgent/AdminAgentPanel.tsx
+++ b/admin-ui/src/components/AdminAgent/AdminAgentPanel.tsx
@@ -5,6 +5,7 @@ import AdminAgentMessage from "./AdminAgentMessage";
 import FeedbackPrompt from "./FeedbackPrompt";
 import ReplyCard from "./ReplyCard";
 import { submitConsultation, type FeedbackReply } from "./useFeedbackReplies";
+import { shouldSubmitOnEnter } from "../../lib/utils";
 
 interface AdminAgentPanelProps {
   isOpen: boolean;
@@ -81,13 +82,7 @@ export default function AdminAgentPanel({
   }, [onMarkReplyRead]);
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
-    if (
-      e.key === "Enter" &&
-      !e.shiftKey &&
-      !e.nativeEvent.isComposing &&
-      !isComposing &&
-      e.nativeEvent.keyCode !== 229
-    ) {
+    if (shouldSubmitOnEnter(e, isComposing)) {
       e.preventDefault();
       void handleSend();
     }

--- a/admin-ui/src/lib/utils.test.ts
+++ b/admin-ui/src/lib/utils.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import type { KeyboardEvent } from "react";
+import { shouldSubmitOnEnter } from "./utils";
+
+// KeyboardEvent の実体を作らず、判定に使うプロパティだけを持つ最小のモックで検証する
+// (IMEの変換中状態は happy-dom では忠実に再現できないため、条件そのものを直接叩く)。
+function keyEvent(
+  key: string,
+  opts: { shiftKey?: boolean; isComposing?: boolean; keyCode?: number } = {},
+): KeyboardEvent {
+  return {
+    key,
+    shiftKey: opts.shiftKey ?? false,
+    nativeEvent: {
+      isComposing: opts.isComposing ?? false,
+      keyCode: opts.keyCode ?? 13,
+    },
+  } as unknown as KeyboardEvent;
+}
+
+describe("shouldSubmitOnEnter (IMEガード)", () => {
+  it("素のEnterは送信する", () => {
+    expect(shouldSubmitOnEnter(keyEvent("Enter"), false)).toBe(true);
+  });
+
+  it("nativeEvent.isComposing が true(変換中)なら送信しない", () => {
+    expect(shouldSubmitOnEnter(keyEvent("Enter", { isComposing: true }), false)).toBe(false);
+  });
+
+  it("nativeEvent.isComposing が false でも isComposing 引数が true なら送信しない(冗長な保険)", () => {
+    expect(shouldSubmitOnEnter(keyEvent("Enter", { isComposing: false }), true)).toBe(false);
+  });
+
+  it("keyCode === 229(isComposingを立てない旧/モバイルIME)なら送信しない", () => {
+    expect(shouldSubmitOnEnter(keyEvent("Enter", { keyCode: 229 }), false)).toBe(false);
+  });
+
+  it("Shift+Enterは送信しない(改行として通す)", () => {
+    expect(shouldSubmitOnEnter(keyEvent("Enter", { shiftKey: true }), false)).toBe(false);
+  });
+
+  it("Enter以外のキーは送信しない", () => {
+    expect(shouldSubmitOnEnter(keyEvent("a"), false)).toBe(false);
+  });
+});

--- a/admin-ui/src/lib/utils.ts
+++ b/admin-ui/src/lib/utils.ts
@@ -1,6 +1,24 @@
 import { clsx, type ClassValue } from "clsx";
 import { twMerge } from "tailwind-merge";
+import type { KeyboardEvent } from "react";
 
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
+}
+
+// 日本語入力(IME)中のEnterはかな漢字変換の確定であり、送信であってはならない。
+// 4つの条件はそれぞれ別のブラウザ差異を塞いでいるため、1つも省略できない:
+//   - e.nativeEvent.isComposing: 標準の変換中フラグ
+//   - isComposing (React state): nativeEvent が遅れて false になるブラウザ向けの保険
+//     (onCompositionStart/End で管理する)
+//   - keyCode === 229: isComposing を立てない古い/モバイルIMEが送る変換中キーコード
+//   - !e.shiftKey: Shift+Enter は改行として通す
+export function shouldSubmitOnEnter(e: KeyboardEvent, isComposing: boolean): boolean {
+  return (
+    e.key === "Enter" &&
+    !e.shiftKey &&
+    !e.nativeEvent.isComposing &&
+    !isComposing &&
+    e.nativeEvent.keyCode !== 229
+  );
 }

--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -325,3 +325,130 @@ describe("CopilotPreviewPage — 旧UI案内リンクカード", () => {
     expect(screen.getByText("別タブで開きます。この会話はそのまま残ります。")).toBeTruthy();
   });
 });
+
+function getComposer(): HTMLTextAreaElement {
+  return screen.getByPlaceholderText(/指示ルール/) as HTMLTextAreaElement;
+}
+
+// 想定ユーザーは100%日本語入力の店主。かな漢字変換の確定Enterで未変換のまま
+// 送信されてしまう不具合の回帰テスト(判定条件自体は lib/utils.test.ts で検証済み)。
+describe("CopilotPreviewPage — コンポーザのIME/改行", () => {
+  beforeEach(() => {
+    vi.mocked(authFetch).mockReset();
+    mockNavigate.mockReset();
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (String(url).includes("/v1/admin/my-tenant")) {
+        return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
+      }
+      return mockOk({ reply: "了解しました。", actions: [] });
+    });
+    // タイプライター演出を無効化して応答を同期的に確定させる
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: true,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  });
+
+  it("IME変換中(compositionStart後)のEnterでは送信しない", async () => {
+    renderPage();
+    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
+
+    const composer = getComposer();
+    fireEvent.compositionStart(composer);
+    fireEvent.change(composer, { target: { value: "そうりょう" } });
+
+    const callsBefore = vi.mocked(authFetch).mock.calls.length;
+    fireEvent.keyDown(composer, { key: "Enter" });
+
+    expect(vi.mocked(authFetch).mock.calls.length).toBe(callsBefore);
+    expect(composer.value).toBe("そうりょう");
+  });
+
+  it("変換確定後(compositionEnd後)のEnterでは送信する", async () => {
+    renderPage();
+    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
+
+    const composer = getComposer();
+    fireEvent.compositionStart(composer);
+    fireEvent.change(composer, { target: { value: "送料を教えて" } });
+    fireEvent.compositionEnd(composer);
+    fireEvent.keyDown(composer, { key: "Enter" });
+
+    await waitFor(() => expect(screen.getByText("送料を教えて")).toBeTruthy());
+    expect(getComposer().value).toBe("");
+  });
+
+  it("Shift+Enterでは送信しない(改行のため)", async () => {
+    renderPage();
+    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
+
+    const composer = getComposer();
+    fireEvent.change(composer, { target: { value: "1行目" } });
+
+    const callsBefore = vi.mocked(authFetch).mock.calls.length;
+    fireEvent.keyDown(composer, { key: "Enter", shiftKey: true });
+
+    expect(vi.mocked(authFetch).mock.calls.length).toBe(callsBefore);
+    expect(composer.value).toBe("1行目");
+  });
+});
+
+// GID 1217007364341838: 下書き提案のチップ(保存して/やめておく)を押さずに別の話題を
+// 打った場合、未使用のチップが宙ぶらりんで残り、新しい応答の隣に古い選択肢が並んでいた。
+// 入力欄は塞がない(=チップを無視して打てる)まま、送信時にチップを使用済みにする。
+describe("CopilotPreviewPage — 保留中の下書きチップを無視して送信", () => {
+  beforeEach(() => {
+    vi.mocked(authFetch).mockReset();
+    mockNavigate.mockReset();
+    let agentCalls = 0;
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (String(url).includes("/v1/admin/my-tenant")) {
+        return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
+      }
+      agentCalls += 1;
+      if (agentCalls === 1) return mockOk({ reply: "今週も順調です。", actions: [] });
+      if (agentCalls === 2) {
+        return mockOk({
+          reply: "こんな内容でどうでしょう？",
+          actions: [{ tool: "suggest_faq", result: "質問: 送料はいくら？\n回答: 全国一律550円です。\n分類: 配送" }],
+        });
+      }
+      return mockOk({ reply: "承知しました。", actions: [] });
+    });
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: true,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  });
+
+  it("チップを押さず自由入力を送ると、チップは使用済みになり新しいメッセージが送信される", async () => {
+    renderPage();
+    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
+
+    fireEvent.change(getComposer(), { target: { value: "送料のFAQを作って" } });
+    fireEvent.click(screen.getByLabelText("送信"));
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "保存して" })).toBeTruthy());
+    // チップ待ちでも入力欄は塞がない(「やっぱりいいです」と打てる)
+    expect(getComposer().disabled).toBe(false);
+
+    fireEvent.change(getComposer(), { target: { value: "やっぱりやめて、営業時間を教えて" } });
+    fireEvent.click(screen.getByLabelText("送信"));
+
+    await waitFor(() => expect(screen.getByText("やっぱりやめて、営業時間を教えて")).toBeTruthy());
+    expect(screen.queryByRole("button", { name: "保存して" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "やめておく" })).toBeNull();
+  });
+});

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -14,6 +14,7 @@ import { useNavigate } from "react-router-dom";
 import { LogOut } from "lucide-react";
 import { authFetch, API_BASE } from "../../lib/api";
 import { isChatFirstDefaultEnabled, setChatFirstDefaultEnabled } from "../../lib/chatFirstDefault";
+import { shouldSubmitOnEnter } from "../../lib/utils";
 import { useAuth } from "../../auth/useAuth";
 import { ONBOARDING_INDUSTRIES } from "../../components/onboarding/industryFaqTemplates";
 import { PREVIEW_MODE_BANNER_HEIGHT } from "../../components/PreviewModeBanner";
@@ -249,6 +250,7 @@ export default function CopilotPreviewPage() {
   const navigate = useNavigate();
   const [active, setActive] = useState("assistant");
   const [input, setInput] = useState("");
+  const [isComposing, setIsComposing] = useState(false);
   // モバイル用: 左レール(ドロワー)の開閉状態。デスクトップでは未使用(CSSで常時表示)。
   const [railOpen, setRailOpen] = useState(false);
   // 起動直後は空。bootstrap()が実データの週次ブリーフィングを積む
@@ -259,6 +261,22 @@ export default function CopilotPreviewPage() {
   const [realHistory, setRealHistory] = useState<{ role: "user" | "assistant"; content: string }[]>([]);
   const [sending, setSending] = useState(false);
   const [realActionCount, setRealActionCount] = useState(0); // 実際に成功した書き込み操作の件数
+
+  // textareaは行が増えても自動では伸びないため、入力量に応じて高さを合わせる
+  // (伸ばさないと2行目以降を打った時に前の行が枠外へ隠れてしまう)
+  const composerRef = useRef<HTMLTextAreaElement>(null);
+  useEffect(() => {
+    const el = composerRef.current;
+    if (!el) return;
+    // 空の時は rows=1 の高さ(=きっちり1行)に戻す。高さを明示すると、Chromeでは
+    // 長いplaceholderの折り返しがscrollHeightに乗って未入力でも枠が伸びてしまう
+    if (!input) {
+      el.style.height = "";
+      return;
+    }
+    el.style.height = "auto";
+    el.style.height = `${Math.min(el.scrollHeight, 140)}px`;
+  }, [input]);
 
   const threadRef = useRef<HTMLDivElement>(null);
   useEffect(() => {
@@ -495,8 +513,19 @@ export default function CopilotPreviewPage() {
   const handleSend = () => {
     const text = input.trim();
     if (!text || sending) return;
+    // チップ(保存して/やめておく)を無視して別の話題を打った場合、そのままだと未使用の
+    // チップが宙ぶらりんで残り、新しい応答の横に古い選択肢が並んでしまう。入力欄は
+    // 塞がず(=「やっぱりいいです」と打てるようにしたまま)、送信時に使用済みにする。
+    if (lastMsg && awaitingUserDecision) consumeChips(lastMsg.id);
     setInput("");
     void sendReal(text);
+  };
+
+  const handleComposerKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    if (shouldSubmitOnEnter(e, isComposing)) {
+      e.preventDefault();
+      handleSend();
+    }
   };
 
   // ─── レイアウト ───────────────────────────────────────────────────────────
@@ -630,13 +659,19 @@ export default function CopilotPreviewPage() {
         <div className="cp-composer-wrap" style={{ flexShrink: 0 }}>
           <div style={{ maxWidth: 820, margin: "0 auto" }}>
             <div style={{ display: "flex", alignItems: "center", gap: 12, padding: "12px 12px 12px 20px", border: `1px solid ${sending ? AGENT_BORDER : "var(--border)"}`, borderRadius: 16, background: "var(--input, var(--card))" }}>
-              <input
+              {/* textarea(1行から始まり複数行も書ける)。Enterで送信、Shift+Enterで改行。
+                  IME変換中のEnterは shouldSubmitOnEnter が弾く(旧UIパネルと共通実装) */}
+              <textarea
+                ref={composerRef}
                 value={input}
                 onChange={(e) => setInput(e.target.value)}
-                onKeyDown={(e) => { if (e.key === "Enter") handleSend(); }}
+                onKeyDown={handleComposerKeyDown}
+                onCompositionStart={() => setIsComposing(true)}
+                onCompositionEnd={() => setIsComposing(false)}
                 placeholder="指示ルールを話しかけてみてください（例：保証について聞かれたら2年と答えて）"
+                rows={1}
                 disabled={sending}
-                style={{ flex: 1, border: "none", outline: "none", background: "transparent", color: "var(--foreground)", fontSize: 16, minHeight: 32 }}
+                style={{ flex: 1, border: "none", outline: "none", background: "transparent", color: "var(--foreground)", fontSize: 16, maxHeight: 140, resize: "none", fontFamily: "inherit", lineHeight: 1.6, padding: 0, overflowY: "auto" }}
               />
               <button onClick={handleSend} disabled={sending} aria-label="送信" style={{ width: 40, height: 40, borderRadius: 12, border: "none", background: AGENT, color: "#fff", cursor: sending ? "not-allowed" : "pointer", opacity: sending ? 0.6 : 1, fontSize: 18 }}>
                 {sending ? "…" : "↑"}


### PR DESCRIPTION
Asana GID 1217007364341838

## 背景 / 不具合
`/copilot-preview`(チャット・ファースト新UI)のコンポーザには2つの実害があった。想定ユーザーは非エンジニアの店主で、入力は100%日本語。

1. **IME誤送信**: `onKeyDown={(e) => { if (e.key === "Enter") handleSend(); }}` だけで変換中判定が無く、かな漢字変換の確定 Enter で未変換のまま送信されていた。
2. **保留チップの取り残し**: 下書き提案(suggest_faq 等)のチップ「保存して/やめておく」を押さずに別の話題を打つと送信自体は通るが、`awaitingUserDecision` は左レールのロックにしか使われておらず、未使用チップがそのまま残る。結果、新しい応答の隣に無関係な古い選択肢が並んで表示されていた。

旧UI(`AdminAgentPanel`)には既に正しいIME判定があったため、作り直さず共通化した。

## 変更
- `admin-ui/src/lib/utils.ts`: `shouldSubmitOnEnter(e, isComposing)` を追加。`AdminAgentPanel` のインライン条件をそのまま抽出(4条件 — `nativeEvent.isComposing` / React state の `isComposing` / 旧・モバイルIME向け `keyCode === 229` / `Shift` — はそれぞれ別のブラウザ差異を塞ぐため全て維持)。
- `AdminAgentPanel.tsx`: インライン条件を `shouldSubmitOnEnter` 呼び出しに置換(純粋な抽出。挙動不変)。
- `copilot-preview/index.tsx`:
  - `isComposing` state と `onCompositionStart/End` を配線し、`onKeyDown` を `shouldSubmitOnEnter` に切り替え。
  - コンポーザを `input` → `textarea` 化(Shift+Enterで改行)。入力量に応じて1行〜140pxまで自動で伸び、空の時は `rows=1` の1行に戻る(見た目は従来の1行コンポーザのまま)。
  - 送信時、直前AIメッセージに未使用チップがあれば `consumeChips` で使用済みにする。**入力欄は塞がない**(「やっぱりいいです」と打って離脱できる状態を維持)。

## テスト
- 新規 `admin-ui/src/lib/utils.test.ts` (6件): 素のEnter / nativeEvent.isComposing / React state の isComposing / keyCode 229 / Shift+Enter / Enter以外。
- `copilot-preview/index.test.tsx` に4件追加: 変換中Enterは送信しない / 変換確定後のEnterは送信する / Shift+Enterは送信しない / チップを無視した自由入力送信でチップが使用済みになる。
  - 修正を戻すと新規3件が落ちることを確認済み(偽greenでないことの確認)。
- `AdminAgentPanel.test.tsx` は**無変更**で green(抽出が挙動を変えていない回帰証明)。
- admin-ui: `vitest run` 23ファイル 168件 pass / backend: `jest src/api/admin/agent/agentRoutes.test.ts` 150件 pass(バックエンドは未変更)。
- `npm run lint`(root oxlint) / `npx tsc --noEmit`(root) pass。`copilot-preview/index.tsx` に残る eslint `no-explicit-any` 1件は既存の `catch (err: any)`(本PR範囲外)。

## 目視確認
ローカル dev server で desktop(1142px)と mobile(373px)を確認。空の状態は従来と同じ1行の見た目、Shift+Enterで2行に伸びて両行が見え、Enterで送信され改行を保ったまま吹き出し表示・コンポーザは1行に戻る。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177MCsC7jN3a51F7TdaW9vH