### PR TITLE
fix(admin-ui): 下書きカードを実際に保存される内容と一致させる (D6)

### DIFF
--- a/admin-ui/src/lib/useAgentChatTransport.ts
+++ b/admin-ui/src/lib/useAgentChatTransport.ts
@@ -76,6 +76,15 @@ export type TuningRulesListAgentActionCard = {
   totalCount: number;
 };
 
+// suggest_tuning_rule の下書き提案(D6)。truncateされない生の提案値を運び、
+// save_tuning_rule に渡される内容とカードの表示内容を一致させる。
+export type TuningRuleDraftAgentActionCard = {
+  kind: "tuning_rule_draft";
+  triggerPattern: string;
+  expectedBehavior: string;
+  priority: number;
+};
+
 // フィールド形状は actionExecutor.ts の WeeklySummaryCardPayload と1対1に保つ。
 export type WeeklySummaryAgentActionCard = {
   kind: "weekly_summary";
@@ -92,6 +101,7 @@ export type AgentActionCard =
   | LegacyLinkAgentActionCard
   | AvatarPresetAgentActionCard
   | TuningRulesListAgentActionCard
+  | TuningRuleDraftAgentActionCard
   | WeeklySummaryAgentActionCard
   | ChatSessionListAgentActionCard
   | ChatSessionMessagesAgentActionCard

--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -884,6 +884,65 @@ describe("CopilotPreviewPage — 構造化カード(card)からの描画", () =>
     // 完全一致ではなく正規表現の部分一致で確認する(他のagentAction回帰テストと同じ形式)。
     expect(await screen.findByText(/有効な指示ルールはありません/)).toBeTruthy();
   });
