### PR TITLE
test(e2e): super_admin用storageStateがCIで生成されず Role C が恒久skipされるのを直す

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,12 +51,25 @@ jobs:
           E2E_ENABLED: '1'
         run: npx playwright test --project=setup
 
+      # Phase A-2: super_admin 用 storageState 生成
+      # qa-irregular-3roles.spec.ts の Role C(super_admin 越境/プレビュー)群が依存する。
+      # TEST_SUPERADMIN_* 未設定の場合は superadmin.setup.ts が空スケルトンを書き、
+      # Role C は spec 側の saReady チェックで graceful skip される(CIは赤化しない)。
+      - name: Super admin auth setup
+        env:
+          TEST_SUPERADMIN_EMAIL: ${{ secrets.TEST_SUPERADMIN_EMAIL }}
+          TEST_SUPERADMIN_PASSWORD: ${{ secrets.TEST_SUPERADMIN_PASSWORD }}
+          E2E_ENABLED: '1'
+        run: npx playwright test --project=superadmin-setup
+
       # E2E テスト (admin-ui project + public project)
       - name: Run E2E tests
         env:
           E2E_ENABLED: '1'
           TEST_ADMIN_EMAIL: ${{ secrets.TEST_ADMIN_EMAIL }}
           TEST_ADMIN_PASSWORD: ${{ secrets.TEST_ADMIN_PASSWORD }}
+          TEST_SUPERADMIN_EMAIL: ${{ secrets.TEST_SUPERADMIN_EMAIL }}
+          TEST_SUPERADMIN_PASSWORD: ${{ secrets.TEST_SUPERADMIN_PASSWORD }}
         run: npx playwright test --project=admin-ui --project=chromium
 
       # Phase C: ビジュアルリグレッション（linux baseline が存在する場合のみ）

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -24,6 +24,16 @@ export default defineConfig({
       name: 'setup',
       testMatch: /auth\.setup\.ts/,
     },
+    // super_admin 用 storageState(tests/e2e/.auth/superadmin.json)を生成する。
+    // これが無いと qa-irregular-3roles.spec.ts の Role C(super_admin)群は
+    // saReady=false で恒久的に skip される。
+    // superadmin.setup.ts は .setup.ts のため既定の testMatch(*.spec.ts / *.test.ts)に
+    // 一致せず、chromium プロジェクトの testIgnore にも該当しないため、
+    // 専用プロジェクトで明示的に拾わないとどこからも実行されない。
+    {
+      name: 'superadmin-setup',
+      testMatch: /superadmin\.setup\.ts/,
+    },
     {
       name: 'admin-ui',
       testMatch: /(responsive|avatar-test-button)\.spec\.ts/,
@@ -44,8 +54,14 @@ export default defineConfig({
     },
     {
       name: 'chromium',
-      testIgnore: /auth\.setup\.ts|(responsive|avatar-test-button|visual-regression)\.spec\.ts/,
+      // superadmin.setup.ts は既定の testMatch(*.spec.ts / *.test.ts)に一致しないため
+      // 現状は拾われないが、将来 testMatch を緩めたときに setup が本テストとして
+      // 二重実行されるのを防ぐため、auth.setup.ts と同様に明示的に除外しておく。
+      testIgnore: /(auth|superadmin)\.setup\.ts|(responsive|avatar-test-button|visual-regression)\.spec\.ts/,
       use: { browserName: 'chromium' },
+      // Role C(super_admin)テストは storageState をファイルから直接読むため
+      // storageState 指定は不要だが、生成の順序保証のために依存を張る。
+      dependencies: ['setup', 'superadmin-setup'],
     },
   ],
 });


### PR DESCRIPTION
## 問題

`tests/e2e/superadmin.setup.ts` は #479 で追加されたが、**以来一度も実行されていなかった可能性が高い**。

- `playwright.config.ts` の `setup` プロジェクトは `testMatch: /auth\.setup\.ts/` のみ
- `superadmin.setup.ts` は `.setup.ts` のため、既定の testMatch(`*.spec.ts` / `*.test.ts`)にも一致しない
- 結果、**どのプロジェクトからも実行されず** `tests/e2e/.auth/superadmin.json` が生成されない
- `qa-irregular-3roles.spec.ts` の Role C(super_admin 越境/プレビュー)群は `saReady=false` となり `test.skip` される

つまり「テストコードは存在するが、CI上で一度も実行されていない」状態だった。PR #644 のカバレッジ監査で発見。

**S1(#629 書籍/PDF の R2C運用限定)の中核claimである「previewMode中のsuper_adminはPDFを投入できる」を検証する E2E も、この Role C 群に含まれる。**

## 修正

| ファイル | 変更 |
|---|---|
| `playwright.config.ts` | `superadmin-setup` プロジェクトを追加(`testMatch` で `superadmin.setup.ts` を明示的に拾う)。`chromium` に `dependencies` を張り生成順序を保証。将来 `testMatch` を緩めたときの二重実行を防ぐため `testIgnore` にも追加 |
| `.github/workflows/e2e.yml` | `Super admin auth setup` ステップを追加し、`TEST_SUPERADMIN_EMAIL` / `TEST_SUPERADMIN_PASSWORD` を渡す |

## 確認済み

- **修正前**: `--project=superadmin-setup` で **0件** → **修正後: 1件**を正しく解決
- Role C(`qa-irregular-3roles.spec.ts`)は `chromium` プロジェクトに含まれることを確認
- **シークレット未設定でも `superadmin.setup.ts` が空スケルトンを書いて pass し、Role C は graceful skip される(CIを赤化させない)ことを実際に実行して確認**
- `npx tsc --noEmit`: 0 errors / YAML 構文: OK

## ⚠️ このPRだけでは完了しません

**GitHub Secrets への登録が必要です(hkobayashi の操作が必須)。**

| Secret | 用途 |
|---|---|
| `TEST_SUPERADMIN_EMAIL` | Role C 用 super_admin アカウント |
| `TEST_SUPERADMIN_PASSWORD` | 同上 |

登録されるまで Role C は従来どおり skip されます(**挙動は現状から悪化しません**)。

### セキュリティ上の注意

E2E は `playwright.config.ts` の `baseURL` 経由で**本番環境(`https://admin.r2c.biz`)を直接叩きます**。super_admin 権限の認証情報を CI に置くことは client_admin とは別種のリスクです。方針Aとして「専用の検証用 super_admin アカウントを作り、権限を最小化して登録する」ことを前提にしています。**既存の運用アカウントを流用しないでください。**

## 一切しないこと(確認)

- [x] 既存の `setup` / `admin-ui` / `visual-regression` / `chromium` プロジェクトの挙動は変更していない
- [x] テストコード(`qa-irregular-3roles.spec.ts` / `superadmin.setup.ts`)は変更していない(配線のみ)
- [x] `tests/e2e/.auth/superadmin.json`(生成物)はコミットしていない

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgWB82fsx7LMjhJqpd1rCx