### PR TITLE
refactor(tuning): 一致判定を純関数に切り出し、区切り文字と表記ゆれを吸収する (D1/D2)

### DIFF
--- a/src/agent/tools/synthesisTool.ts
+++ b/src/agent/tools/synthesisTool.ts
@@ -7,6 +7,7 @@ import {
   getActiveRulesForTenant,
   buildTuningPromptSection,
 } from '../../api/admin/tuning/tuningRulesRepository';
+import { matchesTriggerPattern } from '../../api/admin/tuning/triggerMatching';
 import type { PrincipleChunk } from '../psychology/principleSearch';
 import { selectVariant, type PromptVariant } from '../ab-test/variantSelector';
 import type { BehaviorContext } from '../../api/events/behaviorContext';
@@ -122,19 +123,6 @@ const BASE_SYSTEM_PROMPT = `あなたは中古車販売店のAIコンシェル�
 - 敬語を使う
 - 箇条書きではなく自然な文章で答える
 - FAQ情報が不十分な場合は「詳しくはお問い合わせください」と案内する`;
-
-/**
- * チューニングルールのトリガーパターンがクエリにマッチするか判定する。
- * trigger_pattern はカンマ区切りのキーワードリスト。
- */
-function matchesTriggerPattern(query: string, triggerPattern: string): boolean {
-  const lowerQuery = query.toLowerCase();
-  return triggerPattern
-    .split(',')
-    .map((k) => k.trim())
-    .filter(Boolean)
-    .some((k) => lowerQuery.includes(k.toLowerCase()));
-}
 
 /**
  * Groq LLM（llama-3.3-70b-versatile）で自然な日本語回答を生成する。

--- a/src/api/admin/tuning/triggerMatching.test.ts
+++ b/src/api/admin/tuning/triggerMatching.test.ts
@@ -1,0 +1,93 @@
+// src/api/admin/tuning/triggerMatching.test.ts
+
+import { matchesTriggerPattern, getMatchingKeywords, splitTriggerKeywords } from './triggerMatching';
+
+describe('splitTriggerKeywords — 区切り文字', () => {
+  it('半角カンマで分割する', () => {
+    expect(splitTriggerKeywords('保証,返品')).toEqual(['保証', '返品']);
+  });
+
+  it('全角カンマで分割する(D1: 以前は1個のキーワード扱いで永久に不一致だった)', () => {
+    expect(splitTriggerKeywords('保証，返品')).toEqual(['保証', '返品']);
+  });
+
+  it('読点(、)で分割する(D1: 日本語として最も自然な区切り)', () => {
+    expect(splitTriggerKeywords('保証、返品')).toEqual(['保証', '返品']);
+  });
+
+  it('区切り文字が混在していても分割する', () => {
+    expect(splitTriggerKeywords('保証、返品,送料')).toEqual(['保証', '返品', '送料']);
+  });
+
+  it('前後の空白を除去する', () => {
+    expect(splitTriggerKeywords(' 保証 、 返品 ')).toEqual(['保証', '返品']);
+  });
+
+  it('空要素は除去する(連続区切り・先頭末尾の区切り)', () => {
+    expect(splitTriggerKeywords('保証、、返品、')).toEqual(['保証', '返品']);
+  });
+
+  it('空文字列は空配列を返す', () => {
+    expect(splitTriggerKeywords('')).toEqual([]);
+  });
+
+  it('区切り文字を含まない単一キーワードはそのまま1件になる', () => {
+    expect(splitTriggerKeywords('保証')).toEqual(['保証']);
+  });
+});
+
+describe('matchesTriggerPattern — 表記ゆれ吸収(D2)', () => {
+  it('完全一致する', () => {
+    expect(matchesTriggerPattern('保証について教えて', '保証')).toBe(true);
+  });
+
+  it('全角カンマ区切りのキーワードが質問文にあれば発火する(D1の回帰)', () => {
+    expect(matchesTriggerPattern('保証について教えて', '保証，返品')).toBe(true);
+    expect(matchesTriggerPattern('返品したいです', '保証，返品')).toBe(true);
+  });
+
+  it('読点区切りのキーワードが質問文にあれば発火する(D1の回帰)', () => {
+    expect(matchesTriggerPattern('保証について教えて', '保証、返品')).toBe(true);
+  });
+
+  it('ひらがな⇔カタカナの表記ゆれで一致する', () => {
+    expect(matchesTriggerPattern('ホショウについて教えて', '保証')).toBe(false); // 漢字とカタカナは別表記なので不一致(想定どおり)
+    expect(matchesTriggerPattern('ほしょうについて教えて', 'ホショウ')).toBe(true); // かな⇔カナは一致
+    expect(matchesTriggerPattern('ホショウについて教えて', 'ほしょう')).toBe(true);
+  });
+
+  it('全角英数字と半角英数字の表記ゆれで一致する', () => {
+    expect(matchesTriggerPattern('ＳＮＳ運用について', 'SNS')).toBe(true);
+    expect(matchesTriggerPattern('SNS運用について', 'ＳＮＳ')).toBe(true);
+  });
+
+  it('大文字小文字の表記ゆれで一致する', () => {
+    expect(matchesTriggerPattern('ABCで困っています', 'abc')).toBe(true);
+  });
+
+  it('質問文にキーワードが含まれなければ不一致', () => {
+    expect(matchesTriggerPattern('営業時間を教えて', '保証、返品')).toBe(false);
+  });
+
+  it('空のtrigger_patternは常に不一致(既存仕様どおり)', () => {
+    expect(matchesTriggerPattern('保証について教えて', '')).toBe(false);
+  });
+
+  it('「（常時適用）」は特別扱いせず、文字列として不一致になる(D4はsave側で防ぐ別スコープ)', () => {
+    expect(matchesTriggerPattern('保証について教えて', '（常時適用）')).toBe(false);
+  });
+});
+
+describe('getMatchingKeywords — 可視化用の発火キーワード抽出', () => {
+  it('発火したキーワードのみを返す', () => {
+    expect(getMatchingKeywords('保証について教えて', '保証、返品、送料')).toEqual(['保証']);
+  });
+
+  it('複数のキーワードが同時に発火する場合は全件返す', () => {
+    expect(getMatchingKeywords('保証と返品について教えて', '保証、返品')).toEqual(['保証', '返品']);
+  });
+
+  it('発火しない場合は空配列を返す', () => {
+    expect(getMatchingKeywords('営業時間を教えて', '保証、返品')).toEqual([]);
+  });
+});

--- a/src/api/admin/tuning/triggerMatching.ts
+++ b/src/api/admin/tuning/triggerMatching.ts
@@ -1,0 +1,46 @@
+// src/api/admin/tuning/triggerMatching.ts
+// 指示ルール(tuning_rules)の発火条件判定。DB・ネットワークに触れない純関数。
+//
+// 旧UI(/admin/tuning)経由で保存されたルールと、チャット(/copilot-preview)経由で
+// 保存されたルールが、同じ質問文に対して同じ発火可否を返すことを保証するため、
+// この判定は1箇所にのみ実装する(2箇所に複製すると挙動が割れる。
+// CLAUDE.md「指示ルール(tuning_rules)の不変ルール」)。
+//
+// 発火条件の可視化(下書きカードでの提示)も getMatchingKeywords の結果を使うこと。
+// 判定と可視化が別ロジックだと、カードには出ない条件で発火する/しないという
+// 食い違いが起こる。
+
+// trigger_pattern の区切り文字: 半角カンマ・全角カンマ・読点(、)
+const DELIMITER_RE = /[,，、]/;
+
+// カタカナ(U+30A1-U+30F6) → ひらがな(U+3041-U+3096)への折り畳み。
+// NFKC は全角英数・半角カナ等は正規化するが、カタカナ⇔ひらがなは変換しないため別途行う。
+function katakanaToHiragana(s: string): string {
+  return s.replace(/[ァ-ヶ]/g, (ch) => String.fromCharCode(ch.charCodeAt(0) - 0x60));
+}
+
+function normalize(s: string): string {
+  return katakanaToHiragana(s.normalize('NFKC')).toLowerCase().trim();
+}
+
+/** trigger_pattern をキーワード配列に分割する(空要素・前後空白は除去)。 */
+export function splitTriggerKeywords(triggerPattern: string): string[] {
+  return triggerPattern
+    .split(DELIMITER_RE)
+    .map((k) => k.trim())
+    .filter(Boolean);
+}
+
+/**
+ * クエリ文字列に対して実際に発火するキーワードを返す(0件なら不一致)。
+ * 表記ゆれ(全角半角・ひらがな/カタカナ)は正規化した上で部分一致を取る。
+ */
+export function getMatchingKeywords(query: string, triggerPattern: string): string[] {
+  const normalizedQuery = normalize(query);
+  return splitTriggerKeywords(triggerPattern).filter((k) => normalizedQuery.includes(normalize(k)));
+}
+
+/** チューニングルールのトリガーパターンがクエリにマッチするか判定する。 */
+export function matchesTriggerPattern(query: string, triggerPattern: string): boolean {
+  return getMatchingKeywords(query, triggerPattern).length > 0;
+}


