### PR TITLE
refactor(admin-ui): チャット2面のtransport層(sessionId/履歴/対象テナント/エラー文言)を共有フックに一本化

### DIFF
--- a/admin-ui/src/components/AdminAgent/useAdminAgent.ts
+++ b/admin-ui/src/components/AdminAgent/useAdminAgent.ts
@@ -1,27 +1,15 @@
 // admin-ui/src/components/AdminAgent/useAdminAgent.ts
 import { useState, useCallback, useEffect } from "react";
-import { authFetch, API_BASE } from "../../lib/api";
 import {
   CHAT_SESSION_SURFACE_PANEL,
   restoreChatSession,
   saveChatSession,
 } from "../../lib/chatSessionStore";
+import { useAgentChatTransport } from "../../lib/useAgentChatTransport";
+import type { AgentAction, AnsweredFrom } from "../../lib/useAgentChatTransport";
 
-export type AnsweredFrom = "faq_list" | "tool_action" | "general";
-
-// バックエンド(actionExecutor.ts の LegacyLinkCardPayload)が自然文に添えて返す
-// 構造化カード。現時点で card を返すのは get_legacy_ui_link だけで、他のツールは
-// 従来どおり result の自然文のみ。このパネル(Surface A)はまだ card を描画しないが、
-// /copilot-preview と同じレスポンスを消費するため型は共通にしておく。
-export type AgentActionCard = {
-  kind: "legacy_link";
-  label: string;
-  url: string;
-  description: string;
-};
-
-export type AgentAction = { tool: string; result: string; card?: AgentActionCard };
-
+// transport 層(sessionId / 履歴ウィンドウ / targetTenantId 導出 / エラー文言)と
+// レスポンス型は、全画面UI(/copilot-preview)と共有する lib/useAgentChatTransport.ts が持つ。
 export interface AgentMessage {
   role: "user" | "assistant";
   content: string;
@@ -47,8 +35,11 @@ export function useAdminAgent(): UseAdminAgentResult {
   const [messages, setMessages] = useState<AgentMessage[]>(restored?.messages ?? []);
   const [isOpen, setIsOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  // セッションIDはコンポーネントのライフタイム中に一度だけ生成(復元できた場合はその続き)
-  const [sessionId] = useState<string>(() => restored?.sessionId ?? crypto.randomUUID());
+
+  const { sessionId, send } = useAgentChatTransport({
+    surface: "panel",
+    initialSessionId: restored?.sessionId,
+  });
 
   useEffect(() => {
     if (messages.length === 0) return;
@@ -58,74 +49,31 @@ export function useAdminAgent(): UseAdminAgentResult {
   const sendMessage = useCallback(async (text: string, targetTenantId?: string) => {
     if (!text.trim() || isLoading) return;
 
-    // G2: サーバはステートレスなので、直近の会話履歴を毎回送ってマルチターンの文脈を持たせる
-    // （このターンで追加するユーザーメッセージより前の履歴。直近20件・各4000字までに制限）
-    const history = messages
-      .filter((m) => m.content.trim())
-      .slice(-20)
-      .map((m) => ({ role: m.role, content: m.content.slice(0, 4000) }));
+    // このターンで追加するユーザーメッセージより前の履歴を渡す(件数・文字数の上限は transport 側)
+    const history = messages.map((m) => ({ role: m.role, content: m.content }));
 
     // optimistic にユーザーメッセージを追加
     setMessages((prev) => [...prev, { role: "user", content: text }]);
     setIsLoading(true);
 
     try {
-      const body: { message: string; sessionId: string; targetTenantId?: string; history?: typeof history } = {
-        message: text,
-        sessionId,
-      };
-      if (targetTenantId) {
-        body.targetTenantId = targetTenantId;
-      }
-      if (history.length > 0) {
-        body.history = history;
-      }
-
-      const res = await authFetch(`${API_BASE}/v1/admin/agent/chat`, {
-        method: "POST",
-        body: JSON.stringify(body),
-      });
-
-      if (!res.ok) {
-        setMessages((prev) => [
-          ...prev,
-          {
-            role: "assistant",
-            content: "うまく送信できませんでした。少し時間をおいてお試しください。",
-            actions: [],
-          },
-        ]);
-        return;
-      }
-
-      const data = (await res.json()) as {
-        reply: string;
-        actions: AgentAction[];
-        answered_from?: AnsweredFrom;
-      };
+      const result = await send(text, { history, targetTenantId });
 
       setMessages((prev) => [
         ...prev,
-        {
-          role: "assistant",
-          content: data.reply,
-          actions: data.actions,
-          answeredFrom: data.answered_from,
-        },
-      ]);
-    } catch {
-      setMessages((prev) => [
-        ...prev,
-        {
-          role: "assistant",
-          content: "うまく送信できませんでした。少し時間をおいてお試しください。",
-          actions: [],
-        },
+        result.ok
+          ? {
+              role: "assistant",
+              content: result.data.reply,
+              actions: result.data.actions,
+              answeredFrom: result.data.answered_from,
+            }
+          : { role: "assistant", content: result.message, actions: [] },
       ]);
     } finally {
       setIsLoading(false);
     }
-  }, [isLoading, sessionId, messages]);
+  }, [isLoading, messages, send]);
 
   return {
     messages,

--- a/admin-ui/src/lib/useAgentChatTransport.test.ts
+++ b/admin-ui/src/lib/useAgentChatTransport.test.ts
@@ -1,0 +1,297 @@
+// GID 1217008593800087: チャットUI 2面(パネル/全画面)が独立に手書きしていた transport 層
+// (sessionId / 直近履歴ウィンドウ / targetTenantId 導出 / エラー文言)を共有フックに一本化した
+// 分の単体テスト。特に targetTenantId の導出は認可に触れる(super_adminのプレビュー対象を
+// 決める)ため、ロール・previewMode の組み合わせを明示的に固定する。
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import {
+  AGENT_CHAT_AUTH_REQUIRED_MESSAGE,
+  AGENT_CHAT_ERROR_MESSAGE,
+  AGENT_CHAT_HISTORY_MAX_CHARS,
+  AGENT_CHAT_HISTORY_MAX_ENTRIES,
+  useAgentChatTransport,
+} from "./useAgentChatTransport";
+import type { ChatHistoryEntry } from "./chatSessionStore";
+
+vi.mock("./api", () => ({
+  API_BASE: "http://localhost:3100",
+  authFetch: vi.fn(),
+}));
+
+vi.mock("../auth/useAuth", () => ({
+  useAuth: vi.fn(),
+}));
+
+import { authFetch } from "./api";
+import { useAuth } from "../auth/useAuth";
+
+const CHAT_URL = "http://localhost:3100/v1/admin/agent/chat";
+
+const mockOk = (data: unknown): Promise<Response> =>
+  Promise.resolve({ ok: true, status: 200, json: () => Promise.resolve(data) } as Response);
+
+function baseAuth(overrides: Partial<ReturnType<typeof useAuth>> = {}) {
+  return {
+    user: { id: "1", email: "a@example.com", role: "client_admin", tenantId: "tenant-a", tenantName: "Tenant A" },
+    isLoading: false,
+    isSuperAdmin: false,
+    isClientAdmin: true,
+    logout: vi.fn().mockResolvedValue(undefined),
+    previewMode: false,
+    previewTenantId: null,
+    previewTenantName: null,
+    enterPreview: vi.fn(),
+    exitPreview: vi.fn(),
+    tenantPlan: null,
+    ...overrides,
+  } as ReturnType<typeof useAuth>;
+}
+
+function setAuth(overrides: Partial<ReturnType<typeof useAuth>> = {}) {
+  vi.mocked(useAuth).mockReturnValue(baseAuth(overrides));
+}
+
+/** 最後に送られたリクエストボディを読む */
+function lastBody(): Record<string, unknown> {
+  const call = vi.mocked(authFetch).mock.calls.at(-1)!;
+  return JSON.parse(String((call[1] as RequestInit).body)) as Record<string, unknown>;
+}
+
+const entries = (n: number): ChatHistoryEntry[] =>
+  Array.from({ length: n }, (_, i) => ({
+    role: (i % 2 === 0 ? "user" : "assistant") as ChatHistoryEntry["role"],
+    content: `メッセージ${i + 1}`,
+  }));
+
+beforeEach(() => {
+  vi.mocked(authFetch).mockReset();
+  vi.mocked(authFetch).mockImplementation(() => mockOk({ reply: "了解しました。", actions: [] }));
+  setAuth();
+});
+
+describe("useAgentChatTransport — sessionId", () => {
+  it("マウント時に一度だけ発行され、再レンダーを跨いでも変わらない", () => {
+    const { result, rerender } = renderHook(() => useAgentChatTransport({ surface: "panel" }));
+    const first = result.current.sessionId;
+
+    expect(first).toBeTruthy();
+    rerender();
+    rerender();
+    expect(result.current.sessionId).toBe(first);
+  });
+
+  it("送信を跨いでも同じ sessionId を送り続ける(マルチターンがサーバ側で繋がる)", async () => {
+    const { result } = renderHook(() => useAgentChatTransport({ surface: "panel" }));
+    const sessionId = result.current.sessionId;
+
+    await act(async () => { await result.current.send("1通目"); });
+    await act(async () => { await result.current.send("2通目"); });
+
+    const bodies = vi.mocked(authFetch).mock.calls.map((c) => JSON.parse(String((c[1] as RequestInit).body)));
+    expect(bodies.map((b) => b.sessionId)).toEqual([sessionId, sessionId]);
+  });
+
+  it("initialSessionId を渡すと復元した会話の続きとして始まる(新規発行しない)", () => {
+    const { result } = renderHook(() =>
+      useAgentChatTransport({ surface: "panel", initialSessionId: "restored-session-id" }),
+    );
+
+    expect(result.current.sessionId).toBe("restored-session-id");
+  });
+
+  it("adoptSessionId でマウント後に復元した sessionId を引き継ぎ、以降の送信に反映される", async () => {
+    const { result } = renderHook(() => useAgentChatTransport({ surface: "fullscreen" }));
+
+    act(() => { result.current.adoptSessionId("adopted-session-id"); });
+    expect(result.current.sessionId).toBe("adopted-session-id");
+
+    await act(async () => { await result.current.send("送料を教えて"); });
+    expect(lastBody().sessionId).toBe("adopted-session-id");
+  });
+});
+
+describe("useAgentChatTransport — 直近履歴ウィンドウ", () => {
+  it("上限件数までは全件そのまま送る(境界)", async () => {
+    const { result } = renderHook(() => useAgentChatTransport({ surface: "panel" }));
+
+    await act(async () => {
+      await result.current.send("次の質問", { history: entries(AGENT_CHAT_HISTORY_MAX_ENTRIES) });
+    });
+
+    const history = lastBody().history as ChatHistoryEntry[];
+    expect(history).toHaveLength(AGENT_CHAT_HISTORY_MAX_ENTRIES);
+    expect(history[0].content).toBe("メッセージ1");
+  });
+
+  it("上限を超えた分は古い側から捨てる(境界+1)", async () => {
+    const { result } = renderHook(() => useAgentChatTransport({ surface: "panel" }));
+
+    await act(async () => {
+      await result.current.send("次の質問", { history: entries(AGENT_CHAT_HISTORY_MAX_ENTRIES + 1) });
+    });
+
+    const history = lastBody().history as ChatHistoryEntry[];
+    expect(history).toHaveLength(AGENT_CHAT_HISTORY_MAX_ENTRIES);
+    expect(history[0].content).toBe("メッセージ2");
+    expect(history.at(-1)!.content).toBe(`メッセージ${AGENT_CHAT_HISTORY_MAX_ENTRIES + 1}`);
+  });
+
+  it("1件あたりの文字数も上限で切る", async () => {
+    const { result } = renderHook(() => useAgentChatTransport({ surface: "panel" }));
+    const long = "あ".repeat(AGENT_CHAT_HISTORY_MAX_CHARS + 500);
+
+    await act(async () => {
+      await result.current.send("次の質問", { history: [{ role: "user", content: long }] });
+    });
+
+    const history = lastBody().history as ChatHistoryEntry[];
+    expect(history[0].content).toHaveLength(AGENT_CHAT_HISTORY_MAX_CHARS);
+  });
+
+  it("空文字・空白だけの履歴は送らず、履歴が0件ならキー自体を省く", async () => {
+    const { result } = renderHook(() => useAgentChatTransport({ surface: "panel" }));
+
+    await act(async () => {
+      await result.current.send("最初の質問", { history: [{ role: "assistant", content: "  " }] });
+    });
+
+    expect(lastBody()).not.toHaveProperty("history");
+  });
+});
+
+describe("useAgentChatTransport — targetTenantId の導出(認可)", () => {
+  it("client_admin では送らない(サーバがJWTの tenant_id を使う)", async () => {
+    setAuth();
+    const { result } = renderHook(() => useAgentChatTransport({ surface: "panel" }));
+
+    expect(result.current.targetTenantId).toBeUndefined();
+    await act(async () => { await result.current.send("送料を教えて"); });
+    expect(lastBody()).not.toHaveProperty("targetTenantId");
+  });
+
+  it("super_admin がプレビュー中なら previewTenantId を送る", async () => {
+    setAuth({
+      isSuperAdmin: false, // previewMode 中は useAuth の実効ロールが client_admin になる
+      isClientAdmin: true,
+      previewMode: true,
+      previewTenantId: "tenant-preview",
+      previewTenantName: "Preview Tenant",
+      user: { id: "2", email: "admin@example.com", role: "super_admin", tenantId: null, tenantName: null },
+    });
+    const { result } = renderHook(() => useAgentChatTransport({ surface: "panel" }));
+
+    expect(result.current.targetTenantId).toBe("tenant-preview");
+    await act(async () => { await result.current.send("送料を教えて"); });
+    expect(lastBody().targetTenantId).toBe("tenant-preview");
+  });
+
+  it("super_admin がプレビュー外(テナント未選択)なら送らない", async () => {
+    setAuth({
+      isSuperAdmin: true,
+      isClientAdmin: false,
+      previewMode: false,
+      previewTenantId: null,
+      user: { id: "2", email: "admin@example.com", role: "super_admin", tenantId: null, tenantName: null },
+    });
+    const { result } = renderHook(() => useAgentChatTransport({ surface: "panel" }));
+
+    expect(result.current.targetTenantId).toBeUndefined();
+    await act(async () => { await result.current.send("送料を教えて"); });
+    expect(lastBody()).not.toHaveProperty("targetTenantId");
+  });
+
+  it("previewMode でも previewTenantId が無ければ送らない", async () => {
+    setAuth({ previewMode: true, previewTenantId: null });
+    const { result } = renderHook(() => useAgentChatTransport({ surface: "panel" }));
+
+    expect(result.current.targetTenantId).toBeUndefined();
+    await act(async () => { await result.current.send("送料を教えて"); });
+    expect(lastBody()).not.toHaveProperty("targetTenantId");
+  });
+
+  it("呼び出し側の明示指定は導出結果より優先される(パネルの既存API互換の経路)", async () => {
+    setAuth();
+    const { result } = renderHook(() => useAgentChatTransport({ surface: "panel" }));
+
+    await act(async () => { await result.current.send("送料を教えて", { targetTenantId: "tenant-explicit" }); });
+    expect(lastBody().targetTenantId).toBe("tenant-explicit");
+  });
+});
+
+describe("useAgentChatTransport — エラーの正規化", () => {
+  it("fetch が失敗したら共通の文言で ok:false を返す(例外は投げない)", async () => {
+    vi.mocked(authFetch).mockRejectedValue(new Error("network down"));
+    const { result } = renderHook(() => useAgentChatTransport({ surface: "panel" }));
+
+    let outcome!: Awaited<ReturnType<typeof result.current.send>>;
+    await act(async () => { outcome = await result.current.send("送料を教えて"); });
+
+    expect(outcome).toEqual({ ok: false, kind: "network", message: AGENT_CHAT_ERROR_MESSAGE });
+    // 技術的な内容(例外メッセージ)は画面に出す文言へ漏らさない
+    expect(outcome.ok === false && outcome.message).not.toContain("network down");
+  });
+
+  it("未ログイン(__AUTH_REQUIRED__)はログイン案内に振り分ける", async () => {
+    vi.mocked(authFetch).mockRejectedValue(new Error("__AUTH_REQUIRED__"));
+    const { result } = renderHook(() => useAgentChatTransport({ surface: "fullscreen" }));
+
+    let outcome!: Awaited<ReturnType<typeof result.current.send>>;
+    await act(async () => { outcome = await result.current.send("送料を教えて"); });
+
+    expect(outcome).toEqual({ ok: false, kind: "auth", message: AGENT_CHAT_AUTH_REQUIRED_MESSAGE });
+  });
+
+  it("HTTPエラーでサーバが error を返せばそれを、無ければ共通文言を使う", async () => {
+    vi.mocked(authFetch).mockResolvedValue({
+      ok: false,
+      status: 400,
+      json: () => Promise.resolve({ error: "プランの上限に達しています" }),
+    } as Response);
+    const { result } = renderHook(() => useAgentChatTransport({ surface: "panel" }));
+
+    let outcome!: Awaited<ReturnType<typeof result.current.send>>;
+    await act(async () => { outcome = await result.current.send("送料を教えて"); });
+    expect(outcome).toEqual({ ok: false, kind: "http", message: "エラー: プランの上限に達しています" });
+
+    vi.mocked(authFetch).mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: () => Promise.reject(new Error("not json")),
+    } as unknown as Response);
+    await act(async () => { outcome = await result.current.send("送料を教えて"); });
+    expect(outcome).toEqual({ ok: false, kind: "http", message: AGENT_CHAT_ERROR_MESSAGE });
+  });
+
+  it("成功時はパースしたレスポンスをそのまま返す", async () => {
+    vi.mocked(authFetch).mockImplementation(() =>
+      mockOk({ reply: "10時から19時です。", actions: [{ tool: "get_faq_list", result: "3件" }], answered_from: "faq_list" }),
+    );
+    const { result } = renderHook(() => useAgentChatTransport({ surface: "panel" }));
+
+    let outcome!: Awaited<ReturnType<typeof result.current.send>>;
+    await act(async () => { outcome = await result.current.send("営業時間を教えて"); });
+
+    expect(outcome.ok).toBe(true);
+    expect(outcome.ok === true && outcome.data).toEqual({
+      reply: "10時から19時です。",
+      actions: [{ tool: "get_faq_list", result: "3件" }],
+      answered_from: "faq_list",
+    });
+  });
+});
+
+describe("useAgentChatTransport — surface", () => {
+  it("受け取った面の識別子をそのまま公開する(サーバ側のラベル付けは別タスク)", () => {
+    const { result } = renderHook(() => useAgentChatTransport({ surface: "fullscreen" }));
+    expect(result.current.surface).toBe("fullscreen");
+  });
+
+  it("面の識別子はまだリクエストボディに載せない(既存スキーマを変えないため)", async () => {
+    const { result } = renderHook(() => useAgentChatTransport({ surface: "fullscreen" }));
+
+    await act(async () => { await result.current.send("送料を教えて"); });
+
+    expect(vi.mocked(authFetch).mock.calls.at(-1)![0]).toBe(CHAT_URL);
+    expect(lastBody()).not.toHaveProperty("surface");
+  });
+});

--- a/admin-ui/src/lib/useAgentChatTransport.ts
+++ b/admin-ui/src/lib/useAgentChatTransport.ts
@@ -1,0 +1,157 @@
+// admin-ui/src/lib/useAgentChatTransport.ts
+// POST /v1/admin/agent/chat の transport 層(sessionId / 直近履歴ウィンドウ /
+// targetTenantId 導出 / エラー文言)を、チャットUI 2面で共有するフック。
+//
+// なぜ共有するのか: パネル(components/AdminAgent/)と全画面(pages/copilot-preview/)は
+// 同じエンドポイントを叩きながら、この4点をそれぞれ独立に手書きしていた。同じ構造の重複が
+// 既に一度ユーザー影響のあるバグ(IME確定Enterの誤送信が片面だけ約13日間壊れていた)を
+// 産んでおり、transport 層も同じ再発条件を持っていた(docs/CHAT_SURFACE_DECISION.md §2.1 #1〜#4,#9)。
+//
+// この層が持たないもの: メッセージ列そのもの(型が面ごとに違う)、演出、カード描画、
+// 永続化(lib/chatSessionStore.ts)。会話履歴の保持は面側に残し、送信時のウィンドウ整形だけを
+// ここで一本化する。
+
+import { useCallback, useRef, useState } from "react";
+import { authFetch, API_BASE } from "./api";
+import { useAuth } from "../auth/useAuth";
+import type { ChatHistoryEntry } from "./chatSessionStore";
+
+// どちらの面から来たリクエストかの識別子。サーバ側のメトリクスラベル付け(別タスク)で
+// 消費される。現時点ではリクエストボディには載せず、面が自分を名乗る値として保持するだけ。
+export type AgentChatSurface = "panel" | "fullscreen";
+
+export type AnsweredFrom = "faq_list" | "tool_action" | "general";
+
+// バックエンド(actionExecutor.ts の LegacyLinkCardPayload)が自然文に添えて返す
+// 構造化カード。現時点で card を返すのは get_legacy_ui_link だけで、他のツールは
+// 従来どおり result の自然文のみ。
+export type AgentActionCard = {
+  kind: "legacy_link";
+  label: string;
+  url: string;
+  description: string;
+};
+
+export type AgentAction = { tool: string; result: string; card?: AgentActionCard };
+
+export interface AgentChatReply {
+  reply: string;
+  actions: AgentAction[];
+  answered_from?: AnsweredFrom;
+}
+
+// 送信失敗時に画面へ出す文言。技術的な詳細は出さず、次の行動(時間をおく / ログインする)だけ伝える。
+export const AGENT_CHAT_ERROR_MESSAGE = "うまく送信できませんでした。少し時間をおいてお試しください。";
+export const AGENT_CHAT_AUTH_REQUIRED_MESSAGE =
+  "ログインが必要です。別タブで管理画面にログインしてから、もう一度お試しください。";
+
+// サーバはステートレスなので、直近の会話履歴を毎回送ってマルチターンの文脈を持たせる。
+// 件数・1件あたりの文字数の両方に上限を置く(プロンプトの肥大とコストの上限を固定するため)。
+export const AGENT_CHAT_HISTORY_MAX_ENTRIES = 20;
+export const AGENT_CHAT_HISTORY_MAX_CHARS = 4000;
+
+export function buildAgentChatHistoryWindow(entries: ChatHistoryEntry[]): ChatHistoryEntry[] {
+  return entries
+    .filter((e) => e.content.trim())
+    .slice(-AGENT_CHAT_HISTORY_MAX_ENTRIES)
+    .map((e) => ({ role: e.role, content: e.content.slice(0, AGENT_CHAT_HISTORY_MAX_CHARS) }));
+}
+
+export type AgentChatResult =
+  | { ok: true; data: AgentChatReply }
+  // kind は面側が経路ごとに出し分けたい場合のためで、message はどの経路でもそのまま表示できる。
+  | { ok: false; kind: "http" | "network" | "auth"; message: string };
+
+export interface UseAgentChatTransportOptions {
+  surface: AgentChatSurface;
+  /** 復元した会話の続きとして始める場合の sessionId(未指定なら新規発行) */
+  initialSessionId?: string;
+}
+
+export interface AgentChatSendOptions {
+  /** 面側が保持している会話履歴。ウィンドウ整形はこのフックが行う */
+  history?: ChatHistoryEntry[];
+  /**
+   * 導出結果を上書きする対象テナントID。パネル側が既存の外部APIを保つためだけに使う経路で、
+   * 未指定(通常)なら previewMode から導出した値が使われる。
+   */
+  targetTenantId?: string;
+}
+
+export interface UseAgentChatTransportResult {
+  surface: AgentChatSurface;
+  sessionId: string;
+  /** previewMode から導出した対象テナントID(送らない場合は undefined) */
+  targetTenantId: string | undefined;
+  /** マウント後に復元した会話の sessionId を引き継ぐ(全画面UIの復元経路用) */
+  adoptSessionId: (sessionId: string) => void;
+  send: (message: string, opts?: AgentChatSendOptions) => Promise<AgentChatResult>;
+}
+
+export function useAgentChatTransport({
+  surface,
+  initialSessionId,
+}: UseAgentChatTransportOptions): UseAgentChatTransportResult {
+  // sessionId はコンポーネントのライフタイム中で安定させる。送信時は再レンダーを待たずに
+  // 最新値を読む必要があるため ref を真の値とし、state は描画用に同期させる。
+  const sessionIdRef = useRef<string | null>(null);
+  if (sessionIdRef.current === null) {
+    sessionIdRef.current = initialSessionId ?? crypto.randomUUID();
+  }
+  const [sessionId, setSessionId] = useState<string>(sessionIdRef.current);
+
+  const adoptSessionId = useCallback((next: string) => {
+    sessionIdRef.current = next;
+    setSessionId(next);
+  }, []);
+
+  // super_admin がテナントプレビュー中の場合だけ、対象テナントIDを渡す。client_admin は
+  // 自身のJWT由来の tenantId がサーバ側で使われるため送らない。サーバは
+  // `isSuperAdmin ? (targetTenantId ?? tenantId) : tenantId` (agentRoutes.ts) で
+  // 実効テナントを決めるため、client_admin が送っても無視される(認可の主役はサーバ側)。
+  const { previewMode, previewTenantId } = useAuth();
+  const derivedTargetTenantId = previewMode && previewTenantId ? previewTenantId : undefined;
+
+  const send = useCallback(
+    async (message: string, opts?: AgentChatSendOptions): Promise<AgentChatResult> => {
+      const history = buildAgentChatHistoryWindow(opts?.history ?? []);
+      const targetTenantId = opts?.targetTenantId ?? derivedTargetTenantId;
+
+      const body: {
+        message: string;
+        sessionId: string;
+        targetTenantId?: string;
+        history?: ChatHistoryEntry[];
+      } = { message, sessionId: sessionIdRef.current as string };
+      if (targetTenantId) body.targetTenantId = targetTenantId;
+      if (history.length > 0) body.history = history;
+
+      try {
+        const res = await authFetch(`${API_BASE}/v1/admin/agent/chat`, {
+          method: "POST",
+          body: JSON.stringify(body),
+        });
+
+        if (!res.ok) {
+          const errBody = (await res.json().catch(() => ({}))) as { error?: string };
+          return {
+            ok: false,
+            kind: "http",
+            message: errBody.error ? `エラー: ${errBody.error}` : AGENT_CHAT_ERROR_MESSAGE,
+          };
+        }
+
+        return { ok: true, data: (await res.json()) as AgentChatReply };
+      } catch (err) {
+        // authFetch はトークンが取れない時に Error("__AUTH_REQUIRED__") を投げる
+        if ((err as { message?: string } | null)?.message === "__AUTH_REQUIRED__") {
+          return { ok: false, kind: "auth", message: AGENT_CHAT_AUTH_REQUIRED_MESSAGE };
+        }
+        return { ok: false, kind: "network", message: AGENT_CHAT_ERROR_MESSAGE };
+      }
+    },
+    [derivedTargetTenantId],
+  );
+
+  return { surface, sessionId, targetTenantId: derivedTargetTenantId, adoptSessionId, send };
+}

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -19,6 +19,10 @@ import {
   restoreChatSession,
   saveChatSession,
 } from "../../lib/chatSessionStore";
+import {
+  AGENT_CHAT_HISTORY_MAX_ENTRIES,
+  useAgentChatTransport,
+} from "../../lib/useAgentChatTransport";
 import { shouldSubmitOnEnter } from "../../lib/utils";
 import { useAuth } from "../../auth/useAuth";
 import { ONBOARDING_INDUSTRIES } from "../../components/onboarding/industryFaqTemplates";
@@ -28,8 +32,6 @@ import { PREVIEW_MODE_BANNER_HEIGHT } from "../../components/PreviewModeBanner";
 // 切り出した(旧UIとの共有コンポーネント。詳細は common/ThemeToggle.tsx 参照)。
 import { NotificationBell } from "../../components/common/NotificationBell";
 import { ThemeToggle } from "../../components/common/ThemeToggle";
-// レスポンス形は本番パネル(Surface A)と共有のため、型も一箇所から取る。
-import type { AgentAction } from "../../components/AdminAgent/useAdminAgent";
 import LangSwitcher from "../../components/LangSwitcher";
 import AppSwitcher from "../../components/AppSwitcher";
 
@@ -291,8 +293,14 @@ export default function CopilotPreviewPage() {
   // 起動直後は空。bootstrap()が実データの週次ブリーフィングを積む
   const [msgs, setMsgs] = useState<Msg[]>([]);
 
-  // 自由入力欄・起動時ブリーフィング・サイドバー各カテゴリーが繋がる実チャットの状態
-  const sessionIdRef = useRef<string>(crypto.randomUUID());
+  // 自由入力欄・起動時ブリーフィング・サイドバー各カテゴリーが繋がる実チャットの状態。
+  // sessionId・履歴ウィンドウ・targetTenantId 導出・エラー文言はパネル(Surface A)と
+  // 共有の transport 層が持つ(lib/useAgentChatTransport.ts)。
+  const {
+    sessionId: realSessionId,
+    adoptSessionId,
+    send: sendAgentChat,
+  } = useAgentChatTransport({ surface: "fullscreen" });
   const [realHistory, setRealHistory] = useState<{ role: "user" | "assistant"; content: string }[]>([]);
   const [sending, setSending] = useState(false);
   const [realActionCount, setRealActionCount] = useState(0); // 実際に成功した書き込み操作の件数
@@ -367,135 +375,115 @@ export default function CopilotPreviewPage() {
     if (!text.trim() || sending) return;
     if (!opts?.silent) push(me(text));
     setSending(true);
-    try {
-      const body: { message: string; sessionId: string; history?: typeof realHistory; targetTenantId?: string } = {
-        message: text,
-        sessionId: sessionIdRef.current,
-      };
-      if (realHistory.length > 0) body.history = realHistory.slice(-20);
-      if (previewMode && previewTenantId) body.targetTenantId = previewTenantId;
 
-      const res = await authFetch(`${API_BASE}/v1/admin/agent/chat`, {
-        method: "POST",
-        body: JSON.stringify(body),
-      });
-
-      if (!res.ok) {
-        const errBody = await res.json().catch(() => ({} as { error?: string }));
-        push(say(errBody.error ? `エラー: ${errBody.error}` : "うまく送信できませんでした。少し時間をおいてお試しください。"));
-        setSending(false);
-        return;
-      }
-
-      const data = (await res.json()) as { reply: string; actions: AgentAction[] };
-      setRealHistory((prev) =>
-        [
-          ...prev,
-          { role: "user" as const, content: text },
-          { role: "assistant" as const, content: data.reply },
-        ].slice(-20),
-      );
-
-      // ツール結果を、可能なら提案書と同じ見た目のカードにパースする。
-      // 想定外の形式(下書き生成失敗時のエラー文など)は汎用の agentAction カードにフォールバック。
-      const actionMsgs: Msg[] = (data.actions ?? []).map((a) => {
-        // 構造化カードが来ていればそれを直接描画する。自然文の言い回しが変わっても
-        // カードが黙って消えない経路。card が無いツール(現状 get_legacy_ui_link 以外の
-        // すべて)は、これまでどおり下の正規表現パースにフォールバックする。
-        if (a.card?.kind === "legacy_link") {
-          const { label, url, description } = a.card;
-          return { id: nextId(), role: "ai", card: { kind: "link", label, url, description } };
-        }
-        if (a.tool === "suggest_faq") {
-          const parsed = parseSuggestFaq(a.result);
-          if (parsed) return { id: nextId(), role: "ai", card: { kind: "faq", ...parsed } };
-        } else if (a.tool === "suggest_tuning_rule") {
-          const parsed = parseSuggestTuningRule(a.result);
-          if (parsed) return { id: nextId(), role: "ai", card: { kind: "rule", ...parsed } };
-        } else if (a.tool === "suggest_engagement_rule") {
-          const parsed = parseSuggestEngagementRule(a.result);
-          if (parsed) return { id: nextId(), role: "ai", card: { kind: "engagement", ...parsed } };
-        } else if (a.tool === "get_legacy_ui_link") {
-          const parsed = parseLegacyUiLink(a.result);
-          if (parsed) return { id: nextId(), role: "ai", card: { kind: "link", ...parsed } };
-        } else if (
-          (a.tool === "save_faq" || a.tool === "save_tuning_rule" || a.tool === "save_engagement_rule") &&
-          SAVE_SUCCESS_RE.test(a.result)
-        ) {
-          return { id: nextId(), role: "ai", card: { kind: "success", text: a.result } };
-        }
-        return { id: nextId(), role: "ai", card: { kind: "agentAction", tool: a.tool, result: a.result } };
-      });
-
-      // 実際にDBへ書き込んだ操作(確認ブロックで弾かれたものは除く)だけを実進捗としてカウントする。
-      // ブロック理由は2種類あり、どちらも書き込みが起きていないため除外する:
-      //   1. confirmed=false        → 「確認が必要です」
-      //   2. 同一ターン内の連鎖ブロック → 「確認をスキップできません」(agentRoutes.ts:239)
-      const writesThisTurn = (data.actions ?? []).filter(
-        (a) =>
-          REAL_WRITE_TOOLS.has(a.tool) &&
-          !a.result.includes("確認が必要") &&
-          !a.result.includes("確認をスキップできません"),
-      ).length;
-      if (writesThisTurn > 0) setRealActionCount((n) => n + writesThisTurn);
-
-      // suggest系の下書きが出たら、そのまま自然文で確定できるチップを添える
-      const SUGGEST_TOOLS = new Set(["suggest_tuning_rule", "suggest_faq", "suggest_engagement_rule"]);
-      const suggested = data.actions?.some((a) => SUGGEST_TOOLS.has(a.tool));
-      // Saiへの依頼がconfirmed待ちでブロックされた場合も、そのまま同意できるチップを添える
-      const saiPendingConfirm = data.actions?.some(
-        (a) => a.tool === "request_sai_task" && a.result.includes("確認が必要"),
-      );
-      // エスカレーションへの返信/対応完了がconfirmed待ちでブロックされた場合も同様
-      const escalationPendingConfirm = data.actions?.some(
-        (a) =>
-          (a.tool === "reply_to_escalation" || a.tool === "resolve_escalation") &&
-          a.result.includes("確認が必要"),
-      );
-      // オンボーディングのFAQテンプレート提案がconfirmed待ちでブロックされた場合も同様
-      const industryTemplatePendingConfirm = data.actions?.some(
-        (a) => a.tool === "import_industry_faq_templates" && a.result.includes("よろしければ登録しますか"),
-      );
-      const chips: Chip[] | undefined = suggested
-        ? [
-            { label: "保存して", action: "__real:保存してください", tone: "primary" },
-            { label: "やめておく", action: "__real:やめておきます", tone: "ghost" },
-          ]
-        : saiPendingConfirm
-        ? [
-            { label: "お願いする", action: "__real:はい、お願いします", tone: "primary" },
-            { label: "やめておく", action: "__real:やめておきます", tone: "ghost" },
-          ]
-        : escalationPendingConfirm
-        ? [
-            { label: "実行して", action: "__real:はい、お願いします", tone: "primary" },
-            { label: "やめておく", action: "__real:やめておきます", tone: "ghost" },
-          ]
-        : industryTemplatePendingConfirm
-        ? [
-            { label: "登録して", action: "__real:登録してください", tone: "primary" },
-            { label: "あとで", action: "__real:あとでにします", tone: "ghost" },
-          ]
-        : undefined;
-
-      push(...actionMsgs);
-
-      // 最終返信だけを少しずつ流し込む(演出)。チップは流し込み完了後に表示する。
-      const replyId = nextId();
-      push({ id: replyId, role: "ai", text: "" });
-      revealText(replyId, data.reply || "（応答なし）", () => {
-        if (chips) setMsgs((prev) => prev.map((m) => (m.id === replyId ? { ...m, chips } : m)));
-        setSending(false);
-      });
-      return; // setSending(false) は revealText の完了コールバックに任せる
-    } catch (err: any) {
-      if (err?.message === "__AUTH_REQUIRED__") {
-        push(say("ログインが必要です。別タブで管理画面にログインしてから、もう一度お試しください。"));
-      } else {
-        push(say("うまく送信できませんでした。少し時間をおいてお試しください。"));
-      }
+    const result = await sendAgentChat(text, { history: realHistory });
+    if (!result.ok) {
+      push(say(result.message));
+      setSending(false);
+      return;
     }
-    setSending(false);
+
+    const data = result.data;
+    setRealHistory((prev) =>
+      [
+        ...prev,
+        { role: "user" as const, content: text },
+        { role: "assistant" as const, content: data.reply },
+      ].slice(-AGENT_CHAT_HISTORY_MAX_ENTRIES),
+    );
+
+    // ツール結果を、可能なら提案書と同じ見た目のカードにパースする。
+    // 想定外の形式(下書き生成失敗時のエラー文など)は汎用の agentAction カードにフォールバック。
+    const actionMsgs: Msg[] = (data.actions ?? []).map((a) => {
+      // 構造化カードが来ていればそれを直接描画する。自然文の言い回しが変わっても
+      // カードが黙って消えない経路。card が無いツール(現状 get_legacy_ui_link 以外の
+      // すべて)は、これまでどおり下の正規表現パースにフォールバックする。
+      if (a.card?.kind === "legacy_link") {
+        const { label, url, description } = a.card;
+        return { id: nextId(), role: "ai", card: { kind: "link", label, url, description } };
+      }
+      if (a.tool === "suggest_faq") {
+        const parsed = parseSuggestFaq(a.result);
+        if (parsed) return { id: nextId(), role: "ai", card: { kind: "faq", ...parsed } };
+      } else if (a.tool === "suggest_tuning_rule") {
+        const parsed = parseSuggestTuningRule(a.result);
+        if (parsed) return { id: nextId(), role: "ai", card: { kind: "rule", ...parsed } };
+      } else if (a.tool === "suggest_engagement_rule") {
+        const parsed = parseSuggestEngagementRule(a.result);
+        if (parsed) return { id: nextId(), role: "ai", card: { kind: "engagement", ...parsed } };
+      } else if (a.tool === "get_legacy_ui_link") {
+        const parsed = parseLegacyUiLink(a.result);
+        if (parsed) return { id: nextId(), role: "ai", card: { kind: "link", ...parsed } };
+      } else if (
+        (a.tool === "save_faq" || a.tool === "save_tuning_rule" || a.tool === "save_engagement_rule") &&
+        SAVE_SUCCESS_RE.test(a.result)
+      ) {
+        return { id: nextId(), role: "ai", card: { kind: "success", text: a.result } };
+      }
+      return { id: nextId(), role: "ai", card: { kind: "agentAction", tool: a.tool, result: a.result } };
+    });
+
+    // 実際にDBへ書き込んだ操作(確認ブロックで弾かれたものは除く)だけを実進捗としてカウントする。
+    // ブロック理由は2種類あり、どちらも書き込みが起きていないため除外する:
+    //   1. confirmed=false        → 「確認が必要です」
+    //   2. 同一ターン内の連鎖ブロック → 「確認をスキップできません」(agentRoutes.ts:239)
+    const writesThisTurn = (data.actions ?? []).filter(
+      (a) =>
+        REAL_WRITE_TOOLS.has(a.tool) &&
+        !a.result.includes("確認が必要") &&
+        !a.result.includes("確認をスキップできません"),
+    ).length;
+    if (writesThisTurn > 0) setRealActionCount((n) => n + writesThisTurn);
+
+    // suggest系の下書きが出たら、そのまま自然文で確定できるチップを添える
+    const SUGGEST_TOOLS = new Set(["suggest_tuning_rule", "suggest_faq", "suggest_engagement_rule"]);
+    const suggested = data.actions?.some((a) => SUGGEST_TOOLS.has(a.tool));
+    // Saiへの依頼がconfirmed待ちでブロックされた場合も、そのまま同意できるチップを添える
+    const saiPendingConfirm = data.actions?.some(
+      (a) => a.tool === "request_sai_task" && a.result.includes("確認が必要"),
+    );
+    // エスカレーションへの返信/対応完了がconfirmed待ちでブロックされた場合も同様
+    const escalationPendingConfirm = data.actions?.some(
+      (a) =>
+        (a.tool === "reply_to_escalation" || a.tool === "resolve_escalation") &&
+        a.result.includes("確認が必要"),
+    );
+    // オンボーディングのFAQテンプレート提案がconfirmed待ちでブロックされた場合も同様
+    const industryTemplatePendingConfirm = data.actions?.some(
+      (a) => a.tool === "import_industry_faq_templates" && a.result.includes("よろしければ登録しますか"),
+    );
+    const chips: Chip[] | undefined = suggested
+      ? [
+          { label: "保存して", action: "__real:保存してください", tone: "primary" },
+          { label: "やめておく", action: "__real:やめておきます", tone: "ghost" },
+        ]
+      : saiPendingConfirm
+      ? [
+          { label: "お願いする", action: "__real:はい、お願いします", tone: "primary" },
+          { label: "やめておく", action: "__real:やめておきます", tone: "ghost" },
+        ]
+      : escalationPendingConfirm
+      ? [
+          { label: "実行して", action: "__real:はい、お願いします", tone: "primary" },
+          { label: "やめておく", action: "__real:やめておきます", tone: "ghost" },
+        ]
+      : industryTemplatePendingConfirm
+      ? [
+          { label: "登録して", action: "__real:登録してください", tone: "primary" },
+          { label: "あとで", action: "__real:あとでにします", tone: "ghost" },
+        ]
+      : undefined;
+
+    push(...actionMsgs);
+
+    // 最終返信だけを少しずつ流し込む(演出)。チップは流し込み完了後に表示する。
+    const replyId = nextId();
+    push({ id: replyId, role: "ai", text: "" });
+    revealText(replyId, data.reply || "（応答なし）", () => {
+      if (chips) setMsgs((prev) => prev.map((m) => (m.id === replyId ? { ...m, chips } : m)));
+      setSending(false);
+    });
+    // setSending(false) は revealText の完了コールバックに任せる
   };
 
   // マウント時、まず同一タブに保存済みの会話があれば復元する(リロード・ブラウザバック・
@@ -518,7 +506,7 @@ export default function CopilotPreviewPage() {
     const restored = restoreChatSession<Msg>(CHAT_SESSION_SURFACE_FULLSCREEN);
     if (restored && restored.messages.length > 0) {
       reserveIds(restored.messages);
-      sessionIdRef.current = restored.sessionId;
+      adoptSessionId(restored.sessionId);
       setMsgs(restored.messages);
       setRealHistory(restored.history ?? []);
       return;
@@ -580,13 +568,13 @@ export default function CopilotPreviewPage() {
     if (msgs.length === 0) return;
     const timer = setTimeout(() => {
       saveChatSession(CHAT_SESSION_SURFACE_FULLSCREEN, {
-        sessionId: sessionIdRef.current,
+        sessionId: realSessionId,
         messages: msgs,
         history: realHistory,
       });
     }, 300);
     return () => clearTimeout(timer);
-  }, [msgs, realHistory]);
+  }, [msgs, realHistory, realSessionId]);
 
   // 新UI(サイドバー型ではないため)にはログアウト手段が無く、Phase4トグルで
   // このブラウザの既定画面にすると詰む(GID: 新UI常用時にログアウトできない)。
@@ -1084,7 +1072,7 @@ function CardView({ card }: { card: Card }) {
       return (
         <CardShell hd={<><span>🔗</span>{card.label}へご案内します</>}>
           <Field k="この操作について" v={card.description} />
-          {/* 同一SPA内のパスなので、target無しだとこのページごとアンマウントされ会話履歴(msgs/sessionIdRef)が消える */}
+          {/* 同一SPA内のパスなので、target無しだとこのページごとアンマウントされ会話履歴(msgs/sessionId)が消える */}
           <a
             href={card.url}
             target="_blank"


### PR DESCRIPTION
## 背景

R2C には同じ `POST /v1/admin/agent/chat` を叩くチャットUIが2面ある。

- **Surface A(パネル)** — `admin-ui/src/components/AdminAgent/useAdminAgent.ts`
- **Surface B(全画面)** — `admin-ui/src/pages/copilot-preview/index.tsx` の `sendReal`

この2面が **sessionId の生成/保持・直近履歴ウィンドウ・`targetTenantId` の導出・送信失敗の文言** を独立に手書きしていた(`docs/CHAT_SURFACE_DECISION.md` §2.1 #1〜#4, #9)。同じ構造の重複は既に一度ユーザー影響のあるバグを産んでいる — 正しいIMEガードがSurface Aに1ヶ月以上前から存在したのにSurface Bは再利用せず、日本語変換の確定Enterでの誤送信が **約13日間** 本番相当コードに載っていた(同 §3.1)。本PRは transport 層を `admin-ui/src/lib/useAgentChatTransport.ts` に一本化し、この再発条件を構造的に消す。決定ドキュメントの即時アクション #2 に対応する。

面固有のもの(チップ、カード描画、タイプライター演出、ブートストラップ、左レール、永続化)は一切動かしていない。

## 変更内容

| ファイル | 内容 |
|---|---|
| `admin-ui/src/lib/useAgentChatTransport.ts` **(新規)** | 共有 transport フック。sessionId、履歴ウィンドウ、`targetTenantId` 導出、`send()`、エラー正規化、レスポンス型(`AgentAction` 等)の正本 |
| `admin-ui/src/lib/useAgentChatTransport.test.ts` **(新規)** | 上記の単体テスト(19件) |
| `admin-ui/src/components/AdminAgent/useAdminAgent.ts` | 内部を共有フックへ委譲。**外部API(`messages` / `isOpen` / `isLoading` / `sessionId` / `setIsOpen` / `sendMessage(text, targetTenantId?)`)は不変** — `AdminAgentPanel.tsx` は無変更 |
| `admin-ui/src/pages/copilot-preview/index.tsx` | `sendReal` の transport 部分のみ共有フックへ。`sessionIdRef` → フックの `sessionId` / `adoptSessionId`。それ以外は無変更 |

## 見つかった挙動差と、どちら側へ寄せたか

### 1. `targetTenantId` の導出 — **認可に触れる。最重要**

| | 変更前 | 変更後 |
|---|---|---|
| Surface A | `AdminAgentPanel.tsx:61,70` の `isSuperAdmin ? (tenantId ?? undefined) : undefined`(`tenantId` は `App.tsx:107` の `effectiveTenantId`) | 共有フックが `previewMode && previewTenantId` から導出 |
| Surface B | `index.tsx` の `previewMode && previewTenantId ? previewTenantId : undefined` | 同上(実質不変) |

**Surface B 側へ寄せた。Surface A の条件式はバグだったため。**

`useAuth` の `isSuperAdmin` は `effectiveRole === "super_admin"` で、`effectiveRole` は **previewMode 中は `"client_admin"` に落ちる**(`useAuth.tsx:213-214`)。したがって Surface A では:

- **super_admin がクライアントビュー(previewMode)中** → `isSuperAdmin === false` になり `targetTenantId` を **送っていなかった**。`effectiveTenantId` は `previewTenantId` に解決されているのに、それが body に載らない。サーバは `isSuperAdmin ? (targetTenantId ?? tenantId) : tenantId`(`agentRoutes.ts:621`)で実効テナントを決めるため、JWT 由来の tenantId(super_admin では常に null)にフォールバックし、ほぼ全ツールが「テナントが特定できません」になる経路だった。
- **super_admin が previewMode 外** → `isSuperAdmin === true` だが `effectiveTenantId = user?.tenantId` で、これは super_admin では常に null(`App.tsx:104-106` のコメントどおり)。→ 送らない。変更後も送らない(同じ)。
- **client_admin** → 送らない。変更後も送らない(同じ)。

**つまり Surface A は previewMode 中の super_admin で壊れていて、本PRでそれが直る。** これがこの統合で唯一の実質的な機能修正で、他は挙動不変または文言の統一。

権限の主役はサーバ側に残っている点も確認済み: `targetTenantId` は **JWT のロールが super_admin の時だけ** 尊重され(`agentRoutes.ts:621`)、client_admin が送っても無視される。クライアント側で `previewMode` から導出することが越境の入口にはならない(previewMode は `sessionStorage` 由来でクライアント改変可能だが、サーバがロールで弾く)。

**外部API保持の都合:** `useAdminAgent.sendMessage(text, targetTenantId?)` のシグネチャは維持し、渡された値は「導出結果の明示上書き」として扱う(`opts.targetTenantId ?? derived`)。そのため `AdminAgentPanel.tsx` は無変更で済み、かつ上記のとおりパネルが渡す値は実際には常に `undefined`(previewMode 中)または `undefined`(super_admin の null tenantId)なので導出結果が効く。
**フォローアップ推奨(本PRのスコープ外):** `AdminAgentPanel.tsx` の `isSuperAdmin ? (tenantId ?? undefined) : undefined` と `tenantId` / `isSuperAdmin` props は transport 層に責務が移ったため既に不要。props API を変えるためここでは触っていない。

### 2. 直近履歴ウィンドウの上限

| | 変更前 | 変更後 |
|---|---|---|
| Surface A | 直近20件・**各4000字まで**・空文字は除外 | 20件 + 4000字 + 空文字除外(不変) |
| Surface B | 直近20件・**文字数上限なし**・空文字も送る | 20件 + **4000字**(新規) + 空文字除外(新規) |

**保守的な側(Surface A)へ寄せた。** 依頼どおり小さい方を採用。**Surface B の挙動変化:** 4000字を超えるメッセージが履歴として送られる際に切り詰められる。これは送信時のウィンドウ整形のみで、画面表示・`sessionStorage` に保存される履歴(`realHistory`)は従来どおり切り詰めない。プロンプト長とコストの上限が両面で同じになる。

### 3. 送信失敗時の文言

| 経路 | 変更前 Surface A | 変更前 Surface B | 変更後(両面) |
|---|---|---|---|
| HTTP エラー + サーバが `error` を返す | 共通文言のみ | `エラー: {error}` | `エラー: {error}` |
| HTTP エラー(`error` なし) | 共通文言 | 共通文言 | 共通文言 |
| 未ログイン(`__AUTH_REQUIRED__`) | 共通文言 | ログイン案内 | ログイン案内 |
| その他ネットワーク失敗 | 共通文言 | 共通文言 | 共通文言 |

**Surface B 側へ寄せた**(情報量が多く、行き止まりになりにくいため)。**Surface A の挙動変化:** これまで全失敗が「うまく送信できませんでした。少し時間をおいてお試しください。」だったところに、サーバのエラー文言(プラン上限等、ユーザー向け日本語)と未ログイン案内の2経路が出るようになる。例外メッセージ等の技術的な内容は文言に混ぜていない(テストで固定)。共通文言は4箇所のハードコードから定数1本になった。

### 4. sessionId の保持方式(挙動不変)

Surface A は `useState(() => restored?.sessionId ?? crypto.randomUUID())`、Surface B は `useRef(crypto.randomUUID())` + 復元時に `sessionIdRef.current` を代入、という別実装だった。共有フックは ref を真の値・state を描画用として持ち、**初期化時の引き継ぎ(`initialSessionId`、パネル用)と マウント後の引き継ぎ(`adoptSessionId`、全画面の復元用)の両方** を提供する。どちらも従来と同じタイミング・同じ値になる。

### 5. `surface` パラメータ

`surface: "panel" | "fullscreen"` を受け取って保持・公開するところまで。**リクエストボディには載せていない**(サーバ側のスキーマとメトリクスラベル配線は別タスクのため)。載っていないことをテストで固定してあるので、別タスクがそのテストを裏返す形で配線できる。

### 6. スコープ外として据え置いたもの

- **`useAdminAgent.ts` の会話永続化** — 別タスクとして扱う旨の指示だったが、**現在の `origin/main` では既に `chatSessionStore` で実装済み**(パネル専用キー `admin-agent-panel`)だった。本PRでは触っていない。
- **2面で sessionId を共有するか**(決定ドキュメント §5 の「共有ストア1本」)は面ごとに独立のまま。`knowledgeImportStaging` の孤児化の穴は本PRでは塞がらない。
- **`answered_from`** は Surface B が依然として消費していない(A のみ)。transport 層は両面に返しているので、B 側で使う準備はできた状態。

## 検証

| 項目 | 結果 |
|---|---|
| `npm run lint` | ✅ exit 0(触ったファイルに新規の警告なし) |
| `npx tsc --noEmit`(root / admin-ui) | ✅ 両方エラーなし |
| 対象4スイート | ✅ **67 passed**(既存48 + 新規19) |
| admin-ui 全スイート | ✅ **216 passed / 26 files** |
| `git diff --stat origin/main -- '*.sql' '.env*' 'package.json'` | ✅ 空 |

**既存アサーションの変更は0件。** `git diff --name-only origin/main -- '*.test.ts' '*.test.tsx'` が空(新規ファイルのみ追加)。変更前のベースライン(`copilot-preview/index.test.tsx` + `useAdminAgent.test.tsx` + `AdminAgentPanel.test.tsx`)も 48 passed で、変更後と同数・同内容。

新規テスト(`useAgentChatTransport.test.ts`)がカバーする範囲:
- sessionId: 再レンダー跨ぎの安定性 / 複数送信で同一 / `initialSessionId` / `adoptSessionId`
- 履歴: 上限ちょうど(20件)・上限+1件の境界 / 1件4000字の切り詰め / 空文字除外と `history` キー省略
- `targetTenantId`: client_admin(送らない) / super_admin previewMode 中(`previewTenantId` を送る) / super_admin previewMode 外(送らない) / previewMode だが `previewTenantId` なし(送らない) / 明示指定の優先
- エラー: fetch 失敗 / `__AUTH_REQUIRED__` / HTTP + サーバ error / HTTP + JSON パース不能 / 成功時のパース
- `surface`: 公開されること / ボディに載らないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177MCsC7jN3a51F7TdaW9vH
