### PR TITLE
fix: 評価/エスカレーションの無言truncate・一覧カードのoutcome欠落・確認マーカー重複を解消する

### DIFF
--- a/admin-ui/src/components/AdminAgent/AdminAgentMessage.tsx
+++ b/admin-ui/src/components/AdminAgent/AdminAgentMessage.tsx
@@ -1,16 +1,14 @@
 // admin-ui/src/components/AdminAgent/AdminAgentMessage.tsx
 import type { AgentMessage } from "./useAdminAgent";
 
+// このパネル面(components/AdminAgent/)は凍結方針(admin-ui/CLAUDE.md)のため、
+// 全画面UI(pages/copilot-preview/)が追加した新ツールのラベルはここに追加しない。
+// 未登録のツール名は toolLabel() の `?? tool` フォールバックで生の英語名のまま
+// 表示される(意図的な劣化。パネル面は今後増えないため許容している)。
 const TOOL_LABEL: Record<string, string> = {
-  list_faqs: "FAQ一覧取得",
   add_faq: "FAQ追加",
   update_faq: "FAQ更新",
   delete_faq: "FAQ削除",
-  list_tenants: "テナント一覧取得",
-  get_tenant: "テナント情報取得",
-  update_tenant: "テナント更新",
-  list_knowledge: "ナレッジ一覧取得",
-  add_knowledge: "ナレッジ追加",
 };
 
 function toolLabel(tool: string): string {

--- a/admin-ui/src/lib/useAgentChatTransport.ts
+++ b/admin-ui/src/lib/useAgentChatTransport.ts
@@ -46,7 +46,13 @@ export type LegacyLinkAgentActionCard = {
 export type ChatSessionListAgentActionCard = {
   kind: "chat_session_list";
   total: number;
-  sessions: Array<{ shortId: string; startedAt: string; messageCount: number; preview: string }>;
+  sessions: Array<{
+    shortId: string;
+    startedAt: string;
+    messageCount: number;
+    preview: string;
+    outcome: string | null;
+  }>;
 };
 
 export type ChatSessionMessagesAgentActionCard = {

--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -544,6 +544,32 @@ describe("CopilotPreviewPage — 構造化カード(card)からの描画", () =>
     expect(chip).toBeTruthy();
   });
 
+  it("chat_session_list カードは記録済みのoutcomeがあればバッジを表示する(未記録ならバッジを出さない)", async () => {
+    mockAgent({
+      reply: "直近の会話は2件です。",
+      actions: [
+        {
+          tool: "get_chat_sessions",
+          result: "会話セッション一覧（全2件中2件）:\n[sess-aaa] 2026-07-17 (4件) 「送料はいくらですか」\n[sess-bbb] 2026-07-16 (2件) 「ありがとうございました」",
+          card: {
+            kind: "chat_session_list",
+            total: 2,
+            sessions: [
+              { shortId: "sess-aaa", startedAt: "2026-07-17T10:00:00Z", messageCount: 4, preview: "送料はいくらですか", outcome: null },
+              { shortId: "sess-bbb", startedAt: "2026-07-16T10:00:00Z", messageCount: 2, preview: "ありがとうございました", outcome: "購入完了" },
+            ],
+          },
+        },
+      ],
+    });
+
+    await send("最近の会話を見せて");
+
+    expect(await screen.findByText("購入完了")).toBeTruthy();
+    // 未記録(null)のセッション行にはバッジのテキスト自体が存在しない(件数1つだけ)
+    expect(screen.getAllByText("購入完了")).toHaveLength(1);
+  });
+
   it("chat_session_list のチップを押すと、短縮IDを含む自然文が実送信される", async () => {
     vi.mocked(authFetch).mockReset();
     let agentCalls = 0;

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -154,7 +154,13 @@ type Card =
   | {
       kind: "chatSessionList";
       total: number;
-      sessions: Array<{ shortId: string; startedAt: string; messageCount: number; preview: string }>;
+      sessions: Array<{
+        shortId: string;
+        startedAt: string;
+        messageCount: number;
+        preview: string;
+        outcome: string | null;
+      }>;
     }
   // 会話本文(get_chat_session_messages)。role のラベルはサーバ側(CHAT_ROLE_LABELS)を
   // 単一の情報源とし、ここでは辞書を持たずそのまま描画する。
@@ -276,6 +282,15 @@ const REAL_WRITE_TOOLS = new Set([
   "record_session_outcome",
   "delete_chat_session",
 ]);
+
+// 確認待ち/連鎖ブロックの判定に使う部分一致マーカー。サーバ側の実体は
+// src/api/admin/agent/agentRoutes.ts の BLOCKED_UNCONFIRMED_MARKER('確認が必要です')・
+// BLOCKED_CHAIN_MARKER('確認をスキップできません')。この2ファイルは別プロジェクト
+// (Node/Vite)のため定数を直接共有できず、文言はここに複製している。サーバ側の文言を
+// 変える場合はここも同時に更新すること(ここでは完全一致ではなく includes による
+// 部分一致にしてあるため、サーバ側の文言が「〜まで」を含む限り前方一致で検出できる)。
+const CONFIRM_REQUIRED_MARKER = "確認が必要";
+const CHAIN_BLOCKED_MARKER = "確認をスキップできません";
 
 // Phase2 (P7): ログイン直後に能動的に状況を尋ねる自動キックオフメッセージ。
 // 左レール「今週のまとめ」(handleCategory の "weekly" 分岐)と実質同じ依頼文で
@@ -738,8 +753,8 @@ export default function CopilotPreviewPage() {
     const writesThisTurn = (data.actions ?? []).filter(
       (a) =>
         REAL_WRITE_TOOLS.has(a.tool) &&
-        !a.result.includes("確認が必要") &&
-        !a.result.includes("確認をスキップできません"),
+        !a.result.includes(CONFIRM_REQUIRED_MARKER) &&
+        !a.result.includes(CHAIN_BLOCKED_MARKER),
     ).length;
     if (writesThisTurn > 0) setRealActionCount((n) => n + writesThisTurn);
 
@@ -748,13 +763,13 @@ export default function CopilotPreviewPage() {
     const suggested = data.actions?.some((a) => SUGGEST_TOOLS.has(a.tool));
     // Saiへの依頼がconfirmed待ちでブロックされた場合も、そのまま同意できるチップを添える
     const saiPendingConfirm = data.actions?.some(
-      (a) => a.tool === "request_sai_task" && a.result.includes("確認が必要"),
+      (a) => a.tool === "request_sai_task" && a.result.includes(CONFIRM_REQUIRED_MARKER),
     );
     // エスカレーションへの返信/対応完了がconfirmed待ちでブロックされた場合も同様
     const escalationPendingConfirm = data.actions?.some(
       (a) =>
         (a.tool === "reply_to_escalation" || a.tool === "resolve_escalation") &&
-        a.result.includes("確認が必要"),
+        a.result.includes(CONFIRM_REQUIRED_MARKER),
     );
     // オンボーディングのFAQテンプレート提案がconfirmed待ちでブロックされた場合も同様
     const industryTemplatePendingConfirm = data.actions?.some(
@@ -762,11 +777,11 @@ export default function CopilotPreviewPage() {
     );
     // 成果(コンバージョン)記録がconfirmed待ちでブロックされた場合も同様
     const outcomePendingConfirm = data.actions?.some(
-      (a) => a.tool === "record_session_outcome" && a.result.includes("確認が必要"),
+      (a) => a.tool === "record_session_outcome" && a.result.includes(CONFIRM_REQUIRED_MARKER),
     );
     // 会話セッション削除(不可逆)がconfirmed待ちでブロックされた場合も同様
     const deletePendingConfirm = data.actions?.some(
-      (a) => a.tool === "delete_chat_session" && a.result.includes("確認が必要"),
+      (a) => a.tool === "delete_chat_session" && a.result.includes(CONFIRM_REQUIRED_MARKER),
     );
     // 会話一覧(get_chat_sessions)が返ってきたら、短縮IDを手打ちさせず次の1件を
     // 選べるチップを添える。同じターンに複数の会話一覧が返ることは無い前提(最初の1件)。
@@ -2184,6 +2199,11 @@ function CardView({
             <div key={s.shortId} style={{ display: "flex", flexDirection: "column", gap: 3, paddingBottom: 10, borderBottom: "1px solid var(--border)" }}>
               <div style={{ fontSize: 12.5, color: "var(--muted-foreground)" }}>
                 {s.startedAt.slice(0, 10)} ・ {s.messageCount}件
+                {s.outcome && (
+                  <span style={{ marginLeft: 8, padding: "1px 8px", borderRadius: 999, fontSize: 11.5, fontWeight: 600, background: "rgba(34,197,94,0.15)", color: "#16a34a" }}>
+                    {s.outcome}
+                  </span>
+                )}
               </div>
               <div style={{ fontSize: 15, color: "var(--foreground)" }}>{s.preview}</div>
             </div>

--- a/docs/LEGACY_UI_SUNSET.md
+++ b/docs/LEGACY_UI_SUNSET.md
@@ -38,9 +38,9 @@
 
 **参照した実装 (2026-07-30 実測):**
 
-- ツール定義: `src/api/admin/agent/toolDefinitions.ts` — `ADMIN_AGENT_TOOLS` は **49 本**（本文書作成時点の45本 + 会話の履歴カテゴリ拡張で追加した4本: `get_conversation_evaluation` / `get_session_outcome` / `record_session_outcome` / `delete_chat_session`。`name:` 実測49件）。
-- 実行系: `src/api/admin/agent/actionExecutor.ts` — 49 本すべてに `case` が存在。
-- 旧UI案内: `actionExecutor.ts:1659–1710` の `LEGACY_UI_LINKS` — **9 キー** (`billing` / `avatar_studio` / `escalation_reply` / `session_deletion` / `analytics` / `conversion` / `chat_test` / `avatar_wizard` / `knowledge_pdf`)。`get_legacy_ui_link` の `feature` enum と 1:1 対応。
+- ツール定義: `src/api/admin/agent/toolDefinitions.ts` — `ADMIN_AGENT_TOOLS` は本文書作成時点の45本から増え続けている（会話の履歴カテゴリ拡張で4本、その後のPRでも追加あり。**`name:` の実測件数を都度 `grep -c "^\s*name: '" toolDefinitions.ts` で確認すること**。以下の行番号・件数は本文書の実測時点のスナップショットであり、この文書自体が更新頻度に追いつけていない前提で読むこと）。
+- 実行系: `src/api/admin/agent/actionExecutor.ts` — ツール定義と同数の `case` が存在するはず(乖離があれば `confirmPolicy.test.ts` が検出する)。
+- 旧UI案内: `actionExecutor.ts` の `LEGACY_UI_LINKS`（行番号は移動しやすいため `grep -n "LEGACY_UI_LINKS" actionExecutor.ts` で確認）— **10 キー** (`billing` / `avatar_studio` / `escalation_reply` / `session_deletion` / `analytics` / `conversion` / `chat_test` / `avatar_wizard` / `knowledge_pdf` / `knowledge_attribution`)。`get_legacy_ui_link` の `feature` enum と 1:1 対応（§1.2-4 で `knowledge_attribution` を追加、以前の版は9キーだった）。
 
 > **`feature` の 9 値の所在について**: `origin/main` (`ef9ac629`) 時点では `toolDefinitions.ts:839–849` の enum リテラルに直接書かれている。**PR #571 着地後は `LEGACY_UI_FEATURES` (`toolDefinitions.ts:26`) が唯一の値の所在**になり、enum は `enum: LEGACY_UI_FEATURES` (`:860`) として参照するだけになる。以下、本ドキュメントで「`feature` enum」と書いている箇所は**値の集合**を指しており、着地後は `LEGACY_UI_FEATURES` を読むこと (行番号は §3 Stage B に最新のものを記載)。
 

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -279,10 +279,19 @@ export type WeeklySummaryCardPayload = {
 
 // 会話一覧カード。短縮ID(shortId)をそのまま次のツール呼び出しに使える形で持たせ、
 // フロント側が短縮IDの手打ちなしで次の1件を選べるようにする(チップの action に使う)。
+// outcome は getSessions() が既にSELECTしているため、ここで持たせることで
+// 「どの会話が成約したか」を知るために get_session_outcome をセッション数だけ
+// 往復する必要が無くなる。
 export type ChatSessionListCardPayload = {
   kind: 'chat_session_list';
   total: number;
-  sessions: Array<{ shortId: string; startedAt: string; messageCount: number; preview: string }>;
+  sessions: Array<{
+    shortId: string;
+    startedAt: string;
+    messageCount: number;
+    preview: string;
+    outcome: string | null;
+  }>;
 };
 
 // 会話本文カード。role のラベル化はサーバ側の CHAT_ROLE_LABELS を単一の情報源とし、
@@ -2066,6 +2075,7 @@ export async function executeToolCall(
               startedAt: s.started_at,
               messageCount: s.message_count,
               preview: s.first_message_preview,
+              outcome: s.outcome,
             })),
           },
         };
@@ -2209,7 +2219,10 @@ export async function executeToolCall(
         const axesText = axes.map((a) => `${a.label}: ${a.score ?? '未測定'}`).join(' / ');
         const shortId8 = resolved.session.session_id.slice(0, 8);
         return {
-          text: truncate(
+          // notes はJudgeの自由記述で、書き込み系の500字予算(truncate)だと所見の
+          // 大半が無言で切れうる(card側は全文を持つため、LLMだけが根拠を読めない
+          // 非対称が起きる)。閲覧系の予算(truncateRead, 4000字+打ち切り注記)を使う。
+          text: truncateRead(
             `セッション[${shortId8}]の対応品質評価: 総合${ev.overall_score}点\n${axesText}` +
             (ev.notes ? `\n所見: ${ev.notes}` : ''),
           ),
@@ -2241,7 +2254,9 @@ export async function executeToolCall(
         const lines = escalations.map(
           (e) => `[${e.session_id.slice(0, 8)}] ${e.escalated_at.slice(0, 16).replace('T', ' ')} 「${e.first_message_preview}」`,
         );
-        return truncate(`対応中のエスカレーション（${escalations.length}件）:\n` + lines.join('\n'));
+        // 件数の上限を設けていない一覧のため、書き込み系の500字予算(truncate)だと
+        // 対応待ちの顧客が黙って表示から消えうる。閲覧系の予算(truncateRead)を使う。
+        return truncateRead(`対応中のエスカレーション（${escalations.length}件）:\n` + lines.join('\n'));
       } catch (err) {
         logger.warn('[actionExecutor] get_escalations failed', err);
         return truncate('エスカレーション一覧の取得に失敗しました');

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -265,6 +265,26 @@ function makeGroqResponse(
   };
 }
 
+// resolveSessionByShortId(短縮IDのテナント境界解決)を経由するツール(get_chat_session_messages /
+// delete_chat_session / get_session_outcome・record_session_outcome / get_conversation_evaluation /
+// reply_to_escalation・resolve_escalation / get_legacy_ui_link)のテストが共有するモックヘルパー。
+// テナント越境防止という同一のセキュリティロジックを検証するため、個々のdescribeで
+// コピーを持たせず1箇所にする(片方だけ実装を直して他方が古いまま気付かない事故を防ぐ)。
+// 固定の rows を返すのではなく、resolveSessionByShortId が実行する SQL
+// (tenant_id = $1 AND session_id LIKE $2 || '%')を tenant_id + 前方一致で忠実に再現する。
+type SessionRow = { id: string; tenant_id: string; session_id: string };
+function seedSessions(rows: SessionRow[]) {
+  mockQuery.mockImplementation(async (_sql: string, params?: unknown[]) => {
+    if (!Array.isArray(params)) return { rows: [] };
+    const [tenantId, prefix] = params as [string, string];
+    return {
+      rows: rows
+        .filter((r) => r.tenant_id === tenantId && r.session_id.startsWith(prefix))
+        .map((r) => ({ id: r.id, session_id: r.session_id })),
+    };
+  });
+}
+
 // ---------------------------------------------------------------------------
 // テストスイート
 // ---------------------------------------------------------------------------
@@ -3618,9 +3638,29 @@ describe('POST /v1/admin/agent/chat', () => {
         kind: 'chat_session_list',
         total: 42,
         sessions: [
-          { shortId: 'sess-aaa', startedAt: '2026-07-17T10:00:00Z', messageCount: 4, preview: '送料はいくらですか' },
+          { shortId: 'sess-aaa', startedAt: '2026-07-17T10:00:00Z', messageCount: 4, preview: '送料はいくらですか', outcome: null },
         ],
       });
+    });
+
+    it('get_chat_sessions: 記録済みのoutcomeはカードにそのまま渡る(一覧から成約状況が分かる)', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-rd-outcome', 'get_chat_sessions', {}))
+        .mockResolvedValueOnce(makeGroqResponse('直近の会話は1件です。'));
+
+      mockGetSessions.mockResolvedValueOnce({
+        sessions: [
+          { id: 'db-1', tenant_id: 'tenant-abc', session_id: 'sess-bbbbbbbb-2222', started_at: '2026-07-17T10:00:00Z', last_message_at: '2026-07-17T10:05:00Z', message_count: 2, first_message_preview: 'ありがとうございました', outcome: '購入完了', outcome_recorded_at: '2026-07-17T11:00:00Z' },
+        ],
+        total: 1,
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '最近の会話を見せて', sessionId: 'sess-rd-outcome' });
+
+      const action = res.body.actions[0] as { card?: { sessions?: Array<{ outcome: string | null }> } };
+      expect(action.card?.sessions?.[0]?.outcome).toBe('購入完了');
     });
 
     it('get_chat_sessions: period/search/sentiment/sort_by/sort_order/offset がgetSessionsへ渡る', async () => {
@@ -3861,8 +3901,7 @@ describe('POST /v1/admin/agent/chat', () => {
       };
     }
 
-    type SessionRow = { id: string; tenant_id: string; session_id: string };
-
+    // SessionRow / seedSessions はファイル先頭の共有ヘルパーを使う。
     const OWN_SESSION: SessionRow = {
       id: 'db-sess-own', tenant_id: 'tenant-abc', session_id: 'a1b2c3d4-1111-4aaa-8000-000000000001',
     };
@@ -3875,21 +3914,6 @@ describe('POST /v1/admin/agent/chat', () => {
     const DUP_B: SessionRow = {
       id: 'db-sess-dup-b', tenant_id: 'tenant-abc', session_id: 'dupdup00-2222-4ddd-8000-000000000004',
     };
-
-    // resolveSessionByShortId の SQL（tenant_id = $1 AND session_id LIKE $2 || '%'）を
-    // 忠実に再現する。テナント越境が「SQLの条件で」防がれていることを検証するため、
-    // 固定の rows を返すのではなく tenant_id + 前方一致でフィルタする。
-    function seedSessions(rows: SessionRow[]) {
-      mockQuery.mockImplementation(async (_sql: string, params?: unknown[]) => {
-        if (!Array.isArray(params)) return { rows: [] };
-        const [tenantId, prefix] = params as [string, string];
-        return {
-          rows: rows
-            .filter((r) => r.tenant_id === tenantId && r.session_id.startsWith(prefix))
-            .map((r) => ({ id: r.id, session_id: r.session_id })),
-        };
-      });
-    }
 
     it('自テナントのセッションは短縮IDで本文を取得できる', async () => {
       mockFetch
@@ -4195,7 +4219,7 @@ describe('POST /v1/admin/agent/chat', () => {
       };
     }
 
-    type SessionRow = { id: string; tenant_id: string; session_id: string };
+    // SessionRow / seedSessions はファイル先頭の共有ヘルパーを使う。
     const OWN_SESSION: SessionRow = {
       id: 'db-sess-del', tenant_id: 'tenant-abc', session_id: 'dddd1111-1111-4aaa-8000-000000000001',
     };
@@ -4205,18 +4229,6 @@ describe('POST /v1/admin/agent/chat', () => {
     const PREVIEW_SESSION: SessionRow = {
       id: 'db-sess-del-preview', tenant_id: 'tenant-preview', session_id: 'dddd3333-3333-4ccc-8000-000000000003',
     };
-
-    function seedSessions(rows: SessionRow[]) {
-      mockQuery.mockImplementation(async (_sql: string, params?: unknown[]) => {
-        if (!Array.isArray(params)) return { rows: [] };
-        const [tenantId, prefix] = params as [string, string];
-        return {
-          rows: rows
-            .filter((r) => r.tenant_id === tenantId && r.session_id.startsWith(prefix))
-            .map((r) => ({ id: r.id, session_id: r.session_id })),
-        };
-      });
-    }
 
     beforeEach(() => {
       mockDeleteSession.mockReset();
@@ -4577,22 +4589,10 @@ describe('POST /v1/admin/agent/chat', () => {
       };
     }
 
-    type SessionRow = { id: string; tenant_id: string; session_id: string };
+    // SessionRow / seedSessions はファイル先頭の共有ヘルパーを使う。
     const OWN_SESSION: SessionRow = {
       id: 'db-sess-outcome', tenant_id: 'tenant-abc', session_id: 'oooo1111-1111-4aaa-8000-000000000001',
     };
-
-    function seedSessions(rows: SessionRow[]) {
-      mockQuery.mockImplementation(async (_sql: string, params?: unknown[]) => {
-        if (!Array.isArray(params)) return { rows: [] };
-        const [tenantId, prefix] = params as [string, string];
-        return {
-          rows: rows
-            .filter((r) => r.tenant_id === tenantId && r.session_id.startsWith(prefix))
-            .map((r) => ({ id: r.id, session_id: r.session_id })),
-        };
-      });
-    }
 
     beforeEach(() => {
       mockGetConversionTypes.mockReset();
@@ -4907,25 +4907,13 @@ describe('POST /v1/admin/agent/chat', () => {
       };
     }
 
-    type SessionRow = { id: string; tenant_id: string; session_id: string };
+    // SessionRow / seedSessions はファイル先頭の共有ヘルパーを使う。
     const OWN_SESSION: SessionRow = {
       id: 'db-sess-eval', tenant_id: 'tenant-abc', session_id: 'eeee1111-1111-4aaa-8000-000000000001',
     };
     const OTHER_TENANT_SESSION: SessionRow = {
       id: 'db-sess-eval-other', tenant_id: 'tenant-zzz', session_id: 'ffff2222-2222-4bbb-8000-000000000002',
     };
-
-    function seedSessions(rows: SessionRow[]) {
-      mockQuery.mockImplementation(async (_sql: string, params?: unknown[]) => {
-        if (!Array.isArray(params)) return { rows: [] };
-        const [tenantId, prefix] = params as [string, string];
-        return {
-          rows: rows
-            .filter((r) => r.tenant_id === tenantId && r.session_id.startsWith(prefix))
-            .map((r) => ({ id: r.id, session_id: r.session_id })),
-        };
-      });
-    }
 
     beforeEach(() => {
       mockGetEvaluationsBySession.mockReset();
@@ -5127,28 +5115,13 @@ describe('POST /v1/admin/agent/chat', () => {
       };
     }
 
-    type SessionRow = { id: string; tenant_id: string; session_id: string };
-
+    // SessionRow / seedSessions はファイル先頭の共有ヘルパーを使う。
     const OWN_SESSION: SessionRow = {
       id: 'db-esc-own', tenant_id: 'tenant-abc', session_id: 'e5c0abcd-1111-4aaa-8000-000000000011',
     };
     const OTHER_TENANT_SESSION: SessionRow = {
       id: 'db-esc-other', tenant_id: 'tenant-zzz', session_id: 'ffee0000-9999-4bbb-8000-000000000012',
     };
-
-    // resolveSessionByShortId の SQL（tenant_id = $1 AND session_id LIKE $2 || '%'）を
-    // 忠実に再現し、テナント越境が「SQLの条件で」防がれていることを検証する。
-    function seedSessions(rows: SessionRow[]) {
-      mockQuery.mockImplementation(async (_sql: string, params?: unknown[]) => {
-        if (!Array.isArray(params)) return { rows: [] };
-        const [tenantId, prefix] = params as [string, string];
-        return {
-          rows: rows
-            .filter((r) => r.tenant_id === tenantId && r.session_id.startsWith(prefix))
-            .map((r) => ({ id: r.id, session_id: r.session_id })),
-        };
-      });
-    }
 
     it('reply: confirmed 未指定なら「確認が必要」を返し、返信を保存しない', async () => {
       mockFetch
@@ -5628,20 +5601,7 @@ describe('POST /v1/admin/agent/chat', () => {
     });
 
     // session_deletion の deep-link（resolveSessionByShortId で短縮IDを解決する）
-    type SessionRow = { id: string; tenant_id: string; session_id: string };
-
-    function seedSessions(rows: SessionRow[]) {
-      mockQuery.mockImplementation(async (_sql: string, params?: unknown[]) => {
-        if (!Array.isArray(params)) return { rows: [] };
-        const [tenantId, prefix] = params as [string, string];
-        return {
-          rows: rows
-            .filter((r) => r.tenant_id === tenantId && r.session_id.startsWith(prefix))
-            .map((r) => ({ id: r.id, session_id: r.session_id })),
-        };
-      });
-    }
-
+    // SessionRow / seedSessions はファイル先頭の共有ヘルパーを使う。
     const OWN_SESSION: SessionRow = {
       id: '8f14e45f-ceea-467a-9d0f-2b3c4d5e6f70', tenant_id: 'tenant-abc', session_id: 'a1b2c3d4-1111-4aaa-8000-000000000001',
     };


### PR DESCRIPTION
## Summary
「会話履歴カテゴリ」実装の厳しいレビュー(#646の後続)、P2〜P4を対応。

### P2: LLMとユーザーが別の情報を見ている
1. **`get_conversation_evaluation` / `get_escalations` の無言truncate** — 書き込み系の500字予算(`truncate`、無言カット)のままだった。Judge所見はヘッダ込みで実質約420字しか残らず、そこで無言に切れる。カード側には全文が渡るため、**LLMは切られた根拠を要約し、人間は全文を見る**という非対称があった。閲覧系の予算(`truncateRead`、4000字+打ち切り注記)に統一。
2. **一覧カードの outcome 欠落** — `getSessions()` は `outcome`/`outcome_recorded_at` を既にSELECTしているのに `chat_session_list` カードが捨てていた。「どの会話が成約したか」を知るには `get_session_outcome` をセッション数だけ往復する必要があった。カードに `outcome` を追加し、一覧にバッジ表示。

### P4: 一貫性・重複
3. **パネル面の死んだラベル** — `components/AdminAgent/AdminAgentMessage.tsx` の `TOOL_LABEL` に存在しない6ツール名(`list_faqs`等)が残存。パネル面は凍結方針のため新ツールのラベルは追加せず、死んだエントリのみ削除。
4. **確認マーカーの重複** — `"確認が必要"` 等の判定文字列がフロント側6箇所にベタ書き(サーバの定数とは別ファイルのため直接共有不可)。frontend内で1つの定数に集約。
5. **テストヘルパーの重複** — `agentRoutes.test.ts` でテナント境界シミュレーション(`seedSessions`/`SessionRow`)が6箇所にコピーされていた。同一のセキュリティロジックが片方だけ直されて事故る経路を塞ぐため、ファイル先頭の共有ヘルパーに統合(フィクスチャデータは各describeにローカルのまま)。
6. **`LEGACY_UI_SUNSET.md` の陳腐化した要約** — 「49本」「9キー」が実態(54本・10キー)と食い違っていた最上部の記述を修正。個別の行番号citationはこのリポジトリの更新頻度では追従できないため、grepでの再確認を促す注記に置き換えた(全citationの精緻な追従はスコープ外)。

## 対応しなかった項目
**P3(構造化カードdescribeの単独実行不可、29件)** — 調査の結果、この問題は `index.test.tsx` 内の無関係な複数describe(AppSwitcherのロックタブ、リクエストボディのsurface等、chat-history機能と一切関係ない箇所)にも及ぶ広範な既存のテスト分離課題と判明した。フルファイル実行では全て緑になるため実害は「`-t`によるデバッグができない」ことに限られるが、根本原因の特定には別途まとまった調査が必要と判断し、本PRのスコープ外とした。

## Test plan
- [x] `npx tsc --noEmit`(server / admin-ui)
- [x] `npx oxlint src admin-ui/src`
- [x] `agentRoutes.test.ts` 327件、`confirmPolicy.test.ts`、`chat-history/*` 全通過(dedup後もテナント境界テストの実効性を再確認)
- [x] admin-ui `index.test.tsx` 126件(outcomeバッジの新規テスト含む)、`components/AdminAgent/*` 19件、全通過
- [x] admin-ui `vite build` 成功

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UpYM4tvAGHfu4vc9NQqPfY