### PR TITLE
test: 週次まとめ機能のテスト強化 + コードレビューで見つけた2件の実バグ修正

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -1454,6 +1454,78 @@ describe("CopilotPreviewPage — super_adminのテナント選択", () => {
   });
 });
 
+// GID: super_adminがプレビュー中に別テナントへ切り替えても、bootstrapped(useRef)が
+// needsTenantSelectionのみをキーにしており previewMode のままでは再評価されないため、
+// 会話スレッド(weeklySummaryカードを含む)が前テナントのまま残っていた。修正の回帰テスト。
+describe("CopilotPreviewPage — テナント切替時の会話リセット", () => {
+  beforeEach(() => {
+    vi.mocked(authFetch).mockReset();
+    mockNavigate.mockReset();
+  });
+
+  it("previewMode中に別テナントへ切り替えると、会話がリセットされ新テナントのブリーフィングが取り直される", async () => {
+    let currentTenant = "tenant-a";
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (isBadgeUrl(url)) return mockEmptyBadges();
+      if (String(url).includes("/v1/admin/agent/chat")) {
+        return mockOk({ reply: `${currentTenant}の状況です。`, actions: [] });
+      }
+      return mockOk({});
+    });
+
+    const { rerender } = renderPage({ ...SUPER_ADMIN_IN_PREVIEW, previewTenantId: "tenant-a" });
+    await waitFor(() => expect(screen.getByText("tenant-aの状況です。")).toBeTruthy());
+
+    const callsBeforeSwitch = vi.mocked(authFetch).mock.calls.filter(([url]) =>
+      String(url).includes("/v1/admin/agent/chat"),
+    ).length;
+
+    // 別テナントへ切替(previewTenantIdのみ変化。previewMode/isSuperAdminは維持)
+    currentTenant = "tenant-b";
+    vi.mocked(useAuth).mockReturnValue(
+      baseAuth({ ...SUPER_ADMIN_IN_PREVIEW, previewTenantId: "tenant-b" }),
+    );
+    rerender(
+      <MemoryRouter>
+        <CopilotPreviewPage />
+      </MemoryRouter>,
+    );
+
+    // 新テナントのブリーフィングが自動的に取り直される(手動操作不要)
+    await waitFor(() => expect(screen.getByText("tenant-bの状況です。")).toBeTruthy());
+    // 前テナントの応答は会話から消えている(リセットされた証拠)
+    expect(screen.queryByText("tenant-aの状況です。")).toBeNull();
+
+    const callsAfterSwitch = vi.mocked(authFetch).mock.calls.filter(([url]) =>
+      String(url).includes("/v1/admin/agent/chat"),
+    ).length;
+    expect(callsAfterSwitch).toBeGreaterThan(callsBeforeSwitch);
+  });
+
+  it("同じテナントのままの再レンダーでは会話をリセットしない", async () => {
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (isBadgeUrl(url)) return mockEmptyBadges();
+      return mockOk({ reply: "今週も順調です。", actions: [] });
+    });
+
+    const { rerender } = renderPage(SUPER_ADMIN_IN_PREVIEW);
+    await waitFor(() => expect(screen.getByText("今週も順調です。")).toBeTruthy());
+
+    const callsBefore = vi.mocked(authFetch).mock.calls.length;
+
+    // previewTenantIdが変わらない通常の再レンダー(例: 他stateの更新に伴う再描画)
+    vi.mocked(useAuth).mockReturnValue(baseAuth(SUPER_ADMIN_IN_PREVIEW));
+    rerender(
+      <MemoryRouter>
+        <CopilotPreviewPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByText("今週も順調です。")).toBeTruthy();
+    expect(vi.mocked(authFetch).mock.calls.length).toBe(callsBefore);
+  });
+});
+
 // GID 1217007387443283: GUI固有として旧UIへ丸投げしていたPDF取り込みを、会話の中の
 // カードとして完結させる最初の1件。受付条件(拡張子/MIME/サイズ)は旧UIのPDFタブと
 // lib/bookPdfUpload.ts を共有しているため、ここで見るのは「会話UIとして成立しているか」

