### PR TITLE
feat(admin-ui): PDF取り込みを旧UIへ渡さずチャット内で完結させる(試作1件目)

### DIFF
--- a/admin-ui/src/components/knowledge/PdfUploadTab.tsx
+++ b/admin-ui/src/components/knowledge/PdfUploadTab.tsx
@@ -3,11 +3,14 @@ import { API_BASE } from "../../lib/api";
 import { useAuth } from "../../auth/useAuth";
 import { useLang } from "../../i18n/LangContext";
 import { fetchWithAuth, getAccessToken } from "./shared";
+import {
+  classifyUploadStatus,
+  uploadBookPdfWithProgress,
+  validateBookPdfFile,
+} from "../../lib/bookPdfUpload";
 import BookChunksPanel from "../../pages/admin/knowledge/BookChunksPanel";
 
 // ─── PDFアップロードタブ ──────────────────────────────────────────────────────
-
-const MAX_BOOK_PDF_SIZE = 10 * 1024 * 1024; // 10MB フロントエンド制限
 
 interface BookUpload {
   id: number;
@@ -272,41 +275,14 @@ function fileStatusLabel(status: FileUploadStatus, t: TFunc): string {
 
 /** XHRのstatusコードからユーザー向けエラーメッセージを分類する */
 function classifyUploadError(status: number, t: TFunc, fallback?: string): string {
-  if (status === 401 || status === 403) return t("knowledge.pdf_error_auth");
-  if (status === 413) return t("knowledge.pdf_error_too_large");
-  return fallback || t("knowledge.pdf_error_generic");
-}
-
-/** FormDataをXHRで送信し、進捗(0-100)をonProgressへ通知する */
-function uploadWithProgress(
-  url: string,
-  form: FormData,
-  token: string | null,
-  onProgress: (pct: number) => void
-): Promise<{ status: number; body: unknown; networkError?: boolean }> {
-  return new Promise((resolve) => {
-    const xhr = new XMLHttpRequest();
-    xhr.upload.addEventListener("progress", (e) => {
-      if (e.lengthComputable) {
-        onProgress(Math.round((e.loaded / e.total) * 100));
-      }
-    });
-    xhr.addEventListener("load", () => {
-      let body: unknown = null;
-      try {
-        body = JSON.parse(xhr.responseText);
-      } catch {
-        body = null;
-      }
-      resolve({ status: xhr.status, body });
-    });
-    xhr.addEventListener("error", () => {
-      resolve({ status: 0, body: null, networkError: true });
-    });
-    xhr.open("POST", url);
-    if (token) xhr.setRequestHeader("Authorization", `Bearer ${token}`);
-    xhr.send(form);
-  });
+  switch (classifyUploadStatus(status)) {
+    case "auth":
+      return t("knowledge.pdf_error_auth");
+    case "too_large":
+      return t("knowledge.pdf_error_too_large");
+    default:
+      return fallback || t("knowledge.pdf_error_generic");
+  }
 }
 
 export default function PdfUploadTab({ tenantId }: { tenantId: string }) {
@@ -398,26 +374,22 @@ export default function PdfUploadTab({ tenantId }: { tenantId: string }) {
     setTimeout(() => setToast(null), 3500);
   };
 
-  const ZIP_TYPES = new Set(["application/zip", "application/x-zip-compressed", "application/x-zip"]);
-  const MAX_ZIP_SIZE = 50 * 1024 * 1024; // 50MB
-
   const validateAndAddFiles = useCallback((files: FileList | File[]) => {
     const arr = Array.from(files);
     const newEntries: QueuedFile[] = [];
     for (const f of arr) {
-      const isZip = ZIP_TYPES.has(f.type) || f.name.toLowerCase().endsWith(".zip");
-      const isPdf = f.type === "application/pdf" || f.name.toLowerCase().endsWith(".pdf");
+      const verdict = validateBookPdfFile(f);
 
-      if (!isPdf && !isZip) {
-        showToast(`${f.name}: ${t("knowledge.pdf_error_type")}`, false);
+      if (verdict.kind === "rejected") {
+        const messageKey =
+          verdict.reason === "type" ? "knowledge.pdf_error_type"
+          : verdict.reason === "zip_size" ? "knowledge.pdf_error_zip_size"
+          : "knowledge.pdf_error_size";
+        showToast(`${f.name}: ${t(messageKey)}`, false);
         continue;
       }
 
-      if (isZip) {
-        if (f.size > MAX_ZIP_SIZE) {
-          showToast(`${f.name}: ${t("knowledge.pdf_error_zip_size")}`, false);
-          continue;
-        }
+      if (verdict.kind === "zip") {
         // ZIPはタイトル不要（サーバー側でファイル名から自動設定）
         newEntries.push({
           id: `${Date.now()}-${Math.random()}`,
@@ -429,17 +401,11 @@ export default function PdfUploadTab({ tenantId }: { tenantId: string }) {
         continue;
       }
 
-      // PDF
-      if (f.size > MAX_BOOK_PDF_SIZE) {
-        showToast(`${f.name}: ${t("knowledge.pdf_error_size")}`, false);
-        continue;
-      }
-      // デフォルトタイトル: ファイル名から拡張子除去
-      const defaultTitle = f.name.replace(/\.pdf$/i, "");
+      // デフォルトタイトル: ファイル名から拡張子除去（この面では利用者が上書きできる）
       newEntries.push({
         id: `${Date.now()}-${Math.random()}`,
         file: f,
-        title: defaultTitle,
+        title: f.name.replace(/\.pdf$/i, ""),
         status: "pending",
       });
     }
@@ -519,7 +485,7 @@ export default function PdfUploadTab({ tenantId }: { tenantId: string }) {
           form.append("title", item.title.trim());
         }
 
-        const { status, body, networkError } = await uploadWithProgress(
+        const { status, body, networkError } = await uploadBookPdfWithProgress(
           uploadUrl,
           form,
           token,

--- a/admin-ui/src/lib/bookPdfUpload.ts
+++ b/admin-ui/src/lib/bookPdfUpload.ts
@@ -1,0 +1,87 @@
+// 書籍PDF取り込み(POST /v1/admin/knowledge/book-pdf)のクライアント側ルール。
+// 旧UI(components/knowledge/PdfUploadTab.tsx)と新UI(pages/copilot-preview)の双方から
+// 参照する。同じ操作を2面に置く以上、受け付ける拡張子・MIME・サイズ上限が片方だけ
+// 緩む/厳しくなる事故を型で防ぐため、判定はここだけに置く。
+// 文言は面ごとに異なる(旧UIはi18n辞書・新UIは会話体)ため、ここでは持たない。
+
+export const MAX_BOOK_PDF_SIZE = 10 * 1024 * 1024; // 10MB
+export const MAX_ZIP_SIZE = 50 * 1024 * 1024; // 50MB
+
+const ZIP_TYPES = new Set(["application/zip", "application/x-zip-compressed", "application/x-zip"]);
+
+export function isZipFile(file: File): boolean {
+  return ZIP_TYPES.has(file.type) || file.name.toLowerCase().endsWith(".zip");
+}
+
+export function isPdfFile(file: File): boolean {
+  return file.type === "application/pdf" || file.name.toLowerCase().endsWith(".pdf");
+}
+
+export type BookPdfRejection = "type" | "pdf_size" | "zip_size";
+
+export type BookPdfValidation =
+  | { kind: "pdf" }
+  | { kind: "zip" }
+  | { kind: "rejected"; reason: BookPdfRejection };
+
+/** ブラウザ側の受付判定。サーバー側の上限(multer 50MB)とは別で、ここは体感を良くするための事前弾き */
+export function validateBookPdfFile(file: File): BookPdfValidation {
+  const zip = isZipFile(file);
+  if (!isPdfFile(file) && !zip) return { kind: "rejected", reason: "type" };
+  if (zip) {
+    return file.size > MAX_ZIP_SIZE ? { kind: "rejected", reason: "zip_size" } : { kind: "zip" };
+  }
+  return file.size > MAX_BOOK_PDF_SIZE ? { kind: "rejected", reason: "pdf_size" } : { kind: "pdf" };
+}
+
+/** 拡張子を落としたタイトル(サーバーが単体PDFに必須で要求する)。空になる名前ではファイル名をそのまま使う */
+export function defaultBookTitle(fileName: string): string {
+  return fileName.replace(/\.pdf$/i, "").trim() || fileName;
+}
+
+export type UploadErrorKind = "auth" | "too_large" | "generic";
+
+/** HTTPステータスを面に依存しないエラー種別へ落とす。文言の組み立ては呼び出し側の責務 */
+export function classifyUploadStatus(status: number): UploadErrorKind {
+  if (status === 401 || status === 403) return "auth";
+  if (status === 413) return "too_large";
+  return "generic";
+}
+
+export interface UploadResult {
+  status: number;
+  body: unknown;
+  networkError?: boolean;
+}
+
+/** FormDataをXHRで送信し、進捗(0-100)をonProgressへ通知する(fetchでは送信進捗が取れない) */
+export function uploadBookPdfWithProgress(
+  url: string,
+  form: FormData,
+  token: string | null,
+  onProgress: (pct: number) => void,
+): Promise<UploadResult> {
+  return new Promise((resolve) => {
+    const xhr = new XMLHttpRequest();
+    xhr.upload.addEventListener("progress", (e) => {
+      if (e.lengthComputable) {
+        onProgress(Math.round((e.loaded / e.total) * 100));
+      }
+    });
+    xhr.addEventListener("load", () => {
+      let body: unknown = null;
+      try {
+        body = JSON.parse(xhr.responseText);
+      } catch {
+        body = null;
+      }
+      resolve({ status: xhr.status, body });
+    });
+    xhr.addEventListener("error", () => {
+      resolve({ status: 0, body: null, networkError: true });
+    });
+    xhr.open("POST", url);
+    if (token) xhr.setRequestHeader("Authorization", `Bearer ${token}`);
+    xhr.send(form);
+  });
+}

--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -1,7 +1,7 @@
 // GID: 新UI(/copilot-preview)にログアウト手段が無く、Phase4トグルでこの画面を
 // 既定にすると詰む不具合の回帰テスト。左レール下部のログアウトボタンが
 // logout() → navigate("/login") を実行することを検証する。
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import CopilotPreviewPage from "./index";
@@ -40,6 +40,12 @@ vi.mock("../../lib/chatSessionStore", async () => {
     clearChatSession: vi.fn(),
   };
 });
+
+// PDF取り込みは multipart のため authFetch(常にJSONヘッダを付ける)ではなくXHRで送る。
+// トークン取得だけを差し替え、supabaseクライアントの実体はテストに持ち込まない。
+vi.mock("../../components/knowledge/shared", () => ({
+  getAccessToken: vi.fn(() => Promise.resolve("test-token")),
+}));
 
 const mockNavigate = vi.fn();
 vi.mock("react-router-dom", async () => {
@@ -860,5 +866,208 @@ describe("CopilotPreviewPage — super_adminのテナント選択", () => {
     renderPage(SUPER_ADMIN_NO_PREVIEW);
 
     await waitFor(() => expect(screen.getByText(/テナント一覧を取得できませんでした/)).toBeTruthy());
+  });
+});
+
+// GID 1217007387443283: GUI固有として旧UIへ丸投げしていたPDF取り込みを、会話の中の
+// カードとして完結させる最初の1件。受付条件(拡張子/MIME/サイズ)は旧UIのPDFタブと
+// lib/bookPdfUpload.ts を共有しているため、ここで見るのは「会話UIとして成立しているか」
+// (通信前に断れているか・失敗してもチャットが死なないか・成功が他の書き込み操作と
+// 同じ形で伝わるか)に絞る。
+type XhrListener = (...args: unknown[]) => void;
+
+class MockXHR {
+  static instances: MockXHR[] = [];
+  uploadListeners: Record<string, XhrListener[]> = {};
+  upload = {
+    addEventListener: (event: string, cb: XhrListener) => {
+      (this.uploadListeners[event] ??= []).push(cb);
+    },
+  };
+  listeners: Record<string, XhrListener[]> = {};
+  status = 0;
+  responseText = "";
+  open = vi.fn();
+  setRequestHeader = vi.fn();
+  send = vi.fn();
+
+  constructor() {
+    MockXHR.instances.push(this);
+  }
+
+  addEventListener(event: string, cb: XhrListener) {
+    (this.listeners[event] ??= []).push(cb);
+  }
+
+  fireProgress(loaded: number, total: number) {
+    for (const cb of this.uploadListeners["progress"] ?? []) {
+      cb({ lengthComputable: true, loaded, total });
+    }
+  }
+
+  fireLoad(status: number, body: unknown) {
+    this.status = status;
+    this.responseText = JSON.stringify(body);
+    for (const cb of this.listeners["load"] ?? []) cb();
+  }
+
+  fireError() {
+    for (const cb of this.listeners["error"] ?? []) cb();
+  }
+}
+
+function makeFile(name: string, type: string, size = 1024): File {
+  return new File([new Uint8Array(size)], name, { type });
+}
+
+/** コンポーザ(textareaと送信ボタンを含む枠)がドロップの受け皿 */
+function getComposerDropZone(): HTMLElement {
+  return getComposer().parentElement as HTMLElement;
+}
+
+function dropFiles(files: File[]) {
+  fireEvent.drop(getComposerDropZone(), {
+    dataTransfer: { files, items: [], types: ["Files"] },
+  });
+}
+
+describe("CopilotPreviewPage — コンポーザへのPDFドラッグ＆ドロップ", () => {
+  beforeEach(() => {
+    vi.mocked(authFetch).mockReset();
+    mockNavigate.mockReset();
+    MockXHR.instances = [];
+    vi.stubGlobal("XMLHttpRequest", MockXHR as unknown as typeof XMLHttpRequest);
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (isBadgeUrl(url)) return mockEmptyBadges();
+      if (String(url).includes("/v1/admin/my-tenant")) {
+        return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
+      }
+      return mockOk({ reply: "了解しました。", actions: [] });
+    });
+    // タイプライター演出を無効化して応答を同期的に確定させる
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: true,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  async function readyPage(overrides: Partial<ReturnType<typeof useAuth>> = {}) {
+    renderPage(overrides);
+    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
+  }
+
+  it("PDFを落とすと旧UIと同じ既存エンドポイントへ送信が始まる(新APIを作らない)", async () => {
+    await readyPage();
+
+    dropFiles([makeFile("料金表.pdf", "application/pdf")]);
+
+    await waitFor(() => expect(MockXHR.instances.length).toBe(1));
+    const xhr = MockXHR.instances[0]!;
+    expect(xhr.open).toHaveBeenCalledWith("POST", "http://localhost:3100/v1/admin/knowledge/book-pdf");
+    expect(xhr.setRequestHeader).toHaveBeenCalledWith("Authorization", "Bearer test-token");
+    // 会話の中に進捗カードが出る
+    expect(await screen.findByText("PDFを受け取っています")).toBeTruthy();
+    expect(screen.getByText("料金表.pdf")).toBeTruthy();
+
+    xhr.fireProgress(40, 100);
+    expect(await screen.findByText("40%")).toBeTruthy();
+  });
+
+  it("previewMode中のsuper_adminはプレビュー対象テナント宛に送信する", async () => {
+    await readyPage(SUPER_ADMIN_IN_PREVIEW);
+
+    dropFiles([makeFile("manual.pdf", "application/pdf")]);
+
+    await waitFor(() => expect(MockXHR.instances.length).toBe(1));
+    expect(MockXHR.instances[0]!.open).toHaveBeenCalledWith(
+      "POST",
+      "http://localhost:3100/v1/admin/knowledge/book-pdf?tenant=tenant-preview",
+    );
+  });
+
+  it("PDF以外を落とすと、通信せずやわらかい日本語で断る", async () => {
+    await readyPage();
+
+    dropFiles([makeFile("メモ.txt", "text/plain")]);
+
+    expect(await screen.findByText("PDFを受け取れませんでした")).toBeTruthy();
+    expect(screen.getByText("PDFファイル（またはPDFをまとめたZIPファイル）を送ってください。")).toBeTruthy();
+    expect(MockXHR.instances.length).toBe(0);
+  });
+
+  it("上限を超えるPDFは通信する前に断る", async () => {
+    await readyPage();
+
+    dropFiles([makeFile("大きい資料.pdf", "application/pdf", 11 * 1024 * 1024)]);
+
+    expect(await screen.findByText("PDFは1ファイル10MBまでです。分割してから送ってみてください。")).toBeTruthy();
+    expect(MockXHR.instances.length).toBe(0);
+  });
+
+  it("通信に失敗してもチャットは壊れず、そのまま次のメッセージを送れる", async () => {
+    await readyPage();
+
+    dropFiles([makeFile("料金表.pdf", "application/pdf")]);
+    await waitFor(() => expect(MockXHR.instances.length).toBe(1));
+    MockXHR.instances[0]!.fireError();
+
+    expect(
+      await screen.findByText("うまく送れませんでした。通信の状態を確かめて、もう一度お試しください。"),
+    ).toBeTruthy();
+    // 技術的な文言(ステータスコード等)は出さない
+    expect(screen.queryByText(/413|MIME|status/i)).toBeNull();
+
+    fireEvent.change(getComposer(), { target: { value: "営業時間を教えて" } });
+    fireEvent.click(screen.getByLabelText("送信"));
+    expect(await screen.findByText("営業時間を教えて")).toBeTruthy();
+  });
+
+  it("サーバー側で失敗した場合もやわらかい案内カードになる", async () => {
+    await readyPage();
+
+    dropFiles([makeFile("料金表.pdf", "application/pdf")]);
+    await waitFor(() => expect(MockXHR.instances.length).toBe(1));
+    MockXHR.instances[0]!.fireLoad(401, { error: "unauthorized" });
+
+    expect(
+      await screen.findByText("ログインの有効期限が切れたようです。もう一度ログインしてからお試しください。"),
+    ).toBeTruthy();
+    expect(screen.queryByText(/unauthorized/)).toBeNull();
+  });
+
+  it("成功すると成功カードが出て、他の書き込み操作と同じく実操作の件数に加算される", async () => {
+    await readyPage();
+    expect(screen.getByLabelText("実際の操作 0件")).toBeTruthy();
+
+    dropFiles([makeFile("料金表.pdf", "application/pdf")]);
+    await waitFor(() => expect(MockXHR.instances.length).toBe(1));
+    MockXHR.instances[0]!.fireLoad(201, { id: 42, title: "料金表", status: "uploaded" });
+
+    expect(await screen.findByText("PDFを受け取りました")).toBeTruthy();
+    expect(
+      screen.getByText("読み込みが終わると、この資料の内容から答えられるようになります。"),
+    ).toBeTruthy();
+    await waitFor(() => expect(screen.getByLabelText("実際の操作 1件")).toBeTruthy());
+  });
+
+  it("📎ボタンからでも同じ取り込みができる(ドラッグできない環境向け)", async () => {
+    await readyPage();
+
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    expect(screen.getByLabelText("PDFを添付")).toBeTruthy();
+    fireEvent.change(input, { target: { files: [makeFile("料金表.pdf", "application/pdf")] } });
+
+    await waitFor(() => expect(MockXHR.instances.length).toBe(1));
+    expect(await screen.findByText("PDFを受け取っています")).toBeTruthy();
   });
 });

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -20,6 +20,16 @@ import {
   saveChatSession,
 } from "../../lib/chatSessionStore";
 import { shouldSubmitOnEnter } from "../../lib/utils";
+// PDF取り込みの受付ルール(拡張子/MIME/サイズ上限)と送信は旧UIのPDFタブと同じ実装を共有する。
+// 同じ操作が2面にある状態なので、片方だけ条件が緩む/厳しくなることを避けるため。
+import {
+  classifyUploadStatus,
+  defaultBookTitle,
+  uploadBookPdfWithProgress,
+  validateBookPdfFile,
+  type BookPdfRejection,
+} from "../../lib/bookPdfUpload";
+import { getAccessToken } from "../../components/knowledge/shared";
 import { useAuth } from "../../auth/useAuth";
 import { ONBOARDING_INDUSTRIES } from "../../components/onboarding/industryFaqTemplates";
 import { PREVIEW_MODE_BANNER_HEIGHT } from "../../components/PreviewModeBanner";
@@ -62,7 +72,17 @@ type Card =
   | { kind: "engagement"; when: string; message: string }
   | { kind: "success"; text: string }
   | { kind: "link"; label: string; url: string; description: string }
-  | { kind: "agentAction"; tool: string; result: string };
+  | { kind: "agentAction"; tool: string; result: string }
+  // GUI固有だった操作(PDF取り込み)を旧UIへ渡さず会話の中で完結させる最初の1件。
+  // 送信の進捗までしか追わない(取り込み完了までの追跡は旧UIのPDFタブが担当)ため、
+  // 状態は「送っている / 受け取った / 受け取れなかった」の3つで足りる。
+  | {
+      kind: "pdfUpload";
+      status: "uploading" | "success" | "error";
+      fileName: string;
+      progress?: number;
+      message?: string;
+    };
 
 // 自由入力欄からの実API呼び出しで使うツール名 → 日本語ラベル
 const REAL_TOOL_LABEL: Record<string, string> = {
@@ -203,6 +223,22 @@ function parseLegacyUiLink(result: string): { label: string; url: string; descri
 
 const SAVE_SUCCESS_RE = /を(保存|登録|削除|更新|有効化|設定)しました/;
 
+// ─── PDF取り込みの案内文 ─────────────────────────────────────────────────────
+// 判定条件は lib/bookPdfUpload.ts で旧UIと共有し、文言だけをこの面の話し言葉に合わせる。
+// 店主に読ませるものなので、拡張子以外の技術用語(MIME・ステータスコード等)は出さない。
+
+const PDF_REJECTION_MESSAGE: Record<BookPdfRejection, string> = {
+  type: "PDFファイル（またはPDFをまとめたZIPファイル）を送ってください。",
+  pdf_size: "PDFは1ファイル10MBまでです。分割してから送ってみてください。",
+  zip_size: "ZIPファイルは50MBまでです。分けてから送ってみてください。",
+};
+
+const PDF_UPLOAD_AUTH_ERROR = "ログインの有効期限が切れたようです。もう一度ログインしてからお試しください。";
+const PDF_UPLOAD_TOO_LARGE_ERROR = "ファイルが大きすぎて受け取れませんでした。分割してから送ってみてください。";
+const PDF_UPLOAD_NETWORK_ERROR = "うまく送れませんでした。通信の状態を確かめて、もう一度お試しください。";
+const PDF_UPLOAD_GENERIC_ERROR = "うまく受け取れませんでした。少し時間をおいてお試しください。";
+const PDF_UPLOAD_ZIP_EMPTY_ERROR = "ZIPの中に取り込めるPDFが見つかりませんでした。";
+
 // ─── 進行中テキストを少しずつ流し込む（体感の良さ重視の演出。本物の
 //     トークンストリーミングではなく、確定済みの応答文字列をクライアント側で
 //     少しずつ表示するだけ。真のストリーミングにはバックエンドの
@@ -297,14 +333,15 @@ export default function CopilotPreviewPage() {
   const [sending, setSending] = useState(false);
   const [realActionCount, setRealActionCount] = useState(0); // 実際に成功した書き込み操作の件数
 
-  // 左レールのバッジ用件数(旧UIと同じ既存エンドポイントの再利用)。
-  // テナントを特定できない場合(preview中でないsuper_admin)は取得しない。
-  // 全テナント横断の合計が「この店の件数」として出てしまうため。
-  const badgeTenantId = previewMode ? (previewTenantId ?? "") : (user?.tenantId ?? "");
+  // この画面が対象にしているテナント。左レールのバッジ件数とPDF取り込みの両方で使う。
+  // テナントを特定できない場合(preview中でないsuper_admin)は空になり、バッジは取得しない
+  // (全テナント横断の合計が「この店の件数」として出てしまうため)。なお、その状態では
+  // needsTenantSelection でチャット自体がまだ描画されないため、コンポーザは存在しない。
+  const scopedTenantId = previewMode ? (previewTenantId ?? "") : (user?.tenantId ?? "");
   const [railCounts, setRailCounts] = useState<RailCounts>({});
   useEffect(() => {
-    if (!badgeTenantId) return;
-    const qs = `?tenant=${encodeURIComponent(badgeTenantId)}`;
+    if (!scopedTenantId) return;
+    const qs = `?tenant=${encodeURIComponent(scopedTenantId)}`;
     void (async () => {
       // 失敗しても店主には何も見せない(バッジが出ないだけ)。片方だけ失敗しても
       // もう片方は出せるよう allSettled で個別に扱う。
@@ -323,7 +360,7 @@ export default function CopilotPreviewPage() {
       }
       setRailCounts(next);
     })();
-  }, [badgeTenantId]);
+  }, [scopedTenantId]);
 
   // textareaは行が増えても自動では伸びないため、入力量に応じて高さを合わせる
   // (伸ばさないと2行目以降を打った時に前の行が枠外へ隠れてしまう)
@@ -653,6 +690,141 @@ export default function CopilotPreviewPage() {
     }
   };
 
+  // ─── PDF取り込み(コンポーザへのドラッグ＆ドロップ / 📎ボタン) ─────────────────
+  // 会話ではなくファイルそのものが指示なので、LLMのツール呼び出しループは通さず、旧UIの
+  // PDFタブと同じ既存エンドポイントへ直接送る。エージェントに「アップロードするか」を
+  // 判断させる余地は無い(落とした行為が意思表示そのもの)。
+  const uploadUrl = isSuperAdmin && scopedTenantId
+    ? `${API_BASE}/v1/admin/knowledge/book-pdf?tenant=${encodeURIComponent(scopedTenantId)}`
+    : `${API_BASE}/v1/admin/knowledge/book-pdf`;
+
+  const pdfInputRef = useRef<HTMLInputElement>(null);
+  const [pdfDragOver, setPdfDragOver] = useState(false);
+  const pdfDragCounterRef = useRef(0);
+
+  const updatePdfCard = useCallback((msgId: number, patch: Partial<Extract<Card, { kind: "pdfUpload" }>>) => {
+    setMsgs((prev) =>
+      prev.map((m) =>
+        m.id === msgId && m.card?.kind === "pdfUpload" ? { ...m, card: { ...m.card, ...patch } } : m,
+      ),
+    );
+  }, []);
+
+  const acceptFiles = async (files: FileList | File[]) => {
+    const accepted: { file: File; isZip: boolean }[] = [];
+    for (const file of Array.from(files)) {
+      const verdict = validateBookPdfFile(file);
+      if (verdict.kind === "rejected") {
+        // 受け付けない形式・大きさは通信する前にこの場で断る
+        push({
+          id: nextId(),
+          role: "ai",
+          card: {
+            kind: "pdfUpload",
+            status: "error",
+            fileName: file.name,
+            message: PDF_REJECTION_MESSAGE[verdict.reason],
+          },
+        });
+        continue;
+      }
+      accepted.push({ file, isZip: verdict.kind === "zip" });
+    }
+    if (accepted.length === 0) return;
+
+    const token = await getAccessToken();
+
+    // 旧UIと同じく1件ずつ順に送る(同時送信で回線と取り込みキューを圧迫しないため)
+    for (const { file, isZip } of accepted) {
+      const cardId = nextId();
+      push({
+        id: cardId,
+        role: "ai",
+        card: { kind: "pdfUpload", status: "uploading", fileName: file.name, progress: 0 },
+      });
+
+      const form = new FormData();
+      form.append("file", file);
+      // ZIPはサーバー側が中の各PDFのファイル名からタイトルを付けるため送らない
+      if (!isZip) form.append("title", defaultBookTitle(file.name));
+
+      const { status, body, networkError } = await uploadBookPdfWithProgress(
+        uploadUrl,
+        form,
+        token,
+        (pct) => updatePdfCard(cardId, { progress: pct }),
+      );
+
+      if (networkError) {
+        updatePdfCard(cardId, { status: "error", message: PDF_UPLOAD_NETWORK_ERROR });
+        continue;
+      }
+
+      if (status < 200 || status >= 300) {
+        const kind = classifyUploadStatus(status);
+        const serverMessage = (body as { error?: string } | null)?.error;
+        updatePdfCard(cardId, {
+          status: "error",
+          message:
+            kind === "auth" ? PDF_UPLOAD_AUTH_ERROR
+            : kind === "too_large" ? PDF_UPLOAD_TOO_LARGE_ERROR
+            : serverMessage || PDF_UPLOAD_GENERIC_ERROR,
+        });
+        continue;
+      }
+
+      if (isZip) {
+        const results = (body as { results?: { status: string }[] } | null)?.results ?? [];
+        const okCount = results.filter((r) => r.status === "ok").length;
+        if (okCount === 0) {
+          updatePdfCard(cardId, { status: "error", message: PDF_UPLOAD_ZIP_EMPTY_ERROR });
+          continue;
+        }
+        updatePdfCard(cardId, {
+          status: "success",
+          message: `${okCount}件のPDFを受け取りました。読み込みが終わると、内容から答えられるようになります。`,
+        });
+      } else {
+        updatePdfCard(cardId, {
+          status: "success",
+          message: "読み込みが終わると、この資料の内容から答えられるようになります。",
+        });
+      }
+      // 他の書き込み操作と同じく、実際にDBへ入った件数としてヘッダーのバッジに反映する
+      setRealActionCount((n) => n + 1);
+    }
+  };
+
+  const handlePdfDrop = (e: React.DragEvent) => {
+    e.preventDefault();
+    pdfDragCounterRef.current = 0;
+    setPdfDragOver(false);
+    if (e.dataTransfer.files.length > 0) void acceptFiles(e.dataTransfer.files);
+  };
+
+  const handlePdfDragEnter = (e: React.DragEvent) => {
+    e.preventDefault();
+    pdfDragCounterRef.current += 1;
+    setPdfDragOver(true);
+  };
+
+  const handlePdfDragLeave = (e: React.DragEvent) => {
+    e.preventDefault();
+    pdfDragCounterRef.current -= 1;
+    if (pdfDragCounterRef.current <= 0) {
+      pdfDragCounterRef.current = 0;
+      setPdfDragOver(false);
+    }
+  };
+
+  // ドラッグ＆ドロップができない環境(モバイル・キーボード操作)向けの同等手段
+  const handlePdfInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files.length > 0) {
+      void acceptFiles(e.target.files);
+      e.target.value = "";
+    }
+  };
+
   // ─── レイアウト ───────────────────────────────────────────────────────────
   if (needsTenantSelection) {
     return (
@@ -796,10 +968,26 @@ export default function CopilotPreviewPage() {
           </div>
         </div>
 
-        {/* コンポーザ（実API接続） */}
+        {/* コンポーザ（実API接続）。PDFはここへ落とすと会話の中で取り込みが始まる */}
         <div className="cp-composer-wrap" style={{ flexShrink: 0 }}>
           <div style={{ maxWidth: 820, margin: "0 auto" }}>
-            <div style={{ display: "flex", alignItems: "center", gap: 12, padding: "12px 12px 12px 20px", border: `1px solid ${sending ? AGENT_BORDER : "var(--border)"}`, borderRadius: 16, background: "var(--input, var(--card))" }}>
+            <div
+              onDragEnter={handlePdfDragEnter}
+              onDragOver={(e) => e.preventDefault()}
+              onDragLeave={handlePdfDragLeave}
+              onDrop={handlePdfDrop}
+              style={{ display: "flex", alignItems: "center", gap: 12, padding: "12px 12px 12px 20px", border: pdfDragOver ? `2px dashed ${AGENT}` : `1px solid ${sending ? AGENT_BORDER : "var(--border)"}`, borderRadius: 16, background: pdfDragOver ? AGENT_SOFT : "var(--input, var(--card))" }}
+            >
+              <input
+                ref={pdfInputRef}
+                type="file"
+                accept=".pdf,.zip,application/pdf,application/zip"
+                multiple
+                style={{ display: "none" }}
+                aria-hidden="true"
+                tabIndex={-1}
+                onChange={handlePdfInputChange}
+              />
               {/* textarea(1行から始まり複数行も書ける)。Enterで送信、Shift+Enterで改行。
                   IME変換中のEnterは shouldSubmitOnEnter が弾く(旧UIパネルと共通実装) */}
               <textarea
@@ -814,12 +1002,20 @@ export default function CopilotPreviewPage() {
                 disabled={sending}
                 style={{ flex: 1, border: "none", outline: "none", background: "transparent", color: "var(--foreground)", fontSize: 16, maxHeight: 140, resize: "none", fontFamily: "inherit", lineHeight: 1.6, padding: 0, overflowY: "auto" }}
               />
+              <button
+                onClick={() => pdfInputRef.current?.click()}
+                aria-label="PDFを添付"
+                title="PDFを添付（ここへドラッグ＆ドロップでも取り込めます）"
+                style={{ width: 40, height: 40, borderRadius: 12, border: "1px solid var(--border)", background: "transparent", color: "var(--muted-foreground)", cursor: "pointer", fontSize: 17, flexShrink: 0 }}
+              >
+                📎
+              </button>
               <button onClick={handleSend} disabled={sending} aria-label="送信" style={{ width: 40, height: 40, borderRadius: 12, border: "none", background: AGENT, color: "#fff", cursor: sending ? "not-allowed" : "pointer", opacity: sending ? 0.6 : 1, fontSize: 18 }}>
                 {sending ? "…" : "↑"}
               </button>
             </div>
             <div style={{ marginTop: 8, fontSize: 12, color: "var(--muted-foreground)", textAlign: "center" }}>
-              実際の R2Cエージェントに接続されています。要ログイン。
+              実際の R2Cエージェントに接続されています。要ログイン。PDFはここへドラッグ＆ドロップできます。
             </div>
           </div>
         </div>
@@ -975,7 +1171,7 @@ function Phase4DefaultToggle() {
 
 function RealActionBadge({ count }: { count: number }) {
   return (
-    <div style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 12.5, color: count > 0 ? "#16a34a" : "var(--muted-foreground)" }}>
+    <div aria-label={`実際の操作 ${count}件`} style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 12.5, color: count > 0 ? "#16a34a" : "var(--muted-foreground)" }}>
       <span style={{ fontSize: 13 }}>{count > 0 ? "✅" : "◦"}</span>
       実際の操作 <strong style={{ fontVariantNumeric: "tabular-nums" }}>{count}</strong>件
     </div>
@@ -1015,10 +1211,10 @@ function MessageRow({ m, onChip }: { m: Msg; onChip: (a: string, id: number) => 
   );
 }
 
-function CardShell({ hd, tone = "agent", children, foot }: { hd: React.ReactNode; tone?: "agent" | "brand" | "good"; children: React.ReactNode; foot?: React.ReactNode }) {
-  const border = tone === "good" ? "rgba(34,197,94,0.4)" : tone === "brand" ? "rgba(217,147,32,0.4)" : AGENT_BORDER;
-  const hdBg = tone === "good" ? "rgba(34,197,94,0.12)" : tone === "brand" ? "rgba(217,147,32,0.12)" : AGENT_SOFT;
-  const hdColor = tone === "good" ? "#16a34a" : tone === "brand" ? "#b45309" : AGENT;
+function CardShell({ hd, tone = "agent", children, foot }: { hd: React.ReactNode; tone?: "agent" | "brand" | "good" | "bad"; children: React.ReactNode; foot?: React.ReactNode }) {
+  const border = tone === "bad" ? "rgba(239,68,68,0.4)" : tone === "good" ? "rgba(34,197,94,0.4)" : tone === "brand" ? "rgba(217,147,32,0.4)" : AGENT_BORDER;
+  const hdBg = tone === "bad" ? "rgba(239,68,68,0.12)" : tone === "good" ? "rgba(34,197,94,0.12)" : tone === "brand" ? "rgba(217,147,32,0.12)" : AGENT_SOFT;
+  const hdColor = tone === "bad" ? "#dc2626" : tone === "good" ? "#16a34a" : tone === "brand" ? "#b45309" : AGENT;
   return (
     <div style={{ width: "100%", maxWidth: "100%", border: `1px solid ${border}`, borderRadius: 16, overflow: "hidden", background: "var(--card)", boxShadow: "0 2px 4px rgba(0,0,0,0.05), 0 10px 28px rgba(0,0,0,0.07)" }}>
       <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "14px 18px", background: hdBg, borderBottom: `1px solid ${border}`, fontWeight: 700, fontSize: 15, color: hdColor }}>{hd}</div>
@@ -1080,6 +1276,8 @@ function CardView({ card }: { card: Card }) {
           <span style={{ fontSize: 17 }}>✅</span>{card.text}
         </div>
       );
+    case "pdfUpload":
+      return <PdfUploadCard card={card} />;
     case "link":
       return (
         <CardShell hd={<><span>🔗</span>{card.label}へご案内します</>}>
@@ -1101,6 +1299,52 @@ function CardView({ card }: { card: Card }) {
     default:
       return null;
   }
+}
+
+// PDF取り込みカード。旧UIのPDFタブと同じ3点(ファイル名・送信の進捗%・結果)を、
+// 会話の流れの中で見せる。成功時の見た目は他の書き込み操作の成功カードと同じ緑系に揃える。
+function PdfUploadCard({ card }: { card: Extract<Card, { kind: "pdfUpload" }> }) {
+  if (card.status === "uploading") {
+    const pct = card.progress ?? 0;
+    return (
+      <CardShell hd={<><span>📄</span>PDFを受け取っています</>}>
+        <Field k="ファイル" v={card.fileName} />
+        <div>
+          <div
+            role="progressbar"
+            aria-label="PDFの送信の進みぐあい"
+            aria-valuenow={pct}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            style={{ width: "100%", height: 6, borderRadius: 999, background: "var(--muted, rgba(120,120,140,0.15))", overflow: "hidden" }}
+          >
+            <div style={{ height: "100%", borderRadius: 999, background: AGENT, width: `${pct}%`, transition: "width 0.2s ease" }} />
+          </div>
+          <div style={{ marginTop: 5, fontSize: 12.5, color: "var(--muted-foreground)", fontVariantNumeric: "tabular-nums" }}>{pct}%</div>
+        </div>
+      </CardShell>
+    );
+  }
+
+  if (card.status === "success") {
+    return (
+      <CardShell tone="good" hd={<><span>📚</span>PDFを受け取りました</>}>
+        <Field k="ファイル" v={card.fileName} />
+        {card.message && <div style={{ fontSize: 14, color: "var(--muted-foreground)", lineHeight: 1.7 }}>{card.message}</div>}
+      </CardShell>
+    );
+  }
+
+  return (
+    <CardShell
+      tone="bad"
+      hd={<><span>📄</span>PDFを受け取れませんでした</>}
+      foot={<CardActionsNote note="会話はそのまま続けられます。もう一度ファイルを送るか、内容を文章で教えてください。" />}
+    >
+      <Field k="ファイル" v={card.fileName} />
+      {card.message && <div style={{ fontSize: 15, color: "var(--foreground)", lineHeight: 1.7 }}>{card.message}</div>}
+    </CardShell>
+  );
 }
 
 function CardActionsNote({ note }: { note: string }) {

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -1750,7 +1750,11 @@ export async function executeToolCall(
           path: '/admin/avatar/wizard',
           description: 'アバターを新しく作る手順（ウィザード）はこちらの画面で行えます',
         },
-        // PDFアップロードはファイル選択がGUI固有の操作のためチャット化せず、旧UIへ誘導する。
+        // PDFアップロードはファイル選択がGUI固有の操作のため、当初チャット化せず旧UIへ誘導していた。
+        // docs/CHAT_SURFACE_DECISION.md の方針に沿い、新UI(/copilot-preview)のコンポーザへの
+        // ドラッグ＆ドロップで会話内に取り込む経路を試作済み(同じ book-pdf エンドポイントを直接叩く)。
+        // ただし取り込み後の状態追跡・タイトル編集・書籍一覧はこの旧UIにしか無いため、案内先としては
+        // 引き続き有効。docs/LEGACY_UI_SUNSET.md のクローズ判定を通るまでこのキーは残す(追加のみ)。
         // /admin/knowledge (tenantId無し)は KnowledgeIndexPage が navigate() で
         // /admin/knowledge/:tenantId へリダイレクトする際に location.search を引き継がず
         // ?tab=pdf が失われるため、他のキーと異なりここでは tenantId を path に含める必要がある


### PR DESCRIPTION
Asana GID 1217007387443283

## やったこと

GUI固有として `get_legacy_ui_link` で丸ごと旧UIへ受け渡していた操作のうち、PDF取り込みを新UI(`/copilot-preview`)の**会話内カード**として扱えるようにした。`docs/CHAT_SURFACE_DECISION.md` の方針(チャットUIを将来の既定にする)の最初の検証で、いちばんリスクが低い1件目。

- コンポーザ(入力欄+送信ボタンの枠)にPDF/ZIPを落とすと、その場で取り込みが始まる。ドラッグできない環境向けに 📎 ボタンも同じ入口として置いた。
- 既存の `POST /v1/admin/knowledge/book-pdf` をそのまま使う。**新しいエンドポイントもLLMツールも追加していない。**
- 受付条件・送信・エラー分類は `admin-ui/src/lib/bookPdfUpload.ts` に切り出し、旧UIの `PdfUploadTab` と共有。旧UI側は挙動不変。
- `LEGACY_UI_LINKS.knowledge_pdf` は**残したまま**、コメントだけ現状に合わせた(置き換えではなく並行追加)。

## バックエンドのツール配線は追加していない(直接アップロード)

ファイルを落とした行為そのものが意思表示なので、「アップロードするか」をLLMに判断させる余地がない。既存エンドポイントは multipart + Bearer だけで足り、リクエスト形の都合で新しいツールラッパーが必要になる箇所もなかったため、フロントから直接送っている(`authFetch` は常に `Content-Type: application/json` を付けるので使えず、旧UIと同じ XHR 経路)。

## 旧UIのPDFタブとの正直な比較

**良くなった点**
- 手数は減った。旧UI: 案内カードを開く → 別タブ → (super_adminはテナント選択) → PDFタブ → ドロップ → タイトル確認 → 「1件をアップロード」→ 計6〜7手。新UI: **落とすだけの1手**。画面遷移もタブ移動もない。
- 失敗しても会話が途切れない。エラーカードのまま次のメッセージを打てる(テストで固定済み)。

**明確に悪くなった点(こちらのほうが重いと考えている)**
1. **取り込み完了が分からない。** 旧UIは5秒ポーリングで `uploaded → 処理中 → 登録完了` まで追い、何件に分割されたかまで出す。新UIは**送信完了までしか追っていない**ので「受け取りました」で止まる。実際に検索に使えるようになったかどうかは旧UIを開かないと分からない。知識登録の目的からすると、ここが分からないのは機能的な後退。
2. **タイトルを付けられない。** サーバーは単体PDFに `title` を必須で要求するため、ファイル名から自動生成して送っている。旧UIはアップロード前に編集できる。`スキャン_001.pdf` のような名前がそのまま書籍名になる。
3. **一覧・詳細・やり直しが無い。** 何を入れたかの一覧、チャンクの確認、失敗した書籍の再処理はすべて旧UIだけの機能。
4. **狙いを外すと危ない。** コンポーザの外に落とすとブラウザ既定動作でそのPDFが開き、画面から離脱する(会話は sessionStorage から復元されるが体験としては事故)。旧UIは専用タブの広いドロップゾーンなので外しにくい。
5. **モバイルではドラッグ＆ドロップが成立しない。** 📎 ボタンで代替しているが、そのボタンのぶんコンポーザの入力幅が 390px 時に **約280px → 約228px(−19%)** 縮む。チャットの主用途である文章入力を、月に数回の操作のために常時削っている。

**結論**: パターン自体は成立する(実装は動く・テストも通る)が、**現状の完成度では旧UIのPDFタブより劣る**。1手で始められる価値より、1〜3の「入れた結果が追えない」欠落のほうが大きい。このまま `knowledge_pdf` の案内を畳める状態ではない。畳むには最低でも取り込み状況のポーリング(または完了通知)と、書籍一覧の会話内提示が要る。「動いたので移行完了」ではなく「パターンの検証はできた、単体では旧UIの代替にならない」が正しい報告。

## スクリーンショット

CDP経由のスクリーンショット取得がこの環境で失敗したため**画像は取れていない**。代わりに実ブラウザ(vite dev)で挙動と寸法を確認した。
- 非PDF・10MB超・通信失敗の3カードがいずれも実ブラウザで意図どおり描画されることを確認(拒否の2件は通信ゼロ)。
- デスクトップ(1431px): コンポーザ幅670px・入力欄533px・ボタン40x40・横スクロールなし。
- 390px時の入力幅は上記5.のとおりCSSから算出した値で、実機の目視確認はできていない。

## 検証

- `npm run lint` (root): exit 0
- `npx tsc --noEmit` (root): exit 0 / `admin-ui` の tsc は変更ファイルにエラーなし(残るエラーは `tenantPlan` 不足など既存のテストファイル由来)
- `admin-ui` 全テスト: **205 passed (25 files)**。`copilot-preview/index.test.tsx` は既存35件を1行も書き換えずに8件追加して43件、`PdfUploadTab.test.tsx` の8件も緑。
- `git diff --stat -- '*.sql' '.env*' 'package.json'` vs origin/main: 空(マイグレーション・環境変数・依存の追加なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177MCsC7jN3a51F7TdaW9vH
