### PR TITLE
fix: record_session_outcomeの監査ログ欠落と書き込みツール登録漏れを解消する

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -247,11 +247,21 @@ const REAL_TOOL_LABEL: Record<string, string> = {
   publish_faq_drafts: "下書きFAQの公開",
 };
 
-// 実際にDBを書き換える(=「進捗」としてカウントしてよい)ツール名
+// 実際にDBを書き換える(=「進捗」としてカウントしてよい)ツール名。
+// src/api/admin/agent/confirmPolicy.ts の WRITE_TOOL_RISK_TIERS(サーバ側の書き込み
+// ツール一覧)の部分集合であるべきで、confirmPolicy.test.ts が双方向の突き合わせを
+// 機械的に検証する(サーバに書き込みツールを追加してここへの追加を忘れると、その
+// テストが落ちる)。
 const REAL_WRITE_TOOLS = new Set([
   "save_tuning_rule",
+  "update_tuning_rule",
+  "delete_tuning_rule",
+  "approve_tuning_rule_response",
+  "remove_approved_response",
   "save_faq",
   "save_engagement_rule",
+  "update_engagement_rule",
+  "delete_engagement_rule",
   "add_faq",
   "update_faq",
   "delete_faq",
@@ -266,6 +276,10 @@ const REAL_WRITE_TOOLS = new Set([
   "reply_to_escalation",
   "resolve_escalation",
   "publish_faq_drafts",
+  "dismiss_knowledge_gap",
+  "request_sai_task",
+  "record_session_outcome",
+  "delete_chat_session",
 ]);
 
 // Phase2 (P7): ログイン直後に能動的に状況を尋ねる自動キックオフメッセージ。

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -2369,15 +2369,13 @@ export async function executeToolCall(
           );
         }
 
-        // executeToolCall は現状、実行者(メールアドレス等)を受け取っていない
-        // (reply_to_escalation 等の既存の書き込みツールと同じ制約)。HTTP経由の
-        // PATCH /v1/admin/chat-history/sessions/:id/outcome は email を記録できるが、
-        // チャット経由はここでは null になる。
         await recordOutcome({
           sessionDbId: resolved.session.id,
           tenantId,
           outcome: outcomeValue,
-          recordedBy: null,
+          // actor.email は '' になりうる('' は audit_logs 上 null と区別する意味を
+          // 持たないため null に正規化する。HTTP経路(routes.ts)と同じ規約)。
+          recordedBy: actor.email || null,
         });
         return truncate(`セッション[${display}]の成果を「${outcomeValue}」として記録しました`);
       } catch (err) {

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -3943,6 +3943,33 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(res.body.actions[0].result).toContain('5件');
     });
 
