### PR TITLE
feat(admin-ui): 会話・知識ギャップから指示ルールを作る導線をチャットに配線する(P5-1)

### DIFF
--- a/admin-ui/src/lib/useAgentChatTransport.ts
+++ b/admin-ui/src/lib/useAgentChatTransport.ts
@@ -59,7 +59,15 @@ export type ChatSessionMessagesAgentActionCard = {
   kind: "chat_session_messages";
   shortId: string;
   totalMessages: number;
-  messages: Array<{ roleLabel: string; content: string }>;
+  messages: Array<{ role: string; roleLabel: string; content: string }>;
+};
+
+// P5-1: 知識ギャップ一覧(get_knowledge_gaps)。各行から「このギャップから
+// ルールを作る」チップに繋げる。
+export type KnowledgeGapsListAgentActionCard = {
+  kind: "knowledge_gaps_list";
+  gaps: Array<{ id: number; userQuestion: string; ragHitCount: number }>;
+  totalCount: number;
 };
 
 export type AvatarPresetAgentActionCard = {
@@ -135,7 +143,8 @@ export type AgentActionCard =
   | WeeklySummaryAgentActionCard
   | ChatSessionListAgentActionCard
   | ChatSessionMessagesAgentActionCard
-  | ConversationEvaluationAgentActionCard;
+  | ConversationEvaluationAgentActionCard
+  | KnowledgeGapsListAgentActionCard;
 
 export type AgentAction = { tool: string; result: string; card?: AgentActionCard };
 

--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -630,6 +630,102 @@ describe("CopilotPreviewPage — 構造化カード(card)からの描画", () =>
     expect(screen.getByText("送料はいくらですか")).toBeTruthy();
   });
 
+  // P5-1: 会話の全文表示から画面遷移なしでルール下書きに繋げる導線。
+  it("「この会話からルールを作る」は直前にお客様発言があるAI応答にのみ表示され、押すと会話内容を埋め込んだ自然文を実送信する", async () => {
+    mockAgent({
+      reply: "会話内容はこちらです。",
+      actions: [
+        {
+          tool: "get_chat_session_messages",
+          result: "セッション[a1b2c3d4]の会話（全2件中2件）:\nお客様: 送料はいくらですか\nAI: 全国一律500円です",
+          card: {
+            kind: "chat_session_messages",
+            shortId: "a1b2c3d4",
+            totalMessages: 2,
+            messages: [
+              { role: "user", roleLabel: "お客様", content: "送料はいくらですか" },
+              { role: "assistant", roleLabel: "AI", content: "全国一律500円です" },
+            ],
+          },
+        },
+      ],
+    });
+
+    await send("a1b2c3d4の会話を見せて");
+
+    const chip = await screen.findByRole("button", { name: "🎛️ この会話からルールを作る" });
+    // お客様発言そのものにはボタンが出ない(AI応答1個・チップ1個であることの確認)
+    expect(screen.getAllByRole("button", { name: "🎛️ この会話からルールを作る" })).toHaveLength(1);
+
+    fireEvent.click(chip);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("この会話(お客様:「送料はいくらですか」→AI:「全国一律500円です」)から指示ルールを提案してください"),
+      ).toBeTruthy(),
+    );
+  });
+
+  it("「この会話からルールを作る」は直前のお客様発言が無いAI応答には表示されない", async () => {
+    mockAgent({
+      reply: "会話内容はこちらです。",
+      actions: [
+        {
+          tool: "get_chat_session_messages",
+          result: "セッション[a1b2c3d4]の会話（全1件中1件）:\nAI: いらっしゃいませ",
+          card: {
+            kind: "chat_session_messages",
+            shortId: "a1b2c3d4",
+            totalMessages: 1,
+            messages: [{ role: "assistant", roleLabel: "AI", content: "いらっしゃいませ" }],
+          },
+        },
+      ],
+    });
+
+    await send("a1b2c3d4の会話を見せて");
+
+    expect(await screen.findByText("いらっしゃいませ")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "🎛️ この会話からルールを作る" })).toBeNull();
+  });
+
+  // P5-1: 知識ギャップ一覧から画面遷移なしでルール下書きに繋げる導線。
+  it("知識ギャップカードは行ごとに「このギャップからルールを作る」チップを出し、押すとID/質問を埋め込んだ自然文を実送信する", async () => {
+    mockAgent({
+      reply: "未対応の質問は2件あります。",
+      actions: [
+        {
+          tool: "get_knowledge_gaps",
+          result: "知識ギャップ一覧（未対応2件中2件）:\n[1] 送料はいくらですか？（9件ヒット）\n[2] 返品はできますか？（2件ヒット）",
+          card: {
+            kind: "knowledge_gaps_list",
+            gaps: [
+              { id: 1, userQuestion: "送料はいくらですか？", ragHitCount: 9 },
+              { id: 2, userQuestion: "返品はできますか？", ragHitCount: 2 },
+            ],
+            totalCount: 2,
+          },
+        },
+      ],
+    });
+
+    await send("知識ギャップを見せて");
+
+    expect(await screen.findByText("送料はいくらですか？")).toBeTruthy();
+    expect(screen.getByText("返品はできますか？")).toBeTruthy();
+
+    const chips = screen.getAllByRole("button", { name: "🎛️ このギャップからルールを作る" });
+    expect(chips).toHaveLength(2);
+
+    fireEvent.click(chips[0]);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText("知識ギャップ（ID: 1、質問:「送料はいくらですか？」）から指示ルールを提案してください"),
+      ).toBeTruthy(),
+    );
+  });
+
   it("record_session_outcome が確認待ちのときは「記録して」チップを出し、押すと実送信する", async () => {
     vi.mocked(authFetch).mockReset();
     mockNavigate.mockReset();

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -164,11 +164,20 @@ type Card =
     }
   // 会話本文(get_chat_session_messages)。role のラベルはサーバ側(CHAT_ROLE_LABELS)を
   // 単一の情報源とし、ここでは辞書を持たずそのまま描画する。
+  // role(生の値)はP5-1で追加: AI応答の直後にのみ「この会話からルールを作る」
+  // チップを出すための判定に使う(roleLabelは表示用の日本語で判定に使わない)。
   | {
       kind: "chatSessionMessages";
       shortId: string;
       totalMessages: number;
-      messages: Array<{ roleLabel: string; content: string }>;
+      messages: Array<{ role: string; roleLabel: string; content: string }>;
+    }
+  // P5-1: 知識ギャップ一覧(get_knowledge_gaps)。各行から「このギャップから
+  // ルールを作る」チップに繋げる。
+  | {
+      kind: "knowledgeGapsList";
+      gaps: Array<{ id: number; userQuestion: string; ragHitCount: number }>;
+      totalCount: number;
     }
   // AI品質評価(get_conversation_evaluation)。4軸ラベルはサーバ側で確定済みのものを
   // そのまま描画する(旧UIの JudgeEvaluationSection.tsx と同一語彙)。
@@ -707,6 +716,10 @@ export default function CopilotPreviewPage() {
       if (a.card?.kind === "tuning_rules_list") {
         const { rules, totalCount } = a.card;
         return { id: nextId(), role: "ai", card: { kind: "rulesList", rules, totalCount } };
+      }
+      if (a.card?.kind === "knowledge_gaps_list") {
+        const { gaps, totalCount } = a.card;
+        return { id: nextId(), role: "ai", card: { kind: "knowledgeGapsList", gaps, totalCount } };
       }
       if (a.card?.kind === "weekly_summary") {
         const { asOf, sessions, avgScore, conversions, faq, pendingTuningRules, gaps } = a.card;
@@ -2216,7 +2229,32 @@ function CardView({
     case "chatSessionMessages":
       return (
         <CardShell hd={<><span>📜</span>会話[{card.shortId}]（全{card.totalMessages}件中{card.messages.length}件）</>}>
-          {card.messages.map((m, i) => <Field key={i} k={m.roleLabel} v={m.content} quote />)}
+          {card.messages.map((m, i) => {
+            // P5-1: AI応答の直後にのみ「この会話からルールを作る」を出す。
+            // 直前が必ずしもお客様発言とは限らない(担当者返信を挟む等)ため、
+            // 遡って直近のuser発言を探す。見つからなければチップを出さない。
+            const prevUser =
+              m.role === "assistant"
+                ? card.messages.slice(0, i).reverse().find((p) => p.role === "user")
+                : undefined;
+            return (
+              <div key={i} style={{ display: "flex", flexDirection: "column", gap: 6 }}>
+                <Field k={m.roleLabel} v={m.content} quote />
+                {prevUser && onSendReal && (
+                  <button
+                    onClick={() =>
+                      onSendReal(
+                        `__real:この会話(お客様:「${prevUser.content.slice(0, 300)}」→AI:「${m.content.slice(0, 300)}」)から指示ルールを提案してください`,
+                      )
+                    }
+                    style={{ alignSelf: "flex-start", fontSize: 12.5, fontWeight: 700, padding: "8px 14px", borderRadius: 8, cursor: "pointer", border: "1px solid var(--border)", background: "transparent", color: "var(--muted-foreground)", minHeight: 44 }}
+                  >
+                    🎛️ この会話からルールを作る
+                  </button>
+                )}
+              </div>
+            );
+          })}
         </CardShell>
       );
     case "evaluation": {
@@ -2245,6 +2283,29 @@ function CardView({
     }
     case "weeklySummary":
       return <WeeklySummaryCard card={card} />;
+    case "knowledgeGapsList":
+      return (
+        <CardShell hd={<><span>📚</span>知識ギャップ一覧（{card.totalCount}件）</>}>
+          {card.gaps.map((g) => (
+            <div key={g.id} style={{ display: "flex", flexDirection: "column", gap: 6, paddingBottom: 12, borderBottom: "1px solid var(--border)" }}>
+              <div style={{ fontSize: 14.5, color: "var(--foreground)" }}>{g.userQuestion}</div>
+              <div style={{ fontSize: 12.5, color: "var(--muted-foreground)" }}>{g.ragHitCount}件ヒット</div>
+              {onSendReal && (
+                <button
+                  onClick={() =>
+                    onSendReal(
+                      `__real:知識ギャップ（ID: ${g.id}、質問:「${g.userQuestion}」）から指示ルールを提案してください`,
+                    )
+                  }
+                  style={{ alignSelf: "flex-start", fontSize: 13.5, fontWeight: 700, padding: "8px 14px", borderRadius: 10, cursor: "pointer", border: "1px solid var(--border)", background: "transparent", color: "var(--muted-foreground)", minHeight: 44 }}
+                >
+                  🎛️ このギャップからルールを作る
+                </button>
+              )}
+            </div>
+          ))}
+        </CardShell>
+      );
     default:
       return null;
   }

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -8,7 +8,7 @@ import {
   insertEmbeddingAsync,
   upsertToEsAsync,
 } from '../knowledge/faqCrudRoutes';
-import { callGroq8bSuggestFromText } from '../tuning/routes';
+import { callGroq8bSuggestFromText, callGroq8bSuggest } from '../tuning/routes';
 import { listRules, createRule, updateRule, deleteRule, type ApprovedResponse, type RuleEvidence } from '../tuning/tuningRulesRepository';
 import { splitTriggerKeywords } from '../tuning/triggerMatching';
 import { generateTestResponses } from '../tuning/testResponseRoutes';
@@ -303,7 +303,10 @@ export type ChatSessionMessagesCardPayload = {
   kind: 'chat_session_messages';
   shortId: string;
   totalMessages: number;
-  messages: Array<{ roleLabel: string; content: string }>;
+  // role は 'user' | 'assistant' | 'operator' 等の生の値。P5-1で
+  // 「この会話からルールを作る」チップをAI応答直後にのみ出すために必要
+  // (roleLabelは表示用の日本語ラベルで判定に使うと言語非依存性が崩れる)。
+  messages: Array<{ role: string; roleLabel: string; content: string }>;
 };
 
 // AI品質評価(Judge)カード。4軸ラベルは旧UI(admin-ui の JudgeEvaluationSection.tsx)と
@@ -316,6 +319,14 @@ export type ConversationEvaluationCardPayload = {
   notes: string | null;
 };
 
+// P5-1: 知識ギャップ一覧カード。各行から「このギャップからルールを作る」チップに
+// 繋げるため、質問文とヒット件数を店主が読める形で持たせる。
+export type KnowledgeGapsListCardPayload = {
+  kind: 'knowledge_gaps_list';
+  gaps: Array<{ id: number; userQuestion: string; ragHitCount: number }>;
+  totalCount: number;
+};
+
 export type ActionCardPayload =
   | LegacyLinkCardPayload
   | AvatarPresetCardPayload
@@ -325,7 +336,8 @@ export type ActionCardPayload =
   | WeeklySummaryCardPayload
   | ChatSessionListCardPayload
   | ChatSessionMessagesCardPayload
-  | ConversationEvaluationCardPayload;
+  | ConversationEvaluationCardPayload
+  | KnowledgeGapsListCardPayload;
 
 // ツール結果は既定では素の文字列で、構造化データを添えるツールだけが
 // { text, card } 形を返す。card は text の置き換えではなく追加である
@@ -1017,16 +1029,24 @@ export async function executeToolCall(
     // -----------------------------------------------------------------------
     case 'suggest_tuning_rule': {
       const freeText = String(args['free_text'] ?? '').trim();
-      if (!freeText) {
-        return truncate('free_text は必須です');
+      const userMessage = String(args['user_message'] ?? '').trim();
+      const aiMessage = String(args['ai_message'] ?? '').trim();
+      // P5-1: 会話の全文表示・知識ギャップの一覧から画面遷移なしでルールの下書きに
+      // 繋げる導線。既存のfree_text経路とは別に、会話1往復(user_message/ai_message)
+      // からの提案経路を追加する。新しい提案ロジックは書かず、旧UI(TuningRuleModal.tsx)
+      // が使っているのと同じ callGroq8bSuggest に分岐するだけ。
+      const isConversationMode = Boolean(userMessage && aiMessage);
+      if (!freeText && !isConversationMode) {
+        return truncate('free_text か、user_message と ai_message の組み合わせのいずれかが必要です');
       }
       if (!tenantId) {
         return truncate('テナントが特定できません。super_admin の場合は対象テナントを指定してください');
       }
 
       try {
+        const anchorText = isConversationMode ? userMessage : freeText;
         const [knowledgeCtx, existingRules] = await Promise.all([
-          searchKnowledgeForSuggestion(tenantId, freeText).catch(() => ({ results: [] })),
+          searchKnowledgeForSuggestion(tenantId, anchorText).catch(() => ({ results: [] })),
           listRules(tenantId).catch(() => []),
         ]);
         const knowledgeSection = formatKnowledgeContext(knowledgeCtx);
@@ -1035,7 +1055,9 @@ export async function executeToolCall(
           .map((r) => `- [${r.trigger_pattern}] ${r.expected_behavior}`)
           .join('\n');
 
-        const suggestion = await callGroq8bSuggestFromText(freeText, knowledgeSection, existingRulesSection);
+        const suggestion = isConversationMode
+          ? await callGroq8bSuggest(userMessage, aiMessage, knowledgeSection, existingRulesSection)
+          : await callGroq8bSuggestFromText(freeText, knowledgeSection, existingRulesSection);
 
         if (!suggestion.trigger_pattern && !suggestion.instruction) {
           return truncate('提案の生成に失敗しました。もう少し具体的に教えてください');
@@ -1528,7 +1550,16 @@ export async function executeToolCall(
           return truncate('未対応の知識ギャップはありません');
         }
         const lines = gaps.map((g) => `[${g.id}] ${g.user_question.slice(0, 100)}（${g.rag_hit_count}件ヒット）`);
-        return truncate(`知識ギャップ一覧（未対応${total}件中${gaps.length}件）:\n` + lines.join('\n'));
+        // P5-1: cardに全件の質問文をそのまま持たせ、フロントの「このギャップから
+        // ルールを作る」チップが id と質問文をそのまま自然文に埋め込めるようにする。
+        return {
+          text: truncate(`知識ギャップ一覧（未対応${total}件中${gaps.length}件）:\n` + lines.join('\n')),
+          card: {
+            kind: 'knowledge_gaps_list',
+            gaps: gaps.map((g) => ({ id: g.id, userQuestion: g.user_question, ragHitCount: g.rag_hit_count })),
+            totalCount: total,
+          },
+        };
       } catch (err) {
         logger.warn('[actionExecutor] get_knowledge_gaps failed', err);
         return truncate('知識ギャップ一覧の取得に失敗しました');
@@ -2120,7 +2151,7 @@ export async function executeToolCall(
             totalMessages: messages.length,
             // role のラベル化はここ(CHAT_ROLE_LABELS)を単一の情報源とする。
             // フロント側に同じ辞書を二重に持たせない。
-            messages: recent.map((m) => ({ roleLabel: CHAT_ROLE_LABELS[m.role] ?? m.role, content: m.content })),
+            messages: recent.map((m) => ({ role: m.role, roleLabel: CHAT_ROLE_LABELS[m.role] ?? m.role, content: m.content })),
           },
         };
       } catch (err) {

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -37,8 +37,11 @@ jest.mock('../knowledge/faqCrudRoutes', () => ({
 
 // suggest_tuning_rule / save_tuning_rule が使う依存をモック（実DB/実Groq呼び出し回避）
 const mockCallGroq8bSuggestFromText = jest.fn();
+// P5-1: 会話1往復(user_message/ai_message)からの提案モード用
+const mockCallGroq8bSuggest = jest.fn();
 jest.mock('../tuning/routes', () => ({
   callGroq8bSuggestFromText: (...args: any[]) => mockCallGroq8bSuggestFromText(...args),
+  callGroq8bSuggest: (...args: any[]) => mockCallGroq8bSuggest(...args),
 }));
 
 const mockListRules = jest.fn();
@@ -1077,6 +1080,88 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(res.status).toBe(200);
       expect(res.body.actions[0].result).toContain('どんな質問をした時に使いたいですか');
       expect(res.body.actions[0].result).not.toContain('save_tuning_rule を呼び出してください');
+    });
+
+    // P5-1: 会話1往復(user_message/ai_message)から提案する経路。free_text 経路の
+    // callGroq8bSuggestFromText とは別の callGroq8bSuggest に分岐する。
+    it('P5-1: user_message/ai_message が両方指定されると callGroq8bSuggest(会話モード)に分岐する（callGroq8bSuggestFromTextは呼ばれない）', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            choices: [{
+              message: {
+                content: null,
+                tool_calls: [{
+                  id: 'call-tr-conv-1',
+                  type: 'function',
+                  function: {
+                    name: 'suggest_tuning_rule',
+                    arguments: JSON.stringify({
+                      user_message: '送料はいくらですか',
+                      ai_message: 'ご質問の内容に完全に一致するFAQは見つかりませんでした。',
+                    }),
+                  },
+                }],
+              },
+            }],
+          }),
+          text: async () => '',
+        })
+        .mockResolvedValueOnce(makeGroqResponse('こう提案します。保存してよいですか？'));
+
+      mockCallGroq8bSuggest.mockResolvedValueOnce({
+        trigger_pattern: '送料',
+        instruction: '送料は全国一律500円とお伝えする',
+        priority: 5,
+        reason: '送料に関する知識ギャップが多いため',
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'この会話からルールを作って', sessionId: 'sess-030d' });
+
+      expect(res.status).toBe(200);
+      expect(mockCallGroq8bSuggest).toHaveBeenCalledWith(
+        '送料はいくらですか',
+        'ご質問の内容に完全に一致するFAQは見つかりませんでした。',
+        expect.any(String),
+        expect.any(String),
+      );
+      expect(mockCallGroq8bSuggestFromText).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('送料は全国一律500円とお伝えする');
+    });
+
+    // P5-1: free_text も user_message/ai_message の組も無い呼び出し(パラメータ欠落や
+    // モデルの引数生成ミス)は、DBもGroqも呼ばずに聞き返す文言で終える。
+    it('P5-1: free_text も user_message/ai_message の組も無い場合は提案を試みずエラー文言を返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            choices: [{
+              message: {
+                content: null,
+                tool_calls: [{
+                  id: 'call-tr-conv-2',
+                  type: 'function',
+                  function: { name: 'suggest_tuning_rule', arguments: JSON.stringify({ user_message: '送料はいくらですか' }) },
+                }],
+              },
+            }],
+          }),
+          text: async () => '',
+        })
+        .mockResolvedValueOnce(makeGroqResponse('もう少し詳しく教えてください。'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルールを作って', sessionId: 'sess-030e' });
+
+      expect(res.status).toBe(200);
+      expect(mockCallGroq8bSuggest).not.toHaveBeenCalled();
+      expect(mockCallGroq8bSuggestFromText).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('free_text か、user_message と ai_message の組み合わせのいずれかが必要です');
     });
   });
 
