### PR TITLE
fix: プラン制限の案内を会話内で繰り返さない + super_adminのcopilot-preview入口を用意する

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -60,6 +60,18 @@ function baseAuth(overrides: Partial<ReturnType<typeof useAuth>> = {}) {
   } as ReturnType<typeof useAuth>;
 }
 
+// super_admin は my-tenant のオンボーディング判定をスキップして直接ブリーフィングへ進む。
+// プレビュー未選択(previewMode=false)のsuper_adminはテナント選択画面になるため、
+// チャット本体の挙動を検証するテストではクライアントビューに入った状態を使う。
+const SUPER_ADMIN_IN_PREVIEW: Partial<ReturnType<typeof useAuth>> = {
+  isSuperAdmin: true,
+  isClientAdmin: false,
+  previewMode: true,
+  previewTenantId: "tenant-preview",
+  previewTenantName: "Preview Tenant",
+  user: { id: "2", email: "admin@example.com", role: "super_admin", tenantId: null, tenantName: null },
+};
+
 function renderPage(overrides: Partial<ReturnType<typeof useAuth>> = {}) {
   vi.mocked(useAuth).mockReturnValue(baseAuth(overrides));
   return render(
@@ -148,8 +160,7 @@ describe("CopilotPreviewPage — モバイル左レールのドロワー化", ()
   });
 
   it("初期状態ではドロワーは閉じており、オーバーレイも存在しない", async () => {
-    // super_admin(client_admin以外)は my-tenant 判定をスキップして直接ブリーフィングへ進む
-    renderPage({ isSuperAdmin: true, isClientAdmin: false, user: { id: "2", email: "admin@example.com", role: "super_admin", tenantId: null, tenantName: null } });
+    renderPage(SUPER_ADMIN_IN_PREVIEW);
     await waitFor(() => expect(authFetch).toHaveBeenCalledTimes(1));
 
     expect(getRail().className).not.toContain("cp-rail-open");
@@ -157,7 +168,7 @@ describe("CopilotPreviewPage — モバイル左レールのドロワー化", ()
   });
 
   it("ハンバーガーボタンでドロワーが開き、背景オーバーレイが表示される", async () => {
-    renderPage({ isSuperAdmin: true, isClientAdmin: false, user: { id: "2", email: "admin@example.com", role: "super_admin", tenantId: null, tenantName: null } });
+    renderPage(SUPER_ADMIN_IN_PREVIEW);
     await waitFor(() => expect(authFetch).toHaveBeenCalledTimes(1));
 
     fireEvent.click(screen.getByRole("button", { name: "メニューを開く" }));
@@ -167,7 +178,7 @@ describe("CopilotPreviewPage — モバイル左レールのドロワー化", ()
   });
 
   it("オーバーレイをタップするとドロワーが閉じる", async () => {
-    renderPage({ isSuperAdmin: true, isClientAdmin: false, user: { id: "2", email: "admin@example.com", role: "super_admin", tenantId: null, tenantName: null } });
+    renderPage(SUPER_ADMIN_IN_PREVIEW);
     await waitFor(() => expect(authFetch).toHaveBeenCalledTimes(1));
 
     fireEvent.click(screen.getByRole("button", { name: "メニューを開く" }));
@@ -180,7 +191,7 @@ describe("CopilotPreviewPage — モバイル左レールのドロワー化", ()
   });
 
   it("レール内の閉じるボタン(✕)でもドロワーが閉じる", async () => {
-    renderPage({ isSuperAdmin: true, isClientAdmin: false, user: { id: "2", email: "admin@example.com", role: "super_admin", tenantId: null, tenantName: null } });
+    renderPage(SUPER_ADMIN_IN_PREVIEW);
     await waitFor(() => expect(authFetch).toHaveBeenCalledTimes(1));
 
     fireEvent.click(screen.getByRole("button", { name: "メニューを開く" }));
@@ -191,7 +202,7 @@ describe("CopilotPreviewPage — モバイル左レールのドロワー化", ()
   });
 
   it("会話中でない状態でカテゴリーを選択するとドロワーが閉じる", async () => {
-    renderPage({ isSuperAdmin: true, isClientAdmin: false, user: { id: "2", email: "admin@example.com", role: "super_admin", tenantId: null, tenantName: null } });
+    renderPage(SUPER_ADMIN_IN_PREVIEW);
     // bootstrap完了(送信ボタンのdisabled解除)を待ってから操作する
     await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
 
@@ -207,7 +218,7 @@ describe("CopilotPreviewPage — モバイル左レールのドロワー化", ()
     vi.mocked(authFetch).mockImplementation(
       () => new Promise<Response>((resolve) => { resolveFetch = resolve; }),
     );
-    renderPage({ isSuperAdmin: true, isClientAdmin: false, user: { id: "2", email: "admin@example.com", role: "super_admin", tenantId: null, tenantName: null } });
+    renderPage(SUPER_ADMIN_IN_PREVIEW);
     await waitFor(() => expect(authFetch).toHaveBeenCalledTimes(1));
 
     fireEvent.click(screen.getByRole("button", { name: "メニューを開く" }));
@@ -450,5 +461,83 @@ describe("CopilotPreviewPage — 保留中の下書きチップを無視して�
     await waitFor(() => expect(screen.getByText("やっぱりやめて、営業時間を教えて")).toBeTruthy());
     expect(screen.queryByRole("button", { name: "保存して" })).toBeNull();
     expect(screen.queryByRole("button", { name: "やめておく" })).toBeNull();
+  });
+});
+
+// GID 1217007275510096: プレビュー未選択のsuper_adminは、ほぼ全てのツールが
+// 「テナントが特定できません」を返して会話が行き止まりになっていた。チャットを
+// 始める前にテナントを選ばせ、既存のクライアントビュー(enterPreview)へ入れる。
+describe("CopilotPreviewPage — super_adminのテナント選択", () => {
+  const TENANTS = [
+    { id: "tenant-a", name: "あおぞら商店" },
+    { id: "tenant-b", name: "みどり工房" },
+  ];
+
+  const SUPER_ADMIN_NO_PREVIEW: Partial<ReturnType<typeof useAuth>> = {
+    isSuperAdmin: true,
+    isClientAdmin: false,
+    previewMode: false,
+    user: { id: "2", email: "admin@example.com", role: "super_admin", tenantId: null, tenantName: null },
+  };
+
+  beforeEach(() => {
+    vi.mocked(authFetch).mockReset();
+    mockNavigate.mockReset();
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (String(url).includes("/v1/admin/tenants")) return mockOk({ tenants: TENANTS, total: TENANTS.length });
+      if (String(url).includes("/v1/admin/my-tenant")) {
+        return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
+      }
+      return mockOk({ reply: "了解しました。", actions: [] });
+    });
+  });
+
+  it("previewMode未選択のsuper_adminにはテナント選択が出て、チャット(ブリーフィング)は始まらない", async () => {
+    renderPage(SUPER_ADMIN_NO_PREVIEW);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: /あおぞら商店/ })).toBeTruthy());
+    expect(screen.getByRole("heading", { name: /どのお客様として見ますか/ })).toBeTruthy();
+    // チャット本体(コンポーザ)はまだ出さない
+    expect(screen.queryByLabelText("送信")).toBeNull();
+    // 一覧取得のみ。エージェントAPI(ブリーフィング)は叩かない
+    expect(vi.mocked(authFetch).mock.calls.every(([url]) => String(url).includes("/v1/admin/tenants"))).toBe(true);
+  });
+
+  it("テナントを選ぶと enterPreview(テナントID, テナント名) が呼ばれる", async () => {
+    const enterPreview = vi.fn();
+    renderPage({ ...SUPER_ADMIN_NO_PREVIEW, enterPreview });
+
+    const button = await waitFor(() => screen.getByRole("button", { name: /みどり工房/ }));
+    fireEvent.click(button);
+
+    expect(enterPreview).toHaveBeenCalledWith("tenant-b", "みどり工房");
+  });
+
+  it("previewMode中のsuper_adminはテナント選択を挟まず通常のチャットになる", async () => {
+    renderPage(SUPER_ADMIN_IN_PREVIEW);
+
+    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
+    expect(screen.queryByRole("heading", { name: /どのお客様として見ますか/ })).toBeNull();
+    expect(vi.mocked(authFetch).mock.calls.some(([url]) => String(url).includes("/v1/admin/tenants"))).toBe(false);
+  });
+
+  it("client_adminにはテナント選択が出ず、常に通常のチャットになる", async () => {
+    renderPage();
+
+    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
+    expect(screen.queryByRole("heading", { name: /どのお客様として見ますか/ })).toBeNull();
+    expect(vi.mocked(authFetch).mock.calls.some(([url]) => String(url).includes("/v1/admin/tenants"))).toBe(false);
+  });
+
+  it("テナント一覧が取得できない場合は再読み込みを促す(白画面にしない)", async () => {
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (String(url).includes("/v1/admin/tenants")) {
+        return Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({}) } as Response);
+      }
+      return mockOk({ reply: "了解しました。", actions: [] });
+    });
+    renderPage(SUPER_ADMIN_NO_PREVIEW);
+
+    await waitFor(() => expect(screen.getByText(/テナント一覧を取得できませんでした/)).toBeTruthy());
   });
 });

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -31,6 +31,12 @@ import AppSwitcher from "../../components/AppSwitcher";
 type Category =
   | { key: string; label: string; icon: string; dim?: boolean };
 
+// GET /v1/admin/tenants(既存・super_admin限定)のうち、テナント選択に使う項目だけ
+interface TenantOption {
+  id: string;
+  name: string;
+}
+
 type Card =
   | { kind: "faq"; question: string; answer: string; category: string }
   | { kind: "rule"; trigger: string; behavior: string }
@@ -246,8 +252,13 @@ export default function CopilotPreviewPage() {
   // super_adminがテナントプレビュー中の場合、対象テナントIDをtargetTenantIdとしてAPIに渡す
   // (他画面のescalations/knowledge-gaps等と同じパターン)。client_adminは自身のJWT由来の
   // tenantIdがサーバー側で使われるため、previewMode=falseのままで問題ない。
-  const { user, previewMode, previewTenantId, logout } = useAuth();
+  const { user, isSuperAdmin, previewMode, previewTenantId, enterPreview, logout } = useAuth();
   const navigate = useNavigate();
+  // super_adminがプレビューに入っていない場合、テナントが特定できないため
+  // ほぼ全てのツールが「テナントが特定できません」になり会話が行き止まりになる。
+  // 先にテナントを選ばせて既存のクライアントビュー(previewMode)へ入れる。
+  // previewModeに入れば以降はclient_adminと同じ経路をそのまま辿る。
+  const needsTenantSelection = isSuperAdmin && !previewMode;
   const [active, setActive] = useState("assistant");
   const [input, setInput] = useState("");
   const [isComposing, setIsComposing] = useState(false);
@@ -433,6 +444,10 @@ export default function CopilotPreviewPage() {
   // super_admin(プレビュー中含む)はオンボーディング判定の対象外(常に週次ブリーフィング側)。
   const bootstrapped = useRef(false);
   useEffect(() => {
+    // テナント選択待ちの間は取りに行かない（テナント未特定のブリーフィングは
+    // 「テナントが特定できません」で埋まるだけのため）。選択してpreviewModeに
+    // 入った時点でこのeffectが再評価され、通常どおりブリーフィングが走る。
+    if (needsTenantSelection) return;
     if (bootstrapped.current) return;
     bootstrapped.current = true;
 
@@ -461,7 +476,29 @@ export default function CopilotPreviewPage() {
       }
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [needsTenantSelection]);
+
+  // テナント選択用の一覧。既存の GET /v1/admin/tenants(super_admin限定)をそのまま使う。
+  const [tenants, setTenants] = useState<TenantOption[] | null>(null);
+  const [tenantsFailed, setTenantsFailed] = useState(false);
+  useEffect(() => {
+    if (!needsTenantSelection) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const res = await authFetch(`${API_BASE}/v1/admin/tenants`);
+        if (!res.ok) {
+          if (!cancelled) setTenantsFailed(true);
+          return;
+        }
+        const data = (await res.json()) as { tenants?: TenantOption[] };
+        if (!cancelled) setTenants(data.tenants ?? []);
+      } catch {
+        if (!cancelled) setTenantsFailed(true);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, [needsTenantSelection]);
 
   // 新UI(サイドバー型ではないため)にはログアウト手段が無く、Phase4トグルで
   // このブラウザの既定画面にすると詰む(GID: 新UI常用時にログアウトできない)。
@@ -529,6 +566,16 @@ export default function CopilotPreviewPage() {
   };
 
   // ─── レイアウト ───────────────────────────────────────────────────────────
+  if (needsTenantSelection) {
+    return (
+      <TenantSelection
+        tenants={tenants}
+        failed={tenantsFailed}
+        onSelect={(t) => enterPreview(t.id, t.name)}
+      />
+    );
+  }
+
   return (
     <div
       className="cp-shell"
@@ -688,6 +735,71 @@ export default function CopilotPreviewPage() {
 }
 
 // ─── 部品 ────────────────────────────────────────────────────────────────────
+
+// super_adminがプレビュー未選択で入ってきた時だけ出す、チャット開始前のテナント選択。
+// 選ぶと既存の enterPreview(=クライアントビュー)に入り、以降の画面・ツールは
+// client_adminと同じ挙動になる(super_admin専用の機能は一切増やさない)。
+function TenantSelection({
+  tenants,
+  failed,
+  onSelect,
+}: {
+  tenants: TenantOption[] | null;
+  failed: boolean;
+  onSelect: (t: TenantOption) => void;
+}) {
+  return (
+    <div
+      style={{
+        minHeight: "100vh", display: "flex", alignItems: "center", justifyContent: "center",
+        padding: "24px 16px", background: "var(--background)", color: "var(--foreground)",
+        fontFamily: "var(--font-sans, system-ui, sans-serif)",
+      }}
+    >
+      <div style={{ width: "100%", maxWidth: 420, display: "flex", flexDirection: "column", gap: 16 }}>
+        <div style={{ display: "flex", alignItems: "center", gap: 12 }}>
+          <AgentMark />
+          <div>
+            <h1 style={{ margin: 0, fontSize: 19, fontWeight: 800, letterSpacing: "-0.02em" }}>
+              どのお客様として見ますか？
+            </h1>
+            <div style={{ fontSize: 13, color: "var(--muted-foreground)", marginTop: 3, lineHeight: 1.5 }}>
+              テナントを選ぶとクライアントビューに入り、そのお客様と同じチャットを再現できます。
+            </div>
+          </div>
+        </div>
+
+        {failed ? (
+          <div style={{ fontSize: 14, color: "var(--muted-foreground)", lineHeight: 1.7 }}>
+            テナント一覧を取得できませんでした。ページを再読み込みしてお試しください。
+          </div>
+        ) : tenants === null ? (
+          <div style={{ fontSize: 14, color: "var(--muted-foreground)" }}>テナント一覧を読み込んでいます…</div>
+        ) : tenants.length === 0 ? (
+          <div style={{ fontSize: 14, color: "var(--muted-foreground)" }}>表示できるテナントがありません。</div>
+        ) : (
+          <div style={{ display: "flex", flexDirection: "column", gap: 8, maxHeight: "60vh", overflowY: "auto" }}>
+            {tenants.map((t) => (
+              <button
+                key={t.id}
+                onClick={() => onSelect(t)}
+                style={{
+                  display: "flex", flexDirection: "column", alignItems: "flex-start", gap: 3,
+                  width: "100%", padding: "12px 14px", borderRadius: 12,
+                  border: `1px solid ${AGENT_BORDER}`, background: "var(--card)",
+                  color: "var(--foreground)", cursor: "pointer", textAlign: "left", minHeight: 44,
+                }}
+              >
+                <span style={{ fontSize: 15, fontWeight: 700 }}>{t.name}</span>
+                <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>{t.id}</span>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
 
 function PreviewBadge() {
   return (

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -23,6 +23,7 @@ import {
   setStagedFaqImport,
   getStagedFaqImport,
   clearStagedFaqImport,
+  recordPlanLimitMention,
 } from './knowledgeImportStaging';
 import { suggestEngagementRuleFromText } from './engagementSuggest';
 import { getSessions, getActiveEscalations, getMessages, saveMessage, resolveEscalation } from '../chat-history/chatHistoryRepository';
@@ -41,6 +42,40 @@ const MAX_IMPORT_FAQS = 20;
 // 有人返信1件の最大文字数。POST /v1/admin/chat-history/sessions/:id/reply の
 // zod スキーマ(z.string().min(1).max(2000))と揃える。
 const MAX_OPERATOR_REPLY_LENGTH = 2000;
+
+// ---------------------------------------------------------------------------
+// プラン制限の案内文
+// ---------------------------------------------------------------------------
+//
+// full は他のAPI(analytics/routes.ts, tenants/routes.ts 等)と同じ文言。変更しないこと。
+// 同じ会話の中で同じ機能について何度も full を返すと同じ売り込みの繰り返しになるため、
+// 2回目以降は short に切り替える(制限そのものは変わらない)。判定は
+// knowledgeImportStaging.ts の recordPlanLimitMention((tenantId, sessionId, feature)単位)。
+type PlanLimitedFeature = 'avatar' | 'analytics' | 'conversion' | 'sai_task';
+
+const PLAN_LIMIT_NOTICES: Record<PlanLimitedFeature, { full: string; short: string }> = {
+  avatar: {
+    full: 'AIアバター機能はGrowthプラン以上でご利用いただけます',
+    short: 'AIアバター機能はプラン対象外のままです',
+  },
+  analytics: {
+    full: 'この機能はGrowthプラン以上でご利用いただけます',
+    short: 'この機能はプラン対象外のままです',
+  },
+  conversion: {
+    full: 'この機能はGrowthプラン以上でご利用いただけます',
+    short: 'この機能はプラン対象外のままです',
+  },
+  sai_task: {
+    full: 'Saiへの代行依頼はEnterpriseプラン以上でご利用いただけます',
+    short: 'Saiへの代行依頼はプラン対象外のままです',
+  },
+};
+
+function planLimitNotice(tenantId: string, sessionId: string, feature: PlanLimitedFeature): string {
+  const notice = PLAN_LIMIT_NOTICES[feature];
+  return recordPlanLimitMention(tenantId, sessionId, feature) ? notice.short : notice.full;
+}
 
 // ---------------------------------------------------------------------------
 // Avatar activate（avatar/routes.ts は無改変、ここで再実装）
@@ -476,7 +511,7 @@ export async function executeToolCall(
       // 使ってしまい、テストのモックPoolと食い違って汚染するため queryTenantPlan を直接使う）。
       const plan = await queryTenantPlan(db, tenantId);
       if (!planHasFeature(plan, 'avatar')) {
-        return truncate('AIアバター機能はGrowthプラン以上でご利用いただけます');
+        return truncate(planLimitNotice(tenantId, sessionId, 'avatar'));
       }
 
       const client = await db.connect();
@@ -1590,7 +1625,7 @@ export async function executeToolCall(
       if (!isSuperAdmin) {
         const plan = await queryTenantPlan(db, tenantId);
         if (!planHasFeature(plan, 'sai_task')) {
-          return truncate('Saiへの代行依頼はEnterpriseプラン以上でご利用いただけます');
+          return truncate(planLimitNotice(tenantId, sessionId, 'sai_task'));
         }
       }
 
@@ -1722,7 +1757,7 @@ export async function executeToolCall(
         }
         const plan = await queryTenantPlan(db, tenantId);
         if (!planHasFeature(plan, feature)) {
-          return truncate('この機能はGrowthプラン以上でご利用いただけます');
+          return truncate(planLimitNotice(tenantId, sessionId, feature));
         }
       }
 
@@ -1771,7 +1806,7 @@ export async function executeToolCall(
       }
       const plan = await queryTenantPlan(db, tenantId);
       if (!planHasFeature(plan, feature)) {
-        return truncate('この機能はGrowthプラン以上でご利用いただけます');
+        return truncate(planLimitNotice(tenantId, sessionId, feature));
       }
 
       const period = args['period'] === '7d' ? '7d' : '30d';

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -176,7 +176,11 @@ import { ADMIN_AGENT_TOOLS, LEGACY_UI_FEATURES } from './toolDefinitions';
 // ステージング(knowledgeImportStaging.ts)はモックせず実物を使う。
 // suggest_faq_import_from_text/urls → commit_faq_import の2ターン検証、
 // TTL/上限とは独立にテスト間の状態リークを防ぐためのリセット関数として使う。
-import { getStagedFaqImport, __resetKnowledgeImportStagingForTest } from './knowledgeImportStaging';
+import {
+  getStagedFaqImport,
+  __resetKnowledgeImportStagingForTest,
+  __resetPlanLimitNoticesForTest,
+} from './knowledgeImportStaging';
 
 // ---------------------------------------------------------------------------
 // ヘルパー
@@ -246,6 +250,9 @@ describe('POST /v1/admin/agent/chat', () => {
     // knowledgeImportStaging はモックしない実物のモジュールなので、
     // jest.resetAllMocks() では消えないプロセス内Mapをテストごとに明示的にリセットする。
     __resetKnowledgeImportStagingForTest();
+    // プラン制限の「案内済み」フラグも同じプロセス内Mapのため、テストごとにリセットする
+    // (残っていると次のテストが2回目扱いになり短い文が返る)。
+    __resetPlanLimitNoticesForTest();
   });
 
   // -------------------------------------------------------------------------
@@ -3344,6 +3351,93 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(res.status).toBe(200);
       expect(res.body.actions[0].result).toContain('Growthプラン以上');
       expect(mockConnect).not.toHaveBeenCalled();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GID 1217007275510096: 同じ会話の中で同じプラン制限の全文案内を毎回繰り返さない。
+  // 初回は従来の全文のまま、2回目以降は短い確認だけ。判定はセッション単位・機能単位。
+  // (制限そのものは変わらない = 数値やリンクは相変わらず返さない)
+  // -------------------------------------------------------------------------
+  describe('プラン制限メッセージの繰り返し抑制', () => {
+    function toolCallResponse(id: string, name: string, args: Record<string, unknown> = {}) {
+      return {
+        ok: true,
+        json: async () => ({
+          choices: [{
+            message: {
+              content: null,
+              tool_calls: [{ id, type: 'function', function: { name, arguments: JSON.stringify(args) } }],
+            },
+          }],
+        }),
+        text: async () => '',
+      };
+    }
+
+    // 他のAPI(analytics/routes.ts 等)と共有している既存の文言。この繰り返し抑制で
+    // 初回メッセージの文言が変わっていないことを1文字単位で固定する。
+    const FULL_GROWTH_NOTICE = 'この機能はGrowthプラン以上でご利用いただけます';
+    const FULL_AVATAR_NOTICE = 'AIアバター機能はGrowthプラン以上でご利用いただけます';
+
+    /** starterプランのテナントとしてプラン制限付きツールを1ターン実行し、その結果文字列を返す */
+    async function askGated(
+      toolName: string,
+      sessionId: string,
+      callId: string,
+      args: Record<string, unknown> = {},
+    ): Promise<string> {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse(callId, toolName, args))
+        .mockResolvedValueOnce(makeGroqResponse('プラン制限のためお伝えしました。'));
+      mockQuery.mockResolvedValueOnce({ rows: [{ plan: 'starter' }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '分析を見せて', sessionId });
+
+      expect(res.status).toBe(200);
+      return res.body.actions[0].result as string;
+    }
+
+    it('初回は既存の全文をそのまま返す', async () => {
+      const result = await askGated('get_analytics_summary', 'sess-plan-rep-01', 'call-rep-1');
+      expect(result).toBe(FULL_GROWTH_NOTICE);
+    });
+
+    it('同一セッション・同一機能の2回目は全文を繰り返さず短い文になる', async () => {
+      const first = await askGated('get_analytics_summary', 'sess-plan-rep-02', 'call-rep-2');
+      expect(first).toBe(FULL_GROWTH_NOTICE);
+
+      const second = await askGated('get_analytics_summary', 'sess-plan-rep-02', 'call-rep-3');
+      expect(second).not.toBe(FULL_GROWTH_NOTICE);
+      expect(second).not.toContain('Growthプラン以上');
+      expect(second.length).toBeLessThan(FULL_GROWTH_NOTICE.length * 0.8);
+      // 短くなっても制限は効いたまま(数値は一切返さない)
+      expect(mockFetchAnalyticsSummary).not.toHaveBeenCalled();
+    });
+
+    it('別セッションなら同じ機能でも初回として全文を返す(グローバルな抑制ではない)', async () => {
+      expect(await askGated('get_analytics_summary', 'sess-plan-rep-03', 'call-rep-4')).toBe(FULL_GROWTH_NOTICE);
+      expect(await askGated('get_analytics_summary', 'sess-plan-rep-04', 'call-rep-5')).toBe(FULL_GROWTH_NOTICE);
+    });
+
+    it('同一セッションでも別の機能なら初回として全文を返す(機能ごとに1回ずつ案内する)', async () => {
+      expect(await askGated('get_analytics_summary', 'sess-plan-rep-05', 'call-rep-6')).toBe(FULL_GROWTH_NOTICE);
+      expect(await askGated('get_conversion_summary', 'sess-plan-rep-05', 'call-rep-7')).toBe(FULL_GROWTH_NOTICE);
+      expect(await askGated('activate_avatar', 'sess-plan-rep-05', 'call-rep-8', { id: 'av-1' })).toBe(FULL_AVATAR_NOTICE);
+      expect(mockConnect).not.toHaveBeenCalled();
+    });
+
+    it('旧UI案内(get_legacy_ui_link)と数値サマリーは同じ機能の案内として1回に集約される', async () => {
+      const first = await askGated('get_legacy_ui_link', 'sess-plan-rep-06', 'call-rep-9', { feature: 'analytics' });
+      expect(first).toBe(FULL_GROWTH_NOTICE);
+
+      const second = await askGated('get_analytics_summary', 'sess-plan-rep-06', 'call-rep-10');
+      expect(second).not.toContain('Growthプラン以上');
+      // 押せないリンクカードが出ないことは短い文でも変わらない
+      expect(second).not.toMatch(/画面:/);
+      expect(second).not.toMatch(/URL:/);
     });
   });
 

--- a/src/api/admin/agent/knowledgeImportStaging.ts
+++ b/src/api/admin/agent/knowledgeImportStaging.ts
@@ -99,3 +99,49 @@ export function clearStagedFaqImport(tenantId: string, sessionId: string): void 
 export function __resetKnowledgeImportStagingForTest(): void {
   staging.clear();
 }
+
+// ---------------------------------------------------------------------------
+// プラン制限の案内済みフラグ
+// ---------------------------------------------------------------------------
+//
+// プラン未満の機能を尋ねられるたびに同じ案内文を丸ごと返すと、1つの会話の中で
+// 同じ売り込み文を何度も読ませることになる（ダッシュボードのグレーアウトした
+// ボタンより体験が悪い）。初回だけ従来どおりの全文を返し、2回目以降は短い
+// 確認だけに切り替えるため、「もう案内したか」をここで覚えておく。
+//
+// 保存の仕組み・前提条件（単一プロセス運用）・TTL・エントリ数上限は上の
+// ステージングと同じ方針に揃えている。キーに feature を含めるのは、別の機能で
+// 制限に当たったときは初回として全文を出すため（機能ごとに1回ずつ案内する）。
+
+const planLimitNotices = new Map<string, number>();
+
+function planLimitKey(tenantId: string, sessionId: string, feature: string): string {
+  return `${tenantId}::${sessionId}::${feature}`;
+}
+
+/**
+ * 当該セッション・当該機能のプラン制限を「案内済み」として記録し、
+ * 2回目以降（＝すでに案内済み）なら true を返す。
+ * 呼び出し側は false なら従来の全文、true なら短い文に切り替える。
+ */
+export function recordPlanLimitMention(tenantId: string, sessionId: string, feature: string): boolean {
+  const now = Date.now();
+  for (const [key, createdAt] of planLimitNotices) {
+    if (now - createdAt > TTL_MS) planLimitNotices.delete(key);
+  }
+
+  const key = planLimitKey(tenantId, sessionId, feature);
+  if (planLimitNotices.has(key)) return true;
+
+  if (planLimitNotices.size >= MAX_ENTRIES) {
+    const oldestKey = planLimitNotices.keys().next().value;
+    if (oldestKey !== undefined) planLimitNotices.delete(oldestKey);
+  }
+  planLimitNotices.set(key, now);
+  return false;
+}
+
+/** テスト用: 内部Mapを空にする */
+export function __resetPlanLimitNoticesForTest(): void {
+  planLimitNotices.clear();
+}


### PR DESCRIPTION
Asana GID 1217007275510096

小さく独立した2件の修正。どちらも既存の仕組みを使い回すだけで、新規ファイル・新規エンドポイントなし。

## Fix 1: プラン制限の売り込み文を会話内で繰り返さない

**問題**: プラン未満のテナントがGrowth+の機能(分析・成約・アバター有効化・Sai代行)について尋ねるたび、毎回同じ全文(「この機能はGrowthプラン以上でご利用いただけます」)が返っていた。1つの会話の中で3つの機能について尋ねれば3回、同じ機能を2回尋ねれば2回。ダッシュボードのグレーアウトしたボタンより体験が悪い。

**修正**: セッション内で「その機能の制限をもう案内したか」を覚え、
- 初回: **既存の全文をそのまま**返す(文言は1文字も変更していない。他APIと共有しているため)
- 2回目以降: 短い確認だけ(例 `この機能はプラン対象外のままです`)

判定単位は **(tenantId, sessionId, feature)**。別セッションなら初回として全文、同一セッションでも別の機能なら初回として全文を出す(機能ごとに1回ずつ案内する)。

保存先は `src/api/admin/agent/knowledgeImportStaging.ts`(既にセッションスコープの一時状態を持つ既存の置き場)に追記。プロセス内Map・TTL 30分・上限200件という既存の方針をそのまま踏襲した。

適用箇所は `planHasFeature` を呼んでいる全てのゲート:
- `activate_avatar`
- `request_sai_task`
- `get_legacy_ui_link`(analytics / conversion)
- `get_analytics_summary` / `get_conversion_summary`

**プラン制限そのものは変えていない**(何が使えるかは不変。変わるのは2回目以降の文言だけ)。

## Fix 2: super_admin の /copilot-preview が行き止まりにならないようにする

**問題**: super_admin が previewMode なし(特定顧客のクライアントビューに入っていない状態)で `/copilot-preview` を開くと、ほぼ全てのツールが「テナントが特定できません」を返し、しかもチャットの中から復帰する手段が無かった。顧客のチャット体験を再現したいサポート業務が詰む。

**修正**: `isSuperAdmin && !previewMode` のときだけ、チャット開始前(ブリーフィング取得前)にテナント選択を表示し、選択で既存の `enterPreview(tenantId, tenantName)` を呼んでクライアントビューへ入れる。previewMode に入れば既存の分岐がそのまま効くので、以降の挙動は client_admin と完全に同一。

- テナント一覧は既存の `GET /v1/admin/tenants` を利用(新規エンドポイントなし)
- **super_admin専用のツール・機能は一切追加していない**。PR #507 で撤去した「super_admin限定機能を /copilot-preview に足す」ものとは逆で、既存のクライアントプレビュー機構に super_admin を通すだけ
- 取得失敗時は白画面にせず再読み込みを促す

## テスト

`src/api/admin/agent/agentRoutes.test.ts` (+5):
- 初回は既存の全文と完全一致(`toBe`で1文字単位に固定)
- 同一セッション・同一機能の2回目は全文を繰り返さず短くなる(かつ数値・リンクは依然返さない)
- 別セッションは同じ機能でも全文(グローバルな抑制ではない)
- 同一セッションでも別機能なら全文(analytics → conversion → activate_avatar)
- `get_legacy_ui_link(analytics)` と `get_analytics_summary` は同じ機能の案内として1回に集約される

`admin-ui/src/pages/copilot-preview/index.test.tsx` (+5):
- previewMode未選択のsuper_admin → テナント選択が出てブリーフィングは走らない
- 選択で `enterPreview("tenant-b", "みどり工房")` が呼ばれる
- previewMode中のsuper_admin → 従来どおりのチャット(選択画面なし)
- client_admin → 常に従来どおりのチャット
- 一覧取得失敗 → 再読み込みの案内

既存テストのアサーションは変更なし。ただしモバイルドロワーのテスト6件だけ、認証フィクスチャを「super_adminのクライアントビュー(previewMode=true)」に揃えた(元は previewMode 無しの super_admin で、それが今回テナント選択画面になるため。my-tenant判定をスキップしてブリーフィングへ直行するという各テストの意図は保たれている)。

## 検証
- `npm run lint` : exit 0
- `npx tsc --noEmit` (root / admin-ui 両方) : exit 0
- `npx jest src/api/admin/agent/agentRoutes.test.ts` : 158 passed
- `npx vitest run src/pages/copilot-preview/index.test.tsx` : 24 passed
- `git diff --stat origin/main -- '*.sql' '.env*' 'package.json'` : 空

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177MCsC7jN3a51F7TdaW9vH
