### PR TITLE
feat(agent): チャット経由のテナント設定変更を tenant_settings_history に記録する

### DIFF
--- a/src/api/admin/agent/agentAuditLog.test.ts
+++ b/src/api/admin/agent/agentAuditLog.test.ts
@@ -1,0 +1,93 @@
+// src/api/admin/agent/agentAuditLog.test.ts
+// チャット経由のテナント設定変更を tenant_settings_history へ記録する監査ログのテスト
+
+jest.mock('../../../lib/logger', () => ({
+  logger: { warn: jest.fn(), info: jest.fn(), error: jest.fn() },
+}));
+
+import { recordAgentSettingsChange } from './agentAuditLog';
+import { logger } from '../../../lib/logger';
+
+const mockQuery = jest.fn();
+const mockDb = { query: mockQuery } as any;
+
+describe('recordAgentSettingsChange', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('tenant_settings_history へ1行 INSERT する', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    await recordAgentSettingsChange(mockDb, {
+      tenantId: 'tenant-abc',
+      changedBy: 'admin@example.com',
+      fieldName: 'ga4_measurement_id',
+      oldValue: 'G-OLD111',
+      newValue: 'G-NEW222',
+    });
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockQuery.mock.calls[0]!;
+    expect(sql).toContain('INSERT INTO tenant_settings_history');
+    expect(sql).toContain('(tenant_id, changed_by, field_name, old_value, new_value)');
+    expect(params).toEqual([
+      'tenant-abc',
+      'admin@example.com',
+      'ga4_measurement_id',
+      JSON.stringify('G-OLD111'),
+      JSON.stringify('G-NEW222'),
+    ]);
+  });
+
+  it('oldValue が null の場合は SQL NULL のまま渡す（jsonb の "null" に変換しない）', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    await recordAgentSettingsChange(mockDb, {
+      tenantId: 'tenant-abc',
+      changedBy: 'admin@example.com',
+      fieldName: 'posthog_host',
+      oldValue: null,
+      newValue: 'https://app.posthog.com',
+    });
+
+    const [, params] = mockQuery.mock.calls[0]!;
+    expect(params[3]).toBeNull();
+    expect(params[4]).toBe(JSON.stringify('https://app.posthog.com'));
+  });
+
+  it('oldValue が undefined でも null として受け付ける', async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    await recordAgentSettingsChange(mockDb, {
+      tenantId: 'tenant-abc',
+      changedBy: 'admin@example.com',
+      fieldName: 'widget_theme',
+      oldValue: undefined,
+      newValue: { primaryColor: '#3B82F6' },
+    });
+
+    const [, params] = mockQuery.mock.calls[0]!;
+    expect(params[3]).toBeNull();
+    expect(params[4]).toBe(JSON.stringify({ primaryColor: '#3B82F6' }));
+  });
+
+  it('DBエラーは logger.warn に落とすだけで呼び出し側へ投げない', async () => {
+    mockQuery.mockRejectedValueOnce(new Error('relation does not exist'));
+
+    await expect(
+      recordAgentSettingsChange(mockDb, {
+        tenantId: 'tenant-abc',
+        changedBy: 'admin@example.com',
+        fieldName: 'ga4_measurement_id',
+        oldValue: null,
+        newValue: 'G-NEW222',
+      }),
+    ).resolves.toBeUndefined();
+
+    expect(logger.warn).toHaveBeenCalledWith(
+      expect.stringContaining('tenant_settings_history'),
+      expect.any(Error),
+    );
+  });
+});

--- a/src/api/admin/agent/agentAuditLog.ts
+++ b/src/api/admin/agent/agentAuditLog.ts
@@ -1,0 +1,45 @@
+/**
+ * 管理AIエージェント（/copilot-preview）経由のテナント設定変更を
+ * tenant_settings_history へ記録する。
+ *
+ * 旧UI（PATCH /v1/admin/tenants/:id）は Phase72-A から同テーブルへ記録済みだが、
+ * チャット経由の設定変更は記録されていなかった。新しいテーブルは作らず、
+ * 既存の tenant_settings_history をそのまま再利用する。
+ *
+ * 制約:
+ *   - fire-and-forget。失敗は logger.warn に落とすだけで呼び出し側へ投げない
+ *     （監査記録の失敗がチャット応答を壊してはならない）
+ *   - old_value は NULL 可。migration の COMMENT が
+ *     「NULL = 新規設定 / 初期値不明」を正規の意味として定義しているため、
+ *     変更前の値が手元にない場合は NULL をそのまま入れる（エラーではない）
+ */
+
+import type { Pool } from 'pg';
+import { logger } from '../../../lib/logger';
+
+export interface AgentSettingsChangeInput {
+  tenantId: string;
+  changedBy: string;
+  fieldName: string;
+  oldValue: unknown;
+  newValue: unknown;
+}
+
+export async function recordAgentSettingsChange(db: Pool, input: AgentSettingsChangeInput): Promise<void> {
+  try {
+    await db.query(
+      `INSERT INTO tenant_settings_history (tenant_id, changed_by, field_name, old_value, new_value)
+       VALUES ($1, $2, $3, $4::jsonb, $5::jsonb)`,
+      [
+        input.tenantId,
+        input.changedBy,
+        input.fieldName,
+        // jsonb の 'null' リテラルではなく SQL NULL を入れる（「初期値不明」の意味を保つ）
+        input.oldValue === null || input.oldValue === undefined ? null : JSON.stringify(input.oldValue),
+        JSON.stringify(input.newValue),
+      ],
+    );
+  } catch (err) {
+    logger.warn('[agentAuditLog] tenant_settings_history INSERT failed', err);
+  }
+}

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -167,6 +167,17 @@ function recordedMetrics(metricName: string): Array<Record<string, any>> {
     .filter((input) => input?.metricName === metricName);
 }
 
+// agentAuditLog モック（設定変更の監査ログ。実DBへのINSERTを避けつつ記録内容を検証する）
+const mockRecordAgentSettingsChange = jest.fn();
+jest.mock('./agentAuditLog', () => ({
+  recordAgentSettingsChange: (...args: any[]) => mockRecordAgentSettingsChange(...args),
+}));
+
+/** mockRecordAgentSettingsChange に記録された監査入力を取り出す */
+function recordedSettingsChanges(): Array<Record<string, any>> {
+  return mockRecordAgentSettingsChange.mock.calls.map(([, input]) => input as Record<string, any>);
+}
+
 // ---------------------------------------------------------------------------
 // テスト対象を import
 // ---------------------------------------------------------------------------
@@ -3687,6 +3698,239 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(mockCreateRule).not.toHaveBeenCalled();
       const saveAction = res.body.actions.find((a: any) => a.tool === 'save_tuning_rule');
       expect(saveAction.result).toContain('同一ターン内での連続実行');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // 設定変更の監査ログ (tenant_settings_history)
+  // チャット経由の設定変更が旧UIと同じテーブルに追跡できることの回帰テスト
+  // -------------------------------------------------------------------------
+  describe('設定変更の監査ログ (tenant_settings_history)', () => {
+    // extractAuth は su.email を changedBy に使うため、email 付きのユーザーで検証する
+    const AUDIT_USER = {
+      email: 'admin@example.com',
+      app_metadata: { role: 'client_admin', tenant_id: 'tenant-abc' },
+    };
+
+    function toolCallResponse(id: string, name: string, args: Record<string, unknown> = {}) {
+      return {
+        ok: true,
+        json: async () => ({
+          choices: [{
+            message: {
+              content: null,
+              tool_calls: [{ id, type: 'function', function: { name, arguments: JSON.stringify(args) } }],
+            },
+          }],
+        }),
+        text: async () => '',
+      };
+    }
+
+    it('set_ga4_id 成功時に ga4_measurement_id の変更を記録する', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-au-1', 'set_ga4_id', { measurement_id: 'G-ABC123' }))
+        .mockResolvedValueOnce(makeGroqResponse('GA4 IDを設定しました。'));
+      mockQuery.mockResolvedValueOnce({ rows: [] }); // UPDATE tenants
+
+      const res = await request(makeApp(AUDIT_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'GA4を G-ABC123 にして', sessionId: 'sess-audit-01' });
+
+      expect(res.status).toBe(200);
+      expect(recordedSettingsChanges()).toEqual([
+        {
+          tenantId: 'tenant-abc',
+          changedBy: 'admin@example.com',
+          fieldName: 'ga4_measurement_id',
+          oldValue: null,
+          newValue: 'G-ABC123',
+        },
+      ]);
+    });
+
+    it('set_posthog 成功時に posthog_host の変更を記録する', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-au-2', 'set_posthog', { host: 'https://app.posthog.com' }))
+        .mockResolvedValueOnce(makeGroqResponse('PostHogを設定しました。'));
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      const res = await request(makeApp(AUDIT_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'PostHogを設定して', sessionId: 'sess-audit-02' });
+
+      expect(res.status).toBe(200);
+      expect(recordedSettingsChanges()).toEqual([
+        {
+          tenantId: 'tenant-abc',
+          changedBy: 'admin@example.com',
+          fieldName: 'posthog_host',
+          oldValue: null,
+          newValue: 'https://app.posthog.com',
+        },
+      ]);
+    });
+
+    it('set_widget_theme 成功時に widget_theme の差分を記録する', async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          toolCallResponse('call-au-3', 'set_widget_theme', { theme: { primaryColor: '#3B82F6' } }),
+        )
+        .mockResolvedValueOnce(makeGroqResponse('テーマを更新しました。'));
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      const res = await request(makeApp(AUDIT_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'テーマを青にして', sessionId: 'sess-audit-03' });
+
+      expect(res.status).toBe(200);
+      expect(recordedSettingsChanges()).toEqual([
+        {
+          tenantId: 'tenant-abc',
+          changedBy: 'admin@example.com',
+          fieldName: 'widget_theme',
+          oldValue: null,
+          newValue: { primaryColor: '#3B82F6' },
+        },
+      ]);
+    });
+
+    it('activate_avatar 成功時に active_avatar_config_id の変更を記録する', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-au-4', 'activate_avatar', { id: 'av-1' }))
+        .mockResolvedValueOnce(makeGroqResponse('アバターを有効化しました。'));
+      mockQuery.mockResolvedValueOnce({ rows: [{ plan: 'growth' }] });
+      const clientQuery = jest.fn()
+        .mockResolvedValueOnce({ rows: [] }) // BEGIN
+        .mockResolvedValueOnce({ rows: [] }) // deactivate all
+        .mockResolvedValueOnce({ rows: [{ id: 'av-1' }] }) // activate target
+        .mockResolvedValueOnce({ rows: [] }) // tenants.features sync
+        .mockResolvedValueOnce({ rows: [] }); // COMMIT
+      mockConnect.mockResolvedValueOnce({ query: clientQuery, release: jest.fn() });
+
+      const res = await request(makeApp(AUDIT_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'アバターを有効化して', sessionId: 'sess-audit-04' });
+
+      expect(res.status).toBe(200);
+      expect(recordedSettingsChanges()).toEqual([
+        {
+          tenantId: 'tenant-abc',
+          changedBy: 'admin@example.com',
+          fieldName: 'active_avatar_config_id',
+          oldValue: null,
+          newValue: 'av-1',
+        },
+      ]);
+    });
+
+    it('activate_avatar がプラン制限でブロックされた場合は記録しない', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-au-5', 'activate_avatar', { id: 'av-1' }))
+        .mockResolvedValueOnce(makeGroqResponse('プラン制限のためお伝えしました。'));
+      mockQuery.mockResolvedValueOnce({ rows: [{ plan: 'starter' }] });
+
+      const res = await request(makeApp(AUDIT_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'アバターを有効化して', sessionId: 'sess-audit-05' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('Growthプラン以上');
+      expect(mockConnect).not.toHaveBeenCalled();
+      expect(mockRecordAgentSettingsChange).not.toHaveBeenCalled();
+    });
+
+    it('set_ga4_id が形式不正で書き込まれなかった場合は記録しない', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-au-5b', 'set_ga4_id', { measurement_id: 'INVALID' }))
+        .mockResolvedValueOnce(makeGroqResponse('形式が正しくありませんでした。'));
+
+      const res = await request(makeApp(AUDIT_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'GA4を INVALID にして', sessionId: 'sess-audit-05b' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('形式が不正です');
+      expect(mockRecordAgentSettingsChange).not.toHaveBeenCalled();
+    });
+
+    it('set_ga4_id の UPDATE が失敗した場合は記録しない', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-au-5c', 'set_ga4_id', { measurement_id: 'G-ABC123' }))
+        .mockResolvedValueOnce(makeGroqResponse('設定に失敗しました。'));
+      mockQuery.mockRejectedValueOnce(new Error('db down'));
+
+      const res = await request(makeApp(AUDIT_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'GA4を G-ABC123 にして', sessionId: 'sess-audit-05c' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('失敗しました');
+      expect(mockRecordAgentSettingsChange).not.toHaveBeenCalled();
+    });
+
+    it('確認ブロックされた書き込み(confirmed=false)は記録しない', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-au-6', 'save_faq', { question: 'q', answer: 'a', confirmed: false }))
+        .mockResolvedValueOnce(makeGroqResponse('確認をお願いします。'));
+
+      const res = await request(makeApp(AUDIT_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'FAQを保存して', sessionId: 'sess-audit-06' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('確認が必要です');
+      expect(mockRecordAgentSettingsChange).not.toHaveBeenCalled();
+    });
+
+    it('対象4ツール以外の書き込み(save_faq成功)は tenant_settings_history に記録しない', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-au-7', 'save_faq', { question: 'q', answer: 'a', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('FAQを保存しました。'));
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ id: 1, question: 'q', answer: 'a', is_published: true }],
+      });
+
+      const res = await request(makeApp(AUDIT_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'FAQを保存して', sessionId: 'sess-audit-07' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('FAQを保存しました');
+      expect(mockRecordAgentSettingsChange).not.toHaveBeenCalled();
+    });
+
+    it('監査記録が例外を投げてもチャット応答は 200 のまま返る', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-au-8', 'set_ga4_id', { measurement_id: 'G-ABC123' }))
+        .mockResolvedValueOnce(makeGroqResponse('GA4 IDを設定しました。'));
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+      mockRecordAgentSettingsChange.mockImplementation(() => {
+        throw new Error('audit boom');
+      });
+
+      const res = await request(makeApp(AUDIT_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'GA4を G-ABC123 にして', sessionId: 'sess-audit-08' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.reply).toBe('GA4 IDを設定しました。');
+      expect(res.body.actions[0].result).toContain('G-ABC123');
+    });
+
+    it('監査記録が reject してもチャット応答は 200 のまま返る', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-au-9', 'set_ga4_id', { measurement_id: 'G-ABC123' }))
+        .mockResolvedValueOnce(makeGroqResponse('GA4 IDを設定しました。'));
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+      mockRecordAgentSettingsChange.mockRejectedValue(new Error('audit boom'));
+
+      const res = await request(makeApp(AUDIT_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'GA4を G-ABC123 にして', sessionId: 'sess-audit-09' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.reply).toBe('GA4 IDを設定しました。');
     });
   });
 

--- a/src/api/admin/agent/agentRoutes.ts
+++ b/src/api/admin/agent/agentRoutes.ts
@@ -11,6 +11,7 @@ import { executeToolCall } from './actionExecutor';
 import { requiresConfirmation } from './confirmPolicy';
 import { trackUsage } from '../../../lib/billing/usageTracker';
 import { recordAgentMetric, type AgentMetricInput } from '../../../lib/metrics/agentMetrics';
+import { recordAgentSettingsChange } from './agentAuditLog';
 import { GROQ_VERSATILE_70B } from '../../../config/groqModels';
 import { isUnanswered } from '../ai-assist/systemPrompt';
 
@@ -45,6 +46,72 @@ function classifyToolResult(result: string): {
   if (result.includes(BLOCKED_CHAIN_MARKER)) return { outcome: 'blocked', reason: 'chain' };
   if (result.includes(BLOCKED_UNCONFIRMED_MARKER)) return { outcome: 'blocked', reason: 'unconfirmed' };
   return { outcome: 'ok' };
+}
+
+// ---------------------------------------------------------------------------
+// 設定変更の監査ログ（tenant_settings_history。旧UI PATCH /v1/admin/tenants/:id と同じテーブル）
+// ---------------------------------------------------------------------------
+
+// 「テナント単位の単一設定フィールドを変える」ツールだけを対象にする。
+// FAQ・指示ルール・エンゲージメントルール・エスカレーションは実体（エンティティ）の
+// 書き込みであり field_name/old_value/new_value の形に収まらないため対象外
+// （別テーブルが必要になるので将来の別タスク）。
+//
+// successMarker: classifyToolResult の ok/blocked 判定だけでは足りないため併用する。
+// 確認ゲート以外の理由で書き込みが行われなかったケース（activate_avatar のプラン制限、
+// set_ga4_id の形式不正、DB例外時の失敗メッセージ）は blocked マーカーを含まないため
+// outcome=ok に落ちる。それをそのまま記録すると「実際には変更されていない変更」が
+// 監査ログに残るので、各ツールの成功メッセージの一致も必須条件にする
+// （メッセージ変更で無言に記録が止まらないよう、4ツール分すべてを
+//  agentRoutes.test.ts の「設定変更の監査ログ」で固定している）。
+const AUDITED_SETTINGS_TOOLS: Record<
+  string,
+  { fieldName: string; successMarker: string; readNewValue: (args: Record<string, unknown>) => unknown }
+> = {
+  set_ga4_id: {
+    fieldName: 'ga4_measurement_id',
+    successMarker: 'に設定しました',
+    readNewValue: (args) => args['measurement_id'],
+  },
+  set_posthog: {
+    fieldName: 'posthog_host',
+    successMarker: 'に設定しました',
+    readNewValue: (args) => args['host'],
+  },
+  // 実装は既存 widget_theme への JSONB マージなので、記録されるのは「今回当てた差分」。
+  set_widget_theme: {
+    fieldName: 'widget_theme',
+    successMarker: 'を更新しました',
+    readNewValue: (args) => args['theme'],
+  },
+  // tenants の列ではないが、テナントで稼働中のアバター設定という単一の設定値。
+  activate_avatar: {
+    fieldName: 'active_avatar_config_id',
+    successMarker: 'を有効化しました',
+    readNewValue: (args) => args['id'],
+  },
+};
+
+/** 監査記録も fire-and-forget。記録の失敗をチャット応答に一切影響させない。 */
+function fireSettingsAudit(
+  db: Pool,
+  params: { tenantId: string; changedBy: string; fieldName: string; newValue: unknown },
+): void {
+  try {
+    void Promise.resolve(
+      recordAgentSettingsChange(db, {
+        tenantId: params.tenantId,
+        changedBy: params.changedBy,
+        fieldName: params.fieldName,
+        // 変更前の値は 45分岐の case 本体からは取り出せない（取り出すには case 側の
+        // 改変が必要になる）。migration の COMMENT どおり NULL =「初期値不明」として記録する。
+        oldValue: null,
+        newValue: params.newValue,
+      }),
+    ).catch(() => undefined);
+  } catch {
+    // 監査記録の失敗は応答に影響させない
+  }
 }
 
 function recordTurnCompleted(
@@ -276,6 +343,7 @@ async function executeHopToolCalls(
   messages: GroqMessage[],
   isSuperAdmin: boolean,
   sessionId: string,
+  changedBy: string,
 ): Promise<void> {
   for (const toolCall of toolCalls) {
     const { id, name, args } = toolCall;
@@ -329,6 +397,22 @@ async function executeHopToolCalls(
         tenantId: metricTenantId,
         labels: { tool: name, reason },
         value: 1,
+      });
+    }
+    // 設定変更の監査記録。ブロックされた書き込み(outcome=blocked)は実際にDBを変えていないため
+    // 記録しない（記録すると監査ログに偽のエントリが残る）。
+    const auditedSetting = AUDITED_SETTINGS_TOOLS[name];
+    if (
+      auditedSetting &&
+      outcome === 'ok' &&
+      result.includes(auditedSetting.successMarker) &&
+      effectiveTenantId
+    ) {
+      fireSettingsAudit(db, {
+        tenantId: effectiveTenantId,
+        changedBy,
+        fieldName: auditedSetting.fieldName,
+        newValue: auditedSetting.readNewValue(args),
       });
     }
     if (name === 'get_legacy_ui_link') {
@@ -614,7 +698,7 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
             }));
 
             const beforeCount = actions.length;
-            await executeHopToolCalls(parsedToolCalls, effectiveTenantId, db, suggestedThisTurn, actions, messages, isSuperAdmin, sessionId);
+            await executeHopToolCalls(parsedToolCalls, effectiveTenantId, db, suggestedThisTurn, actions, messages, isSuperAdmin, sessionId, email);
             for (const action of actions.slice(beforeCount)) {
               res.write(`event: action\ndata: ${JSON.stringify(action)}\n\n`);
             }
@@ -711,7 +795,7 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
           args: parseToolArgs(toolCall.function.arguments),
         }));
 
-        await executeHopToolCalls(parsedToolCalls, effectiveTenantId, db, suggestedThisTurn, actions, messages, isSuperAdmin, sessionId);
+        await executeHopToolCalls(parsedToolCalls, effectiveTenantId, db, suggestedThisTurn, actions, messages, isSuperAdmin, sessionId, email);
       }
 
       const hitHopLimit = finalReply === null;


### PR DESCRIPTION
## 背景

R2C は旧UI（`PATCH /v1/admin/tenants/:id`）からの設定変更を Phase72-A で `tenant_settings_history` に記録している。一方 `/copilot-preview` のチャットエージェント経由の変更は**どこにも記録されていなかった**ため、「誰がいつこのテナントの GA4 ID を変えたか」がチャット経由だと追跡不能だった。このPRは**設定型の変更**についてそのギャップを埋める。

## 対象の4ツール（すべて `toolDefinitions.ts` に現行名で存在を確認済み。名称変更なし）

| ツール | `field_name` | `new_value` の由来 | `old_value` |
|---|---|---|---|
| `set_ga4_id` | `ga4_measurement_id` | `args.measurement_id` | **NULL** |
| `set_posthog` | `posthog_host` | `args.host` | **NULL** |
| `set_widget_theme` | `widget_theme` | `args.theme`（JSONBマージの差分） | **NULL** |
| `activate_avatar` | `active_avatar_config_id` | `args.id` | **NULL** |

### `old_value` は4ツールすべて NULL（既知の制約）

**4ツールとも変更前の値を安価に取り出せる箇所がなかった**ため、全件 `NULL` で記録している。`set_ga4_id` / `set_posthog` / `set_widget_theme` は case 本体が `UPDATE ... RETURNING` を使わず結果文字列にも旧値を含めない。`activate_avatar` も同様に旧アクティブIDを返さない。取り出すには `actionExecutor.ts` の45分岐の case 本体を改変する必要があり、本リポジトリの「45分岐は触らない」規約に反するため見送った。

migration の `COMMENT ON COLUMN tenant_settings_history.old_value` が `NULL = 新規設定 / 初期値不明` を正規の意味として定義済みなので、これはエラーケースではなく想定内の値。旧値まで欲しい場合は case 本体側の `RETURNING` 化が前提になるため別タスク。