--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -572,6 +572,40 @@ describe("CopilotPreviewPage — 構造化カード(card)からの描画", () =>
     expect(screen.queryByRole("button", { name: "確認する" })).toBeNull();
   });
 
+  // GID: 1ターンに suggest_faq(下書き提案の確認待ち)と get_weekly_briefing(未回答質問あり)が
+  // 同時に来た場合、優先されるべきは「保存して/やめておく」(確認が必要な保留中の書き込み)で、
+  // 週次まとめのチップではない。同時発生は稀だが、chips は現状 if/elseif の単一選択(排他)で
+  // 実装されているため、優先順位が実装の分岐順そのものに委ねられている。この境界を固定する。
+  it("suggest_faqの確認待ちと週次まとめの行動チップが同一ターンに同居した場合、確認待ちの保存/やめるが優先される", async () => {
+    mockAgent({
+      reply: "下書きと今週の状況をまとめました。",
+      actions: [
+        { tool: "suggest_faq", result: "質問: 送料はいくら？\n回答: 全国一律550円です。\n分類: 配送" },
+        {
+          tool: "get_weekly_briefing",
+          result: "今週(月曜起点)の状況:\n会話数 10件",
+          card: {
+            kind: "weekly_summary",
+            asOf: "2026-08-05T03:00:00.000Z",
+            sessions: { total: 10, changePct: null, prevTotal: 0 },
+            avgScore: null,
+            conversions: null,
+            faq: null,
+            pendingTuningRules: 2,
+            gaps: { total: 5, top: [{ id: 1, question: "返品はできますか？" }] },
+          },
+        },
+      ],
+    });
+
+    await send("FAQ案を作りつつ今週の状況も教えて");
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "保存して" })).toBeTruthy());
+    expect(screen.getByRole("button", { name: "やめておく" })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "FAQにする" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "確認する" })).toBeNull();
+  });
+
   // GID 1217040318322843: 会話復元(sessionStorage)で古いまとめがそのまま画面に残り、
   // いつ時点のデータか分からないまま今日の数字として読まれてしまう問題の回帰テスト。
   it("集計時点(asOf)が今日なら鮮度の注記を出さない", async () => {
@@ -627,6 +661,38 @@ describe("CopilotPreviewPage — 構造化カード(card)からの描画", () =>
 
     await screen.findByText("50件");
     expect(await screen.findByText(/別の日に取得した内容です/)).toBeTruthy();
+  });
+
+  // GID: asOf は改ざん/破損した sessionStorage から復元される可能性がある(手動編集・
+  // 古いスキーマのデータ等)。修正前は new Date(不正値) を toISOString() に渡した瞬間に
+  // 例外が飛び、WeeklySummaryCard の描画自体が失敗して画面がスレッドごと真っ白になっていた
+  // (このページに React Error Boundary は無い)。回帰テスト。
+  it("集計時点(asOf)が不正な値でもクラッシュせず「不明」として表示する", async () => {
+    mockAgent({
+      reply: "今週の状況です。",
+      actions: [
+        {
+          tool: "get_weekly_briefing",
+          result: "今週(月曜起点)の状況:\n会話数 50件",
+          card: {
+            kind: "weekly_summary",
+            asOf: "this-is-not-a-valid-date",
+            sessions: { total: 50, changePct: null, prevTotal: 0 },
+            avgScore: null,
+            conversions: null,
+            faq: null,
+            pendingTuningRules: null,
+            gaps: null,
+          },
+        },
+      ],
+    });
+
+    await send("今週の状況を教えて");
+
+    // クラッシュしていれば "50件" を含むこの後続描画自体に到達しない
+    await screen.findByText("50件");
+    expect(screen.getByText(/集計時点: 不明/)).toBeTruthy();
   });
 
   // REAL_TOOL_LABEL への登録を忘れると、画面に生の英語ツール名がそのまま出る
@@ -1178,6 +1244,46 @@ describe("CopilotPreviewPage — 会話の復元(sessionStorage)", () => {
     expect(urls.some((u) => u.includes("/v1/admin/my-tenant"))).toBe(false);
   });
 
+  // GID: weeklySummary カードは複数フィールドが null になり得る構造(部分失敗を反映するため)。
+  // sessionStorage への JSON.stringify → 復元後の描画という往復で、null を含むネストが
+  // 壊れずに残ること、かつ復元されたカードは(取得した日と同じでない限り)鮮度が古いと
+  // 表示されることを確認する。
+  it("weeklySummaryカードを含む会話を復元しても、null混じりのフィールドが壊れず描画される", async () => {
+    vi.mocked(restoreChatSession).mockReturnValue({
+      sessionId: "restored-session-id",
+      messages: [
+        { id: 201, role: "me", text: "今週の状況を教えて" },
+        {
+          id: 202,
+          role: "ai",
+          card: {
+            kind: "weeklySummary",
+            asOf: "2020-01-01T00:00:00.000Z",
+            sessions: { total: 12, changePct: null, prevTotal: 0 },
+            avgScore: null,
+            conversions: null,
+            faq: { total: 3, published: 3, lastUpdated: null },
+            pendingTuningRules: null,
+            gaps: null,
+          },
+        },
+      ],
+      history: [],
+    });
+
+    renderPage();
+
+    expect(await screen.findByText("12件")).toBeTruthy();
+    // ラベルと値は別divなので、それぞれ別のテキストノードとして検証する
+    expect(screen.getByText("FAQ")).toBeTruthy();
+    expect(screen.getByText("3件（公開3件）")).toBeTruthy();
+    // avgScore/conversions/pendingTuningRules/gaps が null のため、それらの欄は描画されない
+    expect(screen.queryByText(/\/100/)).toBeNull();
+    expect(screen.queryByText("承認待ちの指示ルール")).toBeNull();
+    // 復元された古いasOfにより、鮮度の注記が出る
+    expect(screen.getByText(/別の日に取得した内容です/)).toBeTruthy();
+  });
+
   it("保存済みの会話が無ければ、従来通り起動時ブリーフィングを取得する(回帰)", async () => {
     renderPage();
 
@@ -1241,6 +1347,32 @@ describe("CopilotPreviewPage — リクエストボディの surface", () => {
     // ブリーフィングと手動送信の2本。どちらも同じ transport 経由なので同じ値を名乗る
     expect(chatBodies.length).toBeGreaterThanOrEqual(2);
     expect(chatBodies.map((b) => b.surface)).toEqual(chatBodies.map(() => "fullscreen"));
+  });
+
+  // GID: 起動時ブリーフィング(BOOTSTRAP_PROMPT)と左レール「今週のまとめ」クリックは
+  // 同一ツール(get_weekly_briefing)に着地する前提(「必ず再取得する」で統一、重複は
+  // 許容する設計)。起動時は「ログインしたところです。」という挨拶が前置されるが、
+  // 実際に状況を尋ねる依頼文の核("今週の状況を教えてください。要点と次にやるべき
+  // ことを最大3つまで、簡潔に教えてください。")は完全一致でなければならない。
+  // この2箇所は別々の文字列リテラルとして存在するため、片方だけ表現を直すと
+  // 定義が黙って割れる。核の一致を固定してその再発を防ぐ。
+  it("起動時ブリーフィングと「今週のまとめ」クリックは同一の依頼文の核を送る", async () => {
+    renderPage();
+    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
+
+    fireEvent.click(screen.getByRole("button", { name: /今週のまとめ/ }));
+    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
+
+    const chatBodies = vi
+      .mocked(authFetch)
+      .mock.calls.filter(([url]) => String(url).includes("/v1/admin/agent/chat"))
+      .map(([, init]) => JSON.parse(String((init as RequestInit).body)) as Record<string, unknown>);
+
+    expect(chatBodies.length).toBeGreaterThanOrEqual(2);
+    const [bootstrapMessage, categoryClickMessage] = chatBodies.map((b) => String(b.message));
+    const core = "今週の状況を教えてください。要点と次にやるべきことを最大3つまで、簡潔に教えてください。";
+    expect(categoryClickMessage).toBe(core);
+    expect(bootstrapMessage.endsWith(core)).toBe(true);
   });
 });
 

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -16,6 +16,7 @@ import { authFetch, API_BASE } from "../../lib/api";
 import { isChatFirstDefaultEnabled, setChatFirstDefaultEnabled } from "../../lib/chatFirstDefault";
 import {
   CHAT_SESSION_SURFACE_FULLSCREEN,
+  clearChatSession,
   restoreChatSession,
   saveChatSession,
 } from "../../lib/chatSessionStore";
@@ -696,6 +697,37 @@ export default function CopilotPreviewPage() {
     })();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [needsTenantSelection]);
