### PR TITLE
test(e2e): アバター設定フローのライブテスト受け渡しと完走E2Eを追加

### DIFF
--- a/tests/e2e/qa-copilot-preview.spec.ts
+++ b/tests/e2e/qa-copilot-preview.spec.ts
@@ -47,6 +47,152 @@ test.describe('copilot-preview — Role B (client_admin)', () => {
     expect(body).not.toContain(NO_TENANT_MSG);
   });
 
+  // CP-B-3: アバター設定フローの完走（未作成 → 推奨提示 → 採用 → 画像 → 声 → 有効化 → ライブテスト）。
+  // /v1/admin/agent/chat・fal/generate・match-voice・configs PATCH をすべてモックする。理由は3つ:
+  //   (1) 実LLM(Groq)のツール選択の揺れに依存させず決定論的にする
+  //   (2) fal.ai/Fish Audioへの実課金(#594で計上対応済みだが、CI実行毎に発生させる理由が無い)を発生させない
+  //   (3) carnationの実 avatar_configs を本番でCI実行のたびに書き換えない(このファイルの
+  //       他テストと同じ「実データで読む」前提を、書き込みを伴うこのテストにまで広げない)
+  // widget-fab-avatar.spec.ts が anam-session/room-token を同じ理由でモックしている先例に倣う。
+  // 検証したいのはUIの実配線(クリック→カード遷移→PATCH送出→復元)であって、LLM/外部APIの
+  // 中身そのものではないため、モックはこの目的に対して妥当な選択である。
+  test('CP-B-3: 未作成テナントが会話だけで公開まで到達し、離脱はライブテストの1回だけ', async ({ page, context }) => {
+    let chatCalls = 0;
+    const chatMessages: string[] = [];
+
+    await page.route('**/v1/admin/agent/chat', async (route) => {
+      const body = JSON.parse(route.request().postData() || '{}') as { message?: string };
+      chatCalls += 1;
+      chatMessages.push(body.message ?? '');
+
+      if (chatCalls === 1) {
+        // 起動時ブリーフィング
+        return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ reply: '今週も順調です。', actions: [] }) });
+      }
+      if (body.message?.includes('アバターを作りたい')) {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            reply: '見本をご提案しました。',
+            actions: [{
+              tool: 'suggest_avatar_preset',
+              result: '「Haruka」というアバターの見本があります。\nプリセットID: preset-e2e-1\nこのまま採用しますか？',
+              card: { kind: 'avatar_preset', presetId: 'preset-e2e-1', name: 'Haruka', imageUrl: null, description: 'とても丁寧な性格です。' },
+            }],
+          }),
+        });
+      }
+      if (body.message === '採用してください') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            reply: '採用しました。',
+            actions: [{
+              tool: 'adopt_avatar_preset',
+              result: 'アバター「Haruka」を採用しました。まだ公開はされていません。',
+              card: { kind: 'avatar_adopted', configId: 'cfg-e2e-1', name: 'Haruka', imageUrl: null, description: 'とても丁寧な性格です。' },
+            }],
+          }),
+        });
+      }
+      if (body.message?.includes('有効化して')) {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ reply: '有効化しました。', actions: [{ tool: 'activate_avatar', result: 'アバター（ID: cfg-e2e-1）を有効化しました' }] }),
+        });
+      }
+      if (body.message?.includes('テストチャットで確認したい')) {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            reply: 'テストチャットをご案内しました。',
+            actions: [{
+              tool: 'get_legacy_ui_link',
+              result: 'この操作はテストチャット画面から行えます。',
+              card: { kind: 'legacy_link', label: 'テストチャット', url: '/admin/chat-test', description: '設定した内容を実際のチャットで試すのはこちらの画面で行えます' },
+            }],
+          }),
+        });
+      }
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ reply: '了解しました。', actions: [] }) });
+    });
+
+    await page.route('**/v1/admin/avatar/fal/generate', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ images: ['https://img.example/1.png', 'https://img.example/2.png', 'https://img.example/3.png', 'https://img.example/4.png'] }),
+      }),
+    );
+    await page.route('**/v1/admin/avatar/match-voice', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ recommendations: [{ id: 'voice-e2e-1', title: 'Haruka Voice', description: '明るく親しみやすい声', score: 0.9 }] }),
+      }),
+    );
+    let patchCount = 0;
+    await page.route('**/v1/admin/avatar/configs/cfg-e2e-1', (route) => {
+      if (route.request().method() === 'PATCH') {
+        patchCount += 1;
+        return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ id: 'cfg-e2e-1' }) });
+      }
+      return route.continue();
+    });
+
+    await page.goto(`${ADMIN}/copilot-preview`, { waitUntil: 'domcontentloaded', timeout: 20000 });
+    await waitForBootstrapReply(page);
+
+    const composer = page.getByPlaceholder(/指示ルール/);
+    const send = page.getByLabel('送信');
+
+    // ① 未作成 → 推奨提示
+    await composer.fill('アバターを作りたい');
+    await send.click();
+    await expect(page.getByRole('button', { name: '採用して' })).toBeVisible({ timeout: 10000 });
+
+    // ② 採用（チップ経由）
+    await page.getByRole('button', { name: '採用して' }).click();
+    await expect(page.getByRole('button', { name: '画像を新しく生成する' })).toBeVisible({ timeout: 10000 });
+
+    // ③ 画像候補の生成・採用
+    await page.getByRole('button', { name: '画像を新しく生成する' }).click();
+    await expect(page.getByRole('button', { name: 'これにする' }).first()).toBeVisible({ timeout: 10000 });
+    await page.getByRole('button', { name: 'これにする' }).first().click();
+    await expect(page.getByRole('button', { name: 'これに決定' })).toBeVisible({ timeout: 10000 });
+
+    // ④ 声の候補の検索・採用
+    await page.getByRole('button', { name: '声を探す' }).click();
+    await expect(page.getByRole('button', { name: 'この声にする' })).toBeVisible({ timeout: 10000 });
+    await page.getByRole('button', { name: 'この声にする' }).click();
+    await expect(page.getByText('Haruka Voice')).toBeVisible();
+
+    expect(patchCount).toBe(2); // 画像1回 + 声1回。二重PATCHが起きていないこと
+
+    // ⑤ 有効化（公開）
+    await composer.fill('アバターを有効化してください');
+    await send.click();
+    await expect(page.getByText(/有効化しました/)).toBeVisible({ timeout: 10000 });
+
+    // ⑥ ライブテストへの受け渡し（唯一の離脱点）。別タブで開き、この会話は残ったままであること。
+    await composer.fill('テストチャットで確認したい');
+    await send.click();
+    const linkPromise = context.waitForEvent('page');
+    await page.getByRole('link', { name: /テストチャットを開く/ }).click();
+    const newTab = await linkPromise;
+    await newTab.waitForLoadState('domcontentloaded');
+    expect(newTab.url()).toContain('/admin/chat-test');
+    await newTab.close();
+
+    // 別タブに離脱しただけで、元の会話(アシスタントの発言・カード群)はそのまま残っている
+    expect(page.url()).toContain('/copilot-preview');
+    await expect(page.getByText('Haruka Voice')).toBeVisible();
+  });
+
   // GID 1217040318322843: 週次まとめカード(指標が5〜6個並ぶ)が最も崩れやすいカードのため、
   // 390pxモバイルビューポート(CLAUDE.md Mobile First)で個別に確認する。
   test.describe('390pxモバイルビューポート', () => {

--- a/tests/e2e/qa-irregular-3roles.spec.ts
+++ b/tests/e2e/qa-irregular-3roles.spec.ts
@@ -174,6 +174,130 @@ test.describe('Irregular — Role B (client_admin RBAC/tenant boundary)', () => 
     const pdfTabCount = await page.getByText('PDFアップロード', { exact: true }).count();
     expect(pdfTabCount).toBe(0);
   });
+
+  // このファイルの方針(非破壊のみ)に従い、以下2件も /v1/admin/agent/chat・fal/generate・
+  // configs PATCH をモックする(理由は qa-copilot-preview.spec.ts CP-B-3 のコメントと同じ:
+  // 実LLM/実課金/carnationの実データ書き換えに依存させない)。検証対象はUIの実配線であり、
+  // モックは非破壊性を担保する手段そのものである。
+  async function mockAvatarFlowUpToAdopted(page: any) {
+    let chatCalls = 0;
+    const sentMessages: string[] = [];
+    await page.route('**/v1/admin/agent/chat', async (route: any) => {
+      const body = JSON.parse(route.request().postData() || '{}') as { message?: string };
+      chatCalls += 1;
+      sentMessages.push(body.message ?? '');
+      if (chatCalls === 1) {
+        return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ reply: '今週も順調です。', actions: [] }) });
+      }
+      if (body.message?.includes('アバターを作りたい')) {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            reply: '見本をご提案しました。',
+            actions: [{
+              tool: 'suggest_avatar_preset',
+              result: '「Haruka」というアバターの見本があります。\nプリセットID: preset-e2e-1\nこのまま採用しますか？',
+              card: { kind: 'avatar_preset', presetId: 'preset-e2e-1', name: 'Haruka', imageUrl: null, description: 'とても丁寧な性格です。' },
+            }],
+          }),
+        });
+      }
+      if (body.message === '採用してください') {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            reply: '採用しました。',
+            actions: [{
+              tool: 'adopt_avatar_preset',
+              result: 'アバター「Haruka」を採用しました。まだ公開はされていません。',
+              card: { kind: 'avatar_adopted', configId: 'cfg-e2e-1', name: 'Haruka', imageUrl: null, description: 'とても丁寧な性格です。' },
+            }],
+          }),
+        });
+      }
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ reply: '了解しました。', actions: [] }) });
+    });
+    await page.route('**/v1/admin/avatar/fal/generate', (route: any) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ images: ['https://img.example/1.png', 'https://img.example/2.png', 'https://img.example/3.png', 'https://img.example/4.png'] }),
+      }),
+    );
+    return {
+      totalCalls: () => chatCalls,
+      countMessage: (message: string) => sentMessages.filter((m) => m === message).length,
+    };
+  }
+
+  // 下書き(画像候補)そのものはサーバに永続化されない一方、採用済みアバター自体
+  // (avatar_configs行 = adopt_avatar_presetの結果)はサーバ側に実在する。
+  // sessionStorage(chatSessionStore)からの会話復元が、生成完了後の状態を正しく
+  // 保つことを検証する。「生成の途中(status=generating)」でのリロードは、対応する
+  // fetchそのものが中断されるため復帰しない(既知の制約。カードは永久にgenerating表示の
+  // ままになる)。本テストは生成が完了した状態からのリロードのみを対象とする。
+  test('B-IRR-5: 画像候補の生成が完了した状態でリロードしても会話が復元し、採用を続けられる', async ({ page }) => {
+    await mockAvatarFlowUpToAdopted(page);
+    let patchCount = 0;
+    await page.route('**/v1/admin/avatar/configs/cfg-e2e-1', (route: any) => {
+      if (route.request().method() === 'PATCH') {
+        patchCount += 1;
+        return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ id: 'cfg-e2e-1' }) });
+      }
+      return route.continue();
+    });
+
+    await page.goto(`${ADMIN}/copilot-preview`, { waitUntil: 'domcontentloaded', timeout: 20000 });
+    await page.waitForTimeout(2000);
+
+    const composer = page.getByPlaceholder(/指示ルール/);
+    const send = page.getByLabel('送信');
+    await composer.fill('アバターを作りたい');
+    await send.click();
+    await page.getByRole('button', { name: '採用して' }).waitFor({ timeout: 10000 });
+    await page.getByRole('button', { name: '採用して' }).click();
+    await page.getByRole('button', { name: '画像を新しく生成する' }).waitFor({ timeout: 10000 });
+    await page.getByRole('button', { name: '画像を新しく生成する' }).click();
+    await page.getByRole('button', { name: 'これにする' }).first().waitFor({ timeout: 10000 });
+
+    // このタイミングで4枚の候補が既に描画されている(=生成は完了済み)。ここでリロードする。
+    await page.reload({ waitUntil: 'domcontentloaded', timeout: 20000 });
+    await page.waitForTimeout(1500);
+
+    // 会話(sessionStorage)が復元し、候補カードとボタンがそのまま操作できる
+    await expect(page.getByRole('button', { name: 'これにする' }).first()).toBeVisible({ timeout: 10000 });
+    await page.getByRole('button', { name: 'これにする' }).first().click();
+    await expect(page.getByRole('button', { name: 'これに決定' })).toBeVisible({ timeout: 10000 });
+    expect(patchCount).toBe(1);
+  });
+
+  // GID: 下書き提案のチップを連打しても、2通目の「採用してください」が二重送信されない
+  // (Msg.chipsUsed による使用済み化。連打はユーザーが実際にやりがちな操作)。
+  test('B-IRR-6: 「採用して」チップを連打しても採用は1回しか実行されない', async ({ page }) => {
+    const mock = await mockAvatarFlowUpToAdopted(page);
+
+    await page.goto(`${ADMIN}/copilot-preview`, { waitUntil: 'domcontentloaded', timeout: 20000 });
+    await page.waitForTimeout(2000);
+
+    const composer = page.getByPlaceholder(/指示ルール/);
+    const send = page.getByLabel('送信');
+    await composer.fill('アバターを作りたい');
+    await send.click();
+    const adoptChip = page.getByRole('button', { name: '採用して' });
+    await adoptChip.waitFor({ timeout: 10000 });
+
+    // 連打(2回)。1回目のクリックでチップは使用済みになり消えるため、2回目は
+    // 同じ要素に当たらず何も起きない想定。
+    await adoptChip.click();
+    await adoptChip.click({ timeout: 1000 }).catch(() => {}); // 消えていれば即タイムアウトでよい
+
+    await expect(page.getByRole('button', { name: '画像を新しく生成する' })).toBeVisible({ timeout: 10000 });
+    // 二重の実UI状態(チップが残っていない)と、実際の送信回数(サーバ視点)の両方を確認する
+    expect(await page.getByRole('button', { name: '採用して' }).count()).toBe(0);
+    expect(mock.countMessage('採用してください')).toBe(1);
+  });
 });
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -245,5 +369,31 @@ test.describe('Irregular — Role C (super_admin cross-tenant & preview)', () =>
     await page.waitForTimeout(2000);
     const pdfTabCount = await page.getByText('PDFアップロード', { exact: true }).count();
     expect(pdfTabCount).toBeGreaterThan(0);
+  });
+
+  // previewMode を一切設定せず /copilot-preview を直接開く(page.gotoで良い。previewMode
+  // 未設定=状態を消す心配が無いため他のC-LEAK系テストのような制約が無い)。
+  // activate_avatar はテナントが解決できないため未確定のIDに対しても実行前に拒否され、
+  // DBへは触れない(既存jestテスト同様のガード。実backendに対して安全に実行できる)。
+  test('C-IRR-5: super_adminがpreview未選択のままアバターの有効化を指示すると拒否される', async ({ page }) => {
+    await page.goto(`${ADMIN}/copilot-preview`, { waitUntil: 'domcontentloaded', timeout: 20000 });
+    await page
+      .waitForResponse((res) => res.url().includes('/v1/admin/agent/chat') && res.request().method() === 'POST', { timeout: 20000 })
+      .catch(() => {});
+    await page.waitForTimeout(2000);
+
+    const composer = page.getByPlaceholder(/指示ルール/);
+    const send = page.getByLabel('送信');
+    await composer.fill('アバターを有効化してください');
+    const chatResP = page.waitForResponse(
+      (res) => res.url().includes('/v1/admin/agent/chat') && res.request().method() === 'POST',
+      { timeout: 20000 },
+    );
+    await send.click();
+    await chatResP;
+    await page.waitForTimeout(1500);
+
+    const body = (await page.textContent('body')) ?? '';
+    expect(body).toContain('テナントが特定できません');
   });
 });

