### PR TITLE
feat(agent): アバターの声の選択・採用をチャット内で完結させる

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -1108,6 +1108,134 @@ describe("CopilotPreviewPage — アバター画像候補の生成・採用", ()
   });
 });
 
+// POST /match-voice はテキストの候補(id/title/description/score)のみを返し音声
+// プレビューURLを持たない(旧UIウィザードのStudioVoiceSectionも試聴機能を持たない)。
+// 計画は「試聴要素の存在」を前提にしていたが、実装を確認するとその基盤が無いため、
+// 一覧から選ぶ形に修正し、代わりに「プレビューは提供されていない」旨を明示するテストを書く。
+describe("CopilotPreviewPage — アバターの声の選択・採用", () => {
+  function mockAdoptedThenVoiceEndpoints(opts: {
+    match?: () => Promise<Response>;
+    patch?: () => Promise<Response>;
+  }) {
+    vi.mocked(authFetch).mockReset();
+    mockNavigate.mockReset();
+    let agentCalls = 0;
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (isBadgeUrl(url)) return mockEmptyBadges();
+      if (String(url).includes("/v1/admin/my-tenant")) {
+        return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
+      }
+      if (isUnreadFeedbackUrl(url)) return mockNoFeedbackReplies();
+      if (String(url).includes("/v1/admin/avatar/match-voice")) {
+        return opts.match
+          ? opts.match()
+          : mockOk({ recommendations: [{ id: "voice-1", title: "Haruka Voice", description: "明るく親しみやすい声", score: 0.92 }] });
+      }
+      if (String(url).includes("/v1/admin/avatar/configs/")) {
+        return opts.patch ? opts.patch() : mockOk({ id: "cfg-1" });
+      }
+      if (String(url).includes("/v1/admin/agent/chat")) {
+        agentCalls += 1;
+        if (agentCalls === 1) return mockOk({ reply: "今週も順調です。", actions: [] });
+        return mockOk({
+          reply: "採用しました。",
+          actions: [
+            {
+              tool: "adopt_avatar_preset",
+              result: "アバター「Haruka」を採用しました。まだ公開はされていません。",
+              card: { kind: "avatar_adopted", configId: "cfg-1", name: "Haruka", imageUrl: null, description: "とても丁寧な性格です。" },
+            },
+          ],
+        });
+      }
+      return mockOk({});
+    });
+  }
+
+  async function sendAndFindVoiceButton() {
+    renderPage();
+    await waitFor(() => expect(screen.getByText("今週も順調です。")).toBeTruthy());
+    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
+    fireEvent.change(getComposer(), { target: { value: "採用してください" } });
+    fireEvent.click(screen.getByLabelText("送信"));
+    return screen.findByRole("button", { name: "声を探す" });
+  }
+
+  it("候補が描画され、音声プレビューが無い旨が明示される(試聴URLを持たないため)", async () => {
+    mockAdoptedThenVoiceEndpoints({});
+
+    const voiceButton = await sendAndFindVoiceButton();
+    fireEvent.click(voiceButton);
+
+    expect(await screen.findByText("Haruka Voice")).toBeTruthy();
+    expect(screen.getByText("明るく親しみやすい声")).toBeTruthy();
+    expect(screen.getByText("92%")).toBeTruthy();
+    expect(screen.getByText("音声のプレビューは提供されていません。名前と説明を参考にお選びください。")).toBeTruthy();
+    expect(document.querySelector("audio")).toBeNull();
+
+    const matchCall = vi.mocked(authFetch).mock.calls.find(([url]) => String(url).includes("/match-voice"));
+    expect(matchCall).toBeTruthy();
+    // 声の説明を新たに尋ねず、採用済みの性格・話し方の説明をそのまま検索クエリにする
+    expect(JSON.parse(String((matchCall![1] as RequestInit).body))).toEqual({ description: "とても丁寧な性格です。" });
+  });
+
+  it("採用でPATCHが呼ばれ、二重押しできない", async () => {
+    mockAdoptedThenVoiceEndpoints({});
+
+    const voiceButton = await sendAndFindVoiceButton();
+    fireEvent.click(voiceButton);
+
+    const adoptButton = await screen.findByRole("button", { name: "この声にする" });
+    fireEvent.click(adoptButton);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "これに決定" })).toBeTruthy());
+    const patchCall = vi
+      .mocked(authFetch)
+      .mock.calls.find(([url]) => String(url).includes("/v1/admin/avatar/configs/cfg-1"));
+    expect(patchCall).toBeTruthy();
+    expect((patchCall![1] as RequestInit).method).toBe("PATCH");
+    expect(JSON.parse(String((patchCall![1] as RequestInit).body))).toEqual({ voice_id: "voice-1" });
+    expect((screen.getByRole("button", { name: "これに決定" }) as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("候補が0件でも失敗として確定する(無限スピナーを残さない)", async () => {
+    mockAdoptedThenVoiceEndpoints({ match: () => mockOk({ recommendations: [] }) });
+
+    const voiceButton = await sendAndFindVoiceButton();
+    fireEvent.click(voiceButton);
+
+    expect(await screen.findByText("合う声が見つかりませんでした。もう一度お試しください。")).toBeTruthy();
+    expect(screen.queryByText("少し時間がかかることがあります。このまま他の操作もできます。")).toBeNull();
+    expect(await screen.findByRole("button", { name: "もう一度試す" })).toBeTruthy();
+  });
+
+  it("検索が5xxで失敗しても確定する", async () => {
+    mockAdoptedThenVoiceEndpoints({
+      match: () => Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({ error: "声マッチングに失敗しました" }) } as Response),
+    });
+
+    const voiceButton = await sendAndFindVoiceButton();
+    fireEvent.click(voiceButton);
+
+    expect(await screen.findByText("声マッチングに失敗しました")).toBeTruthy();
+  });
+
+  it("採用のPATCHが失敗しても、まだ採用されていない扱いのままエラーを示す", async () => {
+    mockAdoptedThenVoiceEndpoints({
+      patch: () => Promise.resolve({ ok: false, status: 500, json: () => Promise.resolve({ error: "更新に失敗しました" }) } as Response),
+    });
+
+    const voiceButton = await sendAndFindVoiceButton();
+    fireEvent.click(voiceButton);
+    const adoptButton = await screen.findByRole("button", { name: "この声にする" });
+    fireEvent.click(adoptButton);
+
+    expect(await screen.findByText("更新に失敗しました")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "これに決定" })).toBeNull();
+    expect(screen.getByRole("button", { name: "この声にする" })).toBeTruthy();
+  });
+});
+
 // 想定ユーザーは100%日本語入力の店主。かな漢字変換の確定Enterで未変換のまま
 // 送信されてしまう不具合の回帰テスト(判定条件自体は lib/utils.test.ts で検証済み)。
 describe("CopilotPreviewPage — コンポーザのIME/改行", () => {

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -104,6 +104,19 @@ type Card =
       message?: string;
       adoptedUrl?: string;
     }
+  // 声の候補提示〜採用。POST /match-voice はテキストの候補(id/title/description/score)
+  // のみを返し音声プレビューを持たないため(旧UIウィザードのStudioVoiceSectionも同様に
+  // 試聴機能を持たない)、本カードも一覧から選ぶ形にする。description は再検索(もう一度
+  // 探す)用に保持する。他の失敗系カードと同じく、必ず status="failed" で確定させる。
+  | {
+      kind: "avatarVoiceCandidates";
+      configId: string;
+      description: string;
+      status: "matching" | "done" | "failed";
+      recommendations?: Array<{ id: string; title: string; description: string; score: number }>;
+      message?: string;
+      adoptedVoiceId?: string;
+    }
   // D3: 一覧が15件・1行60/100字で黙って切れていたのを解消するための全件カード。
   | {
       kind: "rulesList";
@@ -340,6 +353,9 @@ const PDF_UPLOAD_ZIP_EMPTY_ERROR = "ZIPの中に取り込めるPDFが見つか�
 
 const AVATAR_GENERATE_GENERIC_ERROR = "画像を生成できませんでした。少し時間をおいてもう一度お試しください。";
 const AVATAR_ADOPT_GENERIC_ERROR = "この画像を反映できませんでした。少し時間をおいてもう一度お試しください。";
+const AVATAR_VOICE_MATCH_GENERIC_ERROR = "声を検索できませんでした。少し時間をおいてもう一度お試しください。";
+const AVATAR_VOICE_MATCH_EMPTY_ERROR = "合う声が見つかりませんでした。もう一度お試しください。";
+const AVATAR_VOICE_ADOPT_GENERIC_ERROR = "この声を反映できませんでした。少し時間をおいてもう一度お試しください。";
 
 // ─── 進行中テキストを少しずつ流し込む（体感の良さ重視の演出。本物の
 //     トークンストリーミングではなく、確定済みの応答文字列をクライアント側で
@@ -1117,6 +1133,73 @@ export default function CopilotPreviewPage() {
     }
   };
 
+  // ─── アバターの声の選択・採用 ─────────────────────────────────────────────────
+  // POST /match-voice はテキストの候補(id/title/description/score)のみを返す
+  // (旧UIウィザードのStudioVoiceSectionも同様に試聴機能を持たない。Fish Audio
+  // 検索APIの応答に音声プレビューURLが含まれないため)。「声の説明」は新たに
+  // 尋ねず、採用済みアバターの性格・話し方の説明をそのまま検索クエリに使う
+  // (「選ばせない」方針。ユーザーは声だけの追加質問に答えなくてよい)。
+  const updateAvatarVoiceCard = useCallback((msgId: number, patch: Partial<Extract<Card, { kind: "avatarVoiceCandidates" }>>) => {
+    setMsgs((prev) =>
+      prev.map((m) =>
+        m.id === msgId && m.card?.kind === "avatarVoiceCandidates" ? { ...m, card: { ...m.card, ...patch } } : m,
+      ),
+    );
+  }, []);
+
+  const matchAvatarVoice = async (configId: string, description: string) => {
+    const cardId = nextId();
+    const boundedDescription = description.slice(0, 300);
+    push({ id: cardId, role: "ai", card: { kind: "avatarVoiceCandidates", configId, description: boundedDescription, status: "matching" } });
+
+    try {
+      const res = await authFetch(`${API_BASE}/v1/admin/avatar/match-voice`, {
+        method: "POST",
+        body: JSON.stringify({ description: boundedDescription }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as { error?: string } | null;
+        updateAvatarVoiceCard(cardId, { status: "failed", message: body?.error || AVATAR_VOICE_MATCH_GENERIC_ERROR });
+        return;
+      }
+      const data = (await res.json()) as { recommendations?: Array<{ id: string; title: string; description: string; score: number }> };
+      const recommendations = data.recommendations ?? [];
+      if (recommendations.length === 0) {
+        updateAvatarVoiceCard(cardId, { status: "failed", message: AVATAR_VOICE_MATCH_EMPTY_ERROR });
+        return;
+      }
+      updateAvatarVoiceCard(cardId, { status: "done", recommendations });
+    } catch (err) {
+      const message =
+        (err as { message?: string } | null)?.message === "__AUTH_REQUIRED__"
+          ? AGENT_CHAT_AUTH_REQUIRED_MESSAGE
+          : AVATAR_VOICE_MATCH_GENERIC_ERROR;
+      updateAvatarVoiceCard(cardId, { status: "failed", message });
+    }
+  };
+
+  const adoptAvatarVoice = async (cardMsgId: number, configId: string, voiceId: string) => {
+    try {
+      const res = await authFetch(`${API_BASE}/v1/admin/avatar/configs/${configId}`, {
+        method: "PATCH",
+        body: JSON.stringify({ voice_id: voiceId }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => null)) as { error?: string } | null;
+        updateAvatarVoiceCard(cardMsgId, { message: body?.error || AVATAR_VOICE_ADOPT_GENERIC_ERROR });
+        return;
+      }
+      updateAvatarVoiceCard(cardMsgId, { adoptedVoiceId: voiceId });
+      setRealActionCount((n) => n + 1);
+    } catch (err) {
+      const message =
+        (err as { message?: string } | null)?.message === "__AUTH_REQUIRED__"
+          ? AGENT_CHAT_AUTH_REQUIRED_MESSAGE
+          : AVATAR_VOICE_ADOPT_GENERIC_ERROR;
+      updateAvatarVoiceCard(cardMsgId, { message });
+    }
+  };
+
   const handlePdfDrop = (e: React.DragEvent) => {
     e.preventDefault();
     pdfDragCounterRef.current = 0;
@@ -1293,6 +1376,8 @@ export default function CopilotPreviewPage() {
                 onChip={runAction}
                 onGenerateAvatarCandidates={generateAvatarCandidates}
                 onAdoptAvatarCandidate={adoptAvatarCandidate}
+                onMatchAvatarVoice={matchAvatarVoice}
+                onAdoptAvatarVoice={adoptAvatarVoice}
               />
             ))}
             {/* key に直近メッセージのidを与え、回答が変わるたびに新しい確認として出す
@@ -1538,11 +1623,15 @@ function MessageRow({
   onChip,
   onGenerateAvatarCandidates,
   onAdoptAvatarCandidate,
+  onMatchAvatarVoice,
+  onAdoptAvatarVoice,
 }: {
   m: Msg;
   onChip: (a: string, id: number) => void;
   onGenerateAvatarCandidates: (configId: string, name: string) => void | Promise<void>;
   onAdoptAvatarCandidate: (cardMsgId: number, configId: string, imageUrl: string) => void | Promise<void>;
+  onMatchAvatarVoice: (configId: string, description: string) => void | Promise<void>;
+  onAdoptAvatarVoice: (cardMsgId: number, configId: string, voiceId: string) => void | Promise<void>;
 }) {
   const isMe = m.role === "me";
   return (
@@ -1565,6 +1654,8 @@ function MessageRow({
           msgId={m.id}
           onGenerateAvatarCandidates={onGenerateAvatarCandidates}
           onAdoptAvatarCandidate={onAdoptAvatarCandidate}
+          onMatchAvatarVoice={onMatchAvatarVoice}
+          onAdoptAvatarVoice={onAdoptAvatarVoice}
         />
       )}
       {m.chips && !m.chipsUsed && (
@@ -1759,11 +1850,15 @@ function CardView({
   msgId,
   onGenerateAvatarCandidates,
   onAdoptAvatarCandidate,
+  onMatchAvatarVoice,
+  onAdoptAvatarVoice,
 }: {
   card: Card;
   msgId: number;
   onGenerateAvatarCandidates: (configId: string, name: string) => void | Promise<void>;
   onAdoptAvatarCandidate: (cardMsgId: number, configId: string, imageUrl: string) => void | Promise<void>;
+  onMatchAvatarVoice: (configId: string, description: string) => void | Promise<void>;
+  onAdoptAvatarVoice: (cardMsgId: number, configId: string, voiceId: string) => void | Promise<void>;
 }) {
   switch (card.kind) {
     case "agentAction":
@@ -1847,9 +1942,11 @@ function CardView({
         </CardShell>
       );
     case "avatarAdopted":
-      return <AvatarAdoptedCard card={card} onGenerate={onGenerateAvatarCandidates} />;
+      return <AvatarAdoptedCard card={card} onGenerate={onGenerateAvatarCandidates} onMatchVoice={onMatchAvatarVoice} />;
     case "avatarCandidates":
       return <AvatarCandidatesCard card={card} msgId={msgId} onGenerate={onGenerateAvatarCandidates} onAdopt={onAdoptAvatarCandidate} />;
+    case "avatarVoiceCandidates":
+      return <AvatarVoiceCard card={card} msgId={msgId} onMatch={onMatchAvatarVoice} onAdopt={onAdoptAvatarVoice} />;
     case "link":
       return (
         <CardShell hd={<><span>🔗</span>{card.label}へご案内します</>}>
@@ -2034,21 +2131,29 @@ function WeeklySummaryCard({ card }: { card: Extract<Card, { kind: "weeklySummar
 function AvatarAdoptedCard({
   card,
   onGenerate,
+  onMatchVoice,
 }: {
   card: Extract<Card, { kind: "avatarAdopted" }>;
   onGenerate: (configId: string, name: string) => void | Promise<void>;
+  onMatchVoice: (configId: string, description: string) => void | Promise<void>;
 }) {
-  const [busy, setBusy] = useState(false);
+  const [busyImage, setBusyImage] = useState(false);
+  const [busyVoice, setBusyVoice] = useState(false);
   const handleGenerate = () => {
-    setBusy(true);
-    void Promise.resolve(onGenerate(card.configId, card.name)).finally(() => setBusy(false));
+    setBusyImage(true);
+    void Promise.resolve(onGenerate(card.configId, card.name)).finally(() => setBusyImage(false));
+  };
+  const handleMatchVoice = () => {
+    setBusyVoice(true);
+    // 声の説明を新たに尋ねず、採用済みの性格・話し方の説明をそのまま検索クエリにする。
+    void Promise.resolve(onMatchVoice(card.configId, card.description)).finally(() => setBusyVoice(false));
   };
 
   return (
     <CardShell
       tone="good"
       hd={<><span>✅</span>アバター「{card.name}」を採用しました</>}
-      foot={<CardActionsNote note="生成のたびに少額の費用が発生します。気に入った1枚を選ぶまで何度でもやり直せます。" />}
+      foot={<CardActionsNote note="生成・検索のたびに少額の費用が発生します。気に入るまで何度でもやり直せます。" />}
     >
       {card.imageUrl && (
         <img
@@ -2058,17 +2163,30 @@ function AvatarAdoptedCard({
         />
       )}
       <Field k="性格・話し方" v={card.description} quote />
-      <button
-        onClick={handleGenerate}
-        disabled={busy}
-        style={{
-          alignSelf: "flex-start", fontSize: 14.5, fontWeight: 700, padding: "10px 18px", borderRadius: 12, minHeight: 44,
-          border: "none", background: AGENT, color: "#fff",
-          cursor: busy ? "not-allowed" : "pointer", opacity: busy ? 0.6 : 1,
-        }}
-      >
-        {busy ? "生成しています…" : "画像を新しく生成する"}
-      </button>
+      <div style={{ display: "flex", gap: 10, flexWrap: "wrap" }}>
+        <button
+          onClick={handleGenerate}
+          disabled={busyImage}
+          style={{
+            alignSelf: "flex-start", fontSize: 14.5, fontWeight: 700, padding: "10px 18px", borderRadius: 12, minHeight: 44,
+            border: "none", background: AGENT, color: "#fff",
+            cursor: busyImage ? "not-allowed" : "pointer", opacity: busyImage ? 0.6 : 1,
+          }}
+        >
+          {busyImage ? "生成しています…" : "画像を新しく生成する"}
+        </button>
+        <button
+          onClick={handleMatchVoice}
+          disabled={busyVoice}
+          style={{
+            alignSelf: "flex-start", fontSize: 14.5, fontWeight: 700, padding: "10px 18px", borderRadius: 12, minHeight: 44,
+            border: "1px solid var(--border)", background: "transparent", color: "var(--foreground)",
+            cursor: busyVoice ? "not-allowed" : "pointer", opacity: busyVoice ? 0.6 : 1,
+          }}
+        >
+          {busyVoice ? "声を探しています…" : "声を探す"}
+        </button>
+      </div>
     </CardShell>
   );
 }
@@ -2176,6 +2294,113 @@ function AvatarCandidatesCard({
                 }}
               >
                 {isAdopted ? "これに決定" : adopting === url ? "反映中…" : "これにする"}
+              </button>
+            </div>
+          );
+        })}
+      </div>
+    </CardShell>
+  );
+}
+
+// 声の候補〜採用。match-voice はテキストの候補(id/title/description/score)のみを
+// 返し、音声プレビューURLを持たない(旧UIウィザードのStudioVoiceSectionも試聴機能を
+// 持たない。Fish Audio検索APIの応答に含まれないため)。名前とスコアを頼りに選ぶ形になる。
+function AvatarVoiceCard({
+  card,
+  msgId,
+  onMatch,
+  onAdopt,
+}: {
+  card: Extract<Card, { kind: "avatarVoiceCandidates" }>;
+  msgId: number;
+  onMatch: (configId: string, description: string) => void | Promise<void>;
+  onAdopt: (cardMsgId: number, configId: string, voiceId: string) => void | Promise<void>;
+}) {
+  const [adopting, setAdopting] = useState<string | null>(null);
+
+  if (card.status === "matching") {
+    return (
+      <CardShell hd={<><span>🔊</span>合う声を探しています</>}>
+        <div style={{ fontSize: 14, color: "var(--muted-foreground)", lineHeight: 1.7 }}>
+          少し時間がかかることがあります。このまま他の操作もできます。
+        </div>
+      </CardShell>
+    );
+  }
+
+  if (card.status === "failed") {
+    return (
+      <CardShell
+        tone="bad"
+        hd={<><span>🔊</span>声を検索できませんでした</>}
+        foot={
+          <div style={{ padding: "10px 18px", borderTop: "1px solid var(--border)" }}>
+            <button
+              onClick={() => void onMatch(card.configId, card.description)}
+              style={{
+                fontSize: 13.5, fontWeight: 700, padding: "7px 16px", borderRadius: 999, minHeight: 36,
+                border: `1px solid ${AGENT_BORDER}`, background: AGENT_SOFT, color: AGENT, cursor: "pointer",
+              }}
+            >
+              もう一度試す
+            </button>
+          </div>
+        }
+      >
+        {card.message && <div style={{ fontSize: 15, color: "var(--foreground)", lineHeight: 1.7 }}>{card.message}</div>}
+      </CardShell>
+    );
+  }
+
+  const handleAdopt = (voiceId: string) => {
+    setAdopting(voiceId);
+    void Promise.resolve(onAdopt(msgId, card.configId, voiceId)).finally(() => setAdopting(null));
+  };
+
+  return (
+    <CardShell
+      tone="good"
+      hd={<><span>🔊</span>声の候補です</>}
+      foot={
+        <CardActionsNote note="音声のプレビューは提供されていません。名前と説明を参考にお選びください。" />
+      }
+    >
+      {card.message && <div style={{ fontSize: 13, color: "var(--muted-foreground)" }}>{card.message}</div>}
+      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+        {(card.recommendations ?? []).map((rec) => {
+          const isAdopted = card.adoptedVoiceId === rec.id;
+          const disabled = !!card.adoptedVoiceId || adopting !== null;
+          return (
+            <div
+              key={rec.id}
+              style={{
+                display: "flex", alignItems: "center", justifyContent: "space-between", gap: 12,
+                padding: "10px 14px", borderRadius: 10,
+                border: isAdopted ? `1px solid ${AGENT}` : "1px solid var(--border)",
+                background: isAdopted ? AGENT_SOFT : "transparent",
+              }}
+            >
+              <div style={{ minWidth: 0 }}>
+                <div style={{ display: "flex", alignItems: "baseline", gap: 8 }}>
+                  <span style={{ fontSize: 14, fontWeight: 700, color: "var(--foreground)" }}>{rec.title}</span>
+                  <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>{Math.round(rec.score * 100)}%</span>
+                </div>
+                <div style={{ fontSize: 12.5, color: "var(--muted-foreground)", marginTop: 2 }}>{rec.description}</div>
+              </div>
+              <button
+                onClick={() => handleAdopt(rec.id)}
+                disabled={disabled}
+                style={{
+                  flexShrink: 0, fontSize: 12.5, fontWeight: 700, padding: "7px 14px", borderRadius: 999, minHeight: 36,
+                  border: isAdopted ? "none" : "1px solid var(--border)",
+                  background: isAdopted ? AGENT : "transparent",
+                  color: isAdopted ? "#fff" : "var(--muted-foreground)",
+                  cursor: disabled ? "not-allowed" : "pointer",
+                  opacity: disabled && !isAdopted ? 0.5 : 1,
+                }}
+              >
+                {isAdopted ? "これに決定" : adopting === rec.id ? "反映中…" : "この声にする"}
               </button>
             </div>
           );


### PR DESCRIPTION
Asana: feat: アバターの声の選択・試聴をチャット内で完結させる
GID 1217040570444264 ※スコープを実装に合わせて修正（下記）

## 背景

アバター設定の最後の主要項目として、声の候補提示〜採用をチャットを離れずに完結させる（`docs/AVATAR_CHAT_MIGRATION.md` §4.1 層B）。#632（画像候補の生成と採用）の続き。

## スコープの修正（実装中の発見）

計画は「候補提示・**試聴**・採用」を前提にしていたが、実装を確認すると `POST /v1/admin/avatar/match-voice` は**テキストの候補（id/title/description/score）のみを返し、音声プレビューURLを一切持たない**。旧UIウィザードの `StudioVoiceSection.tsx` も同じ理由（Fish Audio検索APIの応答に音声サンプルURLが含まれない）で `<audio>` 要素を一切持たず、一覧から選ぶだけの実装だった。

したがって**「試聴」機能は実装していない**。一覧から選ぶ形にし、代わりに「音声のプレビューは提供されていません」と明示する（黙って省略しない）。これは fal 課金訂正（#594）・`generate-prompt` 誤認（#632）と同種の、計画の前提が実装と食い違っていたケース。

## 変更内容（2ファイル・新規ファイル/新規エンドポイントなし・サーバ変更なし）

### `admin-ui/src/pages/copilot-preview/index.tsx`
- `Card` union に `avatarVoiceCandidates` を追加（`matching`/`done`/`failed`）。`description`（検索クエリ）を保持しリトライ可能にする
- `matchAvatarVoice` / `adoptAvatarVoice` を追加。画像候補（#632）と同じ理由でエージェントツール経由にせず、`POST /match-voice` と `PATCH /configs/:id`（`voice_id`）をフロントから直接叩く
- **「声の説明」を新たに尋ねない**: 採用済みアバターの性格・話し方の説明（`avatarAdopted` カードの `description`）をそのまま検索クエリに使う（「選ばせない」方針をここでも一貫させる）
- `AvatarAdoptedCard` に「声を探す」ボタンを追加（画像生成ボタンと並列。それぞれ独立した `busy` 状態）
- `AvatarVoiceCard` を追加。失敗（5xx・ネットワークエラー・0件）は必ず `status="failed"` で確定させ、無限スピナーを残さない

音声クローン（`voice-clone`）には触れていません（enterprise限定のため対象外、計画どおり）。

## テスト

追加5件（frontend）:
- 候補が描画され、**音声プレビュー不在の明示文と `<audio>` 要素の不在を検証**。検索クエリが採用済みの性格説明そのままであることも検証
- 採用でPATCH（`voice_id`）が呼ばれ、二重押しできない
- 候補0件でも失敗として確定する
- 検索が5xxで失敗しても確定する
- 採用のPATCH失敗時もエラーを示し、採用済み扱いにしない

検証結果:
- `vitest run`（admin-ui 全体）→ 285 passed
- `jest src/api/admin/agent` → 296 passed（本PRはサーバ変更なしのため対象外の確認）
- `tsc --noEmit`（backend）→ 0 errors、`tsc -b`（admin-ui）→ 13 errors（`origin/main` と同数の既知差分）
- `oxlint --max-warnings 63` → exit 0

## やっていないこと

- 音声のプレビュー/試聴機能（基盤側に存在しないため。上記スコープ修正）
- `voice-clone` エンドポイントの呼び出し（enterprise限定、別タスク）
- 新規エンドポイントの追加
- 旧UIスタジオの音声セクションの変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StqjjaijseYkGkmG2k5LJ