### PR TITLE
feat(agent): アバター画像候補の生成と採用をチャット内で完結させる

### DIFF
--- a/admin-ui/src/lib/useAgentChatTransport.ts
+++ b/admin-ui/src/lib/useAgentChatTransport.ts
@@ -42,6 +42,15 @@ export type AvatarPresetAgentActionCard = {
   description: string;
 };
 
+// adopt_avatar_preset の採用直後カード。configId は自テナント側の avatar_configs.id。
+export type AvatarAdoptedAgentActionCard = {
+  kind: "avatar_adopted";
+  configId: string;
+  name: string;
+  imageUrl: string | null;
+  description: string;
+};
+
 export type TuningRulesListAgentActionCard = {
   kind: "tuning_rules_list";
   rules: Array<{
@@ -69,6 +78,7 @@ export type WeeklySummaryAgentActionCard = {
 export type AgentActionCard =
   | LegacyLinkAgentActionCard
   | AvatarPresetAgentActionCard
+  | AvatarAdoptedAgentActionCard
   | TuningRulesListAgentActionCard
   | WeeklySummaryAgentActionCard;
 

--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -745,6 +745,130 @@ function getComposer(): HTMLTextAreaElement {
   return screen.getByPlaceholderText(/指示ルール/) as HTMLTextAreaElement;
 }
 
+// アバター画像候補の生成・採用は、エージェントツール経由にせずチャットから直接
+// POST /v1/admin/avatar/fal/generate / PATCH /v1/admin/avatar/configs/:id を叩く。
+// この2エンドポイントの応答を authFetch のURL分岐で個別に制御する。
+describe("CopilotPreviewPage — アバター画像候補の生成・採用", () => {
+  function mockAdoptedThenEndpoints(opts: {
+    generate?: () => Promise<Response>;
+    patch?: () => Promise<Response>;
+  }) {
+    vi.mocked(authFetch).mockReset();
+    mockNavigate.mockReset();
+    let agentCalls = 0;
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (isBadgeUrl(url)) return mockEmptyBadges();
+      if (String(url).includes("/v1/admin/my-tenant")) {
+        return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
+      }
+      if (isUnreadFeedbackUrl(url)) return mockNoFeedbackReplies();
+      if (String(url).includes("/v1/admin/avatar/fal/generate")) {
+        return opts.generate ? opts.generate() : mockOk({ images: ["https://img/1.png"] });
+      }
+      if (String(url).includes("/v1/admin/avatar/configs/")) {
+        return opts.patch ? opts.patch() : mockOk({ id: "cfg-1" });
+      }
+      if (String(url).includes("/v1/admin/agent/chat")) {
+        agentCalls += 1;
+        if (agentCalls === 1) return mockOk({ reply: "今週も順調です。", actions: [] });
+        return mockOk({
+          reply: "採用しました。",
+          actions: [
+            {
+              tool: "adopt_avatar_preset",
+              result: "アバター「Haruka」を採用しました。まだ公開はされていません。",
+              card: { kind: "avatar_adopted", configId: "cfg-1", name: "Haruka", imageUrl: null, description: "とても丁寧な性格です。" },
+            },
+          ],
+        });
+      }
+      return mockOk({});
+    });
+  }
+
+  async function sendAndAdopt() {
+    renderPage();
+    // 起動時ブリーフィングのタイプライター演出が完了する(sendingがfalseへ確定する)まで待つ。
+    // 早すぎるタイミングでdisabled判定すると、演出中にsendingが再びtrueへ倒れる前の
+    // 初期レンダー(sending初期値false)を素通りしてしまい、直後のクリックが disabled な
+    // ボタンに当たって何も起きない(実際にこの競合でテストが落ちた)。
+    await waitFor(() => expect(screen.getByText("今週も順調です。")).toBeTruthy());
+    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
+    fireEvent.change(getComposer(), { target: { value: "採用してください" } });
+    fireEvent.click(screen.getByLabelText("送信"));
+    return screen.findByRole("button", { name: "画像を新しく生成する" });
+  }
+
+  it("生成→完了で候補4枚が描画され、採用でPATCHが呼ばれて二重押しできない", async () => {
+    const images = ["https://img/1.png", "https://img/2.png", "https://img/3.png", "https://img/4.png"];
+    mockAdoptedThenEndpoints({ generate: () => mockOk({ images }) });
+
+    const generateButton = await sendAndAdopt();
+    fireEvent.click(generateButton);
+
+    await waitFor(() => expect(screen.getAllByRole("button", { name: "これにする" }).length).toBe(4));
+
+    const generateCall = vi
+      .mocked(authFetch)
+      .mock.calls.find(([url]) => String(url).includes("/fal/generate"));
+    expect(generateCall).toBeTruthy();
+    expect(JSON.parse(String((generateCall![1] as RequestInit).body)).numImages).toBe(4);
+
+    fireEvent.click(screen.getAllByRole("button", { name: "これにする" })[1]!);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "これに決定" })).toBeTruthy());
+    const patchCall = vi
+      .mocked(authFetch)
+      .mock.calls.find(([url]) => String(url).includes("/v1/admin/avatar/configs/cfg-1"));
+    expect(patchCall).toBeTruthy();
+    expect((patchCall![1] as RequestInit).method).toBe("PATCH");
+    expect(JSON.parse(String((patchCall![1] as RequestInit).body))).toEqual({ image_url: images[1] });
+
+    // 決定後は残りの「これにする」ボタンが押せない(二重採用の防止)
+    const remaining = screen.getAllByRole("button", { name: "これにする" });
+    for (const btn of remaining) expect((btn as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("生成が5xxで失敗しても確定し、無限スピナーを残さない", async () => {
+    mockAdoptedThenEndpoints({
+      generate: () =>
+        Promise.resolve({ ok: false, status: 502, json: () => Promise.resolve({ error: "画像生成サービスでエラーが発生しました" }) } as Response),
+    });
+
+    const generateButton = await sendAndAdopt();
+    fireEvent.click(generateButton);
+
+    expect(await screen.findByText("画像生成サービスでエラーが発生しました")).toBeTruthy();
+    expect(screen.queryByText("数十秒かかることがあります。このまま他の操作もできます。")).toBeNull();
+    expect(await screen.findByRole("button", { name: "もう一度試す" })).toBeTruthy();
+  });
+
+  it("ネットワークエラーでも失敗として確定する(汎用の文言)", async () => {
+    mockAdoptedThenEndpoints({ generate: () => Promise.reject(new Error("network down")) });
+
+    const generateButton = await sendAndAdopt();
+    fireEvent.click(generateButton);
+
+    expect(await screen.findByText("画像を生成できませんでした。少し時間をおいてもう一度お試しください。")).toBeTruthy();
+  });
+
+  it("採用のPATCHが失敗しても、まだ採用されていない扱いのままエラーを示す", async () => {
+    mockAdoptedThenEndpoints({
+      generate: () => mockOk({ images: ["https://img/1.png"] }),
+      patch: () => Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({ error: "更新に失敗しました" }) } as Response),
+    });
+
+    const generateButton = await sendAndAdopt();
+    fireEvent.click(generateButton);
+    const adoptButton = await screen.findByRole("button", { name: "これにする" });
+    fireEvent.click(adoptButton);
+
+    expect(await screen.findByText("更新に失敗しました")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "これに決定" })).toBeNull();
+    expect(screen.getByRole("button", { name: "これにする" })).toBeTruthy();
+  });
+});
+
 // 想定ユーザーは100%日本語入力の店主。かな漢字変換の確定Enterで未変換のまま
 // 送信されてしまう不具合の回帰テスト(判定条件自体は lib/utils.test.ts で検証済み)。
 describe("CopilotPreviewPage — コンポーザのIME/改行", () => {

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -21,10 +21,14 @@ import {
 } from "../../lib/chatSessionStore";
 import { priorityToTier } from "../../lib/tuningPriority";
 import {
+  AGENT_CHAT_AUTH_REQUIRED_MESSAGE,
   AGENT_CHAT_HISTORY_MAX_ENTRIES,
   useAgentChatTransport,
 } from "../../lib/useAgentChatTransport";
 import type { AnsweredFrom } from "../../lib/useAgentChatTransport";
+// アバター画像候補のプロンプト組み立ては旧UIウィザードと同じ関数を使う(再実装しない)。
+// チャットは選択肢を集めないため、固定の標準的な選択で呼ぶ。
+import { buildAvatarPrompt } from "../../lib/buildAvatarPrompt";
 // 相談窓口(担当者への相談 → 返信 → 解決確認)のループ。ポーリング・既読化・相談投稿は
 // パネル(Surface A)と同じ実装を共有し(lib/feedbackReplies.ts)、見せ方だけこの面の
 // カード/メッセージの作法に合わせる。
@@ -82,6 +86,23 @@ type Card =
   | { kind: "link"; label: string; url: string; description: string }
   | { kind: "agentAction"; tool: string; result: string }
   | { kind: "avatarPreset"; presetId: string; name: string; imageUrl: string | null; description: string }
+  // adopt_avatar_preset の採用直後カード。configId は自テナント側の avatar_configs.id
+  // (presetIdとは別物)で、以降の画像候補生成・採用はすべてこのidを使う。
+  | { kind: "avatarAdopted"; configId: string; name: string; imageUrl: string | null; description: string }
+  // 画像候補の生成(POST /v1/admin/avatar/fal/generate)と採用(PATCH /configs/:id)を
+  // チャット画面内で完結させるためのカード。生成はエージェントツール経由にしない
+  // (画像URL群はツール結果の500字に収まらないため)。フロントから直接叩き、
+  // タイムアウト・5xx・429いずれの失敗でも status="failed" で確定させる
+  // (無限スピナーを残さない)。adoptedUrl は採用済みの1枚(二重採用の防止・ハイライト用)。
+  | {
+      kind: "avatarCandidates";
+      configId: string;
+      name: string;
+      status: "generating" | "done" | "failed";
+      images?: string[];
+      message?: string;
+      adoptedUrl?: string;
+    }
   // D3: 一覧が15件・1行60/100字で黙って切れていたのを解消するための全件カード。
   | {
       kind: "rulesList";
@@ -284,6 +305,9 @@ const PDF_UPLOAD_TOO_LARGE_ERROR = "ファイルが大きすぎて受け取れ�
 const PDF_UPLOAD_NETWORK_ERROR = "うまく送れませんでした。通信の状態を確かめて、もう一度お試しください。";
 const PDF_UPLOAD_GENERIC_ERROR = "うまく受け取れませんでした。少し時間をおいてお試しください。";
 const PDF_UPLOAD_ZIP_EMPTY_ERROR = "ZIPの中に取り込めるPDFが見つかりませんでした。";
+
+const AVATAR_GENERATE_GENERIC_ERROR = "画像を生成できませんでした。少し時間をおいてもう一度お試しください。";
+const AVATAR_ADOPT_GENERIC_ERROR = "この画像を反映できませんでした。少し時間をおいてもう一度お試しください。";
 
 // ─── 進行中テキストを少しずつ流し込む（体感の良さ重視の演出。本物の
 //     トークンストリーミングではなく、確定済みの応答文字列をクライアント側で
@@ -522,6 +546,10 @@ export default function CopilotPreviewPage() {
       if (a.card?.kind === "avatar_preset") {
         const { presetId, name, imageUrl, description } = a.card;
         return { id: nextId(), role: "ai", card: { kind: "avatarPreset", presetId, name, imageUrl, description } };
+      }
+      if (a.card?.kind === "avatar_adopted") {
+        const { configId, name, imageUrl, description } = a.card;
+        return { id: nextId(), role: "ai", card: { kind: "avatarAdopted", configId, name, imageUrl, description } };
       }
       if (a.card?.kind === "tuning_rules_list") {
         const { rules, totalCount } = a.card;
@@ -935,6 +963,78 @@ export default function CopilotPreviewPage() {
     }
   };
 
+  // ─── アバター画像候補の生成・採用(採用が気に入らなかった場合の分岐) ────────────
+  // PDF取り込みと同じ理由でエージェントツール経由にしない: 画像URL群はツール結果の
+  // 500字に収まらない。プロンプトは wizard と同じ buildAvatarPrompt を固定の標準的な
+  // 選択(人物・バストショット・自然な笑顔・シンプル背景)で使う。チャットは選択肢を
+  // 集めない(「選ばせない」方針)ため、雰囲気を変えたい場合は生成をやり直すだけで良い。
+  const updateAvatarCandidatesCard = useCallback((msgId: number, patch: Partial<Extract<Card, { kind: "avatarCandidates" }>>) => {
+    setMsgs((prev) =>
+      prev.map((m) =>
+        m.id === msgId && m.card?.kind === "avatarCandidates" ? { ...m, card: { ...m.card, ...patch } } : m,
+      ),
+    );
+  }, []);
+
+  const generateAvatarCandidates = async (configId: string, name: string) => {
+    const cardId = nextId();
+    push({ id: cardId, role: "ai", card: { kind: "avatarCandidates", configId, name, status: "generating" } });
+
+    const { prompt } = buildAvatarPrompt({
+      type: "human",
+      composition: "bust",
+      expression: "smile",
+      background: "simple",
+    });
+
+    try {
+      const res = await authFetch(`${API_BASE}/v1/admin/avatar/fal/generate`, {
+        method: "POST",
+        body: JSON.stringify({ prompt, numImages: 4 }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as { error?: string } | null;
+        updateAvatarCandidatesCard(cardId, { status: "failed", message: body?.error || AVATAR_GENERATE_GENERIC_ERROR });
+        return;
+      }
+      const data = (await res.json()) as { images?: string[] };
+      const images = data.images ?? [];
+      if (images.length === 0) {
+        updateAvatarCandidatesCard(cardId, { status: "failed", message: AVATAR_GENERATE_GENERIC_ERROR });
+        return;
+      }
+      updateAvatarCandidatesCard(cardId, { status: "done", images });
+    } catch (err) {
+      const message =
+        (err as { message?: string } | null)?.message === "__AUTH_REQUIRED__"
+          ? AGENT_CHAT_AUTH_REQUIRED_MESSAGE
+          : AVATAR_GENERATE_GENERIC_ERROR;
+      updateAvatarCandidatesCard(cardId, { status: "failed", message });
+    }
+  };
+
+  const adoptAvatarCandidate = async (cardMsgId: number, configId: string, imageUrl: string) => {
+    try {
+      const res = await authFetch(`${API_BASE}/v1/admin/avatar/configs/${configId}`, {
+        method: "PATCH",
+        body: JSON.stringify({ image_url: imageUrl }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as { error?: string } | null;
+        updateAvatarCandidatesCard(cardMsgId, { message: body?.error || AVATAR_ADOPT_GENERIC_ERROR });
+        return;
+      }
+      updateAvatarCandidatesCard(cardMsgId, { adoptedUrl: imageUrl });
+      setRealActionCount((n) => n + 1);
+    } catch (err) {
+      const message =
+        (err as { message?: string } | null)?.message === "__AUTH_REQUIRED__"
+          ? AGENT_CHAT_AUTH_REQUIRED_MESSAGE
+          : AVATAR_ADOPT_GENERIC_ERROR;
+      updateAvatarCandidatesCard(cardMsgId, { message });
+    }
+  };
+
   const handlePdfDrop = (e: React.DragEvent) => {
     e.preventDefault();
     pdfDragCounterRef.current = 0;
@@ -1105,7 +1205,13 @@ export default function CopilotPreviewPage() {
         <div ref={threadRef} className="cp-thread" style={{ flex: 1, overflowY: "auto", display: "flex", flexDirection: "column", gap: 18 }}>
           <div style={{ width: "100%", maxWidth: 820, margin: "0 auto", display: "flex", flexDirection: "column", gap: 18 }}>
             {msgs.map((m) => (
-              <MessageRow key={m.id} m={m} onChip={runAction} />
+              <MessageRow
+                key={m.id}
+                m={m}
+                onChip={runAction}
+                onGenerateAvatarCandidates={generateAvatarCandidates}
+                onAdoptAvatarCandidate={adoptAvatarCandidate}
+              />
             ))}
             {/* key に直近メッセージのidを与え、回答が変わるたびに新しい確認として出す
                 (前の回答で「はい」を押した状態を持ち越さない) */}
@@ -1345,7 +1451,17 @@ function RealActionBadge({ count }: { count: number }) {
   );
 }
 
-function MessageRow({ m, onChip }: { m: Msg; onChip: (a: string, id: number) => void }) {
+function MessageRow({
+  m,
+  onChip,
+  onGenerateAvatarCandidates,
+  onAdoptAvatarCandidate,
+}: {
+  m: Msg;
+  onChip: (a: string, id: number) => void;
+  onGenerateAvatarCandidates: (configId: string, name: string) => void | Promise<void>;
+  onAdoptAvatarCandidate: (cardMsgId: number, configId: string, imageUrl: string) => void | Promise<void>;
+}) {
   const isMe = m.role === "me";
   return (
     <div style={{ display: "flex", flexDirection: "column", alignItems: isMe ? "flex-end" : "flex-start", gap: 10 }}>
@@ -1361,7 +1477,14 @@ function MessageRow({ m, onChip }: { m: Msg; onChip: (a: string, id: number) => 
           {ANSWERED_FROM_LABEL[m.answeredFrom]}
         </div>
       )}
-      {m.card && <CardView card={m.card} />}
+      {m.card && (
+        <CardView
+          card={m.card}
+          msgId={m.id}
+          onGenerateAvatarCandidates={onGenerateAvatarCandidates}
+          onAdoptAvatarCandidate={onAdoptAvatarCandidate}
+        />
+      )}
       {m.chips && !m.chipsUsed && (
         <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
           {m.chips.map((c, i) => (
@@ -1549,7 +1672,17 @@ function Field({ k, v, quote, hi }: { k: string; v: string; quote?: boolean; hi?
   );
 }
 
-function CardView({ card }: { card: Card }) {
+function CardView({
+  card,
+  msgId,
+  onGenerateAvatarCandidates,
+  onAdoptAvatarCandidate,
+}: {
+  card: Card;
+  msgId: number;
+  onGenerateAvatarCandidates: (configId: string, name: string) => void | Promise<void>;
+  onAdoptAvatarCandidate: (cardMsgId: number, configId: string, imageUrl: string) => void | Promise<void>;
+}) {
   switch (card.kind) {
     case "agentAction":
       return (
@@ -1630,6 +1763,10 @@ function CardView({ card }: { card: Card }) {
           <Field k="性格・話し方" v={card.description} quote />
         </CardShell>
       );
+    case "avatarAdopted":
+      return <AvatarAdoptedCard card={card} onGenerate={onGenerateAvatarCandidates} />;
+    case "avatarCandidates":
+      return <AvatarCandidatesCard card={card} msgId={msgId} onGenerate={onGenerateAvatarCandidates} onAdopt={onAdoptAvatarCandidate} />;
     case "link":
       return (
         <CardShell hd={<><span>🔗</span>{card.label}へご案内します</>}>
@@ -1758,6 +1895,163 @@ function WeeklySummaryCard({ card }: { card: Extract<Card, { kind: "weeklySummar
           </div>
         </div>
       )}
+    </CardShell>
+  );
+}
+
+// 採用直後のカード。この画面のまま画像候補の生成に進める入口を持つ。
+// ボタンは相談窓口の ResolutionPrompt/ConsultReplyCard と同じく、チャットの
+// ツール呼び出しループを経由せずここから直接バックエンドを叩く(チップとは別系統)。
+function AvatarAdoptedCard({
+  card,
+  onGenerate,
+}: {
+  card: Extract<Card, { kind: "avatarAdopted" }>;
+  onGenerate: (configId: string, name: string) => void | Promise<void>;
+}) {
+  const [busy, setBusy] = useState(false);
+  const handleGenerate = () => {
+    setBusy(true);
+    void Promise.resolve(onGenerate(card.configId, card.name)).finally(() => setBusy(false));
+  };
+
+  return (
+    <CardShell
+      tone="good"
+      hd={<><span>✅</span>アバター「{card.name}」を採用しました</>}
+      foot={<CardActionsNote note="生成のたびに少額の費用が発生します。気に入った1枚を選ぶまで何度でもやり直せます。" />}
+    >
+      {card.imageUrl && (
+        <img
+          src={card.imageUrl}
+          alt={card.name}
+          style={{ width: 96, height: 96, borderRadius: 12, objectFit: "cover", alignSelf: "flex-start" }}
+        />
+      )}
+      <Field k="性格・話し方" v={card.description} quote />
+      <button
+        onClick={handleGenerate}
+        disabled={busy}
+        style={{
+          alignSelf: "flex-start", fontSize: 14.5, fontWeight: 700, padding: "10px 18px", borderRadius: 12, minHeight: 44,
+          border: "none", background: AGENT, color: "#fff",
+          cursor: busy ? "not-allowed" : "pointer", opacity: busy ? 0.6 : 1,
+        }}
+      >
+        {busy ? "生成しています…" : "画像を新しく生成する"}
+      </button>
+    </CardShell>
+  );
+}
+
+// 画像候補の生成〜採用。生成はエージェントツール経由にしない(画像URL群はツール結果の
+// 500字に収まらない)ため、直接バックエンドを叩く。3つの状態(生成中/完了/失敗)は
+// 必ずどれかで確定させ、無限スピナーを残さない。
+function AvatarCandidatesCard({
+  card,
+  msgId,
+  onGenerate,
+  onAdopt,
+}: {
+  card: Extract<Card, { kind: "avatarCandidates" }>;
+  msgId: number;
+  onGenerate: (configId: string, name: string) => void | Promise<void>;
+  onAdopt: (cardMsgId: number, configId: string, imageUrl: string) => void | Promise<void>;
+}) {
+  const [adopting, setAdopting] = useState<string | null>(null);
+
+  if (card.status === "generating") {
+    return (
+      <CardShell hd={<><span>🎨</span>新しい画像を生成しています</>}>
+        <div style={{ fontSize: 14, color: "var(--muted-foreground)", lineHeight: 1.7 }}>
+          数十秒かかることがあります。このまま他の操作もできます。
+        </div>
+      </CardShell>
+    );
+  }
+
+  if (card.status === "failed") {
+    return (
+      <CardShell
+        tone="bad"
+        hd={<><span>🎨</span>画像を生成できませんでした</>}
+        foot={
+          <div style={{ padding: "10px 18px", borderTop: "1px solid var(--border)" }}>
+            <button
+              onClick={() => void onGenerate(card.configId, card.name)}
+              style={{
+                fontSize: 13.5, fontWeight: 700, padding: "7px 16px", borderRadius: 999, minHeight: 36,
+                border: `1px solid ${AGENT_BORDER}`, background: AGENT_SOFT, color: AGENT, cursor: "pointer",
+              }}
+            >
+              もう一度試す
+            </button>
+          </div>
+        }
+      >
+        {card.message && <div style={{ fontSize: 15, color: "var(--foreground)", lineHeight: 1.7 }}>{card.message}</div>}
+      </CardShell>
+    );
+  }
+
+  const handleAdopt = (imageUrl: string) => {
+    setAdopting(imageUrl);
+    void Promise.resolve(onAdopt(msgId, card.configId, imageUrl)).finally(() => setAdopting(null));
+  };
+
+  return (
+    <CardShell
+      tone="good"
+      hd={<><span>🎨</span>新しい候補です</>}
+      foot={
+        !card.adoptedUrl ? (
+          <div style={{ padding: "10px 18px", borderTop: "1px solid var(--border)" }}>
+            <button
+              onClick={() => void onGenerate(card.configId, card.name)}
+              style={{
+                fontSize: 13.5, fontWeight: 700, padding: "7px 16px", borderRadius: 999, minHeight: 36,
+                border: "1px solid var(--border)", background: "transparent", color: "var(--muted-foreground)", cursor: "pointer",
+              }}
+            >
+              別の候補を見る
+            </button>
+          </div>
+        ) : undefined
+      }
+    >
+      {card.message && <div style={{ fontSize: 13, color: "var(--muted-foreground)" }}>{card.message}</div>}
+      <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+        {(card.images ?? []).map((url) => {
+          const isAdopted = card.adoptedUrl === url;
+          const disabled = !!card.adoptedUrl || adopting !== null;
+          return (
+            <div key={url} style={{ display: "flex", flexDirection: "column", alignItems: "center", gap: 6 }}>
+              <img
+                src={url}
+                alt="アバター候補"
+                style={{
+                  width: 96, height: 96, borderRadius: 12, objectFit: "cover",
+                  border: isAdopted ? `2px solid ${AGENT}` : "1px solid var(--border)",
+                }}
+              />
+              <button
+                onClick={() => handleAdopt(url)}
+                disabled={disabled}
+                style={{
+                  fontSize: 12.5, fontWeight: 700, padding: "5px 12px", borderRadius: 999, minHeight: 32,
+                  border: isAdopted ? "none" : "1px solid var(--border)",
+                  background: isAdopted ? AGENT : "transparent",
+                  color: isAdopted ? "#fff" : "var(--muted-foreground)",
+                  cursor: disabled ? "not-allowed" : "pointer",
+                  opacity: disabled && !isAdopted ? 0.5 : 1,
+                }}
+              >
+                {isAdopted ? "これに決定" : adopting === url ? "反映中…" : "これにする"}
+              </button>
+            </div>
+          );
+        })}
+      </div>
     </CardShell>
   );
 }

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -206,6 +206,18 @@ export type AvatarPresetCardPayload = {
   description: string;
 };
 
+// adopt_avatar_preset が返す、採用直後のカード。configId は自テナント側の
+// avatar_configs.id（presetId とは別物）で、フロントはこの id を画像候補生成
+// （POST /v1/admin/avatar/fal/generate は本カードとは無関係にフロントから直接叩く）と
+// 採用確定（PATCH /v1/admin/avatar/configs/:id）にそのまま使う。
+export type AvatarAdoptedCardPayload = {
+  kind: 'avatar_adopted';
+  configId: string;
+  name: string;
+  imageUrl: string | null;
+  description: string;
+};
+
 // get_tuning_rules の全件データ。text(自然文・500字)は件数の要約のみとし、
 // 一覧の欠落(D3: 15件に切ってさらに1行60/100字に切っていたため実質3〜4件しか
 // 出ていなかった)を、件数によらず全件をここに載せることで解消する。
@@ -250,6 +262,7 @@ export type ActionResult =
       card?:
         | LegacyLinkCardPayload
         | AvatarPresetCardPayload
+        | AvatarAdoptedCardPayload
         | TuningRulesListCardPayload
         | WeeklySummaryCardPayload;
     };
@@ -781,17 +794,29 @@ export async function executeToolCall(
                   false, false
              FROM avatar_configs
             WHERE id = $2 AND tenant_id = 'r2c_default' AND is_default = true
-           RETURNING name`,
+           RETURNING id, name, image_url, personality_prompt`,
           [tenantId, presetId],
         );
-        const created = result.rows[0] as { name: string } | undefined;
+        const created = result.rows[0] as
+          { id: string; name: string; image_url: string | null; personality_prompt: string | null } | undefined;
         if (!created) {
           return truncate('指定のアバター見本が見つかりませんでした。suggest_avatar_preset で提案をやり直してください');
         }
-        return truncate(
-          `アバター「${created.name}」を採用しました。まだ公開はされていません。` +
-          '声・名前・話し方を調整してから activate_avatar で公開できます',
-        );
+        // card の configId は自テナント側の新規行（presetId とは別物）。
+        // フロントはこの id で以降の画像候補生成・PATCHを行う。
+        return {
+          text: truncate(
+            `アバター「${created.name}」を採用しました。まだ公開はされていません。` +
+            '声・名前・話し方を調整してから activate_avatar で公開できます',
+          ),
+          card: {
+            kind: 'avatar_adopted',
+            configId: created.id,
+            name: created.name,
+            imageUrl: created.image_url,
+            description: (created.personality_prompt ?? '').slice(0, 120),
+          },
+        };
       } catch (err) {
         logger.warn('[actionExecutor] adopt_avatar_preset failed', err);
         return truncate('アバターの採用に失敗しました');

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -4466,24 +4466,36 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(mockQuery).not.toHaveBeenCalled();
     });
 
-    it('confirmed=trueで自テナントへ複製され、is_default/is_activeともにfalseで作られる', async () => {
+    it('confirmed=trueで自テナントへ複製され、is_default/is_activeともにfalseで作られる。カードは自テナント側の新規idを持つ', async () => {
       mockFetch
         .mockResolvedValueOnce(toolCallResponse('call-ap-2', 'adopt_avatar_preset', { preset_id: 'preset-1', confirmed: true }))
         .mockResolvedValueOnce(makeGroqResponse('採用しました。'));
 
-      mockQuery.mockResolvedValueOnce({ rows: [{ name: 'Haruka' }] });
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ id: 'cfg-own-1', name: 'Haruka', image_url: 'https://img/haruka.png', personality_prompt: 'とても丁寧な性格です。' }],
+      });
 
       const res = await request(makeApp(CLIENT_ADMIN_USER))
         .post('/v1/admin/agent/chat')
         .send({ message: '採用してください', sessionId: 'sess-ap-02' });
 
       expect(res.status).toBe(200);
-      expect(res.body.actions[0].result).toContain('Haruka」を採用しました');
-      expect(res.body.actions[0].result).toContain('まだ公開はされていません');
+      const action = res.body.actions[0];
+      expect(action.result).toContain('Haruka」を採用しました');
+      expect(action.result).toContain('まだ公開はされていません');
+      // configId は presetId(r2c_default側)とは別物。画像候補の生成・PATCHはこのidを使う。
+      expect(action.card).toEqual({
+        kind: 'avatar_adopted',
+        configId: 'cfg-own-1',
+        name: 'Haruka',
+        imageUrl: 'https://img/haruka.png',
+        description: 'とても丁寧な性格です。',
+      });
       const [sql, params] = mockQuery.mock.calls[0]!;
       expect(sql as string).toContain("tenant_id = 'r2c_default'");
       expect(sql as string).toContain('is_default = true');
       expect(sql as string).toContain('false, false');
+      expect(sql as string).toContain('RETURNING id, name, image_url, personality_prompt');
       expect(params).toEqual(['tenant-abc', 'preset-1']);
     });
 

--- a/src/api/admin/agent/agentRoutes.ts
+++ b/src/api/admin/agent/agentRoutes.ts
@@ -12,6 +12,7 @@ import type {
   ActionResult,
   LegacyLinkCardPayload,
   AvatarPresetCardPayload,
+  AvatarAdoptedCardPayload,
   TuningRulesListCardPayload,
   WeeklySummaryCardPayload,
 } from './actionExecutor';
@@ -162,7 +163,7 @@ type AnsweredFrom = 'faq_list' | 'tool_action' | 'general';
 type ChatAction = {
   tool: string;
   result: string;
-  card?: LegacyLinkCardPayload | AvatarPresetCardPayload | TuningRulesListCardPayload | WeeklySummaryCardPayload;
+  card?: LegacyLinkCardPayload | AvatarPresetCardPayload | AvatarAdoptedCardPayload | TuningRulesListCardPayload | WeeklySummaryCardPayload;
 };
 
 function determineAnsweredFrom(actions: Array<{ tool: string; result: string }>): AnsweredFrom {
@@ -405,7 +406,7 @@ async function executeHopToolCalls(
     const blockSameTurnChain = alreadySuggestedThisTurn && requiresConfirmation(name);
 
     let result: string;
-    let card: LegacyLinkCardPayload | AvatarPresetCardPayload | TuningRulesListCardPayload | WeeklySummaryCardPayload | undefined;
+    let card: LegacyLinkCardPayload | AvatarPresetCardPayload | AvatarAdoptedCardPayload | TuningRulesListCardPayload | WeeklySummaryCardPayload | undefined;
     if (blockSameTurnChain) {
       // 同一ターン内で suggest → save が連鎖しようとしている: 人間の確認を経ていないためブロック
       result = 'この保存は同一ターン内での連続実行のため確認をスキップできません。提案内容を確認のうえ、あらためて「保存して」等のメッセージを送ってください。';


### PR DESCRIPTION
Asana: feat: アバター画像候補の生成と採用をチャット内で完結させる
GID 1217040717806977 ※実装方針を2点修正（下記）

## 背景

「提案が気に入らなかった場合」の分岐として、画像候補の生成〜採用をチャットを離れずに完結させる（`docs/AVATAR_CHAT_MIGRATION.md` §2-3）。#611（既定見本の提案・採用）の続き。

## 計画からの修正（実装中の発見）

**1. 生成プロンプトは `generate-prompt` エンドポイントを使わない**

計画は「既存 `POST /v1/admin/avatar/generate-prompt` を使う」としていたが、実装を読むとこのエンドポイントは**チャットの人格用 `system_prompt` + `emotion_tags` を生成するもの**で、fal向けの英語ビジュアル記述とは無関係だった。誤って呼ぶとレスポンス形状が合わず動かない。

画像プロンプトの組み立ては、旧UIウィザードが実際に使っている純関数 `buildAvatarPrompt`（`admin-ui/src/lib/buildAvatarPrompt.ts`、LLM呼び出し無しの文字列組み立て）を、固定の標準的な選択（人物・バストショット・自然な笑顔・シンプル背景）で再利用した。チャットは選択肢を集めない（「選ばせない」方針）ため、雰囲気を変えたい場合は生成をやり直すだけでよい。

**2. `adopt_avatar_preset` の戻り値にカードが必要と新たに判明した**

画像候補をPATCHで反映するには、採用直後の**自テナント側 `avatar_configs.id`**（presetIdとは別物）をフロントが知る必要があるが、#611時点の戻り値は自然文のみだった。`RETURNING` に `id/image_url/personality_prompt` を追加し、`avatar_preset` と対になる `avatar_adopted` カードとして返すよう拡張した（#611のテストをカードの中身まで検証するよう強化）。

## 変更内容（6ファイル・新規ファイルなし）

| ファイル | 変更点 |
|---|---|
| `actionExecutor.ts` | `AvatarAdoptedCardPayload` 追加、`adopt_avatar_preset` が card を返すよう変更 |
| `agentRoutes.ts` | card の型に `AvatarAdoptedCardPayload` を追加（型のみ） |
| `useAgentChatTransport.ts` | `AgentActionCard` に `avatar_adopted` バリアント追加 |
| `copilot-preview/index.tsx` | `Card` union に `avatarAdopted`/`avatarCandidates` 追加。生成・採用のハンドラとカード描画コンポーネント |

### 生成・採用はエージェントツール経由にしない

PDF取り込みと同じ理由（画像URL群がツール結果の500字に収まらない）で、`POST /fal/generate` と `PATCH /configs/:id` をフロントから直接叩く。カードのボタンは相談窓口の `ConsultReplyCard`/`ResolutionPrompt` と同じ「`CardShell` + 直接叩くボタン」のidiomを踏襲した（チップ経由のLLM往復はさせない）。

### 失敗は必ず確定させる

タイムアウト・5xx・429・ネットワークエラーのいずれでも `status="failed"` に落とし、無限スピナーを残さない。429は上流fal APIのレート制限をサーバが502＋日本語メッセージとして転送する形（自前の上限は持たない。#594の課金訂正どおり）。

### 費用の扱い

生成のたびに従量課金が発生する（#594で計上済み）。確認ダイアログは挟まず、ボタン脇に常時「生成のたびに少額の費用が発生します」を明示する形にした（`CLAUDE.md`「やってはいけないこと」10の現行版に準拠）。

## テスト

追加5件（backend 1 / frontend 4）:
- `adopt_avatar_preset` が返すカードの中身（configId/name/imageUrl/description）を検証
- 生成→完了で候補4枚が描画され、採用でPATCHが呼ばれ二重押しできない
- 生成が5xxで失敗しても確定する（無限スピナー無し、message表示、リトライ導線あり）
- ネットワークエラーでも汎用文言で確定する
- 採用のPATCH失敗時もエラーを示し、採用済み扱いにしない（ボタンは再度押せる）

検証結果:
- `jest src/api/admin/agent` → 264 passed
- `vitest run`（admin-ui 全体）→ 271 passed
- `tsc --noEmit`（backend）→ 0 errors
- `oxlint --max-warnings 63` → exit 0
- `tsc -b`（admin-ui）→ 13 errors。`origin/main` と同数の既知差分（#593/#594/#611 で確認済み）

## デバッグメモ（レビューの参考）

フロントのテストで最初「送信」ボタンが押せない事象にはまった。原因は、起動時ブリーフィングのタイプライター演出が完了する前（`sending` の初期値 `false` の瞬間）に `disabled=false` の `waitFor` が素通りしてしまい、その直後にブートストラップの `sendReal` が非同期で `sending=true` に倒すため、クリックが disabled なボタンに当たっていたこと。ブリーフィングの返信テキストが実際に描画されるまで待ってから操作する形に修正して解消した。

## やっていないこと

- 新規エンドポイント・新規ページの追加
- `fal` 呼び出しロジックを `actionExecutor.ts` に複製する
- 旧UIウィザード/スタジオの変更
- 自前の生成回数上限（#594の方針どおり不要）
- 自然文の要望（「もう少し若く」等）をプロンプトへ反映する仕組み（固定の標準プロンプトで再生成するのみ。スコープ外として記録）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StqjjaijseYkGkmG2k5LJ