### PR TITLE
fix(agent): AI自動生成ルールの無断有効化を止める (is_active明示 + source='judge')

### DIFF
--- a/src/agent/judge/evaluationAnalyzer.test.ts
+++ b/src/agent/judge/evaluationAnalyzer.test.ts
@@ -147,6 +147,20 @@ describe('analyzeTuningRules', () => {
     expect(insertCalls[0][0]).toContain('ON CONFLICT DO NOTHING');
   });
 
+  it('3c. INSERT文でis_activeがfalseに明示される（列を省略するとスキーマ既定DEFAULT trueで無断有効化されるため）', async () => {
+    const mockRepo = createMockRepo(sampleEvaluations);
+    const mockPool = createMockPool();
+    mockCallGroq.mockResolvedValueOnce(mockRulesResponse);
+
+    await analyzeTuningRules('tenant-test', mockRepo as any, mockPool as any);
+
+    const insertCalls = (mockPool.query as jest.Mock).mock.calls.filter(
+      (call: any[]) => call[0].includes('INSERT INTO tuning_rules'),
+    );
+    expect(insertCalls[0][0]).toContain('is_active');
+    expect(insertCalls[0][0]).toContain('false');
+  });
+
   it('3b. INSERT文にevidence列が含まれ、返り値と同じevidenceがJSON永続化される（GID 1215916762299598: 以前は計算のみでDB未保存だった）', async () => {
     const mockRepo = createMockRepo(sampleEvaluations);
     const mockPool = createMockPool();

--- a/src/agent/judge/evaluationAnalyzer.ts
+++ b/src/agent/judge/evaluationAnalyzer.ts
@@ -138,11 +138,13 @@ export async function analyzeTuningRules(
 
     try {
       // ON CONFLICT DO NOTHING で重複防止（trigger_pattern と tenant_id でユニーク判定）
+      // is_active は必ず false で入れる。列を省略するとスキーマ既定 DEFAULT true が効いて
+      // 店主の承認なしに本番の応答方針へ即反映されてしまう(CLAUDE.md「指示ルールの不変ルール」)。
       await pool.query(
         `INSERT INTO tuning_rules
            (tenant_id, trigger_pattern, expected_behavior, priority,
-            source, suggested_at, evidence)
-         VALUES ($1, $2, $3, $4, 'judge', NOW(), $5::jsonb)
+            is_active, source, suggested_at, evidence)
+         VALUES ($1, $2, $3, $4, false, 'judge', NOW(), $5::jsonb)
          ON CONFLICT DO NOTHING`,
         [tenantId, rule.triggerPattern, rule.expectedBehavior, 0, JSON.stringify(evidence)],
       );

--- a/src/agent/judge/judgeEvaluator.test.ts
+++ b/src/agent/judge/judgeEvaluator.test.ts
@@ -196,6 +196,10 @@ describe('evaluateSession', () => {
     expect(mockPool.query.mock.calls.length).toBeGreaterThanOrEqual(5);
     const tuningInsertCall = mockPool.query.mock.calls[4]!;
     expect(tuningInsertCall[0]).toContain('tuning_rules');
+    // is_active=false と source='judge' が明示されること(店主の承認なしに有効化しない)
+    expect(tuningInsertCall[0]).toContain('is_active');
+    expect(tuningInsertCall[0]).toContain('false');
+    expect(tuningInsertCall[0]).toContain("'judge'");
   });
 
   it('3. high score does NOT insert tuning_rules (score >= 60)', async () => {

--- a/src/agent/judge/judgeEvaluator.ts
+++ b/src/agent/judge/judgeEvaluator.ts
@@ -304,10 +304,12 @@ export async function evaluateSession(sessionId: string): Promise<JudgeEvaluatio
     if (result.overall_score < threshold && result.suggested_rules.length > 0) {
       for (const rule of result.suggested_rules) {
         try {
+          // source='judge' を明示する。未設定だとスキーマ既定 'manual' になり、
+          // 店主が作ったルールと出所を区別できなくなる(承認導線で必須の情報)。
           await pool.query(
             `INSERT INTO tuning_rules
-               (tenant_id, trigger_pattern, expected_behavior, priority, is_active)
-             VALUES ($1, $2, $3, $4, false)
+               (tenant_id, trigger_pattern, expected_behavior, priority, is_active, source)
+             VALUES ($1, $2, $3, $4, false, 'judge')
              ON CONFLICT DO NOTHING`,
             [
               tenantId,


### PR DESCRIPTION
## 何をするPRか

指示ルール(tuning_rules)は店主が承認していないルールが本番の応答方針に無断で注入されないことが不変条件(CLAUDE.md「指示ルール(tuning_rules)の不変ルール」)。2つのjudge由来ルール生成経路でこの条件が破れていた(D8)。

## 直した内容

| ファイル | 問題 | 対処 |
|---|---|---|
| `src/agent/judge/evaluationAnalyzer.ts` | INSERTで`is_active`列を省略しており、スキーマ既定`DEFAULT true`が効いて即座に有効化されていた | `is_active=false`を明示 |
| `src/agent/judge/judgeEvaluator.ts` | `is_active=false`は既に正しかったが、`source`列が未設定(既定`'manual'`)で店主が作ったルールと出所を区別できなかった | `source='judge'`を明示 |

grepで確認した第3のINSERT経路(`evaluationsRepository.ts`の`insertTuningRuleFromSuggestion`)は`routes.ts`の`action==='approve'`後にのみ呼ばれる承認済み経路で、`is_active=true`は正しい。修正不要。

## テスト

- `evaluationAnalyzer.test.ts` / `judgeEvaluator.test.ts` に回帰テストを追加(is_active=false / source='judge'の検証)
- 対象2ファイル: typecheck OK / lint(oxlint) OK
- dead-code-check: 既知の4件(notionSchemas.ts、無関係)のみ
- security-scan: CRITICAL/HIGH = 0、PASS

## 注意

⚠️ 既にこのバグの影響で`is_active=true`のまま入ってしまったjudge由来ルールの棚卸しは別タスク(P1-2)。本PRはコードの是正のみ。

Asana: https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217040570337126

🤖 Generated with [Claude Code](https://claude.com/claude-code)