@@ -2407,6 +2492,35 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(result).toContain('未対応11件中2件');
       expect(result).toContain('送料はいくらですか？');
       expect(result).toContain('返品はできますか？');
+    });
+
+    // P5-1: 一覧の各行から「このギャップからルールを作る」チップに繋げるためのカード。
+    it('P5-1: get_knowledge_gaps は knowledge_gaps_list カードを返す（id/userQuestion/ragHitCount/totalCount）', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-kg-card-1', 'get_knowledge_gaps', {}))
+        .mockResolvedValueOnce(makeGroqResponse('未対応の質問は2件あります。'));
+
+      mockGetGaps.mockResolvedValueOnce({
+        gaps: [
+          { id: 1, tenant_id: 'tenant-abc', user_question: '送料はいくらですか？', session_id: null, message_id: null, rag_hit_count: 9, rag_top_score: 0, status: 'open', resolved_faq_id: null, created_at: '' },
+          { id: 2, tenant_id: 'tenant-abc', user_question: '返品はできますか？', session_id: null, message_id: null, rag_hit_count: 2, rag_top_score: 0, status: 'open', resolved_faq_id: null, created_at: '' },
+        ],
+        total: 11,
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '知識ギャップを見せて', sessionId: 'sess-kg-card-01' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].card).toEqual({
+        kind: 'knowledge_gaps_list',
+        gaps: [
+          { id: 1, userQuestion: '送料はいくらですか？', ragHitCount: 9 },
+          { id: 2, userQuestion: '返品はできますか？', ragHitCount: 2 },
+        ],
+        totalCount: 11,
+      });
     });
 
     it('get_knowledge_gaps: 0件の場合は「ありません」と返す', async () => {
@@ -3972,7 +4086,9 @@ describe('POST /v1/admin/agent/chat', () => {
         kind: 'chat_session_messages',
         shortId: 'a1b2c3d4',
         totalMessages: 1,
-        messages: [{ roleLabel: 'お客様', content: '送料はいくらですか' }],
+        // P5-1: role(生の値)を追加。「この会話からルールを作る」チップの
+        // 判定(AI応答の直後にのみ出す)に使う。
+        messages: [{ role: 'user', roleLabel: 'お客様', content: '送料はいくらですか' }],
       });
     });
 

