### PR TITLE
feat(agent): チャット2面(パネル/全画面)のどちらから来たターンかを全メトリクスに記録する

### DIFF
--- a/admin-ui/src/components/AdminAgent/useAdminAgent.test.tsx
+++ b/admin-ui/src/components/AdminAgent/useAdminAgent.test.tsx
@@ -87,3 +87,27 @@ describe("useAdminAgent — 会話の復元(sessionStorage)", () => {
     expect(window.sessionStorage.getItem(chatSessionKey(CHAT_SESSION_SURFACE_FULLSCREEN))).toBe(fullscreenBefore);
   });
 });
+
+// GID 1217008695995707: サーバは全メトリクスの surface ラベルにこの値をそのまま載せる
+// (docs/AGENT_METRICS.md)。この面が名乗り損ねると、パネル由来のターンが 'unknown' に
+// 混ざって面ごとの比較ができなくなる。
+describe("useAdminAgent — リクエストボディの surface", () => {
+  beforeEach(() => {
+    vi.mocked(authFetch).mockReset();
+    vi.mocked(authFetch).mockImplementation(() => mockOk({ reply: "10時から19時です。", actions: [] }));
+    window.sessionStorage.clear();
+  });
+
+  it("送信するリクエストに surface: panel が載る", async () => {
+    render(<Probe />);
+    fireEvent.click(screen.getByText("send"));
+
+    await waitFor(() => expect(authFetch).toHaveBeenCalled());
+
+    const chatCall = vi
+      .mocked(authFetch)
+      .mock.calls.find(([url]) => String(url).includes("/v1/admin/agent/chat"))!;
+    const body = JSON.parse(String((chatCall[1] as RequestInit).body)) as Record<string, unknown>;
+    expect(body.surface).toBe("panel");
+  });
+});

--- a/admin-ui/src/lib/useAgentChatTransport.test.ts
+++ b/admin-ui/src/lib/useAgentChatTransport.test.ts
@@ -281,17 +281,33 @@ describe("useAgentChatTransport — エラーの正規化", () => {
 });
 
 describe("useAgentChatTransport — surface", () => {
-  it("受け取った面の識別子をそのまま公開する(サーバ側のラベル付けは別タスク)", () => {
+  it("受け取った面の識別子をそのまま公開する", () => {
     const { result } = renderHook(() => useAgentChatTransport({ surface: "fullscreen" }));
     expect(result.current.surface).toBe("fullscreen");
   });
 
-  it("面の識別子はまだリクエストボディに載せない(既存スキーマを変えないため)", async () => {
+  // サーバはこの値を全メトリクスの surface ラベルに載せる(docs/AGENT_METRICS.md)。
+  // 送らないと 'unknown' に丸められ、面ごとの比較(docs/CHAT_SURFACE_DECISION.md の
+  // 「全画面UIが主たる面になりつつあるのか」)ができなくなる。
+  it.each(["panel", "fullscreen"] as const)(
+    "設定された面の識別子(%s)をリクエストボディに載せて送る",
+    async (surface) => {
+      const { result } = renderHook(() => useAgentChatTransport({ surface }));
+
+      await act(async () => { await result.current.send("送料を教えて"); });
+
+      expect(vi.mocked(authFetch).mock.calls.at(-1)![0]).toBe(CHAT_URL);
+      expect(lastBody().surface).toBe(surface);
+    },
+  );
+
+  it("送信を跨いでも面の識別子は変わらない", async () => {
     const { result } = renderHook(() => useAgentChatTransport({ surface: "fullscreen" }));
 
-    await act(async () => { await result.current.send("送料を教えて"); });
+    await act(async () => { await result.current.send("1通目"); });
+    await act(async () => { await result.current.send("2通目"); });
 
-    expect(vi.mocked(authFetch).mock.calls.at(-1)![0]).toBe(CHAT_URL);
-    expect(lastBody()).not.toHaveProperty("surface");
+    const bodies = vi.mocked(authFetch).mock.calls.map((c) => JSON.parse(String((c[1] as RequestInit).body)));
+    expect(bodies.map((b) => b.surface)).toEqual(["fullscreen", "fullscreen"]);
   });
 });

--- a/admin-ui/src/lib/useAgentChatTransport.ts
+++ b/admin-ui/src/lib/useAgentChatTransport.ts
@@ -16,8 +16,9 @@ import { authFetch, API_BASE } from "./api";
 import { useAuth } from "../auth/useAuth";
 import type { ChatHistoryEntry } from "./chatSessionStore";
 
-// どちらの面から来たリクエストかの識別子。サーバ側のメトリクスラベル付け(別タスク)で
-// 消費される。現時点ではリクエストボディには載せず、面が自分を名乗る値として保持するだけ。
+// どちらの面から来たリクエストかの識別子。リクエストボディに載せて送り、サーバ側が
+// 挙動メトリクスの surface ラベルとして記録する(docs/AGENT_METRICS.md)。
+// この値だけが「全画面UIが実際に主たる面になりつつあるのか」を面ごとに数える手段になる。
 export type AgentChatSurface = "panel" | "fullscreen";
 
 export type AnsweredFrom = "faq_list" | "tool_action" | "general";
@@ -120,9 +121,10 @@ export function useAgentChatTransport({
       const body: {
         message: string;
         sessionId: string;
+        surface: AgentChatSurface;
         targetTenantId?: string;
         history?: ChatHistoryEntry[];
-      } = { message, sessionId: sessionIdRef.current as string };
+      } = { message, sessionId: sessionIdRef.current as string, surface };
       if (targetTenantId) body.targetTenantId = targetTenantId;
       if (history.length > 0) body.history = history;
 
@@ -150,7 +152,7 @@ export function useAgentChatTransport({
         return { ok: false, kind: "network", message: AGENT_CHAT_ERROR_MESSAGE };
       }
     },
-    [derivedTargetTenantId],
+    [derivedTargetTenantId, surface],
   );
 
   return { surface, sessionId, targetTenantId: derivedTargetTenantId, adoptSessionId, send };

--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -820,6 +820,42 @@ describe("CopilotPreviewPage — 会話の復元(sessionStorage)", () => {
   });
 });
 
+// GID 1217008695995707: サーバは全メトリクスの surface ラベルにこの値をそのまま載せる
+// (docs/AGENT_METRICS.md)。この面が名乗り損ねると、全画面UI由来のターンが 'unknown' に
+// 混ざり、docs/CHAT_SURFACE_DECISION.md の「全画面UIが主たる面になりつつあるのか」に
+// 数字で答えられなくなる。
+describe("CopilotPreviewPage — リクエストボディの surface", () => {
+  beforeEach(() => {
+    vi.mocked(authFetch).mockReset();
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (isBadgeUrl(url)) return mockEmptyBadges();
+      if (String(url).includes("/v1/admin/my-tenant")) {
+        return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
+      }
+      return mockOk({ reply: "今週も順調です。", actions: [] });
+    });
+  });
+
+  it("起動時ブリーフィングも手動送信も surface: fullscreen で送る", async () => {
+    renderPage();
+    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
+
+    fireEvent.change(getComposer(), { target: { value: "営業時間を教えて" } });
+    fireEvent.click(screen.getByLabelText("送信"));
+
+    await waitFor(() => expect(screen.getByText("営業時間を教えて")).toBeTruthy());
+
+    const chatBodies = vi
+      .mocked(authFetch)
+      .mock.calls.filter(([url]) => String(url).includes("/v1/admin/agent/chat"))
+      .map(([, init]) => JSON.parse(String((init as RequestInit).body)) as Record<string, unknown>);
+
+    // ブリーフィングと手動送信の2本。どちらも同じ transport 経由なので同じ値を名乗る
+    expect(chatBodies.length).toBeGreaterThanOrEqual(2);
+    expect(chatBodies.map((b) => b.surface)).toEqual(chatBodies.map(() => "fullscreen"));
+  });
+});
+
 // GID 1217007275510096: プレビュー未選択のsuper_adminは、ほぼ全てのツールが
 // 「テナントが特定できません」を返して会話が行き止まりになっていた。チャットを
 // 始める前にテナントを選ばせ、既存のクライアントビュー(enterPreview)へ入れる。

--- a/docs/AGENT_METRICS.md
+++ b/docs/AGENT_METRICS.md
@@ -35,6 +35,50 @@ CREATE TABLE IF NOT EXISTS metrics_snapshots (
   enum 値と、ツール名のような固定語彙だけ。
 - `snapshot_at`: DB 既定値（`NOW()`）に任せる。
 
+## 全メトリクス共通のラベル: `surface`
+
+チャットターン由来の**5つのメトリクス**
+（`agent_tool_invoked` / `agent_write_blocked` / `agent_turn_hops` /
+`agent_legacy_handoff` / `agent_turn_completed`）は、下表の固有ラベルに加えて
+**必ず `surface` を持つ**。
+
+| `surface` | 意味 |
+| --- | --- |
+| `panel` | 旧UIに埋め込まれたチャットパネル（`admin-ui/src/components/AdminAgent/`） |
+| `fullscreen` | 全画面のチャットUI（`admin-ui/src/pages/copilot-preview/`） |
+| `unknown` | `POST /v1/admin/agent/chat` のリクエストが `surface` を送ってこなかった |
+
+`surface` はリクエストボディの**任意項目**（`chatSchema` の
+`z.enum(['panel','fullscreen']).optional()`）。両面のフロントは共有 transport 層
+（`admin-ui/src/lib/useAgentChatTransport.ts`）が自面の値を必ず載せるため、
+実運用で `unknown` に落ちるのは API を直接叩く経路だけである。
+なお `panel` / `fullscreen` 以外のリテラルを送った場合は `unknown` に丸めず、
+他のフィールドと同様に **400 `invalid_request`** で弾く（ラベルの語彙をサーバ側で閉じる）。
+
+`chat_first_toggle` は例外で `surface` を持たない。これはチャットターンではなく
+`POST /v1/admin/agent/ui-event` 経由のUI操作で、トグルの実体が全画面UIの左レールにしか
+存在しないため、面を記録しても常に同じ値になり情報量がない。
+
+### 過去データ: `surface` が「無い」行と `"unknown"` の行は別物
+
+**この変更より前に記録された行には `surface` キー自体が存在しない**（`"unknown"` ですらない）。
+`metrics_snapshots` を横断して集計するクエリはこれを区別しなければならない。
+
+```sql
+-- labels->>'surface' は3値ではなく4状態を取る
+--   'panel' / 'fullscreen' / 'unknown' / NULL(キーが無い = この変更以前の行)
+SELECT COALESCE(labels->>'surface', 'pre_surface_label') AS surface, COUNT(*)
+FROM metrics_snapshots
+WHERE metric_name = 'agent_turn_completed'
+GROUP BY 1;
+```
+
+- `labels->>'surface' = 'unknown'` は「この変更以後に、面を名乗らないクライアントから来た」行。
+- `labels->>'surface' IS NULL` は「この変更以前の行」。面ごとの比率を出す分母に混ぜると
+  全画面UI側を過小に見せるため、面別の集計では期間を切るか NULL を明示的に除外する。
+- 既存行の遡及埋め（バックフィル）は行わない。当時の面は記録されておらず復元できないため、
+  `"unknown"` を後付けすると「送ってこなかった」という別の意味と衝突する。
+
 ## メトリクス一覧（この6つのみ）
 
 | metric_name | labels | value | 発火タイミング |
@@ -45,6 +89,9 @@ CREATE TABLE IF NOT EXISTS metrics_snapshots (
 | `agent_legacy_handoff` | `{ feature: string }` | 常に `1` | `get_legacy_ui_link` が呼ばれたとき。「チャットがまだ旧UIへ何回受け渡しているか」の**分子** |
 | `agent_turn_completed` | `{ answered_from: string }` | 常に `1` | 結果に関わらずターンが完了したとき。handoff率の**分母** |
 | `chat_first_toggle` | `{ enabled: boolean }` | 常に `1` | 「これを既定の画面にする」トグルが切り替わったとき（`POST /v1/admin/agent/ui-event`） |
+
+上表の `labels` は各メトリクス**固有**のキーのみを示す。`chat_first_toggle` 以外の5つは
+これに加えて共通ラベル `surface` を持つ（前節）。
 
 ### `agent_tool_invoked`
 

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -332,7 +332,7 @@ describe('POST /v1/admin/agent/chat', () => {
         {
           metricName: 'agent_tool_invoked',
           tenantId: 'tenant-abc',
-          labels: { tool: 'get_tenant_settings', outcome: 'ok' },
+          labels: { tool: 'get_tenant_settings', outcome: 'ok', surface: 'unknown' },
           value: 1,
         },
       ]);
@@ -341,7 +341,7 @@ describe('POST /v1/admin/agent/chat', () => {
         {
           metricName: 'agent_turn_hops',
           tenantId: 'tenant-abc',
-          labels: { hit_limit: false },
+          labels: { hit_limit: false, surface: 'unknown' },
           value: 1,
         },
       ]);
@@ -349,7 +349,7 @@ describe('POST /v1/admin/agent/chat', () => {
         {
           metricName: 'agent_turn_completed',
           tenantId: 'tenant-abc',
-          labels: { answered_from: 'tool_action' },
+          labels: { answered_from: 'tool_action', surface: 'unknown' },
           value: 1,
         },
       ]);
@@ -365,10 +365,10 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(res.status).toBe(200);
       expect(recordedMetrics('agent_tool_invoked')).toEqual([]);
       expect(recordedMetrics('agent_turn_hops')).toEqual([
-        { metricName: 'agent_turn_hops', tenantId: 'tenant-abc', labels: { hit_limit: false }, value: 0 },
+        { metricName: 'agent_turn_hops', tenantId: 'tenant-abc', labels: { hit_limit: false, surface: 'unknown' }, value: 0 },
       ]);
       expect(recordedMetrics('agent_turn_completed')).toEqual([
-        { metricName: 'agent_turn_completed', tenantId: 'tenant-abc', labels: { answered_from: 'general' }, value: 1 },
+        { metricName: 'agent_turn_completed', tenantId: 'tenant-abc', labels: { answered_from: 'general', surface: 'unknown' }, value: 1 },
       ]);
     });
 
@@ -410,6 +410,129 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(res.body.reply).toBe('GA4は未設定です。');
       expect(res.body.actions[0].tool).toBe('get_tenant_settings');
       expect(res.body.answered_from).toBe('tool_action');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GID 1217008695995707: どちらのチャットUI(パネル/全画面)から来たターンかを
+  // 全メトリクスの surface ラベルに載せる。docs/CHAT_SURFACE_DECISION.md の
+  // 「全画面UIが実際に主たる面になりつつあるのか」は面ごとの数字がないと答えられないため、
+  // 1つでもラベルが欠けたメトリクスがあるとその指標だけ面別に切れなくなる。
+  // -------------------------------------------------------------------------
+  describe('surface ラベル', () => {
+    /**
+     * get_legacy_ui_link を1回呼ぶターン。この1リクエストで
+     * agent_tool_invoked / agent_legacy_handoff / agent_turn_hops / agent_turn_completed
+     * の4種が発火するので、「そのターンの全メトリクス」をまとめて検証できる。
+     */
+    function mockLegacyHandoffTurn() {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            choices: [{
+              message: {
+                content: null,
+                tool_calls: [{
+                  id: 'call-surface',
+                  type: 'function',
+                  function: { name: 'get_legacy_ui_link', arguments: JSON.stringify({ feature: 'billing' }) },
+                }],
+              },
+            }],
+          }),
+          text: async () => '',
+        })
+        .mockResolvedValueOnce(makeGroqResponse('旧管理画面をご確認ください。'));
+    }
+
+    /** 記録された全メトリクスを [metric_name, labels.surface] の組で取り出す */
+    function recordedSurfaces(): Array<[string, unknown]> {
+      return mockRecordAgentMetric.mock.calls.map(([, input]) => [
+        (input as Record<string, any>).metricName,
+        (input as Record<string, any>).labels?.surface,
+      ]);
+    }
+
+    it.each(['panel', 'fullscreen'])(
+      'surface=%s → そのターンに記録された全メトリクスが同じ値のラベルを持つ',
+      async (surface) => {
+        mockLegacyHandoffTurn();
+
+        const res = await request(makeApp(CLIENT_ADMIN_USER))
+          .post('/v1/admin/agent/chat')
+          .send({ message: '請求書を再送したい', sessionId: 'sess-surface-01', surface });
+
+        expect(res.status).toBe(200);
+        // 4種すべてが発火していることを固定する(取りこぼすと、その指標だけ面別に切れなくなる)
+        expect(recordedSurfaces().map(([name]) => name).sort()).toEqual([
+          'agent_legacy_handoff',
+          'agent_tool_invoked',
+          'agent_turn_completed',
+          'agent_turn_hops',
+        ]);
+        expect(recordedSurfaces()).toEqual(recordedSurfaces().map(([name]) => [name, surface]));
+      },
+    );
+
+    it('surface=panel: 確認ゲートでブロックされた書き込み(agent_write_blocked)にも載る', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            choices: [{
+              message: {
+                content: null,
+                tool_calls: [{
+                  id: 'call-surface-blocked',
+                  type: 'function',
+                  function: { name: 'update_tuning_rule', arguments: JSON.stringify({ id: 1, is_active: false }) },
+                }],
+              },
+            }],
+          }),
+          text: async () => '',
+        })
+        .mockResolvedValueOnce(makeGroqResponse('確認をお願いします。'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルール1を無効にして', sessionId: 'sess-surface-02', surface: 'panel' });
+
+      expect(res.status).toBe(200);
+      expect(recordedMetrics('agent_write_blocked')).toEqual([
+        {
+          metricName: 'agent_write_blocked',
+          tenantId: 'tenant-abc',
+          labels: { tool: 'update_tuning_rule', reason: 'unconfirmed', surface: 'panel' },
+          value: 1,
+        },
+      ]);
+    });
+
+    it('surface を送らない既存クライアントは 200 のまま、unknown として記録される(後方互換)', async () => {
+      mockLegacyHandoffTurn();
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '請求書を再送したい', sessionId: 'sess-surface-03' });
+
+      // 必須項目にしていないので、送ってこないクライアントを拒否してはならない
+      expect(res.status).toBe(200);
+      expect(recordedSurfaces()).toEqual(recordedSurfaces().map(([name]) => [name, 'unknown']));
+    });
+
+    it('surface が enum 外のリテラルなら 400 で弾く(unknown へ黙って丸めない)', async () => {
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '請求書を再送したい', sessionId: 'sess-surface-04', surface: 'mobile' });
+
+      // 語彙はサーバ側で閉じる。黙って unknown に丸めると、面を名乗らないクライアントと
+      // 未知の面を名乗るクライアントが同じバケツに入って区別できなくなる。
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('invalid_request');
+      // バリデーションで落ちたターンは計測もしない
+      expect(mockRecordAgentMetric).not.toHaveBeenCalled();
     });
   });
 
@@ -947,7 +1070,7 @@ describe('POST /v1/admin/agent/chat', () => {
         {
           metricName: 'agent_tool_invoked',
           tenantId: 'tenant-abc',
-          labels: { tool: 'update_tuning_rule', outcome: 'blocked' },
+          labels: { tool: 'update_tuning_rule', outcome: 'blocked', surface: 'unknown' },
           value: 1,
         },
       ]);
@@ -955,7 +1078,7 @@ describe('POST /v1/admin/agent/chat', () => {
         {
           metricName: 'agent_write_blocked',
           tenantId: 'tenant-abc',
-          labels: { tool: 'update_tuning_rule', reason: 'unconfirmed' },
+          labels: { tool: 'update_tuning_rule', reason: 'unconfirmed', surface: 'unknown' },
           value: 1,
         },
       ]);
@@ -2760,7 +2883,7 @@ describe('POST /v1/admin/agent/chat', () => {
         {
           metricName: 'agent_legacy_handoff',
           tenantId: 'tenant-abc',
-          labels: { feature },
+          labels: { feature, surface: 'unknown' },
           value: 1,
         },
       ]);
@@ -2783,7 +2906,7 @@ describe('POST /v1/admin/agent/chat', () => {
         {
           metricName: 'agent_legacy_handoff',
           tenantId: 'tenant-abc',
-          labels: { feature: 'unknown' },
+          labels: { feature: 'unknown', surface: 'unknown' },
           value: 1,
         },
       ]);
@@ -3905,12 +4028,12 @@ describe('POST /v1/admin/agent/chat', () => {
         {
           metricName: 'agent_write_blocked',
           tenantId: 'tenant-abc',
-          labels: { tool: 'save_faq', reason: 'chain' },
+          labels: { tool: 'save_faq', reason: 'chain', surface: 'unknown' },
           value: 1,
         },
       ]);
       expect(recordedMetrics('agent_turn_hops')).toEqual([
-        { metricName: 'agent_turn_hops', tenantId: 'tenant-abc', labels: { hit_limit: false }, value: 2 },
+        { metricName: 'agent_turn_hops', tenantId: 'tenant-abc', labels: { hit_limit: false, surface: 'unknown' }, value: 2 },
       ]);
     });
 
@@ -4258,15 +4381,15 @@ describe('POST /v1/admin/agent/chat', () => {
         {
           metricName: 'agent_tool_invoked',
           tenantId: 'tenant-abc',
-          labels: { tool: 'get_tenant_settings', outcome: 'ok' },
+          labels: { tool: 'get_tenant_settings', outcome: 'ok', surface: 'unknown' },
           value: 1,
         },
       ]);
       expect(recordedMetrics('agent_turn_hops')).toEqual([
-        { metricName: 'agent_turn_hops', tenantId: 'tenant-abc', labels: { hit_limit: false }, value: 1 },
+        { metricName: 'agent_turn_hops', tenantId: 'tenant-abc', labels: { hit_limit: false, surface: 'unknown' }, value: 1 },
       ]);
       expect(recordedMetrics('agent_turn_completed')).toEqual([
-        { metricName: 'agent_turn_completed', tenantId: 'tenant-abc', labels: { answered_from: 'tool_action' }, value: 1 },
+        { metricName: 'agent_turn_completed', tenantId: 'tenant-abc', labels: { answered_from: 'tool_action', surface: 'unknown' }, value: 1 },
       ]);
     });
 

--- a/src/api/admin/agent/agentRoutes.ts
+++ b/src/api/admin/agent/agentRoutes.ts
@@ -31,6 +31,12 @@ const BLOCKED_CHAIN_MARKER = '確認をスキップできません';
 // docs/LEGACY_UI_SUNSET.md のトリップワイヤーが無言で作動しなくなる）。
 const LEGACY_HANDOFF_FEATURES = new Set<string>(LEGACY_UI_FEATURES);
 
+// 全メトリクスに載せる「どちらのチャットUIから来たターンか」。リクエストが surface を
+// 送ってこない場合(この項目より前のクライアント / 直接APIを叩く経路)は 'unknown' に丸める。
+// docs/AGENT_METRICS.md: この項目以前に記録された行はキー自体を持たないため、
+// 'unknown' と「キーなし」は集計上区別できる別物である。
+type MetricSurface = 'panel' | 'fullscreen' | 'unknown';
+
 /** 計測は fire-and-forget。記録の失敗をチャット応答に一切影響させない。 */
 function fireAgentMetric(db: Pool, input: AgentMetricInput): void {
   try {
@@ -117,18 +123,24 @@ function fireSettingsAudit(
 
 function recordTurnCompleted(
   db: Pool,
-  params: { tenantId: string | null; toolHops: number; hitHopLimit: boolean; answeredFrom: AnsweredFrom },
+  params: {
+    tenantId: string | null;
+    toolHops: number;
+    hitHopLimit: boolean;
+    answeredFrom: AnsweredFrom;
+    surface: MetricSurface;
+  },
 ): void {
   fireAgentMetric(db, {
     metricName: 'agent_turn_hops',
     tenantId: params.tenantId,
-    labels: { hit_limit: params.hitHopLimit },
+    labels: { hit_limit: params.hitHopLimit, surface: params.surface },
     value: params.toolHops,
   });
   fireAgentMetric(db, {
     metricName: 'agent_turn_completed',
     tenantId: params.tenantId,
-    labels: { answered_from: params.answeredFrom },
+    labels: { answered_from: params.answeredFrom, surface: params.surface },
     value: 1,
   });
 }
@@ -211,6 +223,11 @@ const chatSchema = z.object({
   history: z.array(historyItemSchema).max(20).optional(),
   // 明示的にオプトインした場合のみ true。省略時(既存クライアント)は従来通りJSON一括応答のまま。
   stream: z.boolean().optional(),
+  // どちらのチャットUIから来たリクエストか。省略時は 'unknown' として計測する(必須にはしない
+  // ため、この値を送らない既存クライアントは従来どおり動く)。値そのものは enum で閉じており、
+  // 未知のリテラルは他のフィールドと同様 zod のバリデーションで 400 になる
+  // （ラベルの語彙を有界に保つ責任をサーバ側に置く）。
+  surface: z.enum(['panel', 'fullscreen']).optional(),
 });
 
 // UIイベント計測の受け口。event は**閉じた enum** にしておく。自由記述のイベント名を
@@ -359,6 +376,7 @@ async function executeHopToolCalls(
   isSuperAdmin: boolean,
   sessionId: string,
   changedBy: string,
+  surface: MetricSurface,
 ): Promise<void> {
   for (const toolCall of toolCalls) {
     const { id, name, args } = toolCall;
@@ -389,7 +407,7 @@ async function executeHopToolCalls(
         fireAgentMetric(db, {
           metricName: 'agent_tool_invoked',
           tenantId: effectiveTenantId || null,
-          labels: { tool: name, outcome: 'error' },
+          labels: { tool: name, outcome: 'error', surface },
           value: 1,
         });
         throw err;
@@ -415,14 +433,14 @@ async function executeHopToolCalls(
     fireAgentMetric(db, {
       metricName: 'agent_tool_invoked',
       tenantId: metricTenantId,
-      labels: { tool: name, outcome },
+      labels: { tool: name, outcome, surface },
       value: 1,
     });
     if (reason) {
       fireAgentMetric(db, {
         metricName: 'agent_write_blocked',
         tenantId: metricTenantId,
-        labels: { tool: name, reason },
+        labels: { tool: name, reason, surface },
         value: 1,
       });
     }
@@ -447,7 +465,7 @@ async function executeHopToolCalls(
       fireAgentMetric(db, {
         metricName: 'agent_legacy_handoff',
         tenantId: metricTenantId,
-        labels: { feature: LEGACY_HANDOFF_FEATURES.has(feature) ? feature : 'unknown' },
+        labels: { feature: LEGACY_HANDOFF_FEATURES.has(feature) ? feature : 'unknown', surface },
         value: 1,
       });
     }
@@ -626,6 +644,8 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
     }
 
     const { message, sessionId, targetTenantId, history } = parsed.data;
+    // 送ってこないクライアントも受け入れる代わりに、計測側では 'unknown' として1つの語彙に丸める。
+    const surface: MetricSurface = parsed.data.surface ?? 'unknown';
 
     // effectiveTenantId: super_admin は targetTenantId を使用可、client_admin は JWT 由来のみ
     const effectiveTenantId = isSuperAdmin ? (targetTenantId ?? tenantId) : tenantId;
@@ -725,7 +745,7 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
             }));
 
             const beforeCount = actions.length;
-            await executeHopToolCalls(parsedToolCalls, effectiveTenantId, db, suggestedThisTurn, actions, messages, isSuperAdmin, sessionId, email);
+            await executeHopToolCalls(parsedToolCalls, effectiveTenantId, db, suggestedThisTurn, actions, messages, isSuperAdmin, sessionId, email, surface);
             for (const action of actions.slice(beforeCount)) {
               res.write(`event: action\ndata: ${JSON.stringify(action)}\n\n`);
             }
@@ -765,6 +785,7 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
             toolHops,
             hitHopLimit,
             answeredFrom,
+            surface,
           });
 
           res.write(`event: done\ndata: ${JSON.stringify({ reply: finalReply, actions, answered_from: answeredFrom })}\n\n`);
@@ -822,7 +843,7 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
           args: parseToolArgs(toolCall.function.arguments),
         }));
 
-        await executeHopToolCalls(parsedToolCalls, effectiveTenantId, db, suggestedThisTurn, actions, messages, isSuperAdmin, sessionId, email);
+        await executeHopToolCalls(parsedToolCalls, effectiveTenantId, db, suggestedThisTurn, actions, messages, isSuperAdmin, sessionId, email, surface);
       }
 
       const hitHopLimit = finalReply === null;
@@ -850,6 +871,7 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
         toolHops,
         hitHopLimit,
         answeredFrom,
+        surface,
       });
 
       return res.json({ reply: finalReply, actions, answered_from: answeredFrom });


### PR DESCRIPTION
Asana GID 1217008695995707

## 背景
`POST /v1/admin/agent/chat` を叩く面が2つある(旧UI埋め込みのチャットパネル / 全画面 `/copilot-preview`)のに、バックエンドはどちらから来たリクエストか判別できなかった。`docs/CHAT_SURFACE_DECISION.md` は「全画面UIが実際に主たる面になりつつあるのか」という製品判断が**面別の数値なしには答えられない**ことを明示しており、これがブロッカーになっていた。

共有 transport 層(`useAgentChatTransport.ts`)は既に面の識別子を受け取って公開していたが、リクエストボディには載せていなかった。その最後の1本を繋ぐ。

## 変更内容
- **フロント**: 共有 transport が送信ボディに `surface` を載せる。両面の呼び出し側は既に正しいリテラルを渡しているため、面側の変更は不要(`useAdminAgent.ts` → `panel` / `copilot-preview/index.tsx` → `fullscreen`)。
- **スキーマ**: `chatSchema` に `surface: z.enum(['panel','fullscreen']).optional()`。**任意項目**なので送らないクライアントは従来どおり 200。enum外のリテラル(例 `"mobile"`)は他のフィールドと同様 **400 `invalid_request`** で弾く(黙って `unknown` に丸めない — 丸めると「名乗らない」と「未知の面を名乗る」が同じバケツに入って区別できなくなる)。
- **計測**: チャットターン由来の5つ(`agent_tool_invoked` / `agent_write_blocked` / `agent_turn_hops` / `agent_legacy_handoff` / `agent_turn_completed`)の `labels` に `surface` を追加。未指定は `'unknown'`。`recordAgentMetric` のシグネチャは変更なし(`labels` は元から `Record<string, unknown>`)。
- **`chat_first_toggle` は対象外**: チャットターンではなく `POST /v1/admin/agent/ui-event` 経由のUI操作で、トグルの実体が全画面UIの左レールにしか存在しないため、面を記録しても常に同じ値になり情報量がない。ドキュメントにこの例外を明記した。
- **ドキュメント**: `docs/AGENT_METRICS.md` に共通ラベル節を追加。特に**この変更以前の行は `surface` キー自体を持たない**(`'unknown'` ですらない)ため、`labels->>'surface'` は `panel`/`fullscreen`/`unknown`/**NULL** の4状態を取ることと、面別集計の分母に NULL を混ぜると全画面UI側を過小に見せることを、SQL例付きで明記。既存行の遡及埋めは行わない(当時の面は復元できず、`'unknown'` を後付けすると別の意味と衝突する)。

## テスト
- `agentRoutes.test.ts`: `surface=panel` / `fullscreen` でそのターンの**全メトリクス**が同じ値を持つこと、ブロックされた書き込み(`agent_write_blocked`)にも載ること、**未指定でも200のまま `unknown`** で記録されること(後方互換)、enum外は**400 で計測もされない**ことを追加。→ 192 tests green
- `useAgentChatTransport.test.ts`: 両面のリテラルがボディに載ること、送信を跨いで変わらないこと。「まだボディに載せない」という**前提が今回覆った既存テストは差し替え**。
- `copilot-preview/index.test.tsx` / `useAdminAgent.test.tsx`: 各面の送信リクエストが正しいリテラルを持つことをエンドツーエンドで固定。
- admin-ui 全体: 27 files / 236 tests green。

### 既存アサーションについて（レビュー時の注意）
本タスクは「純粋な追加ラベルなので既存アサーションは無変更のはず」という前提だったが、既存の計測テスト14箇所は `toEqual` で `labels` を**完全一致**で固定しているため、ラベルが1つ増えると必ず落ちる。意味を緩めずに済む形として、この14行に `surface: 'unknown'`(これらのテストは `surface` を送らない)を機械的に追加した。`objectContaining` への置換のような**検証の弱体化はしていない**。

## 影響なし
- マイグレーション / 環境変数 / 依存関係の差分: なし(`git diff origin/main -- '*.sql' '.env*' 'package.json'` は空)。既存の汎用シンク `metrics_snapshots` の再利用のみ。
- `recordAgentMetric` のシグネチャ、transport の session/history/tenant 導出ロジックは未変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177MCsC7jN3a51F7TdaW9vH