--- a/tests/e2e/qa-preview-scope-leak.spec.ts
+++ b/tests/e2e/qa-preview-scope-leak.spec.ts
@@ -133,4 +133,51 @@ test.describe('Preview scope leak (known bug) — escalations が preview テナ
       `プレビュー中(lp-demo)に他テナントのアバター設定が漏洩: ${JSON.stringify(foreign)}`,
     ).toHaveLength(0);
   });
+
+  // C-LEAK-4: /copilot-preview のアバター関連ツール(get_avatar_list等)は previewMode 中、
+  // targetTenantId をリクエストボディに明示的に付与して送る(docs/CHAT_SURFACE_DECISION.md §1.9
+  // が指摘する「super_adminのtargetTenantId導出が2箇所別実装」の懸念に対する回帰ガード)。
+  // C-LEAK-1〜3と異なりこのツールはテキスト応答のみでJSON構造化データを持たないため、
+  // レスポンス本文からのテナント混入検査ではなく、リクエスト側のスコープ付与を検証する。
+  test('C-LEAK-4: carnation プレビュー中の /copilot-preview で targetTenantId が正しく付与される(アバター一覧)', async ({
+    page,
+  }) => {
+    // 1. テナント詳細を開き、プレビュー投入
+    await page.goto(`${ADMIN}/admin/tenants/${PREVIEW_TENANT}`, { waitUntil: 'domcontentloaded' });
+    const previewBtn = page.getByRole('button', { name: /クライアントビューで見る/ });
+    await previewBtn.waitFor({ timeout: 15000 });
+    await previewBtn.click();
+    await expect(page.getByText(/プレビューモード|元に戻す/).first()).toBeVisible({ timeout: 10000 });
+
+    // 2. SPA内リンククリックでチャットへ(page.gotoはpreview状態をリセットしてしまうため使わない)。
+    // previewMode中は isClientAdmin が true になるため「AIチャットに戻る」導線が出る
+    // (App.tsx の showAIChat 判定コメント参照)。
+    await page.getByText('AIチャットに戻る').first().click();
+    await page.waitForURL((url) => url.pathname === '/copilot-preview', { timeout: 15000 });
+    await page
+      .waitForResponse((r) => r.url().includes('/v1/admin/agent/chat') && r.request().method() === 'POST', { timeout: 20000 })
+      .catch(() => {});
+    await page.waitForTimeout(1500);
+
+    // 3. アバター一覧を尋ね、リクエストボディの targetTenantId を検証
+    const composer = page.getByPlaceholder(/指示ルール/);
+    const send = page.getByLabel('送信');
+    await composer.fill('アバターの一覧を見せて');
+    const chatResP = page.waitForResponse(
+      (r) => r.url().includes('/v1/admin/agent/chat') && r.request().method() === 'POST',
+      { timeout: 20000 },
+    );
+    await send.click();
+    const chatRes = await chatResP;
+    const reqBody = JSON.parse(chatRes.request().postData() || '{}') as { targetTenantId?: string };
+
+    test.info().annotations.push({ type: 'targetTenantId', description: String(reqBody.targetTenantId) });
+    expect(reqBody.targetTenantId).toBe(PREVIEW_TENANT);
+    expect(reqBody.targetTenantId).not.toBe(PREVIEW_TENANT_2);
+
+    // 4. テナント未特定エラーに落ちていない(=正しくスコープ解決できている)こと
+    await page.waitForTimeout(1500);
+    const body = (await page.textContent('body')) ?? '';
+    expect(body).not.toContain('テナントが特定できません');
+  });
 });


### PR DESCRIPTION
Asana: feat: アバター設定フローのライブテスト受け渡しと完走E2Eを追加
GID 1217040704587948

## 背景

決定5（hkobayashi 2026-07-31）: ライブテストへの離脱1回は正常状態として許容する。未作成テナントが会話だけで公開まで到達できることをE2Eに固定する（`docs/AVATAR_CHAT_MIGRATION.md` §4.1 層C）。#635（声の選択・採用）の続きで、アバター系タスクの最後の実装項目。

## 実装手順1: chat_test の説明文の確認

`LEGACY_UI_LINKS.chat_test` の description（「設定した内容を実際のチャットで試すのはこちらの画面で行えます」）は既にアバター文脈でも自然に読めるため、**文言変更は不要**と判断した（確認のみ・コード変更なし）。`avatar_wizard` / `avatar_studio` のキーは変更していない。

## 実装方針: 費用が発生する外部呼び出しをモックする（重要な判断）

`playwright.config.ts` の baseURL は**本番（admin.r2c.biz）**。CIは `concurrency: e2e-production` で**全PRが本番に対して直接E2Eを実行する**（`.github/workflows/e2e.yml`）。

したがって、このタスクを素朴に「推奨提示→採用→画像生成→声検索→有効化」を実行するE2Eとして書くと、**PRを出すたびに fal.ai/Fish Audio への実課金と、carnation（Role Bの実テナント）の実 `avatar_configs` 書き換えが発生する**。これは既存のE2E群には無い、新しいコスト・データ変更カテゴリになる（既存の avatar 関連E2Eは読み取り専用のスコープ検査のみ）。