## スコープ外（このテーブルには入れない）

FAQ / 指示ルール / エンゲージメントルールの作成・更新・削除、エスカレーションの返信・対応完了は**エンティティの書き込み**であり、`field_name` / `old_value` / `new_value` という単一フィールドの形に収まらない。別テーブルが必要になるため、このPRでは意図的に対象外にしている（将来の別タスク）。

## 実装

- **新規** `src/api/admin/agent/agentAuditLog.ts` — `recordAgentSettingsChange(db, input)`。単一 INSERT、fire-and-forget、失敗は `logger.warn` のみで呼び出し側へ投げない。`agentMetrics.ts` と同じ形。
- **新規** `src/api/admin/agent/agentAuditLog.test.ts`
- **変更** `src/api/admin/agent/agentRoutes.ts` — 呼び出しは `executeHopToolCalls` 内の**1か所のみ**（メトリクス計測の隣）。JSON経路・SSE経路の両方がここを通る。
  - `changedBy`: `extractAuth` が既に返す `su.email`（新しい認可参照は追加していない）
  - `tenantId`: このファイルが既に解決している `effectiveTenantId`。**LLMのツール引数からは取らない**
- **マイグレーション・テーブルは新規作成せず**、既存 `tenant_settings_history` をスキーマ変更ゼロで再利用。
- `actionExecutor.ts` は**1行も変更していない**。

### 成功判定について（レビューしてほしい点）

マージ済みメトリクス計測の `classifyToolResult`（ok/blocked）をそのまま再利用しているが、**それだけでは不十分だった**ことがテストで判明した。確認ゲート以外の理由で書き込まれなかったケース—`activate_avatar` のプラン制限（`Growthプラン以上でご利用いただけます`）、`set_ga4_id` の形式不正、DB例外時の失敗メッセージ—はブロックマーカーを含まないため `outcome=ok` に落ち、**実際には変更されていない変更が監査ログに残ってしまう**（実装中に実際にテストが落ちて検出）。

そのため `outcome === 'ok'` に加えて**各ツールの成功メッセージとの一致**も必須条件にしている。ok/blocked 判定そのものは再実装していない。結果文字列への依存が増えるトレードオフはあるが、メッセージ変更で無言に記録が止まらないよう4ツール分すべてをテストで固定した。

## テスト

`npx jest src/api/admin/agent src/api/admin/tenants` → **7 suites / 220 tests すべて green**（対象2ファイルのみで 168 passed）。

`agentRoutes.test.ts` への追加（既存の約174アサーションは**1つも変更していない**）:
- 4ツールそれぞれの成功時に正しい `field_name` / `new_value` で記録されること
- **確認ブロック**（`save_faq` confirmed=false）では記録されないこと
- **プラン制限でブロック**された `activate_avatar` では記録されないこと
- 形式不正 / UPDATE失敗 では記録されないこと
- スコープ外ツール（`save_faq` 成功）では記録されないこと
- `recordAgentSettingsChange` が throw / reject してもチャットは 200 + 正常な reply を返すこと

## 検証

- `npm run lint` → exit 0（変更ファイルに指摘なし）
- `npx tsc --noEmit` → エラーなし
- `git diff --stat origin/main -- '*.sql' '.env*' 'package.json'` → **空**（マイグレーション / env / 依存の差分ゼロ）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177MCsC7jN3a51F7TdaW9vH
