### PR TITLE
test(admin-ui): 左レールのバッジ取得と共存できるようテスト待機条件を修正

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -193,7 +193,10 @@ describe("CopilotPreviewPage — モバイル左レールのドロワー化", ()
 
   it("初期状態ではドロワーは閉じており、オーバーレイも存在しない", async () => {
     renderPage(SUPER_ADMIN_IN_PREVIEW);
-    await waitFor(() => expect(authFetch).toHaveBeenCalledTimes(1));
+    // bootstrap完了(送信ボタンのdisabled解除)を待ってから操作する。左レールの件数
+    // バッジ取得(gaps/count・escalations)がbootstrapと並行して独立に走るため、
+    // 呼び出し回数の厳密一致では待てない。
+    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
 
     expect(getRail().className).not.toContain("cp-rail-open");
     expect(getBackdrop()).toBeNull();
@@ -201,7 +204,7 @@ describe("CopilotPreviewPage — モバイル左レールのドロワー化", ()
 
   it("ハンバーガーボタンでドロワーが開き、背景オーバーレイが表示される", async () => {
     renderPage(SUPER_ADMIN_IN_PREVIEW);
-    await waitFor(() => expect(authFetch).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
 
     fireEvent.click(screen.getByRole("button", { name: "メニューを開く" }));
 
@@ -211,7 +214,7 @@ describe("CopilotPreviewPage — モバイル左レールのドロワー化", ()
 
   it("オーバーレイをタップするとドロワーが閉じる", async () => {
     renderPage(SUPER_ADMIN_IN_PREVIEW);
-    await waitFor(() => expect(authFetch).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
 
     fireEvent.click(screen.getByRole("button", { name: "メニューを開く" }));
     expect(getBackdrop()).not.toBeNull();
@@ -224,7 +227,7 @@ describe("CopilotPreviewPage — モバイル左レールのドロワー化", ()
 
   it("レール内の閉じるボタン(✕)でもドロワーが閉じる", async () => {
     renderPage(SUPER_ADMIN_IN_PREVIEW);
-    await waitFor(() => expect(authFetch).toHaveBeenCalledTimes(1));
+    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
 
     fireEvent.click(screen.getByRole("button", { name: "メニューを開く" }));
     expect(getRail().className).toContain("cp-rail-open");
@@ -251,7 +254,9 @@ describe("CopilotPreviewPage — モバイル左レールのドロワー化", ()
       () => new Promise<Response>((resolve) => { resolveFetch = resolve; }),
     );
     renderPage(SUPER_ADMIN_IN_PREVIEW);
-    await waitFor(() => expect(authFetch).toHaveBeenCalledTimes(1));
+    // このモックは全fetch呼び出し(bootstrap本体+左レールのバッジ取得2件)を未解決のまま止める。
+    // 呼び出し回数の厳密一致では待てないため、最低1回発火したことだけを確認する。
+    await waitFor(() => expect(authFetch).toHaveBeenCalled());
 
     fireEvent.click(screen.getByRole("button", { name: "メニューを開く" }));
     expect(getRail().className).toContain("cp-rail-open");
@@ -681,6 +686,9 @@ describe("CopilotPreviewPage — 左レールの件数バッジ", () => {
   });
 
   it("テナントを特定できないsuper_admin(preview外)では件数を取得しない(全テナント合計を出さない)", async () => {
+    // previewMode未選択のsuper_adminはテナント選択画面に入るため(別PRで追加)、
+    // 通常のチャット/左レール自体がまだマウントされない。そのためバッジ用エンドポイントは
+    // 一切呼ばれない — 「全テナント合計」を誤って出す経路が無いことがここでの確認点。
     mockBadges({ gaps: { count: 7 }, escalations: { escalations: [{ id: "e1" }] } });
     renderPage({
       isSuperAdmin: true,
@@ -688,7 +696,8 @@ describe("CopilotPreviewPage — 左レールの件数バッジ", () => {
       user: { id: "2", email: "admin@example.com", role: "super_admin", tenantId: null, tenantName: null },
     });
 
-    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
+    await waitFor(() => expect(screen.getByRole("heading", { name: /どのお客様として見ますか/ })).toBeTruthy());
+    expect(screen.queryByLabelText("送信")).toBeNull();
     const urls = vi.mocked(authFetch).mock.calls.map((c) => String(c[0]));
     expect(urls.some(isBadgeUrl)).toBe(false);
     expect(screen.queryByLabelText(/未回答質問 /)).toBeNull();


### PR DESCRIPTION
## 背景

#579(左レールの件数バッジ)と#580(super_adminのテナント選択)はそれぞれ別のmain断面でテスト済み(共に全green)のままマージされたが、両方が揃った統合後のmainで2種の相互作用が表面化した。個々のPRのロジックに誤りはなく、統合時に初めて起きる後方互換性の問題。

## 直した内容(テストのみ、プロダクションコード変更なし)

1. **モバイル左レールのドロワー化(5件)**: `waitFor(() => expect(authFetch).toHaveBeenCalledTimes(1))` という厳密回数一致でbootstrap完了を待っていたが、左レールの件数バッジ取得(gaps/count・escalations)がbootstrapと並行して独立に走るようになったため、呼び出し回数が1件に留まらず永久にタイムアウトしていた。同じdescribe内の他テストが既に使っている「送信ボタンのdisabled解除を待つ」パターンに統一(1件はfetchを意図的にぶら下げたまま検証するため`toHaveBeenCalled()`に変更)。
2. **左レールの件数バッジ(1件)**: previewMode未選択のsuper_adminでは通常のチャットが出ることを前提にしていたが、#580でこの状態はテナント選択画面に置き換わっている(通常チャット自体が非マウント)。テナント選択画面が出て送信欄が存在しないことを検証する形に更新。「バッジ用エンドポイントが呼ばれない」という元の確認意図は維持した。

## 検証

- admin-ui: `copilot-preview/index.test.tsx` 35/35、他関連ファイル計49件、合わせて84/84 pass
- backend: `agentRoutes.test.ts`ほか198/198 pass
- `npx tsc --noEmit` クリーン、lint 既存警告のみ
- マイグレーション・env・依存追加 差分ゼロ

🤖 Generated with [Claude Code](https://claude.com/claude-code)