これを避けるため、`/v1/admin/agent/chat`・`fal/generate`・`match-voice`・`configs` PATCH をすべて `page.route()` でモックした。`widget-fab-avatar.spec.ts` が `anam-session`/`room-token` を同じ理由でモックしている先例に倣っている。検証対象はUIの実配線（クリック→カード遷移→PATCH送出→リロード復元）であって、LLM/外部APIの中身そのものではないため、この技法は目的に対して妥当。既存の C-LEAK 系スコープ漏洩テストのように、実バックエンドの認可判定そのものを検証する箇所（C-IRR-5, C-LEAK-4）は実通信のまま残している。

## 変更内容（3ファイル・新規ファイルなし）

### `tests/e2e/qa-copilot-preview.spec.ts`
- **CP-B-3**: 完走E2E。推奨提示→採用→画像候補生成/採用→声候補検索/採用→有効化→ライブテスト（別タブ）まで。離脱がその1回だけで、別タブを閉じると元の会話がそのまま残っていることを検証

### `tests/e2e/qa-irregular-3roles.spec.ts`
- **B-IRR-5**: 画像候補が**完了した状態**でのリロード復元。**生成"途中"（`status=generating`）でのリロードは対応する fetch が中断され復帰しない既知の制約があるため、本テストは完了後のリロードのみを対象とする**（コメントで明記。テストできないことを黙って通さない）
- **B-IRR-6**: 「採用して」チップの連打で二重送信されないことを、実UI状態（チップの消失）と送信回数（サーバ視点）の両方で検証
- **C-IRR-5**: super_adminがpreview未選択のままアバター有効化を指示すると「テナントが特定できません」で拒否される（既存CP-C-1と同型・DB非破壊）

### `tests/e2e/qa-preview-scope-leak.spec.ts`
- **C-LEAK-4**: carnationプレビュー中、`/copilot-preview` のアバター一覧取得が `targetTenantId` を正しく付与することを検証（`CHAT_SURFACE_DECISION.md` §1.9 が指摘する super_admin の `targetTenantId` 導出重複への回帰ガード）

## 検証の限界（率直に開示）

このセッションには `TEST_ADMIN_EMAIL`/`TEST_ADMIN_PASSWORD` が無く、本番の `admin.r2c.biz` に対して実行できません（`auth.setup.ts` は認証情報が無い場合 graceful skip する設計のため、試みても空の `storageState` で全テストが skip される）。加えて、たとえ認証情報があっても初回実装をいきなり本番へ実行するのは適切ではないと判断しました。

**ローカルで検証したのはここまで**:
- `npx playwright test --list` で28件（既存23+新規5）が構文エラー無く収集されること
- `E2E_ENABLED` 未設定でのドライラン（`npx playwright test --project=chromium`）で28件全てがクラッシュせず graceful skip すること

**実際のクリック連鎖・DOM描画・`page.route()` の実効性は未検証**です。CI（本番相当環境・`TEST_ADMIN_EMAIL` 設定済み）での初回実行結果を確認する必要があります。CIが赤くなった場合、セレクタや `page.route()` のパターンマッチ漏れなど、実環境特有の調整が必要になる可能性があります。

## DoD

- [x] 完走E2Eが1本あり、離脱がライブテストの1回だけであることを確認している（コード上）
- [x] イレギュラー3件のE2Eが追加されている
- [x] 越境シナリオが `qa-preview-scope-leak.spec.ts` に追加されている
- [x] `avatar_wizard` / `avatar_studio` の handoff キーが残っている
- [ ] `pnpm test:e2e` が通る — **CI（本番）での実行結果待ち。ローカルでは認証情報が無く確認不可**

## やっていないこと

- `avatar_wizard` / `avatar_studio` の handoff キーの削除
- 旧UIページのリダイレクト・削除
- `chat_test` 側（`/admin/chat-test`）の仕様変更

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StqjjaijseYkGkmG2k5LJ