### PR TITLE
refactor(agent): ツール結果に構造化カード(card)チャネルを追加(get_legacy_ui_link のみ移行)

### DIFF
--- a/admin-ui/src/components/AdminAgent/useAdminAgent.ts
+++ b/admin-ui/src/components/AdminAgent/useAdminAgent.ts
@@ -4,10 +4,23 @@ import { authFetch, API_BASE } from "../../lib/api";
 
 export type AnsweredFrom = "faq_list" | "tool_action" | "general";
 
+// バックエンド(actionExecutor.ts の LegacyLinkCardPayload)が自然文に添えて返す
+// 構造化カード。現時点で card を返すのは get_legacy_ui_link だけで、他のツールは
+// 従来どおり result の自然文のみ。このパネル(Surface A)はまだ card を描画しないが、
+// /copilot-preview と同じレスポンスを消費するため型は共通にしておく。
+export type AgentActionCard = {
+  kind: "legacy_link";
+  label: string;
+  url: string;
+  description: string;
+};
+
+export type AgentAction = { tool: string; result: string; card?: AgentActionCard };
+
 export interface AgentMessage {
   role: "user" | "assistant";
   content: string;
-  actions?: { tool: string; result: string }[];
+  actions?: AgentAction[];
   needsConfirmation?: boolean;
   answeredFrom?: AnsweredFrom;
 }
@@ -73,7 +86,7 @@ export function useAdminAgent(): UseAdminAgentResult {
 
       const data = (await res.json()) as {
         reply: string;
-        actions: { tool: string; result: string }[];
+        actions: AgentAction[];
         answered_from?: AnsweredFrom;
       };
 

--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -326,6 +326,79 @@ describe("CopilotPreviewPage — 旧UI案内リンクカード", () => {
   });
 });
 
+// GID: バックエンドの構造化カード(card)から直接リンクカードを描画する経路の回帰テスト。
+// 自然文の言い回しが変わるとカードが黙って消える正規表現依存を外すための追加経路で、
+// card を返すのは現状 get_legacy_ui_link のみ。card が無いツールは従来の正規表現
+// フォールバックで描画され続ける(この2経路の共存をここで固定する)。
+describe("CopilotPreviewPage — 構造化カード(card)からの描画", () => {
+  function mockAgent(secondResponse: unknown) {
+    vi.mocked(authFetch).mockReset();
+    mockNavigate.mockReset();
+    // 起動時ブリーフィングも同じエンドポイントを叩くため、カードは2回目の応答にだけ載せる
+    let agentCalls = 0;
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (String(url).includes("/v1/admin/my-tenant")) {
+        return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
+      }
+      agentCalls += 1;
+      if (agentCalls === 1) return mockOk({ reply: "今週のまとめです。", actions: [] });
+      return mockOk(secondResponse);
+    });
+  }
+
+  async function send(text: string) {
+    renderPage();
+    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
+    fireEvent.change(screen.getByPlaceholderText(/指示ルール/), { target: { value: text } });
+    fireEvent.click(screen.getByLabelText("送信"));
+  }
+
+  it("card があれば、自然文が3行フォーマットに一致しなくてもリンクカードを描画する", async () => {
+    const description = "画像候補の選択・音声クローン・性格設定・ライブテストはこちらの画面で行えます";
+    mockAgent({
+      reply: "アバタースタジオをご案内しました。",
+      actions: [
+        {
+          tool: "get_legacy_ui_link",
+          // 正規表現(画面:/URL:/説明:)に一切一致しない自然文。従来のパース経路だけなら
+          // カードにならず汎用表示に落ちるため、描画されたことが card 経由の証拠になる。
+          result: "アバタースタジオでご対応いただけます。",
+          card: { kind: "legacy_link", label: "アバタースタジオ", url: "/admin/avatar/studio", description },
+        },
+      ],
+    });
+
+    await send("アバターを設定したい");
+
+    const link = await screen.findByRole("link", { name: /アバタースタジオを開く/ });
+    expect(link.getAttribute("href")).toBe("/admin/avatar/studio");
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+    // 説明文も card の構造化フィールドから来ている
+    expect(screen.getByText(description)).toBeTruthy();
+  });
+
+  it("card が無い既存ツールは、従来どおり自然文の正規表現パースでリンクカードになる", async () => {
+    const description = "会話内容の確認とその会話セッションの削除はこちらの画面で行えます";
+    mockAgent({
+      reply: "会話履歴画面をご案内しました。",
+      actions: [
+        {
+          tool: "get_legacy_ui_link",
+          result: `この操作は会話履歴画面から行えます。\n画面: 会話履歴\nURL: /admin/chat-history\n説明: ${description}`,
+        },
+      ],
+    });
+
+    await send("会話を削除したい");
+
+    const link = await screen.findByRole("link", { name: /会話履歴を開く/ });
+    expect(link.getAttribute("href")).toBe("/admin/chat-history");
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(screen.getByText(description)).toBeTruthy();
+  });
+});
+
 function getComposer(): HTMLTextAreaElement {
   return screen.getByPlaceholderText(/指示ルール/) as HTMLTextAreaElement;
 }

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -23,6 +23,8 @@ import { PREVIEW_MODE_BANNER_HEIGHT } from "../../components/PreviewModeBanner";
 // 切り出した(旧UIとの共有コンポーネント。詳細は common/ThemeToggle.tsx 参照)。
 import { NotificationBell } from "../../components/common/NotificationBell";
 import { ThemeToggle } from "../../components/common/ThemeToggle";
