### PR TITLE
fix: suggest_avatar_preset→adopt_avatar_presetの同一ターン連鎖をブロックする

### DIFF
--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -6991,6 +6991,45 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(result).toContain('見つかりませんでした');
       expect(result).toContain('suggest_avatar_preset');
     });
+
+    // suggest_faq → save_faq 等と同じ理由: confirmed=true はモデルの自己申告でしかなく、
+    // 同一ターン(同一ユーザーメッセージ)内では人間の実際の同意を経ていない。
+    // このガードが SUGGEST_TO_SAVE_TOOL に登録されていないと、ユーザーが
+    // 「アバターを作りたい」と言っただけの1ターンで、モデルが suggest → adopt を
+    // 自己判断で連鎖させ、カードを提示して同意を得る前に永続レコードが作られてしまう。
+    it('同一ターン内で suggest_avatar_preset → adopt_avatar_preset(confirmed=true) を連鎖しようとするとブロックされ、DBには書き込まれない', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-ap-chain-1', 'suggest_avatar_preset', {}))
+        .mockResolvedValueOnce(toolCallResponse('call-ap-chain-2', 'adopt_avatar_preset', { preset_id: 'preset-1', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('確認をお願いします。'));
+
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [{ id: 'preset-1', name: 'Haruka', image_url: null, personality_prompt: '丁寧な性格です。', default_template_id: 'default_01' }],
+        }) // suggest_avatar_preset 内の見本取得
+        .mockResolvedValueOnce({ rows: [] }); // suggest_avatar_preset 内の自テナント既存名取得(未採用)
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'アバターを作りたい', sessionId: 'sess-ap-chain-01' });
+
+      expect(res.status).toBe(200);
+      // adopt_avatar_preset の INSERT が発火していないこと(suggest側の2回のSELECTのみ)
+      expect(mockQuery).toHaveBeenCalledTimes(2);
+      expect(mockQuery).not.toHaveBeenCalledWith(expect.stringContaining('INSERT INTO avatar_configs'), expect.anything());
+
+      const adoptAction = res.body.actions.find((a: any) => a.tool === 'adopt_avatar_preset');
+      expect(adoptAction.result).toContain('同一ターン内での連続実行');
+
+      expect(recordedMetrics('agent_write_blocked')).toEqual([
+        {
+          metricName: 'agent_write_blocked',
+          tenantId: 'tenant-abc',
+          labels: { tool: 'adopt_avatar_preset', reason: 'chain', surface: 'unknown' },
+          value: 1,
+        },
+      ]);
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/src/api/admin/agent/agentRoutes.ts
+++ b/src/api/admin/agent/agentRoutes.ts
@@ -642,6 +642,10 @@ const SUGGEST_TO_SAVE_TOOL: Record<string, string> = {
   // 会話本文の取得直後に、その内容(顧客が書いた文字列=注入されうる)に反応して
   // 同一ターンで削除が確定するのを防ぐ。削除は必ず別ターンでのユーザーの同意を要求する。
   get_chat_session_messages: 'delete_chat_session',
+  // 見本の提示と採用(永続レコード作成)が同一ターンで連鎖しないようにする。他の
+  // suggest_*→save_* と同じ理由: confirmed=true はモデルが自己申告する値でしかなく、
+  // 同一ターン内では人間の実際の同意を経ていない。
+  suggest_avatar_preset: 'adopt_avatar_preset',
 };
 
 // MAX_TOOL_HOPS到達後の強制まとめ呼び出し用。tools無しにしただけでは、モデルがまだ


### PR DESCRIPTION
## Summary

アバターチャット機能の厳しいレビュー（既存設計との一貫性チェック）中に発見した実装バグの修正。

`agentRoutes.ts` の `SUGGEST_TO_SAVE_TOOL` は、`suggest_faq→save_faq` / `suggest_tuning_rule→save_tuning_rule` / `suggest_engagement_rule→save_engagement_rule` / `suggest_faq_import_from_*→commit_faq_import` / `get_chat_session_messages→delete_chat_session` という、すべての「suggest系ツール→書き込み系ツール」ペアを登録し、同一ユーザーターン内での確認なし連鎖書き込みをブロックしている。

しかし `suggest_avatar_preset→adopt_avatar_preset` だけこの登録が漏れていた。`record_session_outcome`（`get_chat_session_messages` キーが既に `delete_chat_session` に使われているため登録できない、構造上の制約で意図的に未対応・別途「既知のギャップ」としてテストで固定済み）とは異なり、`suggest_avatar_preset` はどのキーとも衝突しない未使用のキーであり、単純な登録漏れと判断した。

## 影響

未登録の状態では、ユーザーが「アバターを作りたい」と1回発言しただけで、モデルが同一ターン内（`MAX_TOOL_HOPS=4`以内）で `suggest_avatar_preset → adopt_avatar_preset(confirmed=true)` を連鎖させられる。`confirmed` はモデルの自己申告値でしかなく、他の suggest/save ペアと同様、同一ターン内では人間の実際の同意を経ていない。修正前のコードでテストを実行し、実際に `INSERT INTO avatar_configs` が発火する（連鎖がブロックされない）ことを確認済み。

データ自体は `is_active=false` で作られるため即座に顧客影響は出ないが、ユーザーの同意なく永続レコードが作られてしまう点は他の suggest/save ペアと同じ重大度で扱うべきと判断した。

## 変更内容

- `src/api/admin/agent/agentRoutes.ts`: `SUGGEST_TO_SAVE_TOOL` に `suggest_avatar_preset: 'adopt_avatar_preset'` を追加
- `src/api/admin/agent/agentRoutes.test.ts`: `suggest_faq→save_faq` の連鎖ブロックテストと同じパターンで、`suggest_avatar_preset→adopt_avatar_preset` の連鎖ブロックを検証するテストを追加（修正前は失敗することを確認済み）

## Test plan

- [x] 追加テストが修正前は失敗（INSERT発火）、修正後は成功することを確認
- [x] `npx jest src/api/admin/agent/agentRoutes.test.ts` — 対象テスト単体・フルスイートとも green（フルスイートはローカル環境の接続数逼迫により無関係なテストが単発flakyになることがあるが、対象テストは毎回green）
- [x] `npx jest src/api/admin/agent/confirmPolicy.test.ts` — green（網羅性テストへの影響なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StqjjaijseYkGkmG2k5LJ