### PR TITLE
fix(lp): 装飾用アバター画像でroom-token API呼び出しをやめる(全ページビューで発生していたコスト漏れ)

### DIFF
--- a/public/lp/index.html
+++ b/public/lp/index.html
@@ -1396,33 +1396,21 @@
   };
 
   // ===== 7. Avatar Image Loader =====
-  // r2c_default テナントのアバター設定から画像URLを取得し、LP上の全アバター円に表示
+  // LP上の全アバター円（装飾用）に静止画を表示する。
+  // 以前は /api/avatar/room-token（LiveKitルーム発行を伴う）をページ表示のたびに
+  // 呼び出して画像URLだけを取得していたが、これは全訪問者のページロード毎に発生する
+  // 不要なバックエンド負荷・コストだった。チャットウィジェット側の
+  // data-avatar-image-url と同じ既知の静止画URLを直接使うことでAPI呼び出しを排除する。
+  var LP_AVATAR_IMAGE_URL = 'https://rpqrwifbrhlebbelyqog.supabase.co/storage/v1/object/public/avatar-defaults/default_02.png';
   function loadAvatarImage() {
-    fetch('https://api.r2c.biz/api/avatar/room-token', {
-      method: 'POST',
-      headers: {
-        'x-api-key': 'rjc_77aaa951edede3a8faa44161a6f505eca44f4c0517e051ec1f8bb6bc9f22b29b',
-        'content-type': 'application/json'
-      },
-      body: JSON.stringify({ connect: false })
-    })
-    .then(function(r) { return r.json(); })
-    .then(function(data) {
-      if (!data.enabled || !data.imageUrl) return;
-      var imageUrl = data.imageUrl;
-      var avatarName = data.avatarName || 'Rei';
-
-      // 全ての .lp-avatar-circle 要素の絵文字を画像に置き換え
-      document.querySelectorAll('.lp-avatar-circle').forEach(function(circle) {
-        var img = document.createElement('img');
-        img.src = imageUrl;
-        img.alt = avatarName;
-        img.style.cssText = 'width:100%;height:100%;border-radius:50%;object-fit:cover;object-position:top center;display:block;';
-        circle.textContent = '';
-        circle.appendChild(img);
-      });
-    })
-    .catch(function() { /* フォールバック: 絵文字のまま */ });
+    document.querySelectorAll('.lp-avatar-circle').forEach(function(circle) {
+      var img = document.createElement('img');
+      img.src = LP_AVATAR_IMAGE_URL;
+      img.alt = 'Rei';
+      img.style.cssText = 'width:100%;height:100%;border-radius:50%;object-fit:cover;object-position:top center;display:block;';
+      circle.textContent = '';
+      circle.appendChild(img);
+    });
   }
 
   // ===== Initialize =====


### PR DESCRIPTION
## Summary
LPの装飾用アバター円(`.lp-avatar-circle`)の画像取得が、全訪問者の全ページビューで
`/api/avatar/room-token`(LiveKitルーム発行を伴う重いAPI)を呼んでいた。チャットを
開く/開かないに関係なく発生するため、これまでのコスト対策(#595/#605/#631/#637)を
一部相殺していた。

チャットウィジェット側の`data-avatar-image-url`と同じ既知の静止画URLを直接使う形に
変更し、API呼び出し自体を削除。`widget.js`側の変更は無し。

## 発見経緯
`data-avatar-mode="animated"`のE2Eテストを書いて実際に本番へ実行したところ、
「LiveKit関連のリクエストがゼロであること」を検証するテストが失敗し発覚。
このE2Eテスト自体は、本修正が本番反映された後の別PRで追加する
(E2Eは本番URLに対して実行される仕様のため、順序が逆だとCIがブロックされる)。

## Test plan
- [x] `node -c public/widget.js` — widget.js は無変更のため影響なし
- [ ] マージ・デプロイ後、本番LPで room-token 呼び出しがゼロになることをE2Eで検証(次PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BGig9LEuwT77kNnCKKeBR2