### PR TITLE
fix(e2e): アバターE2Eの2件のレース条件を修正（#640の追い遅れ分）

### DIFF
--- a/tests/e2e/qa-copilot-preview.spec.ts
+++ b/tests/e2e/qa-copilot-preview.spec.ts
@@ -169,7 +169,9 @@ test.describe('copilot-preview — Role B (client_admin)', () => {
     await page.getByRole('button', { name: '声を探す' }).click();
     await expect(page.getByRole('button', { name: 'この声にする' })).toBeVisible({ timeout: 10000 });
     await page.getByRole('button', { name: 'この声にする' }).click();
-    await expect(page.getByText('Haruka Voice')).toBeVisible();
+    // 「Haruka Voice」は候補提示の時点で既に表示されているため、それだけでは採用完了の
+    // 証拠にならない。「これに決定」が画像・声で2つに増えたことをもって採用完了を待つ。
+    await expect(page.getByRole('button', { name: 'これに決定' })).toHaveCount(2, { timeout: 10000 });
 
     expect(patchCount).toBe(2); // 画像1回 + 声1回。二重PATCHが起きていないこと
 

--- a/tests/e2e/qa-copilot-preview.spec.ts
+++ b/tests/e2e/qa-copilot-preview.spec.ts
@@ -178,7 +178,11 @@ test.describe('copilot-preview — Role B (client_admin)', () => {
     // ⑤ 有効化（公開）
     await composer.fill('アバターを有効化してください');
     await send.click();
-    await expect(page.getByText(/有効化しました/)).toBeVisible({ timeout: 10000 });
+    // モック応答の reply(「有効化しました。」)と、agentActionカードの result
+    // (「アバター（ID: cfg-e2e-1）を有効化しました」句点なし)の両方が"有効化しました"を
+    // 含むため、緩い正規表現だと strict mode violation(複数要素にマッチ)になる。
+    // アシスタントの返信バブル(句点まで含めた完全一致)だけを狙う。
+    await expect(page.getByText('有効化しました。', { exact: true })).toBeVisible({ timeout: 10000 });
 
     // ⑥ ライブテストへの受け渡し（唯一の離脱点）。別タブで開き、この会話は残ったままであること。
     await composer.fill('テストチャットで確認したい');

--- a/tests/e2e/qa-irregular-3roles.spec.ts
+++ b/tests/e2e/qa-irregular-3roles.spec.ts
@@ -262,7 +262,13 @@ test.describe('Irregular — Role B (client_admin RBAC/tenant boundary)', () => 
     await page.getByRole('button', { name: '画像を新しく生成する' }).click();
     await page.getByRole('button', { name: 'これにする' }).first().waitFor({ timeout: 10000 });
 
-    // このタイミングで4枚の候補が既に描画されている(=生成は完了済み)。ここでリロードする。
+    // 会話の保存(chatSessionStore)は msgs 更新から300msデバウンスされている
+    // (index.tsx: タイプライター演出の1応答あたり数百回書き込みを避けるため)。
+    // 保存が実際にflushされる前にリロードすると、復元対象が無く会話が最初から
+    // やり直しになってしまうため、デバウンス分より余裕を持って待つ。
+    await page.waitForTimeout(800);
+
+    // このタイミングで4枚の候補が既に描画され、保存も完了している(=生成は完了済み)。ここでリロードする。
     await page.reload({ waitUntil: 'domcontentloaded', timeout: 20000 });
     await page.waitForTimeout(1500);
 


### PR DESCRIPTION
## 背景

PR #640（アバター設定フローの完走E2E追加）はマージ済みだが、**マージのタイミングが本PRの修正コミットのpushより前だった**ため、CI初回実行で見つかった2件のレース条件修正が main に含まれていない。

- #640 マージ: 2026-07-31T05:10:02Z
- 修正コミットのpush: 2026-07-31T05:13頃

このため main には既知の失敗パターンを持つE2Eテストが2件残っている。放置すると `tests/e2e/**` を触る以降の全PRでこの2件が再びCIで失敗する。

## 内容

#640のブランチで作成済みだった修正コミットを、現在の main を起点にした新しいブランチへ cherry-pick しただけ（内容の変更なし）。

### CP-B-3: `patchCount` の検証が早すぎた
「この声にする」クリック直後に `getByText('Haruka Voice')` を待っていたが、このテキストは候補提示の時点（採用前）から既に画面にあり、採用完了の証拠にならない。PATCH完了前に `patchCount` を検証していたため期待値2に対し1で失敗していた。「これに決定」ボタンが画像・声で2つに増えたことを待つよう修正。

### B-IRR-5: リロードのタイミングが早すぎた
会話の保存（`chatSessionStore`）は `msgs` 更新から300msデバウンスされている（タイプライター演出の書き込み過多を防ぐため）。候補カード描画直後に即リロードすると、デバウンスがflushされる前にページが破棄され、sessionStorageへの書き込みが一度も起きないままリロードしていた（＝リロード復元機能自体は壊れていない。テストの待ち時間が不足していただけ）。候補描画後・リロード前に800ms待つよう修正。

## 検証

CI初回実行（#640）: 77 passed / 2 failed（本修正対象の2件のみ）。新規5件のうちB-IRR-6・C-IRR-5・C-LEAK-4は初回から成功済み。本PRのCI結果で2件も含めて全通過することを確認する。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StqjjaijseYkGkmG2k5LJ