### PR TITLE
test: S1-S4(書籍PDF/FAQ件数/貢献度handoff/通知先是正)の壊れやすい箇所を追加検証

### DIFF
--- a/admin-ui/src/pages/admin/knowledge/[tenantId].test.tsx
+++ b/admin-ui/src/pages/admin/knowledge/[tenantId].test.tsx
@@ -147,6 +147,22 @@ describe("TenantKnowledgePage — PDFタブの可視性(R2C運用限定, GID 121
     expect(screen.getByText("PDFアップロード")).toBeTruthy();
   });
 
+  // 上の2件(「PDFアップロード」ボタンが出る)はボタンの可視性しか検証していない。
+  // canManageBookPdf を参照する箇所はタブ配列・フォールバックuseEffect・実描画条件の
+  // 3箇所あり、将来どれか1つだけ更新されて分岐した場合、ボタンは出るのに中身(PdfUploadTab)
+  // が描画されない、という壊れ方をボタン可視性テストだけでは検知できない。
+  // 実際に ?tab=pdf へ遷移してタブ内容が描画されることまで固定する。
+  it("super_adminは?tab=pdfへ実際に遷移でき、PdfUploadTab(pdf-tab-stub)が描画される", async () => {
+    renderPage("/admin/knowledge/tenant-a?tab=pdf", {
+      isSuperAdmin: true,
+      isClientAdmin: false,
+      user: { id: "2", email: "admin@example.com", role: "super_admin", tenantId: null, tenantName: null },
+    });
+
+    await screen.findByTestId("pdf-tab-stub");
+    expect(screen.queryByTestId("list-tab-stub")).toBeNull();
+  });
+
   it("client_adminが?tab=pdfへ直リンクしても、白画面にならずlistタブへフォールバックする", async () => {
     renderPage("/admin/knowledge/tenant-a?tab=pdf");
 

--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -2416,6 +2416,56 @@ describe("CopilotPreviewPage — コンポーザへのPDFドラッグ＆ドロ�
     await waitFor(() => expect(MockXHR.instances.length).toBe(1));
     expect(await screen.findByText("PDFを受け取っています")).toBeTruthy();
   });
+
+  // previewMode中にsuper_adminが別テナントへ切り替えた直後にPDFを投げた場合、
+  // uploadUrlが古いpreviewTenantIdを使い回して誤テナントへ送信しないことを固定する。
+  it("previewMode中に別テナントへ切り替えた直後にPDFを落とすと、新テナント宛に送信される(古いテナントIDが混入しない)", async () => {
+    const { rerender } = renderPage(SUPER_ADMIN_IN_PREVIEW);
+    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
+
+    // 別テナントへ切替(previewTenantIdのみ変化)
+    vi.mocked(useAuth).mockReturnValue(
+      baseAuth({ ...SUPER_ADMIN_IN_PREVIEW, previewTenantId: "tenant-preview-2" }),
+    );
+    rerender(
+      <MemoryRouter>
+        <CopilotPreviewPage />
+      </MemoryRouter>,
+    );
+
+    dropFiles([makeFile("料金表.pdf", "application/pdf")]);
+
+    await waitFor(() => expect(MockXHR.instances.length).toBe(1));
+    const xhr = MockXHR.instances[0]!;
+    expect(xhr.open).toHaveBeenCalledWith(
+      "POST",
+      "http://localhost:3100/v1/admin/knowledge/book-pdf?tenant=tenant-preview-2",
+    );
+  });
+
+  // acceptFilesは1件ずつ順次送信するfor...ofループのみで、多重呼び出しをブロックする
+  // ロック/フラグが無い。1件目がアップロード中(fireLoad未発火)のまま2件目を落とすと
+  // どうなるかを固定する(現状の挙動を可視化するテストで、特定の対処を強制するものではない)。
+  it("【現状の挙動】1件目のアップロード中に2件目をドロップすると、2件目も独立して送信が始まる(排他制御なし)", async () => {
+    await readyPage(SUPER_ADMIN_IN_PREVIEW);
+
+    dropFiles([makeFile("1件目.pdf", "application/pdf")]);
+    await waitFor(() => expect(MockXHR.instances.length).toBe(1));
+    // 1件目はまだ fireLoad していない(アップロード中)状態のまま2件目を落とす
+    expect(screen.getByText("1件目.pdf")).toBeTruthy();
+
+    dropFiles([makeFile("2件目.pdf", "application/pdf")]);
+    await waitFor(() => expect(MockXHR.instances.length).toBe(2));
+
+    // 両方の進捗カードが会話に共存する(片方が壊れて消えたりしない)
+    expect(screen.getByText("1件目.pdf")).toBeTruthy();
+    expect(screen.getByText("2件目.pdf")).toBeTruthy();
+
+    // 1件目を完了させても2件目のXHRは影響を受けず独立して継続する
+    MockXHR.instances[0]!.fireLoad(201, { id: 1, title: "1件目", status: "uploaded" });
+    await waitFor(() => expect(screen.getAllByText("PDFを受け取りました").length).toBe(1));
+    expect(screen.getByText("2件目.pdf")).toBeTruthy();
+  });
 });
 
 // GID 1217040818410419: 「書籍/PDFはR2C運用限定」の実装反映。テナント(client_admin)からの

