### PR TITLE
fix(agent): ツールのlimitが小数のままSQLのLIMITへ渡るのを整数化して防ぐ

### DIFF
--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -47,12 +47,15 @@ const MAX_IMPORT_FAQS = 20;
 // zod スキーマ(z.string().min(1).max(2000))と揃える。
 const MAX_OPERATOR_REPLY_LENGTH = 2000;
 
-// ツールの limit 引数を [1, max] にクランプする。"abc" のような非数値は Number() で
+// ツールの limit 引数を [1, max] の整数にクランプする。"abc" のような非数値は Number() で
 // NaN になり、Math.min/max を素通りして NaN のまま残ってしまう(NaN との比較は常に false)。
 // NaN が SQL の LIMIT パラメータに渡ると実DBではエラーになるため、既定値にフォールバックする。
+// また limit は toolDefinitions.ts 上 integer だが、LLMが 1.5 のような小数を返す可能性があり、
+// 小数のまま SQL の LIMIT に渡ると実DBでエラーになる。クランプ後に整数化して防ぐ
+// (クランプ→整数化の順にするのは「範囲に収めてから丸める」意図を読み取れるようにするため)。
 function clampToolLimit(raw: unknown, defaultValue: number, max: number): number {
   const n = Number(raw ?? defaultValue);
-  return Math.min(Math.max(Number.isFinite(n) ? n : defaultValue, 1), max);
+  return Math.floor(Math.min(Math.max(Number.isFinite(n) ? n : defaultValue, 1), max));
 }
 
 // suggest_tuning_rule がトリガー未決定時に案内していたプレースホルダ文字列。

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -2626,13 +2626,17 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(mockQuery.mock.calls[1]?.[1]).toEqual(['tenant-abc', 10]);
     });
 
-    it('【既知の未対応】limit=1.5（小数）は整数化されずそのままSQLパラメータに渡る', async () => {
-      // clampToolLimit は Number.isFinite チェックのみで Math.floor/round を行わないため、
-      // JSON Schema上 type:'number' の limit にLLMが小数を返すと非整数のままLIMITへ渡る。
-      // 実DBでは型により無視/丸め/エラーいずれもありうる未検証の経路。このテストはバグを
-      // 推奨するものではなく、現状の挙動を固定して可視化するもの。
+    // LLMが小数を返しても、非整数のまま SQL の LIMIT に渡らないことを固定する
+    // (実DBでは非整数の LIMIT はエラーになる)。clampToolLimit はクランプ後に
+    // Math.floor で整数化する。
+    it.each([
+      { input: 1.5, expected: 1 },
+      { input: 19.9, expected: 19 },
+      { input: 0.4, expected: 1 },   // クランプで1に持ち上がってから整数化される
+      { input: 20.7, expected: 20 }, // 上限20でクランプされてから整数化される
+    ])('limit=$input（小数）は整数$expectedに切り捨てられてSQLに渡る', async ({ input, expected }) => {
       mockFetch
-        .mockResolvedValueOnce(toolCallResponse('call-fl-clamp-decimal', 'get_faq_list', { limit: 1.5 }))
+        .mockResolvedValueOnce(toolCallResponse(`call-fl-clamp-decimal-${input}`, 'get_faq_list', { limit: input }))
         .mockResolvedValueOnce(makeGroqResponse('FAQ一覧です。'));
 
       mockQuery
@@ -2641,10 +2645,19 @@ describe('POST /v1/admin/agent/chat', () => {
 
       const res = await request(makeApp(CLIENT_ADMIN_USER))
         .post('/v1/admin/agent/chat')
-        .send({ message: 'FAQ一覧を見せて', sessionId: 'sess-fl-clamp-decimal' });
+        .send({ message: 'FAQ一覧を見せて', sessionId: `sess-fl-clamp-decimal-${input}` });
 
       expect(res.status).toBe(200);
-      expect(mockQuery.mock.calls[1]?.[1]).toEqual(['tenant-abc', 1.5]);
+      expect(mockQuery.mock.calls[1]?.[1]).toEqual(['tenant-abc', expected]);
+      expect(Number.isInteger(mockQuery.mock.calls[1]?.[1]?.[1])).toBe(true);
+    });
+
+    // limit の JSON Schema は integer だが、LLMがスキーマを無視して小数を返す可能性は
+    // 残るため、サーバ側(clampToolLimit)でも整数化する多層防御になっていることを固定する。
+    it('limit の JSON Schema は integer で、LLM側にも小数を返させない', () => {
+      const tool = ADMIN_AGENT_TOOLS.find((t) => t.function.name === 'get_faq_list');
+      const limitProp = tool!.function.parameters.properties['limit'] as { type: string };
+      expect(limitProp.type).toBe('integer');
     });
 
     it.each([

--- a/src/api/admin/agent/toolDefinitions.ts
+++ b/src/api/admin/agent/toolDefinitions.ts
@@ -93,7 +93,7 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
         type: 'object',
         properties: {
           limit: {
-            type: 'number',
+            type: 'integer',
             description: '取得件数（1〜20、デフォルト10）',
           },
           search: {
@@ -527,7 +527,7 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
       parameters: {
         type: 'object',
         properties: {
-          limit: { type: 'number', description: '取得件数の上限（任意、省略時10、最大20）' },
+          limit: { type: 'integer', description: '取得件数の上限（任意、省略時10、最大20）' },
         },
         required: [],
       },
@@ -784,8 +784,8 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
       parameters: {
         type: 'object',
         properties: {
-          limit: { type: 'number', description: '取得件数の上限（任意、省略時10、最大20）' },
-          offset: { type: 'number', description: '取得開始位置（任意、省略時0）。前回の続きを見るときに limit ずつ進める' },
+          limit: { type: 'integer', description: '取得件数の上限（任意、省略時10、最大20）' },
+          offset: { type: 'integer', description: '取得開始位置（任意、省略時0）。前回の続きを見るときに limit ずつ進める' },
           period: {
             type: 'string',
             enum: ['7', '30', '90', 'all'],
@@ -823,7 +823,7 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
             type: 'string',
             description: 'セッションID。get_chat_sessions の [xxxxxxxx] 表記の短縮ID（8文字）をそのまま指定してよい',
           },
-          limit: { type: 'number', description: '取得するメッセージ数の上限（任意、省略時20、最大50。新しい方から取得）' },
+          limit: { type: 'integer', description: '取得するメッセージ数の上限（任意、省略時20、最大50。新しい方から取得）' },
         },
         required: ['session_id'],
       },


### PR DESCRIPTION
## 問題

`clampToolLimit`(`src/api/admin/agent/actionExecutor.ts`)は `Number.isFinite` による非数値フォールバックのみで、**整数化を行っていなかった**。

JSON Schema上 `limit` は `type: 'number'` だったため、LLMが `1.5` のような小数を返すとクランプを素通りして**非整数のまま SQL の `LIMIT` パラメータに渡る**。実DBでは非整数の `LIMIT` はエラーになる。

同ファイル内の別経路(`normalizeSessionListParams` → `coerceInt`)は整数化しており、`clampToolLimit` だけが欠けていた。

PR #644 のテスト強化で発見し、当時は「既知の未対応」として可視化のみに留めていたもの。

## 修正

| ファイル | 変更 |
|---|---|
| `actionExecutor.ts` | `clampToolLimit` にクランプ後の `Math.floor` を追加(1行)。**ヘルパー1箇所の修正で4つの呼び出しを同時に是正**(`get_faq_list` / `get_knowledge_gaps` / `get_chat_sessions` / `get_chat_session_messages`) |
| `toolDefinitions.ts` | `limit`/`offset` の JSON Schema を `number` → `integer`(5箇所)。LLM側にも小数を返させない多層防御 |

「クランプ→整数化」の順にしているのは、`0.4` が `1` に持ち上がってから丸められる意図(=範囲に収めてから丸める)を読み取れるようにするため。

## テスト

PR #644 で追加した「【既知の未対応】limit=1.5がそのまま渡る」テストを、実際の期待値へ更新:

- `1.5 → 1` / `19.9 → 19` / `0.4 → 1`(下限クランプ後) / `20.7 → 20`(上限クランプ後)の4パターン
- SQLパラメータが `Number.isInteger` を満たすことも併せて検証
- JSON Schema が `integer` であることを検証するテストを追加

## 実行結果

- `npx tsc --noEmit`: 0 errors
- `bash SCRIPTS/security-scan.sh`: PASS (CRITICAL/HIGH: 0)
- `agentRoutes.test.ts` の対象範囲(get_faq_list / get_knowledge_gaps / get_chat_sessions / get_chat_session_messages): 全て PASS

フルスイートでは無関係な2件(監査ログ・削除scope)が5000msタイムアウトで落ちたが、単体実行では両方緑。このマシン既知の環境要因(TIME_WAIT蓄積)。

## 一切しないこと(確認)

- [x] 各ツールの既定値・上限は変更していない(1.5→1 のように整数化のみ)
- [x] 新規ファイルなし
- [x] `normalizeSessionListParams` 側(既に `coerceInt` で整数化済み)には触れていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgWB82fsx7LMjhJqpd1rCx