### PR TITLE
fix(admin-ui): 新UIでAppSwitcherのR2C2タブが無反応な問題を直す

### DIFF
--- a/admin-ui/src/components/AppSwitcher.test.tsx
+++ b/admin-ui/src/components/AppSwitcher.test.tsx
@@ -1,0 +1,81 @@
+// GID: /copilot-preview では AppSwitcher のロックタブ(R2C2)クリックが無反応だった
+// 不具合の回帰テスト。あの画面には AdminAgentUIProvider が無いため、
+// useAdminAgentUI() を無条件に呼ぶと throw する。旧UI(Provider有り)の挙動を
+// 変えないまま、Provider無しでも onSeedQuery 経由で動くことを固定する。
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import AppSwitcher from "./AppSwitcher";
+import { AdminAgentUIProvider, useAdminAgentUI } from "../contexts/AdminAgentUIContext";
+import { authFetch } from "../lib/api";
+
+// AAAS_ADMIN_URL 未設定だと AppSwitcher は null を返すため、モジュール評価前に立てる
+vi.hoisted(() => {
+  vi.stubEnv("VITE_AAAS_ADMIN_URL", "https://r2c2.example.test");
+});
+
+vi.mock("../auth/useAuth", () => ({
+  useAuth: vi.fn(() => ({ isSuperAdmin: false, isLoading: false })),
+}));
+
+vi.mock("../lib/api", () => ({
+  API_BASE: "http://localhost:3100",
+  authFetch: vi.fn(),
+}));
+
+vi.mock("../lib/supabaseClient", () => ({
+  supabase: { auth: { getSession: vi.fn() } },
+}));
+
+beforeEach(() => {
+  // has_r2c2=false = R2C2未契約 → ロックタブ(質問を種まきする側)になる
+  vi.mocked(authFetch).mockReset();
+  vi.mocked(authFetch).mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({ has_r2c2: false }),
+  } as Response);
+});
+
+// Provider の openWithQuery が呼ばれたことを、Provider の実状態で確認する
+function SeedProbe() {
+  const { isOpen, seedQuery } = useAdminAgentUI();
+  return <div data-testid="probe">{`${isOpen ? "open" : "closed"}/${seedQuery ?? "-"}`}</div>;
+}
+
+async function clickR2c2Tab() {
+  await waitFor(() => expect(vi.mocked(authFetch)).toHaveBeenCalled());
+  fireEvent.click(screen.getByRole("button", { name: /R2C2/ }));
+}
+
+describe("AppSwitcher", () => {
+  it("旧UI(onSeedQuery無し): ロックタブのクリックで openWithQuery が呼ばれる", async () => {
+    render(
+      <AdminAgentUIProvider>
+        <AppSwitcher />
+        <SeedProbe />
+      </AdminAgentUIProvider>,
+    );
+
+    expect(screen.getByTestId("probe").textContent).toBe("closed/-");
+
+    await clickR2c2Tab();
+
+    await waitFor(() =>
+      expect(screen.getByTestId("probe").textContent).toBe("open/R2C2について教えて"),
+    );
+  });
+
+  it("Provider無し(=/copilot-preview相当)でも onSeedQuery があればクラッシュしない", () => {
+    expect(() => render(<AppSwitcher onSeedQuery={vi.fn()} />)).not.toThrow();
+    expect(screen.getByRole("button", { name: /R2C2/ })).toBeTruthy();
+  });
+
+  it("Provider無し: ロックタブのクリックで onSeedQuery が質問文で呼ばれる", async () => {
+    const onSeedQuery = vi.fn();
+    render(<AppSwitcher onSeedQuery={onSeedQuery} />);
+
+    await clickR2c2Tab();
+
+    expect(onSeedQuery).toHaveBeenCalledWith("R2C2について教えて");
+  });
+});

