### PR TITLE
fix(security): E2E由来のリクエストから管理APIへの書き込みを拒否する

### DIFF
--- a/src/api/middleware/e2eWriteGuard.test.ts
+++ b/src/api/middleware/e2eWriteGuard.test.ts
@@ -1,0 +1,126 @@
+// src/api/middleware/e2eWriteGuard.test.ts
+// E2E由来の書き込みを管理APIで拒否するガードの回帰テスト。
+// このガードが黙って無効化されると、CIに置いたsuper_admin認証情報で
+// 本番の他テナントデータを壊せる状態に戻るため、境界を明示的に固定する。
+
+import express from "express";
+import request from "supertest";
+import { e2eWriteGuard, shouldBlockE2eWrite } from "./e2eWriteGuard";
+import { TRAFFIC_SOURCE_HEADER } from "../../lib/traffic/trafficSource";
+
+describe("shouldBlockE2eWrite (純関数)", () => {
+  it.each(["GET", "HEAD", "OPTIONS", "get", "head", "options"])(
+    "読み取りメソッド(%s)はE2E由来でも通す",
+    (method) => {
+      expect(shouldBlockE2eWrite(method, "e2e")).toBe(false);
+    },
+  );
+
+  it.each(["POST", "PUT", "PATCH", "DELETE", "post", "delete"])(
+    "書き込みメソッド(%s)はE2E由来なら拒否する",
+    (method) => {
+      expect(shouldBlockE2eWrite(method, "e2e")).toBe(true);
+    },
+  );
+
+  it("大文字小文字が違うヘッダ値(E2E / E2e)も拒否する", () => {
+    expect(shouldBlockE2eWrite("POST", "E2E")).toBe(true);
+    expect(shouldBlockE2eWrite("POST", "E2e")).toBe(true);
+  });
+
+  it.each([
+    ["ヘッダ未設定(undefined)", undefined],
+    ["null", null],
+    ["空文字列", ""],
+    ["別の値(user)", "user"],
+    ["別の値(demo)", "demo"],
+    ["部分一致を狙った値(e2e-like)", "e2e-like"],
+    ["配列(重複ヘッダ)", ["e2e"]],
+    ["数値", 1],
+  ])("%s の場合は書き込みでも通す(正規ユーザーを巻き込まない)", (_label, headerValue) => {
+    expect(shouldBlockE2eWrite("POST", headerValue)).toBe(false);
+  });
+
+  // UAベースの判定を採用していないことの確認。
+  // trafficSource.resolveTrafficSource は HeadlessChrome を e2e と見なすが、
+  // ここでそれを流用すると正規テナントの運用まで書き込み拒否になりうるため
+  // 明示ヘッダのみで判定している。その設計を固定する。
+  it("User-Agentがヘッドレスでも、明示ヘッダが無ければ書き込みを通す", () => {
+    expect(shouldBlockE2eWrite("POST", "HeadlessChrome/120.0.0.0")).toBe(false);
+  });
+});
+
+describe("e2eWriteGuard (Expressミドルウェア)", () => {
+  function makeApp() {
+    const app = express();
+    app.use(express.json());
+    app.use(["/v1/admin", "/admin"], e2eWriteGuard);
+    app.get("/v1/admin/tenants", (_req, res) => res.json({ ok: true, read: true }));
+    app.post("/v1/admin/tenants", (_req, res) => res.status(201).json({ ok: true, created: true }));
+    app.delete("/v1/admin/knowledge/faq/bulk", (_req, res) => res.json({ ok: true, deleted: true }));
+    // ガードの対象外(ウィジェット等の公開API)。E2Eの書き込みでも素通りすること。
+    app.post("/api/chat/escalate", (_req, res) => res.json({ ok: true, escalated: true }));
+    return app;
+  }
+
+  it("E2Eヘッダ付きのGETは通る(画面到達性の検証は妨げない)", async () => {
+    const res = await request(makeApp())
+      .get("/v1/admin/tenants")
+      .set(TRAFFIC_SOURCE_HEADER, "e2e");
+
+    expect(res.status).toBe(200);
+    expect(res.body.read).toBe(true);
+  });
+
+  it("E2Eヘッダ付きのPOSTは403で拒否される", async () => {
+    const res = await request(makeApp())
+      .post("/v1/admin/tenants")
+      .set(TRAFFIC_SOURCE_HEADER, "e2e")
+      .send({ name: "evil" });
+
+    expect(res.status).toBe(403);
+    // 専門用語(403/権限/ヘッダ名等)を出さない、優しい日本語であること
+    expect(res.body.error).not.toMatch(/403|権限|ヘッダ|header/i);
+  });
+
+  it("E2Eヘッダ付きのDELETE(FAQ一括削除)は403で拒否される", async () => {
+    const res = await request(makeApp())
+      .delete("/v1/admin/knowledge/faq/bulk")
+      .set(TRAFFIC_SOURCE_HEADER, "e2e");
+
+    expect(res.status).toBe(403);
+    expect(res.body.deleted).toBeUndefined();
+  });
+
+  it("ヘッダ無しのPOSTは通る(通常のテナント運用を止めない)", async () => {
+    const res = await request(makeApp()).post("/v1/admin/tenants").send({ name: "normal" });
+
+    expect(res.status).toBe(201);
+    expect(res.body.created).toBe(true);
+  });
+
+  it("管理API以外(公開API)はE2Eヘッダ付きの書き込みでも通る", async () => {
+    // ウィジェット側のE2E(qa-irregular-3roles.spec.ts の Role A/B)が
+    // POST /api/chat/escalate を実行しており、これを巻き込んで壊さないこと。
+    const res = await request(makeApp())
+      .post("/api/chat/escalate")
+      .set(TRAFFIC_SOURCE_HEADER, "e2e")
+      .send({ sessionId: "x" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.escalated).toBe(true);
+  });
+
+  it("/admin(レガシーFAQ管理)配下もガードの対象になる", async () => {
+    const app = express();
+    app.use(express.json());
+    app.use(["/v1/admin", "/admin"], e2eWriteGuard);
+    app.delete("/admin/faqs/:id", (_req, res) => res.json({ ok: true }));
+
+    const res = await request(app)
+      .delete("/admin/faqs/1")
+      .set(TRAFFIC_SOURCE_HEADER, "e2e");
+
+    expect(res.status).toBe(403);
+  });
+});

--- a/src/api/middleware/e2eWriteGuard.ts
+++ b/src/api/middleware/e2eWriteGuard.ts
@@ -1,0 +1,52 @@
+// src/api/middleware/e2eWriteGuard.ts
+//
+// E2E(Playwright)由来のリクエストから管理APIへの書き込みを拒否する。
+//
+// 背景: E2E は専用のステージング環境を持たず、playwright.config.ts の baseURL 経由で
+// 本番(https://admin.r2c.biz)を直接叩く。CIには super_admin の認証情報を置く構想があるが、
+// super_admin は他テナントへの越境書き込み・削除・Stripe実課金・APIキー発行・ユーザー招待が
+// 全部できてしまい、read-only 相当の中間ロールはこのコードベースに存在しない
+// (roleAuth.ts の UserRole は super_admin / client_admin / anonymous の3値のみ)。
+//
+// そこでサーバ側で「E2E由来の書き込みは受け付けない」という境界を1本引く。
+// E2E の検証対象は画面到達性・表示の出し分けであって副作用ではないため、
+// 読み取り(GET/HEAD/OPTIONS)は従来どおり通す。
+//
+// 限界(意図的に受け入れている点):
+//   - ヘッダは攻撃者が外せる。これは「認証情報漏洩そのもの」への対策ではなく、
+//     CI経由の事故(テストの書き換えミス・想定外のリトライ等)で本番データが壊れるのを防ぐもの。
+//   - 根本対策はステージング環境(E2E_BASE_URL)であり、これはその代替ではなく併用する緩和策。
+
+import type { Request, Response, NextFunction } from "express";
+import { TRAFFIC_SOURCE_HEADER } from "../../lib/traffic/trafficSource";
+
+/** 副作用を持たない(と見なす)HTTPメソッド。 */
+const READ_ONLY_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
+
+/**
+ * E2E由来かつ書き込みメソッドなら true(=拒否すべき)。
+ *
+ * 判定はヘッダの明示のみで行い、User-Agent による推測はしない。
+ * trafficSource.ts の resolveTrafficSource は UA も見て 'e2e' と判定するが、
+ * ここで UA 判定を採用すると「HeadlessChrome を名乗る正規のテナント運用」まで
+ * 書き込み拒否になりうる。誤って本番運用を止めるより、E2Eの明示ヘッダに限定して
+ * 取りこぼす方を選ぶ(Playwright側は extraHTTPHeaders で常時付与している)。
+ */
+export function shouldBlockE2eWrite(method: string, headerValue: unknown): boolean {
+  if (READ_ONLY_METHODS.has(method.toUpperCase())) return false;
+  return typeof headerValue === "string" && headerValue.toLowerCase() === "e2e";
+}
+
+/**
+ * 管理API(/v1/admin, /admin)より前に app.use() で挿す。
+ * 拒否時は 403 と、専門用語を避けた日本語メッセージを返す。
+ */
+export function e2eWriteGuard(req: Request, res: Response, next: NextFunction): void {
+  if (shouldBlockE2eWrite(req.method, req.headers[TRAFFIC_SOURCE_HEADER])) {
+    res.status(403).json({
+      error: "テスト用の接続からは、内容を変更する操作を受け付けていません。",
+    });
+    return;
+  }
+  next();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -58,6 +58,7 @@ import { superAdminMiddleware } from "./api/admin/tenants/superAdminMiddleware";
 import { langDetectMiddleware } from "./api/middleware/langDetect";
 import { createOriginCheckMiddleware } from "./api/middleware/originCheck";
 import { internalNetworkOnly } from "./api/middleware/internalNetworkOnly";
+import { e2eWriteGuard } from "./api/middleware/e2eWriteGuard";
 import { assertInternalSecretConfigured } from "./lib/startup/internalSecretGuard";
 import { registerWidgetRoutes } from "./api/widget/routes";
 import { registerAuthRoutes } from "./api/auth/routes";
@@ -509,6 +510,12 @@ app.get(
 );
 
 const port = Number(process.env.PORT || 3000);
+
+// E2E(Playwright)由来のリクエストから管理APIへの書き込みを拒否する。
+// E2Eは専用環境を持たず本番を直接叩くため、CIからの事故で本番データが壊れるのを防ぐ。
+// 管理系ルートの登録より前に置くこと(以降の register* は全てこのガードの内側になる)。
+// 読み取り(GET/HEAD/OPTIONS)は通すので、画面到達性を見るE2Eの検証内容には影響しない。
+app.use(["/v1/admin", "/admin"], e2eWriteGuard);
 
 // Legacy FAQ admin routes (/admin/faqs)
 registerFaqAdminRoutes(app);


### PR DESCRIPTION
## 背景

E2E用 super_admin 認証情報を GitHub Secrets に置く検討([Asana 1217044447142530](https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217044447142530))にあたり、**super_admin の権限範囲を棚卸しした結果、当初の想定より遥かにリスクが大きい**ことが判明した。

- E2Eは専用環境を持たず、`playwright.config.ts` の `baseURL` 経由で**本番を直接叩く**
- ログインは**メール+パスワードのみで MFA が無い**(`signInWithPassword`)
- super_admin は他テナントへの**越境書き込み・削除・Stripe実課金・平文APIキー発行・ユーザー招待**が全部できる
- **read-only 相当の中間ロールが存在しない**(`roleAuth.ts` の `UserRole` は `super_admin`/`client_admin`/`anonymous` の3値)
- **`previewMode` はクライアント側の見た目だけ**で、APIを直叩きすれば全権限が使える
- **kill-switch / APIキー発行 / 招待 / Stripe retry-invoice には監査テーブル書き込みが無い**

つまり「権限を絞った専用アカウント」はこのコードベースでは作れない。

## 対応

サーバ側に「**E2E由来の書き込みは受け付けない**」という境界を1本引く。

Playwright は `extraHTTPHeaders` で `x-r2c-traffic-source: e2e` を**常時付与済み**(集計汚染対策で導入、GID 1216970103691946)。この既存の仕組みをそのまま利用する。

| ファイル | 内容 |
|---|---|
| `src/api/middleware/e2eWriteGuard.ts`(新規) | 判定を純関数 `shouldBlockE2eWrite` に切り出し、Expressミドルウェアはその薄いラッパ |
| `src/index.ts` | 管理系ルート登録より前に `app.use(["/v1/admin","/admin"], e2eWriteGuard)` |

## 設計判断

- **UAベースの判定は採用しない。** `resolveTrafficSource` は `HeadlessChrome` を e2e と見なすが、それを流用すると HeadlessChrome を名乗る**正規テナント運用まで書き込み拒否**になりうる。誤って本番を止めるより取りこぼす方を選び、明示ヘッダに限定した
- **読み取り(GET/HEAD/OPTIONS)は通す。** E2Eの検証対象は画面到達性であって副作用ではない
- 拒否メッセージに専門用語(403/権限/ヘッダ名)を出さない

## 既存E2Eへの影響: なし(確認済み)

- 管理APIへの**実書き込みを行うE2Eは存在しない**
- `request.post` は `/api/chat`, `/api/chat/escalate` のみ(**公開API、ガード対象外**)
- ブラウザ操作による書き込み(「採用して」「これにする」等)は `page.route()` で**全てモック済み**で実サーバーに到達しない(`/v1/admin/agent/chat`, `/avatar/fal/generate`, `/avatar/configs/*`)

## 限界(意図的に受け入れる)

ヘッダは攻撃者が外せるため、**認証情報漏洩そのものへの対策ではない**。CI経由の事故(テスト書き換えミス・想定外のリトライ等)で本番データが壊れるのを防ぐ緩和策であり、根本対策はステージング環境(`E2E_BASE_URL` は既に存在)。

## テスト

`src/api/middleware/e2eWriteGuard.test.ts`(新規、**28ケース**)

- 読み取り/書き込みメソッドの出し分け、大文字小文字
- ヘッダ未設定/`null`/空文字/別の値/**部分一致狙い(`e2e-like`)**/配列/数値 → **正規ユーザーを巻き込まない**
- UAがヘッドレスでも明示ヘッダが無ければ通す(設計判断の固定)
- **管理API以外(`/api/chat/escalate`)は素通りする**(既存E2Eを壊さないことの回帰)
- `/admin`(レガシーFAQ管理)配下もガード対象

## 実行結果

- `npx tsc --noEmit`: 0 errors
- `npx oxlint`: exit 0(警告は既存分のみ)
- `bash SCRIPTS/security-scan.sh`: PASS(CRITICAL/HIGH: 0)
- 新規テスト: 28/28 PASS

## このPR後の状態

Secrets登録([Asana 1217044447142530](https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217044447142530))を行う場合でも、**CI経由では管理APIの書き込みが構造的に不可能**になる。ただし上記「限界」のとおり、漏洩時の被害を完全に消すものではない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgWB82fsx7LMjhJqpd1rCx