--- a/src/agent/gap/gapDetector.test.ts
+++ b/src/agent/gap/gapDetector.test.ts
@@ -150,4 +150,102 @@ describe('gapDetector — frequency>=5 の通知先', () => {
       expect.objectContaining({ recipientRole: 'client_admin', recipientTenantId: 'tenant-b' }),
     );
   });
+
+  it('client_admin宛の発行が失敗してもsuper_admin宛は独立して成功する(逆方向も検証)', async () => {
+    // notifyFrequentGap は role ごとに個別の try/catch を持つ設計。
+    // 片方が reject しても他方の呼び出しが道連れにならないことを確認する。
+    mockCreateNotification.mockImplementation(async (params: { recipientRole: string }) => {
+      if (params.recipientRole === 'client_admin') throw new Error('client通知DB書き込み失敗');
+    });
+    mockExistingGapUpdate(42, 5);
+
+    await expect(detectGap(baseInput)).resolves.toEqual(
+      expect.objectContaining({ detected: true, gapId: 42 }),
+    );
+    await flushPromises();
+
+    // client_admin向けは失敗したが、呼び出し自体は行われている
+    expect(mockCreateNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ recipientRole: 'client_admin' }),
+    );
+    // super_admin向けは client_admin の失敗に巻き込まれず成功している
+    expect(mockCreateNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ recipientRole: 'super_admin' }),
+    );
+    expect(mockCreateNotification).toHaveBeenCalledTimes(2);
+  });
+
+  it('super_admin宛の発行が失敗してもclient_admin宛は独立して成功する', async () => {
+    mockCreateNotification.mockImplementation(async (params: { recipientRole: string }) => {
+      if (params.recipientRole === 'super_admin') throw new Error('super通知DB書き込み失敗');
+    });
+    mockExistingGapUpdate(42, 5);
+
+    await expect(detectGap(baseInput)).resolves.toEqual(
+      expect.objectContaining({ detected: true, gapId: 42 }),
+    );
+    await flushPromises();
+
+    expect(mockCreateNotification).toHaveBeenCalledWith(
+      expect.objectContaining({ recipientRole: 'client_admin', recipientTenantId: 'tenant-a' }),
+    );
+    expect(mockCreateNotification).toHaveBeenCalledTimes(2);
+  });
+
+  it('同一テナントで異なる2件のgapが同時に頻出閾値を超えても、gapIdごとに通知が混同しない', async () => {
+    // 1件目: gapId=42(質問A)がfrequency5到達
+    mockExistingGapUpdate(42, 5, '返品ポリシーについて教えてください');
+    await detectGap(baseInput);
+    await flushPromises();
+
+    // 2件目: gapId=77(質問B、別の会話)が同じテナントでfrequency5到達
+    mockExistingGapUpdate(77, 5, '営業時間を教えてください');
+    await detectGap({ ...baseInput, sessionId: '22222222-2222-2222-2222-222222222222', userMessage: '営業時間を教えてください' });
+    await flushPromises();
+
+    // 合計4件(2 gap × 2 role)、metadata.gapIdが取り違えられていない
+    expect(mockCreateNotification).toHaveBeenCalledTimes(4);
+    const gap42Calls = mockCreateNotification.mock.calls.filter(
+      ([params]) => params.metadata?.gapId === 42,
+    );
+    const gap77Calls = mockCreateNotification.mock.calls.filter(
+      ([params]) => params.metadata?.gapId === 77,
+    );
+    expect(gap42Calls).toHaveLength(2);
+    expect(gap77Calls).toHaveLength(2);
+    expect(gap42Calls.every(([p]) => p.message.includes('返品ポリシー'))).toBe(true);
+    expect(gap77Calls.every(([p]) => p.message.includes('営業時間'))).toBe(true);
+    // 重複抑止キーもgapIdごとに分離している(42_client_adminと77_client_adminが別キー)
+    expect(gap42Calls.some(([p]) => p.metadata?.gap_role === '42_client_admin')).toBe(true);
+    expect(gap77Calls.some(([p]) => p.metadata?.gap_role === '77_client_admin')).toBe(true);
+  });
+
+  it('frequencyが閾値ちょうどでなく一気に100へ飛んでも通知は重複せず1組(2件)のみ作られる', async () => {
+    mockExistingGapUpdate(42, 100);
+
+    await detectGap(baseInput);
+    await flushPromises();
+
+    expect(mockCreateNotification).toHaveBeenCalledTimes(2);
+    const clientCall = mockCreateNotification.mock.calls.find(
+      ([p]) => p.recipientRole === 'client_admin',
+    );
+    expect(clientCall?.[0].message).toContain('100回聞かれています');
+  });
+
+  it('【既知の未対応】tenantIdが空文字列の場合、recipientTenantIdは空文字列のままDB層へ渡る(nullに正規化されない)', async () => {
+    // notifications.ts の createNotification は `recipientTenantId ?? null` であり、
+    // ?? は null/undefined のみを対象とするため空文字列はそのまま通過する。
+    // gapDetector 自身にも空文字列を弾くガードは無い(呼び出し元のtruthyチェックに依存)。
+    // このテストは「バグを推奨する」ものではなく、現状の挙動を固定して可視化するもの。
+    mockExistingGapUpdate(42, 5);
+
+    await detectGap({ ...baseInput, tenantId: '' });
+    await flushPromises();
+
+    const clientCall = mockCreateNotification.mock.calls.find(
+      ([p]) => p.recipientRole === 'client_admin',
+    );
+    expect(clientCall?.[0].recipientTenantId).toBe('');
+  });
 });

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -2176,6 +2176,40 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(res.body.actions[0].result).toContain('ありません');
     });
 
+    it.each([
+      { input: 0, expected: 1 },
+      { input: -1, expected: 1 },
+      { input: 999, expected: 20 },
+    ])('get_knowledge_gaps: limit=$input は例外にならず$expectedにクランプされる(get_faq_listと同じclampToolLimitヘルパーへの信頼を個別に固定する)', async ({ input, expected }) => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse(`call-kg-clamp-${input}`, 'get_knowledge_gaps', { limit: input }))
+        .mockResolvedValueOnce(makeGroqResponse('未対応の質問一覧です。'));
+
+      mockGetGaps.mockResolvedValueOnce({ gaps: [], total: 0 });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '知識ギャップを見せて', sessionId: `sess-kg-clamp-${input}` });
+
+      expect(res.status).toBe(200);
+      expect(mockGetGaps).toHaveBeenCalledWith({ tenantId: 'tenant-abc', status: 'open', limit: expected });
+    });
+
+    it('get_knowledge_gaps: limit="abc"（数値でない）は例外にならず既定件数(10)にフォールバックする', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-kg-clamp-abc', 'get_knowledge_gaps', { limit: 'abc' }))
+        .mockResolvedValueOnce(makeGroqResponse('未対応の質問一覧です。'));
+
+      mockGetGaps.mockResolvedValueOnce({ gaps: [], total: 0 });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '知識ギャップを見せて', sessionId: 'sess-kg-clamp-abc' });
+
+      expect(res.status).toBe(200);
+      expect(mockGetGaps).toHaveBeenCalledWith({ tenantId: 'tenant-abc', status: 'open', limit: 10 });
+    });
+
     it('dismiss_knowledge_gap: confirmed=false → 更新されずブロックされる', async () => {
       mockFetch
         .mockResolvedValueOnce(toolCallResponse('call-kg-4', 'dismiss_knowledge_gap', { id: 1, confirmed: false }))
@@ -2363,6 +2397,48 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(result).not.toContain('取得に失敗しました');
       expect(result).toContain('FAQ 一覧（1件）:');
       // NaN のまま LIMIT の SQL パラメータに渡らず、既定値10にフォールバックしていることを確認する
+      expect(mockQuery.mock.calls[1]?.[1]).toEqual(['tenant-abc', 10]);
+    });
+
+    it('【既知の未対応】limit=1.5（小数）は整数化されずそのままSQLパラメータに渡る', async () => {
+      // clampToolLimit は Number.isFinite チェックのみで Math.floor/round を行わないため、
+      // JSON Schema上 type:'number' の limit にLLMが小数を返すと非整数のままLIMITへ渡る。
+      // 実DBでは型により無視/丸め/エラーいずれもありうる未検証の経路。このテストはバグを
+      // 推奨するものではなく、現状の挙動を固定して可視化するもの。
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-fl-clamp-decimal', 'get_faq_list', { limit: 1.5 }))
+        .mockResolvedValueOnce(makeGroqResponse('FAQ一覧です。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ n: 1 }] })
+        .mockResolvedValueOnce({ rows: [{ id: 1, question: 'q1', answer: 'a1' }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'FAQ一覧を見せて', sessionId: 'sess-fl-clamp-decimal' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery.mock.calls[1]?.[1]).toEqual(['tenant-abc', 1.5]);
+    });
+
+    it.each([
+      { input: Infinity, label: 'Infinity' },
+      { input: -Infinity, label: '-Infinity' },
+    ])('limit=$label は既定値(10)にフォールバックする', async ({ input }) => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-fl-clamp-inf', 'get_faq_list', { limit: input }))
+        .mockResolvedValueOnce(makeGroqResponse('FAQ一覧です。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ n: 1 }] })
+        .mockResolvedValueOnce({ rows: [{ id: 1, question: 'q1', answer: 'a1' }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'FAQ一覧を見せて', sessionId: `sess-fl-clamp-inf-${input}` });
+
+      expect(res.status).toBe(200);
+      // Number.isFinite(Infinity) は false なので defaultValue(10) にフォールバックする
       expect(mockQuery.mock.calls[1]?.[1]).toEqual(['tenant-abc', 10]);
     });
 
@@ -3626,6 +3702,71 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(result).not.toContain('古い質問');
     });
 
+    it.each([
+      { input: 0, expectedShown: 1 },
+      { input: -1, expectedShown: 1 },
+    ])('limit=$input は例外にならず1件にクランプされる(0件表示にはならない)', async ({ input, expectedShown }) => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse(`call-cm-clamp-${input}`, 'get_chat_session_messages', { session_id: 'a1b2c3d4', limit: input }))
+        .mockResolvedValueOnce(makeGroqResponse('直近の会話です。'));
+
+      seedSessions([OWN_SESSION]);
+      mockGetMessages.mockResolvedValueOnce([
+        { id: 1, role: 'user', content: '古い質問', metadata: {}, created_at: '2026-07-17T10:00:00Z' },
+        { id: 2, role: 'user', content: '新しい質問', metadata: {}, created_at: '2026-07-17T10:01:00Z' },
+      ]);
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '直近だけ見せて', sessionId: `sess-cm-clamp-${input}` });
+
+      expect(res.status).toBe(200);
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain(`全2件中${expectedShown}件`);
+      expect(result).toContain('新しい質問');
+      expect(result).not.toContain('古い質問');
+    });
+
+    it('limit=999は上限(50)にクランプされ、実際のメッセージ数(3件)がそのまま返る', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-cm-clamp-999', 'get_chat_session_messages', { session_id: 'a1b2c3d4', limit: 999 }))
+        .mockResolvedValueOnce(makeGroqResponse('会話全体です。'));
+
+      seedSessions([OWN_SESSION]);
+      mockGetMessages.mockResolvedValueOnce([
+        { id: 1, role: 'user', content: '質問1', metadata: {}, created_at: '2026-07-17T10:00:00Z' },
+        { id: 2, role: 'user', content: '質問2', metadata: {}, created_at: '2026-07-17T10:01:00Z' },
+        { id: 3, role: 'user', content: '質問3', metadata: {}, created_at: '2026-07-17T10:02:00Z' },
+      ]);
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '全部見せて', sessionId: 'sess-cm-clamp-999' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('全3件中3件');
+    });
+
+    it('limit="abc"（数値でない）は例外にならず既定件数(20)にフォールバックする', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-cm-clamp-abc', 'get_chat_session_messages', { session_id: 'a1b2c3d4', limit: 'abc' }))
+        .mockResolvedValueOnce(makeGroqResponse('会話内容はこちらです。'));
+
+      seedSessions([OWN_SESSION]);
+      mockGetMessages.mockResolvedValueOnce([
+        { id: 1, role: 'user', content: '質問1', metadata: {}, created_at: '2026-07-17T10:00:00Z' },
+      ]);
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '会話を見せて', sessionId: 'sess-cm-clamp-abc' });
+
+      expect(res.status).toBe(200);
+      const result = res.body.actions[0].result as string;
+      expect(result).not.toContain('失敗');
+      expect(result).toContain('全1件中1件');
+    });
+
     it('他テナントのセッションIDは「見つかりません」となり本文を漏らさない', async () => {
       mockFetch
         .mockResolvedValueOnce(toolCallResponse('call-cm-3', 'get_chat_session_messages', { session_id: 'ffeeddcc' }))
@@ -4642,6 +4783,25 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(res.body.actions[0].result).toContain('テナントが特定できません');
     });
 
+    // 上のit.each(L4672付近)は label と URL のみ検証しており、description の本文は
+    // 未検証だった。knowledge_pdf は「R2C運用限定」の方針をユーザーに伝える文言そのもの
+    // であり、ここが「PDFファイルからの知識登録はこちらの画面で行えます」という
+    // 旧文言(旧UI誘導)に静かに戻っても既存テストは一切失敗しない。専用に固定する。
+    it('feature=knowledge_pdf: description が「R2C運営チームが行っている」旨で、旧UI誘導の文言に戻っていない', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-lu-desc', 'get_legacy_ui_link', { feature: 'knowledge_pdf' }))
+        .mockResolvedValueOnce(makeGroqResponse('こちらでご案内します。'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'PDFをアップロードしたい', sessionId: 'sess-lu-desc-01' });
+
+      expect(res.status).toBe(200);
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain('説明: PDFファイルからの知識登録は現在R2C運営チームが行っています');
+      expect(result).not.toContain('こちらの画面で行えます');
+    });
+
     // knowledge_pdf と同じ理由(path に tenantId を埋め込む必要がある)で専用ガードがある
     it('feature=knowledge_attribution: super_admin がテナント未特定 → 「テナントが特定できません」を返す', async () => {
       mockFetch
@@ -4689,6 +4849,46 @@ describe('POST /v1/admin/agent/chat', () => {
         url: '/admin/knowledge/tenant-abc?tab=attribution',
         description: 'ナレッジ(FAQ・書籍)ごとの成約への貢献度はこちらの画面で確認できます',
       });
+    });
+
+    // knowledge_pdf / knowledge_attribution は tenantId 必須の専用ガードがあるため、
+    // 「テナント未特定→エラー」だけでなく「previewModeでtargetTenantIdを指定すれば
+    // 成功する」側も固定する。他機能(session_deletion等)は前提が異なりpreviewModeの
+    // 成功系テストが元から無いため、この2機能で新規に検証する。
+    it.each([
+      ['knowledge_pdf', 'PDFアップロード', '/admin/knowledge/tenant-preview?tab=pdf'],
+      ['knowledge_attribution', '成約への貢献度', '/admin/knowledge/tenant-preview?tab=attribution'],
+    ])('feature=%s: super_adminがpreviewMode(targetTenantId指定)なら成功し、指定テナントのURLが返る', async (feature, label, expectedPath) => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-lu-preview', 'get_legacy_ui_link', { feature }))
+        .mockResolvedValueOnce(makeGroqResponse('こちらの画面でご確認ください。'));
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '確認したい', sessionId: `sess-lu-preview-${feature}`, targetTenantId: 'tenant-preview' });
+
+      expect(res.status).toBe(200);
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain(label);
+      expect(result).toContain(`URL: ${expectedPath}\n`);
+    });
+
+    // LEGACY_UI_FEATURES に新しい値を足した際、上のit.each(通常8件+プラン制限2件)への
+    // 追加を忘れても既存テストは全部passし続ける(手書きリストのため機械的な強制力が無い)。
+    // このテストは追加漏れを検知する安全網として、有効なfeatureの集合と本ファイルで
+    // 実際にテストしている集合を突き合わせる。新しいfeatureを追加したらこの
+    // testedFeatures にも追記すること(追記を忘れるとこのテストが失敗して気づける)。
+    it('LEGACY_UI_FEATURES の全要素がいずれかのテストで検証されている(新feature追加時の検証漏れ検知)', () => {
+      const testedFeatures = new Set([
+        'billing', 'avatar_studio', 'escalation_reply', 'session_deletion',
+        'chat_test', 'avatar_wizard', 'knowledge_pdf', 'knowledge_attribution',
+        'analytics', 'conversion',
+      ]);
+      const untested = LEGACY_UI_FEATURES.filter((f) => !testedFeatures.has(f));
+      expect(untested).toEqual([]);
+      // 逆方向(テスト済みのつもりが実際にはenumから消えている)も検知する
+      const stale = [...testedFeatures].filter((f) => !(LEGACY_UI_FEATURES as readonly string[]).includes(f));
+      expect(stale).toEqual([]);
     });
 
     // 冒頭が「できません」で始まると、旧UIへの案内が行き止まりの謝罪に見えてしまう。

--- a/src/api/admin/knowledge/bookPdfRoutes.test.ts
+++ b/src/api/admin/knowledge/bookPdfRoutes.test.ts
@@ -217,6 +217,23 @@ describe("POST /v1/admin/knowledge/book-pdf — R2C運用限定ガード", () =>
 
     expect(res.status).toBe(201);
   });
+
+  // ガードは `user?.role === "super_admin"` の厳密等価判定のみで安全側(拒否)に倒れる設計。
+  // JWTのroleクレームが欠落/破損した場合も、誤って通過しない(fail-closed)ことを固定する。
+  it.each([
+    ["null", null],
+    ["空文字列", ""],
+    ["大文字違い(Super_Admin)", "Super_Admin"],
+  ])("roleが%s → 403（super_adminと誤認しない）", async (_label, role) => {
+    const { app } = makeApp({ role: role as unknown as string });
+
+    const res = await request(app)
+      .post("/v1/admin/knowledge/book-pdf")
+      .field("title", "テスト書籍")
+      .attach("file", PDF_BUFFER, { filename: "test.pdf", contentType: "application/pdf" });
+
+    expect(res.status).toBe(403);
+  });
 });
 
 describe("POST /v1/admin/knowledge/book-pdf/:id/process — R2C運用限定ガード", () => {
@@ -242,6 +259,21 @@ describe("POST /v1/admin/knowledge/book-pdf/:id/process — R2C運用限定ガ�
 
     expect(res.status).toBe(202);
     expect(res.body).toMatchObject({ ok: true, bookId: 1 });
+  });
+
+  it.each([
+    ["null", null],
+    ["空文字列", ""],
+    ["大文字違い(Super_Admin)", "Super_Admin"],
+  ])("roleが%s → 403（super_adminと誤認しない）", async (_label, role) => {
+    const { app } = makeApp({
+      role: role as unknown as string,
+      dbRows: [{ id: 1, tenant_id: "tenant-a", status: "uploaded" }],
+    });
+
+    const res = await request(app).post("/v1/admin/knowledge/book-pdf/1/process");
+
+    expect(res.status).toBe(403);
   });
 });
 

--- a/tests/phase59/zipUpload.test.ts
+++ b/tests/phase59/zipUpload.test.ts
@@ -298,6 +298,72 @@ describe("ZIP PDFアップロード (Phase59)", () => {
     expect(res.body.error).toContain("不正なファイルパス");
   });
 
+  // ── 9. 壊れたZIPバイト列 ─────────────────────────────────────────────────
+
+  it("9. ZIPとしてパースできないバイト列 → 400エラー「読み込みに失敗しました」", async () => {
+    // ZIPのローカルファイルヘッダ署名(PK\x03\x04)を含まない、ただのランダムバイト列。
+    // AdmZipのコンストラクタが例外を投げる経路(try/catch)を通す。
+    const garbage = Buffer.from("これはZIPファイルではありません。ただのテキストです。".repeat(50), "utf8");
+
+    const { app } = makeApp({});
+    const res = await request(app)
+      .post("/v1/admin/knowledge/book-pdf")
+      .attach("file", garbage, { filename: "not-a-zip.zip", contentType: "application/zip" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("読み込みに失敗しました");
+  });
+
+  // ── 10. PDFと非PDFが混在するZIP(全滅でも全成功でもない) ───────────────────
+
+  it("10. PDF2件+非PDF1件が混在するZIP → 非PDFは静かに除外され、PDF2件のみ処理される", async () => {
+    const zipBuf = makeZip([
+      { name: "book-a.pdf", content: MINIMAL_PDF },
+      { name: "readme.txt", content: Buffer.from("これはPDFではありません") },
+      { name: "book-b.pdf", content: MINIMAL_PDF },
+    ]);
+
+    const { app, db } = makeApp({});
+    const res = await request(app)
+      .post("/v1/admin/knowledge/book-pdf")
+      .attach("file", zipBuf, { filename: "mixed.zip", contentType: "application/zip" });
+
+    expect(res.status).toBe(201);
+    // 非PDFはpdfEntriesの時点でフィルタされ、results配列にすら現れない
+    // (エラー扱いで報告されるのではなく、そもそも対象外として静かに除外される)
+    expect(res.body.total).toBe(2);
+    expect(res.body.results).toHaveLength(2);
+    expect(res.body.results.map((r: any) => r.fileName).sort()).toEqual(["book-a.pdf", "book-b.pdf"]);
+    expect(res.body.results.every((r: any) => r.status === "ok")).toBe(true);
+    const insertCalls = (db.query as jest.Mock).mock.calls.filter((c: any[]) =>
+      typeof c[0] === "string" && c[0].includes("INSERT INTO book_uploads")
+    );
+    expect(insertCalls).toHaveLength(2);
+  });
+
+  // ── 11. 展開後合計サイズが200MB上限を超える ───────────────────────────────
+
+  it("11. 展開後合計サイズが200MBを超えるZIP → 400エラー「200MB」", async () => {
+    // 実際の200MB超のバッファを3エントリに分けて用意する(ゼロ埋めなので圧縮・確保は高速)。
+    // multerのfileSize上限(50MB)は「圧縮後(=送信バイト数)」に効くのに対し、この上限は
+    // 「展開後の合計」に効くため、圧縮率の高いゼロ埋めバッファでmulter制限を回避しつつ
+    // 展開後合計だけを200MB超にできる。
+    const zip = new AdmZip();
+    const CHUNK = 75 * 1024 * 1024; // 75MB × 3 = 225MB(> 200MB上限)
+    for (let i = 0; i < 3; i++) {
+      zip.addFile(`huge-${i + 1}.pdf`, Buffer.alloc(CHUNK, 0x00));
+    }
+    const zipBuf = zip.toBuffer();
+
+    const { app } = makeApp({});
+    const res = await request(app)
+      .post("/v1/admin/knowledge/book-pdf")
+      .attach("file", zipBuf, { filename: "zipbomb.zip", contentType: "application/zip" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("200MB");
+  }, 20000);
+
   // ── 8. 通常PDFアップロードの回帰テスト ───────────────────────────────────
 
   it("8. 通常のPDFアップロード → 既存動作が壊れていない（回帰テスト）", async () => {


### PR DESCRIPTION
## 概要

マージ済み4機能(#629 S1書籍PDF, #610 S2 FAQ件数, #612 S3貢献度handoff, #604 S4通知先是正)に対し、「通るだけのテスト」ではなく「壊れやすいポイントを突くテスト」を追加。**実装コードは一切変更していない**(テストファイルのみ、+462行)。

## 追加内容

### S1(書籍/PDF R2C運用限定)
- `bookPdfRoutes.test.ts`: JWT roleクレームがnull/空文字/大文字違いでもsuper_adminと誤認せず403になることを固定(fail-closed設計の明示的検証)
- `zipUpload.test.ts`: 壊れたZIPバイト列/PDF+非PDF混在/展開後合計200MB超過の3ケースを追加(既存は「全PDF」「全非PDF」の二値のみ)
- `[tenantId].test.tsx`: super_adminが実際に`?tab=pdf`へ遷移しPdfUploadTabの中身まで描画されることを固定(既存はボタン可視性のみで、タブ配列・フォールバックuseEffect・描画条件の3箇所が将来分岐しても検知できなかった)
- `copilot-preview/index.test.tsx`: previewMode中のテナント切替直後にPDFを落としても新テナント宛に送信されること、および1件目アップロード中に2件目を落とした場合の現状の挙動(排他制御なし)を明示
- `agentRoutes.test.ts`: `LEGACY_UI_LINKS.knowledge_pdf`のdescriptionが旧UI誘導文言に戻っていないことを専用に固定

### S2(FAQ件数の頭打ち修正 + clampToolLimit)
- `get_faq_list`の`limit=1.5`(小数)が整数化されずSQLパラメータにそのまま渡る現状の挙動を可視化(**既知の未対応**として明記、修正はしていない)
- `limit=Infinity/-Infinity`が既定値にフォールバックすることを固定
- `get_knowledge_gaps`・`get_chat_session_messages`にも`clampToolLimit`の境界値・非数値フォールバックの個別テストを追加(既存は`get_faq_list`/`get_chat_sessions`のみで、残り2ツールは暗黙の信頼だった)

### S3(成約への貢献度 handoffキー)
- super_adminがpreviewMode(targetTenantId指定)で`knowledge_pdf`/`knowledge_attribution`の両方に成功することを固定
- `LEGACY_UI_FEATURES`全要素がテストされていることを検証する構造的な安全網を追加(手書きのit.eachリストへの追加漏れを機械的に検知)

### S4(未回答質問の通知先是正)
- client_admin宛/super_admin宛の一方が失敗しても他方は独立して成功することを両方向で固定
- 同一テナントで異なる2件のgapが同時に頻出閾値超えしても`metadata.gapId`が取り違えられないことを固定
- frequencyが閾値ちょうどでなく100へ飛んでも通知が重複しないことを追加
- tenantIdが空文字列の場合、`recipientTenantId`が`null`に正規化されずそのままDB層へ渡る現状の挙動を可視化(**既知の未対応**として明記)

## テストでカバーできていないリスク(意図的に対応せず)

| リスク | 理由 |
|---|---|
| **`superadmin.setup.ts`がどのPlaywrightプロジェクトの`testMatch`にも一致せず、CIも`TEST_SUPERADMIN_*`シークレットを渡していない** | previewMode中super_adminのPDF投入というS1の中核claimを検証する唯一のE2E(C-IRR-4)が、CI上で恒久的にスキップされている可能性が高い。インフラ変更を伴うため別タスクとすべき |
| ZIP内の個別エントリの`getData()`失敗 | 人工的な再現がZIPライブラリ内部のCRC検証挙動に依存し、flakyなテストになるため見送り |
| `get_faq_list`のCOUNT取得とLIST取得の間のデータ変化(TOCTOU) | `Promise.all`で並行実行しているため理論上起こりうるが、モックテストでは意味のある検証にならないため見送り |
| 検索語が数千文字/改行/HTMLタグを含む場合 | プレーンテキストとしてチャットバブルに出るのみでReactの標準エスケープで安全なため見送り |
| LLMの発話→ツール選択の切り分け | 全テストがtool_calls応答を直接モックしており、この層では構造的に検証不可能 |

## テスト実行結果

- `pnpm typecheck`(backend): 0 errors
- `bash SCRIPTS/security-scan.sh`: PASS(CRITICAL/HIGH: 0)
- `gapDetector.test.ts` + `bookPdfRoutes.test.ts` + `zipUpload.test.ts`: 43/43 PASS
- `agentRoutes.test.ts`(対象範囲フィルタ): 75/75 PASS
- admin-ui vitest(影響5ファイル): 159/159 PASS

フルスイート(`pnpm test`)はこのマシン固有の環境要因(TIME_WAIT蓄積等、既報告)で無関係なテストがランダムに失敗する既知の不安定さがあり、対象を絞った実行で確認しています。

## 一切しないこと(確認)

- [x] 実装コードの変更なし(テストファイルのみ)
- [x] 新規テストファイルなし(既存ファイルへの追記のみ)
- [x] 発見したバグ(clampToolLimitの小数扱い、空文字列tenantId)は修正せず「既知の未対応」として可視化に留めた

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgWB82fsx7LMjhJqpd1rCx