### PR TITLE
feat(agent): 既定画面トグル(チャットファースト)のON/OFFを計測する

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -862,3 +862,107 @@ describe("CopilotPreviewPage — super_adminのテナント選択", () => {
     await waitFor(() => expect(screen.getByText(/テナント一覧を取得できませんでした/)).toBeTruthy());
   });
 });
+
+// 「これを既定の画面にする」トグルの計測(chat_first_toggle)。トグルの実体は localStorage
+// のままで、この通信は測るだけの副回線 — 成否がトグルの見た目・保存値に影響してはならない。
+describe("CopilotPreviewPage — 既定画面トグルの計測(chat_first_toggle)", () => {
+  const UI_EVENT_URL = "http://localhost:3100/v1/admin/agent/ui-event";
+
+  const uiEventCalls = () =>
+    vi.mocked(authFetch).mock.calls.filter(([url]) => String(url).includes("/v1/admin/agent/ui-event"));
+
+  const sentEvents = () => uiEventCalls().map(([, options]) => JSON.parse(String(options?.body)));
+
+  /** トグルのつまみの位置。ON=19px / OFF=3px（見た目の状態そのもの） */
+  const knobLeft = (button: HTMLElement) => (button.querySelector("span > span") as HTMLElement).style.left;
+
+  const getToggle = () =>
+    waitFor(() => screen.getByRole("button", { name: /これを既定の画面にする/ }));
+
+  // この環境(happy-dom)は window.localStorage を提供しないため、chatFirstDefault.test.ts と
+  // 同じくMapベースの最小実装で補う(トグルの保存値まで検証するため素通りモックにはしない)。
+  function installFakeLocalStorage() {
+    const store = new Map<string, string>();
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+        setItem: (k: string, v: string) => void store.set(k, v),
+        removeItem: (k: string) => void store.delete(k),
+        clear: () => void store.clear(),
+      },
+    });
+  }
+
+  beforeEach(() => {
+    installFakeLocalStorage();
+    vi.mocked(authFetch).mockReset();
+    mockNavigate.mockReset();
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (isBadgeUrl(url)) return mockEmptyBadges();
+      if (String(url).includes("/v1/admin/my-tenant")) {
+        return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
+      }
+      if (String(url).includes("/v1/admin/agent/ui-event")) return mockOk({ ok: true });
+      return mockOk({ reply: "了解しました。", actions: [] });
+    });
+  });
+
+  it("ONにすると enabled:true で ui-event が送られる", async () => {
+    renderPage();
+    const toggle = await getToggle();
+    expect(knobLeft(toggle)).toBe("3px");
+
+    fireEvent.click(toggle);
+
+    await waitFor(() => expect(uiEventCalls().length).toBe(1));
+    expect(uiEventCalls()[0][1]).toMatchObject({ method: "POST" });
+    expect(uiEventCalls()[0][0]).toBe(UI_EVENT_URL);
+    expect(sentEvents()).toEqual([{ event: "chat_first_toggle", enabled: true }]);
+    expect(knobLeft(toggle)).toBe("19px");
+    expect(window.localStorage.getItem("r2c_chat_first_default")).toBe("true");
+  });
+
+  it("OFFに戻すと enabled:false で ui-event が送られる", async () => {
+    window.localStorage.setItem("r2c_chat_first_default", "true");
+    renderPage();
+    const toggle = await getToggle();
+    expect(knobLeft(toggle)).toBe("19px");
+
+    fireEvent.click(toggle);
+
+    await waitFor(() => expect(uiEventCalls().length).toBe(1));
+    expect(sentEvents()).toEqual([{ event: "chat_first_toggle", enabled: false }]);
+    expect(knobLeft(toggle)).toBe("3px");
+    expect(window.localStorage.getItem("r2c_chat_first_default")).toBeNull();
+  });
+
+  it("送信が失敗してもトグルはONになったまま(巻き戻さない・エラーも出さない)", async () => {
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (isBadgeUrl(url)) return mockEmptyBadges();
+      if (String(url).includes("/v1/admin/my-tenant")) {
+        return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
+      }
+      if (String(url).includes("/v1/admin/agent/ui-event")) return Promise.reject(new Error("network down"));
+      return mockOk({ reply: "了解しました。", actions: [] });
+    });
+
+    renderPage();
+    const toggle = await getToggle();
+
+    fireEvent.click(toggle);
+
+    await waitFor(() => expect(uiEventCalls().length).toBe(1));
+    expect(knobLeft(toggle)).toBe("19px");
+    expect(window.localStorage.getItem("r2c_chat_first_default")).toBe("true");
+    expect(screen.queryByText(/エラー/)).toBeNull();
+    expect(screen.queryByText(/うまく送信できませんでした/)).toBeNull();
+  });
+
+  it("トグルを触らなければ ui-event は送られない", async () => {
+    renderPage();
+    await getToggle();
+
+    expect(uiEventCalls()).toEqual([]);
+  });
+});

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -940,6 +940,14 @@ function Phase4DefaultToggle() {
     const next = !enabled;
     setChatFirstDefaultEnabled(next);
     setEnabled(next);
+    // 「オプトインした人が1ヶ月後も残っているか」を測るための計測だけの副回線
+    // (docs/AGENT_METRICS.md の chat_first_toggle)。トグルの実体はあくまで上の
+    // localStorage 側なので、await せず失敗も握り潰す。この通信の成否がトグルの
+    // 見た目・保存値・ユーザーへのエラー表示に影響してはならない。
+    void authFetch(`${API_BASE}/v1/admin/agent/ui-event`, {
+      method: "POST",
+      body: JSON.stringify({ event: "chat_first_toggle", enabled: next }),
+    }).catch(() => undefined);
   };
 
   return (

--- a/docs/AGENT_METRICS.md
+++ b/docs/AGENT_METRICS.md
@@ -35,7 +35,7 @@ CREATE TABLE IF NOT EXISTS metrics_snapshots (
   enum 値と、ツール名のような固定語彙だけ。
 - `snapshot_at`: DB 既定値（`NOW()`）に任せる。
 
-## メトリクス一覧（この5つのみ）
+## メトリクス一覧（この6つのみ）
 
 | metric_name | labels | value | 発火タイミング |
 | --- | --- | --- | --- |
@@ -44,6 +44,7 @@ CREATE TABLE IF NOT EXISTS metrics_snapshots (
 | `agent_turn_hops` | `{ hit_limit: boolean }` | そのターンで実際に消費したツール呼び出しホップ数（`0` 以上） | ターン完了時（1ターン1行） |
 | `agent_legacy_handoff` | `{ feature: string }` | 常に `1` | `get_legacy_ui_link` が呼ばれたとき。「チャットがまだ旧UIへ何回受け渡しているか」の**分子** |
 | `agent_turn_completed` | `{ answered_from: string }` | 常に `1` | 結果に関わらずターンが完了したとき。handoff率の**分母** |
+| `chat_first_toggle` | `{ enabled: boolean }` | 常に `1` | 「これを既定の画面にする」トグルが切り替わったとき（`POST /v1/admin/agent/ui-event`） |
 
 ### `agent_tool_invoked`
 
@@ -137,6 +138,32 @@ CREATE TABLE IF NOT EXISTS metrics_snapshots (
   **「完了ターンあたりの handoff 回数」であって「handoff を含んだターンの割合」ではない**
   （原理的に 1.0 を超えうる）。指標名や文書でこの2つを混同しないこと。
 
+### `chat_first_toggle`
+
+唯一の**UI操作**メトリクス（他の5つはエージェント自身の挙動）。
+`/copilot-preview` 左レールの「これを既定の画面にする」トグルが切り替わるたびに、
+フロント（`admin-ui/src/pages/copilot-preview/index.tsx` の `Phase4DefaultToggle`）が
+`POST /v1/admin/agent/ui-event` を投げて記録する。
+
+- `enabled`: 切り替え**後**の状態。`true` = オプトイン、`false` = オプトアウト。
+- `tenant_id`: JWT 由来のテナントのみ。**body の値は一切見ない**（このイベントに
+  `targetTenantId` 相当の概念はない。テナント未特定の super_admin は `NULL`）。
+- 計測目的は「チャットUIを既定のランディングにした人が、1ヶ月後もそのままか」を
+  数字で見ること。トグルの実体は依然として localStorage だけであり（`chatFirstDefault.ts`）、
+  **このメトリクスは現在の状態の source of truth ではない**。読めるのは
+  「いつ ON になり、いつ OFF に戻されたか」のイベント列だけで、
+  ラベルにユーザー識別子を持たない（PII 禁止）ため個人単位の継続率は出せない。
+  出せるのは期間ごとの `enabled=true` / `enabled=false` の件数と、その比の推移。
+- ブラウザ側からの送信なので**必ず取りこぼす**（オフライン、拡張機能によるブロック、
+  タブを閉じた直後など）。ON/OFF の絶対数ではなく傾向として読む。
+
+#### `event` は閉じた enum である
+
+`POST /v1/admin/agent/ui-event` が受け付ける `event` は `chat_first_toggle` のみで、
+それ以外は 400 を返す。任意の文字列を受けると、この endpoint が命名契約の外にある
+無管理の分析投入口になってしまうため。**UIイベントを増やす場合は、このドキュメントと
+`agentRoutes.ts` の `uiEventSchema` を同時に更新する**（コード側だけ広げてはならない）。
+
 ## 実装上の制約
 
 - 記録は **fire-and-forget**。`recordAgentMetric` は内部で try/catch し、失敗は
@@ -144,3 +171,7 @@ CREATE TABLE IF NOT EXISTS metrics_snapshots (
   **計測の失敗がチャット応答のステータスコードや本文を変えてはならない。**
 - 計測は `agentRoutes.ts` にのみ実装する。`actionExecutor.ts` の 45 個の `case`
   分岐には手を入れない（1箇所で横断的に取れる形を保つ）。
+- `POST /v1/admin/agent/ui-event` は計測専用のため、想定外の例外でも 500 ではなく
+  `{ ok: true }` を返す（権限 403 とバリデーション 400 のみ明示的に返す）。
+  この endpoint の失敗がフロントのトグルの見た目・localStorage の値・
+  ユーザーへのエラー表示に影響してはならない。フロント側も応答を待たずに投げる。

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -4308,3 +4308,138 @@ describe('POST /v1/admin/agent/chat', () => {
     });
   });
 });
+
+// ---------------------------------------------------------------------------
+// UIイベント計測（chat_first_toggle）。計測専用のベストエフォート副回線なので、
+// 「トグルの挙動を絶対に壊さない」ことが本体の契約（docs/AGENT_METRICS.md）。
+// ---------------------------------------------------------------------------
+
+describe('POST /v1/admin/agent/ui-event', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('enabled:true → 200 {ok:true} と chat_first_toggle(JWT由来テナント) を記録する', async () => {
+    const res = await request(makeApp(CLIENT_ADMIN_USER))
+      .post('/v1/admin/agent/ui-event')
+      .send({ event: 'chat_first_toggle', enabled: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+    expect(recordedMetrics('chat_first_toggle')).toEqual([
+      {
+        metricName: 'chat_first_toggle',
+        tenantId: 'tenant-abc',
+        labels: { enabled: true },
+        value: 1,
+      },
+    ]);
+  });
+
+  it('enabled:false → 200 と chat_first_toggle(enabled:false) を記録する', async () => {
+    const res = await request(makeApp(CLIENT_ADMIN_USER))
+      .post('/v1/admin/agent/ui-event')
+      .send({ event: 'chat_first_toggle', enabled: false });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+    expect(recordedMetrics('chat_first_toggle')).toEqual([
+      {
+        metricName: 'chat_first_toggle',
+        tenantId: 'tenant-abc',
+        labels: { enabled: false },
+        value: 1,
+      },
+    ]);
+  });
+
+  it('テナント未特定の super_admin → tenantId は NULL で記録される', async () => {
+    const res = await request(makeApp(SUPER_ADMIN_USER))
+      .post('/v1/admin/agent/ui-event')
+      .send({ event: 'chat_first_toggle', enabled: true });
+
+    expect(res.status).toBe(200);
+    expect(recordedMetrics('chat_first_toggle')).toEqual([
+      { metricName: 'chat_first_toggle', tenantId: null, labels: { enabled: true }, value: 1 },
+    ]);
+  });
+
+  it('supabaseUser なし → 403（chat と同じ）', async () => {
+    const res = await request(makeApp(undefined))
+      .post('/v1/admin/agent/ui-event')
+      .send({ event: 'chat_first_toggle', enabled: true });
+
+    expect(res.status).toBe(403);
+    expect(recordedMetrics('chat_first_toggle')).toEqual([]);
+  });
+
+  it('role が不正（viewer）→ 403', async () => {
+    const res = await request(makeApp({ app_metadata: { role: 'viewer', tenant_id: 'tenant-abc' } }))
+      .post('/v1/admin/agent/ui-event')
+      .send({ event: 'chat_first_toggle', enabled: true });
+
+    expect(res.status).toBe(403);
+    expect(recordedMetrics('chat_first_toggle')).toEqual([]);
+  });
+
+  describe('バリデーション（event は閉じた enum）', () => {
+    it.each([
+      ['event が欠落', { enabled: true }],
+      ['event が未定義の値', { event: 'some_other_ui_event', enabled: true }],
+      ['enabled が欠落', { event: 'chat_first_toggle' }],
+      ['enabled が boolean でない', { event: 'chat_first_toggle', enabled: 'true' }],
+      ['空 body', {}],
+    ])('%s → 400 で何も記録しない', async (_label, body) => {
+      const res = await request(makeApp(CLIENT_ADMIN_USER)).post('/v1/admin/agent/ui-event').send(body);
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('invalid_request');
+      expect(mockRecordAgentMetric).not.toHaveBeenCalled();
+    });
+  });
+
+  it('body の tenantId は無視され JWT 由来テナントで記録される', async () => {
+    const res = await request(makeApp(CLIENT_ADMIN_USER))
+      .post('/v1/admin/agent/ui-event')
+      .send({ event: 'chat_first_toggle', enabled: true, tenantId: 'evil-tenant-override' });
+
+    expect(res.status).toBe(200);
+    expect(recordedMetrics('chat_first_toggle')).toEqual([
+      { metricName: 'chat_first_toggle', tenantId: 'tenant-abc', labels: { enabled: true }, value: 1 },
+    ]);
+  });
+
+  it('recordAgentMetric が throw しても 200 {ok:true} を返す（計測失敗をトグルに見せない）', async () => {
+    mockRecordAgentMetric.mockImplementation(() => {
+      throw new Error('metrics sync boom');
+    });
+
+    const res = await request(makeApp(CLIENT_ADMIN_USER))
+      .post('/v1/admin/agent/ui-event')
+      .send({ event: 'chat_first_toggle', enabled: true });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it('recordAgentMetric が reject しても 200 {ok:true} を返す', async () => {
+    mockRecordAgentMetric.mockImplementation(() => Promise.reject(new Error('metrics async boom')));
+
+    const res = await request(makeApp(CLIENT_ADMIN_USER))
+      .post('/v1/admin/agent/ui-event')
+      .send({ event: 'chat_first_toggle', enabled: false });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it('Groq もDBも呼ばない（計測だけの副回線）', async () => {
+    const res = await request(makeApp(CLIENT_ADMIN_USER))
+      .post('/v1/admin/agent/ui-event')
+      .send({ event: 'chat_first_toggle', enabled: true });
+
+    expect(res.status).toBe(200);
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockQuery).not.toHaveBeenCalled();
+  });
+});

--- a/src/api/admin/agent/agentRoutes.ts
+++ b/src/api/admin/agent/agentRoutes.ts
@@ -213,6 +213,16 @@ const chatSchema = z.object({
   stream: z.boolean().optional(),
 });
 
+// UIイベント計測の受け口。event は**閉じた enum** にしておく。自由記述のイベント名を
+// 受けると管理されない分析投入口になり、docs/AGENT_METRICS.md の命名契約が
+// 意味を失うため、値を増やすときは必ずこのリテラルとドキュメントを同時に更新する。
+// tenant_id は JWT 由来のみを使うので、body に tenantId 相当のキーは定義しない
+// （zod は未知キーを黙って捨てるため、送られてきても参照されることはない）。
+const uiEventSchema = z.object({
+  event: z.literal('chat_first_toggle'),
+  enabled: z.boolean(),
+});
+
 // ---------------------------------------------------------------------------
 // Groq function calling 呼び出し（tools 付き）
 // ---------------------------------------------------------------------------
@@ -846,6 +856,41 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
     } catch (err) {
       logger.warn('[POST /v1/admin/agent/chat]', err);
       return res.status(500).json({ error: 'AIエージェントの応答生成に失敗しました' });
+    }
+  });
+
+  // チャットUIの操作イベントを計測するためだけのベストエフォートな副回線。
+  // 「既定の画面にする」トグル(admin-ui/src/lib/chatFirstDefault.ts)は完全に
+  // localStorage 側で完結しており、この endpoint はその ON/OFF を数えるだけで
+  // 挙動には一切関与しない。したがって想定外の例外でも 500 を返さず ok を返す
+  // （フロントに「本物のエラー」と見えてしまうと、計測の失敗がトグルの不具合に
+  //   見える／トグル自体を壊す余地が生まれる）。
+  app.post('/v1/admin/agent/ui-event', (req: Request, res: Response) => {
+    try {
+      const { role, tenantId } = extractAuth(req);
+
+      if (role !== 'super_admin' && role !== 'client_admin') {
+        return res.status(403).json({ error: 'この操作を実行する権限がありません' });
+      }
+
+      const parsed = uiEventSchema.safeParse(req.body ?? {});
+      if (!parsed.success) {
+        return res.status(400).json({ error: 'invalid_request', details: parsed.error.issues });
+      }
+
+      // テナントは JWT 由来のみ。body の値は（送られてきても）一切使わない。
+      // テナント未特定の super_admin は docs/AGENT_METRICS.md どおり NULL で記録する。
+      fireAgentMetric(db, {
+        metricName: 'chat_first_toggle',
+        tenantId: tenantId || null,
+        labels: { enabled: parsed.data.enabled },
+        value: 1,
+      });
+
+      return res.json({ ok: true });
+    } catch (err) {
+      logger.warn('[POST /v1/admin/agent/ui-event]', err);
+      return res.json({ ok: true });
     }
   });
 }


### PR DESCRIPTION
Asana GID 1217007275501067

## なぜ

`/copilot-preview` の要件分析で挙がった最重要指標は「チャットUIを既定のランディングにした人が、1ヶ月後もそのままか」。言葉ではなく実際の行動で測る指標だが、現状トグル(`admin-ui/src/lib/chatFirstDefault.ts`)は100% localStorage完結で、バックエンドからON/OFFの回数が**全く見えない**。この計測だけを足す。

トグルの既定値・localStorageで挙動をゲートしている構造・既存のクライアント側ロジックは一切変えていない。

## 何を

- **`POST /v1/admin/agent/ui-event` を追加**（`src/api/admin/agent/agentRoutes.ts`）
  - 認証は既存の `/v1/admin/agent/chat` と同じ（`app.use('/v1/admin/agent', supabaseAuthMiddleware)` + role チェック）。したがって未認証・role不正は **403**（chat と同じ挙動に揃えた）。
  - `event` は `z.literal('chat_first_toggle')` の**閉じたenum**。他の値は400。自由記述のイベント名を受けると命名契約の外にある無管理の分析投入口になるため。
  - `tenant_id` は **JWT由来のみ**。bodyに `tenantId` を入れても一切参照しない（zodが未知キーを落とす + 実装がbodyを見ない、の二重）。テナント未特定の super_admin は `NULL`。
  - `recordAgentMetric(db, { metricName: 'chat_first_toggle', labels: { enabled }, value: 1 })` を既存の `fireAgentMetric` 経由で発火。
  - **想定外の例外でも 500 ではなく `{ ok: true }`**（403/400のみ明示的に返す）。計測専用の副回線の失敗がフロントに「本物のエラー」と見えてはならない。
- **フロント**（`admin-ui/src/pages/copilot-preview/index.tsx` の `Phase4DefaultToggle`）
  - `setChatFirstDefaultEnabled(next)` の隣で `void authFetch(...).catch(() => undefined)`。await せず、失敗しても**トグルを巻き戻さない・エラーも出さない**。
- **`chatFirstDefault.ts` は変更なし**。ファイル冒頭のコメント通り副作用ゼロのlocalStorageヘルパーのまま。通信は「使う側のコンポーネント」に置いた。
- **`docs/AGENT_METRICS.md`** に `chat_first_toggle` を追記。あわせて正直な限界も明記した:
  - ラベルにユーザー識別子を持たない(PII禁止)ため**個人単位の継続率は出せない**。出せるのは期間ごとの `enabled=true`/`false` の件数とその推移。
  - ブラウザ側からの送信なので**必ず取りこぼす**（オフライン/拡張機能/タブ即閉じ）。絶対数ではなく傾向として読む。
  - トグルの現在の状態の source of truth は依然 localStorage であってこのメトリクスではない。

## マイグレーション/env/依存

なし。`metrics_snapshots` をそのまま再利用。`git diff --stat origin/main -- '*.sql' '.env*' 'package.json'` は空。

## テスト

- `src/api/admin/agent/agentRoutes.test.ts` → **187 passed**（既存186 + 新規11、既存アサーションの変更ゼロ）
  - `enabled: true` / `false` の正常系（`tenantId`/`labels` を固定）、テナント未特定 super_admin は `tenantId: null`
  - 未認証403 / role不正403、バリデーション5パターン400（event欠落・未定義event・enabled欠落・enabled非boolean・空body）
  - **body の `tenantId` が無視されJWT由来が使われる**
  - `recordAgentMetric` が throw / reject しても 200 `{ok:true}`
  - Groq も DB も叩かない
- `admin-ui/src/pages/copilot-preview/index.test.tsx` → **39 passed**（既存35 + 新規4、既存アサーションの変更ゼロ）
  - ON → `enabled: true`、OFF → `enabled: false` で送信
  - **送信がrejectしてもトグルはONのまま**（つまみの位置・localStorageの値を検証、エラー表示なし）
  - トグルを触らなければ送らない
- `npm run lint` / `npx tsc --noEmit`（ルート・admin-ui 両方）通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177MCsC7jN3a51F7TdaW9vH