### PR TITLE
feat(agent): アバターの一覧取得と停止をチャットから可能にする

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -490,6 +490,25 @@ describe("CopilotPreviewPage — 構造化カード(card)からの描画", () =>
     expect(link.getAttribute("target")).toBe("_blank");
     expect(screen.getByText(description)).toBeTruthy();
   });
+
+  // REAL_TOOL_LABEL への登録を忘れると、画面に生の英語ツール名がそのまま出る
+  // (パネル側のラベル表が9件で取り残されたのと同型の事故)。新ツール追加時の回帰。
+  it("アバターの一覧・停止ツールは生の英語名ではなく日本語ラベルで表示される", async () => {
+    mockAgent({
+      reply: "アバターの状況をお伝えしました。",
+      actions: [
+        { tool: "get_avatar_list", result: "アバター設定は1件あります:\n- 接客担当（稼働中） ID: av-1" },
+        { tool: "deactivate_avatar", result: "アバター「接客担当」を停止しました。" },
+      ],
+    });
+
+    await send("アバターの一覧を見せて");
+
+    expect(await screen.findByText("アバター一覧の取得")).toBeTruthy();
+    expect(screen.getByText("アバターの停止")).toBeTruthy();
+    expect(screen.queryByText("get_avatar_list")).toBeNull();
+    expect(screen.queryByText("deactivate_avatar")).toBeNull();
+  });
 });
 
 function getComposer(): HTMLTextAreaElement {

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -107,7 +107,9 @@ const REAL_TOOL_LABEL: Record<string, string> = {
   add_faq: "FAQの追加",
   update_faq: "FAQの更新",
   delete_faq: "FAQの削除",
+  get_avatar_list: "アバター一覧の取得",
   activate_avatar: "アバターの有効化",
+  deactivate_avatar: "アバターの停止",
   get_embed_code: "埋め込みコードの取得",
   set_widget_theme: "ウィジェットテーマの変更",
   get_tuning_rules: "指示ルール一覧の取得",
@@ -152,6 +154,7 @@ const REAL_WRITE_TOOLS = new Set([
   "set_posthog",
   "set_widget_theme",
   "activate_avatar",
+  "deactivate_avatar",
   "import_industry_faq_templates",
   "commit_faq_import",
   "reply_to_escalation",
@@ -699,7 +702,7 @@ export default function CopilotPreviewPage() {
     } else if (key === "history") {
       void sendReal("最近の会話とエスカレーションの状況を教えて");
     } else if (key === "avatar") {
-      void sendReal("アバターの稼働状況を教えて");
+      void sendReal("アバターの稼働状況と、設定の一覧を教えて");
     } else if (key === "knowledge") {
       // Phase E: get_faq_list/get_knowledge_gaps(実API)に接続。以前はモック固定文言だった
       void sendReal("知識データの状況を教えて（FAQの件数と、AIが答えられなかった質問があれば教えて）");

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -516,6 +516,48 @@ export async function executeToolCall(
     }
 
     // -----------------------------------------------------------------------
+    // 一覧が無いと activate_avatar は「ID を知っている人しか使えない」ツールになるため、
+    // 切替の前段としてここで ID を提示する。
+    // 既定アバター(tenant_id='r2c_default')は avatar_configs の部分unique制約から
+    // 除外されており全行 is_active = true なので、is_active だけで稼働中を判定すると
+    // 見本18体がすべて「稼働中」に見える。稼働中の判定は自テナント行に限る。
+    case 'get_avatar_list': {
+      try {
+        const res = await db.query(
+          `SELECT id, name, is_active, tenant_id
+             FROM avatar_configs
+            WHERE tenant_id = $1 OR tenant_id = 'r2c_default'
+            ORDER BY (tenant_id = $1) DESC, is_default ASC, created_at DESC`,
+          [tenantId],
+        );
+        const rows = res.rows as { id: string; name: string; is_active: boolean; tenant_id: string }[];
+        if (rows.length === 0) {
+          return truncate('アバター設定はまだありません');
+        }
+
+        // 戻り値は500字で切られる。切られると一覧の末尾が黙って欠けるため、
+        // 収まる分だけ出して残件数を明示する（欠落を沈黙させない）。
+        const LIST_CHAR_BUDGET = 420;
+        const lines: string[] = [];
+        let used = 0;
+        for (const row of rows) {
+          const own = row.tenant_id === tenantId;
+          const mark = own ? (row.is_active ? '（稼働中）' : '') : '（既定の見本）';
+          const line = `- ${row.name}${mark} ID: ${row.id}`;
+          if (used + line.length > LIST_CHAR_BUDGET) break;
+          lines.push(line);
+          used += line.length + 1;
+        }
+        const remaining = rows.length - lines.length;
+        const footer = remaining > 0 ? `\nほか${remaining}件` : '';
+        return truncate(`アバター設定は${rows.length}件あります:\n${lines.join('\n')}${footer}`);
+      } catch (err) {
+        logger.warn('[actionExecutor] get_avatar_list failed', err);
+        return truncate('アバター一覧の取得に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
     case 'activate_avatar': {
       const id = String(args['id'] ?? '');
       if (!id) {
@@ -536,14 +578,44 @@ export async function executeToolCall(
       try {
         const res = await activateAvatarConfig(client, id, tenantId);
         if (!res.ok) {
-          return truncate(`アバターの有効化に失敗しました: ${res.error ?? '不明なエラー'}`);
+          // 見つからない原因の大半はIDの取り違え。次の一手（一覧で確認）を示す。
+          return truncate(
+            `アバターの有効化に失敗しました: ${res.error ?? '不明なエラー'}。get_avatar_list で ID を確認してください`,
+          );
         }
         return truncate(`アバター（ID: ${id}）を有効化しました`);
       } catch (err) {
+        // 不正な形式のID（UUIDでない文字列）もここに来る。500にはせず日本語で返す。
         logger.warn('[actionExecutor] activate_avatar failed', err);
-        return truncate('アバターの有効化に失敗しました');
+        return truncate('アバターの有効化に失敗しました。get_avatar_list で ID を確認してください');
       } finally {
         client.release();
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    // 既定アバター(is_default)は全テナント共通の見本で、常に is_active = true の
+    // 前提で運用されている（部分unique制約から除外されている）。停止対象から外す。
+    case 'deactivate_avatar': {
+      try {
+        const res = await db.query(
+          `UPDATE avatar_configs SET is_active = false
+            WHERE tenant_id = $1 AND is_active = true AND (is_default = false OR is_default IS NULL)
+            RETURNING name`,
+          [tenantId],
+        );
+        const stopped = res.rows as { name: string }[];
+        if (stopped.length === 0) {
+          return truncate('稼働中のアバターはありません');
+        }
+        const names = stopped.map((r) => `「${r.name}」`).join('');
+        return truncate(
+          `アバター${names}を停止しました。ウィジェットにアバターは表示されなくなります。` +
+          '再開したいときは activate_avatar で同じ設定を有効化できます',
+        );
+      } catch (err) {
+        logger.warn('[actionExecutor] deactivate_avatar failed', err);
+        return truncate('アバターの停止に失敗しました');
       }
     }
 

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -3567,6 +3567,142 @@ describe('POST /v1/admin/agent/chat', () => {
   });
 
   // -------------------------------------------------------------------------
+  // get_avatar_list / deactivate_avatar
+  // 一覧が無いと activate_avatar は ID を知っている人しか使えない = チャットから実行不能
+  // だったため追加した経路。既定アバターの扱いが最大の罠なのでそこを固定する。
+  // -------------------------------------------------------------------------
+  describe('get_avatar_list / deactivate_avatar', () => {
+    function toolCallResponse(id: string, name: string, args: Record<string, unknown> = {}) {
+      return {
+        ok: true,
+        json: async () => ({
+          choices: [{
+            message: {
+              content: null,
+              tool_calls: [{ id, type: 'function', function: { name, arguments: JSON.stringify(args) } }],
+            },
+          }],
+        }),
+        text: async () => '',
+      };
+    }
+
+    it('既定アバター(r2c_default)は is_active=true でも「稼働中」と表示しない', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-list-1', 'get_avatar_list', {}))
+        .mockResolvedValueOnce(makeGroqResponse('一覧をお伝えしました。'));
+
+      // 既定アバターは部分unique制約から除外されており全行 is_active = true。
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          { id: 'av-own-1', name: '自社スタッフ', is_active: false, tenant_id: 'tenant-abc' },
+          { id: 'av-def-1', name: '見本アバターA', is_active: true, tenant_id: 'r2c_default' },
+          { id: 'av-def-2', name: '見本アバターB', is_active: true, tenant_id: 'r2c_default' },
+        ],
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'アバターの一覧を見せて', sessionId: 'sess-list-01' });
+
+      expect(res.status).toBe(200);
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain('自社スタッフ');
+      expect(result).toContain('見本アバターA（既定の見本）');
+      expect(result).not.toContain('見本アバターA（稼働中）');
+    });
+
+    it('自テナントの稼働中の設定には稼働中の印が付く', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-list-2', 'get_avatar_list', {}))
+        .mockResolvedValueOnce(makeGroqResponse('一覧をお伝えしました。'));
+
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ id: 'av-own-1', name: '接客担当', is_active: true, tenant_id: 'tenant-abc' }],
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'アバターの一覧を見せて', sessionId: 'sess-list-02' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('接客担当（稼働中）');
+    });
+
+    it('件数が多くても500字で黙って欠けず、残件数を明示する', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-list-3', 'get_avatar_list', {}))
+        .mockResolvedValueOnce(makeGroqResponse('一覧をお伝えしました。'));
+
+      const rows = Array.from({ length: 30 }, (_, i) => ({
+        id: `550e8400-e29b-41d4-a716-4466554400${String(i).padStart(2, '0')}`,
+        name: `アバター${i}`,
+        is_active: false,
+        tenant_id: 'tenant-abc',
+      }));
+      mockQuery.mockResolvedValueOnce({ rows });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'アバターの一覧を見せて', sessionId: 'sess-list-03' });
+
+      expect(res.status).toBe(200);
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain('アバター設定は30件あります');
+      expect(result).toMatch(/ほか\d+件/);
+      expect(result.length).toBeLessThanOrEqual(500);
+    });
+
+    it('設定が1件も無い場合はその旨を返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-list-4', 'get_avatar_list', {}))
+        .mockResolvedValueOnce(makeGroqResponse('まだありません。'));
+
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'アバターの一覧を見せて', sessionId: 'sess-list-04' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('まだありません');
+    });
+
+    it('稼働中を停止でき、既定アバターは停止対象から除外される', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-deact-1', 'deactivate_avatar', {}))
+        .mockResolvedValueOnce(makeGroqResponse('停止しました。'));
+
+      mockQuery.mockResolvedValueOnce({ rows: [{ name: '接客担当' }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'アバターを止めて', sessionId: 'sess-deact-01' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('停止しました');
+      const sql = mockQuery.mock.calls[0]![0] as string;
+      expect(sql).toContain('is_default = false OR is_default IS NULL');
+      expect(mockQuery.mock.calls[0]![1]).toEqual(['tenant-abc']);
+    });
+
+    it('稼働中が無いときは停止せずその旨を返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-deact-2', 'deactivate_avatar', {}))
+        .mockResolvedValueOnce(makeGroqResponse('稼働中はありません。'));
+
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'アバターを止めて', sessionId: 'sess-deact-02' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('稼働中のアバターはありません');
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // activate_avatar — プラン制限(Growth〜)がチャット経由でも素通りしないことの回帰テスト
   // -------------------------------------------------------------------------
   describe('activate_avatar: プラン制限', () => {
@@ -3638,6 +3774,51 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(res.status).toBe(200);
       expect(res.body.actions[0].result).toContain('Growthプラン以上');
       expect(mockConnect).not.toHaveBeenCalled();
+    });
+
+    it('IDがUUIDでない場合も500にならず、一覧で確認するよう案内する', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-act-4', 'activate_avatar', { id: 'それっぽいID' }))
+        .mockResolvedValueOnce(makeGroqResponse('IDをご確認ください。'));
+
+      mockQuery.mockResolvedValueOnce({ rows: [{ plan: 'growth' }] });
+      // Postgres は uuid 列への不正値で 22P02 を投げる。executor が握って日本語で返すこと。
+      const invalidUuid = Object.assign(new Error('invalid input syntax for type uuid'), { code: '22P02' });
+      const clientQuery = jest.fn()
+        .mockResolvedValueOnce({ rows: [] }) // BEGIN
+        .mockRejectedValueOnce(invalidUuid) // deactivate all(idを使う前段で落ちる場合もある)
+        .mockResolvedValue({ rows: [] }); // ROLLBACK
+      mockConnect.mockResolvedValueOnce({ query: clientQuery, release: jest.fn() });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'アバターを有効化して', sessionId: 'sess-act-04' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('get_avatar_list');
+    });
+
+    it('他テナントのIDは有効化されず、一覧で確認するよう案内する', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-act-5', 'activate_avatar', { id: 'av-other-tenant' }))
+        .mockResolvedValueOnce(makeGroqResponse('見つかりませんでした。'));
+
+      mockQuery.mockResolvedValueOnce({ rows: [{ plan: 'growth' }] });
+      const clientQuery = jest.fn()
+        .mockResolvedValueOnce({ rows: [] }) // BEGIN
+        .mockResolvedValueOnce({ rows: [] }) // deactivate all
+        .mockResolvedValueOnce({ rows: [] }) // activate target → tenant_id 不一致で0件
+        .mockResolvedValueOnce({ rows: [] }); // ROLLBACK
+      mockConnect.mockResolvedValueOnce({ query: clientQuery, release: jest.fn() });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'アバターを有効化して', sessionId: 'sess-act-05' });
+
+      expect(res.status).toBe(200);
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain('設定が見つかりません');
+      expect(result).toContain('get_avatar_list');
     });
   });
 

--- a/src/api/admin/agent/confirmPolicy.ts
+++ b/src/api/admin/agent/confirmPolicy.ts
@@ -29,6 +29,9 @@ export const WRITE_TOOL_RISK_TIERS: Record<string, RiskTier> = {
   set_posthog: 'low',
   set_widget_theme: 'low',
   activate_avatar: 'low',
+  // 同じ is_active フラグを倒すだけで、activate_avatar で元に戻せる。
+  // 顧客の画面からアバターが消えるが、コンテンツは失われないため activate と同じ階層。
+  deactivate_avatar: 'low',
   // 社内向け分析レコードのステータス変更のみ。顧客影響なし・再度拾い直せる。
   dismiss_knowledge_gap: 'low',
 
@@ -68,6 +71,7 @@ export const NON_WRITE_TOOLS: readonly string[] = [
   'get_tenant_settings',
   'get_faq_list',
   'get_avatar_status',
+  'get_avatar_list',
   'get_embed_code',
   'get_tuning_rules',
   'get_weekly_briefing',

--- a/src/api/admin/agent/toolDefinitions.ts
+++ b/src/api/admin/agent/toolDefinitions.ts
@@ -217,17 +217,48 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
   {
     type: 'function',
     function: {
+      name: 'get_avatar_list',
+      description:
+        'アバター設定の一覧（ID・名前・稼働中かどうか）を取得する読み取り専用ツール。' +
+        'activate_avatar に渡す ID はこのツールで確認したものだけを使うこと。' +
+        'テナント自身の設定に加えて、そのまま使える既定の見本も返す。',
+      parameters: {
+        type: 'object',
+        properties: {},
+        required: [],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
       name: 'activate_avatar',
-      description: '指定した ID のアバター設定を有効化する（他のアバターは自動的に無効化される）',
+      description:
+        '指定した ID のアバター設定を有効化する（他のアバターは自動的に無効化される）。' +
+        'ID を推測してはならない。必ず get_avatar_list で確認した ID を使うこと。',
       parameters: {
         type: 'object',
         properties: {
           id: {
             type: 'string',
-            description: '有効化するアバター設定の ID',
+            description: '有効化するアバター設定の ID（get_avatar_list が返したもの）',
           },
         },
         required: ['id'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
+      name: 'deactivate_avatar',
+      description:
+        '稼働中のアバターを停止する（ウィジェットにアバターが表示されなくなる）。' +
+        '再開したい場合は activate_avatar で同じ設定を有効化すればよい。',
+      parameters: {
+        type: 'object',
+        properties: {},
+        required: [],
       },
     },
   },


### PR DESCRIPTION
Asana: feat: アバターの一覧・停止をチャットから可能にする（activate_avatar を実行可能にする）
GID 1217040717750004

## 背景

`activate_avatar` は `id` 必須だが、**候補一覧を返すツールが存在しない**。`get_avatar_status` は稼働中1件の名前しか返さないため、テナントは旧UIで id を確認してこない限りチャットからアバターを切り替えられなかった。旧UIのアバターページはクローズ対象に分類変更された（#591、`docs/LEGACY_UI_SUNSET.md` §1.2-9）ので、このままページを閉じると**切替手段そのものが消える**。

要件定義は `docs/AVATAR_CHAT_MIGRATION.md` §4.1 の層A。

## 変更内容

### `src/api/admin/agent/toolDefinitions.ts`
- `get_avatar_list`（読み取り専用）と `deactivate_avatar` を追加
- `activate_avatar` の description に「ID を推測してはならない。必ず `get_avatar_list` で確認した ID を使う」を明記

### `src/api/admin/agent/actionExecutor.ts`
- `get_avatar_list`: 自テナントの設定＋既定の見本を ID 付きで返す
- `deactivate_avatar`: 稼働中を停止する（`activate_avatar` で元に戻せる）
- `activate_avatar`: 失敗時の文言に「`get_avatar_list` で ID を確認」の一手を追加

### `src/api/admin/agent/confirmPolicy.ts`
- `get_avatar_list` → `NON_WRITE_TOOLS`、`deactivate_avatar` → `low`

### `admin-ui/src/pages/copilot-preview/index.tsx`
- `REAL_TOOL_LABEL` に2件追加（登録漏れは生の英語ツール名が画面に出る）
- `REAL_WRITE_TOOLS` に `deactivate_avatar` を追加（実書き込み件数バッジの対象）
- 左レール「アバター」の定型文を、稼働状況と一覧の両方を返す文面に変更

## 実装上の判断

**1. 既定アバターの扱い（最大の罠）**
既定アバター（`tenant_id = 'r2c_default'`、18体）は部分unique制約から除外されており（`migration_fix_active_constraint.sql`）**全行 `is_active = true`**。`is_active` だけで稼働中を判定すると見本18体がすべて「稼働中」に見える。稼働中の印は `tenant_id = 自テナント` の行にのみ付け、停止対象からも `is_default` 行を除外している。テストで固定した。

**2. 500字打ち切りへの対応**
ツール戻り値は500字で `truncate` される。UUID が36文字あるため一覧はすぐ溢れる。収まる分だけ出して**残件数を明示**する（黙って欠けさせない）。ページング引数は追加していない。

**3. `deactivate_avatar` に確認ゲートを付けていない**
既存の `activate_avatar` と同じ `is_active` フラグの操作で、`activate_avatar` で1手で戻せる。既存の兄弟操作と非対称にする理由がないため `low` で揃えた。ここは判断が分かれうるので、確認チップを挟むべきならレビューで指摘してほしい。

**4. UUID の事前検証は追加しなかった**
既存の3テストが `id: 'av-1'`（UUID でない）を渡しており、事前検証を入れると既存の回帰テストを書き換えることになる。不正な形式の ID は Postgres の 22P02 が既存の catch に落ちて 200 + 日本語メッセージになるため、要件（500にしない）は満たしている。テストで固定した。

## テスト

追加8件（backend 8 / frontend 1）:
- 既定アバターが `is_active=true` でも「稼働中」と表示されない
- 自テナントの稼働中には印が付く
- 30件でも500字以内で残件数が出る
- 0件時の文言
- 停止成功（SQL に `is_default` 除外条件が含まれることも検証）
- 稼働中が無いときは停止しない
- ID が UUID でない場合も500にならず一覧確認を促す
- 他テナントの ID では有効化されない
- 新ツールが日本語ラベルで表示される（生の英語名が出ない）

検証結果:
- `jest src/api/admin/agent` → 234 passed
- `vitest run`（admin-ui 全体）→ 251 passed
- `tsc --noEmit`（backend）→ 0 errors
- `oxlint src admin-ui/src --max-warnings 63` → exit 0
- `tsc -b`（admin-ui）→ 13 errors。**すべて `origin/main` 由来の既存エラー**（`pages/admin/options/index.test.tsx` の `tenantPlan` 欠落）で、件数は main と同一

## やっていないこと

- 新規ファイル・新規エンドポイント・新規テーブルの追加
- 旧UIアバターページの変更・削除・リダイレクト
- パネル（Surface A）への機能追加
- `avatar_wizard` / `avatar_studio` の handoff キーの削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StqjjaijseYkGkmG2k5LJ