### PR TITLE
fix(lp): 競合に手法が伝わる文言と専門用語を平易な表現に修正

### DIFF
--- a/public/lp/index.html
+++ b/public/lp/index.html
@@ -371,10 +371,10 @@
 
     <!-- Trust badges -->
     <div style="display:flex; flex-wrap:wrap; justify-content:center; gap:12px;">
-      <span style="font-size:12px; color:var(--muted); background:rgba(255,255,255,0.04); border:1px solid rgba(255,255,255,0.08); border-radius:6px; padding:6px 12px;">🔒 AES-256-GCM 暗号化</span>
+      <span style="font-size:12px; color:var(--muted); background:rgba(255,255,255,0.04); border:1px solid rgba(255,255,255,0.08); border-radius:6px; padding:6px 12px;">🔒 強力な暗号化</span>
       <span style="font-size:12px; color:var(--muted); background:rgba(255,255,255,0.04); border:1px solid rgba(255,255,255,0.08); border-radius:6px; padding:6px 12px;">🇯🇵 日本国内保管</span>
-      <span style="font-size:12px; color:var(--muted); background:rgba(255,255,255,0.04); border:1px solid rgba(255,255,255,0.08); border-radius:6px; padding:6px 12px;">🔑 SHA-256 キー管理</span>
-      <span style="font-size:12px; color:var(--muted); background:rgba(255,255,255,0.04); border:1px solid rgba(255,255,255,0.08); border-radius:6px; padding:6px 12px;">💳 Stripe 決済</span>
+      <span style="font-size:12px; color:var(--muted); background:rgba(255,255,255,0.04); border:1px solid rgba(255,255,255,0.08); border-radius:6px; padding:6px 12px;">🔑 安全なキー管理</span>
+      <span style="font-size:12px; color:var(--muted); background:rgba(255,255,255,0.04); border:1px solid rgba(255,255,255,0.08); border-radius:6px; padding:6px 12px;">💳 安全な決済基盤</span>
     </div>
   </div>
 </section>
@@ -488,7 +488,7 @@
         <div class="glass-card" style="border-radius:12px; padding:24px;">
           <div style="font-size:28px; margin-bottom:12px;">🛒</div>
           <div style="font-weight:700; font-size:15px; margin-bottom:8px; color:#fff;">カート離脱防止</div>
-          <div style="font-size:13px; color:var(--muted); line-height:1.65;">カートページで一定時間滞留した訪問者にプロアクティブ声がけ。不安を解消して購入へ。</div>
+          <div style="font-size:13px; color:var(--muted); line-height:1.65;">カートページに留まっている訪問者に、AIから先に声をかけます。不安を解消して購入へ。</div>
         </div>
       </div>
     </div>
@@ -502,7 +502,7 @@
         <div class="glass-card" style="border-radius:12px; padding:24px;">
           <div style="font-size:28px; margin-bottom:12px;">💡</div>
           <div style="font-weight:700; font-size:15px; margin-bottom:8px; color:#fff;">コース提案・アップセル</div>
-          <div style="font-size:13px; color:var(--muted); line-height:1.65;">悩みをヒアリングして最適コースを提案。回数券・定期コースへの誘導でLTVを最大化。</div>
+          <div style="font-size:13px; color:var(--muted); line-height:1.65;">悩みをヒアリングして最適コースを提案。回数券・定期コースへの誘導で、一人あたりの売上を長期的に最大化。</div>
         </div>
         <div class="glass-card" style="border-radius:12px; padding:24px;">
           <div style="font-size:28px; margin-bottom:12px;">📝</div>
@@ -526,7 +526,7 @@
         <div class="glass-card" style="border-radius:12px; padding:24px;">
           <div style="font-size:28px; margin-bottom:12px;">🤝</div>
           <div style="font-weight:700; font-size:15px; margin-bottom:8px; color:#fff;">人間への引き渡し</div>
-          <div style="font-size:13px; color:var(--muted); line-height:1.65;">AIが対応困難な専門的相談は、担当者へシームレスにエスカレーション。AIと人が協調。</div>
+          <div style="font-size:13px; color:var(--muted); line-height:1.65;">AIが対応困難な専門的相談は、担当者へそのまま引き継ぎます。AIと人が協力して対応。</div>
         </div>
       </div>
     </div>
@@ -567,9 +567,9 @@
     <div style="flex:1; min-width:0; text-align:center; padding:0 16px;">
       <div style="width:40px; height:40px; border-radius:50%; background:linear-gradient(135deg,#d946ef,#06b6d4); display:flex; align-items:center; justify-content:center; font-weight:800; font-size:16px; color:#fff; margin:0 auto 16px;">3</div>
       <div style="font-weight:700; font-size:15px; margin-bottom:10px;">AIが24時間自動接客</div>
-      <div style="font-size:13px; color:var(--muted); line-height:1.6; margin-bottom:14px;">あとはR2Cが全自動。会話ログ・CV数・改善提案をダッシュボードで確認。</div>
+      <div style="font-size:13px; color:var(--muted); line-height:1.6; margin-bottom:14px;">あとはR2Cが全自動。会話ログ・成約件数・改善提案を管理画面で確認。</div>
       <div style="background:rgba(6,182,212,0.08); border:1px solid rgba(6,182,212,0.2); border-radius:8px; padding:12px; font-size:12px; color:#67e8f9;">
-        📊 リアルタイムで<br>CVR・会話品質を計測
+        📊 リアルタイムで<br>成約率・会話の質を計測
       </div>
     </div>
   </div>
@@ -614,7 +614,7 @@
           <span style="color:#4ade80;">✓</span> マニュアル不要。迷ったらAIに聞くだけ
         </div>
         <div style="display:flex; align-items:center; gap:10px; font-size:14px; color:#e5e7eb;">
-          <span style="color:#4ade80;">✓</span> 複雑な設定変更は「R2Cエージェント」に依頼すれば管理画面のGUI操作まで代行（Enterprise）
+          <span style="color:#4ade80;">✓</span> 複雑な設定変更は「R2Cエージェント」に頼めば、そのまま代行してもらえる（Enterprise）
         </div>
       </div>
     </div>
@@ -663,8 +663,8 @@
         </div>
         <div class="glass-card" style="border-radius:14px; padding:26px; transition:border-color 0.2s;" onmouseover="this.style.borderColor='rgba(139,92,246,0.35)'" onmouseout="this.style.borderColor='rgba(255,255,255,0.08)'">
           <div style="font-size:32px; margin-bottom:14px;">🔍</div>
-          <div style="font-weight:700; font-size:15px; color:#fff; margin-bottom:8px;">RAG FAQ検索</div>
-          <div style="font-size:13px; color:var(--muted); line-height:1.65;">PDF・URLを貼るだけで即回答。<strong style="color:#c4b5fd;">ハルシネーション（でたらめ回答）なし</strong>で安心運用。</div>
+          <div style="font-weight:700; font-size:15px; color:#fff; margin-bottom:8px;">AI FAQ検索</div>
+          <div style="font-size:13px; color:var(--muted); line-height:1.65;">PDF・URLを貼るだけで即回答。<strong style="color:#c4b5fd;">でたらめな回答をしない</strong>ので安心して運用できます。</div>
         </div>
         <div class="glass-card" style="border-radius:14px; padding:26px; transition:border-color 0.2s;" onmouseover="this.style.borderColor='rgba(139,92,246,0.35)'" onmouseout="this.style.borderColor='rgba(255,255,255,0.08)'">
           <div style="font-size:32px; margin-bottom:14px;">🧠</div>
@@ -674,7 +674,7 @@
         <div class="glass-card" style="border-radius:14px; padding:26px; transition:border-color 0.2s;" onmouseover="this.style.borderColor='rgba(139,92,246,0.35)'" onmouseout="this.style.borderColor='rgba(255,255,255,0.08)'">
           <div style="font-size:32px; margin-bottom:14px;">🔮</div>
           <div style="font-weight:700; font-size:15px; color:#fff; margin-bottom:8px;">行動を読んで、先回りする</div>
-          <div style="font-size:13px; color:var(--muted); line-height:1.65;">滞在時間・回遊・離脱兆候から<strong style="color:#c4b5fd;">購入温度を数値化</strong>。似た行動をした訪問者の成功パターンを参照して、声がけの内容とタイミングを最適化します。</div>
+          <div style="font-size:13px; color:var(--muted); line-height:1.65;">訪問者の行動から<strong style="color:#c4b5fd;">「今、興味が高まっている瞬間」</strong>を見極め、最適なタイミングで自然に声をかけます。</div>
         </div>
         <div class="glass-card" style="border-radius:14px; padding:26px; transition:border-color 0.2s;" onmouseover="this.style.borderColor='rgba(139,92,246,0.35)'" onmouseout="this.style.borderColor='rgba(255,255,255,0.08)'">
           <div style="font-size:32px; margin-bottom:14px;">🤝</div>
