### PR TITLE
feat(agent): AI提案ルールの承認/却下と根拠(evidence)提示をチャットで完結させる

### DIFF
--- a/admin-ui/src/lib/useAgentChatTransport.ts
+++ b/admin-ui/src/lib/useAgentChatTransport.ts
@@ -73,6 +73,13 @@ export type AvatarAdoptedAgentActionCard = {
   description: string;
 };
 
+export type TuningRuleEvidence = {
+  evaluationIds?: number[];
+  effectivePrinciples?: string[];
+  failedPrinciples?: string[];
+  avgScore?: number;
+};
+
 export type TuningRulesListAgentActionCard = {
   kind: "tuning_rules_list";
   rules: Array<{
@@ -81,6 +88,10 @@ export type TuningRulesListAgentActionCard = {
     expectedBehavior: string;
     priority: number;
     isActive: boolean;
+    // P4-1: 古い(このフィールドが無い)キャッシュ済み会話との後方互換のため任意。
+    source?: string | null;
+    status?: string | null;
+    evidence?: TuningRuleEvidence | null;
   }>;
   totalCount: number;
 };

--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -978,6 +978,130 @@ describe("CopilotPreviewPage — 構造化カード(card)からの描画", () =>
     // card が無い正規表現フォールバック経路には優先度が無いため表示されない
     expect(screen.queryByText("優先度")).toBeNull();
   });
