### PR TITLE
test: アバターチャット機能の壊れやすいポイントを突くテストを追加

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -1642,6 +1642,117 @@ describe("CopilotPreviewPage — アバター画像候補の生成・採用", ()
     expect(screen.queryByRole("button", { name: "これに決定" })).toBeNull();
     expect(screen.getByRole("button", { name: "これにする" })).toBeTruthy();
   });
+
+  // 生成のたびに実費用(fal.ai)が発生する(#594)。busyImage state が正しく
+  // ボタンをdisabledにしていないと、連打でコストが二重に発生する。応答を
+  // 意図的に遅延させ、1回目の応答が返る前に2回目をクリックしても
+  // ネットワーク呼び出しが1回しか発生しないことを検証する。
+  it("「画像を新しく生成する」を連打しても、生成中はfal/generateが1回しか呼ばれない", async () => {
+    let resolveGenerate: (() => void) | null = null;
+    const pending = new Promise<Response>((resolve) => {
+      resolveGenerate = () =>
+        resolve({ ok: true, status: 200, json: () => Promise.resolve({ images: ["https://img/1.png"] }) } as Response);
+    });
+    mockAdoptedThenEndpoints({ generate: () => pending });
+
+    const generateButton = await sendAndAdopt();
+    fireEvent.click(generateButton);
+    // 1回目の応答がまだ解決していない間に2回目をクリックする(同じDOMノードを
+    // React が再利用するため、disabled化された後も同じ参照でクリックできる)。
+    await waitFor(() => expect((generateButton as HTMLButtonElement).disabled).toBe(true));
+    fireEvent.click(generateButton);
+
+    const generateCallsWhileInFlight = vi
+      .mocked(authFetch)
+      .mock.calls.filter(([url]) => String(url).includes("/fal/generate")).length;
+    expect(generateCallsWhileInFlight).toBe(1);
+
+    resolveGenerate!();
+    await waitFor(() => expect(screen.getByRole("button", { name: "これにする" })).toBeTruthy());
+    // 解決後も合計1回のまま(遅延クリックが後から発火していない)
+    expect(vi.mocked(authFetch).mock.calls.filter(([url]) => String(url).includes("/fal/generate")).length).toBe(1);
+  });
+
+  // 旧UIウィザードの is_default=true 保護(routes.ts の image_url 変更禁止ガード)は
+  // 既存の仕様だが、チャットからのPATCH経路(#632)がこれに触れた場合の応答を
+  // 明示的に確認していなかった。500汎用エラーとは別の実際のレスポンス形状。
+  it("採用のPATCHがデフォルトアバター保護の400を返した場合も、その文言で確定する", async () => {
+    mockAdoptedThenEndpoints({
+      generate: () => mockOk({ images: ["https://img/1.png"] }),
+      patch: () =>
+        Promise.resolve({ ok: false, status: 400, json: () => Promise.resolve({ error: "デフォルトアバターの画像は変更できません" }) } as Response),
+    });
+
+    const generateButton = await sendAndAdopt();
+    fireEvent.click(generateButton);
+    const adoptButton = await screen.findByRole("button", { name: "これにする" });
+    fireEvent.click(adoptButton);
+
+    expect(await screen.findByText("デフォルトアバターの画像は変更できません")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "これに決定" })).toBeNull();
+  });
+
+  // 「気に入らなかったら何度でもやり直せる」(§7-1)という設計上の約束の直接検証。
+  // 【発見】AvatarCandidatesCard の「別の候補を見る」は !card.adoptedUrl の間だけ表示され、
+  // 一度採用するとそのカードからは消える。再生成の実際の導線は常に表示されている
+  // AvatarAdoptedCard 側の「画像を新しく生成する」であることを、このテストで確定する
+  // (「別の候補を見る」を押せばよいという誤った前提でテストを書くと、この非対称に
+  // 気づけないままになる)。
+  it("1回目を採用した後も、元のカードから再度「画像を新しく生成する」で2回目が独立して生成・採用できる", async () => {
+    let generateCalls = 0;
+    mockAdoptedThenEndpoints({
+      generate: () => {
+        generateCalls += 1;
+        const batch = generateCalls === 1
+          ? ["https://img/1-a.png", "https://img/1-b.png"]
+          : ["https://img/2-a.png", "https://img/2-b.png"];
+        return mockOk({ images: batch });
+      },
+      patch: () => mockOk({ id: "cfg-1" }),
+    });
+
+    const generateButton = await sendAndAdopt();
+    fireEvent.click(generateButton);
+    await waitFor(() => expect(screen.getAllByRole("button", { name: "これにする" }).length).toBe(2));
+    fireEvent.click(screen.getAllByRole("button", { name: "これにする" })[0]!);
+    await waitFor(() => expect(screen.getByRole("button", { name: "これに決定" })).toBeTruthy());
+
+    // 採用後、1回目のカードには「別の候補を見る」が出ない(発見した非対称の固定)
+    expect(screen.queryByRole("button", { name: "別の候補を見る" })).toBeNull();
+    // 1回目のカードの未選択の1枚は「これにする」の文言のまま無効化されて残る
+    // (isAdopted=falseだがdisabled=trueのため、後段のフィルタで見分ける必要がある)
+    expect(
+      (screen.getAllByRole("button", { name: "これにする" })[0] as HTMLButtonElement).disabled,
+    ).toBe(true);
+
+    // 再生成は元の AvatarAdoptedCard の「画像を新しく生成する」から行う
+    fireEvent.click(generateButton);
+    await waitFor(() => {
+      const enabled = screen
+        .getAllByRole("button", { name: "これにする" })
+        .filter((btn) => !(btn as HTMLButtonElement).disabled);
+      expect(enabled.length).toBe(2);
+    });
+
+    // 1回目のカードの採用状態(これに決定)はそのまま残っている
+    expect(screen.getByRole("button", { name: "これに決定" })).toBeTruthy();
+    // 2回目バッチの「有効な(未採用の)これにする」だけを対象にする(1回目カードの
+    // 無効化された残骸1件と混同しない)
+    const secondBatchButtons = screen
+      .getAllByRole("button", { name: "これにする" })
+      .filter((btn) => !(btn as HTMLButtonElement).disabled);
+    expect(secondBatchButtons.length).toBe(2);
+
+    fireEvent.click(secondBatchButtons[1]!);
+    await waitFor(() => expect(screen.getAllByRole("button", { name: "これに決定" }).length).toBe(2));
+
+    const patchCalls = vi
+      .mocked(authFetch)
+      .mock.calls.filter(([url]) => String(url).includes("/v1/admin/avatar/configs/cfg-1"));
+    expect(patchCalls.length).toBe(2);
+    expect(JSON.parse(String((patchCalls[0]![1] as RequestInit).body))).toEqual({ image_url: "https://img/1-a.png" });
+    expect(JSON.parse(String((patchCalls[1]![1] as RequestInit).body))).toEqual({ image_url: "https://img/2-b.png" });
+  });
 });
 
 // POST /match-voice はテキストの候補(id/title/description/score)のみを返し音声
@@ -1769,6 +1880,70 @@ describe("CopilotPreviewPage — アバターの声の選択・採用", () => {
     expect(await screen.findByText("更新に失敗しました")).toBeTruthy();
     expect(screen.queryByRole("button", { name: "これに決定" })).toBeNull();
     expect(screen.getByRole("button", { name: "この声にする" })).toBeTruthy();
+  });
+
+  // match-voice もGroq LLM呼び出しを含み実費用が発生する。画像側と同じ理由で、
+  // busyVoice state による連打防止を明示的に検証する。
+  it("「声を探す」を連打しても、検索中はmatch-voiceが1回しか呼ばれない", async () => {
+    let resolveMatch: (() => void) | null = null;
+    const pending = new Promise<Response>((resolve) => {
+      resolveMatch = () =>
+        resolve({
+          ok: true,
+          status: 200,
+          json: () => Promise.resolve({ recommendations: [{ id: "voice-1", title: "Haruka Voice", description: "明るい声", score: 0.9 }] }),
+        } as Response);
+    });
+    mockAdoptedThenVoiceEndpoints({ match: () => pending });
+
+    const voiceButton = await sendAndFindVoiceButton();
+    fireEvent.click(voiceButton);
+    await waitFor(() => expect((voiceButton as HTMLButtonElement).disabled).toBe(true));
+    fireEvent.click(voiceButton);
+
+    expect(vi.mocked(authFetch).mock.calls.filter(([url]) => String(url).includes("/match-voice")).length).toBe(1);
+
+    resolveMatch!();
+    await waitFor(() => expect(screen.getByRole("button", { name: "この声にする" })).toBeTruthy());
+    expect(vi.mocked(authFetch).mock.calls.filter(([url]) => String(url).includes("/match-voice")).length).toBe(1);
+  });
+
+  // 画像候補は既に複数件(4枚)での排他制御をテスト済みだが、声の候補は単一の
+  // recommendationでしかテストしていなかった(#635実装時の全テストが1件のみ)。
+  // 複数候補のうち1件を採用したとき、他の候補が誤って選べてしまわないかを検証する。
+  it("複数の声の候補から1件を採用すると、残りの候補は選べなくなる", async () => {
+    mockAdoptedThenVoiceEndpoints({
+      match: () =>
+        mockOk({
+          recommendations: [
+            { id: "voice-1", title: "Haruka Voice", description: "明るく親しみやすい声", score: 0.92 },
+            { id: "voice-2", title: "Rei Voice", description: "落ち着いた声", score: 0.81 },
+            { id: "voice-3", title: "Sora Voice", description: "元気な声", score: 0.75 },
+          ],
+        }),
+    });
+
+    const voiceButton = await sendAndFindVoiceButton();
+    fireEvent.click(voiceButton);
+    await waitFor(() => expect(screen.getAllByRole("button", { name: "この声にする" }).length).toBe(3));
+
+    // 真ん中(2番目)の候補を採用する
+    fireEvent.click(screen.getAllByRole("button", { name: "この声にする" })[1]!);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "これに決定" })).toBeTruthy());
+    // 採用されたのは voice-2 であること
+    const patchCall = vi
+      .mocked(authFetch)
+      .mock.calls.find(([url]) => String(url).includes("/v1/admin/avatar/configs/cfg-1"));
+    expect(JSON.parse(String((patchCall![1] as RequestInit).body))).toEqual({ voice_id: "voice-2" });
+
+    // 残り2件(voice-1, voice-3)の「この声にする」は無効化されており、誤って
+    // 別の声を選び直せない(二重採用の防止)
+    const remaining = screen.getAllByRole("button", { name: "この声にする" });
+    expect(remaining.length).toBe(2);
+    for (const btn of remaining) expect((btn as HTMLButtonElement).disabled).toBe(true);
+    // 「これに決定」は1件だけ(誤って複数がハイライトされていない)
+    expect(screen.getAllByRole("button", { name: "これに決定" }).length).toBe(1);
   });
 });
 

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -6591,6 +6591,36 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(res.body.actions[0].result).toContain('接客担当（稼働中）');
     });
 
+    // これまでのテストは自テナントの行が0件か1件のケースのみで、複数の自作アバターを
+    // 持つテナント(旧UIウィザードで何度か作り直した等)で「稼働中でない自テナント行」に
+    // 誤って（稼働中）マークが付かないかを検証していなかった。
+    it('自テナントが複数のアバターを持つ場合、稼働中でない行には印を付けない', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-list-2b', 'get_avatar_list', {}))
+        .mockResolvedValueOnce(makeGroqResponse('一覧をお伝えしました。'));
+
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          { id: 'av-own-1', name: '旧デザイン', is_active: false, tenant_id: 'tenant-abc' },
+          { id: 'av-own-2', name: '接客担当', is_active: true, tenant_id: 'tenant-abc' },
+          { id: 'av-own-3', name: '試作中', is_active: false, tenant_id: 'tenant-abc' },
+        ],
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'アバターの一覧を見せて', sessionId: 'sess-list-02b' });
+
+      expect(res.status).toBe(200);
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain('接客担当（稼働中）');
+      // 非稼働の自テナント行には「（稼働中）」を含まない行として出ること
+      expect(result).toContain('旧デザイン ID:');
+      expect(result).toContain('試作中 ID:');
+      expect(result).not.toContain('旧デザイン（稼働中）');
+      expect(result).not.toContain('試作中（稼働中）');
+    });
+
     it('件数が多くても500字で黙って欠けず、残件数を明示する', async () => {
       mockFetch
         .mockResolvedValueOnce(toolCallResponse('call-list-3', 'get_avatar_list', {}))
@@ -6736,6 +6766,42 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(res.status).toBe(200);
       expect(res.body.actions[0].card.presetId).toBe('preset-2');
       expect(res.body.actions[0].card.name).toBe('Rei');
+    });
+
+    // 既知の限界（バグではあるが本テストは「現状の挙動」を固定し、意図せず悪化させないためのもの）:
+    // 採用済み判定が avatar_configs.name の一致だけで行われている(adopt時に default_template_id を
+    // 引き継がない設計。#611)。そのため、旧UIウィザードで自作したアバターの名前がたまたま
+    // r2c_default の見本と同じ場合、そのテナントは一度も suggest_avatar_preset を使っていなくても
+    // 「採用済み」と誤判定され、本来の見本が二度と提案されなくなる。名前は自由記入欄なので
+    // 現実的に起こりうる（"Haruka" のような既定名をそのまま使う等）。
+    // 直す場合の方向性: adopt時に default_template_id を引き継ぎ、名前ではなくそれで判定する
+    // （デメリット: migration_seed_defaults_v2.sql の再シード時ユニーク制約(tenant_id,
+    // default_template_id)と衝突しうるため、判定方式の変更は別タスクとして検討する）。
+    it('【既知の限界】旧UIで作った自作アバターと見本の名前がたまたま一致すると、未使用でも「採用済み」扱いになる', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-sp-2b', 'suggest_avatar_preset', {}))
+        .mockResolvedValueOnce(makeGroqResponse('見本をご提案しました。'));
+
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [
+            { id: 'preset-1', name: 'Haruka', image_url: null, personality_prompt: '丁寧な性格です。', default_template_id: 'default_01' },
+            { id: 'preset-2', name: 'Rei', image_url: null, personality_prompt: '軽快な性格です。', default_template_id: 'default_02' },
+          ],
+        })
+        // このテナントは suggest_avatar_preset を一度も使っておらず、旧UIウィザードで
+        // 独自に "Haruka" という名前のアバターを作っただけ(r2c_defaultの見本とは無関係)。
+        .mockResolvedValueOnce({ rows: [{ name: 'Haruka' }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'アバターを作りたい', sessionId: 'sess-sp-02b' });
+
+      expect(res.status).toBe(200);
+      // 現状の挙動: 本当は使っていない「Haruka」見本が誤って除外され、Reiが提案される。
+      // 望ましい挙動ではないが、直すには判定方式そのものの変更が要るため、ここでは
+      // この挙動が「意図せず」変わらないことだけを固定する。
+      expect(res.body.actions[0].card.presetId).toBe('preset-2');
     });
 
     it('見本を全て採用済みでも、最初の1件にフォールバックして提案し続ける', async () => {


### PR DESCRIPTION
## Summary

`/copilot-preview` のアバター設定フロー（画像生成・声の選択・見本採用・一覧）に対して、既存PR群（#593, #594, #611, #632, #635, #648, #654）で実装済みの正常系テストに加えて、境界値・異常系・イレギュラー操作を中心にテストを補強する。「通るだけのテスト」ではなく「壊れやすいポイントを突くテスト」を優先。

## 追加したテスト

**バックエンド (`src/api/admin/agent/agentRoutes.test.ts`)**
- `suggest_avatar_preset` の名前一致による採用済み判定の**既知の限界**を固定するテスト。旧UIウィザードで自作したアバターの名前が偶然 r2c_default の見本名と一致すると、一度も見本提案を使っていなくても「採用済み」と誤判定される（`default_template_id` を採用時に引き継がない設計に起因）。バグではあるが直すには判定方式の変更が要るため、現状の挙動が意図せず悪化しないことをテストで固定した。
- `get_avatar_list` で自テナントが複数アバターを持つ場合、稼働中でない行に誤って「稼働中」マークが付かないことを検証（従来は0/1件のケースのみテスト済みだった）。

**フロントエンド (`admin-ui/src/pages/copilot-preview/index.test.tsx`)**
- 画像生成・声の検索それぞれについて、連打してもAPI呼び出しが1回しか発生しないことを検証（fal.ai / match-voiceは実費用が発生するため、busyImage/busyVoice stateの二重発火防止はコストリスク）。
- 画像候補を1回目採用した後も、元の `AvatarAdoptedCard` から独立して2回目の生成・採用ができることを検証。この過程で **`AvatarCandidatesCard` の「別の候補を見る」ボタンが、そのカードから1件でも採用すると消える**という非対称なUXを発見。意図せず悪化しないようテストで固定した（再生成の導線は常に `AvatarAdoptedCard` 側にある）。
- 声の候補が複数件（3件）ある場合に1件採用すると、残り2件が選べなくなることを検証（既存テストは単一候補のケースのみだった — 画像候補側は既に4件での排他制御テストがあったが、声側にはこの非対称があった）。
- デフォルトアバター保護(400)がPATCH経路でもそのままエラー文言で表示されることを検証。

## テストでカバーできていない既知のリスク

- `suggest_avatar_preset` の名前一致判定の限界（上記、テストで意図的に固定・未修正）
- `B-IRR-5`（生成中のリロードで復元できない）は既存のE2Eで別途カバー済み・未修正（#648時点から継続）
- 声のプレビュー（試聴）機能はシステム全体に存在しない（設計上の既知の制約、UIで明示済み）

## Test plan

- [x] `npx jest src/api/admin/agent/agentRoutes.test.ts` — 341/341 pass（対象テストのみで確認、フルスイートはローカル環境の接続数逼迫により単発flakyあり。対象テスト個別実行では毎回green）
- [x] `npx vitest run --config vitest.config.ts src/pages/copilot-preview/index.test.tsx` — 140/140 pass
- [x] rebase on latest main, no conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StqjjaijseYkGkmG2k5LJ