### PR TITLE
feat(admin-ui): パネル固有の2機能(相談窓口ループ・answered_from)を全画面チャットへ移植

### DIFF
--- a/admin-ui/src/App.tsx
+++ b/admin-ui/src/App.tsx
@@ -25,7 +25,7 @@ import TuningPage from "./pages/admin/tuning/index";
 import FeedbackPage from "./pages/admin/feedback/index";
 import AdminAgentButton from "./components/AdminAgent/AdminAgentButton";
 import AdminAgentPanel from "./components/AdminAgent/AdminAgentPanel";
-import { useFeedbackReplies } from "./components/AdminAgent/useFeedbackReplies";
+import { useFeedbackReplies } from "./lib/feedbackReplies";
 import AvatarListPage from "./pages/admin/avatar/index";
 import AvatarStudioPage from "./pages/admin/avatar/studio";
 import AvatarWizardPage from "./pages/admin/avatar/wizard";
@@ -105,10 +105,6 @@ function AppInner() {
   // 実ログインユーザー(super_admin)の user?.tenantId は常にnullのため
   // previewTenantId を優先しないとAIアシスタントがテナント無しで動作してしまう
   const effectiveTenantId = previewMode ? (previewTenantId ?? null) : (user?.tenantId ?? null);
-  const { replies: feedbackReplies, markRead: markReplyRead } = useFeedbackReplies(
-    showAIChat ? effectiveTenantId : null,
-    isSuperAdmin
-  );
   const isAdmin = location.pathname.startsWith("/admin") || location.pathname === "/";
   const isLogin =
     location.pathname === "/login" || location.pathname === "/reset-password";
@@ -124,6 +120,14 @@ function AppInner() {
   const isCopilotPreview =
     location.pathname === "/copilot-preview" ||
     (isLandingPath && (isChatFirstDefaultEnabled() || previewMode));
+
+  // 担当者からの未読返信(相談窓口)。ここで取るのはパネル(Surface A)のFABバッジと
+  // お返事カードのためだけなので、全画面UI(Surface B)を表示している間は取らない
+  // — その画面は同じフックを自分で呼ぶため、ここで取ると60秒ごとに二重取得になる。
+  const { replies: feedbackReplies, markRead: markReplyRead } = useFeedbackReplies(
+    showAIChat && !isCopilotPreview ? effectiveTenantId : null,
+    isSuperAdmin
+  );
 
   if (isAuthBridge) {
     return (

--- a/admin-ui/src/components/AdminAgent/AdminAgentPanel.tsx
+++ b/admin-ui/src/components/AdminAgent/AdminAgentPanel.tsx
@@ -1,10 +1,19 @@
 // admin-ui/src/components/AdminAgent/AdminAgentPanel.tsx
+// 【機能凍結】このパネル(Surface A)には新しい機能を足さない。新機能は全画面UI
+// (pages/copilot-preview/index.tsx = Surface B)側だけに実装する。
+// 根拠: docs/CHAT_SURFACE_DECISION.md が採択した選択肢(c)「パネルは橋。旧UIページの
+// 閉鎖に合わせて畳む」。パネルの存在理由は旧UIページが存在することに従属しており、
+// 守備範囲は旧UIページが閉じるにつれ自動的に縮む(着地点は docs/LEGACY_UI_SUNSET.md §7-1)。
+// 凍結の対象は「面固有の新機能」であって、共有層(lib/useAgentChatTransport.ts,
+// lib/chatSessionStore.ts, lib/feedbackReplies.ts)のバグ修正は対象外。
+// このパネルにしか無かった2機能(相談窓口ループ・answered_from ラベル)は Surface B へ
+// 移植済みのため、ここに機能を足す理由はもう無い。
 import { useRef, useEffect, useState, useCallback } from "react";
 import { useAdminAgent } from "./useAdminAgent";
 import AdminAgentMessage from "./AdminAgentMessage";
 import FeedbackPrompt from "./FeedbackPrompt";
 import ReplyCard from "./ReplyCard";
-import { submitConsultation, type FeedbackReply } from "./useFeedbackReplies";
+import { submitConsultation, type FeedbackReply } from "../../lib/feedbackReplies";
 import { shouldSubmitOnEnter } from "../../lib/utils";
 
 interface AdminAgentPanelProps {

--- a/admin-ui/src/components/AdminAgent/FeedbackPrompt.tsx
+++ b/admin-ui/src/components/AdminAgent/FeedbackPrompt.tsx
@@ -1,7 +1,7 @@
 // admin-ui/src/components/AdminAgent/FeedbackPrompt.tsx
 // 直近のAI回答の下に出す「解決しましたか？」の確認導線。
 import { useState } from "react";
-import { submitConsultation } from "./useFeedbackReplies";
+import { submitConsultation } from "../../lib/feedbackReplies";
 
 interface FeedbackPromptProps {
   question: string;

--- a/admin-ui/src/components/AdminAgent/ReplyCard.tsx
+++ b/admin-ui/src/components/AdminAgent/ReplyCard.tsx
@@ -1,6 +1,6 @@
 // admin-ui/src/components/AdminAgent/ReplyCard.tsx
 import { useState } from "react";
-import type { FeedbackReply } from "./useFeedbackReplies";
+import type { FeedbackReply } from "../../lib/feedbackReplies";
 
 interface ReplyCardProps {
   reply: FeedbackReply;

--- a/admin-ui/src/components/AdminAgent/useAdminAgent.ts
+++ b/admin-ui/src/components/AdminAgent/useAdminAgent.ts
@@ -1,4 +1,10 @@
 // admin-ui/src/components/AdminAgent/useAdminAgent.ts
+//
+// 【機能凍結】パネル(Surface A)側のチャット状態フック。新しい機能は足さず、全画面UI
+// (pages/copilot-preview/index.tsx = Surface B)側だけに実装する。
+// 根拠: docs/CHAT_SURFACE_DECISION.md が採択した選択肢(c)「パネルは橋。旧UIページの
+// 閉鎖に合わせて畳む」。凍結の対象は「面固有の新機能」であって、共有層
+// (lib/useAgentChatTransport.ts, lib/chatSessionStore.ts)のバグ修正は対象外。
 import { useState, useCallback, useEffect } from "react";
 import {
   CHAT_SESSION_SURFACE_PANEL,

--- a/admin-ui/src/index.css
+++ b/admin-ui/src/index.css
@@ -245,6 +245,11 @@ button {
   padding: 0 28px 24px;
 }
 
+/* 相談窓口のお返事(コンポーザ直上に固定)。長文でスレッドを潰さないよう高さを制限する */
+.cp-consult-reply {
+  max-height: 150px;
+}
+
 .cp-rail-backdrop {
   display: none;
 }
@@ -285,5 +290,8 @@ button {
   }
   .cp-composer-wrap {
     padding: 0 12px calc(16px + env(safe-area-inset-bottom));
+  }
+  .cp-consult-reply {
+    max-height: 88px;
   }
 }

--- a/admin-ui/src/lib/feedbackReplies.ts
+++ b/admin-ui/src/lib/feedbackReplies.ts
@@ -1,8 +1,12 @@
-// admin-ui/src/components/AdminAgent/useFeedbackReplies.ts
+// admin-ui/src/lib/feedbackReplies.ts
 // テナントの「相談窓口」: 担当者からの未読返信をポーリングし、
 // FABバッジ・お返事カードの両方が同じ状態を参照できるようにする。
+//
+// チャット2面(パネル / 全画面)の両方が使うため lib/ に置く。transport 層
+// (useAgentChatTransport.ts)・会話の永続化(chatSessionStore.ts)と同じ理由で、
+// 面固有の描画だけを面側(components/AdminAgent/ReplyCard.tsx など)に残している。
 import { useCallback, useEffect, useState } from "react";
-import { authFetch, API_BASE } from "../../lib/api";
+import { authFetch, API_BASE } from "./api";
 
 export interface FeedbackReply {
   id: string;

--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -1244,7 +1244,8 @@ describe("CopilotPreviewPage — 相談窓口(担当者からのお返事)", () 
     renderPage();
 
     expect(await screen.findByText("担当者からお返事が届きました")).toBeTruthy();
-    expect(screen.getByText("送料の設定はどこから変えますか")).toBeTruthy();
+    // どの相談への返事かは日時と同じ1行に収めているため、部分一致で確かめる
+    expect(screen.getByText(/送料の設定はどこから変えますか/)).toBeTruthy();
     expect(screen.getByText("設定ページから変更できます")).toBeTruthy();
   });
 

--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -84,6 +84,11 @@ const BADGE_URL_RE = /knowledge\/gaps\/count|chat-history\/escalations/;
 const isBadgeUrl = (url: unknown) => BADGE_URL_RE.test(String(url));
 const mockEmptyBadges = () => mockOk({ count: 0, escalations: [] });
 
+// 相談窓口(担当者からの未読返信)もマウント時に叩かれる。バッジ2本と同じ理由で、
+// /v1/admin/agent/chat の応答シーケンスを数えているテストでは0件で素通りさせる。
+const isUnreadFeedbackUrl = (url: unknown) => String(url).includes("/v1/admin/feedback?");
+const mockNoFeedbackReplies = () => mockOk({ items: [] });
+
 function baseAuth(overrides: Partial<ReturnType<typeof useAuth>> = {}) {
   return {
     user: { id: "1", email: "a@example.com", role: "client_admin", tenantId: "tenant-a", tenantName: "Tenant A" },
@@ -380,6 +385,7 @@ describe("CopilotPreviewPage — 旧UI案内リンクカード", () => {
       if (String(url).includes("/v1/admin/my-tenant")) {
         return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
       }
+      if (isUnreadFeedbackUrl(url)) return mockNoFeedbackReplies();
       agentCalls += 1;
       if (agentCalls === 1) return mockOk({ reply: "今週のまとめです。", actions: [] });
       return mockOk({
@@ -426,6 +432,7 @@ describe("CopilotPreviewPage — 構造化カード(card)からの描画", () =>
       if (String(url).includes("/v1/admin/my-tenant")) {
         return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
       }
+      if (isUnreadFeedbackUrl(url)) return mockNoFeedbackReplies();
       agentCalls += 1;
       if (agentCalls === 1) return mockOk({ reply: "今週のまとめです。", actions: [] });
       return mockOk(secondResponse);
@@ -572,6 +579,7 @@ describe("CopilotPreviewPage — 保留中の下書きチップを無視して�
       if (String(url).includes("/v1/admin/my-tenant")) {
         return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
       }
+      if (isUnreadFeedbackUrl(url)) return mockNoFeedbackReplies();
       agentCalls += 1;
       if (agentCalls === 1) return mockOk({ reply: "今週も順調です。", actions: [] });
       if (agentCalls === 2) {
@@ -1202,5 +1210,257 @@ describe("CopilotPreviewPage — 既定画面トグルの計測(chat_first_toggl
     await getToggle();
 
     expect(uiEventCalls()).toEqual([]);
+  });
+});
+
+// GID 1217008702879233: パネル(Surface A)にしか無かった2機能を全画面UIへ移植する。
+// 1件目 = 相談窓口ループ(担当者からのお返事 → 解決しました/まだ解決しません)。
+// ロジックは lib/feedbackReplies.ts をパネルと共有しているため、ここで確かめるのは
+// 「この画面がそのフックに繋がっており、同じAPIを同じ手順で叩くか」。
+// 対になるパネル側の回帰テストは components/AdminAgent/AdminAgentPanel.test.tsx。
+const REPLY = {
+  id: "fb-1",
+  message: "送料の設定はどこから変えますか",
+  reply_body: "設定ページから変更できます",
+  replied_at: "2026-07-28T01:00:00Z",
+};
+
+describe("CopilotPreviewPage — 相談窓口(担当者からのお返事)", () => {
+  function mockFeedback(items: unknown[]) {
+    vi.mocked(authFetch).mockReset();
+    mockNavigate.mockReset();
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (isBadgeUrl(url)) return mockEmptyBadges();
+      if (String(url).includes("/v1/admin/my-tenant")) {
+        return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
+      }
+      if (isUnreadFeedbackUrl(url)) return mockOk({ items });
+      return mockOk({ reply: "了解しました。", actions: [] });
+    });
+  }
+
+  it("未読のお返事があると、全画面チャットにもお返事が出る", async () => {
+    mockFeedback([REPLY]);
+    renderPage();
+
+    expect(await screen.findByText("担当者からお返事が届きました")).toBeTruthy();
+    expect(screen.getByText("送料の設定はどこから変えますか")).toBeTruthy();
+    expect(screen.getByText("設定ページから変更できます")).toBeTruthy();
+  });
+
+  it("未読が無ければお返事は出ない", async () => {
+    mockFeedback([]);
+    renderPage();
+
+    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
+    expect(screen.queryByText("担当者からお返事が届きました")).toBeNull();
+  });
+
+  it("2件以上あると「＋あと{n}件」で残りを案内する(パネルと同じ1件表示)", async () => {
+    mockFeedback([REPLY, { ...REPLY, id: "fb-2" }]);
+    renderPage();
+
+    expect(await screen.findByText("＋あと1件")).toBeTruthy();
+  });
+
+  it("「解決しました」で既読化され、お返事は画面から消える", async () => {
+    mockFeedback([REPLY]);
+    renderPage();
+
+    fireEvent.click(await screen.findByRole("button", { name: "解決しました" }));
+
+    await waitFor(() =>
+      expect(vi.mocked(authFetch)).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/admin/feedback/fb-1/read",
+        expect.objectContaining({ method: "PATCH" }),
+      ),
+    );
+    await waitFor(() => expect(screen.queryByText("担当者からお返事が届きました")).toBeNull());
+  });
+
+  it("「まだ解決しません」で既読化 + parent_feedback_id 付きの再相談が送られる(パネルと同一手順)", async () => {
+    mockFeedback([REPLY]);
+    renderPage();
+
+    fireEvent.click(await screen.findByRole("button", { name: "まだ解決しません" }));
+
+    await waitFor(() => {
+      expect(vi.mocked(authFetch)).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/admin/feedback/fb-1/read",
+        expect.objectContaining({ method: "PATCH" }),
+      );
+      expect(vi.mocked(authFetch)).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/admin/feedback",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({
+            message: "送料の設定はどこから変えますか",
+            category: "other",
+            parent_feedback_id: "fb-1",
+          }),
+        }),
+      );
+    });
+  });
+
+  it("previewMode中のsuper_adminはプレビュー対象テナントの未読を取得する", async () => {
+    mockFeedback([]);
+    renderPage(SUPER_ADMIN_IN_PREVIEW);
+
+    await waitFor(() => {
+      const url = vi.mocked(authFetch).mock.calls.map((c) => String(c[0])).find(isUnreadFeedbackUrl);
+      expect(url).toBeTruthy();
+      expect(url).toContain("tenant_id=tenant-preview");
+    });
+  });
+
+  it("テナントを特定できないsuper_admin(preview外)では未読を取得しない", async () => {
+    mockFeedback([]);
+    renderPage({ isSuperAdmin: true, isClientAdmin: false, user: { id: "2", email: "a@example.com", role: "super_admin", tenantId: null, tenantName: null } });
+
+    await waitFor(() => expect(screen.getByText("どのお客様として見ますか？")).toBeTruthy());
+    expect(vi.mocked(authFetch).mock.calls.map((c) => String(c[0])).filter(isUnreadFeedbackUrl)).toEqual([]);
+  });
+});
+
+// 移植した2件目 = 回答の出どころ(answered_from)ラベル。3値の語彙はサーバ
+// (agentRoutes.ts)・パネル(AdminAgentPanel.tsx)と同一で、増やしたり言い換えたりしない。
+describe("CopilotPreviewPage — 回答の出どころ(answered_from)", () => {
+  function mockAnsweredFrom(answeredFrom?: string) {
+    vi.mocked(authFetch).mockReset();
+    mockNavigate.mockReset();
+    let agentCalls = 0;
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (isBadgeUrl(url)) return mockEmptyBadges();
+      if (String(url).includes("/v1/admin/my-tenant")) {
+        return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
+      }
+      if (isUnreadFeedbackUrl(url)) return mockNoFeedbackReplies();
+      agentCalls += 1;
+      // 起動時ブリーフィング(1回目)には載せず、ユーザーの質問への回答(2回目)で検証する
+      if (agentCalls === 1) return mockOk({ reply: "今週も順調です。", actions: [] });
+      return mockOk({
+        reply: "全国一律550円です。",
+        actions: [],
+        ...(answeredFrom ? { answered_from: answeredFrom } : {}),
+      });
+    });
+    // タイプライター演出を切って応答を同期的に確定させる
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: true,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  }
+
+  async function ask() {
+    renderPage();
+    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
+    fireEvent.change(getComposer(), { target: { value: "送料はいくら？" } });
+    fireEvent.click(screen.getByLabelText("送信"));
+    expect(await screen.findByText("全国一律550円です。")).toBeTruthy();
+  }
+
+  it("faq_list は「登録した知識データから回答しました」と出る", async () => {
+    mockAnsweredFrom("faq_list");
+    await ask();
+    expect(screen.getByText("📚 登録した知識データから回答しました")).toBeTruthy();
+  });
+
+  it("tool_action は「操作を実行しました」と出る", async () => {
+    mockAnsweredFrom("tool_action");
+    await ask();
+    expect(screen.getByText("⚙️ 操作を実行しました")).toBeTruthy();
+  });
+
+  it("general は「R2Cの使い方ガイドから回答しました」と出る", async () => {
+    mockAnsweredFrom("general");
+    await ask();
+    expect(screen.getByText("💡 R2Cの使い方ガイドから回答しました")).toBeTruthy();
+  });
+
+  it("answered_from が無い応答ではラベルを出さない(3値以外は表示しない)", async () => {
+    mockAnsweredFrom(undefined);
+    await ask();
+    expect(screen.queryByText(/回答しました|操作を実行しました/)).toBeNull();
+  });
+});
+
+// 相談窓口ループの入口(パネルの FeedbackPrompt と同じ導線)。
+describe("CopilotPreviewPage — 解決確認プロンプト", () => {
+  function mockChat() {
+    vi.mocked(authFetch).mockReset();
+    mockNavigate.mockReset();
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (isBadgeUrl(url)) return mockEmptyBadges();
+      if (String(url).includes("/v1/admin/my-tenant")) {
+        return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
+      }
+      if (isUnreadFeedbackUrl(url)) return mockNoFeedbackReplies();
+      if (String(url).includes("/v1/admin/feedback")) return mockOk({ id: "fb-9" });
+      return mockOk({ reply: "申し訳ございません、その情報は登録されていません。", actions: [] });
+    });
+    window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+      matches: true,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }));
+  }
+
+  async function ask(text: string) {
+    renderPage();
+    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
+    fireEvent.change(getComposer(), { target: { value: text } });
+    fireEvent.click(screen.getByLabelText("送信"));
+    return screen.findByText("このお返事で解決しましたか？");
+  }
+
+  it("起動時ブリーフィングだけの状態では出ない(ユーザーが何も聞いていないため)", async () => {
+    mockChat();
+    renderPage();
+
+    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
+    expect(screen.queryByText("このお返事で解決しましたか？")).toBeNull();
+  });
+
+  it("「うまく解決しなかった」で質問文が相談として送られ、確認文言に変わる", async () => {
+    mockChat();
+    await ask("割引クーポンはありますか");
+
+    fireEvent.click(screen.getByRole("button", { name: "うまく解決しなかった" }));
+
+    await waitFor(() =>
+      expect(vi.mocked(authFetch)).toHaveBeenCalledWith(
+        "http://localhost:3100/v1/admin/feedback",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ message: "割引クーポンはありますか", category: "other" }),
+        }),
+      ),
+    );
+    expect(await screen.findByText("✅ 担当者に伝えました。お返事はこの画面に届きます。")).toBeTruthy();
+  });
+
+  it("「はい」で消え、相談は送られない", async () => {
+    mockChat();
+    await ask("送料を教えて");
+
+    fireEvent.click(screen.getByRole("button", { name: "はい" }));
+
+    expect(screen.queryByText("このお返事で解決しましたか？")).toBeNull();
+    const posted = vi
+      .mocked(authFetch)
+      .mock.calls.filter((c) => String(c[0]).endsWith("/v1/admin/feedback"));
+    expect(posted).toEqual([]);
   });
 });

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -1319,32 +1319,33 @@ function FeedbackReplyNotice({
           </>
         }
       >
-        <Field k="あなたの質問" v={reply.message} />
-        <div style={{ fontSize: 15 }}>
-          <div style={{ fontSize: 12.5, color: "var(--muted-foreground)", fontWeight: 600, marginBottom: 4 }}>
-            お返事
-          </div>
-          {/* 長いお返事でコンポーザが画面外に押し出されないよう高さを制限する */}
-          <div
-            style={{
-              color: "var(--foreground)", background: "var(--muted, rgba(120,120,140,0.1))",
-              borderRadius: 10, padding: "10px 14px", borderLeft: "3px solid #d99320",
-              lineHeight: 1.7, whiteSpace: "pre-wrap", wordBreak: "break-word",
-              maxHeight: 160, overflowY: "auto",
-            }}
-          >
-            {reply.reply_body}
-          </div>
+        {/* コンポーザの上に固定するため、縦幅は詰める(狭い画面ではスレッドが潰れる)。
+            どの相談への返事かは1行で足りるので、ラベル付きの Field にはしない。 */}
+        <div style={{ fontSize: 13, color: "var(--muted-foreground)", lineHeight: 1.5, wordBreak: "break-word" }}>
+          ご相談: {reply.message}
           {reply.replied_at && (
-            <div style={{ fontSize: 12, color: "var(--muted-foreground)", marginTop: 5 }}>
+            <>
+              {" ・ "}
               {new Date(reply.replied_at).toLocaleString("ja-JP", {
                 month: "short",
                 day: "numeric",
                 hour: "2-digit",
                 minute: "2-digit",
               })}
-            </div>
+            </>
           )}
+        </div>
+        {/* 長いお返事でコンポーザが画面外に押し出されないよう、高さを制限して中でスクロールさせる
+            (上限値は狭い画面でさらに小さくする。index.css の .cp-consult-reply) */}
+        <div
+          className="cp-consult-reply"
+          style={{
+            fontSize: 15, color: "var(--foreground)", background: "var(--muted, rgba(120,120,140,0.1))",
+            borderRadius: 10, padding: "10px 14px", borderLeft: "3px solid #d99320",
+            lineHeight: 1.7, whiteSpace: "pre-wrap", wordBreak: "break-word", overflowY: "auto",
+          }}
+        >
+          {reply.reply_body}
         </div>
         <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
           <button

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -23,6 +23,11 @@ import {
   AGENT_CHAT_HISTORY_MAX_ENTRIES,
   useAgentChatTransport,
 } from "../../lib/useAgentChatTransport";
+import type { AnsweredFrom } from "../../lib/useAgentChatTransport";
+// 相談窓口(担当者への相談 → 返信 → 解決確認)のループ。ポーリング・既読化・相談投稿は
+// パネル(Surface A)と同じ実装を共有し(lib/feedbackReplies.ts)、見せ方だけこの面の
+// カード/メッセージの作法に合わせる。
+import { submitConsultation, useFeedbackReplies, type FeedbackReply } from "../../lib/feedbackReplies";
 import { shouldSubmitOnEnter } from "../../lib/utils";
 // PDF取り込みの受付ルール(拡張子/MIME/サイズ上限)と送信は旧UIのPDFタブと同じ実装を共有する。
 // 同じ操作が2面にある状態なので、片方だけ条件が緩む/厳しくなることを避けるため。
@@ -285,7 +290,17 @@ interface Msg {
   card?: Card;
   chips?: Chip[];
   chipsUsed?: boolean;
+  /** この回答がどこから来たか(サーバの answered_from をそのまま持つ) */
+  answeredFrom?: AnsweredFrom;
 }
+
+// 回答の出どころ表示。3値の語彙と文言はパネル(Surface A)と同一にする — 同じ回答が
+// 面によって違う出どころに見えてはならないため(値の定義は agentRoutes.ts が正)。
+const ANSWERED_FROM_LABEL: Record<AnsweredFrom, string> = {
+  faq_list: "📚 登録した知識データから回答しました",
+  tool_action: "⚙️ 操作を実行しました",
+  general: "💡 R2Cの使い方ガイドから回答しました",
+};
 
 const AGENT = "#7c3aed";
 const AGENT_SOFT = "rgba(124,58,237,0.10)";
@@ -346,6 +361,28 @@ export default function CopilotPreviewPage() {
   // (全テナント横断の合計が「この店の件数」として出てしまうため)。なお、その状態では
   // needsTenantSelection でチャット自体がまだ描画されないため、コンポーザは存在しない。
   const scopedTenantId = previewMode ? (previewTenantId ?? "") : (user?.tenantId ?? "");
+
+  // 相談窓口: 担当者からの未読返信。テナントが特定できない間は取りに行かない
+  // (フック側が tenantId=null で素通りする)。
+  const { replies: feedbackReplies, markRead: markFeedbackReplyRead } = useFeedbackReplies(
+    scopedTenantId || null,
+    isSuperAdmin,
+  );
+
+  // 「解決しました」= 既読にするだけ。「まだ解決しません」= 既読にしたうえで、元の質問を
+  // 親IDに紐づけて再投稿する。どちらもパネル(Surface A)と同じ手順・同じAPI。
+  const handleReplyResolved = useCallback(
+    (reply: FeedbackReply) => markFeedbackReplyRead(reply.id),
+    [markFeedbackReplyRead],
+  );
+  const handleReplyNotResolved = useCallback(
+    async (reply: FeedbackReply) => {
+      await markFeedbackReplyRead(reply.id);
+      await submitConsultation({ message: reply.message, parentFeedbackId: reply.id });
+    },
+    [markFeedbackReplyRead],
+  );
+
   const [railCounts, setRailCounts] = useState<RailCounts>({});
   useEffect(() => {
     if (!scopedTenantId) return;
@@ -515,7 +552,7 @@ export default function CopilotPreviewPage() {
 
     // 最終返信だけを少しずつ流し込む(演出)。チップは流し込み完了後に表示する。
     const replyId = nextId();
-    push({ id: replyId, role: "ai", text: "" });
+    push({ id: replyId, role: "ai", text: "", answeredFrom: data.answered_from });
     revealText(replyId, data.reply || "（応答なし）", () => {
       if (chips) setMsgs((prev) => prev.map((m) => (m.id === replyId ? { ...m, chips } : m)));
       setSending(false);
@@ -639,6 +676,18 @@ export default function CopilotPreviewPage() {
   const awaitingUserDecision =
     !!lastMsg && lastMsg.role === "ai" && !!lastMsg.chips && lastMsg.chips.length > 0 && !lastMsg.chipsUsed;
   const busy = sending || awaitingUserDecision;
+
+  // 相談窓口の入口: 直近のAI回答の下に「解決しましたか？」を出す(パネルと同じ導線)。
+  // 出さない場合:
+  //   - 応答待ち・タイプライター中(sending) / まだチップを選んでいない(awaitingUserDecision)
+  //   - ユーザーが一度も質問していない(起動時ブリーフィングだけの状態)。聞いてもいない
+  //     ことに「解決しましたか？」と尋ねる形になるため。
+  const lastUserText = msgs.reduce<string | undefined>(
+    (acc, m) => (m.role === "me" && m.text ? m.text : acc),
+    undefined,
+  );
+  const showResolutionPrompt =
+    !busy && !!lastUserText && !!lastMsg && lastMsg.role === "ai" && !!lastMsg.text;
 
   // ボタン側のdisabledで大半は弾かれるが、ここでも二重に防御する。
   const handleCategory = (key: string) => {
@@ -955,12 +1004,29 @@ export default function CopilotPreviewPage() {
             {msgs.map((m) => (
               <MessageRow key={m.id} m={m} onChip={runAction} />
             ))}
+            {/* key に直近メッセージのidを与え、回答が変わるたびに新しい確認として出す
+                (前の回答で「はい」を押した状態を持ち越さない) */}
+            {showResolutionPrompt && <ResolutionPrompt key={lastMsg.id} question={lastUserText} />}
           </div>
         </div>
 
         {/* コンポーザ（実API接続）。PDFはここへ落とすと会話の中で取り込みが始まる */}
         <div className="cp-composer-wrap" style={{ flexShrink: 0 }}>
           <div style={{ maxWidth: 820, margin: "0 auto" }}>
+            {/* 担当者からのお返事(最新の未読1件のみ。他は件数で案内)。
+                スレッドの中ではなくコンポーザの上に固定する理由が2つある:
+                  1. スレッドは新しい応答が来るたび末尾へ自動スクロールするため、途中に
+                     差し込むと届いた直後に画面外へ流れてしまう。
+                  2. msgs に入れると会話と一緒に sessionStorage へ保存され、既読化した
+                     お返事がリロード後に復活する。ここは常にフックの現在値だけを映す。 */}
+            {feedbackReplies.length > 0 && (
+              <FeedbackReplyNotice
+                reply={feedbackReplies[0]}
+                extraCount={feedbackReplies.length - 1}
+                onResolved={() => handleReplyResolved(feedbackReplies[0])}
+                onNotResolved={() => handleReplyNotResolved(feedbackReplies[0])}
+              />
+            )}
             <div
               onDragEnter={handlePdfDragEnter}
               onDragOver={(e) => e.preventDefault()}
@@ -1185,6 +1251,13 @@ function MessageRow({ m, onChip }: { m: Msg; onChip: (a: string, id: number) => 
           {m.text}
         </div>
       )}
+      {/* 回答の出どころ。テキストが流し込まれるまでは出さない(空バブルの下に
+          ラベルだけが浮くのを避ける) */}
+      {m.text && m.answeredFrom && (
+        <div style={{ fontSize: 12.5, color: "var(--muted-foreground)", padding: "0 4px" }}>
+          {ANSWERED_FROM_LABEL[m.answeredFrom]}
+        </div>
+      )}
       {m.card && <CardView card={m.card} />}
       {m.chips && !m.chipsUsed && (
         <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
@@ -1205,6 +1278,147 @@ function MessageRow({ m, onChip }: { m: Msg; onChip: (a: string, id: number) => 
           ))}
         </div>
       )}
+    </div>
+  );
+}
+
+// ─── 相談窓口(担当者への相談 → 返信 → 解決確認) ──────────────────────────────
+// ロジック(ポーリング・既読化・相談投稿)は lib/feedbackReplies.ts でパネルと共有し、
+// ここは見せ方だけを持つ。パネル側の ReplyCard/FeedbackPrompt をそのまま使わないのは、
+// あれがダークのパネル前提の固定色(#86efac 等)で書かれており、light/dark 両対応の
+// この画面ではコントラストが破綻するため(文言と操作は同一に保っている)。
+
+function FeedbackReplyNotice({
+  reply,
+  extraCount,
+  onResolved,
+  onNotResolved,
+}: {
+  reply: FeedbackReply;
+  extraCount: number;
+  onResolved: () => Promise<void>;
+  onNotResolved: () => Promise<void>;
+}) {
+  const [busy, setBusy] = useState(false);
+
+  const run = (action: () => Promise<void>) => {
+    setBusy(true);
+    void action();
+  };
+
+  return (
+    <div style={{ marginBottom: 12 }}>
+      <CardShell
+        tone="brand"
+        hd={
+          <>
+            <span>💬</span>担当者からお返事が届きました
+            {extraCount > 0 && (
+              <span style={{ fontWeight: 500, fontSize: 12.5, opacity: 0.8 }}>{`＋あと${extraCount}件`}</span>
+            )}
+          </>
+        }
+      >
+        <Field k="あなたの質問" v={reply.message} />
+        <div style={{ fontSize: 15 }}>
+          <div style={{ fontSize: 12.5, color: "var(--muted-foreground)", fontWeight: 600, marginBottom: 4 }}>
+            お返事
+          </div>
+          {/* 長いお返事でコンポーザが画面外に押し出されないよう高さを制限する */}
+          <div
+            style={{
+              color: "var(--foreground)", background: "var(--muted, rgba(120,120,140,0.1))",
+              borderRadius: 10, padding: "10px 14px", borderLeft: "3px solid #d99320",
+              lineHeight: 1.7, whiteSpace: "pre-wrap", wordBreak: "break-word",
+              maxHeight: 160, overflowY: "auto",
+            }}
+          >
+            {reply.reply_body}
+          </div>
+          {reply.replied_at && (
+            <div style={{ fontSize: 12, color: "var(--muted-foreground)", marginTop: 5 }}>
+              {new Date(reply.replied_at).toLocaleString("ja-JP", {
+                month: "short",
+                day: "numeric",
+                hour: "2-digit",
+                minute: "2-digit",
+              })}
+            </div>
+          )}
+        </div>
+        <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+          <button
+            onClick={() => run(onResolved)}
+            disabled={busy}
+            style={{
+              fontSize: 14.5, fontWeight: 700, padding: "10px 18px", borderRadius: 12, minHeight: 44,
+              border: "none", background: AGENT, color: "#fff",
+              cursor: busy ? "not-allowed" : "pointer", opacity: busy ? 0.6 : 1,
+            }}
+          >
+            解決しました
+          </button>
+          <button
+            onClick={() => run(onNotResolved)}
+            disabled={busy}
+            style={{
+              fontSize: 14.5, fontWeight: 700, padding: "10px 18px", borderRadius: 12, minHeight: 44,
+              border: "1px solid var(--border)", background: "transparent", color: "var(--muted-foreground)",
+              cursor: busy ? "not-allowed" : "pointer", opacity: busy ? 0.6 : 1,
+            }}
+          >
+            まだ解決しません
+          </button>
+        </div>
+      </CardShell>
+    </div>
+  );
+}
+
+// 直近のAI回答の下に出す「解決しましたか？」。「うまく解決しなかった」を押すと、その
+// 質問がそのまま担当者への相談として投稿される(= 相談窓口ループの入口)。
+function ResolutionPrompt({ question }: { question: string }) {
+  const [state, setState] = useState<"idle" | "sending" | "sent" | "dismissed">("idle");
+
+  if (state === "dismissed") return null;
+
+  if (state === "sent") {
+    return (
+      <div style={{ fontSize: 13.5, color: "#16a34a", padding: "0 4px" }}>
+        {"✅ 担当者に伝えました。お返事はこの画面に届きます。"}
+      </div>
+    );
+  }
+
+  const handleNotResolved = async () => {
+    setState("sending");
+    const ok = await submitConsultation({ message: question });
+    setState(ok ? "sent" : "idle");
+  };
+
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 10, flexWrap: "wrap", padding: "0 4px" }}>
+      <span style={{ fontSize: 13.5, color: "var(--muted-foreground)" }}>このお返事で解決しましたか？</span>
+      <button
+        onClick={() => setState("dismissed")}
+        style={{
+          fontSize: 13.5, fontWeight: 700, padding: "7px 16px", borderRadius: 999, minHeight: 36,
+          border: `1px solid ${AGENT_BORDER}`, background: AGENT_SOFT, color: AGENT, cursor: "pointer",
+        }}
+      >
+        はい
+      </button>
+      <button
+        onClick={() => void handleNotResolved()}
+        disabled={state === "sending"}
+        style={{
+          fontSize: 13.5, fontWeight: 700, padding: "7px 16px", borderRadius: 999, minHeight: 36,
+          border: "1px solid var(--border)", background: "transparent", color: "var(--muted-foreground)",
+          cursor: state === "sending" ? "not-allowed" : "pointer",
+        }}
+      >
+        {state === "sending" ? "送信中..." : "うまく解決しなかった"}
+      </button>
     </div>
   );
 }

--- a/docs/LEGACY_UI_SUNSET.md
+++ b/docs/LEGACY_UI_SUNSET.md
@@ -489,6 +489,20 @@ showAIChat = isClientAdmin && <クローズ対象外ページのみ>
 
 機能凍結 (同 §4(c)-1) と A 固有 2 機能 (相談窓口ループ・`answered_from` ラベル) の B への移植 (同 §4(c)-3) は、この縮小の前提条件としてそのまま有効。凍結の終期に上限が付くという (c) の利点も維持される — 上限は「Wave 1 + Wave 2 の 6 ページが閉じた時点」で確定する。
 
+#### 7-1-a. 前提条件の充足状況: A 固有 2 機能の移植は完了済み (2026-07-30)
+
+上記の前提条件のうち **移植 (同 §4(c)-3) は済んでいる**。Asana GID `1217008702879233` / PR「パネル固有の2機能を全画面UIへ移植する」で以下を実施した。
+
+| 前提条件 | 状態 | 実装 |
+|---|---|---|
+| 相談窓口ループ (担当者からのお返事 → 解決しました / まだ解決しません) を B へ | **済** | `pages/copilot-preview/index.tsx` がフックを共有 (`lib/feedbackReplies.ts` — 移植に合わせて `components/AdminAgent/useFeedbackReplies.ts` から移動)。描画は同ファイルの `FeedbackReplyNotice` / `ResolutionPrompt` |
+| `answered_from` の出典ラベルを B へ | **済** | 同ファイルの `ANSWERED_FROM_LABEL` (3値の語彙・文言はパネルと同一) |
+| パネルの機能凍結の明文化 | **済** | `components/AdminAgent/AdminAgentPanel.tsx` および `useAdminAgent.ts` 冒頭のコメント |
+
+したがって **パネルに固有で B に無い機能はもう無い**。§7-1 の「可視条件の縮小」を実行する際、機能欠落を理由にブロックされる要素は残っていない (縮小そのものの実装は引き続き別タスク)。
+
+なお **本節が満たしたのは「パネル側の前提条件」だけ** であり、§2.3 の数値基準・§3 の実行手順は一切変更していない。それらはテナント向け旧UIページに対する基準であって、パネル自体の基準ではない (§0.1)。
+
 ### 7-2. 面が区別できないことが C1 に与える影響 (重要)
 
 `CHAT_SURFACE_DECISION.md` §3.3 の指摘どおり、`POST /v1/admin/agent/chat` の `chatSchema` (`src/api/admin/agent/agentRoutes.ts:81–89` — 本ドキュメントでの実測値。受け取るのは `message` / `sessionId` / `targetTenantId` / `history` / `stream` のみ) に面の識別子が無い。このため `agent_legacy_handoff` は次の 2 つを区別できない:


### PR DESCRIPTION
Asana GID `1217008702879233`

## なぜ

`docs/CHAT_SURFACE_DECISION.md` が採択した選択肢(c)「パネルは橋。旧UIページの閉鎖に合わせて畳む」では、パネル(Surface A)を畳む/可視条件を縮小する前提条件として、**A にしか無い2機能を全画面UI(Surface B)へ移す**ことが必要になる(同 §4(c)-3)。移さずに畳むとUIの統合ではなく**実際の機能欠落**になるため、先に移植を済ませて前提条件を満たす。

移植対象は同ドキュメント §2.2 が挙げる2件のみ:
1. 相談窓口ループ(担当者からのお返事 → 解決しました / まだ解決しません)
2. `answered_from` の出典ラベル

## 変えたこと

### 1. 相談窓口ループを Surface B へ

- ロジック(60秒ポーリング・既読化・相談投稿)は **`lib/feedbackReplies.ts` として2面で共有**する。`components/AdminAgent/useFeedbackReplies.ts` から移動したもので、ロジックの二重実装はしていない。面を跨いで共有するものを `lib/` に置くのは transport 層(`useAgentChatTransport.ts`)・会話永続化(`chatSessionStore.ts`)・PDF取り込み(`bookPdfUpload.ts`)と同じ方針。畳む予定の側に共有依存を残さないため。
- お返事は **msgs ではなくコンポーザ直上に固定**した。理由2つ:
  1. スレッドは新しい応答ごとに末尾へ自動スクロールするため、途中に差し込むと届いた直後に画面外へ流れる。
  2. `msgs` に入れると会話と一緒に sessionStorage へ保存され、**既読化したお返事がリロード後に復活する**。ここは常にフックの現在値だけを映す。
- 描画はパネルの `ReplyCard`/`FeedbackPrompt` を再利用せず、この面の `CardShell`/`Field` で作り直した。あちらは**ダークのパネル前提の固定色**(`#86efac` 等)で書かれており、light/dark 両対応のこの画面ではコントラストが破綻する。**文言・操作・叩くAPI・手順は同一**に保っている(「まだ解決しません」= 既読化 + `parent_feedback_id` 付きの再投稿)。
- 解決確認プロンプト(「このお返事で解決しましたか？」)は直近のAI回答の下に出す。**起動時ブリーフィングには出さない** — ユーザーが聞いてもいないことに解決を尋ねる形になるため。

### 2. `answered_from` を Surface B へ

3値(`faq_list` / `tool_action` / `general`)の語彙と文言はサーバ(`agentRoutes.ts`)・パネルと**同一**。増やしていない・言い換えていない。サーバのレスポンスに `answered_from` が載ることは `agentRoutes.ts:855` / `agentRoutes.test.ts` で確認済み。

### 3. パネルの機能凍結を明文化

`AdminAgentPanel.tsx` / `useAdminAgent.ts` の冒頭にコメントを追加しただけで、**挙動は一切変更していない**(既存テストは1行も変えずに緑)。凍結対象は「面固有の新機能」であって共有層のバグ修正は対象外である旨も明記。

### 4. その他

- `App.tsx`: 全画面UI表示中はパネル用の未読ポーリングを止める(同じフックを画面側が呼ぶため、そのままだと60秒ごとに二重取得になる)。
- `docs/LEGACY_UI_SUNSET.md` §7-1-a: 前提条件の充足を記録。**数値基準(§2.3)・実行手順(§3)は変更していない** — あれはテナント向け旧UIページの基準であって、パネル自体の基準ではない(§0.1)。

## テスト

`admin-ui/src/pages/copilot-preview/index.test.tsx` に14件追加(未読の表示/非表示・＋あと{n}件・既読化・`parent_feedback_id` 付き再相談・previewMode のテナントスコープ・テナント未特定時は取得しない・`answered_from` 3値それぞれ・値が無い場合・解決確認プロンプトの3経路)。

既存テストの**アサーションは変更していない**。マウント時に未読取得が1本増えるため、`/v1/admin/agent/chat` の応答シーケンスを数えている3つの describe のモックに、バッジ2本と同じ形で素通り経路を1行追加した(数えるのは元から agent chat 呼び出しだけの意図)。

- `admin-ui`: 246 passed (27 files) — `AdminAgentPanel.test.tsx` / `useAdminAgent.test.tsx` は無変更で緑
- `npm run lint`: exit 0(追加分の警告なし)
- `npx tsc --noEmit`: root / admin-ui ともエラーなし
- `git diff --stat origin/main -- '*.sql' '.env*' 'package.json'`: 空

## 実機確認

ローカルの vite で `/copilot-preview`(認証ゲート外)を開き、デスクトップ幅と 390px 幅で描画を確認した。390px では初版のカードがスレッドをほぼ潰していたため、お返事本文の高さ上限を狭い画面で 88px まで下げ、質問と日時を1行に詰めた(2つ目のコミット)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0177MCsC7jN3a51F7TdaW9vH