+// レスポンス形は本番パネル(Surface A)と共有のため、型も一箇所から取る。
+import type { AgentAction } from "../../components/AdminAgent/useAdminAgent";
 import LangSwitcher from "../../components/LangSwitcher";
 import AppSwitcher from "../../components/AppSwitcher";
 
@@ -324,7 +326,7 @@ export default function CopilotPreviewPage() {
         return;
       }
 
-      const data = (await res.json()) as { reply: string; actions: { tool: string; result: string }[] };
+      const data = (await res.json()) as { reply: string; actions: AgentAction[] };
       setRealHistory((prev) =>
         [
           ...prev,
@@ -336,6 +338,13 @@ export default function CopilotPreviewPage() {
       // ツール結果を、可能なら提案書と同じ見た目のカードにパースする。
       // 想定外の形式(下書き生成失敗時のエラー文など)は汎用の agentAction カードにフォールバック。
       const actionMsgs: Msg[] = (data.actions ?? []).map((a) => {
+        // 構造化カードが来ていればそれを直接描画する。自然文の言い回しが変わっても
+        // カードが黙って消えない経路。card が無いツール(現状 get_legacy_ui_link 以外の
+        // すべて)は、これまでどおり下の正規表現パースにフォールバックする。
+        if (a.card?.kind === "legacy_link") {
+          const { label, url, description } = a.card;
+          return { id: nextId(), role: "ai", card: { kind: "link", label, url, description } };
+        }
         if (a.tool === "suggest_faq") {
           const parsed = parseSuggestFaq(a.result);
           if (parsed) return { id: nextId(), role: "ai", card: { kind: "faq", ...parsed } };

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -135,6 +135,24 @@ const CHAT_ROLE_LABELS: Record<string, string> = {
 };
 
 // ---------------------------------------------------------------------------
+// ツール実行結果
+// ---------------------------------------------------------------------------
+
+// フィールド名は copilot-preview の Card union の link バリアントに揃えてあり、
+// フロントは自然文を正規表現で読み直さずそのまま描画できる。
+export type LegacyLinkCardPayload = {
+  kind: 'legacy_link';
+  label: string;
+  url: string;
+  description: string;
+};
+
+// ツール結果は既定では素の文字列で、構造化データを添えるツールだけが
+// { text, card } 形を返す。card は text の置き換えではなく追加である
+// （text 側の自然文は既存の正規表現パーサのフォールバック契約として残す）。
+export type ActionResult = string | { text: string; card?: LegacyLinkCardPayload };
+
+// ---------------------------------------------------------------------------
 // メインエントリ
 // ---------------------------------------------------------------------------
 
@@ -145,7 +163,7 @@ export async function executeToolCall(
   db: Pool,
   sessionId: string,
   isSuperAdmin: boolean = false
-): Promise<string> {
+): Promise<ActionResult> {
   // 結果は500字以内日本語
   const truncate = (s: string) => s.slice(0, 500);
 
@@ -1756,7 +1774,14 @@ export async function executeToolCall(
       // 冒頭は「できません」ではなく「どこでできるか」から始める(行き止まりに見せない)。
       // 続く3行(画面:/URL:/説明:)は copilot-preview の parseLegacyUiLink が
       // リンクカード描画のために正規表現で読む契約なので、順序・ラベルを変えないこと。
-      return truncate(`この操作は${link.label}画面から行えます。\n画面: ${link.label}\nURL: ${path}\n説明: ${link.description}`);
+      // card を併せて返すことで新しいクライアントは正規表現を経ずに描画できるが、
+      // 自然文だけを見る経路(LLMへの差し戻し・旧クライアント)のために text は不可欠。
+      // 失敗パス(プラン制限・不明なfeature等)は素の文字列を返すため、押せないリンク
+      // カードが出ないという性質は card 側でもそのまま保たれる。
+      return {
+        text: truncate(`この操作は${link.label}画面から行えます。\n画面: ${link.label}\nURL: ${path}\n説明: ${link.description}`),
+        card: { kind: 'legacy_link', label: link.label, url: path, description: link.description },
+      };
     }
 
     // -----------------------------------------------------------------------

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -2950,6 +2950,159 @@ describe('POST /v1/admin/agent/chat', () => {
   });
 
   // -------------------------------------------------------------------------
+  // 構造化カード(card)チャネル
+  //
+  // ツールが自然文に加えて構造化データを返せる経路。フロントが自然文を正規表現で
+  // 読み直さずにカードを描画できるようにするためのもので、現時点で card を返すのは
+  // get_legacy_ui_link だけ。残りのツールは素の文字列を返し続け、result のみが載る
+  // 従来のレスポンス形と完全に同じであること（=union型化が全ツールへ波及していないこと）
+  // をここで固定する。
+  // -------------------------------------------------------------------------
+  describe('構造化カード(card)チャネル', () => {
+    function toolCallResponse(id: string, name: string, args: Record<string, unknown> = {}) {
+      return {
+        ok: true,
+        json: async () => ({
+          choices: [{
+            message: {
+              content: null,
+              tool_calls: [{ id, type: 'function', function: { name, arguments: JSON.stringify(args) } }],
+            },
+          }],
+        }),
+        text: async () => '',
+      };
+    }
+
+    const BILLING_DESCRIPTION = '請求書の再送・金額調整・無料期間設定・一時停止/再開はこちらの画面で行えます';
+
+    it('JSON経路: get_legacy_ui_link は自然文(result)に加えて card を返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-card-1', 'get_legacy_ui_link', { feature: 'billing' }))
+        .mockResolvedValueOnce(makeGroqResponse('請求管理画面をご案内しました。'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '請求書を再送したい', sessionId: 'sess-card-01' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].card).toEqual({
+        kind: 'legacy_link',
+        label: '請求管理',
+        url: '/admin/billing',
+        description: BILLING_DESCRIPTION,
+      });
+
+      // card は自然文の置き換えではなく追加。3行フォーマット(parseLegacyUiLink の契約)は
+      // 正規表現フォールバックのために残り続ける。
+      const result = res.body.actions[0].result as string;
+      expect(typeof result).toBe('string');
+      expect(result).toContain('画面: 請求管理\n');
+      expect(result).toContain('URL: /admin/billing\n');
+      expect(result).toContain(`説明: ${BILLING_DESCRIPTION}`);
+    });
+
+    it('SSE経路: event: done の actions にも同じ card が載る', async () => {
+      function makeStreamingGroqResponse(fullSseText: string) {
+        const bytes = new TextEncoder().encode(fullSseText);
+        let sent = false;
+        return {
+          ok: true,
+          body: {
+            getReader: () => ({
+              read: async () => {
+                if (!sent) {
+                  sent = true;
+                  return { done: false, value: bytes };
+                }
+                return { done: true, value: undefined };
+              },
+            }),
+          },
+          text: async () => '',
+        };
+      }
+
+      const hop1Sse =
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call-card-2","function":{"name":"get_legacy_ui_link","arguments":""}}]}}]}\n\n' +
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"function":{"arguments":"{\\"feature\\":\\"billing\\"}"}}]}}]}\n\n' +
+        'data: [DONE]\n\n';
+      const hop2Sse = 'data: {"choices":[{"delta":{"content":"請求管理画面をご案内しました。"}}]}\n\n' + 'data: [DONE]\n\n';
+
+      mockFetch
+        .mockResolvedValueOnce(makeStreamingGroqResponse(hop1Sse))
+        .mockResolvedValueOnce(makeStreamingGroqResponse(hop2Sse));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '請求書を再送したい', sessionId: 'sess-card-02', stream: true });
+
+      expect(res.status).toBe(200);
+
+      const marker = 'event: done\ndata: ';
+      const start = res.text.indexOf(marker);
+      expect(start).toBeGreaterThan(-1);
+      const done = JSON.parse(res.text.slice(start + marker.length, res.text.indexOf('\n\n', start))) as {
+        actions: Array<{ tool: string; result: string; card?: Record<string, unknown> }>;
+      };
+
+      expect(done.actions[0].tool).toBe('get_legacy_ui_link');
+      expect(done.actions[0].card).toEqual({
+        kind: 'legacy_link',
+        label: '請求管理',
+        url: '/admin/billing',
+        description: BILLING_DESCRIPTION,
+      });
+      expect(done.actions[0].result).toContain('URL: /admin/billing\n');
+    });
+
+    it('素の文字列を返すツール(save_faq)は result のみで card キー自体を持たない', async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          toolCallResponse('call-card-3', 'save_faq', {
+            question: '送料はいくらですか？',
+            answer: '550円です。',
+            category: 'store_info',
+            confirmed: true,
+          }),
+        )
+        .mockResolvedValueOnce(makeGroqResponse('保存しました。'));
+
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ id: 99, question: '送料はいくらですか？', answer: '550円です。', is_published: true }],
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'お願い', sessionId: 'sess-card-03' });
+
+      expect(res.status).toBe(200);
+      const action = res.body.actions[0];
+      expect(typeof action.result).toBe('string');
+      expect(action.result).toContain('ID: 99');
+      // キーの不在まで見る: 未移行ツールのレスポンス形が1バイトも変わっていないこと
+      expect(action.card).toBeUndefined();
+      expect(Object.keys(action)).toEqual(['tool', 'result']);
+    });
+
+    it('get_legacy_ui_link の失敗パス(プラン制限)では card を返さない(押せないカードを作らない)', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-card-4', 'get_legacy_ui_link', { feature: 'analytics' }))
+        .mockResolvedValueOnce(makeGroqResponse('プラン制限のためお伝えしました。'));
+
+      mockQuery.mockResolvedValueOnce({ rows: [{ plan: 'starter' }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '会話の分析を見たい', sessionId: 'sess-card-04' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('Growthプラン以上');
+      expect(res.body.actions[0].card).toBeUndefined();
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // get_analytics_summary / get_conversion_summary
   // -------------------------------------------------------------------------
   describe('get_analytics_summary / get_conversion_summary', () => {

--- a/src/api/admin/agent/agentRoutes.ts
+++ b/src/api/admin/agent/agentRoutes.ts
@@ -8,6 +8,7 @@ import { supabaseAuthMiddleware } from '../../../admin/http/supabaseAuthMiddlewa
 import { logger } from '../../../lib/logger';
 import { ADMIN_AGENT_TOOLS, LEGACY_UI_FEATURES } from './toolDefinitions';
 import { executeToolCall } from './actionExecutor';
+import type { ActionResult, LegacyLinkCardPayload } from './actionExecutor';
 import { requiresConfirmation } from './confirmPolicy';
 import { trackUsage } from '../../../lib/billing/usageTracker';
 import { recordAgentMetric, type AgentMetricInput } from '../../../lib/metrics/agentMetrics';
@@ -70,6 +71,10 @@ function recordTurnCompleted(
 // ---------------------------------------------------------------------------
 
 type AnsweredFrom = 'faq_list' | 'tool_action' | 'general';
+
+// クライアントへ返すツール実行結果。result(自然文)は構造化ツールでも必ず入るので
+// 既存クライアントと既存の正規表現パーサはそのまま動き、card は追加でのみ載る。
+type ChatAction = { tool: string; result: string; card?: LegacyLinkCardPayload };
 
 function determineAnsweredFrom(actions: Array<{ tool: string; result: string }>): AnsweredFrom {
   if (actions.some((a) => a.tool === 'get_faq_list')) return 'faq_list';
@@ -272,7 +277,7 @@ async function executeHopToolCalls(
   effectiveTenantId: string,
   db: Pool,
   suggestedThisTurn: Set<string>,
-  actions: Array<{ tool: string; result: string }>,
+  actions: ChatAction[],
   messages: GroqMessage[],
   isSuperAdmin: boolean,
   sessionId: string,
@@ -294,12 +299,14 @@ async function executeHopToolCalls(
     const blockSameTurnChain = alreadySuggestedThisTurn && requiresConfirmation(name);
 
     let result: string;
+    let card: LegacyLinkCardPayload | undefined;
     if (blockSameTurnChain) {
       // 同一ターン内で suggest → save が連鎖しようとしている: 人間の確認を経ていないためブロック
       result = 'この保存は同一ターン内での連続実行のため確認をスキップできません。提案内容を確認のうえ、あらためて「保存して」等のメッセージを送ってください。';
     } else {
+      let raw: ActionResult;
       try {
-        result = await executeToolCall(name, args, effectiveTenantId, db, sessionId, isSuperAdmin);
+        raw = await executeToolCall(name, args, effectiveTenantId, db, sessionId, isSuperAdmin);
       } catch (err) {
         fireAgentMetric(db, {
           metricName: 'agent_tool_invoked',
@@ -309,10 +316,20 @@ async function executeHopToolCalls(
         });
         throw err;
       }
+      // 構造化結果を「自然文 + 任意のカード」へ正規化する。これ以降の処理
+      // (LLMへの差し戻し・classifyToolResult による計測・answered_from)は
+      // 従来どおり自然文だけを見るため、構造化しても挙動は変わらない。
+      if (typeof raw === 'string') {
+        result = raw;
+      } else {
+        result = raw.text;
+        card = raw.card;
+      }
       if (name in SUGGEST_TO_SAVE_TOOL) suggestedThisTurn.add(name);
     }
 
-    actions.push({ tool: name, result });
+    // card を持たないツールでは JSON に card キー自体を出さない(既存レスポンス形と同一)。
+    actions.push(card ? { tool: name, result, card } : { tool: name, result });
     messages.push({ role: 'tool', tool_call_id: id, name, content: result });
 
     const metricTenantId = effectiveTenantId || null;
@@ -574,7 +591,7 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
 
       let totalPromptTokens = 0;
       let totalCompletionTokens = 0;
-      const actions: Array<{ tool: string; result: string }> = [];
+      const actions: ChatAction[] = [];
       // このリクエスト(ターン)内で suggest_* が呼ばれたツール名を記録し、
       // 対応する save_* が同一ターン内で連鎖実行されるのを防ぐ（G1のリスク軽減策）
       const suggestedThisTurn = new Set<string>();


### PR DESCRIPTION
## 背景

`admin-ui/src/pages/copilot-preview/index.tsx` は、バックエンドが返す**日本語の自然文**に正規表現をかけて UI カード(FAQ提案・指示ルール提案・声がけ提案・旧UIリンク・成功バナー)を組み立てている。

このため `actionExecutor.ts` の言い回しをほんの少し変えるだけで、カードが黙って描画されなくなり(素のテキスト表示にフォールバック)、**型チェックでもコンパイルでもテストの外では検出できない**。

このPRは、将来のツールが「パースされる前提の散文」ではなく実データを返せる**構造化レスポンス経路**を、後方互換のまま追加する。

## 変更内容

- **`src/api/admin/agent/actionExecutor.ts`**: `ActionResult = string | { text, card }` を定義し、`executeToolCall` の戻り値を拡張。`card` のフィールド名は `copilot-preview` の `Card` union の `link` バリアント(`label`/`url`/`description`)に揃えてある。
- **`src/api/admin/agent/agentRoutes.ts`**: ツール結果を「自然文(`result`)+ 任意の `card`」に正規化。`actions` 配列は JSON 経路と SSE 経路で共有されているため、`executeHopToolCalls` 内の単一箇所での正規化が **`res.json()` / `event: done` / `event: action` の全経路**に届く。
- **`admin-ui/src/pages/copilot-preview/index.tsx`**: `card` があればそれを直接描画し、無ければ従来の正規表現パースにフォールバックする**加算的な分岐のみ**を追加。
- **`admin-ui/src/components/AdminAgent/useAdminAgent.ts`**: 両サーフェスが同じレスポンス形を消費するため型を共通化(パネル側のカード描画は本PRのスコープ外。型の乖離だけを防ぐ)。

## 後方互換性 — これは加算的な変更です

- **移行したツールは `get_legacy_ui_link` の1つだけ。** 残り44ツールは素の文字列を返し続け、レスポンスJSONに `card` キー自体が載らない(既存のワイヤ形と完全に同一)。`actionExecutor.ts` の diff が、変更された `case` 本体がこの1つだけであることを示している。
- **`card` は `text` の置き換えではなく追加。** 3行フォーマット(`画面:` / `URL:` / `説明:`)と「成功時のみ・エラー時は決して出さない」性質は**そのまま維持**されている。LLMへの結果差し戻し・`classifyToolResult` による計測・`answered_from` の判定は、従来どおり自然文だけを見る。
- **既存の正規表現パーサは1つも削除していない。** `parseLegacyUiLink` / `SAVE_SUCCESS_RE` などは、未移行の44ツールのフォールバックとして全て残る。
- **既存アサーションの変更はゼロ。** 両テストスイートの diff は純粋な追加のみ(削除行が1行も無いことを確認済み)。

## テスト

追加(計6件):

- `agentRoutes.test.ts`
  - JSON経路で `card` が `kind: 'legacy_link'` + 正しい `label`/`url`/`description` を持つこと(かつ自然文の3行フォーマットが併存すること)
  - SSE の `event: done` の `actions` にも同じ `card` が載ること
  - 素の文字列を返すツール(`save_faq`)は `result` のみで、**`card` キー自体を持たない**こと(`Object.keys` まで検証 → union型化が全ツールへ波及していない証明)
  - 失敗パス(プラン制限)では `card` を返さないこと(押せないカードを作らない)
- `copilot-preview/index.test.tsx`
  - `card` があれば、**自然文が3行フォーマットに一切一致しなくても**リンクカードが描画されること(正規表現非依存の証明)
  - `card` が無い既存ツールは、従来どおり正規表現パースでカードになること

結果:

- `npm run lint` — 通過 (exit 0)
- `npx tsc --noEmit` — 通過(エラー0)
- `npx jest src/api/admin/agent` — **187/187 通過** (4スイート)
- `admin-ui`: `npx vitest run` — **170/170 通過** (23ファイル)
- `git diff --stat origin/main -- '*.sql' '.env*' 'package.json'` — 空

## 今後の作業(本PRのスコープ外)

- 残り44ツールの構造化形への移行
- 移行完了後の正規表現パーサ(`parseLegacyUiLink` / `SAVE_SUCCESS_RE` 等)の撤去
- `AdminAgentPanel`(Surface A)側での `card` 描画

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177MCsC7jN3a51F7TdaW9vH