+    // extractAuth は su.email を actor.email に使うため、email 付きのユーザーで検証する。
+    // CLIENT_ADMIN_USER は email を持たないため、actorEmail: '' というテストが
+    // 「実際にメールが渡っている」ことを一度も検証していなかった(自己言及的な穴)。
+    it('confirmed=true・emailありのユーザー → actorEmailに実メールが渡る(監査ログの実効性)', async () => {
+      const DELETE_USER = {
+        email: 'staff@example.com',
+        app_metadata: { role: 'client_admin', tenant_id: 'tenant-abc' },
+      };
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-del-2b', 'delete_chat_session', { session_id: 'dddd1111', reason: 'ユーザーの依頼により削除', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('削除しました。'));
+
+      seedSessions([OWN_SESSION]);
+      mockDeleteSession.mockResolvedValueOnce({
+        deleted_session_id: 'db-sess-del',
+        affected_counts: { chat_messages: 1, option_orders_nulled: 0 },
+      });
+
+      await request(makeApp(DELETE_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'dddd1111を削除して', sessionId: 'sess-del-2b' });
+
+      expect(mockDeleteSession).toHaveBeenCalledWith(
+        expect.objectContaining({ actorEmail: 'staff@example.com' }),
+      );
+    });
+
     it('previewMode中のsuper_adminが削除しても、scopeは常にtenant(globalにならない)', async () => {
       mockFetch
         .mockResolvedValueOnce(toolCallResponse('call-del-3', 'delete_chat_session', { session_id: 'dddd3333', reason: 'テナント確認のため削除', confirmed: true }))
@@ -4289,6 +4316,31 @@ describe('POST /v1/admin/agent/chat', () => {
         sessionDbId: 'db-sess-outcome', tenantId: 'tenant-abc', outcome: '購入完了', recordedBy: null,
       });
       expect(res.body.actions[0].result).toContain('記録しました');
+    });
+
+    // 実行者のメールアドレスが取得できる場合は recordedBy に反映されることを確認する。
+    // 従来はチャット経由の記録が常に recordedBy: null になっていた(PATCH /v1/admin/
+    // chat-history/sessions/:id/outcome 経由の記録とは非対称だった)ため、その回帰。
+    it('record_session_outcome: emailありのユーザー → recordedByに実メールが渡る(監査ログの実効性)', async () => {
+      const OUTCOME_USER = {
+        email: 'staff@example.com',
+        app_metadata: { role: 'client_admin', tenant_id: 'tenant-abc' },
+      };
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-so-5b', 'record_session_outcome', { session_id: 'oooo1111', outcome: '購入完了', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('記録しました。'));
+
+      seedSessions([OWN_SESSION]);
+      mockGetConversionTypes.mockResolvedValueOnce(['購入完了', '予約完了', '離脱']);
+      mockRecordOutcome.mockResolvedValueOnce({ outcome: '購入完了', recordedAt: '2026-07-17T10:00:00Z', recordedBy: 'staff@example.com' });
+
+      await request(makeApp(OUTCOME_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '購入完了で記録して', sessionId: 'sess-so-05b' });
+
+      expect(mockRecordOutcome).toHaveBeenCalledWith(
+        expect.objectContaining({ recordedBy: 'staff@example.com' }),
+      );
     });
 
     it('record_session_outcome: outcomeが空/未指定なら必須であることを伝え、セッション解決すら行わない', async () => {

--- a/src/api/admin/agent/agentRoutes.ts
+++ b/src/api/admin/agent/agentRoutes.ts
@@ -662,7 +662,10 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
 
   app.post('/v1/admin/agent/chat', async (req: Request, res: Response) => {
     const { su, role, tenantId, isSuperAdmin } = extractAuth(req);
-    const email: string = su?.email ?? '';
+    // src/api/admin/chat-history/routes.ts と同じ規約(su.email が無い場合は
+    // app_metadata.email にフォールバックする)。同一ユーザーが経路によって
+    // 異なる email に解決されないようにする。
+    const email: string = su?.email ?? su?.app_metadata?.email ?? '';
 
     // ロールチェック
     if (role !== 'super_admin' && role !== 'client_admin') {

--- a/src/api/admin/agent/confirmPolicy.test.ts
+++ b/src/api/admin/agent/confirmPolicy.test.ts
@@ -135,6 +135,16 @@ describe('confirmPolicy: フロントの REAL_WRITE_TOOLS との突き合わせ'
     const missing = readFrontendRealWriteTools().filter((name) => !(name in WRITE_TOOL_RISK_TIERS));
     expect(missing).toEqual([]);
   });
+
+  // 上のテストは「フロント ⊆ サーバ」しか見ておらず、逆方向(サーバに書き込みツールを
+  // 追加したのにフロントの実書き込みカウント対象への追加を忘れる)を検出できなかった。
+  // 実際に record_session_outcome / delete_chat_session を含む10ツールがこの穴を
+  // 通り抜けて RealActionBadge の集計から漏れていた(発見時点のレビューで判明)。
+  it('リスク階層表の書き込みツールはすべてフロントの REAL_WRITE_TOOLS にも登録されている', () => {
+    const front = new Set(readFrontendRealWriteTools());
+    const missing = Object.keys(WRITE_TOOL_RISK_TIERS).filter((name) => !front.has(name));
+    expect(missing).toEqual([]);
+  });
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
「会話履歴カテゴリ」実装の厳しいレビュー(PR #613〜#621, #638の後続)で見つけた、実害のある2件を修正。

### 1. record_session_outcome の監査ログ欠落(P1)
`actionExecutor.ts` の `record_session_outcome` は常に `recordedBy: null` を渡していた。コメントには「executeToolCall は実行者を受け取っていない」とあったが、これは #620 で `actor: {role, email}` が必須引数に追加された時点で嘘になっていた(`delete_chat_session` は既に `actor.email` を使っている)。

同じ `recordOutcome()` ヘルパーを呼ぶ HTTP経路(`PATCH /v1/admin/chat-history/sessions/:id/outcome`)は `email || null` を渡しており、**同じユーザーが同じ操作をしても経路によって監査ログの実効者が残ったり消えたりする**非対称があった。

修正:
- `recordedBy: actor.email || null` に変更、古いコメントを削除
- `agentRoutes.ts` の email抽出を `su?.email ?? su?.app_metadata?.email ?? ''` に統一(HTTP経路と同じ規約)
- 既存の `actorEmail: ''` アサーションはテストフィクスチャに email が無いため「空文字であること」しか検証していなかった(このテスト自体、通るだけのテストでした)。email付きユーザーで実メールが渡ることを検証するテストを delete/outcome 両方に追加

### 2. REAL_WRITE_TOOLS の登録漏れ10件(P1)
フロントの実書き込みカウント対象 `REAL_WRITE_TOOLS`(17件)が、サーバのリスク階層表 `WRITE_TOOL_RISK_TIERS`(27件)より10件遅れていた。`record_session_outcome` と `delete_chat_session` を含む書き込みが `RealActionBadge` の集計から漏れていた。

原因: `confirmPolicy.test.ts` の突き合わせテストが「フロント⊆サーバ」の片方向しか見ておらず、逆方向のドリフトを検出できない構造だった。

修正:
- 逆方向の突き合わせテストを追加(追加前に実際に赤くなり、今回の10件がすべて検出されることを確認済み)
- `REAL_WRITE_TOOLS` に10件を追加

## Test plan
- [x] 逆方向ガードテストが**修正前は10件検出して失敗**することを確認してから実装
- [x] `npx tsc --noEmit`(server / admin-ui)
- [x] `npx oxlint src admin-ui/src`
- [x] `agentRoutes.test.ts` 303件、`confirmPolicy.test.ts` 18件(新規1件含む)、`chat-history/*` 60件、すべて通過
- [x] admin-ui `index.test.tsx` 120件通過
- [x] admin-ui `vite build` 成功

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UpYM4tvAGHfu4vc9NQqPfY