### PR TITLE
feat(admin-ui): 新UI左レールに未回答質問/対応中の会話の件数バッジを表示

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -43,6 +43,12 @@ import { authFetch } from "../../lib/api";
 const mockOk = (data: unknown): Promise<Response> =>
   Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(data) } as Response);
 
+// 左レールの件数バッジ用にマウント時に叩かれる2本(既存の /v1/admin/agent/chat の応答
+// シーケンスに割り込まないよう、既存テストでは常に0件で素通りさせる)
+const BADGE_URL_RE = /knowledge\/gaps\/count|chat-history\/escalations/;
+const isBadgeUrl = (url: unknown) => BADGE_URL_RE.test(String(url));
+const mockEmptyBadges = () => mockOk({ count: 0, escalations: [] });
+
 function baseAuth(overrides: Partial<ReturnType<typeof useAuth>> = {}) {
   return {
     user: { id: "1", email: "a@example.com", role: "client_admin", tenantId: "tenant-a", tenantName: "Tenant A" },
@@ -75,6 +81,7 @@ describe("CopilotPreviewPage — ログアウト", () => {
     mockNavigate.mockReset();
     // マウント時のブリーフィング取得(sendReal)・オンボーディング判定を素通りさせる
     vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (isBadgeUrl(url)) return mockEmptyBadges();
       if (String(url).includes("/v1/admin/my-tenant")) {
         return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
       }
@@ -133,7 +140,9 @@ describe("CopilotPreviewPage — モバイル左レールのドロワー化", ()
   beforeEach(() => {
     vi.mocked(authFetch).mockReset();
     mockNavigate.mockReset();
-    vi.mocked(authFetch).mockImplementation(() => mockOk({ reply: "今週も順調です", actions: [] }));
+    vi.mocked(authFetch).mockImplementation((url: string) =>
+      isBadgeUrl(url) ? mockEmptyBadges() : mockOk({ reply: "今週も順調です", actions: [] }),
+    );
     // タイプライター演出(setInterval)を無効化し、応答を同期的に確定させてテストを決定的にする
     window.matchMedia = vi.fn().mockImplementation((query: string) => ({
       matches: true,
@@ -235,6 +244,7 @@ describe("CopilotPreviewPage — 共通シェル機能パリティ(テーマ/言
     vi.mocked(authFetch).mockReset();
     mockNavigate.mockReset();
     vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (isBadgeUrl(url)) return mockEmptyBadges();
       if (String(url).includes("/v1/admin/my-tenant")) {
         return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
       }
@@ -292,6 +302,7 @@ describe("CopilotPreviewPage — 旧UI案内リンクカード", () => {
     // ユーザーが送った2回目以降の応答にだけ載せる(カードが1枚だけであることを保証する)
     let agentCalls = 0;
     vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (isBadgeUrl(url)) return mockEmptyBadges();
       if (String(url).includes("/v1/admin/my-tenant")) {
         return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
       }
@@ -337,6 +348,7 @@ describe("CopilotPreviewPage — コンポーザのIME/改行", () => {
     vi.mocked(authFetch).mockReset();
     mockNavigate.mockReset();
     vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (isBadgeUrl(url)) return mockEmptyBadges();
       if (String(url).includes("/v1/admin/my-tenant")) {
         return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
       }
@@ -408,6 +420,7 @@ describe("CopilotPreviewPage — 保留中の下書きチップを無視して�
     mockNavigate.mockReset();
     let agentCalls = 0;
     vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (isBadgeUrl(url)) return mockEmptyBadges();
       if (String(url).includes("/v1/admin/my-tenant")) {
         return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
       }
@@ -450,5 +463,126 @@ describe("CopilotPreviewPage — 保留中の下書きチップを無視して�
     await waitFor(() => expect(screen.getByText("やっぱりやめて、営業時間を教えて")).toBeTruthy());
     expect(screen.queryByRole("button", { name: "保存して" })).toBeNull();
     expect(screen.queryByRole("button", { name: "やめておく" })).toBeNull();
+  });
+});
+
+// GID 1217007275511487: 左レールが「今どれだけ溜まっているか」を一切示しておらず、
+// 旧ダッシュボードのstatカード無しでは対応漏れに気づけなかった。既存エンドポイント
+// (knowledge/gaps/count・chat-history/escalations)の件数をバッジで出す。
+// 0件・取得失敗時はバッジを出さない(店主に「0」やエラーを読ませない)。
+describe("CopilotPreviewPage — 左レールの件数バッジ", () => {
+  // バッジ用件数の応答だけを差し替え、それ以外(オンボーディング判定・エージェント応答)は共通
+  function mockBadges(opts: { gaps?: unknown; escalations?: unknown; reject?: boolean }) {
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      const u = String(url);
+      if (isBadgeUrl(u)) {
+        if (opts.reject) return Promise.reject(new Error("network down"));
+        if (u.includes("gaps/count")) return mockOk(opts.gaps ?? { count: 0 });
+        return mockOk(opts.escalations ?? { escalations: [] });
+      }
+      if (u.includes("/v1/admin/my-tenant")) {
+        return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
+      }
+      return mockOk({ reply: "了解しました。", actions: [] });
+    });
+  }
+
+  beforeEach(() => {
+    vi.mocked(authFetch).mockReset();
+    mockNavigate.mockReset();
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: true,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  });
+
+  it("未回答質問・対応中の会話が1件以上あればカテゴリーに件数バッジが出る", async () => {
+    mockBadges({
+      gaps: { count: 3 },
+      escalations: { escalations: [{ id: "e1" }, { id: "e2" }] },
+    });
+    renderPage();
+
+    expect(await screen.findByLabelText("未回答質問 3件")).toBeTruthy();
+    expect(screen.getByLabelText("対応中の会話 2件")).toBeTruthy();
+    // バッジはカテゴリーボタンの中に出る(独立した要素ではない)
+    expect(screen.getByRole("button", { name: /知識データ/ }).textContent).toContain("3");
+    expect(screen.getByRole("button", { name: /会話の履歴/ }).textContent).toContain("2");
+  });
+
+  it("テナントのIDでスコープした既存エンドポイントを叩く(新規APIを作らない)", async () => {
+    mockBadges({ gaps: { count: 1 }, escalations: { escalations: [] } });
+    renderPage();
+
+    await screen.findByLabelText("未回答質問 1件");
+    const urls = vi.mocked(authFetch).mock.calls.map((c) => String(c[0]));
+    expect(urls).toContain("http://localhost:3100/v1/admin/knowledge/gaps/count?tenant=tenant-a");
+    expect(urls).toContain("http://localhost:3100/v1/admin/chat-history/escalations?tenant=tenant-a");
+  });
+
+  it("previewMode中はプレビュー対象テナントの件数を取得する", async () => {
+    mockBadges({ gaps: { count: 5 }, escalations: { escalations: [] } });
+    renderPage({
+      previewMode: true,
+      previewTenantId: "tenant-preview",
+      previewTenantName: "Preview Tenant",
+      isSuperAdmin: true,
+    });
+
+    await screen.findByLabelText("未回答質問 5件");
+    const urls = vi.mocked(authFetch).mock.calls.map((c) => String(c[0]));
+    expect(urls).toContain("http://localhost:3100/v1/admin/knowledge/gaps/count?tenant=tenant-preview");
+  });
+
+  it("0件のカテゴリーにはバッジを出さない", async () => {
+    mockBadges({ gaps: { count: 0 }, escalations: { escalations: [] } });
+    renderPage();
+
+    // バッジ取得の完了を待つため、件数のある側(ここでは無い)ではなくボタン自体の描画を待つ
+    await waitFor(() => expect(screen.getByRole("button", { name: /知識データ/ })).toBeTruthy());
+    await waitFor(() =>
+      expect(vi.mocked(authFetch).mock.calls.some((c) => String(c[0]).includes("gaps/count"))).toBe(true),
+    );
+
+    expect(screen.queryByLabelText(/未回答質問 /)).toBeNull();
+    expect(screen.queryByLabelText(/対応中の会話 /)).toBeNull();
+    expect(screen.getByRole("button", { name: /知識データ/ }).textContent).not.toContain("0");
+  });
+
+  it("件数の取得に失敗してもエラーを出さず、チャットはそのまま使える", async () => {
+    mockBadges({ reject: true });
+    renderPage();
+
+    // チャットは通常どおり起動し、送信もできる
+    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
+    fireEvent.change(getComposer(), { target: { value: "送料を教えて" } });
+    fireEvent.click(screen.getByLabelText("送信"));
+    await waitFor(() => expect(screen.getByText("送料を教えて")).toBeTruthy());
+
+    // バッジは出ず、技術的なエラー文言も一切出さない
+    expect(screen.queryByLabelText(/未回答質問 /)).toBeNull();
+    expect(screen.queryByLabelText(/対応中の会話 /)).toBeNull();
+    expect(screen.queryByText(/network down/)).toBeNull();
+    expect(screen.queryByText(/失敗/)).toBeNull();
+  });
+
+  it("テナントを特定できないsuper_admin(preview外)では件数を取得しない(全テナント合計を出さない)", async () => {
+    mockBadges({ gaps: { count: 7 }, escalations: { escalations: [{ id: "e1" }] } });
+    renderPage({
+      isSuperAdmin: true,
+      isClientAdmin: false,
+      user: { id: "2", email: "admin@example.com", role: "super_admin", tenantId: null, tenantName: null },
+    });
+
+    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
+    const urls = vi.mocked(authFetch).mock.calls.map((c) => String(c[0]));
+    expect(urls.some(isBadgeUrl)).toBe(false);
+    expect(screen.queryByLabelText(/未回答質問 /)).toBeNull();
   });
 });

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -29,7 +29,19 @@ import AppSwitcher from "../../components/AppSwitcher";
 // ─── モデル ──────────────────────────────────────────────────────────────────
 
 type Category =
-  | { key: string; label: string; icon: string; dim?: boolean };
+  | { key: string; label: string; icon: string; dim?: boolean; badge?: RailBadgeKind };
+
+// 左レールのバッジに出す「何件あるか」の種別。旧ダッシュボードのstatカードが担っていた
+// 一目での「対応が必要な件数」の把握を、チャットUIに戻すためのもの。
+// 自然な件数が存在しないカテゴリー(アシスタント/指示ルール/アバター等)には付けない。
+type RailBadgeKind = "gaps" | "escalations";
+
+type RailCounts = Partial<Record<RailBadgeKind, number>>;
+
+const RAIL_BADGE_LABEL: Record<RailBadgeKind, string> = {
+  gaps: "未回答質問",
+  escalations: "対応中の会話",
+};
 
 type Card =
   | { kind: "faq"; question: string; answer: string; category: string }
@@ -231,8 +243,8 @@ const AGENT_BORDER = "rgba(124,58,237,0.30)";
 const CATEGORIES: Category[] = [
   { key: "assistant", label: "アシスタント", icon: "✨" },
   { key: "weekly", label: "今週のまとめ", icon: "📊" },
-  { key: "history", label: "会話の履歴", icon: "💬" },
-  { key: "knowledge", label: "知識データ", icon: "📚" },
+  { key: "history", label: "会話の履歴", icon: "💬", badge: "escalations" },
+  { key: "knowledge", label: "知識データ", icon: "📚", badge: "gaps" },
   { key: "rules", label: "指示ルール", icon: "🎛️" },
   { key: "avatar", label: "アバター", icon: "🎭" },
 ];
@@ -261,6 +273,34 @@ export default function CopilotPreviewPage() {
   const [realHistory, setRealHistory] = useState<{ role: "user" | "assistant"; content: string }[]>([]);
   const [sending, setSending] = useState(false);
   const [realActionCount, setRealActionCount] = useState(0); // 実際に成功した書き込み操作の件数
+
+  // 左レールのバッジ用件数(旧UIと同じ既存エンドポイントの再利用)。
+  // テナントを特定できない場合(preview中でないsuper_admin)は取得しない。
+  // 全テナント横断の合計が「この店の件数」として出てしまうため。
+  const badgeTenantId = previewMode ? (previewTenantId ?? "") : (user?.tenantId ?? "");
+  const [railCounts, setRailCounts] = useState<RailCounts>({});
+  useEffect(() => {
+    if (!badgeTenantId) return;
+    const qs = `?tenant=${encodeURIComponent(badgeTenantId)}`;
+    void (async () => {
+      // 失敗しても店主には何も見せない(バッジが出ないだけ)。片方だけ失敗しても
+      // もう片方は出せるよう allSettled で個別に扱う。
+      const [gapRes, escRes] = await Promise.allSettled([
+        authFetch(`${API_BASE}/v1/admin/knowledge/gaps/count${qs}`),
+        authFetch(`${API_BASE}/v1/admin/chat-history/escalations${qs}`),
+      ]);
+      const next: RailCounts = {};
+      if (gapRes.status === "fulfilled" && gapRes.value.ok) {
+        const data = (await gapRes.value.json().catch(() => null)) as { count?: number } | null;
+        if (typeof data?.count === "number") next.gaps = data.count;
+      }
+      if (escRes.status === "fulfilled" && escRes.value.ok) {
+        const data = (await escRes.value.json().catch(() => null)) as { escalations?: unknown[] } | null;
+        if (Array.isArray(data?.escalations)) next.escalations = data.escalations.length;
+      }
+      setRailCounts(next);
+    })();
+  }, [badgeTenantId]);
 
   // textareaは行が増えても自動では伸びないため、入力量に応じて高さを合わせる
   // (伸ばさないと2行目以降を打った時に前の行が枠外へ隠れてしまう)
@@ -569,6 +609,7 @@ export default function CopilotPreviewPage() {
         <PreviewBadge />
         {CATEGORIES.map((c) => {
           const locked = busy && c.key !== active;
+          const count = c.badge ? railCounts[c.badge] : undefined;
           return (
             <button
               key={c.key}
@@ -585,7 +626,12 @@ export default function CopilotPreviewPage() {
                 opacity: locked ? 0.35 : c.dim ? 0.55 : 1, minHeight: 44,
               }}
             >
-              <span style={{ fontSize: 18 }}>{c.icon}</span>{c.label}
+              <span style={{ fontSize: 18 }}>{c.icon}</span>
+              <span style={{ minWidth: 0 }}>{c.label}</span>
+              {/* 0件はバッジを出さない(「0」は情報ではなくノイズになる) */}
+              {c.badge && count !== undefined && count > 0 && (
+                <RailCountBadge count={count} label={RAIL_BADGE_LABEL[c.badge]} />
+              )}
             </button>
           );
         })}
@@ -694,6 +740,24 @@ function PreviewBadge() {
     <div style={{ margin: "6px 8px 10px", fontSize: 11.5, fontWeight: 700, letterSpacing: "0.03em", color: "#b45309", background: "rgba(245,158,11,0.14)", border: "1px solid rgba(245,158,11,0.3)", borderRadius: 8, padding: "6px 10px", lineHeight: 1.45 }}>
       PROTOTYPE ・ 全ての操作が実際のR2Cエージェント(実API)に接続されています
     </div>
+  );
+}
+
+// 左レールの件数バッジ。marginLeft:auto で行末に寄せ、flexShrink:0 で
+// ラベルに押し潰されないようにする(狭い幅ではラベル側が折り返す)。
+function RailCountBadge({ count, label }: { count: number; label: string }) {
+  return (
+    <span
+      aria-label={`${label} ${count}件`}
+      style={{
+        marginLeft: "auto", flexShrink: 0, minWidth: 24, padding: "1px 7px", borderRadius: 999,
+        fontSize: 13, fontWeight: 700, lineHeight: 1.5, textAlign: "center",
+        color: "#b45309", background: "rgba(245,158,11,0.16)", border: "1px solid rgba(245,158,11,0.35)",
+        fontVariantNumeric: "tabular-nums",
+      }}
+    >
+      {count}
+    </span>
   );
 }
 


### PR DESCRIPTION
Asana GID 1217007275511487

## 背景
`/copilot-preview` の左レールは6カテゴリーへの送信トリガーだけで、状態を一切示していない。
旧ダッシュボードの statカード(未回答質問◯件 等)が無いと「今どれだけ溜まっているか」に
気づけず、チャットUIを常用するほど対応漏れしやすい。第二のダッシュボードにはせず、
「今なにを見るべきか」の一目把握だけを戻す。

## 変更
自然な件数を持つ2カテゴリーにだけバッジを出す(既存エンドポイントの再利用のみ、新規APIなし)。

| カテゴリー | 件数 | 再利用したエンドポイント |
|---|---|---|
| 📚 知識データ | 未回答質問(status=open) | `GET /v1/admin/knowledge/gaps/count?tenant=` (旧ダッシュボード `pages/admin/index.tsx` と同一) |
| 💬 会話の履歴 | 対応中のエスカレーション | `GET /v1/admin/chat-history/escalations?tenant=` (旧UI `pages/admin/escalations/index.tsx` と同一) |

`アシスタント` / `今週のまとめ` / `指示ルール` / `アバター` は自然な「件数」が無いためバッジ無し。

- **0件はバッジ無し** — 「0」は情報ではなくノイズになるため
- **取得失敗は黙って劣化** — バッジが出ないだけ。エラー文言もチャットへの影響も無し(`Promise.allSettled` で片方だけ失敗してももう片方は出す)
- **テナント未特定(preview外のsuper_admin)では取得しない** — 全テナント横断の合計が「この店の件数」として出てしまうため
- `targetTenantId` の解決は同ファイル内の既存パターン(`previewMode ? previewTenantId : user.tenantId`)に合わせた

### 知識ギャップは一覧ではなく count エンドポイントを使った
`knowledge-gaps/index.tsx` は一覧(`/knowledge/gaps?status=open`)を叩くが、バックエンドには
バッジ用の既存 count エンドポイント(`getGapCount()` = `status='open'` の COUNT)がある。
どちらも既存APIで、レールのバッジには行を1件も転送しない後者が適切。旧ダッシュボードも同じものを使っている。

### プランゲート
バッジを付けた2カテゴリー(未回答質問・対応中の会話)は **どちらも Growth+ ゲート対象ではない**
(`AppSidebar.tsx` の `requiresPlan` は 会話分析/成約・効果分析 のみ)。よってゲート判定は
デッドコードになるため追加せず、その旨のテストも入れていない。
プランゲート対象の `アバター` はそもそもバッジ対象外。

## アクセシビリティ
- バッジ文字サイズ **13px**(11/12px不使用。実測 `computedStyle.fontSize === "13px"`)
- カテゴリーボタンのタップ領域は **48.4px**(≥44px を維持。390px幅で実測)
- 390px幅でラベルと衝突・切り詰めなし(実測: ラベル `scrollWidth === clientWidth`、ラベル右端とバッジ左端の間に67pxの余白)
- バッジは `aria-label="未回答質問 3件"` を持ち、数字だけが読み上げられることを避けている

## 検証
- `npm run lint` ✅ (警告数は変化なし)
- `npx tsc --noEmit` (root / admin-ui とも) ✅
- `npx vitest run src/pages/copilot-preview/index.test.tsx` ✅ 25 passed (既存19 + 新規6)
- admin-ui 全体 ✅ 174 passed / 23 files
- 既存テストのアサーション変更ゼロ。マウント時のfetchが2本増えるため、各 `beforeEach` の
  authFetch モックにバッジURLの素通り分岐(0件)だけを追加している
- 実際の390px viewport(iframe)とデスクトップ幅の両方でバッジ描画をスクリーンショット確認済み
- `git diff --stat -- '*.sql' '.env*' 'package.json'` は空(フロントエンドのみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177MCsC7jN3a51F7TdaW9vH