--- a/admin-ui/src/components/AppSwitcher.tsx
+++ b/admin-ui/src/components/AppSwitcher.tsx
@@ -25,9 +25,27 @@ async function bridgeToR2C2() {
   window.location.href = `${AAAS_ADMIN_URL}/auth/bridge#${hash}`;
 }
 
-export default function AppSwitcher() {
-  const { isSuperAdmin, isLoading } = useAuth();
+const R2C2_QUERY = "R2C2について教えて";
+
+/** ロックタブの質問を、どのチャットに流すか。
+ *
+ * 旧UI(AppSidebar配下)は AdminAgentUIProvider があるので openWithQuery で
+ * Surface A のパネルを開く。新UI(/copilot-preview)は App.tsx が旧UIツリーより
+ * 手前で早期returnするため Provider が存在せず、useAdminAgentUI() は throw する。
+ * そのため呼び出し側から onSeedQuery を受け取れるようにし、フックを呼ぶ経路自体を
+ * Provider がある場合だけに分離している。
+ */
+export default function AppSwitcher({ onSeedQuery }: { onSeedQuery?: (query: string) => void }) {
+  return onSeedQuery ? <AppSwitcherTabs onSeedQuery={onSeedQuery} /> : <AppSwitcherWithPanelSeed />;
+}
+
+function AppSwitcherWithPanelSeed() {
   const { openWithQuery } = useAdminAgentUI();
+  return <AppSwitcherTabs onSeedQuery={openWithQuery} />;
+}
+
+function AppSwitcherTabs({ onSeedQuery }: { onSeedQuery: (query: string) => void }) {
+  const { isSuperAdmin, isLoading } = useAuth();
   const [hasR2c2, setHasR2c2] = useState(isSuperAdmin);
 
   useEffect(() => {
@@ -78,7 +96,7 @@ export default function AppSwitcher() {
         R2C
       </span>
       <button
-        onClick={() => (hasR2c2 ? void bridgeToR2C2() : openWithQuery("R2C2について教えて"))}
+        onClick={() => (hasR2c2 ? void bridgeToR2C2() : onSeedQuery(R2C2_QUERY))}
         title={hasR2c2 ? "R2C2に切り替え" : "R2C2とは？ AIアシスタントに聞いてみる"}
         style={{
           flex: 1,

--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -25,8 +25,14 @@ vi.mock("../../components/common/NotificationBell", () => ({
   NotificationBell: () => <div data-testid="notification-bell-stub" />,
 }));
 
+// スタブだが onSeedQuery は実体と同じ引数で呼ぶ(この画面がロックタブの質問を
+// 自分のチャットへ流せているかを検証するため)。質問文自体の固定は AppSwitcher.test.tsx 側。
 vi.mock("../../components/AppSwitcher", () => ({
-  default: () => <div data-testid="app-switcher-stub" />,
+  default: ({ onSeedQuery }: { onSeedQuery?: (query: string) => void }) => (
+    <button data-testid="app-switcher-stub" onClick={() => onSeedQuery?.("R2C2について教えて")}>
+      R2C2
+    </button>
+  ),
 }));
 
 // 会話の永続化(sessionStorage)はストアをモックして検証する。既定は「保存済みの会話なし」
@@ -327,6 +333,29 @@ describe("CopilotPreviewPage — 共通シェル機能パリティ(テーマ/言
     await waitFor(() => expect(screen.getByRole("button", { name: /ログアウト/ })).toBeTruthy());
 
     expect(screen.getByTestId("app-switcher-stub")).toBeTruthy();
+  });
+
+  // GID: この画面には旧UIのチャットパネル(Surface A)が無く、AppSwitcherのロックタブは
+  // openWithQuery(誰も見ていないContext)を叩くだけで無反応だった。
+  it("AppSwitcherのロックタブ(R2C2)の質問が、この画面自身のチャットに送られる", async () => {
+    renderPage();
+    // 起動時ブリーフィングの完了を待つ(sending中は sendReal が無視されるため)
+    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
+
+    fireEvent.click(screen.getByTestId("app-switcher-stub"));
+
+    // 自分が送った質問として会話に積まれ、実APIにも送られている
+    expect(await screen.findByText("R2C2について教えて")).toBeTruthy();
+    await waitFor(() => {
+      const chatCall = vi
+        .mocked(authFetch)
+        .mock.calls.find(
+          ([url, init]) =>
+            String(url).includes("/v1/admin/agent/chat") &&
+            String((init as RequestInit | undefined)?.body).includes("R2C2について教えて"),
+        );
+      expect(chatCall).toBeTruthy();
+    });
   });
 });
 

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -697,9 +697,11 @@ export default function CopilotPreviewPage() {
             ✕
           </button>
         </div>
-        {/* AppSwitcher (R2C ⇄ R2C2)。旧UI(AppSidebar)と同じくヘッダー直下に配置 */}
+        {/* AppSwitcher (R2C ⇄ R2C2)。旧UI(AppSidebar)と同じくヘッダー直下に配置。
+            この画面には旧UIのチャットパネル(Surface A)が無いため、ロックタブの
+            質問はこの画面自身のチャットへ流す(onSeedQuery)。 */}
         <div style={{ padding: "0 2px" }}>
-          <AppSwitcher />
+          <AppSwitcher onSeedQuery={(query) => void sendReal(query)} />
         </div>
         <PreviewBadge />
         {CATEGORIES.map((c) => {


### PR DESCRIPTION
## 問題 (GID 1217008593637820)

`/copilot-preview`(新UI・全画面チャット)の左レールにある AppSwitcher の
R2C2タブをクリックしても**何も起きなかった**。

`App.tsx` は `/copilot-preview` を旧UIツリーより手前で早期returnするため、
この画面には `AdminAgentUIProvider` も `AdminAgentPanel`(Surface A)も無い。
にもかかわらず AppSwitcher のロックタブは `openWithQuery()` を呼んでおり、
誰も購読していない Context の state を更新するだけで終わっていた。

## 対応

- `AppSwitcher` に任意プロパティ `onSeedQuery?: (query: string) => void` を追加。
  渡された場合はそれを、渡されない場合は従来どおり `useAdminAgentUI().openWithQuery`
  を使う。
- `useAdminAgentUI()` は Provider が無いと throw するため、**フックを呼ぶ経路自体を
  別コンポーネント(`AppSwitcherWithPanelSeed`)へ分離**し、`onSeedQuery` 未指定の
  ときだけ通るようにした(条件付きフック呼び出しにはしていない)。
- `/copilot-preview` からは、チップ・起動時ブリーフィングと同じ `sendReal` に繋ぎ、
  質問をこの画面自身のチャットへ送るようにした。

**旧UI(AppSidebar配下)の挙動は不変** — プロパティ無しの呼び出しはこれまでと同じ
`openWithQuery` 経路を通る。

## テスト

- `admin-ui/src/components/AppSwitcher.test.tsx`(新規)
  - 旧UI相当(プロパティ無し・Provider有り): クリックで `openWithQuery` が呼ばれる
    (Provider の実状態 `isOpen`/`seedQuery` で確認)
  - **Provider無しでもクラッシュしない**ことを描画で確認
  - Provider無し: クリックで `onSeedQuery("R2C2について教えて")` が呼ばれる
- `admin-ui/src/pages/copilot-preview/index.test.tsx`(追加1件)
  - ロックタブの質問がこの画面のチャットに積まれ、`/v1/admin/agent/chat` にも
    送られることを確認。修正を戻すと**このテストは落ちる**ことを確認済み。

## 検証

- `npm run lint` … pass (exit 0 / 追加warning無し)
- `npx tsc --noEmit`(root / admin-ui 両方) … pass
- `admin-ui` 全テスト … 26 files / 201 tests すべて pass(既存アサーションの変更ゼロ)
- `git diff --stat origin/main -- '*.sql' '.env*' 'package.json'` … 空

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177MCsC7jN3a51F7TdaW9vH