+
+  // D6: 下書きカードの表示内容が保存内容(トリガー/対応方針/優先度)と一致することの回帰。
+  it("suggest_tuning_rule: cardがあれば優先度も表示される(D6、以前は黙って捨てられていた)", async () => {
+    mockAgent({
+      reply: "こう提案します。保存してよいですか？",
+      actions: [
+        {
+          tool: "suggest_tuning_rule",
+          result: "提案:\nトリガー: 保証\n対応方針: 2年とお伝えする\n優先度: 8\n",
+          card: { kind: "tuning_rule_draft", triggerPattern: "保証", expectedBehavior: "2年とお伝えする", priority: 8 },
+        },
+      ],
+    });
+
+    await send("保証について聞かれたら2年と答えて");
+
+    expect(await screen.findByText("どんな時に")).toBeTruthy();
+    expect(screen.getByText("保証")).toBeTruthy();
+    expect(screen.getByText("2年とお伝えする")).toBeTruthy();
+    expect(screen.getByText("優先度")).toBeTruthy();
+    expect(screen.getByText("高")).toBeTruthy();
+  });
+
+  it("suggest_tuning_rule: 対応方針が複数行でも1行目だけに切られず全行表示される(D6)", async () => {
+    const multiline = "1行目の案内。\n2行目の補足。\n3行目の締めくくり。";
+    mockAgent({
+      reply: "こう提案します。保存してよいですか？",
+      actions: [
+        {
+          tool: "suggest_tuning_rule",
+          result: `提案:\nトリガー: 保証\n対応方針: ${multiline}\n優先度: 5\n`,
+          card: { kind: "tuning_rule_draft", triggerPattern: "保証", expectedBehavior: multiline, priority: 5 },
+        },
+      ],
+    });
+
+    await send("保証について聞かれたら2年と答えて");
+
+    expect(await screen.findByText("1行目の案内。", { exact: false })).toBeTruthy();
+    expect(screen.getByText("2行目の補足。", { exact: false })).toBeTruthy();
+    expect(screen.getByText("3行目の締めくくり。", { exact: false })).toBeTruthy();
+  });
+
+  it("suggest_tuning_rule: cardが無い場合は従来どおり自然文の正規表現パースでカードになる(後方互換)", async () => {
+    mockAgent({
+      reply: "こう提案します。保存してよいですか？",
+      actions: [
+        { tool: "suggest_tuning_rule", result: "提案:\nトリガー: 保証\n対応方針: 2年とお伝えする\n優先度: 5\n" },
+      ],
+    });
+
+    await send("保証について聞かれたら2年と答えて");
+
+    expect(await screen.findByText("どんな時に")).toBeTruthy();
+    expect(screen.getByText("保証")).toBeTruthy();
+    expect(screen.getByText("2年とお伝えする")).toBeTruthy();
+    // card が無い正規表現フォールバック経路には優先度が無いため表示されない
+    expect(screen.queryByText("優先度")).toBeNull();
+  });
 });
 
 function getComposer(): HTMLTextAreaElement {

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -76,7 +76,8 @@ interface TenantOption {
 
 type Card =
   | { kind: "faq"; question: string; answer: string; category: string }
-  | { kind: "rule"; trigger: string; behavior: string }
+  // priorityはcard経由(D6)の場合のみ入る。正規表現フォールバック時は未設定のまま。
+  | { kind: "rule"; trigger: string; behavior: string; priority?: number }
   | { kind: "engagement"; when: string; message: string }
   | { kind: "success"; text: string }
   | { kind: "link"; label: string; url: string; description: string }
@@ -140,6 +141,9 @@ type Card =
       pendingTuningRules: number | null;
       gaps: { total: number; top: Array<{ id: number; question: string }> } | null;
     };
+
+// 優先度3段階(lib/tuningPriority.ts)の店主向け表示ラベル。rule / rulesList カードで共有する。
+const TIER_LABEL: Record<"low" | "normal" | "high", string> = { low: "低", normal: "普通", high: "高" };
 
 // 自由入力欄からの実API呼び出しで使うツール名 → 日本語ラベル
 const REAL_TOOL_LABEL: Record<string, string> = {
@@ -570,6 +574,15 @@ export default function CopilotPreviewPage() {
           id: nextId(),
           role: "ai",
           card: { kind: "weeklySummary", asOf, sessions, avgScore, conversions, faq, pendingTuningRules, gaps },
+        };
+      }
+      // D6: 優先度を含め、正規表現では拾えなかった内容(複数行の対応方針)もそのまま運ぶ。
+      if (a.card?.kind === "tuning_rule_draft") {
+        const { triggerPattern, expectedBehavior, priority } = a.card;
+        return {
+          id: nextId(),
+          role: "ai",
+          card: { kind: "rule", trigger: triggerPattern, behavior: expectedBehavior, priority },
         };
       }
       if (a.tool === "suggest_faq") {
@@ -1588,11 +1601,11 @@ function CardShell({ hd, tone = "agent", children, foot }: { hd: React.ReactNode
   );
 }
 
-function Field({ k, v, quote, hi }: { k: string; v: string; quote?: boolean; hi?: boolean }) {
+function Field({ k, v, quote, hi, pre }: { k: string; v: string; quote?: boolean; hi?: boolean; pre?: boolean }) {
   return (
     <div style={{ fontSize: 15 }}>
       <div style={{ fontSize: 12.5, color: "var(--muted-foreground)", fontWeight: 600, marginBottom: 4 }}>{k}</div>
-      <div style={{ color: "var(--foreground)", ...(quote ? { background: "var(--muted, rgba(120,120,140,0.1))", borderRadius: 10, padding: "10px 14px", borderLeft: `3px solid ${hi ? "#d99320" : AGENT}`, lineHeight: 1.7 } : {}) }}>{v}</div>
+      <div style={{ color: "var(--foreground)", ...(pre ? { whiteSpace: "pre-wrap" } : {}), ...(quote ? { background: "var(--muted, rgba(120,120,140,0.1))", borderRadius: 10, padding: "10px 14px", borderLeft: `3px solid ${hi ? "#d99320" : AGENT}`, lineHeight: 1.7 } : {}) }}>{v}</div>
     </div>
   );
 }
@@ -1623,11 +1636,13 @@ function CardView({ card }: { card: Card }) {
         <CardShell hd={<><span>🎛️</span>AIへの指示ルールを追加します</>}
           foot={<CardActionsNote note="「いつ・どう振る舞うか」を1つの指示にまとめました。" />}>
           <Field k="どんな時に" v={card.trigger} />
-          <Field k="こう振る舞う" v={card.behavior} quote />
+          <Field k="こう振る舞う" v={card.behavior} quote pre />
+          {card.priority !== undefined && (
+            <Field k="優先度" v={TIER_LABEL[priorityToTier(card.priority)]} />
+          )}
         </CardShell>
       );
-    case "rulesList": {
-      const tierLabel: Record<"low" | "normal" | "high", string> = { low: "低", normal: "普通", high: "高" };
+    case "rulesList":
       return (
         <CardShell hd={<><span>🎛️</span>指示ルール一覧（{card.totalCount}件）</>}>
           {card.rules.map((r) => (
@@ -1637,7 +1652,7 @@ function CardView({ card }: { card: Card }) {
             >
               <div style={{ display: "flex", alignItems: "center", gap: 10, fontSize: 12.5, color: "var(--muted-foreground)" }}>
                 <span>{r.isActive ? "✅ 有効" : "⏸️ 無効"}</span>
-                <span>優先度: {tierLabel[priorityToTier(r.priority)]}</span>
+                <span>優先度: {TIER_LABEL[priorityToTier(r.priority)]}</span>
               </div>
               <div style={{ fontSize: 14.5, color: "var(--foreground)" }}>
                 <strong>{r.triggerPattern}</strong> → {r.expectedBehavior}
@@ -1646,7 +1661,6 @@ function CardView({ card }: { card: Card }) {
           ))}
         </CardShell>
       );
-    }
     case "engagement":
       return (
         <CardShell hd={<><span>⚡</span>お客様への声がけを設定します</>}

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -222,6 +222,19 @@ export type TuningRulesListCardPayload = {
   totalCount: number;
 };
 
+// suggest_tuning_rule の下書き提案。D6: フロントは自然文を正規表現で
+// (トリガー:(.+) / 対応方針:(.+))読み直しており、①優先度を拾えない
+// ②対応方針が複数行だと1行目以降が失われる、という2つの欠落があった。
+// この card は truncate されない生の提案値を運ぶため、save_tuning_rule に
+// そのまま渡される内容(trigger_pattern/expected_behavior/priority)と
+// カードの表示内容が一致する。
+export type TuningRuleDraftCardPayload = {
+  kind: 'tuning_rule_draft';
+  triggerPattern: string;
+  expectedBehavior: string;
+  priority: number;
+};
+
 // get_weekly_briefing 用。数値はLLMの生成文を経由せず、この構造化データを
 // そのままカードとして描画する(数値=サーバ、解釈=LLMの文、という権威分離の実体)。
 // 各グループは対応するクエリが失敗した場合に null になる(Promise.allSettledでの
@@ -270,6 +283,7 @@ export type ActionCardPayload =
   | LegacyLinkCardPayload
   | AvatarPresetCardPayload
   | TuningRulesListCardPayload
+  | TuningRuleDraftCardPayload
   | WeeklySummaryCardPayload
   | ChatSessionListCardPayload
   | ChatSessionMessagesCardPayload
@@ -918,14 +932,22 @@ export async function executeToolCall(
           );
         }
 
-        return truncate(
-          `提案:\n` +
-          `トリガー: ${suggestion.trigger_pattern}\n` +
-          `対応方針: ${suggestion.instruction}\n` +
-          `優先度: ${suggestion.priority}\n` +
-          (suggestion.reason ? `理由: ${suggestion.reason}\n` : '') +
-          `\nこの内容でよいかユーザーに確認し、同意が得られたら save_tuning_rule を呼び出してください（trigger_pattern/expected_behavior/priority は上記の提案値を使うこと）。`
-        );
+        return {
+          text: truncate(
+            `提案:\n` +
+            `トリガー: ${suggestion.trigger_pattern}\n` +
+            `対応方針: ${suggestion.instruction}\n` +
+            `優先度: ${suggestion.priority}\n` +
+            (suggestion.reason ? `理由: ${suggestion.reason}\n` : '') +
+            `\nこの内容でよいかユーザーに確認し、同意が得られたら save_tuning_rule を呼び出してください（trigger_pattern/expected_behavior/priority は上記の提案値を使うこと）。`
+          ),
+          card: {
+            kind: 'tuning_rule_draft',
+            triggerPattern: suggestion.trigger_pattern,
+            expectedBehavior: suggestion.instruction,
+            priority: suggestion.priority,
+          },
+        };
       } catch (err) {
         logger.warn('[actionExecutor] suggest_tuning_rule failed', err);
         return truncate('ルールの提案に失敗しました');

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -927,6 +927,48 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(res.body.actions[0].result).toContain('保証期間は2年とお伝えする');
     });
 
+    // D6: 下書きカードに優先度を表示し、複数行の対応方針も欠落なく運ぶための構造化カード。
+    it('D6: cardにtrigger_pattern/expected_behavior/priorityがtruncateされずそのまま載る', async () => {
+      const multilineInstruction = '1行目の案内。\n2行目の補足。\n3行目の締めくくり。';
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            choices: [{
+              message: {
+                content: null,
+                tool_calls: [{
+                  id: 'call-tr-1b',
+                  type: 'function',
+                  function: { name: 'suggest_tuning_rule', arguments: JSON.stringify({ free_text: '保証について聞かれたら2年と答えて' }) },
+                }],
+              },
+            }],
+          }),
+          text: async () => '',
+        })
+        .mockResolvedValueOnce(makeGroqResponse('こう提案します。保存してよいですか？'));
+
+      mockCallGroq8bSuggestFromText.mockResolvedValueOnce({
+        trigger_pattern: '保証',
+        instruction: multilineInstruction,
+        priority: 8,
+        reason: '',
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '保証について聞かれたら2年と答えて', sessionId: 'sess-030c' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].card).toEqual({
+        kind: 'tuning_rule_draft',
+        triggerPattern: '保証',
+        expectedBehavior: multilineInstruction,
+        priority: 8,
+      });
+    });
+
     it('D4: トリガーが決まらない場合は「（常時適用）」を提案せず、聞き返す文言を返す', async () => {
       mockFetch
         .mockResolvedValueOnce({


### PR DESCRIPTION
## 何をするPRか

`suggest_tuning_rule`は「優先度: N」を自然文で返していたが、フロントの`parseSuggestTuningRule`はトリガーと対応方針しか正規表現で拾わず、**優先度は黙って捨てられていた**(D6)。対応方針が複数行の場合も`(.+)`が改行に一致しないため1行目以降が失われていた。

## 直した内容

P2-3(#609)で確立したcardパターンを踏襲:

- `actionExecutor.ts`: `TuningRuleDraftCardPayload`を追加。`suggest_tuning_rule`の成功時、truncateされない生の提案値(trigger_pattern/expected_behavior/priority)をcardとして返す。text(自然文)は変更なし。
- `agentRoutes.ts` / `useAgentChatTransport.ts`: `ActionResult.card` / `AgentActionCard`のunionに追加。
- `copilot-preview/index.tsx`:
  - `type Card`の`rule`バリアントに任意の`priority`を追加(card経由の場合のみ入る。正規表現フォールバック時は未設定)
  - `card.kind === "tuning_rule_draft"`の分岐を追加(既存の正規表現パーサは変更なし、後方互換)
  - `Field`に任意の`pre`(`white-space: pre-wrap`)を追加し、ruleカードの「こう振る舞う」に適用。複数行の対応方針が視覚的にも失われない
  - `rulesList`case にあった`tierLabel`ローカル定数を`TIER_LABEL`としてモジュールレベルに格上げし、rule/rulesList双方で共有(重複排除)

## テスト

- `agentRoutes.test.ts`: cardにtrigger_pattern/expected_behavior/priorityがtruncateされずそのまま載ることを検証
- `index.test.tsx`: 優先度表示・複数行対応方針の全行表示・card無し時の後方互換(優先度は出ない)の3件を追加
- 全231件(backend) / 75件(frontend)通過
- typecheck OK(私の変更ファイルにエラーなし) / lint OK
- dead-code-check: 既知の4件(notionSchemas.ts、無関係)のみ
- security-scan: CRITICAL/HIGH = 0、PASS

grep確認: `tuning_rule_draft`のcard構築箇所は1箇所のみ。

Asana: https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217040622654093

🤖 Generated with [Claude Code](https://claude.com/claude-code)