### PR TITLE
fix: 書き込み系ツールの確認ゲートが型混同で回避されうる問題を直す

### DIFF
--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -58,6 +58,23 @@ function clampToolLimit(raw: unknown, defaultValue: number, max: number): number
   return Math.floor(Math.min(Math.max(Number.isFinite(n) ? n : defaultValue, 1), max));
 }
 
+// 書き込み系ツールの確認フラグ(confirmed)を読む唯一の入口。
+//
+// かつては Boolean() による判定と厳密等価(=== true)による判定が混在していた。
+// 前者は Boolean('false') === true という JS の仕様により、文字列 'false' を
+// 「確認済み」と誤判定する。本リポジトリでは Groq が引数を文字列化して送ってくる
+// 事象が実測されている(agentRoutes.ts の parseToolArgs のコメント: 無引数ツールに
+// 対し文字列 "null" が送られてくるケース)ため、この誤判定は机上のものではない。
+//
+// 逆に === true だけに統一すると、Groq が文字列 "true" を送ってきた場合に
+// ユーザーが同意し続けても永久に実行されないループに陥る。両方向に対応するため、
+// boolean の true と文字列 "true" のみを受理し、それ以外は未確認として扱う
+// (未知の型は安全側=未確認に倒す)。
+function isConfirmed(raw: unknown): boolean {
+  if (raw === true) return true;
+  return typeof raw === 'string' && raw.trim().toLowerCase() === 'true';
+}
+
 // suggest_tuning_rule がトリガー未決定時に案内していたプレースホルダ文字列。
 // save_tuning_rule にそのまま渡ってきた場合、文字列としてtrigger_patternに
 // 保存させない(D4: 保存は成功するが質問文に一致せず永久に発火しない)。
@@ -602,7 +619,7 @@ export async function executeToolCall(
     // -----------------------------------------------------------------------
     case 'delete_faq': {
       const id = Number(args['id']);
-      const confirmed = Boolean(args['confirmed']);
+      const confirmed = isConfirmed(args['confirmed']);
 
       if (!confirmed) {
         return truncate(`FAQ（ID: ${id}）の削除には確認が必要です。confirmed=true を指定して再度実行してください`);
@@ -652,7 +669,7 @@ export async function executeToolCall(
       if (!isOnboardingIndustry(industryRaw)) {
         return truncate(`不明な業種です: ${String(industryRaw)}`);
       }
-      const confirmed = Boolean(args['confirmed']);
+      const confirmed = isConfirmed(args['confirmed']);
       const templates = INDUSTRY_FAQ_TEMPLATES[industryRaw];
       const label = ONBOARDING_INDUSTRY_LABELS[industryRaw];
 
@@ -716,7 +733,7 @@ export async function executeToolCall(
       if (!tenantId) {
         return truncate('テナントが特定できません。super_admin の場合は対象テナントを指定してください');
       }
-      const confirmed = Boolean(args['confirmed']);
+      const confirmed = isConfirmed(args['confirmed']);
 
       if (!confirmed) {
         try {
@@ -953,7 +970,7 @@ export async function executeToolCall(
       if (!presetId) {
         return truncate('preset_id は必須です');
       }
-      const confirmed = Boolean(args['confirmed']);
+      const confirmed = isConfirmed(args['confirmed']);
       if (!confirmed) {
         return truncate(
           '採用には確認が必要です。ユーザーに内容を提示し、同意を得てから confirmed=true で再度呼び出してください',
@@ -1121,7 +1138,7 @@ export async function executeToolCall(
 
     // -----------------------------------------------------------------------
     case 'save_tuning_rule': {
-      const confirmed = Boolean(args['confirmed']);
+      const confirmed = isConfirmed(args['confirmed']);
       const triggerPattern = String(args['trigger_pattern'] ?? '').slice(0, 1000);
       const expectedBehavior = String(args['expected_behavior'] ?? '').slice(0, 4000);
       // D5: ユーザーが「高い優先度で」等、3段階の言葉で話した場合は priority_tier を優先する。
@@ -1208,7 +1225,7 @@ export async function executeToolCall(
     // -----------------------------------------------------------------------
     case 'update_tuning_rule': {
       const id = Number(args['id']);
-      const confirmed = Boolean(args['confirmed']);
+      const confirmed = isConfirmed(args['confirmed']);
 
       if (!confirmed) {
         return truncate(`指示ルール（ID: ${id}）の更新には確認が必要です。confirmed=true を指定して再度実行してください`);
@@ -1276,7 +1293,7 @@ export async function executeToolCall(
     // -----------------------------------------------------------------------
     case 'delete_tuning_rule': {
       const id = Number(args['id']);
-      const confirmed = Boolean(args['confirmed']);
+      const confirmed = isConfirmed(args['confirmed']);
 
       if (!confirmed) {
         return truncate(`指示ルール（ID: ${id}）の削除には確認が必要です。confirmed=true を指定して再度実行してください`);
@@ -1338,7 +1355,7 @@ export async function executeToolCall(
       const text = String(args['text'] ?? '').trim().slice(0, 4000);
       const style = String(args['style'] ?? '').trim().slice(0, 50);
       const reason = typeof args['reason'] === 'string' ? args['reason'].trim().slice(0, 1000) || undefined : undefined;
-      const confirmed = Boolean(args['confirmed']);
+      const confirmed = isConfirmed(args['confirmed']);
 
       if (!confirmed) {
         return truncate('返答の採用には確認が必要です。ユーザーに内容を提示し、同意を得てから confirmed=true で再度呼び出してください');
@@ -1376,7 +1393,7 @@ export async function executeToolCall(
     case 'remove_approved_response': {
       const id = Number(args['id']);
       const index = Number(args['index']);
-      const confirmed = Boolean(args['confirmed']);
+      const confirmed = isConfirmed(args['confirmed']);
 
       if (!confirmed) {
         return truncate('採用済み返答の取消には確認が必要です。confirmed=true を指定して再度実行してください');
@@ -1603,7 +1620,7 @@ export async function executeToolCall(
     // -----------------------------------------------------------------------
     case 'dismiss_knowledge_gap': {
       const id = Number(args['id']);
-      const confirmed = Boolean(args['confirmed']);
+      const confirmed = isConfirmed(args['confirmed']);
 
       if (!confirmed) {
         return truncate(`知識ギャップ（ID: ${id}）を片付けるには確認が必要です。confirmed=true を指定して再度実行してください`);
@@ -1668,7 +1685,7 @@ export async function executeToolCall(
     // -----------------------------------------------------------------------
     // Phase3: save_faq — confirmedゲート必須のFAQ保存(add_faqと同じINSERT経路)
     case 'save_faq': {
-      const confirmed = Boolean(args['confirmed']);
+      const confirmed = isConfirmed(args['confirmed']);
       const question = String(args['question'] ?? '').slice(0, 500);
       const answer = String(args['answer'] ?? '').slice(0, 2000);
       const category = typeof args['category'] === 'string' ? args['category'] : null;
@@ -1829,7 +1846,7 @@ export async function executeToolCall(
     // チャット版 FAQ一括取り込みのコミット: suggest_faq_import_from_text/urls で
     // ステージング済みのFAQをDBに登録する。confirmedゲート必須。
     case 'commit_faq_import': {
-      const confirmed = Boolean(args['confirmed']);
+      const confirmed = isConfirmed(args['confirmed']);
       const targetRaw = typeof args['target'] === 'string' ? args['target'] : undefined;
 
       if (!confirmed) {
@@ -1927,7 +1944,7 @@ export async function executeToolCall(
     // -----------------------------------------------------------------------
     // Phase3: save_engagement_rule — confirmedゲート必須の声がけルール保存(trigger_rules)
     case 'save_engagement_rule': {
-      const confirmed = Boolean(args['confirmed']);
+      const confirmed = isConfirmed(args['confirmed']);
       const triggerType = String(args['trigger_type'] ?? '');
       const messageTemplate = String(args['message_template'] ?? '').slice(0, 500);
       const priorityRaw = Number(args['priority']);
@@ -1997,7 +2014,7 @@ export async function executeToolCall(
     // -----------------------------------------------------------------------
     case 'update_engagement_rule': {
       const id = Number(args['id']);
-      const confirmed = Boolean(args['confirmed']);
+      const confirmed = isConfirmed(args['confirmed']);
 
       if (!confirmed) {
         return truncate(`声がけルール（ID: ${id}）の更新には確認が必要です。confirmed=true を指定して再度実行してください`);
@@ -2070,7 +2087,7 @@ export async function executeToolCall(
     // -----------------------------------------------------------------------
     case 'delete_engagement_rule': {
       const id = Number(args['id']);
-      const confirmed = Boolean(args['confirmed']);
+      const confirmed = isConfirmed(args['confirmed']);
 
       if (!confirmed) {
         return truncate(`声がけルール（ID: ${id}）の削除には確認が必要です。confirmed=true を指定して再度実行してください`);
@@ -2204,7 +2221,7 @@ export async function executeToolCall(
       }
       const shortId = String(args['session_id'] ?? '').trim();
       const reason = String(args['reason'] ?? '').trim();
-      const confirmed = args['confirmed'] === true;
+      const confirmed = isConfirmed(args['confirmed']);
 
       try {
         const resolved = await resolveSessionByShortId(db, tenantId, shortId);
@@ -2341,7 +2358,7 @@ export async function executeToolCall(
       }
       const shortId = String(args['session_id'] ?? '').trim();
       const content = String(args['content'] ?? '').trim();
-      const confirmed = args['confirmed'] === true;
+      const confirmed = isConfirmed(args['confirmed']);
 
       if (!content) {
         return truncate('返信内容（content）は必須です');
@@ -2384,7 +2401,7 @@ export async function executeToolCall(
         return truncate('テナントが特定できません。super_admin の場合は対象テナントを指定してください');
       }
       const shortId = String(args['session_id'] ?? '').trim();
-      const confirmed = args['confirmed'] === true;
+      const confirmed = isConfirmed(args['confirmed']);
 
       try {
         const resolved = await resolveSessionByShortId(db, tenantId, shortId);
@@ -2446,7 +2463,7 @@ export async function executeToolCall(
       }
       const shortId = String(args['session_id'] ?? '').trim();
       const outcomeValue = String(args['outcome'] ?? '').trim();
-      const confirmed = args['confirmed'] === true;
+      const confirmed = isConfirmed(args['confirmed']);
 
       if (!outcomeValue) {
         return truncate('outcome（記録する成果）は必須です');
@@ -2510,7 +2527,7 @@ export async function executeToolCall(
     // 費用は一回限りの即時課金ではなく、他のLLM機能(admin_agent等)と同じ従量課金
     // (trackUsage → usage_logs → 月次Stripe請求)に計上される。
     case 'request_sai_task': {
-      const confirmed = Boolean(args['confirmed']);
+      const confirmed = isConfirmed(args['confirmed']);
       const description = String(args['description'] ?? '').trim().slice(0, 2000);
 
       if (!confirmed) {

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -4416,6 +4416,155 @@ describe('POST /v1/admin/agent/chat', () => {
   });
 
   // -------------------------------------------------------------------------
+  // 確認フラグ(confirmed)の型混同 — isConfirmed() の振る舞い
+  //
+  // かつては Boolean(args['confirmed']) と === true の2方式が混在しており、
+  // 前者は Boolean('false') === true という JS の仕様で文字列 'false' を
+  // 「確認済み」と誤判定していた。Groq が引数を文字列化して送ってくる事象は
+  // 本リポジトリで実測されている(parseToolArgs のコメント)ため机上の話ではない。
+  // 判定を isConfirmed() へ集約したうえで、両方向の挙動をここで固定する。
+  // -------------------------------------------------------------------------
+  describe('確認フラグの型混同 (isConfirmed)', () => {
+    function toolCallResponse(id: string, name: string, args: Record<string, unknown> = {}) {
+      return {
+        ok: true,
+        json: async () => ({
+          choices: [{
+            message: {
+              content: null,
+              tool_calls: [{ id, type: 'function', function: { name, arguments: JSON.stringify(args) } }],
+            },
+          }],
+        }),
+        text: async () => '',
+      };
+    }
+
+    // 実行された/されなかったを、各ツールの実書き込み経路で判定する。
+    // confirmed 以外の条件で弾かれないよう、前提条件はすべて満たしておく。
+    const CONFIRMED_ACCEPTED: Array<[string, unknown]> = [
+      ['boolean の true', true],
+      ['文字列の "true"（Groqの文字列化を想定）', 'true'],
+      ['大文字混じりの "True"', 'True'],
+    ];
+    const CONFIRMED_REJECTED: Array<[string, unknown]> = [
+      ['文字列の "false"（Boolean()なら誤って通っていた）', 'false'],
+      ['文字列の "0"', '0'],
+      ['数値の 0', 0],
+      ['数値の 1（真偽値ではない）', 1],
+      ['null', null],
+      ['未指定', undefined],
+    ];
+
+    describe('delete_faq（high・不可逆削除）', () => {
+      function seedFaq() {
+        // 1回目: 存在確認の SELECT（自テナントのFAQ）
+        mockQuery.mockResolvedValueOnce({ rows: [{ id: 7, tenant_id: 'tenant-abc', question: '送料は?' }] });
+        // 2回目: DELETE
+        mockQuery.mockResolvedValueOnce({ rows: [] });
+      }
+
+      it.each(CONFIRMED_ACCEPTED)('confirmed=%s は削除される', async (_label, confirmed) => {
+        mockFetch
+          .mockResolvedValueOnce(toolCallResponse('call-cf-a', 'delete_faq', { id: 7, confirmed }))
+          .mockResolvedValueOnce(makeGroqResponse('削除しました。'));
+        seedFaq();
+
+        const res = await request(makeApp(CLIENT_ADMIN_USER))
+          .post('/v1/admin/agent/chat')
+          .send({ message: 'FAQ7番を削除して', sessionId: `sess-cf-a-${String(confirmed)}` });
+
+        expect(res.status).toBe(200);
+        expect(res.body.actions[0].result).not.toContain('確認が必要');
+      });
+
+      it.each(CONFIRMED_REJECTED)('confirmed=%s は確認待ちになりDELETEに到達しない', async (_label, confirmed) => {
+        const args: Record<string, unknown> = { id: 7 };
+        if (confirmed !== undefined) args['confirmed'] = confirmed;
+        mockFetch
+          .mockResolvedValueOnce(toolCallResponse('call-cf-r', 'delete_faq', args))
+          .mockResolvedValueOnce(makeGroqResponse('確認をお願いします。'));
+
+        const res = await request(makeApp(CLIENT_ADMIN_USER))
+          .post('/v1/admin/agent/chat')
+          .send({ message: 'FAQ7番を削除して', sessionId: `sess-cf-r-${String(confirmed)}` });
+
+        expect(res.status).toBe(200);
+        expect(res.body.actions[0].result).toContain('確認が必要');
+        // 確認前に存在確認SELECTすら投げない(ゲートが最初にある)
+        expect(mockQuery).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('request_sai_task（high・従量課金が発生する）', () => {
+      it('confirmed="false" は依頼されない（Boolean()時代は誤って依頼されていた）', async () => {
+        mockFetch
+          .mockResolvedValueOnce(toolCallResponse('call-cf-sai-1', 'request_sai_task', { description: '送料表記を直して', confirmed: 'false' }))
+          .mockResolvedValueOnce(makeGroqResponse('確認してから依頼します。'));
+
+        const res = await request(makeApp(CLIENT_ADMIN_USER))
+          .post('/v1/admin/agent/chat')
+          .send({ message: '送料表記を直して', sessionId: 'sess-cf-sai-1' });
+
+        expect(mockSubmitSaiTask).not.toHaveBeenCalled();
+        expect(res.body.actions[0].result).toContain('確認が必要');
+      });
+
+      it('confirmed="true" は依頼される（=== true 統一では詰まっていた経路）', async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [{ plan: 'enterprise' }] });
+        mockCheckSaiMonthlyCostCeiling.mockResolvedValueOnce({ ok: true });
+        mockSubmitSaiTask.mockResolvedValueOnce({ taskId: 'sai-1', status: 'queued' });
+        mockFetch
+          .mockResolvedValueOnce(toolCallResponse('call-cf-sai-2', 'request_sai_task', { description: '送料表記を直して', confirmed: 'true' }))
+          .mockResolvedValueOnce(makeGroqResponse('依頼しました。'));
+
+        await request(makeApp(CLIENT_ADMIN_USER))
+          .post('/v1/admin/agent/chat')
+          .send({ message: '送料表記を直して', sessionId: 'sess-cf-sai-2' });
+
+        expect(mockSubmitSaiTask).toHaveBeenCalled();
+      });
+    });
+
+    describe('delete_chat_session（high・従来から === true で安全側だった）', () => {
+      const OWN: SessionRow = {
+        id: 'db-sess-cf', tenant_id: 'tenant-abc', session_id: 'cfcf1111-1111-4aaa-8000-000000000001',
+      };
+
+      it('confirmed="false" は削除されない（従来どおり）', async () => {
+        mockFetch
+          .mockResolvedValueOnce(toolCallResponse('call-cf-del-1', 'delete_chat_session', { session_id: 'cfcf1111', reason: '型混同の検証', confirmed: 'false' }))
+          .mockResolvedValueOnce(makeGroqResponse('確認をお願いします。'));
+        seedSessions([OWN]);
+
+        const res = await request(makeApp(CLIENT_ADMIN_USER))
+          .post('/v1/admin/agent/chat')
+          .send({ message: 'cfcf1111を削除して', sessionId: 'sess-cf-del-1' });
+
+        expect(mockDeleteSession).not.toHaveBeenCalled();
+        expect(res.body.actions[0].result).toContain('確認が必要');
+      });
+
+      it('confirmed="true" は削除される（=== true 時代は永久に詰まっていた回帰）', async () => {
+        mockFetch
+          .mockResolvedValueOnce(toolCallResponse('call-cf-del-2', 'delete_chat_session', { session_id: 'cfcf1111', reason: '型混同の検証', confirmed: 'true' }))
+          .mockResolvedValueOnce(makeGroqResponse('削除しました。'));
+        seedSessions([OWN]);
+        mockDeleteSession.mockResolvedValueOnce({
+          deleted_session_id: 'db-sess-cf',
+          affected_counts: { chat_messages: 1, option_orders_nulled: 0 },
+        });
+
+        await request(makeApp(CLIENT_ADMIN_USER))
+          .post('/v1/admin/agent/chat')
+          .send({ message: 'cfcf1111を削除して', sessionId: 'sess-cf-del-2' });
+
+        expect(mockDeleteSession).toHaveBeenCalled();
+      });
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // delete_chat_session（不可逆削除 / confirmedゲート / previewMode scope / 注入経路の遮断）
   // -------------------------------------------------------------------------
   describe('delete_chat_session', () => {

--- a/src/api/admin/agent/confirmPolicy.test.ts
+++ b/src/api/admin/agent/confirmPolicy.test.ts
@@ -148,6 +148,45 @@ describe('confirmPolicy: フロントの REAL_WRITE_TOOLS との突き合わせ'
 });
 
 // ---------------------------------------------------------------------------
+// 確認フラグ(confirmed)の読み取り方が1箇所に集約されていることの検証。
+//
+// かつては Boolean(args['confirmed']) と args['confirmed'] === true の2方式が
+// 混在していた。前者は Boolean('false') === true という JS の仕様により、
+// 文字列 'false' を「確認済み」と誤判定する。本リポジトリでは Groq が引数を
+// 文字列化して送ってくる事象が実測されている（agentRoutes.ts の parseToolArgs
+// のコメント参照）ため、この誤判定は机上のものではない。
+//
+// 判定を isConfirmed() へ集約したうえで、素の読み取りが再び現れないことを
+// ここで機械的に防ぐ。
+// ---------------------------------------------------------------------------
+
+describe('confirmPolicy: 確認フラグの読み取りが isConfirmed() に集約されている', () => {
+  // args['confirmed'] を isConfirmed() に渡す形以外で参照している箇所を検出する。
+  // 許可されるのは isConfirmed(args['confirmed']) の形のみ。
+  const RAW_CONFIRMED_READS: Array<{ pattern: RegExp; label: string }> = [
+    { pattern: /Boolean\(\s*args\[['"]confirmed['"]\]\s*\)/g, label: "Boolean(args['confirmed'])" },
+    { pattern: /args\[['"]confirmed['"]\]\s*===/g, label: "args['confirmed'] ===" },
+    { pattern: /args\[['"]confirmed['"]\]\s*==[^=]/g, label: "args['confirmed'] ==" },
+    { pattern: /!\s*args\[['"]confirmed['"]\]/g, label: "!args['confirmed']" },
+  ];
+
+  it('Boolean() や === による素の確認フラグ読み取りが残っていない', () => {
+    const found = RAW_CONFIRMED_READS.flatMap(({ pattern, label }) =>
+      (EXECUTOR_CODE.match(pattern) ?? []).map(() => label),
+    );
+    expect(found).toEqual([]);
+  });
+
+  it('確認フラグを読む箇所はすべて isConfirmed() を経由している', () => {
+    // args['confirmed'] の総出現回数と、isConfirmed(args['confirmed']) の出現回数が一致すること。
+    // 片方だけ増えた場合（新しいツールが素の読み取りを書いた場合）に落ちる。
+    const allReads = (EXECUTOR_CODE.match(/args\[['"]confirmed['"]\]/g) ?? []).length;
+    const viaHelper = (EXECUTOR_CODE.match(/isConfirmed\(\s*args\[['"]confirmed['"]\]\s*\)/g) ?? []).length;
+    expect(viaHelper).toBe(allReads);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // requiresConfirmation の挙動（本タスクの時点では階層によらず一律 true）
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Asana: 1217045484955063

## Summary
確認フラグ(confirmed)の判定が2方式に分裂しており、片方に型混同の脆弱性があった。

    Boolean(args['confirmed'])   … 16箇所
    args['confirmed'] === true   … 4箇所

`Boolean('false') === true` という JS の仕様により、前者は文字列 `'false'` を「確認済み」と誤判定する。本リポジトリには Groq が引数を文字列化して送ってくる事象が実測・文書化されている（`agentRoutes.ts` の `parseToolArgs`: 無引数ツールに対し文字列 `"null"` が送られてくるケース）ため、机上の話ではない。影響を受けうるのは `delete_faq` / `delete_tuning_rule` / `delete_engagement_rule`（不可逆削除）、`request_sai_task`（従量課金）を含む16ツール。

## 実装

判定を `isConfirmed()` へ集約（`clampToolLimit` の隣に配置、export しない）。

**単純な `=== true` への統一にはしていない。** それでは Groq が文字列 `"true"` を送った場合にユーザーが同意し続けても永久に実行されないループに陥る。boolean の `true` と文字列 `"true"` の両方を受理し、それ以外（未知の型を含む）は安全側=未確認に倒す。

既存4ツールにとっては許容側への挙動変更だが、受理するのは `"true"` のみなので安全性は保たれる。

## テストが本当に脆弱性を捕まえることの確認

- 静的解析テスト（`confirmPolicy.test.ts`、既存の `MUTATION_PATTERNS` と同方式）を**実装前に追加して赤くなること**（20箇所検出）を確認してから置換した
- 振る舞いテスト（3ツール × 型パターン）追加後、`isConfirmed` を一時的に `Boolean()` へ戻すと**5件が落ちる**ことを確認済み。素通りするテストではない

## ★ 別途ご判断いただきたい件（本PRでは修正していません）

タスク手順1の棚卸しで、**確認ゲートを一切持たない書き込みツールが7本**見つかりました。Asanaにコメント済みです（実コードで3本を目視確認、誤検出ではありません）。

| tier | ツール | 実際の動作 |
|---|---|---|
| low | set_ga4_id / set_posthog / set_widget_theme | `UPDATE tenants` を直接実行 |
| low | activate_avatar / deactivate_avatar | `activateAvatarConfig` で UPDATE |
| medium | **add_faq / update_faq** | `INSERT INTO faq_docs` を直接実行 |

`confirmPolicy.ts` は冒頭で「`requiresConfirmation()` は階層に関わらず常に true を返す」と宣言していますが、この関数は実際には同一ターン連鎖ブロックの判定にしか使われておらず、汎用ゲートとしては機能していません。とくに `add_faq` / `update_faq` は medium でありながら、同じ medium の `save_faq` にはゲートがあるという非対称があり、設計判断というより取りこぼしに見えます。

指示どおり本PRでは修正していません。

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx oxlint src admin-ui/src --max-warnings 63`
- [x] `agentRoutes.test.ts` + `confirmPolicy.test.ts` 377件通過
- [x] 静的解析テストの赤→緑、振る舞いテストのミューテーション確認

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UpYM4tvAGHfu4vc9NQqPfY