@@ -684,7 +684,7 @@
         <div class="glass-card" style="border-radius:14px; padding:26px; transition:border-color 0.2s;" onmouseover="this.style.borderColor='rgba(139,92,246,0.35)'" onmouseout="this.style.borderColor='rgba(255,255,255,0.08)'">
           <div style="font-size:32px; margin-bottom:14px;">📊</div>
           <div style="font-weight:700; font-size:15px; color:#fff; margin-bottom:8px;">成果の可視化</div>
-          <div style="font-size:13px; color:var(--muted); line-height:1.65;">購入・予約・問い合わせへの<strong style="color:#c4b5fd;">AI貢献を数値化</strong>。Judgeエンジンが全会話を4軸評価し、品質を可視化します。</div>
+          <div style="font-size:13px; color:var(--muted); line-height:1.65;">購入・予約・問い合わせへの<strong style="color:#c4b5fd;">AI貢献を数値化</strong>。すべての会話をAIが自動評価し、品質を可視化します。</div>
         </div>
       </div>
     </div>
@@ -713,17 +713,17 @@
         <div class="glass-card" style="border-radius:14px; padding:24px;">
           <div style="font-size:28px; margin-bottom:12px;">⚖️</div>
           <div style="font-weight:700; font-size:15px; color:#fff; margin-bottom:8px;">全会話をAIが採点</div>
-          <div style="font-size:13px; color:var(--muted); line-height:1.65;">Judgeエンジンが4軸で評価。どの応対が良く、どこで失敗したかが数字で見えます。</div>
+          <div style="font-size:13px; color:var(--muted); line-height:1.65;">すべての会話をAIが自動採点。どの応対が良く、どこで改善が必要かが数字で見えます。</div>
         </div>
         <div class="glass-card" style="border-radius:14px; padding:24px;">
           <div style="font-size:28px; margin-bottom:12px;">🌱</div>
           <div style="font-weight:700; font-size:15px; color:#fff; margin-bottom:8px;">良かった会話から学習</div>
-          <div style="font-size:13px; color:var(--muted); line-height:1.65;">高評価だった会話は要点が蒸留され、次回以降の応対に反映されます。</div>
+          <div style="font-size:13px; color:var(--muted); line-height:1.65;">評価の高かった会話の型を学習し、次回以降の応対に自動で活かされます。</div>
         </div>
         <div class="glass-card" style="border-radius:14px; padding:24px;">
           <div style="font-size:28px; margin-bottom:12px;">🗣️</div>
-          <div style="font-weight:700; font-size:15px; color:#fff; margin-bottom:8px;">反論パターンが貯まる</div>
-          <div style="font-size:13px; color:var(--muted); line-height:1.65;">「高い」「今じゃない」といった反応への切り返しが蓄積され、営業トークが磨かれます。</div>
+          <div style="font-weight:700; font-size:15px; color:#fff; margin-bottom:8px;">断られても、次はうまくいく</div>
+          <div style="font-size:13px; color:var(--muted); line-height:1.65;">「高い」「今じゃない」といった声にも、会話を重ねるほど自然に応えられるようになっていきます。</div>
         </div>
       </div>
     </div>
@@ -786,8 +786,6 @@
 
     <div class="pricing-grid" style="display:grid; grid-template-columns:repeat(3,1fr); gap:20px;">
       <style>
-        /* 既存バグ修正: display:contents な内側divにmedia queryが当たっていて767px以下で1カラム化されていなかった。
-           グリッドを実際に形成している外側divに .pricing-grid を付け替えて修正する。 */
         @media (max-width: 767px) { .pricing-grid { grid-template-columns: 1fr !important; } }
       </style>
       <div style="display:contents;">
@@ -799,13 +797,13 @@
           <div style="font-size:13px; color:var(--muted); margin-bottom:24px;">〜500対話/月</div>
           <ul style="list-style:none; padding:0; margin:0 0 24px; display:flex; flex-direction:column; gap:10px;">
             <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> ウィジェット埋め込み</li>