--- a/src/api/admin/agent/toolDefinitions.ts
+++ b/src/api/admin/agent/toolDefinitions.ts
@@ -356,16 +356,27 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
     function: {
       name: 'suggest_tuning_rule',
       description:
-        '店舗管理者の自然な言葉による指示を、AIチャットボットの「指示ルール」（トリガー条件・期待する応答方針・優先度）の下書きに変換する。書き込みは行わない読み取り専用ツール。提案内容は必ずユーザーに提示して明確な同意を得てから save_tuning_rule で保存すること。',
+        '店舗管理者の自然な言葉による指示、または既存の会話のやりとり・知識ギャップから、AIチャットボットの「指示ルール」（トリガー条件・期待する応答方針・優先度）の下書きに変換する。書き込みは行わない読み取り専用ツール。' +
+        'free_text（自然文の指示）か、user_message + ai_message（会話1往復からの提案）のどちらか一方を指定する。' +
+        '会話の全文表示や知識ギャップの一覧から「この会話/ギャップからルールを作って」と言われた場合は、free_text ではなく user_message（お客様の発言・質問）と ai_message（それに対するAIの回答。知識ギャップの場合は「ご質問の内容に完全に一致するFAQは見つかりませんでした。」）を使うこと。' +
+        '提案内容は必ずユーザーに提示して明確な同意を得てから save_tuning_rule で保存すること。',
       parameters: {
         type: 'object',
         properties: {
           free_text: {
             type: 'string',
-            description: '管理者が話した自然文の指示（例:「保証について聞かれたら2年とお伝えして」）',
+            description: '管理者が話した自然文の指示（例:「保証について聞かれたら2年とお伝えして」）。user_message/ai_message とは併用しない。',
+          },
+          user_message: {
+            type: 'string',
+            description: '会話やギャップにおけるお客様側の発言・質問。ai_message と組で指定する。',
+          },
+          ai_message: {
+            type: 'string',
+            description: 'user_message に対するAIの回答。user_message と組で指定する。',
           },
         },
-        required: ['free_text'],
+        required: [],
       },
     },
   },


