### PR TITLE
refactor: weeklySummaryカードの型三重定義を削減しweekRange.tsのコメント腐敗を修正

### DIFF
--- a/admin-ui/src/lib/useAgentChatTransport.ts
+++ b/admin-ui/src/lib/useAgentChatTransport.ts
@@ -105,7 +105,10 @@ export type TuningRuleDraftAgentActionCard = {
   priority: number;
 };
 
-// フィールド形状は actionExecutor.ts の WeeklySummaryCardPayload と1対1に保つ。
+// フィールド形状は src/api/admin/agent/actionExecutor.ts の WeeklySummaryCardPayload と
+// 1対1に保つ(サーバ/フロントの境界を跨ぐため型は共有できず、手動同期が必要)。
+// pages/copilot-preview/index.tsx の Card union はこの型を Omit<..., "kind"> で再利用して
+// いるため、ここを直せば同ファイル内の二重定義は発生しない。
 export type WeeklySummaryAgentActionCard = {
   kind: "weekly_summary";
   asOf: string;

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -26,7 +26,7 @@ import {
   AGENT_CHAT_HISTORY_MAX_ENTRIES,
   useAgentChatTransport,
 } from "../../lib/useAgentChatTransport";
-import type { AnsweredFrom } from "../../lib/useAgentChatTransport";
+import type { AnsweredFrom, WeeklySummaryAgentActionCard } from "../../lib/useAgentChatTransport";
 // アバター画像候補のプロンプト組み立ては旧UIウィザードと同じ関数を使う(再実装しない)。
 // チャットは選択肢を集めないため、固定の標準的な選択で呼ぶ。
 import { buildAvatarPrompt } from "../../lib/buildAvatarPrompt";
@@ -175,16 +175,11 @@ type Card =
     }
   // 週次まとめ。数値はサーバ集計値をそのまま描画する(LLMの生成文を経由しない)。
   // 各グループが null なのは、対応するクエリが失敗し取得できなかった場合(0とは区別する)。
-  | {
-      kind: "weeklySummary";
-      asOf: string;
-      sessions: { total: number; changePct: number | null; prevTotal: number } | null;
-      avgScore: number | null;
-      conversions: { count: number; total: number } | null;
-      faq: { total: number; published: number; lastUpdated: string | null } | null;
-      pendingTuningRules: number | null;
-      gaps: { total: number; top: Array<{ id: number; question: string }> } | null;
-    };
+  // フィールド形状は WeeklySummaryAgentActionCard(useAgentChatTransport.ts)と同一に保つ
+  // 必要があるため、kind(UI向けにcamelCaseへ変える)以外はそこから再利用し、手書きの
+  // 二重定義を避ける。actionExecutor.ts の WeeklySummaryCardPayload とはサーバ/フロント
+  // という境界を跨ぐため型を共有できないが、フィールド名・形は3箇所とも一致させること。
+  | ({ kind: "weeklySummary" } & Omit<WeeklySummaryAgentActionCard, "kind">);
 
 // 優先度3段階(lib/tuningPriority.ts)の店主向け表示ラベル。rule / rulesList カードで共有する。
 const TIER_LABEL: Record<"low" | "normal" | "high", string> = { low: "低", normal: "普通", high: "高" };

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -259,6 +259,11 @@ export type TuningRuleDraftCardPayload = {
 // 各グループは対応するクエリが失敗した場合に null になる(Promise.allSettledでの
 // 部分失敗時、text側で行ごと省略するのと同じ意味)。card はUIが「取得できなかった」を
 // 判別するための情報であり、0埋めしてはならない。
+//
+// フィールドを変更したら、サーバ/フロントの境界を跨いで手動同期が必要な箇所が2つある:
+//   - admin-ui/src/lib/useAgentChatTransport.ts の WeeklySummaryAgentActionCard
+//   - admin-ui/src/pages/copilot-preview/index.tsx の Card union(weeklySummary variant)
+//     は上記から Omit<..., "kind"> で再利用しているため、そちらを直せば自動的に追随する。
 export type WeeklySummaryCardPayload = {
   kind: 'weekly_summary';
   /** この応答を生成した瞬間(ISO)。会話復元時に古いまとめだと判別するために使う */

--- a/src/lib/date/weekRange.ts
+++ b/src/lib/date/weekRange.ts
@@ -1,10 +1,12 @@
 /**
- * 「今週」の境界を計算する（暦週・月曜00:00 JST起点）。
+ * 「今週」の境界を計算する（暦週・月曜00:00 JST起点）。get_weekly_briefing が使う。
  *
- * get_weekly_briefing（週次まとめ）と、撤去予定の weeklyReportGenerator の両方が
- * 同じ期間定義を参照する必要があるため、この1本に集約する。SQL側へ AT TIME ZONE を
- * 直書きしない — JST(UTC+9固定・DSTなし)のオフセットを UTC ベースの算術だけで
- * 適用するため、実行環境の process TZ には一切依存しない。
+ * SQL側へ AT TIME ZONE を直書きしない — JST(UTC+9固定・DSTなし)のオフセットを
+ * UTC ベースの算術だけで適用するため、実行環境の process TZ には一切依存しない。
+ * テスト容易性のため純粋関数として切り出してある(weekRange.test.ts参照)。
+ *
+ * (旧: weeklyReportGeneratorとの共有を理由に切り出していたが、同ジェネレータは
+ *  #602で撤去済み。現在の唯一の利用箇所は actionExecutor.ts の get_weekly_briefing)
  */
 
 const JST_OFFSET_MS = 9 * 60 * 60 * 1000;


### PR DESCRIPTION
## Summary

セルフレビューで指摘したP2項目(単独では見送りとした2件)への対応。

### weekRange.tsのコメント腐敗

冒頭コメントが「get_weekly_briefingと撤去予定のweeklyReportGeneratorの両方が使う」と、既に#602で削除済みのファイルを存在理由として挙げたままだった。唯一の利用箇所(actionExecutor.ts)のみを前提とした説明に修正。

### weeklySummaryカードの型三重定義

`WeeklySummaryCardPayload`(サーバ)/`WeeklySummaryAgentActionCard`(transport)/`Card`unionのweeklySummary variant(copilot-preview/index.tsx)が同じ8フィールドを手書きで3箇所に複製していた。

- admin-ui内(transport⇔page)の複製は解消可能なため、`Card`unionのweeklySummary variantを`{ kind: "weeklySummary" } & Omit<WeeklySummaryAgentActionCard, "kind">`として書き換えた
- サーバ⇔フロントの複製は別TypeScriptプロジェクト間のため型を共有できず、3箇所すべてに相互参照コメントを追加するに留めた(既存の`legacy_link`カードも同じ制約下にあり一貫性を保った)

## E2E CP-B-2(390pxモバイル)について

引き続き私からは実行できません。`tests/e2e/auth.setup.ts`が`https://admin.r2c.biz`を直接ハードコードしており(`E2E_BASE_URL`を見ない)、実credentialでの本番ログインが必須のためです。代替として`WeeklySummaryCard`のレイアウトCSSを静的に再点検し、`flex-wrap`+`minWidth`によるタイル折り返しで固定幅要素が無く横スクロールを起こす要素は見当たりませんでしたが、これは実ブラウザでの検証の代わりにはなりません。CIでの自動実行、または手動実行をお願いします。

## Test plan
- [x] pnpm typecheck (server) / admin-ui typecheck: 新規エラー0件(既存ベースライン13件のみ)
- [x] pnpm lint: 新規警告0件
- [x] copilot-preview/index.test.tsx: 118/118 PASS

🤖 Generated with [Claude Code](https://claude.com/claude-code)