### PR TITLE
fix(agent): 「（常時適用）」が永久に発火しないルールとして保存されるのを止める (D4)

### DIFF
--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -43,6 +43,11 @@ const MAX_IMPORT_FAQS = 20;
 // zod スキーマ(z.string().min(1).max(2000))と揃える。
 const MAX_OPERATOR_REPLY_LENGTH = 2000;
 
+// suggest_tuning_rule がトリガー未決定時に案内していたプレースホルダ文字列。
+// save_tuning_rule にそのまま渡ってきた場合、文字列としてtrigger_patternに
+// 保存させない(D4: 保存は成功するが質問文に一致せず永久に発火しない)。
+const ALWAYS_APPLY_PLACEHOLDER = new Set(['（常時適用）']);
+
 // ---------------------------------------------------------------------------
 // プラン制限の案内文
 // ---------------------------------------------------------------------------
@@ -689,9 +694,22 @@ export async function executeToolCall(
           return truncate('提案の生成に失敗しました。もう少し具体的に教えてください');
         }
 
+        // トリガーが決められなかった場合、「（常時適用）」等のプレースホルダを
+        // 提案値として見せない。それをそのまま save_tuning_rule に渡すと、
+        // 文字列としてtrigger_patternに保存され永久に発火しないルールができる(D4)。
+        // どんな質問の時に使うかを店主に聞き返し、save_tuning_rule へは進めない。
+        if (!suggestion.trigger_pattern) {
+          return truncate(
+            `対応方針の候補: ${suggestion.instruction}\n` +
+            (suggestion.reason ? `理由: ${suggestion.reason}\n` : '') +
+            `\nこの振る舞いは、お客様がどんな質問をした時に使いたいですか？キーワードを教えてください（例:「保証」「返品」など）。` +
+            `決まったら、もう一度 suggest_tuning_rule を呼び出してください。`
+          );
+        }
+
         return truncate(
           `提案:\n` +
-          `トリガー: ${suggestion.trigger_pattern || '（常時適用）'}\n` +
+          `トリガー: ${suggestion.trigger_pattern}\n` +
           `対応方針: ${suggestion.instruction}\n` +
           `優先度: ${suggestion.priority}\n` +
           (suggestion.reason ? `理由: ${suggestion.reason}\n` : '') +
@@ -716,6 +734,14 @@ export async function executeToolCall(
       }
       if (!triggerPattern || !expectedBehavior) {
         return truncate('trigger_pattern と expected_behavior は必須です');
+      }
+      // suggest_tuning_rule がトリガー未決定時に案内していた文字列(「（常時適用）」)が
+      // そのままtrigger_patternとして渡ってきた場合の防御(D4)。これを通すと
+      // 保存は成功するが質問文に一致せず永久に発火しないルールができる。
+      if (ALWAYS_APPLY_PLACEHOLDER.has(triggerPattern)) {
+        return truncate(
+          'トリガーが決まっていないようです。お客様のどんな質問の時にこの振る舞いを使うか、キーワードを教えてください（例:「保証」「返品」など）。'
+        );
       }
       if (!tenantId) {
         return truncate('テナントが特定できません。super_admin の場合は対象テナントを指定してください');

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -914,6 +914,43 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(res.body.actions[0].tool).toBe('suggest_tuning_rule');
       expect(res.body.actions[0].result).toContain('保証期間は2年とお伝えする');
     });
+
+    it('D4: トリガーが決まらない場合は「（常時適用）」を提案せず、聞き返す文言を返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            choices: [{
+              message: {
+                content: null,
+                tool_calls: [{
+                  id: 'call-tr-2',
+                  type: 'function',
+                  function: { name: 'suggest_tuning_rule', arguments: JSON.stringify({ free_text: 'なるべく丁寧にお願いできますか' }) },
+                }],
+              },
+            }],
+          }),
+          text: async () => '',
+        })
+        .mockResolvedValueOnce(makeGroqResponse('どんな時か教えてください。'));
+
+      mockCallGroq8bSuggestFromText.mockResolvedValueOnce({
+        trigger_pattern: '',
+        instruction: '丁寧な言葉遣いで応対する',
+        priority: 5,
+        reason: '',
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'なるべく丁寧にお願いできますか', sessionId: 'sess-030b' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).not.toContain('常時適用');
+      expect(res.body.actions[0].result).toContain('どんな質問をした時に使いたいですか');
+      expect(res.body.actions[0].result).not.toContain('save_tuning_rule を呼び出してください');
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -1007,6 +1044,42 @@ describe('POST /v1/admin/agent/chat', () => {
         }),
       );
       expect(res.body.actions[0].result).toContain('ID: 42');
+    });
+
+    it('D4: trigger_pattern が「（常時適用）」のまま渡された場合は保存せず聞き返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            choices: [{
+              message: {
+                content: null,
+                tool_calls: [{
+                  id: 'call-sv-3',
+                  type: 'function',
+                  function: {
+                    name: 'save_tuning_rule',
+                    arguments: JSON.stringify({
+                      trigger_pattern: '（常時適用）',
+                      expected_behavior: '丁寧な言葉遣いで応対する',
+                      confirmed: true,
+                    }),
+                  },
+                }],
+              },
+            }],
+          }),
+          text: async () => '',
+        })
+        .mockResolvedValueOnce(makeGroqResponse('どんな時か教えてください。'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'お願い', sessionId: 'sess-032b' });
+
+      expect(res.status).toBe(200);
+      expect(mockCreateRule).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('どんな質問の時にこの振る舞いを使うか');
     });
   });
 


### PR DESCRIPTION
## 何をするPRか

`suggest_tuning_rule`はトリガーが決められない時「トリガー: （常時適用）」という文字列を提案値として表示し、そのまま`save_tuning_rule`を呼ぶよう指示していた。`save_tuning_rule`は空トリガーは拒否するが、この文字列は非空のため通過し、質問文には一致しない(`matchesTriggerPattern`は表記そのものを含む質問でしか発火しない)ため、**保存は成功するが永久に発火しないルール**ができていた(D4: 最悪の失敗形=成功に見える不発)。

## 直した内容

- `suggest_tuning_rule`: トリガー未決定時は「（常時適用）」を提案せず、どんな質問の時に使いたいかを店主に聞き返す。`save_tuning_rule`を呼び出す指示も付けない(下書き提示を止める)。
- `save_tuning_rule`: 防御として`ALWAYS_APPLY_PLACEHOLDER`を弾き、同じく聞き返す文言を返す(旧クライアントや将来の変更で文字列がそのまま渡ってきた場合の保険)。

grepで確認: 「常時適用」の他の出現箇所なし。

## テスト

- `agentRoutes.test.ts`に回帰テストを追加(suggest側・save側それぞれ)
- typecheck OK / lint(oxlint) OK
- dead-code-check: 既知の4件(notionSchemas.ts、無関係)のみ
- security-scan: CRITICAL/HIGH = 0、PASS
- 環境メモ: `agentRoutes.test.ts`は並列実行だとサンドボックスのポート競合で無関係なテストが稀に単発タイムアウトする(baselineでも再現)。`--runInBand`で安定。対象テストは複数回の単体実行で確認済み。

Asana: https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217040717631892

🤖 Generated with [Claude Code](https://claude.com/claude-code)