### PR DESCRIPTION
## Summary
- `suggest_tuning_rule` に `user_message`/`ai_message`(会話1往復)からの提案モードを追加。新規の提案ロジックは書かず、旧UI(`TuningRuleModal.tsx`)が使うのと同じ `callGroq8bSuggest` に分岐するだけ。`free_text` 経路(`callGroq8bSuggestFromText`)とは独立。
- `get_knowledge_gaps` が `knowledge_gaps_list` カード(id/userQuestion/ragHitCount/totalCount)を返すようになった。
- `/copilot-preview` の会話全文表示カードに「🎛️ この会話からルールを作る」を追加(AI応答の直後・直前にお客様発言がある場合のみ表示)。知識ギャップ一覧カードに行ごとの「🎛️ このギャップからルールを作る」を追加。どちらも画面遷移なしで `__real:` 経由の自然文提案フローに繋げる。

## Test plan
- [x] `npx tsc --noEmit -p .`(バックエンド)/ `npx tsc -b`(admin-ui、変更ファイルにエラー無し。既存の `useAuth.test.tsx` 等の型エラーは #627 由来で本PR対象外)
- [x] バックエンド新規テスト: 会話モード分岐(`callGroq8bSuggest`が呼ばれ`callGroq8bSuggestFromText`は呼ばれない)/ 両方欠落時のエラー文言 / `knowledge_gaps_list`カード形状
- [x] フロントエンド新規テスト: 「この会話からルールを作る」がAI応答直後・直前お客様発言ありの場合のみ表示され`__real:`送信 / 知識ギャップ行ごとのチップの送信内容
- [x] `oxlint src admin-ui/src`(該当ファイル) clean
- [x] `bash SCRIPTS/dead-code-check.sh`(既存の notionSchemas.ts 未使用exportのみ、本PR無関係)
- [x] `bash SCRIPTS/security-scan.sh` PASS
- [x] `agentRoutes.test.ts`(339件)を分割実行し全グループ成功を確認(単一プロセスでの339件supertest実行はサンドボックス環境のTCPポート枯渇による既知のフレーキーさがあり、分割実行と単体実行で切り分け済み)
- [x] `copilot-preview/index.test.tsx` 133/133 pass

Tier S(admin-ui/src変更)のためhkobayashiの手動マージが必要です。
Asana: 1217040622654477