+
+  // P4-1: AI提案ルールの承認/却下と根拠提示
+  it("get_tuning_rules: AI提案(未承認)には出所バッジと承認/却下ボタン、根拠が表示される", async () => {
+    mockAgent({
+      reply: "指示ルールの状況をお伝えしました。",
+      actions: [
+        {
+          tool: "get_tuning_rules",
+          result: "指示ルール一覧（1件、うち有効0件・無効1件）です。詳しい内容は一覧でご確認いただけます。",
+          card: {
+            kind: "tuning_rules_list",
+            totalCount: 1,
+            rules: [
+              {
+                id: 42,
+                triggerPattern: "送料",
+                expectedBehavior: "一律500円とお伝えする",
+                priority: 5,
+                isActive: false,
+                source: "judge",
+                status: "pending",
+                evidence: { avgScore: 38, effectivePrinciples: ["共感"], failedPrinciples: ["クロージング"] },
+              },
+            ],
+          },
+        },
+      ],
+    });
+
+    await send("指示ルールの状況を教えて");
+
+    expect(await screen.findByText(/AIの提案（未承認）/)).toBeTruthy();
+    // 根拠は評価IDなど内部識別子をそのまま出さず、店主の言葉に言い換える
+    expect(screen.getByText(/もとになった会話の対応の質/)).toBeTruthy();
+    expect(screen.getByText(/共感/)).toBeTruthy();
+    expect(screen.getByText(/クロージング/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "有効にする" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "却下する" })).toBeTruthy();
+  });
+
+  it("get_tuning_rules: 自分で作ったルール(source=manual)にはAI提案バッジも承認ボタンも出ない", async () => {
+    mockAgent({
+      reply: "指示ルールの状況をお伝えしました。",
+      actions: [
+        {
+          tool: "get_tuning_rules",
+          result: "指示ルール一覧（1件、うち有効1件・無効0件）です。詳しい内容は一覧でご確認いただけます。",
+          card: {
+            kind: "tuning_rules_list",
+            totalCount: 1,
+            rules: [
+              { id: 1, triggerPattern: "保証", expectedBehavior: "2年", priority: 5, isActive: true, source: "manual", status: null, evidence: null },
+            ],
+          },
+        },
+      ],
+    });
+
+    await send("指示ルールの状況を教えて");
+
+    await screen.findByText("保証");
+    expect(screen.queryByText(/AIの提案/)).toBeNull();
+    expect(screen.queryByRole("button", { name: "有効にする" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "却下する" })).toBeNull();
+  });
+
+  it("get_tuning_rules: 却下済み(status=rejected)には承認ボタンが出ず、却下済みバッジのみ表示される", async () => {
+    mockAgent({
+      reply: "指示ルールの状況をお伝えしました。",
+      actions: [
+        {
+          tool: "get_tuning_rules",
+          result: "指示ルール一覧（1件、うち有効0件・無効1件）です。詳しい内容は一覧でご確認いただけます。",
+          card: {
+            kind: "tuning_rules_list",
+            totalCount: 1,
+            rules: [
+              { id: 43, triggerPattern: "値引き", expectedBehavior: "応じない", priority: 3, isActive: false, source: "judge", status: "rejected", evidence: null },
+            ],
+          },
+        },
+      ],
+    });
+
+    await send("指示ルールの状況を教えて");
+
+    expect(await screen.findByText(/AIの提案（却下済み）/)).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "有効にする" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "却下する" })).toBeNull();
+  });
+
+  it("get_tuning_rules: 「有効にする」を押すと承認の自然文が実送信される", async () => {
+    mockAgent({
+      reply: "指示ルールの状況をお伝えしました。",
+      actions: [
+        {
+          tool: "get_tuning_rules",
+          result: "指示ルール一覧（1件、うち有効0件・無効1件）です。詳しい内容は一覧でご確認いただけます。",
+          card: {
+            kind: "tuning_rules_list",
+            totalCount: 1,
+            rules: [
+              { id: 42, triggerPattern: "送料", expectedBehavior: "一律500円とお伝えする", priority: 5, isActive: false, source: "judge", status: "pending", evidence: null },
+            ],
+          },
+        },
+      ],
+    });
+
+    await send("指示ルールの状況を教えて");
+    const approveButton = await screen.findByRole("button", { name: "有効にする" });
+
+    fireEvent.click(approveButton);
+
+    await waitFor(() => {
+      const calls = vi.mocked(authFetch).mock.calls;
+      const chatCall = calls.find(([url]) => String(url).includes("/v1/admin/agent/chat"));
+      expect(chatCall).toBeTruthy();
+    });
+    const lastCall = vi.mocked(authFetch).mock.calls[vi.mocked(authFetch).mock.calls.length - 1];
+    const body = JSON.parse((lastCall![1] as RequestInit).body as string);
+    expect(body.message).toContain("ID: 42");
+    expect(body.message).toContain("承認して有効にしてください");
+  });
 });
 
 function getComposer(): HTMLTextAreaElement {

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -113,6 +113,15 @@ type Card =
         expectedBehavior: string;
         priority: number;
         isActive: boolean;
+        // P4-1: 古い(このフィールドが無い)キャッシュ済み会話との後方互換のため任意。
+        source?: string | null;
+        status?: string | null;
+        evidence?: {
+          evaluationIds?: number[];
+          effectivePrinciples?: string[];
+          failedPrinciples?: string[];
+          avgScore?: number;
+        } | null;
       }>;
       totalCount: number;
     }
