### PR TITLE
fix: get_faq_listの件数が上限20で頭打ちになるのを直す

### DIFF
--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -285,7 +285,10 @@ export async function executeToolCall(
         // 「N件」として返しており、LIMIT 20 が総数の頭打ちに見えていた(#実測: 21件以上の
         // テナントで常に「20件」と誤答していた)。
         const [countRes, listRes] = await Promise.all([
-          db.query(`SELECT COUNT(*)::int AS n FROM faq_docs ${whereClause}`, whereParams),
+          db.query(
+            `SELECT COUNT(*)::int AS n FROM faq_docs ${whereClause}`,
+            whereParams,
+          ),
           db.query(
             `SELECT id, question, answer FROM faq_docs ${whereClause} ORDER BY created_at DESC LIMIT $${listParams.length}`,
             listParams,

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -272,28 +272,39 @@ export async function executeToolCall(
         const limit = Math.min(Math.max(Number(args['limit'] ?? 10), 1), 20);
         const search = typeof args['search'] === 'string' ? args['search'] : undefined;
 
-        const params: unknown[] = [tenantId];
+        const whereParams: unknown[] = [tenantId];
         let whereClause = 'WHERE tenant_id = $1';
 
         if (search) {
-          params.push(`%${search}%`);
-          whereClause += ` AND (question ILIKE $${params.length} OR answer ILIKE $${params.length})`;
+          whereParams.push(`%${search}%`);
+          whereClause += ` AND (question ILIKE $${whereParams.length} OR answer ILIKE $${whereParams.length})`;
         }
 
-        params.push(limit);
-        const result = await db.query(
-          `SELECT id, question, answer FROM faq_docs ${whereClause} ORDER BY created_at DESC LIMIT $${params.length}`,
-          params
-        );
+        const listParams = [...whereParams, limit];
+        // 表示件数(上限20)と総数(COUNT)を分けて取得する。以前は result.rows.length を
+        // 「N件」として返しており、LIMIT 20 が総数の頭打ちに見えていた(#実測: 21件以上の
+        // テナントで常に「20件」と誤答していた)。
+        const [countRes, listRes] = await Promise.all([
+          db.query(`SELECT COUNT(*)::int AS n FROM faq_docs ${whereClause}`, whereParams),
+          db.query(
+            `SELECT id, question, answer FROM faq_docs ${whereClause} ORDER BY created_at DESC LIMIT $${listParams.length}`,
+            listParams,
+          ),
+        ]);
 
-        if (result.rows.length === 0) {
+        if (listRes.rows.length === 0) {
           return truncate('FAQ が登録されていません');
         }
 
+        const total = Number(countRes.rows[0]?.n ?? listRes.rows.length);
+
         // anti-slop: answer は .slice(0,200) 必須 / console.log で内容出力禁止
-        const lines = (result.rows as { id: number; question: string; answer: string }[])
+        const lines = (listRes.rows as { id: number; question: string; answer: string }[])
           .map((r) => `[${r.id}] ${r.question} — ${r.answer.slice(0, 200)}`);
-        return truncate(`FAQ 一覧（${result.rows.length}件）:\n` + lines.join('\n'));
+        const header = total > listRes.rows.length
+          ? `FAQ 一覧（全${total}件中${listRes.rows.length}件を表示）:`
+          : `FAQ 一覧（${total}件）:`;
+        return truncate(`${header}\n` + lines.join('\n'));
       } catch (err) {
         logger.warn('[actionExecutor] get_faq_list failed', err);
         return truncate('FAQ 一覧の取得に失敗しました');

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -1548,6 +1548,88 @@ describe('POST /v1/admin/agent/chat', () => {
   });
 
   // -------------------------------------------------------------------------
+  // get_faq_list: 表示件数(上限20)と総数(COUNT)は別物
+  // -------------------------------------------------------------------------
+  describe('get_faq_list', () => {
+    function toolCallResponse(id: string, name: string, args: Record<string, unknown> = {}) {
+      return {
+        ok: true,
+        json: async () => ({
+          choices: [{
+            message: {
+              content: null,
+              tool_calls: [{ id, type: 'function', function: { name, arguments: JSON.stringify(args) } }],
+            },
+          }],
+        }),
+        text: async () => '',
+      };
+    }
+
+    it('総数が表示上限(20件)を超える場合、頭打ちにせず正しい総数を返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-fl-1', 'get_faq_list'))
+        .mockResolvedValueOnce(makeGroqResponse('FAQは合計25件です。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ n: 25 }] }) // COUNT(*)
+        .mockResolvedValueOnce({
+          rows: Array.from({ length: 10 }, (_, i) => ({ id: i + 1, question: `q${i}`, answer: `a${i}` })),
+        }); // 表示用(デフォルトlimit=10)
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'FAQは何件ある?', sessionId: 'sess-fl-01' });
+
+      expect(res.status).toBe(200);
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain('全25件中10件を表示');
+    });
+
+    it('総数が表示件数と同じ場合は「全N件中」を出さない', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-fl-2', 'get_faq_list'))
+        .mockResolvedValueOnce(makeGroqResponse('FAQは3件です。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ n: 3 }] })
+        .mockResolvedValueOnce({
+          rows: [
+            { id: 1, question: 'q1', answer: 'a1' },
+            { id: 2, question: 'q2', answer: 'a2' },
+            { id: 3, question: 'q3', answer: 'a3' },
+          ],
+        });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'FAQ一覧を見せて', sessionId: 'sess-fl-02' });
+
+      expect(res.status).toBe(200);
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain('FAQ 一覧（3件）:');
+      expect(result).not.toContain('全');
+    });
+
+    it('FAQが0件のとき「登録されていません」を返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-fl-3', 'get_faq_list'))
+        .mockResolvedValueOnce(makeGroqResponse('まだ登録がありません。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ n: 0 }] })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'FAQ一覧を見せて', sessionId: 'sess-fl-03' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('FAQ が登録されていません');
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // Phase3: suggest_faq / save_faq
   // -------------------------------------------------------------------------
   describe('suggest_faq / save_faq', () => {


### PR DESCRIPTION
## Summary
- get_faq_list が返す「N件」は LIMIT 20 のページサイズ(result.rows.length)で、テナントに登録されたFAQの実際の総数ではなかった。21件以上登録しているテナントに対して常に「20件」と誤答する
- COUNT(*)による総数取得を追加し、表示件数と総数を区別して返すようにする。表示上限(20件)自体は変更しない

Asana: 1217040449028912

**Base**: main(他の週次まとめPR群とは独立、並行merge可)

## Test plan
- [x] 総数>20の場合に正しい総数が表示されること
- [x] 総数=表示件数の場合は「全N件中」を出さないこと
- [x] 0件の場合の既存挙動が維持されること
- [x] 3ホップ連鎖テスト等、既存のget_faq_list利用テストの回帰なし(195/195 PASS)
- [x] pnpm typecheck / lint 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)