+
+  // super_adminがプレビュー中に別テナントへenterPreviewする経路(AppSwitcher/テナント詳細の
+  // 「クライアントビューで見る」等)を検知し、会話を初期化して新テナントの週次ブリーフィングを
+  // 取り直す。上の bootstrap effect は needsTenantSelection のみを見ており、previewMode の
+  // まま別テナントへ切り替わるケースでは再評価されないため、前テナントの会話(weeklySummary
+  // カードを含む)が残ったまま新テナントの画面として表示され続けていた(GID: PR #633 で報告)。
+  //
+  // 初回確定("" → 最初のテナント)は上の effect が担当するため何もしない。空への遷移
+  // (プレビュー解除)も何もしない(その間は needsTenantSelection の描画分岐でチャット自体が
+  // 表示されない)。scopedTenantId が「別の非空値」に変わった場合だけリセットする。
+  const lastScopedTenantIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    const prev = lastScopedTenantIdRef.current;
+    lastScopedTenantIdRef.current = scopedTenantId || prev;
+
+    if (!prev || !scopedTenantId || scopedTenantId === prev) return;
+
+    // 会話・履歴・sessionId・進捗カウント・保存済みセッション(前テナントのもの)を
+    // すべて破棄してから、新テナントの週次ブリーフィングを取り直す。
+    clearChatSession(CHAT_SESSION_SURFACE_FULLSCREEN);
+    setMsgs([]);
+    setRealHistory([]);
+    setRealActionCount(0);
+    adoptSessionId(crypto.randomUUID());
+
+    void (async () => {
+      push({ id: nextId(), role: "ai", text: "テナントを切り替えました。今週の実データを確認しています…" });
+      await sendReal(BOOTSTRAP_PROMPT, { silent: true });
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [scopedTenantId]);
 
   // テナント選択用の一覧。既存の GET /v1/admin/tenants(super_admin限定)をそのまま使う。
   const [tenants, setTenants] = useState<TenantOption[] | null>(null);

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -1692,10 +1692,17 @@ function WeeklySummaryCard({ card }: { card: Extract<Card, { kind: "weeklySummar
   // 集計時点(asOf)を常に表示する。取得日時をJSTの暦日で比較し、今日でなければ
   // 「別の日に取得した内容」だと分かるようにする(取得直後かどうかは問わない — 復元も
   // 再取得も同じ card 構造なので、この表示ロジック1本だけで両方をカバーできる)。
+  //
+  // asOf は改ざん/破損したsessionStorageから復元される可能性がある(手動編集・古い
+  // スキーマのデータ等)。toISOString() は Invalid Date で例外を投げるため、ここで
+  // throw するとカード1枚のためにスレッド全体の描画が落ちる。素通しせず必ず検証する。
   const asOfDate = new Date(card.asOf);
+  const asOfValid = !Number.isNaN(asOfDate.getTime());
   const jstDayKey = (d: Date) => new Date(d.getTime() + 9 * 60 * 60 * 1000).toISOString().slice(0, 10);
-  const isStale = jstDayKey(asOfDate) !== jstDayKey(new Date());
-  const asOfLabel = asOfDate.toLocaleString("ja-JP", { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+  const isStale = !asOfValid || jstDayKey(asOfDate) !== jstDayKey(new Date());
+  const asOfLabel = asOfValid
+    ? asOfDate.toLocaleString("ja-JP", { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" })
+    : "不明";
 
   return (
     <CardShell

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -343,7 +343,11 @@ export async function executeToolCall(
         let whereClause = 'WHERE tenant_id = $1';
 
         if (search) {
-          whereParams.push(`%${search}%`);
+          // LIKE のワイルドカードを無効化し、意図しない広域一致を防ぐ（Postgres の既定エスケープ文字は \）。
+          // resolveSessionByShortId と同じ規約(この関数固有。呼び出しは1箇所に限る)。
+          // 例: 「50%オフ」で検索すると、エスケープ無しでは「50」+任意文字列+「オフ」に広域一致していた。
+          const escapedSearch = search.replace(/[\\%_]/g, (c) => `\\${c}`);
+          whereParams.push(`%${escapedSearch}%`);
           whereClause += ` AND (question ILIKE $${whereParams.length} OR answer ILIKE $${whereParams.length})`;
         }
 
@@ -1255,9 +1259,13 @@ export async function executeToolCall(
           const row = faqRes.value?.rows?.[0];
           const faqTotal = Number(row?.total ?? 0);
           const faqPublished = Number(row?.published ?? 0);
-          const lastUpdatedIso: string | null = row?.last_updated
-            ? new Date(row.last_updated).toISOString()
-            : null;
+          // last_updated が想定外の値(パース不能)でも toISOString() で例外を投げない。
+          // ここで投げると case 全体の try/catch に捕まり、他6指標が正常に取得できていても
+          // 「取得に失敗しました」に落ちる — Promise.allSettled で守っている部分失敗耐性が
+          // この1行のせいで無効化されてしまうため、必ず検証してから変換する。
+          const lastUpdatedDate = row?.last_updated ? new Date(row.last_updated) : null;
+          const lastUpdatedIso: string | null =
+            lastUpdatedDate && !Number.isNaN(lastUpdatedDate.getTime()) ? lastUpdatedDate.toISOString() : null;
           card.faq = { total: faqTotal, published: faqPublished, lastUpdated: lastUpdatedIso };
           const lastUpdatedDisplay = lastUpdatedIso
             ? new Date(lastUpdatedIso).toLocaleDateString('ja-JP', { year: 'numeric', month: 'short', day: 'numeric' })

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -1777,6 +1777,212 @@ describe('POST /v1/admin/agent/chat', () => {
         jest.useRealTimers();
       }
     });
+
+    // 週境界の統合テスト。weekRange.test.ts は純関数単体のみを検証しているため、
+    // get_weekly_briefing の実クエリまで通した境界値をここで確認する。
+    it.each([
+      ['日曜23:59:59.999 JSTでもまだ今週として扱われる', '2026-08-09T14:59:59.999Z', '2026-08-02T15:00:00.000Z'],
+      ['月曜00:00:00.000 JSTちょうどで週が切り替わる', '2026-08-09T15:00:00.000Z', '2026-08-09T15:00:00.000Z'],
+    ])('%s', async (_label, nowIso, expectedWeekStartIso) => {
+      jest.useFakeTimers({
+        doNotFake: [
+          'setTimeout', 'clearTimeout', 'setInterval', 'clearInterval',
+          'setImmediate', 'clearImmediate', 'queueMicrotask', 'nextTick',
+          'hrtime', 'performance', 'requestAnimationFrame', 'cancelAnimationFrame',
+          'requestIdleCallback', 'cancelIdleCallback',
+        ],
+      }).setSystemTime(new Date(nowIso));
+
+      try {
+        mockFetch
+          .mockResolvedValueOnce({
+            ok: true,
+            json: async () => ({
+              choices: [{
+                message: {
+                  content: null,
+                  tool_calls: [{
+                    id: 'call-wb-boundary',
+                    type: 'function',
+                    function: { name: 'get_weekly_briefing', arguments: '{}' },
+                  }],
+                },
+              }],
+            }),
+            text: async () => '',
+          })
+          .mockResolvedValueOnce(makeGroqResponse('今週の状況です。'));
+
+        mockQuery
+          .mockResolvedValueOnce({ rows: [{ n: 1 }] })
+          .mockResolvedValueOnce({ rows: [{ n: 1 }] })
+          .mockResolvedValueOnce({ rows: [{ avg: '80' }] })
+          .mockResolvedValueOnce({ rows: [{ n: 0, total: '0' }] })
+          .mockResolvedValueOnce({ rows: [{ total: 1, published: 1, last_updated: null }] })
+          .mockResolvedValueOnce({ rows: [{ n: 0 }] });
+
+        mockGetGaps.mockResolvedValueOnce({ gaps: [], total: 0 });
+
+        const res = await request(makeApp(CLIENT_ADMIN_USER))
+          .post('/v1/admin/agent/chat')
+          .send({ message: '今週の状況を教えて', sessionId: 'sess-boundary' });
+
+        expect(res.status).toBe(200);
+        const [sessionsCall] = mockQuery.mock.calls as Array<[string, unknown[]]>;
+        expect((sessionsCall[1][1] as Date).toISOString()).toBe(expectedWeekStartIso);
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    it('会話数が前週より減少した場合、マイナス符号付きで表示される', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            choices: [{
+              message: {
+                content: null,
+                tool_calls: [{
+                  id: 'call-wb-decrease',
+                  type: 'function',
+                  function: { name: 'get_weekly_briefing', arguments: '{}' },
+                }],
+              },
+            }],
+          }),
+          text: async () => '',
+        })
+        .mockResolvedValueOnce(makeGroqResponse('今週は少し落ち着いています。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ n: 10 }] }) // 今週
+        .mockResolvedValueOnce({ rows: [{ n: 40 }] }) // 先週同時点(今週より多い)
+        .mockResolvedValueOnce({ rows: [{ avg: '80' }] })
+        .mockResolvedValueOnce({ rows: [{ n: 0, total: '0' }] })
+        .mockResolvedValueOnce({ rows: [{ total: 1, published: 1, last_updated: null }] })
+        .mockResolvedValueOnce({ rows: [{ n: 0 }] });
+
+      mockGetGaps.mockResolvedValueOnce({ gaps: [], total: 0 });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '今週の状況を教えて', sessionId: 'sess-decrease' });
+
+      expect(res.status).toBe(200);
+      const card = res.body.actions[0].card;
+      expect(card.sessions).toEqual({ total: 10, changePct: -75, prevTotal: 40 });
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain('-75%');
+      expect(result).not.toContain('+-75%'); // 符号が二重に付かないこと
+    });
+
+    it('未回答質問の総数が上位表示件数(3件)を超えても、上位は3件のみ・総数は正しい値を返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            choices: [{
+              message: {
+                content: null,
+                tool_calls: [{
+                  id: 'call-wb-gaps-over',
+                  type: 'function',
+                  function: { name: 'get_weekly_briefing', arguments: '{}' },
+                }],
+              },
+            }],
+          }),
+          text: async () => '',
+        })
+        .mockResolvedValueOnce(makeGroqResponse('未対応の質問があります。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ n: 1 }] })
+        .mockResolvedValueOnce({ rows: [{ n: 1 }] })
+        .mockResolvedValueOnce({ rows: [{ avg: '80' }] })
+        .mockResolvedValueOnce({ rows: [{ n: 0, total: '0' }] })
+        .mockResolvedValueOnce({ rows: [{ total: 1, published: 1, last_updated: null }] })
+        .mockResolvedValueOnce({ rows: [{ n: 0 }] });
+
+      // getGaps は limit:3 で呼ばれる契約なので、上位3件のみ返す実装のふるまいをそのまま再現する
+      mockGetGaps.mockResolvedValueOnce({
+        gaps: [
+          { id: 1, tenant_id: 'tenant-abc', user_question: '質問A', session_id: null, message_id: null, rag_hit_count: 0, rag_top_score: 0, status: 'open', resolved_faq_id: null, created_at: '' },
+          { id: 2, tenant_id: 'tenant-abc', user_question: '質問B', session_id: null, message_id: null, rag_hit_count: 0, rag_top_score: 0, status: 'open', resolved_faq_id: null, created_at: '' },
+          { id: 3, tenant_id: 'tenant-abc', user_question: '質問C', session_id: null, message_id: null, rag_hit_count: 0, rag_top_score: 0, status: 'open', resolved_faq_id: null, created_at: '' },
+        ],
+        total: 42,
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '今週の状況を教えて', sessionId: 'sess-gaps-over' });
+
+      expect(res.status).toBe(200);
+      const card = res.body.actions[0].card;
+      expect(card.gaps.total).toBe(42);
+      expect(card.gaps.top).toHaveLength(3);
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain('42件');
+      expect(result).toContain('質問A');
+      expect(result).toContain('質問C');
+    });
+
+    // GID: FAQ最終更新日(last_updated)がパース不能な値の場合、以前は new Date(...).toISOString()
+    // が例外を投げ、Promise.allSettled で守られているはずの他6指標(会話数・スコア・成約・
+    // 承認待ちルール・未回答質問)まで巻き添えで「取得に失敗しました」に落ちていた
+    // (Promise.allSettled の外側、同期処理内での throw だったため)。修正の回帰テスト。
+    it('FAQのlast_updatedがパース不能な値でも、他の指標は正常に返る', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            choices: [{
+              message: {
+                content: null,
+                tool_calls: [{
+                  id: 'call-wb-baddate',
+                  type: 'function',
+                  function: { name: 'get_weekly_briefing', arguments: '{}' },
+                }],
+              },
+            }],
+          }),
+          text: async () => '',
+        })
+        .mockResolvedValueOnce(makeGroqResponse('今週の状況です。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ n: 25 }] })
+        .mockResolvedValueOnce({ rows: [{ n: 20 }] })
+        .mockResolvedValueOnce({ rows: [{ avg: '77' }] })
+        .mockResolvedValueOnce({ rows: [{ n: 3, total: '5000' }] })
+        // last_updated が不正な文字列(DBドライバの想定外挙動・データ破損等を模擬)
+        .mockResolvedValueOnce({ rows: [{ total: 5, published: 4, last_updated: 'not-a-real-timestamp' }] })
+        .mockResolvedValueOnce({ rows: [{ n: 2 }] });
+
+      mockGetGaps.mockResolvedValueOnce({ gaps: [], total: 0 });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '今週の状況を教えて', sessionId: 'sess-baddate' });
+
+      expect(res.status).toBe(200);
+      const result = res.body.actions[0].result as string;
+      const card = res.body.actions[0].card;
+
+      // 全体が失敗メッセージに落ちていないこと(退行防止の主眼)
+      expect(result).not.toContain('取得に失敗しました');
+      expect(result).toContain('25件');
+      expect(result).toContain('77/100');
+      expect(result).toContain('承認待ちの指示ルール 2件');
+
+      // FAQ自体は不正な日付を握りつぶし、件数は出るが最終更新日は省略される
+      expect(card.faq).toEqual({ total: 5, published: 4, lastUpdated: null });
+      expect(result).toContain('FAQ 5件（公開4件）');
+      expect(result).not.toContain('最終更新');
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -2110,6 +2316,30 @@ describe('POST /v1/admin/agent/chat', () => {
 
       expect(res.status).toBe(200);
       expect(res.body.actions[0].result).toBe('FAQ 一覧の取得に失敗しました');
+    });
+
+    // GID: 検索語に SQL LIKE のワイルドカード文字(%, _)が含まれると、エスケープ無しでは
+    // 文字通りの意味ではなくワイルドカードとして解釈され、意図しない広域一致を起こしていた
+    // (例:「50%オフ」→「50」+任意文字列+「オフ」に一致)。resolveSessionByShortId と
+    // 同じ規約でエスケープするよう修正した回帰テスト。
+    it('検索語に%や_が含まれてもワイルドカードとして解釈されず、リテラルとしてエスケープされる', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-fl-13', 'get_faq_list', { search: '50%offセール_限定' }))
+        .mockResolvedValueOnce(makeGroqResponse('該当するFAQを確認しました。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ n: 1 }] })
+        .mockResolvedValueOnce({ rows: [{ id: 1, question: '50%offセール_限定はいつまで?', answer: '今月末までです' }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '50%offセール_限定について教えて', sessionId: 'sess-fl-13' });
+
+      expect(res.status).toBe(200);
+      const [, listCall] = mockQuery.mock.calls as Array<[string, unknown[]]>;
+      // params[1] が検索パラメータ(%…%でラップされた値)。中身の % と _ がバックスラッシュで
+      // エスケープされていること(先頭と末尾のワイルドカード%はそのまま残る)。
+      expect(listCall[1][1]).toBe('%50\\%offセール\\_限定%');
     });
   });
 


### PR DESCRIPTION
## Summary

「実装された機能に対してテストを作成・強化する」依頼を受け、週次まとめ機能
(#596-#603)のコードを読み直し、テストで突けていなかった境界値・イレギュラー
操作を洗い出した。過程で実バグを3件発見し、いずれもこのPRで修正している。

## 修正した実バグ

1. **WeeklySummaryCard(フロント)のクラッシュ**: `asOf`が改ざん/破損した
   sessionStorageから復元されるなどしてパース不能な値になると、
   `toISOString()`が例外を投げカード描画ごとクラッシュしていた
   (このページにReact Error Boundaryは無い)。検証してから変換するよう修正。
2. **get_weekly_briefing(サーバ)の部分失敗耐性の穴**: FAQの`last_updated`が
   パース不能な値だと、`Promise.allSettled`の外側(同期処理内)でthrowし、
   正常取得できていた他6指標まで巻き添えで「取得に失敗しました」に落ちていた。
3. **super_adminのテナント切替で前テナントの会話が残り続ける**: previewMode中に
   別テナントへenterPreviewしても、`bootstrapped`(useRef)が`needsTenantSelection`
   のみを依存配列に持ち、previewModeのまま切り替わる経路では再評価されないため、
   会話スレッド(weeklySummaryカードを含む)が前テナントのまま残っていた。
   `scopedTenantId`の変化を独立して監視し、「別の非空値」への変化を検知したときだけ
   会話・履歴・sessionId・進捗カウント・保存済みセッションを破棄して新テナントの
   週次ブリーフィングを取り直すようにした。

## 軽微な修正

4. `get_faq_list`の検索語(`%`, `_`)がSQL LIKEワイルドカードとしてエスケープ
   されておらず、「50%オフ」等の検索が意図しない広域一致を起こしていた。
   `resolveSessionByShortId`と同じ規約でエスケープを追加。

## 追加したテスト

- 週境界の統合テスト(日曜23:59:59.999 / 月曜00:00:00.000、agentRoutes経由)
- 前週比が減少(マイナス%)した場合の符号表示
- 未回答質問の総数が上位表示件数(3件)を超える場合の総数と上位件数の分離
- 起動時ブリーフィングと「今週のまとめ」クリックが同一の依頼文の核を送ることの固定
- suggest_faq確認待ちと週次まとめ行動チップが同一ターンに同居した場合の優先順位
- weeklySummaryカードのsessionStorage往復(null混じりフィールドの保持・鮮度表示)
- テナント切替時の会話リセット(切替時はリセット・同一テナントの再レンダーではリセットしない)
- 上記のバグそれぞれの回帰テスト

## Test plan
- [x] pnpm typecheck (server) / admin-ui typecheck: 新規エラー0件(admin-ui既存ベースライン13件のみ)
- [x] pnpm lint: 新規警告0件
- [x] agentRoutes.test.ts フル実行: 242/242 PASS
- [x] weekRange.test.ts: 含む
- [x] copilot-preview/index.test.tsx フル実行: 86/86 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)