### PR TITLE
fix: 下書き公開の確認チップ欠落と、段階到達メトリクス/監査ログの欠落を解消する(オンボ 是正B-1/B-2)

### DIFF
--- a/admin-ui/src/auth/useAuth.tsx
+++ b/admin-ui/src/auth/useAuth.tsx
@@ -27,6 +27,8 @@ export interface OnboardingStageFlags {
   knowledgePublished: boolean;
   widgetInstalled: boolean;
   firstConversation: boolean;
+  /** オンボ 是正A-2: 段階ではなくヒント。stage2の案内文の出し分けにのみ使う。 */
+  hasDraftFaq: boolean;
 }
 
 interface AuthContextValue {

--- a/admin-ui/src/lib/landingDecision.test.ts
+++ b/admin-ui/src/lib/landingDecision.test.ts
@@ -11,6 +11,7 @@ const INCOMPLETE_STAGE: OnboardingStageFlags = {
   knowledgePublished: false,
   widgetInstalled: false,
   firstConversation: false,
+  hasDraftFaq: false,
 };
 
 const COMPLETE_STAGE: OnboardingStageFlags = {
@@ -18,6 +19,7 @@ const COMPLETE_STAGE: OnboardingStageFlags = {
   knowledgePublished: true,
   widgetInstalled: true,
   firstConversation: true,
+  hasDraftFaq: false,
 };
 
 function baseInput(overrides: Partial<LandingDecisionInput> = {}): LandingDecisionInput {

--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -2315,6 +2315,7 @@ describe("CopilotPreviewPage — 会話の復元(sessionStorage)", () => {
             knowledgePublished: false,
             widgetInstalled: false,
             firstConversation: false,
+            hasDraftFaq: true,
           },
         });
       }
@@ -2337,6 +2338,32 @@ describe("CopilotPreviewPage — 会話の復元(sessionStorage)", () => {
     expect(await screen.findByText("全国一律550円です。")).toBeTruthy();
     expect(await screen.findByText(/下書きとして登録済み/)).toBeTruthy();
     expect(screen.getByText("下書きを見る")).toBeTruthy();
+  });
+
+  // オンボ 是正A-2: 業種は答えたが下書きが1件も無い(全INSERT失敗や「あとで」離脱)場合、
+  // 「下書きを見る」チップを出すと空振りになる。業種チップに戻して詰まりを解消する。
+  it("業種回答済みだが下書きが1件も無いなら、下書き確認ではなく業種チップに戻る", async () => {
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (isBadgeUrl(url)) return mockEmptyBadges();
+      if (String(url).includes("/v1/admin/my-tenant")) {
+        return mockOk({
+          onboarding_stage: {
+            industryAnswered: true,
+            knowledgePublished: false,
+            widgetInstalled: false,
+            firstConversation: false,
+            hasDraftFaq: false,
+          },
+        });
+      }
+      return mockOk({ reply: "今週も順調です。", actions: [] });
+    });
+    vi.mocked(restoreChatSession).mockReturnValue(null);
+
+    renderPage();
+
+    expect(await screen.findByText(/たたき台をまだお作りしていません/)).toBeTruthy();
+    expect(screen.queryByText("下書きを見る")).toBeNull();
   });
 
   // N-6/X-11(docs/ONBOARDING_FIRST_LOGIN.md §7.1/§7.3): deriveOnboardingNextStep の

--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -813,6 +813,48 @@ describe("CopilotPreviewPage — 構造化カード(card)からの描画", () =>
     expect(chatBodies.at(-1)?.message).toBe("やめておきます");
   });
 
+  // オンボ 是正B-1: publish_faq_draftsだけ確認チップが無く、下書き公開の動線が自由入力
+  // 頼みになっていた(他のconfirmed待ちツールと同じパターンに揃える)。
+  it("publish_faq_drafts が確認待ちのときは「公開する」チップを出し、押すと実送信する", async () => {
+    mockAgent({
+      reply: "公開してよろしいですか？",
+      actions: [
+        {
+          tool: "publish_faq_drafts",
+          result:
+            "下書き（未公開）のFAQが2件あります:\n1. Q: 送料は？ / A: 550円\nよろしければ公開しますか？（公開後も自由に編集・非公開に戻せます）",
+        },
+      ],
+    });
+
+    await send("下書きを公開して");
+
+    const chip = await screen.findByRole("button", { name: "公開する" });
+    fireEvent.click(chip);
+
+    await waitFor(() => expect(screen.getByText("はい、公開してください")).toBeTruthy());
+  });
+
+  it("publish_faq_drafts が確認待ちのときに「あとで」を押すと、公開せず辞退の自然文を送る", async () => {
+    mockAgent({
+      reply: "公開してよろしいですか？",
+      actions: [
+        {
+          tool: "publish_faq_drafts",
+          result:
+            "下書き（未公開）のFAQが2件あります:\n1. Q: 送料は？ / A: 550円\nよろしければ公開しますか？（公開後も自由に編集・非公開に戻せます）",
+        },
+      ],
+    });
+
+    await send("下書きを公開して");
+
+    const declineButton = await screen.findByRole("button", { name: "あとで" });
+    fireEvent.click(declineButton);
+
+    await waitFor(() => expect(screen.getByText("あとでにします")).toBeTruthy());
+  });
+
   it("delete_chat_session が確認待ちのときは「削除して」チップを出し、押すと実送信する", async () => {
     mockAgent({
       reply: "確認をお願いします。",

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -329,6 +329,8 @@ interface OnboardingStageFlags {
   knowledgePublished: boolean;
   widgetInstalled: boolean;
   firstConversation: boolean;
+  /** オンボ 是正A-2: 段階ではなくヒント。stage2の案内文の出し分けにのみ使う。 */
+  hasDraftFaq: boolean;
 }
 
 // 4段階のうち、まだ到達していない最初の段階に対応する案内文＋チップを返す。
@@ -342,6 +344,15 @@ function deriveOnboardingNextStep(stage: OnboardingStageFlags): { text: string; 
     };
   }
   if (!stage.knowledgePublished) {
+    // オンボ 是正A-2: 業種は答えたが下書きが1件も無い(全INSERT失敗、または
+    // 「あとで」を選んで抜けた等)場合は「下書きを見る」を出しても空振りになる。
+    // 下書きの有無で「公開を促す」か「たたき台作成に戻す」かを分ける。
+    if (!stage.hasDraftFaq) {
+      return {
+        text: "FAQのたたき台をまだお作りしていません。業種を教えていただければ、すぐ使えるたたき台をご提案します。",
+        chips: INDUSTRY_CHIPS,
+      };
+    }
     return {
       text: "業種のFAQたたき台は下書きとして登録済みです。内容をご確認のうえ、よろしければ公開しましょう。",
       chips: [{ label: "下書きを見る", action: "__real:下書きのFAQを見せてください", tone: "ghost" }],

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -799,6 +799,11 @@ export default function CopilotPreviewPage() {
     const industryTemplatePendingConfirm = data.actions?.some(
       (a) => a.tool === "import_industry_faq_templates" && a.result.includes("よろしければ登録しますか"),
     );
+    // オンボ 是正B-1: publish_faq_draftsだけ確認チップが無く、下書き公開の動線が
+    // 自由入力頼みになっていた(request_sai_task等の既存パターンに揃える)。
+    const publishDraftsPendingConfirm = data.actions?.some(
+      (a) => a.tool === "publish_faq_drafts" && a.result.includes("よろしければ公開しますか"),
+    );
     // 成果(コンバージョン)記録がconfirmed待ちでブロックされた場合も同様
     const outcomePendingConfirm = data.actions?.some(
       (a) => a.tool === "record_session_outcome" && a.result.includes(CONFIRM_REQUIRED_MARKER),
@@ -846,6 +851,11 @@ export default function CopilotPreviewPage() {
       : industryTemplatePendingConfirm
       ? [
           { label: "登録して", action: "__real:登録してください", tone: "primary" },
+          { label: "あとで", action: "__real:あとでにします", tone: "ghost" },
+        ]
+      : publishDraftsPendingConfirm
+      ? [
+          { label: "公開する", action: "__real:はい、公開してください", tone: "primary" },
           { label: "あとで", action: "__real:あとでにします", tone: "ghost" },
         ]
       : outcomePendingConfirm

--- a/docs/AGENT_METRICS.md
+++ b/docs/AGENT_METRICS.md
@@ -124,6 +124,14 @@ GROUP BY 1;
   （`src/api/chat/route.ts` 等、管理エージェントとは別系統かつ高頻度経路）に触れる必要があり、
   本タスク群のスコープ外として意図的に残している。
 
+**参照(オンボ 是正B-2で追加):**
+- `GET /v1/admin/analytics/metrics-history?metric=onboarding_stage_reached` から集計参照できる
+  （`src/api/admin/analytics/routes.ts` の `VALID_METRICS`）。追加前は allowlist に無く 400 で
+  弾かれ、書き込まれるだけで一切参照できない状態だった。
+- `import_industry_faq_templates` / `publish_faq_drafts` は `agentRoutes.ts` の
+  `AUDITED_SETTINGS_TOOLS` にも登録済みで、`tenant_settings_history` にも記録される
+  （`actor` はこちらの監査ログには含まれないため、actor別の集計にはこのメトリクスを使うこと）。
+
 ### `agent_tool_invoked`
 
 - `tool`: ツール名（`ADMIN_AGENT_TOOLS` の `name`。例 `get_faq_list`, `save_faq`）。

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -637,16 +637,27 @@ export async function executeToolCall(
       const templates = INDUSTRY_FAQ_TEMPLATES[industryRaw];
       const label = ONBOARDING_INDUSTRY_LABELS[industryRaw];
 
+      if (!tenantId) {
+        return truncate('テナントが特定できません。super_admin の場合は対象テナントを指定してください');
+      }
+
       if (!confirmed) {
+        // オンボ 是正A-2: 業種の回答自体はここで確定させる(FAQ投入とは別の関心事のため
+        // 確認ゲートの対象外)。保存しないと「あとで」を選んだユーザーに次回ログインでも
+        // 「初めまして」の挨拶が再生され続ける(要件§0.2の既知バグ)。
+        db.query(
+          `UPDATE tenants SET onboarding_industry = $1 WHERE id = $2`,
+          [industryRaw, tenantId],
+        ).catch((err) => {
+          logger.warn('[actionExecutor] import_industry_faq_templates industry save failed', err);
+        });
+
         const lines = templates.map((t, i) => `${i + 1}. Q: ${t.question} / A: ${t.answer}`);
         return truncate(
           `「${label}」向けのFAQたたき台を${templates.length}件ご用意しました:\n` +
           lines.join('\n') +
           `\nよろしければ登録しますか？（下書きとして登録し、内容を確認してから公開できます）`,
         );
-      }
-      if (!tenantId) {
-        return truncate('テナントが特定できません。super_admin の場合は対象テナントを指定してください');
       }
 
       try {
@@ -669,6 +680,15 @@ export async function executeToolCall(
           } catch (err) {
             logger.warn('[actionExecutor] import_industry_faq_templates insert failed', err);
           }
+        }
+
+        // オンボ 是正A-2: 0件成功なら段階を進めない(要件どおり「登録しました」を返さない)。
+        // 以前はinsertedの値に関わらずUPDATEと成功文言を返しており、全INSERT失敗時でも
+        // industryAnswered=trueかつ下書き0件のまま stage2 で永久にループしていた。
+        if (inserted === 0) {
+          return truncate(
+            `「${label}」向けのFAQの登録に失敗しました。時間をおいてもう一度お試しください。`,
+          );
         }
 
         await db.query(
@@ -727,12 +747,15 @@ export async function executeToolCall(
            WHERE id IN (
              SELECT id FROM faq_docs WHERE tenant_id = $1 AND is_published = false ORDER BY id LIMIT 20
            )
-           RETURNING id, question, answer`,
+           RETURNING id, question, answer, is_excluded_from_search`,
           [tenantId],
         );
-        const rows = result.rows as { id: number; question: string; answer: string }[];
+        const rows = result.rows as { id: number; question: string; answer: string; is_excluded_from_search: boolean | null }[];
         for (const row of rows) {
-          upsertToEsAsync(tenantId, row.id, row.question, row.answer, true);
+          // オンボ 是正A-3: is_excluded_from_search を引き継がないと、意図的に検索除外
+          // していた下書きを公開した際にESドキュメントがfalseで上書きされ、Phase69-2
+          // PR-C2のES永続フィルタ層が無効化される(faqCrudRoutes.tsの一括公開と揃える)。
+          upsertToEsAsync(tenantId, row.id, row.question, row.answer, true, row.is_excluded_from_search ?? false);
         }
         if (rows.length === 0) {
           return truncate('公開できる下書きのFAQはありません');

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -211,6 +211,10 @@ function recordedSettingsChanges(): Array<Record<string, any>> {
 
 import { registerAdminAgentRoutes } from './agentRoutes';
 import { ADMIN_AGENT_TOOLS, LEGACY_UI_FEATURES } from './toolDefinitions';
+// オンボ 是正A-3: publish_faq_drafts が is_excluded_from_search を正しく引き継ぐことを
+// 検証するため、モック化された upsertToEsAsync への参照を取得する(上のjest.mockで
+// faqCrudRoutes モジュール全体が既にモック済み)。
+import { upsertToEsAsync as mockUpsertToEsAsync } from '../knowledge/faqCrudRoutes';
 // ステージング(knowledgeImportStaging.ts)はモックせず実物を使う。
 // suggest_faq_import_from_text/urls → commit_faq_import の2ターン検証、
 // TTL/上限とは独立にテスト間の状態リークを防ぐためのリセット関数として使う。
@@ -6159,20 +6163,48 @@ describe('POST /v1/admin/agent/chat', () => {
       };
     }
 
-    it('confirmed=false → テンプレート一覧を提示するのみで登録されない', async () => {
+    // オンボ 是正A-2: confirmed=false でも業種はここで保存する(FAQ投入とは別の関心事
+    // のため確認ゲート対象外)。保存しないと「あとで」を選んだユーザーに次回ログインでも
+    // 「初めまして」の挨拶が再生され続ける(要件§0.2の既知バグ、X-3の回帰テスト)。
+    it('confirmed=false → テンプレート一覧を提示するのみで登録されないが、業種はここで保存される(X-3)', async () => {
       mockFetch
         .mockResolvedValueOnce(toolCallResponse('call-ind-1', 'import_industry_faq_templates', { industry: 'beauty', confirmed: false }))
         .mockResolvedValueOnce(makeGroqResponse('こちらでよろしいですか？'));
+      mockQuery.mockResolvedValueOnce({ rows: [] }); // UPDATE tenants (業種のみ、fire-and-forget)
 
       const res = await request(makeApp(CLIENT_ADMIN_USER))
         .post('/v1/admin/agent/chat')
         .send({ message: '美容室です', sessionId: 'sess-ind-01' });
 
       expect(res.status).toBe(200);
-      expect(mockQuery).not.toHaveBeenCalled();
       const result = res.body.actions[0].result as string;
       expect(result).toContain('美容・サロン');
       expect(result).toContain('予約は必要ですか？');
+      // FAQはまだINSERTされない(確認ゲートの対象)
+      expect(mockQuery.mock.calls.some(([sql]) => String(sql).includes('INSERT INTO faq_docs'))).toBe(false);
+      // 業種の保存は onboarding_completed_at を伴わない(FAQ投入の確認完了とは別の更新)
+      await new Promise((r) => setTimeout(r, 0)); // fire-and-forgetの発火を待つ
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE tenants SET onboarding_industry'),
+        ['beauty', 'tenant-abc'],
+      );
+      expect(mockQuery.mock.calls.some(([sql]) => String(sql).includes('onboarding_completed_at'))).toBe(false);
+    });
+
+    // オンボ 是正A-2: super_adminがテナント未指定でconfirmed=falseの場合、業種を保存する
+    // 先が無いため、一覧提示より前に「テナントが特定できません」を返す。
+    it('super_adminがtargetTenantId未指定でconfirmed=false → 「テナントが特定できません」を返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-ind-1b', 'import_industry_faq_templates', { industry: 'beauty', confirmed: false }))
+        .mockResolvedValueOnce(makeGroqResponse('テナントを指定してください。'));
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '美容室です', sessionId: 'sess-ind-01b' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('テナントが特定できません');
+      expect(mockQuery).not.toHaveBeenCalled();
     });
 
     it('不明な業種の場合はその旨を返す', async () => {
@@ -6234,6 +6266,7 @@ describe('POST /v1/admin/agent/chat', () => {
       mockFetch
         .mockResolvedValueOnce(toolCallResponse('call-ind-4', 'import_industry_faq_templates', { industry: 'beauty', confirmed: false }))
         .mockResolvedValueOnce(makeGroqResponse('こちらでよろしいですか？'));
+      mockQuery.mockResolvedValueOnce({ rows: [] }); // UPDATE tenants (業種のみ、fire-and-forget)
 
       const res = await request(makeApp(CLIENT_ADMIN_USER))
         .post('/v1/admin/agent/chat')
@@ -6284,42 +6317,30 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(res.body.actions[0].result).not.toContain('5件');
     });
 
-    // E-3(docs/ONBOARDING_FIRST_LOGIN.md §7.2)。
-    // 【既知のギャップ】要件は「全件失敗なら段階を進めない・完了フラグを立てない」だが、
-    // actionExecutor.ts の UPDATE tenants は INSERT の成否に関わらず無条件に実行される
-    // (この分岐は本タスク群より前から存在する既存ロジックで、P3では is_published の値
-    // だけを変更した。挙動そのものは変えていない)。このテストは「あるべき姿」ではなく
-    // 「現状の実際の挙動」を固定する回帰テストであり、この挙動を仕様として推奨するもの
-    // ではない。修正するかどうかはプロダクト判断が必要。
-    it('E-3(既知のギャップ): 全件INSERT失敗でも onboarding_industry は更新され、段階到達メトリクスも発火してしまう', async () => {
+    // E-3(docs/ONBOARDING_FIRST_LOGIN.md §7.2、オンボ 是正A-2で修正)。
+    // 以前は INSERT の成否に関わらず UPDATE tenants が無条件実行され、0件成功でも
+    // industryAnswered=true・下書き0件のまま stage2 で永久にループする実害があった
+    // (「あるべき姿」を固定できていなかった既知のギャップ)。修正後は0件成功時は
+    // 段階を進めず、失敗を明示する。
+    it('E-3: 全件INSERT失敗なら onboarding_industry は更新せず、失敗を返し、段階到達メトリクスも発火しない', async () => {
       mockFetch
         .mockResolvedValueOnce(toolCallResponse('call-ind-7', 'import_industry_faq_templates', { industry: 'beauty', confirmed: true }))
-        .mockResolvedValueOnce(makeGroqResponse('登録しました。'));
+        .mockResolvedValueOnce(makeGroqResponse('失敗しました。'));
 
       for (let i = 0; i < 5; i++) {
         mockQuery.mockRejectedValueOnce(new Error('insert failed'));
       }
-      mockQuery.mockResolvedValueOnce({ rows: [] }); // UPDATE tenants(無条件に実行される)
 
       const res = await request(makeApp(CLIENT_ADMIN_USER))
         .post('/v1/admin/agent/chat')
         .send({ message: '登録して', sessionId: 'sess-ind-08' });
 
       expect(res.status).toBe(200);
-      expect(res.body.actions[0].result).toContain('0件、下書きとして登録しました');
-      // 現状の実装: 0件成功でも UPDATE tenants は実行され、メトリクスも発火する
-      expect(mockQuery).toHaveBeenCalledWith(
-        expect.stringContaining('UPDATE tenants SET onboarding_industry'),
-        ['beauty', 'tenant-abc'],
-      );
-      expect(recordedMetrics('onboarding_stage_reached')).toEqual([
-        {
-          metricName: 'onboarding_stage_reached',
-          tenantId: 'tenant-abc',
-          labels: { stage: 'industry_answered', actor: 'self', surface: 'unknown' },
-          value: 1,
-        },
-      ]);
+      expect(res.body.actions[0].result).toContain('登録に失敗しました');
+      expect(res.body.actions[0].result).not.toContain('下書きとして登録しました');
+      // 0件成功時は UPDATE tenants を実行しない(段階を進めない)
+      expect(mockQuery.mock.calls.some(([sql]) => String(sql).includes('UPDATE tenants'))).toBe(false);
+      expect(recordedMetrics('onboarding_stage_reached')).toEqual([]);
     });
   });
 
@@ -6406,6 +6427,32 @@ describe('POST /v1/admin/agent/chat', () => {
           value: 1,
         },
       ]);
+    });
+
+    // オンボ 是正A-3: is_excluded_from_search を引き継がないと、意図的に検索除外していた
+    // 下書きを公開した際にESが is_excluded_from_search:false で上書きされ、Phase69-2の
+    // ES永続フィルタ層が無効化される。RETURNING句と upsertToEsAsync 引数の両方を検証する。
+    it('オンボ 是正A-3: 公開時に is_excluded_from_search を引き継いで upsertToEsAsync を呼ぶ', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-pub-3b', 'publish_faq_drafts', { confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('公開しました。'));
+
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          { id: 1, question: 'Q1', answer: 'A1', is_excluded_from_search: true },
+          { id: 2, question: 'Q2', answer: 'A2', is_excluded_from_search: false },
+        ],
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '公開して', sessionId: 'sess-pub-03b' });
+
+      expect(res.status).toBe(200);
+      const updateCalls = mockQuery.mock.calls.filter(([sql]) => String(sql).includes('UPDATE faq_docs SET is_published = true'));
+      expect(String(updateCalls[0][0])).toContain('is_excluded_from_search');
+      expect(mockUpsertToEsAsync).toHaveBeenCalledWith('tenant-abc', 1, 'Q1', 'A1', true, true);
+      expect(mockUpsertToEsAsync).toHaveBeenCalledWith('tenant-abc', 2, 'Q2', 'A2', true, false);
     });
 
     it('super_adminがtargetTenantId指定で代行実行した場合はactor:delegatedで記録される', async () => {

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -7561,6 +7561,76 @@ describe('POST /v1/admin/agent/chat', () => {
       ]);
     });
 
+    // オンボ 是正B-2: import_industry_faq_templates/publish_faq_drafts が未登録で
+    // AC-4「各段階の到達に actor が記録される」が未達だった(メトリクスのactorラベルは
+    // 集計用で監査証跡ではない)。
+    it('import_industry_faq_templates 成功時に onboarding_industry の変更を記録する', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-au-ob1', 'import_industry_faq_templates', { industry: 'beauty', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('登録しました。'));
+
+      for (let i = 0; i < 5; i++) {
+        mockQuery.mockResolvedValueOnce({ rows: [{ id: 100 + i, question: `q${i}`, answer: `a${i}`, is_published: false }] });
+      }
+      mockQuery.mockResolvedValueOnce({ rows: [] }); // UPDATE tenants
+
+      const res = await request(makeApp(AUDIT_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '登録して', sessionId: 'sess-audit-ob1' });
+
+      expect(res.status).toBe(200);
+      expect(recordedSettingsChanges()).toEqual([
+        {
+          tenantId: 'tenant-abc',
+          changedBy: 'admin@example.com',
+          fieldName: 'onboarding_industry',
+          oldValue: null,
+          newValue: 'beauty',
+        },
+      ]);
+    });
+
+    it('import_industry_faq_templates が0件成功(オンボ 是正A-2)の場合は記録しない', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-au-ob2', 'import_industry_faq_templates', { industry: 'beauty', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('失敗しました。'));
+
+      for (let i = 0; i < 5; i++) {
+        mockQuery.mockRejectedValueOnce(new Error('insert failed'));
+      }
+
+      const res = await request(makeApp(AUDIT_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '登録して', sessionId: 'sess-audit-ob2' });
+
+      expect(res.status).toBe(200);
+      expect(mockRecordAgentSettingsChange).not.toHaveBeenCalled();
+    });
+
+    it('publish_faq_drafts 成功時に faq_docs_published の変更を記録する', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-au-ob3', 'publish_faq_drafts', { confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('公開しました。'));
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ id: 1, question: 'Q1', answer: 'A1' }],
+      });
+
+      const res = await request(makeApp(AUDIT_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '公開して', sessionId: 'sess-audit-ob3' });
+
+      expect(res.status).toBe(200);
+      expect(recordedSettingsChanges()).toEqual([
+        {
+          tenantId: 'tenant-abc',
+          changedBy: 'admin@example.com',
+          fieldName: 'faq_docs_published',
+          oldValue: null,
+          newValue: true,
+        },
+      ]);
+    });
+
     it('activate_avatar がプラン制限でブロックされた場合は記録しない', async () => {
       mockFetch
         .mockResolvedValueOnce(toolCallResponse('call-au-5', 'activate_avatar', { id: 'av-1' }))
@@ -7620,7 +7690,8 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(mockRecordAgentSettingsChange).not.toHaveBeenCalled();
     });
 
-    it('対象4ツール以外の書き込み(save_faq成功)は tenant_settings_history に記録しない', async () => {
+    // オンボ 是正B-2でimport_industry_faq_templates/publish_faq_draftsを追加登録し、対象は6ツールになった。
+    it('対象6ツール以外の書き込み(save_faq成功)は tenant_settings_history に記録しない', async () => {
       mockFetch
         .mockResolvedValueOnce(toolCallResponse('call-au-7', 'save_faq', { question: 'q', answer: 'a', confirmed: true }))
         .mockResolvedValueOnce(makeGroqResponse('FAQを保存しました。'));

--- a/src/api/admin/agent/agentRoutes.ts
+++ b/src/api/admin/agent/agentRoutes.ts
@@ -97,6 +97,21 @@ const AUDITED_SETTINGS_TOOLS: Record<
     successMarker: 'を有効化しました',
     readNewValue: (args) => args['id'],
   },
+  // オンボ 是正B-2: オンボ2ツールが未登録で tenant_settings_history に一切記録されず、
+  // 「各段階の到達に actor が記録される」(AC-4)が未達だった。successMarker は
+  // 下のonboarding_stage_reachedメトリクス発火(478行目付近)と同じ文字列に揃える。
+  import_industry_faq_templates: {
+    fieldName: 'onboarding_industry',
+    successMarker: '下書きとして登録しました',
+    readNewValue: (args) => args['industry'],
+  },
+  publish_faq_drafts: {
+    fieldName: 'faq_docs_published',
+    successMarker: '件のFAQを公開しました',
+    // 公開対象のFAQ ID等はactionExecutor内部の戻り値にしかなくargsからは取れないため、
+    // 「公開操作が行われた」ことのみを記録する。
+    readNewValue: () => true,
+  },
 };
 
 /** 監査記録も fire-and-forget。記録の失敗をチャット応答に一切影響させない。 */

--- a/src/api/admin/agent/onboardingStage.test.ts
+++ b/src/api/admin/agent/onboardingStage.test.ts
@@ -7,11 +7,14 @@ import {
   type OnboardingStageFacts,
 } from './onboardingStage';
 
+// カットオフ(2026-07-31T04:55:06Z)より後に作られたテナントとして扱う既定値。
 const NONE: OnboardingStageFacts = {
+  tenantCreatedAt: '2026-08-01T00:00:00Z',
   onboardingIndustry: null,
   onboardingWidgetSeenAt: null,
   hasPublishedFaq: false,
   hasRealConversation: false,
+  hasDraftFaq: false,
 };
 
 describe('deriveOnboardingStage', () => {
@@ -21,59 +24,105 @@ describe('deriveOnboardingStage', () => {
       knowledgePublished: false,
       widgetInstalled: false,
       firstConversation: false,
+      hasDraftFaq: false,
     });
   });
 
   it('全段階到達済みなら全て true', () => {
     const facts: OnboardingStageFacts = {
+      tenantCreatedAt: '2026-08-01T00:00:00Z',
       onboardingIndustry: 'beauty',
       onboardingWidgetSeenAt: new Date('2026-07-31T00:00:00Z'),
       hasPublishedFaq: true,
       hasRealConversation: true,
+      hasDraftFaq: false,
     };
     expect(deriveOnboardingStage(facts)).toEqual({
       industryAnswered: true,
       knowledgePublished: true,
       widgetInstalled: true,
       firstConversation: true,
+      hasDraftFaq: false,
+    });
+  });
+
+  it('hasDraftFaq はそのまま反映され、他の4段階の判定には混ざらない', () => {
+    const facts: OnboardingStageFacts = { ...NONE, hasDraftFaq: true };
+    const status = deriveOnboardingStage(facts);
+    expect(status?.hasDraftFaq).toBe(true);
+    expect(status?.knowledgePublished).toBe(false);
+    expect(isOnboardingComplete(status!)).toBe(false);
+  });
+
+  describe('カットオフ(オンボ 是正A-1)', () => {
+    it('カットオフちょうど(境界)は対象内として扱う(以上/未満の境界は「未満のみ除外」)', () => {
+      const facts: OnboardingStageFacts = { ...NONE, tenantCreatedAt: '2026-07-31T04:55:06Z' };
+      expect(deriveOnboardingStage(facts)).not.toBeNull();
+    });
+
+    it('カットオフの1秒前に作られたテナントは対象外(null)', () => {
+      const facts: OnboardingStageFacts = { ...NONE, tenantCreatedAt: '2026-07-31T04:55:05Z' };
+      expect(deriveOnboardingStage(facts)).toBeNull();
+    });
+
+    it('カットオフの1秒後に作られたテナントは対象(4段階を返す)', () => {
+      const facts: OnboardingStageFacts = { ...NONE, tenantCreatedAt: '2026-07-31T04:55:07Z' };
+      expect(deriveOnboardingStage(facts)).not.toBeNull();
+    });
+
+    it('DBのタイムスタンプ文字列(Date型ではなく文字列)でもカットオフ判定できる', () => {
+      const facts: OnboardingStageFacts = { ...NONE, tenantCreatedAt: '2020-01-01T00:00:00.000Z' };
+      expect(deriveOnboardingStage(facts)).toBeNull();
+    });
+
+    it('カットオフより前でも業種回答等の値に関わらず null を返す(対象外は無条件)', () => {
+      const facts: OnboardingStageFacts = {
+        tenantCreatedAt: '2020-01-01T00:00:00Z',
+        onboardingIndustry: 'beauty',
+        onboardingWidgetSeenAt: new Date(),
+        hasPublishedFaq: true,
+        hasRealConversation: true,
+        hasDraftFaq: false,
+      };
+      expect(deriveOnboardingStage(facts)).toBeNull();
     });
   });
 
   it('onboardingWidgetSeenAt が文字列(DBからのタイムスタンプ)でも true になる', () => {
     const facts: OnboardingStageFacts = { ...NONE, onboardingWidgetSeenAt: '2026-07-31T00:00:00.000Z' };
-    expect(deriveOnboardingStage(facts).widgetInstalled).toBe(true);
+    expect(deriveOnboardingStage(facts)?.widgetInstalled).toBe(true);
   });
 
   it('onboardingIndustry が空文字列は「回答済み」とは見なさない', () => {
     // 決定1準拠: 導出は onboarding_industry の非nullのみで判定する。空文字列はDB上あり得ないが、
     // 万一渡ってきた場合の挙動を固定しておく(空文字列はnullではないため true になる — 呼び出し側でDBのNULL制約に委ねる)。
     const facts: OnboardingStageFacts = { ...NONE, onboardingIndustry: '' };
-    expect(deriveOnboardingStage(facts).industryAnswered).toBe(true);
+    expect(deriveOnboardingStage(facts)?.industryAnswered).toBe(true);
   });
 
   it('knowledgePublished は hasPublishedFaq をそのまま反映する(オンボ由来に限定しない、決定1)', () => {
     const facts: OnboardingStageFacts = { ...NONE, hasPublishedFaq: true };
-    expect(deriveOnboardingStage(facts).knowledgePublished).toBe(true);
+    expect(deriveOnboardingStage(facts)?.knowledgePublished).toBe(true);
   });
 
   it('firstConversation は hasRealConversation をそのまま反映する', () => {
     const facts: OnboardingStageFacts = { ...NONE, hasRealConversation: true };
-    expect(deriveOnboardingStage(facts).firstConversation).toBe(true);
+    expect(deriveOnboardingStage(facts)?.firstConversation).toBe(true);
   });
 });
 
 describe('nextIncompleteStage', () => {
   it('全段階未到達なら industry_answered を返す(先頭)', () => {
-    expect(nextIncompleteStage(deriveOnboardingStage(NONE))).toBe('industry_answered');
+    expect(nextIncompleteStage(deriveOnboardingStage(NONE)!)).toBe('industry_answered');
   });
 
   it('業種回答済みなら knowledge_published を返す', () => {
-    const status = deriveOnboardingStage({ ...NONE, onboardingIndustry: 'food' });
+    const status = deriveOnboardingStage({ ...NONE, onboardingIndustry: 'food' })!;
     expect(nextIncompleteStage(status)).toBe('knowledge_published');
   });
 
   it('業種回答+知識公開済みなら widget_installed を返す', () => {
-    const status = deriveOnboardingStage({ ...NONE, onboardingIndustry: 'food', hasPublishedFaq: true });
+    const status = deriveOnboardingStage({ ...NONE, onboardingIndustry: 'food', hasPublishedFaq: true })!;
     expect(nextIncompleteStage(status)).toBe('widget_installed');
   });
 
@@ -83,17 +132,18 @@ describe('nextIncompleteStage', () => {
       onboardingIndustry: 'food',
       hasPublishedFaq: true,
       onboardingWidgetSeenAt: new Date(),
-    });
+    })!;
     expect(nextIncompleteStage(status)).toBe('first_conversation');
   });
 
   it('全段階到達済みなら null を返す', () => {
     const status = deriveOnboardingStage({
+      ...NONE,
       onboardingIndustry: 'food',
       hasPublishedFaq: true,
       onboardingWidgetSeenAt: new Date(),
       hasRealConversation: true,
-    });
+    })!;
     expect(nextIncompleteStage(status)).toBeNull();
   });
 
@@ -103,23 +153,24 @@ describe('nextIncompleteStage', () => {
       ...NONE,
       hasPublishedFaq: true,
       onboardingWidgetSeenAt: new Date(),
-    });
+    })!;
     expect(nextIncompleteStage(status)).toBe('industry_answered');
   });
 });
 
 describe('isOnboardingComplete', () => {
   it('未到達段階が残っている場合は false', () => {
-    expect(isOnboardingComplete(deriveOnboardingStage(NONE))).toBe(false);
+    expect(isOnboardingComplete(deriveOnboardingStage(NONE)!)).toBe(false);
   });
 
   it('全段階到達済みなら true', () => {
     const status = deriveOnboardingStage({
+      ...NONE,
       onboardingIndustry: 'retail',
       hasPublishedFaq: true,
       onboardingWidgetSeenAt: new Date(),
       hasRealConversation: true,
-    });
+    })!;
     expect(isOnboardingComplete(status)).toBe(true);
   });
 });

--- a/src/api/admin/agent/onboardingStage.ts
+++ b/src/api/admin/agent/onboardingStage.ts
@@ -22,11 +22,23 @@ export type OnboardingStage =
   | 'widget_installed'
   | 'first_conversation';
 
+// P6(#627, 2026-07-31T13:55:06+09:00)がmainにマージされる前に作られたテナントは、
+// 4段階モデル自体が存在しない時期に作られている。onboarding_industry は導入前の
+// 全テナントで一律 NULL のため、カットオフ無しだと「新規テナント」と誤判定され
+// 全既存テナントが新UIへ強制着地する(オンボ 是正A-1)。この列だけで新規/既存を
+// 見分けられないので、テナントの作成日時で線を引く。
+const ONBOARDING_MODEL_CUTOFF = '2026-07-31T04:55:06Z';
+
 export interface OnboardingStageFacts {
+  tenantCreatedAt: Date | string;
   onboardingIndustry: string | null;
   onboardingWidgetSeenAt: Date | string | null;
   hasPublishedFaq: boolean;
   hasRealConversation: boolean;
+  // オンボ 是正A-2: 段階(4つ)ではなくヒント。stage2「下書きを見る」と「たたき台を
+  // 作る」を切り分けるためだけに使い、isOnboardingComplete/nextIncompleteStage の
+  // 判定には混ぜない。
+  hasDraftFaq: boolean;
 }
 
 export interface OnboardingStageStatus {
@@ -34,14 +46,20 @@ export interface OnboardingStageStatus {
   knowledgePublished: boolean;
   widgetInstalled: boolean;
   firstConversation: boolean;
+  hasDraftFaq: boolean;
 }
 
-export function deriveOnboardingStage(facts: OnboardingStageFacts): OnboardingStageStatus {
+/** カットオフより前に作られたテナントは4段階モデルの対象外として null を返す。 */
+export function deriveOnboardingStage(facts: OnboardingStageFacts): OnboardingStageStatus | null {
+  if (new Date(facts.tenantCreatedAt) < new Date(ONBOARDING_MODEL_CUTOFF)) {
+    return null;
+  }
   return {
     industryAnswered: facts.onboardingIndustry !== null,
     knowledgePublished: facts.hasPublishedFaq,
     widgetInstalled: facts.onboardingWidgetSeenAt !== null,
     firstConversation: facts.hasRealConversation,
+    hasDraftFaq: facts.hasDraftFaq,
   };
 }
 

--- a/src/api/admin/analytics/metricsHistory.test.ts
+++ b/src/api/admin/analytics/metricsHistory.test.ts
@@ -158,6 +158,24 @@ describe('GET /v1/admin/analytics/metrics-history', () => {
     expect(res.body.error).toMatch(/granularity/);
   });
 
+  // オンボ 是正B-2: onboarding_stage_reached が VALID_METRICS の allowlist に無く、
+  // 書き込まれるだけでどの画面からも参照できなかった(400で弾かれていた)。
+  it('super_admin + metric=onboarding_stage_reached → 200(オンボ 是正B-2)', async () => {
+    const mockRows = [
+      { timestamp: new Date('2026-07-31T10:00:00Z'), value: 1, labels: { stage: 'industry_answered', actor: 'self' } },
+    ];
+    dbModule.pool = makeMockPool(mockRows);
+
+    const app = makeApp(SUPER_ADMIN_META);
+    const res = await request(app)
+      .get('/v1/admin/analytics/metrics-history')
+      .query({ metric: 'onboarding_stage_reached', period: '7d', granularity: '1h' });
+
+    expect(res.status).toBe(200);
+    expect(res.body).toHaveProperty('metric', 'onboarding_stage_reached');
+    expect(res.body.series).toHaveLength(1);
+  });
+
   it('metric が未指定 → 400', async () => {
     dbModule.pool = makeMockPool();
 

--- a/src/api/admin/analytics/routes.ts
+++ b/src/api/admin/analytics/routes.ts
@@ -1129,6 +1129,9 @@ export function registerAnalyticsRoutes(app: Express): void {
     "rajiuce_loop_detected_total",
     "rajiuce_avatar_requests_total",
     "rajiuce_rag_duration_ms",
+    // オンボ 是正B-2: onboarding_stage_reached(P1で定義した計測契約)が
+    // metrics_snapshots に発火するだけで、どの画面からも参照できない状態だった。
+    "onboarding_stage_reached",
   ] as const);
 
   const VALID_GRANULARITIES: Record<string, string> = {
@@ -1162,7 +1165,7 @@ export function registerAnalyticsRoutes(app: Express): void {
       const metricRaw = req.query["metric"] as string | undefined;
       if (!metricRaw || !VALID_METRICS.has(metricRaw as any)) {
         return res.status(400).json({
-          error: "metric パラメータが必要です。有効な値: rajiuce_conversation_terminal_total, rajiuce_loop_detected_total, rajiuce_avatar_requests_total, rajiuce_rag_duration_ms",
+          error: "metric パラメータが必要です。有効な値: rajiuce_conversation_terminal_total, rajiuce_loop_detected_total, rajiuce_avatar_requests_total, rajiuce_rag_duration_ms, onboarding_stage_reached",
         });
       }
       const metric = metricRaw;

--- a/src/api/admin/tenants/routes.ts
+++ b/src/api/admin/tenants/routes.ts
@@ -90,16 +90,25 @@ async function checkHasR2c2(db: Pool, tenantId: string): Promise<boolean> {
 async function fetchOnboardingStageStatus(
   db: Pool,
   tenantId: string,
+  tenantCreatedAt: string,
   onboardingIndustry: string | null,
   onboardingWidgetSeenAt: string | null
-): Promise<OnboardingStageStatus> {
+): Promise<OnboardingStageStatus | null> {
+  // オンボ 是正A-2: 公開済み/下書きの両方の有無を1クエリで取る(hasDraftFaqは
+  // stage2の「下書きを見る」と「たたき台を作る」を切り分けるためのヒント)。
   let hasPublishedFaq = false;
+  let hasDraftFaq = false;
   try {
     const result = await db.query(
-      `SELECT 1 FROM faq_docs WHERE tenant_id = $1 AND is_published = true LIMIT 1`,
+      `SELECT
+         COUNT(*) FILTER (WHERE is_published) AS published_count,
+         COUNT(*) FILTER (WHERE NOT is_published) AS draft_count
+       FROM faq_docs WHERE tenant_id = $1`,
       [tenantId]
     );
-    hasPublishedFaq = (result.rowCount ?? 0) > 0;
+    const row = result.rows[0] as { published_count: string; draft_count: string } | undefined;
+    hasPublishedFaq = Number(row?.published_count ?? 0) > 0;
+    hasDraftFaq = Number(row?.draft_count ?? 0) > 0;
   } catch (err) {
     logger.warn("[fetchOnboardingStageStatus] faq_docs query failed", err);
   }
@@ -116,10 +125,12 @@ async function fetchOnboardingStageStatus(
   }
 
   return deriveOnboardingStage({
+    tenantCreatedAt,
     onboardingIndustry,
     onboardingWidgetSeenAt,
     hasPublishedFaq,
     hasRealConversation,
+    hasDraftFaq,
   });
 }
 
@@ -196,7 +207,7 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
     }
     try {
       const result = await db.query(
-        `SELECT id, name, plan, features, lemonslice_agent_id, conversion_types, faq_question_hint, faq_answer_hint, onboarding_industry, onboarding_completed_at, onboarding_widget_seen_at FROM tenants WHERE id = $1`,
+        `SELECT id, name, plan, features, lemonslice_agent_id, conversion_types, faq_question_hint, faq_answer_hint, onboarding_industry, onboarding_completed_at, onboarding_widget_seen_at, created_at FROM tenants WHERE id = $1`,
         [tenantId]
       );
       if (result.rowCount === 0) {
@@ -205,11 +216,13 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
       const row = result.rows[0] as {
         onboarding_industry: string | null;
         onboarding_widget_seen_at: string | null;
+        created_at: string;
       };
       const has_r2c2 = await checkHasR2c2(db, tenantId);
       const onboarding_stage = await fetchOnboardingStageStatus(
         db,
         tenantId,
+        row.created_at,
         row.onboarding_industry,
         row.onboarding_widget_seen_at
       );
@@ -396,6 +409,7 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
       const row = result.rows[0] as {
         onboarding_industry: string | null;
         onboarding_widget_seen_at: string | null;
+        created_at: string;
       };
       // Asana 1217040568430944(P7): super_adminのクライアントビュー(previewMode)からも
       // オンボーディングの「次の一手」提示を使えるようにするため、my-tenant同様に
@@ -403,6 +417,7 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
       const onboarding_stage = await fetchOnboardingStageStatus(
         db,
         id,
+        row.created_at,
         row.onboarding_industry,
         row.onboarding_widget_seen_at
       );

--- a/tests/api/admin/tenants/routes.test.ts
+++ b/tests/api/admin/tenants/routes.test.ts
@@ -190,6 +190,7 @@ describe("Tenant Admin Routes", () => {
             rows: [{
               id: "tenant1", name: "Test", features: {}, lemonslice_agent_id: null, conversion_types: [],
               onboarding_industry: null, onboarding_completed_at: null, onboarding_widget_seen_at: null,
+              created_at: "2026-08-01T00:00:00.000Z",
             }],
             rowCount: 1,
           })
@@ -207,6 +208,7 @@ describe("Tenant Admin Routes", () => {
           knowledgePublished: false,
           widgetInstalled: false,
           firstConversation: false,
+          hasDraftFaq: false,
         });
       });
 
@@ -217,11 +219,12 @@ describe("Tenant Admin Routes", () => {
               id: "tenant1", name: "Test", features: {}, lemonslice_agent_id: null, conversion_types: [],
               onboarding_industry: "beauty", onboarding_completed_at: "2026-07-01T00:00:00.000Z",
               onboarding_widget_seen_at: "2026-07-02T00:00:00.000Z",
+              created_at: "2026-08-01T00:00:00.000Z",
             }],
             rowCount: 1,
           })
           .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // checkHasR2c2
-          .mockResolvedValueOnce({ rows: [{ "?column?": 1 }], rowCount: 1 }) // faq_docs: 公開FAQあり
+          .mockResolvedValueOnce({ rows: [{ published_count: "1", draft_count: "0" }], rowCount: 1 }) // faq_docs: 公開FAQあり
           .mockResolvedValueOnce({ rows: [{ "?column?": 1 }], rowCount: 1 }); // chat_sessions: 実会話あり
 
         const res = await request(app)
@@ -234,7 +237,32 @@ describe("Tenant Admin Routes", () => {
           knowledgePublished: true,
           widgetInstalled: true,
           firstConversation: true,
+          hasDraftFaq: false,
         });
+      });
+
+      // オンボ 是正A-2: 下書きが公開済みFAQと独立にカウントされること(1クエリ統合の回帰)。
+      it("公開済みFAQが無くても下書きがあれば hasDraftFaq が true になる", async () => {
+        mockDb.query
+          .mockResolvedValueOnce({
+            rows: [{
+              id: "tenant1", name: "Test", features: {}, lemonslice_agent_id: null, conversion_types: [],
+              onboarding_industry: "beauty", onboarding_completed_at: null, onboarding_widget_seen_at: null,
+              created_at: "2026-08-01T00:00:00.000Z",
+            }],
+            rowCount: 1,
+          })
+          .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // checkHasR2c2
+          .mockResolvedValueOnce({ rows: [{ published_count: "0", draft_count: "3" }], rowCount: 1 }) // faq_docs: 下書きのみ
+          .mockResolvedValueOnce({ rows: [], rowCount: 0 }); // chat_sessions
+
+        const res = await request(app)
+          .get("/v1/admin/my-tenant")
+          .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`);
+
+        expect(res.status).toBe(200);
+        expect(res.body.onboarding_stage.hasDraftFaq).toBe(true);
+        expect(res.body.onboarding_stage.knowledgePublished).toBe(false);
       });
 
       // X-16(docs/ONBOARDING_FIRST_LOGIN.md §7.3): テストチャット(/admin/chat-test)由来の
@@ -248,6 +276,7 @@ describe("Tenant Admin Routes", () => {
             rows: [{
               id: "tenant1", name: "Test", features: {}, lemonslice_agent_id: null, conversion_types: [],
               onboarding_industry: "beauty", onboarding_widget_seen_at: "2026-07-02T00:00:00.000Z",
+              created_at: "2026-08-01T00:00:00.000Z",
             }],
             rowCount: 1,
           })
@@ -279,6 +308,7 @@ describe("Tenant Admin Routes", () => {
               id: "tenant1", name: "Test", features: {}, lemonslice_agent_id: null, conversion_types: [],
               onboarding_industry: "beauty", onboarding_completed_at: "2026-07-01T00:00:00.000Z",
               onboarding_widget_seen_at: null,
+              created_at: "2026-08-01T00:00:00.000Z",
             }],
             rowCount: 1,
           })
@@ -303,6 +333,7 @@ describe("Tenant Admin Routes", () => {
             rows: [{
               id: "tenant1", name: "Test", features: {}, lemonslice_agent_id: null, conversion_types: [],
               onboarding_industry: "beauty", onboarding_completed_at: null, onboarding_widget_seen_at: null,
+              created_at: "2026-08-01T00:00:00.000Z",
             }],
             rowCount: 1,
           })
@@ -317,6 +348,35 @@ describe("Tenant Admin Routes", () => {
         expect(res.status).toBe(200);
         expect(res.body.onboarding_stage.knowledgePublished).toBe(false);
         expect(res.body.onboarding_stage.industryAnswered).toBe(true);
+      });
+
+      // オンボ 是正A-1: P6マージ前(4段階モデル導入前)に作られたテナントは
+      // onboarding_industry が一律 NULL のため、カットオフが無いと「新規」と
+      // 誤判定され新UIに強制着地する(本番影響あり)。created_at がカットオフより
+      // 前なら onboarding_stage 自体が null になることを固定する。
+      it("カットオフより前に作られた既存テナントは onboarding_stage が null になる(新規誤判定の防止)", async () => {
+        // fetchOnboardingStageStatusはカットオフ判定より先にfaq_docs/chat_sessionsを
+        // 実行する(deriveOnboardingStage内でカットオフを見て初めてnullを返す)ため、
+        // 他のテストと同じ4回分のモックが必要。
+        mockDb.query
+          .mockResolvedValueOnce({
+            rows: [{
+              id: "tenant1", name: "Test", features: {}, lemonslice_agent_id: null, conversion_types: [],
+              onboarding_industry: null, onboarding_completed_at: null, onboarding_widget_seen_at: null,
+              created_at: "2026-01-01T00:00:00.000Z",
+            }],
+            rowCount: 1,
+          })
+          .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // checkHasR2c2
+          .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // faq_docs
+          .mockResolvedValueOnce({ rows: [], rowCount: 0 }); // chat_sessions
+
+        const res = await request(app)
+          .get("/v1/admin/my-tenant")
+          .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`);
+
+        expect(res.status).toBe(200);
+        expect(res.body.onboarding_stage).toBeNull();
       });
     });
   });
@@ -416,6 +476,7 @@ describe("Tenant Admin Routes", () => {
           rows: [{
             id: "t1", name: "Test", plan: "starter", is_active: true, features: {},
             onboarding_industry: "beauty", onboarding_widget_seen_at: null,
+            created_at: "2026-08-01T00:00:00.000Z",
           }],
           rowCount: 1,
         })
@@ -432,6 +493,7 @@ describe("Tenant Admin Routes", () => {
         knowledgePublished: false,
         widgetInstalled: false,
         firstConversation: false,
+        hasDraftFaq: false,
       });
     });
 
@@ -440,6 +502,29 @@ describe("Tenant Admin Routes", () => {
         .get("/v1/admin/tenants/t1")
         .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`);
       expect(res.status).toBe(403);
+    });
+
+    // オンボ 是正A-1: super_adminの代行(previewMode)経路でも既存テナントの
+    // 誤判定を防ぐ。my-tenant側と同じカットオフ判定が :id 経路にも効くこと。
+    it("カットオフより前に作られたテナントは onboarding_stage が null になる", async () => {
+      mockDb.query
+        .mockResolvedValueOnce({
+          rows: [{
+            id: "t1", name: "Test", plan: "starter", is_active: true, features: {},
+            onboarding_industry: null, onboarding_widget_seen_at: null,
+            created_at: "2020-01-01T00:00:00.000Z",
+          }],
+          rowCount: 1,
+        })
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // faq_docs
+        .mockResolvedValueOnce({ rows: [], rowCount: 0 }); // chat_sessions
+
+      const res = await request(app)
+        .get("/v1/admin/tenants/t1")
+        .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body.onboarding_stage).toBeNull();
     });
   });
 


### PR DESCRIPTION
## Summary
Asana: 1217044993795601 / 1217044956095004

**このPRは #662(オンボ 是正A-1/A-2/A-3)の上に積んだスタックPRです。#662がmainにマージされたら、baseをmainに retarget します(docs/PR_MERGE_RULES.md の規約どおり)。**

### B-1: publish_faq_draftsの確認チップ欠落 / テナント切替時の再取得
- `copilot-preview/index.tsx` の確認待ちチップ三項連鎖(`request_sai_task`/`reply_to_escalation`/`import_industry_faq_templates`/`record_session_outcome`/`delete_chat_session`)に `publish_faq_drafts` だけ無かった。下書き公開の動線が自由入力頼みになっていたため、既存パターンに揃えて追加。
- 「テナント切替後にオンボーディング段階が再取得されない」問題は、実装に着手した時点で既に別レーン(#652, P1-2/P2-1/P1-3修正)で `runOnboardingAwareBriefing` として解消・テスト済みだったため、重複実装を避けて対応不要と判断。

### B-2: 段階到達メトリクスが参照できない / 監査ログに残らない
- `onboarding_stage_reached` が `GET /v1/admin/analytics/metrics-history` の `VALID_METRICS` allowlist に無く、書き込まれるだけでどの画面からも参照できなかった(指定すると400)。
- `import_industry_faq_templates` / `publish_faq_drafts` が `AUDITED_SETTINGS_TOOLS` に未登録で `tenant_settings_history` に一切記録されず、受け入れ条件AC-4「各段階の到達にactorが記録される」が未達だった(メトリクスのactorラベルは集計用で監査証跡ではない)。

## 変更ファイル
- `admin-ui/src/pages/copilot-preview/index.tsx` — `publishDraftsPendingConfirm` チップ追加
- `src/api/admin/analytics/routes.ts` — `VALID_METRICS` に追加
- `src/api/admin/agent/agentRoutes.ts` — `AUDITED_SETTINGS_TOOLS` に2ツール登録
- `docs/AGENT_METRICS.md` — 参照経路・監査ログ記録先を追記
- テスト: `copilot-preview/index.test.tsx`(確認チップ2件) / `metricsHistory.test.ts`(allowlist) / `agentRoutes.test.ts`(監査ログ3件)

## Test plan
- [x] `npx tsc --noEmit`(backend clean)
- [x] `cd admin-ui && npx tsc -b`(既存ベースライン13件のまま)
- [x] `npx oxlint src admin-ui/src --max-warnings 63`(exit 0)
- [x] 変更ファイルのjest/vitestが全パス(agentRoutes 343/344、残り1件はdelete_engagement_ruleの既存テスト順序依存で単体実行では通過・無関係と確認済み。metricsHistory 8/8、copilot-preview+landingDecision+useAuth 163/163)
- [x] `bash SCRIPTS/dead-code-check.sh`(既存無関係の4件のみ)
- [x] `bash SCRIPTS/security-scan.sh`(PASS, 0 critical/high)

https://claude.ai/code/session_0177MCsC7jN3a51F7TdaW9vH