### PR TITLE
fix: 週次まとめレビューで見つかったP1-2/P2-1/P1-3を修正

### DIFF
--- a/admin-ui/src/components/AdminAgent/useAdminAgent.test.tsx
+++ b/admin-ui/src/components/AdminAgent/useAdminAgent.test.tsx
@@ -116,6 +116,45 @@ describe("useAdminAgent — 会話の復元(sessionStorage)", () => {
     // 全画面UI側のキーは一切触られていない
     expect(window.sessionStorage.getItem(chatSessionKey(CHAT_SESSION_SURFACE_FULLSCREEN))).toBe(fullscreenBefore);
   });
+
+  // レビュー指摘(P1-2): マウント時の復元検証だけでは、パネルをunmountせずに
+  // super_adminがAppSwitcherで別テナントへ切り替えるケースを防げない。以前は
+  // 保存effectがtenantIdの変化を無視してそのまま保存し続けており、前テナントの
+  // 会話が新テナントの会話として保存され直っていた。
+  it("マウント後にtenantIdがライブで変わると、保持中の会話を破棄してから新テナントとして保存し直す", async () => {
+    saveChatSession(CHAT_SESSION_SURFACE_PANEL, {
+      sessionId: "panel-session-tenant-a",
+      messages: [{ role: "user", content: "テナントAの機密の質問" }],
+      tenantId: "tenant-a",
+    });
+
+    const { rerender } = render(<Probe tenantId="tenant-a" />);
+    expect(screen.getByTestId("messages").textContent).toBe("user:テナントAの機密の質問");
+
+    rerender(<Probe tenantId="tenant-b" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId("messages").textContent).toBe("");
+    });
+
+    // まだ何も送信していない(messages.length===0)ため保存effectは書き込まないが、
+    // 破棄自体はclearChatSessionで即座に行われ、テナントAの会話は残らない。
+    const stored = restoreChatSession(CHAT_SESSION_SURFACE_PANEL, "tenant-a");
+    expect(stored).toBeNull();
+  });
+
+  it("同じtenantIdのままの再レンダーでは会話を破棄しない", () => {
+    saveChatSession(CHAT_SESSION_SURFACE_PANEL, {
+      sessionId: "panel-session-tenant-a",
+      messages: [{ role: "user", content: "テナントAの質問" }],
+      tenantId: "tenant-a",
+    });
+
+    const { rerender } = render(<Probe tenantId="tenant-a" />);
+    rerender(<Probe tenantId="tenant-a" />);
+
+    expect(screen.getByTestId("messages").textContent).toBe("user:テナントAの質問");
+  });
 });
 
 // GID 1217008695995707: サーバは全メトリクスの surface ラベルにこの値をそのまま載せる

--- a/admin-ui/src/components/AdminAgent/useAdminAgent.ts
+++ b/admin-ui/src/components/AdminAgent/useAdminAgent.ts
@@ -5,9 +5,10 @@
 // 根拠: docs/CHAT_SURFACE_DECISION.md が採択した選択肢(c)「パネルは橋。旧UIページの
 // 閉鎖に合わせて畳む」。凍結の対象は「面固有の新機能」であって、共有層
 // (lib/useAgentChatTransport.ts, lib/chatSessionStore.ts)のバグ修正は対象外。
-import { useState, useCallback, useEffect } from "react";
+import { useState, useCallback, useEffect, useRef } from "react";
 import {
   CHAT_SESSION_SURFACE_PANEL,
+  clearChatSession,
   restoreChatSession,
   saveChatSession,
 } from "../../lib/chatSessionStore";
@@ -50,10 +51,26 @@ export function useAdminAgent(tenantId?: string | null): UseAdminAgentResult {
   const [isOpen, setIsOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
 
-  const { sessionId, send } = useAgentChatTransport({
+  const { sessionId, send, adoptSessionId } = useAgentChatTransport({
     surface: "panel",
     initialSessionId: restored?.sessionId,
   });
+
+  // ライブテナント切替(super_adminがAppSwitcherで別テナントへ切替える。パネルはunmountされない)
+  // を検知し、保持中の会話を破棄する。マウント時の復元検証(上のrestoreChatSession呼び出し)
+  // だけでは防げない — 検証はマウント時の1回だけで、その後 tenantId が変わっても
+  // 下の保存effectはそのまま新しいtenantIdで保存し続けるため、前テナントの会話が
+  // 新テナントの会話として保存され直ってしまう(GID: 全画面UI側で見つかった同型バグの
+  // パネル側残存箇所)。
+  const lastTenantIdRef = useRef(tenantId);
+  useEffect(() => {
+    const prev = lastTenantIdRef.current;
+    lastTenantIdRef.current = tenantId;
+    if (tenantId === prev) return;
+    clearChatSession(CHAT_SESSION_SURFACE_PANEL);
+    setMessages([]);
+    adoptSessionId(crypto.randomUUID());
+  }, [tenantId, adoptSessionId]);
 
   useEffect(() => {
     if (messages.length === 0) return;

--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -2638,6 +2638,95 @@ describe("CopilotPreviewPage — テナント切替時の会話リセット", ()
     // 送信可能状態も壊れていない(遅れてきたtenant-bの完了処理がsendingを誤って書き換えていない)
     expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false);
   });
+
+  // レビュー指摘(P1-3): 以前はテナント切替後、オンボーディング段階を判定せず常に
+  // 週次ブリーフィングへ直行していた。マウント時の経路(次の一手を提示する)と
+  // 切替後の経路とで挙動が分かれていたため、super_adminが代行のため新規テナントへ
+  // 切り替えても「次の一手」が出ない不整合があった。
+  it("切替後もオンボーディング未完了なら次の一手が提示される(ブリーフィングへ直行しない)", async () => {
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (isBadgeUrl(url)) return mockEmptyBadges();
+      if (String(url).includes("/v1/admin/tenants/tenant-a")) {
+        return mockOk({ onboarding_stage: null });
+      }
+      if (String(url).includes("/v1/admin/tenants/tenant-b")) {
+        return mockOk({
+          onboarding_stage: {
+            industryAnswered: false,
+            knowledgePublished: false,
+            widgetInstalled: false,
+            firstConversation: false,
+          },
+        });
+      }
+      return mockOk({ reply: "今週の状況です。", actions: [] });
+    });
+
+    const { rerender } = renderPage({ ...SUPER_ADMIN_IN_PREVIEW, previewTenantId: "tenant-a" });
+    await waitFor(() => expect(screen.getByText("今週の状況です。")).toBeTruthy());
+
+    vi.mocked(useAuth).mockReturnValue(baseAuth({ ...SUPER_ADMIN_IN_PREVIEW, previewTenantId: "tenant-b" }));
+    rerender(<MemoryRouter><CopilotPreviewPage /></MemoryRouter>);
+
+    expect(await screen.findByText(/どんな業種ですか/)).toBeTruthy();
+    // ブリーフィングの自然文(週次まとめ)は出ていない
+    expect(screen.queryByText("今週の状況です。")).toBeNull();
+  });
+
+  // レビュー指摘(P2-1): テナント切替後のオンボーディング判定(await authFetch)の最中に
+  // さらに別テナントへ切り替わると、以前は世代カウンタで守られておらず、後から届いた
+  // 古い判定結果(前テナントの「次の一手」)が新テナントのスレッドに紛れ込んでいた。
+  it("切替後のオンボーディング判定中にさらに切替が発生しても、古い判定結果は新テナントのスレッドに反映されない", async () => {
+    let resolveTenantBOnboarding: (v: Response) => void = () => {};
+
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (isBadgeUrl(url)) return mockEmptyBadges();
+      if (String(url).includes("/v1/admin/tenants/tenant-a")) {
+        return mockOk({ onboarding_stage: null });
+      }
+      if (String(url).includes("/v1/admin/tenants/tenant-b")) {
+        // tenant-b の判定は保留のまま(手動で解決するまで待つ)
+        return new Promise<Response>((resolve) => { resolveTenantBOnboarding = resolve; });
+      }
+      if (String(url).includes("/v1/admin/tenants/tenant-c")) {
+        return mockOk({ onboarding_stage: null }); // tenant-c は判定完了済み扱い
+      }
+      return mockOk({ reply: "tenant-cの状況です。", actions: [] });
+    });
+
+    const { rerender } = renderPage({ ...SUPER_ADMIN_IN_PREVIEW, previewTenantId: "tenant-a" });
+    await waitFor(() => expect(vi.mocked(authFetch)).toHaveBeenCalled());
+
+    // tenant-b へ切替(オンボーディング判定は保留のまま)
+    vi.mocked(useAuth).mockReturnValue(baseAuth({ ...SUPER_ADMIN_IN_PREVIEW, previewTenantId: "tenant-b" }));
+    rerender(<MemoryRouter><CopilotPreviewPage /></MemoryRouter>);
+    await waitFor(() =>
+      expect(vi.mocked(authFetch).mock.calls.some(([url]) => String(url).includes("tenant-b"))).toBe(true),
+    );
+
+    // tenant-b の判定が届く前に、さらに tenant-c へ切替
+    vi.mocked(useAuth).mockReturnValue(baseAuth({ ...SUPER_ADMIN_IN_PREVIEW, previewTenantId: "tenant-c" }));
+    rerender(<MemoryRouter><CopilotPreviewPage /></MemoryRouter>);
+    await waitFor(() => expect(screen.getByText("tenant-cの状況です。")).toBeTruthy());
+
+    // 遅延していた tenant-b の「次の一手」が今さら届いても、tenant-c のスレッドには出ない
+    resolveTenantBOnboarding({
+      ok: true,
+      status: 200,
+      json: () =>
+        Promise.resolve({
+          onboarding_stage: {
+            industryAnswered: false,
+            knowledgePublished: false,
+            widgetInstalled: false,
+            firstConversation: false,
+          },
+        }),
+    } as unknown as Response);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(screen.queryByText(/どんな業種ですか/)).toBeNull();
+    expect(screen.getByText("tenant-cの状況です。")).toBeTruthy();
+  });
 });
 
 // GID 1217007387443283: GUI固有として旧UIへ丸投げしていたPDF取り込みを、会話の中の

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -867,6 +867,62 @@ export default function CopilotPreviewPage() {
     // setSending(false) は revealText の完了コールバックに任せる
   };
 
+  // オンボーディング段階に応じて「次の一手」を出すか、通常の週次ブリーフィングを取りに
+  // 行くかを決める共通処理。マウント時(初回ログイン/会話復元後)とテナント切替後の
+  // 両方から呼ばれる — 以前はテナント切替側がオンボーディング判定を経由せず常に
+  // ブリーフィングへ直行しており、切替直後は「次の一手」が出ないという2経路の
+  // 不一致があった(P1-3)。
+  //
+  // myEpoch は呼び出し時点の requestEpochRef の値。stage取得(await)の間に、より新しい
+  // 呼び出し(テナント再切替)に追い越されていたら、そのまま何も表示せず抜ける
+  // (追い越した側がこの関数を呼び直すか、sendReal自身の世代ガードに委ねる)。これが
+  // 無いと、切替でスレッドを空にした直後に前テナントの「次の一手」が新テナントの
+  // スレッドへ紛れ込む(P2-1)。
+  const runOnboardingAwareBriefing = async (
+    myEpoch: number,
+    opts: { hasRestoredConversation: boolean; loadingText: string; force?: boolean },
+  ) => {
+    let stage: OnboardingStageFlags | null = null;
+    // Asana 1217040568430944(P7): super_adminのクライアントビュー(previewMode)からも
+    // オンボーディングの「次の一手」提示を使えるようにする(docs/ONBOARDING_FIRST_LOGIN.md 決定D)。
+    // previewMode中はJWTのtenant_idを見るmy-tenantではなくtargetTenantId明示の
+    // /v1/admin/tenants/:id(super_admin専用、useAuthのtenantPlan取得と同じ経路)を使う。
+    try {
+      if (previewMode && previewTenantId) {
+        const res = await authFetch(`${API_BASE}/v1/admin/tenants/${previewTenantId}`);
+        if (res.ok) {
+          const data = (await res.json()) as { onboarding_stage?: OnboardingStageFlags };
+          stage = data.onboarding_stage ?? null;
+        }
+      } else if (!previewMode && user?.role === "client_admin") {
+        const res = await authFetch(`${API_BASE}/v1/admin/my-tenant`);
+        if (res.ok) {
+          const data = (await res.json()) as { onboarding_stage?: OnboardingStageFlags };
+          stage = data.onboarding_stage ?? null;
+        }
+      }
+    } catch {
+      // 取得失敗時は通常の週次ブリーフィング側にフォールバック
+    }
+
+    if (requestEpochRef.current !== myEpoch) return; // より新しい呼び出しに追い越された
+
+    const nextStep = stage ? deriveOnboardingNextStep(stage) : null;
+
+    if (opts.hasRestoredConversation) {
+      if (nextStep) push(say(nextStep.text, nextStep.chips));
+      return;
+    }
+
+    if (nextStep) {
+      push(say(nextStep.text, nextStep.chips));
+      return;
+    }
+
+    push({ id: nextId(), role: "ai", text: opts.loadingText });
+    await sendReal(BOOTSTRAP_PROMPT, { silent: true, force: opts.force });
+  };
+
   // マウント時、まず同一タブに保存済みの会話があれば復元する(リロード・ブラウザバック・
   // モバイルのタブ破棄で会話が消えないように)。
   //
@@ -887,6 +943,7 @@ export default function CopilotPreviewPage() {
     if (bootstrapped.current) return;
     bootstrapped.current = true;
 
+    const myEpoch = requestEpochRef.current;
     const restored = restoreChatSession<Msg>(CHAT_SESSION_SURFACE_FULLSCREEN, scopedTenantId || null);
     const hasRestoredConversation = !!(restored && restored.messages.length > 0);
     if (hasRestoredConversation && restored) {
@@ -896,44 +953,10 @@ export default function CopilotPreviewPage() {
       setRealHistory(restored.history ?? []);
     }
 
-    void (async () => {
-      let stage: OnboardingStageFlags | null = null;
-      // Asana 1217040568430944(P7): super_adminのクライアントビュー(previewMode)からも
-      // オンボーディングの「次の一手」提示を使えるようにする(docs/ONBOARDING_FIRST_LOGIN.md 決定D)。
-      // previewMode中はJWTのtenant_idを見るmy-tenantではなくtargetTenantId明示の
-      // /v1/admin/tenants/:id(super_admin専用、useAuthのtenantPlan取得と同じ経路)を使う。
-      try {
-        if (previewMode && previewTenantId) {
-          const res = await authFetch(`${API_BASE}/v1/admin/tenants/${previewTenantId}`);
-          if (res.ok) {
-            const data = (await res.json()) as { onboarding_stage?: OnboardingStageFlags };
-            stage = data.onboarding_stage ?? null;
-          }
-        } else if (!previewMode && user?.role === "client_admin") {
-          const res = await authFetch(`${API_BASE}/v1/admin/my-tenant`);
-          if (res.ok) {
-            const data = (await res.json()) as { onboarding_stage?: OnboardingStageFlags };
-            stage = data.onboarding_stage ?? null;
-          }
-        }
-      } catch {
-        // 取得失敗時は通常の週次ブリーフィング側にフォールバック
-      }
-
-      const nextStep = stage ? deriveOnboardingNextStep(stage) : null;
-
-      if (hasRestoredConversation) {
-        if (nextStep) push(say(nextStep.text, nextStep.chips));
-        return;
-      }
-
-      if (nextStep) {
-        push(say(nextStep.text, nextStep.chips));
-      } else {
-        push({ id: nextId(), role: "ai", text: "ログイン、お疲れさまです。今週の実データを確認しています…" });
-        await sendReal(BOOTSTRAP_PROMPT, { silent: true });
-      }
-    })();
+    void runOnboardingAwareBriefing(myEpoch, {
+      hasRestoredConversation,
+      loadingText: "ログイン、お疲れさまです。今週の実データを確認しています…",
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [needsTenantSelection]);
 
@@ -953,6 +976,12 @@ export default function CopilotPreviewPage() {
 
     if (!prev || !scopedTenantId || scopedTenantId === prev) return;
 
+    // 世代カウンタを切替の時点で即座に進める(sendReal呼び出しより前)。まだ完了して
+    // いない直前の呼び出し(この後始まる bootstrap 側の onboarding 判定を含む)を
+    // ここで無効化してから会話をリセットする(P2-1)。
+    requestEpochRef.current += 1;
+    const myEpoch = requestEpochRef.current;
+
     // 会話・履歴・sessionId・進捗カウント・保存済みセッション(前テナントのもの)を
     // すべて破棄してから、新テナントの週次ブリーフィングを取り直す。
     clearChatSession(CHAT_SESSION_SURFACE_FULLSCREEN);
@@ -961,13 +990,14 @@ export default function CopilotPreviewPage() {
     setRealActionCount(0);
     adoptSessionId(crypto.randomUUID());
 
-    void (async () => {
-      push({ id: nextId(), role: "ai", text: "テナントを切り替えました。今週の実データを確認しています…" });
-      // force:true — 直前の切替の応答待ち(sending中)でも必ずこの切替を発火させる。
-      // 「新しい切替」は「前のテナントの応答待ち」より常に優先されるべきで、
-      // 追い越された古い呼び出し側は sendReal 内の世代カウンタが無害化する。
-      await sendReal(BOOTSTRAP_PROMPT, { silent: true, force: true });
-    })();
+    // force:true — 直前の切替の応答待ち(sending中)でも必ずこの切替を発火させる。
+    // 「新しい切替」は「前のテナントの応答待ち」より常に優先されるべきで、
+    // 追い越された古い呼び出し側は sendReal 内の世代カウンタが無害化する。
+    void runOnboardingAwareBriefing(myEpoch, {
+      hasRestoredConversation: false,
+      force: true,
+      loadingText: "テナントを切り替えました。今週の実データを確認しています…",
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [scopedTenantId]);
 


### PR DESCRIPTION
## Summary
先の厳格レビューで指摘した3件を修正(admin-ui/src、Tier S — 手動マージ対象)。

- **P1-2(パネルの情報漏れ)**: `useAdminAgent` はマウント時にしかテナント検証を行わず、super_adminがAppSwitcherでライブにテナントを切り替える(パネルはunmountされない)と、前テナントの会話が新テナントの会話として保存し直されていた。全画面UI側で修正済みの同型バグ(#639)のパネル側残存箇所。再現テストで実証済み。
- **P2-1(切替後onboarding判定のレース)**: テナント切替後のonboarding段階取得は世代カウンタ(`requestEpochRef`)で守られておらず、判定中にさらに別テナントへ切り替わると、古い判定結果(前テナントの「次の一手」)が新テナントのスレッドに紛れ込みうる状態だった。
- **P1-3(マウント時と切替後の分岐不一致)**: マウント時はonboarding段階を見て「次の一手」or週次ブリーフィングを出し分けるのに対し、切替後は無条件で週次ブリーフィングへ直行しており、super_adminによる新規テナントの代行導線(P7)と噛み合っていなかった。両経路を`runOnboardingAwareBriefing`に統合。

P1-1(週次レポート系統`AIReportTab`のモック描画・未読バッジ固定値の撤去)は見た目の変更を伴うため別途判断待ち、今回のスコープ外。

## Test plan
- [x] `npx tsc --noEmit`(admin-ui) — 型エラーなし
- [x] `npx eslint`(変更ファイル) — warning無し
- [x] `npx vitest run`(admin-ui全体) — 30ファイル/361テスト全パス
- [x] 新規テスト3件を追加、いずれも修正前のコードに対して意図通り失敗することを個別に確認済み(P1-2はマウント後のrerenderで再現、P2-1はepoch guardを一時的に外して再現、P1-3はロジック未実装状態で再現)