-            <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> FAQ RAG（PDF/URL）</li>
+            <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> FAQ自動回答（PDF/URL）</li>
             <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> テキスト接客</li>
             <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> 心理学Sales AI</li>
-            <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> 有人エスカレーション</li>
+            <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> スタッフへの引き継ぎ</li>
             <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> 未回答質問の自動抽出</li>
-            <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> プロアクティブ声がけ</li>
-            <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> 基本ダッシュボード</li>
+            <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> 先回り声がけ</li>
+            <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> 基本の管理画面</li>
           </ul>
           <a href="#contact" style="display:block; text-align:center; background:rgba(124,58,237,0.15); border:1px solid rgba(124,58,237,0.35); color:#c4b5fd; text-decoration:none; font-weight:600; font-size:14px; padding:12px; border-radius:10px; transition:all 0.2s;" onmouseover="this.style.background='rgba(124,58,237,0.25)'" onmouseout="this.style.background='rgba(124,58,237,0.15)'">無料で始める</a>
         </div>
@@ -819,10 +817,10 @@
           <ul style="list-style:none; padding:0; margin:0 0 24px; display:flex; flex-direction:column; gap:10px;">
             <li style="font-size:13px; color:#fff; display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> Starterの全機能</li>
             <li style="font-size:13px; color:#fff; display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> AIアバター（顔・声）</li>
-            <li style="font-size:13px; color:#fff; display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> 高度なAnalytics</li>
-            <li style="font-size:13px; color:#fff; display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> CV計測</li>
-            <li style="font-size:13px; color:#fff; display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> A/Bテスト</li>
-            <li style="font-size:13px; color:#fff; display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> GA4・PostHog連携</li>
+            <li style="font-size:13px; color:#fff; display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> 詳しい分析レポート</li>
+            <li style="font-size:13px; color:#fff; display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> 成果（購入・予約）の計測</li>
+            <li style="font-size:13px; color:#fff; display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> 接客パターンの比較テスト</li>
+            <li style="font-size:13px; color:#fff; display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> 外部アナリティクス連携</li>
             <li style="font-size:13px; color:#fff; display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> プレミアムアバター生成（従量オプション）</li>
           </ul>
           <a href="#contact" style="display:block; text-align:center; background:linear-gradient(135deg,#7c3aed,#8b5cf6); color:#fff; text-decoration:none; font-weight:700; font-size:14px; padding:12px; border-radius:10px; transition:opacity 0.2s;" onmouseover="this.style.opacity='0.85'" onmouseout="this.style.opacity='1'">無料で始める</a>
@@ -838,10 +836,10 @@
             <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> Growthの全機能</li>
             <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> カスタムアバター</li>
             <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> 専任サポート</li>
-            <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> SLA保証</li>
+            <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> 稼働率保証</li>
             <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> カスタム開発対応</li>
             <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> ディープリサーチ</li>
-            <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> 事前ディスパッチ（低レイテンシ）</li>
+            <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> 優先処理による最速レスポンス</li>
             <li style="font-size:13px; color:var(--muted); display:flex; gap:8px;"><span style="color:#4ade80;">✓</span> R2Cエージェントによる設定代行</li>
           </ul>
           <a href="#contact" style="display:block; text-align:center; background:rgba(124,58,237,0.15); border:1px solid rgba(124,58,237,0.35); color:#c4b5fd; text-decoration:none; font-weight:600; font-size:14px; padding:12px; border-radius:10px; transition:all 0.2s;" onmouseover="this.style.background='rgba(124,58,237,0.25)'" onmouseout="this.style.background='rgba(124,58,237,0.15)'">お問い合わせ</a>
@@ -849,11 +847,10 @@
       </div>
     </div>
 
-    <!-- 個別発注オプション(option_orders: Stripe別建て請求) -->
     <div style="max-width:760px; margin:28px auto 0;">
       <div class="glass-card" style="border-radius:12px; padding:18px 24px; font-size:13px; color:var(--muted); line-height:1.7; text-align:center;">
         <strong style="color:#e5e7eb;">🎨 個別発注オプション（従量課金とは別建て）</strong><br>
-        プレミアムアバターの制作代行や、R2Cエージェントによる各種設定代行など、管理画面でAIと会話しながら依頼できる個別サービスがあります。これらは上記の対話課金とは別に、発注ごとにStripeで都度請求されます（金額は発注時にご案内）。
+        プレミアムアバターの制作代行や、R2Cエージェントによる各種設定代行など、管理画面でAIと会話しながら依頼できる個別サービスがあります。これらは上記の対話課金とは別に、発注ごとに都度ご請求します（金額は発注時にご案内）。
       </div>
     </div>
 
@@ -902,7 +899,7 @@
           <div style="font-weight:700; font-size:14px; color:#fff; margin-bottom:8px;">セットアップ</div>
           <ul style="list-style:none; padding:0; margin:0; display:flex; flex-direction:column; gap:6px;">
             <li style="font-size:13px; color:var(--muted);">• テナント作成</li>
-            <li style="font-size:13px; color:var(--muted);">• APIキー発行</li>
+            <li style="font-size:13px; color:var(--muted);">• 接続キーの発行</li>
             <li style="font-size:13px; color:var(--muted);">• FAQ知識登録</li>
             <li style="font-size:13px; color:var(--muted);">• 1行埋め込みコード提供</li>
           </ul>
@@ -956,7 +953,7 @@
           <tr>
             <td style="font-size:14px; color:var(--muted); padding:14px 16px; border-bottom:1px solid rgba(255,255,255,0.06);">回答精度</td>
             <td style="font-size:14px; color:var(--muted); text-align:center; padding:14px 16px; border-bottom:1px solid rgba(255,255,255,0.06);">シナリオ外で失敗</td>
-            <td class="r2c-col" style="text-align:center; padding:14px 16px; border-bottom:1px solid rgba(124,58,237,0.15);">🎯 RAG + Judge AI</td>
+            <td class="r2c-col" style="text-align:center; padding:14px 16px; border-bottom:1px solid rgba(124,58,237,0.15);">🎯 正確な回答 + 自動品質評価</td>
           </tr>
           <tr>
             <td style="font-size:14px; color:var(--muted); padding:14px 16px; border-bottom:1px solid rgba(255,255,255,0.06);">顔・声</td>
@@ -976,12 +973,12 @@
           <tr>
             <td style="font-size:14px; color:var(--muted); padding:14px 16px; border-bottom:1px solid rgba(255,255,255,0.06);">有人対応</td>
             <td style="font-size:14px; color:var(--muted); text-align:center; padding:14px 16px; border-bottom:1px solid rgba(255,255,255,0.06);">なし／別システム</td>
-            <td class="r2c-col" style="text-align:center; padding:14px 16px; border-bottom:1px solid rgba(124,58,237,0.15);">🤝 文脈を引き継いで即エスカレーション</td>
+            <td class="r2c-col" style="text-align:center; padding:14px 16px; border-bottom:1px solid rgba(124,58,237,0.15);">🤝 会話の流れそのまま、即スタッフ対応</td>
           </tr>
           <tr>
             <td style="font-size:14px; color:var(--muted); padding:14px 16px;">既存ツール連携</td>
             <td style="font-size:14px; color:var(--muted); text-align:center; padding:14px 16px;">なし</td>
-            <td class="r2c-col" style="text-align:center; padding:14px 16px;">🔗 GA4・PostHog連携</td>
+            <td class="r2c-col" style="text-align:center; padding:14px 16px;">🔗 外部アナリティクス連携</td>
           </tr>
         </tbody>
       </table>
@@ -1018,7 +1015,7 @@
       </button>
       <div class="accordion-content">
         <div style="padding:0 20px 18px; font-size:14px; color:var(--muted); line-height:1.75;">
-          ウィジェットはShadow DOMで完全に分離されています。既存のCSS・JSには一切干渉しません。1行のscriptタグを貼るだけなので、WordPressやShopifyなどCMSにも安心してご利用いただけます。
+          ウィジェットは既存サイトの見た目やコードに影響しない形で組み込まれます。既存のCSS・JSには一切干渉しません。1行のscriptタグを貼るだけなので、WordPressやShopifyなどCMSにも安心してご利用いただけます。
         </div>
       </div>
     </div>
@@ -1030,7 +1027,7 @@
       </button>
       <div class="accordion-content">
         <div style="padding:0 20px 18px; font-size:14px; color:var(--muted); line-height:1.75;">