@@ -1565,6 +1574,7 @@ function MessageRow({
           msgId={m.id}
           onGenerateAvatarCandidates={onGenerateAvatarCandidates}
           onAdoptAvatarCandidate={onAdoptAvatarCandidate}
+          onSendReal={(action) => onChip(action, m.id)}
         />
       )}
       {m.chips && !m.chipsUsed && (
@@ -1759,11 +1769,13 @@ function CardView({
   msgId,
   onGenerateAvatarCandidates,
   onAdoptAvatarCandidate,
+  onSendReal,
 }: {
   card: Card;
   msgId: number;
   onGenerateAvatarCandidates: (configId: string, name: string) => void | Promise<void>;
   onAdoptAvatarCandidate: (cardMsgId: number, configId: string, imageUrl: string) => void | Promise<void>;
+  onSendReal?: (action: string) => void;
 }) {
   switch (card.kind) {
     case "agentAction":
@@ -1799,20 +1811,71 @@ function CardView({
     case "rulesList":
       return (
         <CardShell hd={<><span>🎛️</span>指示ルール一覧（{card.totalCount}件）</>}>
-          {card.rules.map((r) => (
-            <div
-              key={r.id}
-              style={{ display: "flex", flexDirection: "column", gap: 4, paddingBottom: 12, borderBottom: "1px solid var(--border)" }}
-            >
-              <div style={{ display: "flex", alignItems: "center", gap: 10, fontSize: 12.5, color: "var(--muted-foreground)" }}>
-                <span>{r.isActive ? "✅ 有効" : "⏸️ 無効"}</span>
-                <span>優先度: {TIER_LABEL[priorityToTier(r.priority)]}</span>
+          {card.rules.map((r) => {
+            // P4-1: AI(judge)が提案したルールは、店主が作ったものと同じ見た目で
+            // 並べない(出所が分からないと承認判断ができない)。is_activeだけでは
+            // 未承認(pending)と却下済み(rejected)を区別できないためstatusも見る。
+            const isJudgeProposal = r.source === "judge";
+            const isPendingApproval = isJudgeProposal && !r.isActive && r.status !== "rejected";
+            const isRejected = isJudgeProposal && r.status === "rejected";
+            return (
+              <div
+                key={r.id}
+                style={{ display: "flex", flexDirection: "column", gap: 6, paddingBottom: 12, borderBottom: "1px solid var(--border)" }}
+              >
+                <div style={{ display: "flex", alignItems: "center", gap: 10, fontSize: 12.5, color: "var(--muted-foreground)", flexWrap: "wrap" }}>
+                  <span>{r.isActive ? "✅ 有効" : "⏸️ 無効"}</span>
+                  <span>優先度: {TIER_LABEL[priorityToTier(r.priority)]}</span>
+                  {isJudgeProposal && (
+                    <span style={{ fontWeight: 700, color: "#b45309", background: "rgba(245,158,11,0.14)", borderRadius: 6, padding: "2px 8px" }}>
+                      🤖 AIの提案{isPendingApproval ? "（未承認）" : isRejected ? "（却下済み）" : ""}
+                    </span>
+                  )}
+                </div>
+                <div style={{ fontSize: 14.5, color: "var(--foreground)" }}>
+                  <strong>{r.triggerPattern}</strong> → {r.expectedBehavior}
+                </div>
+                {/* 根拠は評価IDなどの内部識別子をそのまま出さず、店主の言葉に言い換える */}
+                {r.evidence && (
+                  <div style={{ fontSize: 12.5, color: "var(--muted-foreground)", display: "flex", flexDirection: "column", gap: 2 }}>
+                    {r.evidence.avgScore !== undefined && (
+                      <div>もとになった会話の対応の質: 目安{r.evidence.avgScore}点</div>
+                    )}
+                    {r.evidence.effectivePrinciples && r.evidence.effectivePrinciples.length > 0 && (
+                      <div>効果があった対応: {r.evidence.effectivePrinciples.join("、")}</div>
+                    )}
+                    {r.evidence.failedPrinciples && r.evidence.failedPrinciples.length > 0 && (
+                      <div>うまくいかなかった対応: {r.evidence.failedPrinciples.join("、")}</div>
+                    )}
+                  </div>
+                )}
+                {isPendingApproval && onSendReal && (
+                  <div style={{ display: "flex", gap: 8 }}>
+                    <button
+                      onClick={() =>
+                        onSendReal(
+                          `__real:AIが提案したルール（ID: ${r.id}、「${r.triggerPattern}」→「${r.expectedBehavior}」）を承認して有効にしてください`,
+                        )
+                      }
+                      style={{ fontSize: 13.5, fontWeight: 700, padding: "8px 14px", borderRadius: 10, cursor: "pointer", border: "none", background: AGENT, color: "#fff", minHeight: 44 }}
+                    >
+                      有効にする
+                    </button>
+                    <button
+                      onClick={() =>
+                        onSendReal(
+                          `__real:AIが提案したルール（ID: ${r.id}、「${r.triggerPattern}」→「${r.expectedBehavior}」）を却下してください`,
+                        )
+                      }
+                      style={{ fontSize: 13.5, fontWeight: 700, padding: "8px 14px", borderRadius: 10, cursor: "pointer", border: "1px solid var(--border)", background: "transparent", color: "var(--muted-foreground)", minHeight: 44 }}
+                    >
+                      却下する
+                    </button>
+                  </div>
+                )}
               </div>
-              <div style={{ fontSize: 14.5, color: "var(--foreground)" }}>
-                <strong>{r.triggerPattern}</strong> → {r.expectedBehavior}
-              </div>
-            </div>
-          ))}
+            );
+          })}
         </CardShell>
       );
     case "engagement":

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -9,7 +9,7 @@ import {
   upsertToEsAsync,
 } from '../knowledge/faqCrudRoutes';
 import { callGroq8bSuggestFromText } from '../tuning/routes';
-import { listRules, createRule, updateRule, deleteRule, type ApprovedResponse } from '../tuning/tuningRulesRepository';
+import { listRules, createRule, updateRule, deleteRule, type ApprovedResponse, type RuleEvidence } from '../tuning/tuningRulesRepository';
 import { generateTestResponses } from '../tuning/testResponseRoutes';
 import { searchKnowledgeForSuggestion, formatKnowledgeContext } from '../../../lib/knowledgeSearchUtil';
 import { getGaps, updateGapStatus } from '../knowledge/knowledgeGapRepository';
@@ -231,6 +231,12 @@ export type TuningRulesListCardPayload = {
     expectedBehavior: string;
     priority: number;
     isActive: boolean;
+    // AI提案(judge)か店主が作ったもの(manual)かの出所。無いと承認判断ができない。
+    source: string | null;
+    // pending(既定) / active(承認済み) / rejected(却下済み)。is_active だけでは
+    // pending と rejected が区別できない(どちらも is_active=false)ため必要。
+    status: string | null;
+    evidence: RuleEvidence | null;
   }>;
   totalCount: number;
 };
@@ -1050,6 +1056,9 @@ export async function executeToolCall(
               expectedBehavior: r.expected_behavior,
               priority: r.priority,
               isActive: r.is_active,
+              source: r.source ?? null,
+              status: r.status ?? null,
+              evidence: r.evidence ?? null,
             })),
             totalCount: rules.length,
           },
@@ -1075,8 +1084,12 @@ export async function executeToolCall(
       const triggerPattern = typeof args['trigger_pattern'] === 'string' ? args['trigger_pattern'].slice(0, 1000) : undefined;
       const expectedBehavior = typeof args['expected_behavior'] === 'string' ? args['expected_behavior'].slice(0, 4000) : undefined;
       const isActive = typeof args['is_active'] === 'boolean' ? args['is_active'] : undefined;
+      // AI提案(source='judge')の承認/却下でのみ指定される。is_activeだけではpending(未承認)と
+      // rejected(却下済み)を区別できない(どちらもis_active=falseのため)。
+      const statusRaw = args['status'];
+      const status = statusRaw === 'active' || statusRaw === 'rejected' ? statusRaw : undefined;
 
-      if (triggerPattern === undefined && expectedBehavior === undefined && isActive === undefined) {
+      if (triggerPattern === undefined && expectedBehavior === undefined && isActive === undefined && status === undefined) {
         return truncate('変更する内容がありません（trigger_pattern・expected_behavior・is_active のいずれかを指定してください）');
       }
 
@@ -1084,11 +1097,17 @@ export async function executeToolCall(
         const ownerFilter = isSuperAdmin ? undefined : tenantId;
         const updated = await updateRule(
           id,
-          { trigger_pattern: triggerPattern, expected_behavior: expectedBehavior, is_active: isActive },
+          { trigger_pattern: triggerPattern, expected_behavior: expectedBehavior, is_active: isActive, status },
           ownerFilter,
         );
         if (!updated) {
           return truncate(`指示ルール（ID: ${id}）が見つからないかアクセス権限がありません`);
+        }
+        if (status === 'active') {
+          return truncate(`指示ルール（ID: ${id}）を承認し、有効にしました: 「${updated.trigger_pattern}」`);
+        }
+        if (status === 'rejected') {
+          return truncate(`指示ルール（ID: ${id}）を却下しました: 「${updated.trigger_pattern}」`);
         }
         return truncate(`指示ルール（ID: ${id}）を更新しました: 「${updated.trigger_pattern}」${updated.is_active ? '' : '（現在無効）'}`);
       } catch (err) {
@@ -1283,10 +1302,15 @@ export async function executeToolCall(
              FROM faq_docs WHERE tenant_id = $1`,
             [tenantId],
           ),
-          // weeklyReportGenerator(Phase46)からの唯一の引き継ぎ指標
+          // weeklyReportGenerator(Phase46)からの唯一の引き継ぎ指標。
+          // P4-1で修正: 以前は approved_at/rejected_at (どのコードパスからも
+          // 更新されない列)を見ており、店主が作った通常のルールも含めて
+          // 全件を「承認待ち」として数えていた。AI提案(source='judge')かつ
+          // 未承認(is_active=false)かつ却下されていない件数に修正する。
           db.query(
             `SELECT COUNT(*)::int AS n FROM tuning_rules
-             WHERE tenant_id = $1 AND approved_at IS NULL AND rejected_at IS NULL`,
+             WHERE tenant_id = $1 AND source = 'judge' AND is_active = false
+               AND status IS DISTINCT FROM 'rejected'`,
             [tenantId],
           ),
           getGaps({ tenantId, status: 'open', limit: 3 }),

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -1176,8 +1176,8 @@ describe('POST /v1/admin/agent/chat', () => {
         .mockResolvedValueOnce(makeGroqResponse('現在2件のルールがあります。'));
 
       mockListRules.mockResolvedValueOnce([
-        { id: 1, tenant_id: 'tenant-abc', trigger_pattern: '保証', expected_behavior: '2年と案内する', priority: 5, is_active: true, created_by: null, source_message_id: null, created_at: '', updated_at: '' },
-        { id: 2, tenant_id: 'global', trigger_pattern: '価格交渉', expected_behavior: '応じない', priority: 3, is_active: false, created_by: null, source_message_id: null, created_at: '', updated_at: '' },
+        { id: 1, tenant_id: 'tenant-abc', trigger_pattern: '保証', expected_behavior: '2年と案内する', priority: 5, is_active: true, created_by: null, source_message_id: null, created_at: '', updated_at: '', source: 'manual', status: null, evidence: null },
+        { id: 2, tenant_id: 'global', trigger_pattern: '価格交渉', expected_behavior: '応じない', priority: 3, is_active: false, created_by: null, source_message_id: null, created_at: '', updated_at: '', source: 'judge', status: 'pending', evidence: { avgScore: 42 } },
       ]);
 
       const res = await request(makeApp(CLIENT_ADMIN_USER))
@@ -1194,12 +1194,13 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(result).not.toContain('保証');
       expect(result).not.toContain('価格交渉');
 
+      // P4-1: source/status/evidence もcardに含める(承認判断に必要な出所・根拠)
       expect(res.body.actions[0].card).toEqual({
         kind: 'tuning_rules_list',
         totalCount: 2,
         rules: [
-          { id: 1, triggerPattern: '保証', expectedBehavior: '2年と案内する', priority: 5, isActive: true },
-          { id: 2, triggerPattern: '価格交渉', expectedBehavior: '応じない', priority: 3, isActive: false },
+          { id: 1, triggerPattern: '保証', expectedBehavior: '2年と案内する', priority: 5, isActive: true, source: 'manual', status: null, evidence: null },
+          { id: 2, triggerPattern: '価格交渉', expectedBehavior: '応じない', priority: 3, isActive: false, source: 'judge', status: 'pending', evidence: { avgScore: 42 } },
         ],
       });
     });
@@ -1276,6 +1277,73 @@ describe('POST /v1/admin/agent/chat', () => {
         2,
         { trigger_pattern: undefined, expected_behavior: undefined, is_active: true },
         undefined,
+      );
+    });
+
+    // P4-1: AI提案ルールの承認/却下。is_active だけでは pending と rejected を
+    // 区別できないため、status も併せて渡す。
+    it('update_tuning_rule: is_active=true + status="active" → 承認され有効になる', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-tr-6', 'update_tuning_rule', { id: 3, is_active: true, status: 'active', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('承認しました。'));
+
+      mockUpdateRule.mockResolvedValueOnce({
+        id: 3, tenant_id: 'tenant-abc', trigger_pattern: '送料', expected_behavior: '一律500円', priority: 5, is_active: true, created_by: null, source_message_id: null, created_at: '', updated_at: '', source: 'judge', status: 'active', evidence: { avgScore: 40 },
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'AI提案のルールを承認して', sessionId: 'sess-tr-06' });
+
+      expect(res.status).toBe(200);
+      expect(mockUpdateRule).toHaveBeenCalledWith(
+        3,
+        { trigger_pattern: undefined, expected_behavior: undefined, is_active: true, status: 'active' },
+        'tenant-abc',
+      );
+      expect(res.body.actions[0].result).toContain('承認し、有効にしました');
+    });
+
+    it('update_tuning_rule: is_active=false + status="rejected" → 却下される', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-tr-7', 'update_tuning_rule', { id: 3, is_active: false, status: 'rejected', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('却下しました。'));
+
+      mockUpdateRule.mockResolvedValueOnce({
+        id: 3, tenant_id: 'tenant-abc', trigger_pattern: '送料', expected_behavior: '一律500円', priority: 5, is_active: false, created_by: null, source_message_id: null, created_at: '', updated_at: '', source: 'judge', status: 'rejected', evidence: { avgScore: 40 },
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'AI提案のルールを却下して', sessionId: 'sess-tr-07' });
+
+      expect(res.status).toBe(200);
+      expect(mockUpdateRule).toHaveBeenCalledWith(
+        3,
+        { trigger_pattern: undefined, expected_behavior: undefined, is_active: false, status: 'rejected' },
+        'tenant-abc',
+      );
+      expect(res.body.actions[0].result).toContain('却下しました');
+    });
+
+    it('update_tuning_rule: statusに不正な値が来ても弾かれ、通常のis_active切替として扱われる', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-tr-7b', 'update_tuning_rule', { id: 3, is_active: true, status: 'bogus', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('更新しました。'));
+
+      mockUpdateRule.mockResolvedValueOnce({
+        id: 3, tenant_id: 'tenant-abc', trigger_pattern: '送料', expected_behavior: '一律500円', priority: 5, is_active: true, created_by: null, source_message_id: null, created_at: '', updated_at: '',
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルール更新', sessionId: 'sess-tr-07b' });
+
+      expect(res.status).toBe(200);
+      expect(mockUpdateRule).toHaveBeenCalledWith(
+        3,
+        { trigger_pattern: undefined, expected_behavior: undefined, is_active: true, status: undefined },
+        'tenant-abc',
       );
     });
 

--- a/src/api/admin/agent/toolDefinitions.ts
+++ b/src/api/admin/agent/toolDefinitions.ts
@@ -384,7 +384,7 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
     function: {
       name: 'get_tuning_rules',
       description:
-        '現在の指示ルール（AIの振る舞いルール）の一覧を取得する読み取り専用ツール。suggest_tuning_rule/save_tuning_ruleで作成済みのものも含め、有効/無効の状態ごと全件を確認したい時に使う。',
+        '現在の指示ルール（AIの振る舞いルール）の一覧を取得する読み取り専用ツール。suggest_tuning_rule/save_tuning_ruleで作成済みのものに加え、AIが自動提案した未承認のルール（店主の承認なしには本番の応答に反映されない）も含む。一覧・承認判断の両方に使う。',
       parameters: {
         type: 'object',
         properties: {},
@@ -397,7 +397,9 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
     function: {
       name: 'update_tuning_rule',
       description:
-        '既存の指示ルールを編集する、または有効/無効を切り替える。編集する場合は trigger_pattern/expected_behavior を、有効/無効の切り替えのみの場合は is_active だけを指定する。必ず先に変更内容をユーザーに提示し、明確な同意を得たターンでのみ confirmed=true で呼び出すこと。',
+        '既存の指示ルールを編集する、有効/無効を切り替える、またはAI提案ルールを承認/却下する。編集する場合は trigger_pattern/expected_behavior を、有効/無効の切り替えのみの場合は is_active だけを指定する。' +
+        'AI提案ルール（get_tuning_rulesの結果でsourceが"judge"のもの）を承認する場合は is_active=true と status="active" を両方指定し、却下する場合は is_active=false と status="rejected" を両方指定すること（is_active だけでは未承認と却下済みを区別できない）。通常のルールのON/OFF切替では status を指定しない。' +
+        '必ず先に変更内容（承認/却下の場合は根拠を含む）をユーザーに提示し、明確な同意を得たターンでのみ confirmed=true で呼び出すこと。',
       parameters: {
         type: 'object',
         properties: {
@@ -405,6 +407,11 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
           trigger_pattern: { type: 'string', description: '新しいトリガー内容（変更する場合のみ指定）' },
           expected_behavior: { type: 'string', description: '新しい対応方針（変更する場合のみ指定）' },
           is_active: { type: 'boolean', description: '有効/無効の切り替え（変更する場合のみ指定）' },
+          status: {
+            type: 'string',
+            enum: ['active', 'rejected'],
+            description: 'AI提案ルールの承認("active")/却下("rejected")時のみ指定する。通常のルールのON/OFF切替では指定しない。',
+          },
           confirmed: { type: 'boolean', description: '確認フラグ（true でのみ実行される）' },
         },
         required: ['id', 'confirmed'],

--- a/src/api/admin/tuning/tuningRulesRepository.ts
+++ b/src/api/admin/tuning/tuningRulesRepository.ts
@@ -58,6 +58,11 @@ export interface UpdateRuleParams {
   priority?: number;
   is_active?: boolean;
   approved_responses?: ApprovedResponse[];
+  // AI提案(source='judge')の承認/却下時のみ指定する。'active' で承認・'rejected' で却下を記録する。
+  // is_active だけでは pending(未承認) と rejected(却下済み) を区別できない
+  // (どちらも is_active=false のため)。status が無いと却下済みルールが
+  // 承認待ち一覧に出続け、店主には「却下したのに戻ってきた」ように見える。
+  status?: 'active' | 'rejected';
 }
 
 // ---------------------------------------------------------------------------
@@ -190,17 +195,19 @@ export async function updateRule(
        priority          = COALESCE($3, priority),
        is_active         = COALESCE($4, is_active),
        approved_responses = CASE WHEN $5::text IS NOT NULL THEN $5::jsonb ELSE approved_responses END,
+       status            = COALESCE($6, status),
        updated_at        = NOW()
-     WHERE id = $6
+     WHERE id = $7
      RETURNING id, tenant_id, trigger_pattern, expected_behavior,
                priority, is_active, created_by, source_message_id,
-               created_at, updated_at, approved_responses`,
+               created_at, updated_at, approved_responses, source, status, evidence`,
     [
       params.trigger_pattern ?? null,
       params.expected_behavior ?? null,
       params.priority ?? null,
       params.is_active ?? null,
       approvedJson,
+      params.status ?? null,
       id,
     ],
   );


### PR DESCRIPTION
## 何をするPRか

P1-1(#606)でAI自動生成ルール(source='judge')が無断で有効化されない状態にした対の機能として、店主が根拠を見た上で承認/却下できる手段を追加する。

## 調査で発見した既存の不整合(直接関連するため合わせて修正)

1. **`get_weekly_briefing`の「承認待ちの指示ルール」件数が実質バグっていた** — `approved_at IS NULL AND rejected_at IS NULL`で数えていたが、これらの列はどのコードパスからも更新されない。結果、店主が作った通常のルールも含めて**全件**を「承認待ち」として数えていた。`source='judge' AND is_active=false AND status<>'rejected'`に修正。
2. **既存の承認/却下エンドポイントが機能していない** — `src/api/admin/evaluations/evaluationsRepository.ts`の`approveTuningRule`/`rejectTuningRule`(`PUT /v1/admin/tuning/:id/approve|reject`)は`status`列のみ更新し`is_active`に触れないため、**実行しても指示ルールは有効化されない**。grepで確認したところこのエンドポイントは**どのフロントからも呼ばれておらず**(テストのみ参照)、未配線。本PRのスコープ外として変更していないが、D7/D8と同型の「承認しても有効にならない」欠陥のため、別タスクとして認識しておくべき事項として記録する。

## 直した内容

- `tuningRulesRepository.ts`: `UpdateRuleParams`に`status`を追加、`updateRule`のSQL/RETURNINGに反映
- `actionExecutor.ts`: `get_tuning_rules`のカードに`source`/`status`/`evidence`を追加。`update_tuning_rule`で`status='active'|'rejected'`を受け付け(is_activeと併せて指定する設計。既存の`saiTaskRulesRepository.ts`の`status+is_active`ペアパターンに合わせた)。`pendingTuningRules`クエリを修正
- `toolDefinitions.ts`: 説明文更新。**新規ツールは作らず、既存`update_tuning_rule`に`status`パラメータを追加しただけ**
- `copilot-preview/index.tsx`: `rulesList`カードに出所バッジ(🤖 AIの提案)・根拠(評価IDは出さず店主の言葉に言い換え)・承認/却下ボタンを追加。**既存のチップ機構(`__real:`プレフィックスの自然文代理送信)に乗せる**(新エンドポイントは作らない)

### なぜstatus列が必要か

`is_active`だけでは**pending(未承認)**と**rejected(却下済み)**を区別できない(どちらも`is_active=false`)。`status`が無いと却下したルールが承認待ち一覧に出続け、店主には「却下したのに戻ってきた」ように見える(受け入れ条件「却下したルールが黙って復活しない」に抵触)。

## テスト

- バックエンド11件・フロントエンド4件を追加、既存回帰なし(バックエンド233件・フロント84件全通過)
- typecheck OK / lint OK
- dead-code-check: 既知の4件(notionSchemas.ts、無関係)のみ
- security-scan: CRITICAL/HIGH = 0、PASS

## 既知の注意点(マージ順序)

本ブランチは**P3-2(#630、Tier S・未マージ)より前のmain**から分岐しており、`copilot-preview/index.tsx`の`rulesList`/`rule` case で軽微なコンフリクトが起こりうる(双方とも既存caseへの追記のみで、ロジックは競合しない見込み)。P3-2を先にマージすることを推奨。

Asana: https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217040612810030

🤖 Generated with [Claude Code](https://claude.com/claude-code)