### PR TITLE
fix(test): copilot-previewの単独実行不可(29件超)を修正する — 起動時ブートストラップとのレース

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -360,7 +360,15 @@ describe("CopilotPreviewPage — 共通シェル機能パリティ(テーマ/言
   // openWithQuery(誰も見ていないContext)を叩くだけで無反応だった。
   it("AppSwitcherのロックタブ(R2C2)の質問が、この画面自身のチャットに送られる", async () => {
     renderPage();
-    // 起動時ブリーフィングの完了を待つ(sending中は sendReal が無視されるため)
+    // 起動時ブリーフィングの完了を待つ(sending中は sendReal が無視されるため)。
+    // render()直後はブートストラップの自動送信がまだ authFetch を呼ぶ前(内部のawait前)
+    // のため、disabled=falseだけを見ると早すぎるタイミングで捉えてしまう(レース条件)。
+    // /v1/admin/agent/chatが実際に呼ばれたことを先に確認してから、disabled=falseを待つ。
+    await waitFor(() =>
+      expect(
+        vi.mocked(authFetch).mock.calls.some(([url]) => String(url).includes("/v1/admin/agent/chat")),
+      ).toBe(true),
+    );
     await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
 
     fireEvent.click(screen.getByTestId("app-switcher-stub"));
@@ -414,6 +422,15 @@ describe("CopilotPreviewPage — 旧UI案内リンクカード", () => {
 
   it("リンクは別タブで開き、会話が残る旨の補足が添えられる", async () => {
     renderPage();
+    // render()直後はブートストラップの自動送信(sendReal)がまだ authFetch を呼ぶ前
+    // (内部のawait前)のため、disabled=falseを早すぎるタイミングで捉えると、この後の
+    // 操作がブートストラップ自身のsending中に埋もれて無視される(レース条件)。
+    // /v1/admin/agent/chatが実際に呼ばれたことを先に確認してから、disabled=falseを待つ。
+    await waitFor(() =>
+      expect(
+        vi.mocked(authFetch).mock.calls.some(([url]) => String(url).includes("/v1/admin/agent/chat")),
+      ).toBe(true),
+    );
     await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
 
     fireEvent.change(screen.getByPlaceholderText(/指示ルール/), { target: { value: "請求書を再送したい" } });
@@ -451,6 +468,16 @@ describe("CopilotPreviewPage — 構造化カード(card)からの描画", () =>
 
   async function send(text: string) {
     renderPage();
+    // SCRATCH仮説検証(汎用版・特定の文言に依存しない): render()直後はブートストラップの
+    // 自動送信(sendReal)がまだ authFetch を呼ぶ前(内部のawait前)のため、ボタンの
+    // disabled=falseを早すぎるタイミングで捉えてしまうと、この操作がブートストラップ
+    // 自身のsending中に埋もれて無視される(レース条件)。/v1/admin/agent/chatが実際に
+    // 呼ばれたことを先に確認してから、disabled=falseを待つ。
+    await waitFor(() =>
+      expect(
+        vi.mocked(authFetch).mock.calls.some(([url]) => String(url).includes("/v1/admin/agent/chat")),
+      ).toBe(true),
+    );
     await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
     fireEvent.change(screen.getByPlaceholderText(/指示ルール/), { target: { value: text } });
     fireEvent.click(screen.getByLabelText("送信"));
@@ -1267,6 +1294,10 @@ describe("CopilotPreviewPage — 構造化カード(card)からの描画", () =>
 
     await send("指示ルールの状況を教えて");
     const approveButton = await screen.findByRole("button", { name: "有効にする" });
+    // SCRATCH仮説検証: カード(承認ボタンを含む)はタイプライター演出の完了を待たずに
+    // 即座に描画される(push(...actionMsgs)がrevealText開始より前)。演出完了(=sending=false)
+    // を待たずにクリックすると、sendReal のsendingガードに無言で弾かれる。
+    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
 
     fireEvent.click(approveButton);
 
@@ -1308,6 +1339,9 @@ describe("CopilotPreviewPage — 構造化カード(card)からの描画", () =>
     await send("指示ルールの状況を教えて");
     const approveButtons = await screen.findAllByRole("button", { name: "有効にする" });
     expect(approveButtons).toHaveLength(2);
+    // カードはタイプライター演出の完了を待たずに描画されるため、演出完了(=sending=false)
+    // を待ってからクリックする(送信操作がsendingガードに無言で弾かれるのを防ぐ)。
+    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
 
     // 2件目(ID:20)の「有効にする」だけをクリックする
     fireEvent.click(approveButtons[1]!);
@@ -1670,6 +1704,15 @@ describe("CopilotPreviewPage — コンポーザのIME/改行", () => {
 
   it("IME変換中(compositionStart後)のEnterでは送信しない", async () => {
     renderPage();
+    // render()直後はブートストラップの自動送信(sendReal)がまだ authFetch を呼ぶ前
+    // (内部のawait前)のため、disabled=falseを早すぎるタイミングで捉えると、この後の
+    // 操作がブートストラップ自身のsending中に埋もれて無視される(レース条件)。
+    // /v1/admin/agent/chatが実際に呼ばれたことを先に確認してから、disabled=falseを待つ。
+    await waitFor(() =>
+      expect(
+        vi.mocked(authFetch).mock.calls.some(([url]) => String(url).includes("/v1/admin/agent/chat")),
+      ).toBe(true),
+    );
     await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
 
     const composer = getComposer();
@@ -1685,6 +1728,15 @@ describe("CopilotPreviewPage — コンポーザのIME/改行", () => {
 
   it("変換確定後(compositionEnd後)のEnterでは送信する", async () => {
     renderPage();
+    // render()直後はブートストラップの自動送信(sendReal)がまだ authFetch を呼ぶ前
+    // (内部のawait前)のため、disabled=falseを早すぎるタイミングで捉えると、この後の
+    // 操作がブートストラップ自身のsending中に埋もれて無視される(レース条件)。
+    // /v1/admin/agent/chatが実際に呼ばれたことを先に確認してから、disabled=falseを待つ。
+    await waitFor(() =>
+      expect(
+        vi.mocked(authFetch).mock.calls.some(([url]) => String(url).includes("/v1/admin/agent/chat")),
+      ).toBe(true),
+    );
     await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
 
     const composer = getComposer();
@@ -1699,6 +1751,15 @@ describe("CopilotPreviewPage — コンポーザのIME/改行", () => {
 
   it("Shift+Enterでは送信しない(改行のため)", async () => {
     renderPage();
+    // render()直後はブートストラップの自動送信(sendReal)がまだ authFetch を呼ぶ前
+    // (内部のawait前)のため、disabled=falseを早すぎるタイミングで捉えると、この後の
+    // 操作がブートストラップ自身のsending中に埋もれて無視される(レース条件)。
+    // /v1/admin/agent/chatが実際に呼ばれたことを先に確認してから、disabled=falseを待つ。
+    await waitFor(() =>
+      expect(
+        vi.mocked(authFetch).mock.calls.some(([url]) => String(url).includes("/v1/admin/agent/chat")),
+      ).toBe(true),
+    );
     await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
 
     const composer = getComposer();
@@ -1750,6 +1811,15 @@ describe("CopilotPreviewPage — 保留中の下書きチップを無視して�
 
   it("チップを押さず自由入力を送ると、チップは使用済みになり新しいメッセージが送信される", async () => {
     renderPage();
+    // render()直後はブートストラップの自動送信(sendReal)がまだ authFetch を呼ぶ前
+    // (内部のawait前)のため、disabled=falseを早すぎるタイミングで捉えると、この後の
+    // 操作がブートストラップ自身のsending中に埋もれて無視される(レース条件)。
+    // /v1/admin/agent/chatが実際に呼ばれたことを先に確認してから、disabled=falseを待つ。
+    await waitFor(() =>
+      expect(
+        vi.mocked(authFetch).mock.calls.some(([url]) => String(url).includes("/v1/admin/agent/chat")),
+      ).toBe(true),
+    );
     await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
 
     fireEvent.change(getComposer(), { target: { value: "送料のFAQを作って" } });
@@ -1800,6 +1870,15 @@ describe("CopilotPreviewPage — 対応中の会話カテゴリーと会話の�
       { reply: "対応中の会話が2件あります。", actions: [] },
     ]);
     renderPage();
+    // render()直後はブートストラップの自動送信(sendReal)がまだ authFetch を呼ぶ前
+    // (内部のawait前)のため、disabled=falseを早すぎるタイミングで捉えると、この後の
+    // 操作がブートストラップ自身のsending中に埋もれて無視される(レース条件)。
+    // /v1/admin/agent/chatが実際に呼ばれたことを先に確認してから、disabled=falseを待つ。
+    await waitFor(() =>
+      expect(
+        vi.mocked(authFetch).mock.calls.some(([url]) => String(url).includes("/v1/admin/agent/chat")),
+      ).toBe(true),
+    );
     await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
 
     fireEvent.click(screen.getByRole("button", { name: /対応中の会話/ }));
@@ -1811,6 +1890,15 @@ describe("CopilotPreviewPage — 対応中の会話カテゴリーと会話の�
   it("「会話の履歴」を押すと即送信せず、点検/照会のチップを提示する", async () => {
     mockAgentSequential([{ reply: "今週も順調です。", actions: [] }]);
     renderPage();
+    // render()直後はブートストラップの自動送信(sendReal)がまだ authFetch を呼ぶ前
+    // (内部のawait前)のため、disabled=falseを早すぎるタイミングで捉えると、この後の
+    // 操作がブートストラップ自身のsending中に埋もれて無視される(レース条件)。
+    // /v1/admin/agent/chatが実際に呼ばれたことを先に確認してから、disabled=falseを待つ。
+    await waitFor(() =>
+      expect(
+        vi.mocked(authFetch).mock.calls.some(([url]) => String(url).includes("/v1/admin/agent/chat")),
+      ).toBe(true),
+    );
     await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
 
     fireEvent.click(screen.getByRole("button", { name: /会話の履歴/ }));
@@ -1827,6 +1915,15 @@ describe("CopilotPreviewPage — 対応中の会話カテゴリーと会話の�
       { reply: "問題は見当たりませんでした。", actions: [] },
     ]);
     renderPage();
+    // render()直後はブートストラップの自動送信(sendReal)がまだ authFetch を呼ぶ前
+    // (内部のawait前)のため、disabled=falseを早すぎるタイミングで捉えると、この後の
+    // 操作がブートストラップ自身のsending中に埋もれて無視される(レース条件)。
+    // /v1/admin/agent/chatが実際に呼ばれたことを先に確認してから、disabled=falseを待つ。
+    await waitFor(() =>
+      expect(
+        vi.mocked(authFetch).mock.calls.some(([url]) => String(url).includes("/v1/admin/agent/chat")),
+      ).toBe(true),
+    );
     await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
     fireEvent.click(screen.getByRole("button", { name: /会話の履歴/ }));
     fireEvent.click(await screen.findByRole("button", { name: "最近の会話を点検する" }));
@@ -1845,6 +1942,15 @@ describe("CopilotPreviewPage — 対応中の会話カテゴリーと会話の�
       { reply: "いつ頃の会話か、キーワードなどを教えてください。", actions: [] },
     ]);
     renderPage();
+    // render()直後はブートストラップの自動送信(sendReal)がまだ authFetch を呼ぶ前
+    // (内部のawait前)のため、disabled=falseを早すぎるタイミングで捉えると、この後の
+    // 操作がブートストラップ自身のsending中に埋もれて無視される(レース条件)。
+    // /v1/admin/agent/chatが実際に呼ばれたことを先に確認してから、disabled=falseを待つ。
+    await waitFor(() =>
+      expect(
+        vi.mocked(authFetch).mock.calls.some(([url]) => String(url).includes("/v1/admin/agent/chat")),
+      ).toBe(true),
+    );
     await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
     fireEvent.click(screen.getByRole("button", { name: /会話の履歴/ }));
     fireEvent.click(await screen.findByRole("button", { name: "特定の会話を探す" }));
@@ -1856,6 +1962,15 @@ describe("CopilotPreviewPage — 対応中の会話カテゴリーと会話の�
   it("会話の履歴のチップ提示中は他のカテゴリーへ切り替えられない", async () => {
     mockAgentSequential([{ reply: "今週も順調です。", actions: [] }]);
     renderPage();
+    // render()直後はブートストラップの自動送信(sendReal)がまだ authFetch を呼ぶ前
+    // (内部のawait前)のため、disabled=falseを早すぎるタイミングで捉えると、この後の
+    // 操作がブートストラップ自身のsending中に埋もれて無視される(レース条件)。
+    // /v1/admin/agent/chatが実際に呼ばれたことを先に確認してから、disabled=falseを待つ。
+    await waitFor(() =>
+      expect(
+        vi.mocked(authFetch).mock.calls.some(([url]) => String(url).includes("/v1/admin/agent/chat")),
+      ).toBe(true),
+    );
     await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
     fireEvent.click(screen.getByRole("button", { name: /会話の履歴/ }));
     await screen.findByRole("button", { name: "最近の会話を点検する" });
@@ -1867,6 +1982,15 @@ describe("CopilotPreviewPage — 対応中の会話カテゴリーと会話の�
   it("会話の履歴を連打してもチップメッセージが積み上がらない", async () => {
     mockAgentSequential([{ reply: "今週も順調です。", actions: [] }]);
     renderPage();
+    // render()直後はブートストラップの自動送信(sendReal)がまだ authFetch を呼ぶ前
+    // (内部のawait前)のため、disabled=falseを早すぎるタイミングで捉えると、この後の
+    // 操作がブートストラップ自身のsending中に埋もれて無視される(レース条件)。
+    // /v1/admin/agent/chatが実際に呼ばれたことを先に確認してから、disabled=falseを待つ。
+    await waitFor(() =>
+      expect(
+        vi.mocked(authFetch).mock.calls.some(([url]) => String(url).includes("/v1/admin/agent/chat")),
+      ).toBe(true),
+    );
     await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
 
     fireEvent.click(screen.getByRole("button", { name: /会話の履歴/ }));
@@ -1879,6 +2003,15 @@ describe("CopilotPreviewPage — 対応中の会話カテゴリーと会話の�
   it("7カテゴリー全てがレールに表示される", async () => {
     mockAgentSequential([{ reply: "今週も順調です。", actions: [] }]);
     renderPage();
+    // render()直後はブートストラップの自動送信(sendReal)がまだ authFetch を呼ぶ前
+    // (内部のawait前)のため、disabled=falseを早すぎるタイミングで捉えると、この後の
+    // 操作がブートストラップ自身のsending中に埋もれて無視される(レース条件)。
+    // /v1/admin/agent/chatが実際に呼ばれたことを先に確認してから、disabled=falseを待つ。
+    await waitFor(() =>
+      expect(
+        vi.mocked(authFetch).mock.calls.some(([url]) => String(url).includes("/v1/admin/agent/chat")),
+      ).toBe(true),
+    );
     await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
 
     for (const label of ["アシスタント", "今週のまとめ", "対応中の会話", "会話の履歴", "知識データ", "指示ルール", "アバター"]) {
@@ -2328,6 +2461,15 @@ describe("CopilotPreviewPage — 会話の復元(sessionStorage)", () => {
 
   it("会話が更新されると、その面のキーで保存される", async () => {
     renderPage();
+    // render()直後はブートストラップの自動送信(sendReal)がまだ authFetch を呼ぶ前
+    // (内部のawait前)のため、disabled=falseを早すぎるタイミングで捉えると、この後の
+    // 操作がブートストラップ自身のsending中に埋もれて無視される(レース条件)。
+    // /v1/admin/agent/chatが実際に呼ばれたことを先に確認してから、disabled=falseを待つ。
+    await waitFor(() =>
+      expect(
+        vi.mocked(authFetch).mock.calls.some(([url]) => String(url).includes("/v1/admin/agent/chat")),
+      ).toBe(true),
+    );
     await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
 
     fireEvent.change(getComposer(), { target: { value: "営業時間を教えて" } });
@@ -2364,6 +2506,15 @@ describe("CopilotPreviewPage — リクエストボディの surface", () => {
 
   it("起動時ブリーフィングも手動送信も surface: fullscreen で送る", async () => {
     renderPage();
+    // render()直後はブートストラップの自動送信(sendReal)がまだ authFetch を呼ぶ前
+    // (内部のawait前)のため、disabled=falseを早すぎるタイミングで捉えると、この後の
+    // 操作がブートストラップ自身のsending中に埋もれて無視される(レース条件)。
+    // /v1/admin/agent/chatが実際に呼ばれたことを先に確認してから、disabled=falseを待つ。
+    await waitFor(() =>
+      expect(
+        vi.mocked(authFetch).mock.calls.some(([url]) => String(url).includes("/v1/admin/agent/chat")),
+      ).toBe(true),
+    );
     await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
 
     fireEvent.change(getComposer(), { target: { value: "営業時間を教えて" } });
@@ -2390,6 +2541,15 @@ describe("CopilotPreviewPage — リクエストボディの surface", () => {
   // 定義が黙って割れる。核の一致を固定してその再発を防ぐ。
   it("起動時ブリーフィングと「今週のまとめ」クリックは同一の依頼文の核を送る", async () => {
     renderPage();
+    // render()直後はブートストラップの自動送信(sendReal)がまだ authFetch を呼ぶ前
+    // (内部のawait前)のため、disabled=falseを早すぎるタイミングで捉えると、この後の
+    // 操作がブートストラップ自身のsending中に埋もれて無視される(レース条件)。
+    // /v1/admin/agent/chatが実際に呼ばれたことを先に確認してから、disabled=falseを待つ。
+    await waitFor(() =>
+      expect(
+        vi.mocked(authFetch).mock.calls.some(([url]) => String(url).includes("/v1/admin/agent/chat")),
+      ).toBe(true),
+    );
     await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
 
     fireEvent.click(screen.getByRole("button", { name: /今週のまとめ/ }));
@@ -3224,6 +3384,15 @@ describe("CopilotPreviewPage — 回答の出どころ(answered_from)", () => {
 
   async function ask() {
     renderPage();
+    // render()直後はブートストラップの自動送信(sendReal)がまだ authFetch を呼ぶ前
+    // (内部のawait前)のため、disabled=falseを早すぎるタイミングで捉えると、この後の
+    // 操作がブートストラップ自身のsending中に埋もれて無視される(レース条件)。
+    // /v1/admin/agent/chatが実際に呼ばれたことを先に確認してから、disabled=falseを待つ。
+    await waitFor(() =>
+      expect(
+        vi.mocked(authFetch).mock.calls.some(([url]) => String(url).includes("/v1/admin/agent/chat")),
+      ).toBe(true),
+    );
     await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
     fireEvent.change(getComposer(), { target: { value: "送料はいくら？" } });
     fireEvent.click(screen.getByLabelText("送信"));
@@ -3283,6 +3452,15 @@ describe("CopilotPreviewPage — 解決確認プロンプト", () => {
 
   async function ask(text: string) {
     renderPage();
+    // render()直後はブートストラップの自動送信(sendReal)がまだ authFetch を呼ぶ前
+    // (内部のawait前)のため、disabled=falseを早すぎるタイミングで捉えると、この後の
+    // 操作がブートストラップ自身のsending中に埋もれて無視される(レース条件)。
+    // /v1/admin/agent/chatが実際に呼ばれたことを先に確認してから、disabled=falseを待つ。
+    await waitFor(() =>
+      expect(
+        vi.mocked(authFetch).mock.calls.some(([url]) => String(url).includes("/v1/admin/agent/chat")),
+      ).toBe(true),
+    );
     await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
     fireEvent.change(getComposer(), { target: { value: text } });
     fireEvent.click(screen.getByLabelText("送信"));


### PR DESCRIPTION
## Summary
先のレビュー(#646, #651)で「P3」として保留していた `index.test.tsx` の「`-t` で単独実行すると29件が落ちるが、フルファイル実行だと全部緑になる」問題を調査し、根本原因を特定・修正した。

## 根本原因

`renderPage()` 直後に「送信ボタンが `disabled=false` になるまで待つ」パターンがファイル全体で17箇所コピーされていたが、これはレース条件を含んでいた:

1. `render()` 直後、起動時ブリーフィングの自動送信(bootstrap `useEffect` 内の `sendReal`)はまだ `authFetch` を呼ぶ前(内部の `await` 前)の状態。この瞬間 `sending` state は初期値の `false` のままなので、`waitFor(disabled===false)` はブートストラップの完了を待たずに即座に成立してしまう。
2. テストコードがそのまま `fireEvent.change`/`click` で実送信を試みると、直後にブートストラップ自身の `sendReal` が `setSending(true)` を呼び、テストの送信は `sendReal` の `if (sending) return` ガードに無言で弾かれる(textareaの値がクリアされず、リクエストも一切発生しない)。
3. さらに、カードの描画(`push(...actionMsgs)`)はタイプライター演出(`revealText`)の完了を待たずに即座に行われる一方、`setSending(false)` は演出完了後まで遅延される。そのため「カードのボタンが画面に出た直後にクリックする」テストも同じガードに無言で弾かれることがある(`get_tuning_rules` の承認ボタン等)。

フルファイル実行では偶然この競合窓を避けて緑になっていたため気づかれていなかった。既存コードのコメント(`AppSwitcherのロックタブ...`テスト)を見ると、過去にこの現象自体は認識されており修正が試みられていたが、その修正も同じ不十分なパターン(`disabled=false`のみを待つ)だったため機能していなかった。

## 修正

- **パターン1(bootstrap未着手のまま送信)**: `render()` 直後に「`/v1/admin/agent/chat` が実際に呼ばれたこと」を先に確認してから `disabled=false` を待つよう17箇所を統一修正。
- **パターン2(revealText完了前のクリック)**: カードのボタンをクリックする直前に `disabled=false` を待つ処理を2箇所追加。

**本番コードには一切手を入れていない**(テストファイルのみの変更)。

## 検証
20個のdescribeブロック・130件のテストすべてを `vitest -t <pattern>` で個別に単独実行し、全て通過することを確認済み(修正前は複数describeで最大29件が単独実行不可、`共通シェル機能パリティ`など無関係な既存テストにも及んでいた)。

## Test plan
- [x] `npx tsc --noEmit`(admin-ui)
- [x] `npx oxlint admin-ui/src`
- [x] `index.test.tsx` フルファイル実行 130/130 通過
- [x] 20個のdescribeブロックすべてを個別に `-t` 実行、全て通過(単独実行不可の完全解消を確認)
- [x] admin-ui `vite build` 成功

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UpYM4tvAGHfu4vc9NQqPfY