-          RAG（検索拡張生成）技術により、登録した知識ベースの情報のみを使って回答します。根拠のない回答（ハルシネーション）を大幅に抑制。さらにJudgeエンジンが全会話を4軸評価して品質を可視化し、会話完了率やエラー率など運用指標が悪化した場合は管理側へ自動アラートが届きます。
+登録した知識ベースの情報のみを使って回答する仕組みなので、根拠のないでたらめな回答を大幅に抑制できます。さらに全会話をAIが自動評価して品質を可視化し、応対の質が落ちてきた場合は管理側へ自動でお知らせします。
         </div>
       </div>
     </div>
@@ -1078,7 +1075,7 @@
       </button>
       <div class="accordion-content">
         <div style="padding:0 20px 18px; font-size:14px; color:var(--muted); line-height:1.75;">
-          全データはAES-256-GCM暗号化の上、日本国内サーバーにのみ保管します。APIキーはSHA-256ハッシュで管理。マルチテナント設計により、他社のデータが混入することは一切ありません。
+          全データは強力な暗号化を施した上で、日本国内サーバーにのみ保管します。接続キーも安全な方式で管理。お客様ごとにデータを完全に分けて管理しているので、他社のデータが混ざることは一切ありません。
         </div>
       </div>
     </div>
@@ -1090,7 +1087,7 @@
       </button>
       <div class="accordion-content">
         <div style="padding:0 20px 18px; font-size:14px; color:var(--muted); line-height:1.75;">
-          会話中にメールアドレス・電話番号などのPII（個人情報）が検出された場合、自動フィルターがマスキング処理を行います。ログやメトリクスにPIIが含まれないよう設計されています。
+          会話中にメールアドレス・電話番号などの個人情報が含まれていた場合、自動で伏せ字にする処理を行います。記録や集計データにも個人情報が残らないよう設計されています。
         </div>
       </div>
     </div>
@@ -1114,19 +1111,19 @@
       </button>
       <div class="accordion-content">
         <div style="padding:0 20px 18px; font-size:14px; color:var(--muted); line-height:1.75;">
-          管理画面から知識ベースをいつでも更新できます。FAQの追加・修正・削除はリアルタイムで反映され、次の会話から正しく回答します。Judgeエンジンが誤回答パターンを検出した場合は管理画面に改善提案が届きます。
+          管理画面から知識ベースをいつでも更新できます。FAQの追加・修正・削除はリアルタイムで反映され、次の会話から正しく回答します。誤回答が続くパターンはAIが自動で検知し、管理画面に改善のヒントが届きます。
         </div>
       </div>
     </div>
 
     <div class="glass-card accordion-item" style="border-radius:12px; overflow:hidden; margin-bottom:2px;">
       <button onclick="toggleAccordion(this)" style="width:100%; background:none; border:none; padding:18px 20px; display:flex; justify-content:space-between; align-items:center; cursor:pointer; text-align:left; gap:12px;">
-        <span style="font-size:15px; font-weight:600; color:#fff; line-height:1.4;">既存のGA4やPostHogと繋がりますか？</span>
+        <span style="font-size:15px; font-weight:600; color:#fff; line-height:1.4;">既存の分析ツールと繋がりますか？</span>
         <svg class="accordion-chevron" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" style="flex-shrink:0; color:var(--muted);"><path d="M6 9l6 6 6-6"/></svg>
       </button>
       <div class="accordion-content">
         <div style="padding:0 20px 18px; font-size:14px; color:var(--muted); line-height:1.75;">
-          Growthプラン以上でGA4・PostHog連携に対応しています。AI経由のコンバージョンを既存の分析基盤でも確認できます。
+          Growthプラン以上で外部アナリティクスとの連携に対応しています。AI経由のコンバージョンを既存の分析基盤でも確認できます。
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- LPの文言のうち、内部の実装手法(心理学スコアリング、学習ループの蒸留、GUI自動操作、低レイテンシ最適化等)が競合に伝わりかねない表現をベネフィット訴求に置き換え
- PostHog/GA4/Stripe等の連携先サービス名を汎化
- RAG/CV/PII/SLA/LTV/エスカレーション等の専門用語を、ITリテラシーが高くない訪問者にもわかる表現に置換
- 内部実装メモ(option_orders等)のHTMLコメントを削除

## Note
本番VPSには本PRの変更が既に手動デプロイ済み(rsync経由)。マージ後の次回通常デプロイで内容が一致する。

## Test plan
- [x] ローカルで差分を目視確認
- [x] 本番VPSでLPページの表示文言を確認済み(公開中)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGig9LEuwT77kNnCKKeBR2