### PR DESCRIPTION
## 何をするPRか

`matchesTriggerPattern`(`src/agent/tools/synthesisTool.ts`)はtrigger_patternを半角カンマでのみ分割し、表記ゆれの正規化も無かった。日本語として自然に「保証、返品」と書くと1個のキーワード扱いになり永久に一致しない(D1)。ひらがな/カタカナ・全角半角の言い換えでも不発だった(D2)。

## 直した内容

`src/api/admin/tuning/triggerMatching.ts` を新規作成し、判定ロジックをDB/ネットワークに触れない純関数として切り出した。

- 区切り文字: 半角カンマ・全角カンマ・読点(、)
- 正規化: NFKC + カタカナ→ひらがな折り畳み + 小文字化
- `getMatchingKeywords`: 発火したキーワードを返す(可視化用途とも共有し、判定と可視化が食い違わないようにする)

`synthesisTool.ts` のローカル定義は削除しimportに置き換え。判定ロジックの実装がリポジトリ内で1箇所であることをgrepで確認済み。

## 新規ファイルを作った理由

判定はDB/ネットワークに触れない純関数で、正規化と区切りの組み合わせをケース表で潰すのが品質担保の手段。従来はsynthesisTool内部にあり単体テストできなかった。`confirmPolicy.ts`/`agentAuditLog.ts`と同じ粒度・同じ機能ディレクトリ・隣に`*.test.ts`という既存の先例に一致する(CLAUDE.md「実装の置き場所」の例外条件)。

「（常時適用）」は特別扱いしない(単なる文字列として不一致になる)。それを保存させないための対処は別PR(P2-2)の担当。

## テスト

- `triggerMatching.test.ts` 新規20件(区切り文字8件・表記ゆれ9件・可視化3件)
- typecheck OK / lint(oxlint) OK
- dead-code-check: 既知の4件(notionSchemas.ts、無関係)のみ
- security-scan: CRITICAL/HIGH = 0、PASS

Asana: https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217040612864578

🤖 Generated with [Claude Code](https://claude.com/claude-code)