### PR TITLE
test(e2e): E2E specの本番URLハードコードをconfig定数に統合

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from '@playwright/test';
+import { ADMIN_BASE_URL } from './tests/e2e/config';
 
 const AUTH_FILE = 'tests/e2e/.auth/user.json';
 
@@ -7,7 +8,7 @@ export default defineConfig({
   timeout: 30000,
   retries: 1,
   use: {
-    baseURL: process.env.E2E_BASE_URL || 'https://admin.r2c.biz',
+    baseURL: ADMIN_BASE_URL,
     screenshot: 'only-on-failure',
     trace: 'on-first-retry',
     // GID 1216970103691946: E2Eトラフィックであることをサーバ側(resolveTrafficSource)

--- a/tests/e2e/admin-login.spec.ts
+++ b/tests/e2e/admin-login.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { ADMIN_BASE_URL } from './config';
 
 const E2E_ENABLED = process.env.E2E_ENABLED === '1' || !!process.env.CI;
 
@@ -6,7 +7,7 @@ test.describe('Admin UI — Login Page', () => {
   test.skip(!E2E_ENABLED, 'E2E tests require E2E_ENABLED=1 or CI=true');
 
   test('admin.r2c.biz shows login form', async ({ page }) => {
-    await page.goto('https://admin.r2c.biz');
+    await page.goto(ADMIN_BASE_URL);
 
     // メールまたはパスワード入力欄が表示されることを確認
     // Supabase Auth の実際のログインはスキップ（認証情報不要）
@@ -30,7 +31,7 @@ test.describe('Admin UI — Login Page', () => {
   });
 
   test('admin.r2c.biz page title is not blank', async ({ page }) => {
-    await page.goto('https://admin.r2c.biz');
+    await page.goto(ADMIN_BASE_URL);
     const title = await page.title();
     expect(title.length).toBeGreaterThan(0);
   });

--- a/tests/e2e/auth.setup.ts
+++ b/tests/e2e/auth.setup.ts
@@ -1,6 +1,7 @@
 import { test as setup } from '@playwright/test';
 import fs from 'fs';
 import path from 'path';
+import { ADMIN_BASE_URL } from './config';
 
 const AUTH_FILE = 'tests/e2e/.auth/user.json';
 
@@ -16,7 +17,7 @@ setup('authenticate admin', async ({ page }) => {
     return;
   }
 
-  await page.goto('https://admin.r2c.biz');
+  await page.goto(ADMIN_BASE_URL);
   await page.locator('input[type="email"]').waitFor({ timeout: 15000 });
   await page.fill('input[type="email"]', email);
   await page.fill('input[type="password"]', password);

--- a/tests/e2e/avatar-test-button.spec.ts
+++ b/tests/e2e/avatar-test-button.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { ADMIN_BASE_URL } from './config';
 
 const E2E_ENABLED = process.env.E2E_ENABLED === '1' || !!process.env.CI;
 
@@ -6,7 +7,7 @@ test.describe('Avatar Card — テストチャットボタン', () => {
   test.skip(!E2E_ENABLED, 'E2E tests require E2E_ENABLED=1 or CI=true');
 
   test('非SuperAdmin: テナント固有アバターにテストチャットボタンが表示される', async ({ page }) => {
-    await page.goto('https://admin.r2c.biz/admin/avatar');
+    await page.goto(`${ADMIN_BASE_URL}/admin/avatar`);
 
     // ログイン済み前提（Cookie/LocalStorageに認証情報がある場合）
     // アバターカードが表示されていることを確認
@@ -41,7 +42,7 @@ test.describe('Avatar Card — テストチャットボタン', () => {
   });
 
   test('アバターページにデフォルトアバターが存在する場合、非SuperAdminにはテストチャットボタンが非表示', async ({ page }) => {
-    await page.goto('https://admin.r2c.biz/admin/avatar');
+    await page.goto(`${ADMIN_BASE_URL}/admin/avatar`);
 
     const url = page.url();
     if (url.includes('/login')) {
@@ -69,7 +70,7 @@ test.describe('Avatar Card — テストチャットボタン', () => {
     const dummyAvatarId = 'test-avatar';
 
     await page.goto(
-      `https://admin.r2c.biz/admin/chat-test?tenantId=${dummyTenantId}&avatarConfigId=${dummyAvatarId}`
+      `${ADMIN_BASE_URL}/admin/chat-test?tenantId=${dummyTenantId}&avatarConfigId=${dummyAvatarId}`
     );
 
     const url = page.url();

--- a/tests/e2e/config.ts
+++ b/tests/e2e/config.ts
@@ -1,0 +1,11 @@
+// tests/e2e/config.ts
+//
+// E2E が向き先とする環境のbase URL。
+// 既定値は本番(現時点でこのリポジトリに実在する唯一の環境。docs/24H_AUTONOMOUS_PLAYBOOK.md:3
+// 「R2C は dev/staging を持たず本番 VPS のみ」)。
+//
+// ステージング環境が用意でき次第(Asana 1217045569747485 が前提条件)、
+// E2E_BASE_URL / E2E_API_URL を CI/ローカルで設定するだけで向き先を切り替えられるように、
+// 各 spec はこの定数を経由し、URL を直接ハードコードしない。
+export const ADMIN_BASE_URL = process.env.E2E_BASE_URL || 'https://admin.r2c.biz';
+export const API_BASE_URL = process.env.E2E_API_URL || 'https://api.r2c.biz';

--- a/tests/e2e/health.spec.ts
+++ b/tests/e2e/health.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { API_BASE_URL } from './config';
 
 const E2E_ENABLED = process.env.E2E_ENABLED === '1' || !!process.env.CI;
 
@@ -6,14 +7,14 @@ test.describe('API Health Check', () => {
   test.skip(!E2E_ENABLED, 'E2E tests require E2E_ENABLED=1 or CI=true');
 
   test('GET /health returns 200 with status ok', async ({ request }) => {
-    const response = await request.get('https://api.r2c.biz/health');
+    const response = await request.get(`${API_BASE_URL}/health`);
     expect(response.status()).toBe(200);
     const body = await response.json();
     expect(body.status).toBe('ok');
   });
 
   test('GET /widget.js returns 200 with JavaScript content-type', async ({ request }) => {
-    const response = await request.get('https://api.r2c.biz/widget.js');
+    const response = await request.get(`${API_BASE_URL}/widget.js`);
     expect(response.status()).toBe(200);
     const contentType = response.headers()['content-type'] ?? '';
     expect(contentType).toMatch(/javascript/);

--- a/tests/e2e/phase65-demo.spec.ts
+++ b/tests/e2e/phase65-demo.spec.ts
@@ -1,8 +1,9 @@
 import { test, expect } from '@playwright/test';
 import { gotoWithRetry } from './helpers/gotoRetry';
+import { API_BASE_URL } from './config';
 
 const E2E_ENABLED = process.env.E2E_ENABLED === '1' || !!process.env.CI;
-const DEMO_BASE = 'https://api.r2c.biz/carnation-demo';
+const DEMO_BASE = `${API_BASE_URL}/carnation-demo`;
 
 test.describe('Phase65 carnation-demo サイト', () => {
   test.skip(!E2E_ENABLED, 'E2E tests require E2E_ENABLED=1 or CI=true');
@@ -87,7 +88,7 @@ test.describe('Phase65 carnation-demo サイト', () => {
   test('旧URL /carnation-demo.html が /carnation-demo/index.html へリダイレクトされる', async ({ page }) => {
     test.setTimeout(90_000); // CI runner ↔ VPS の往復が遅い場合に対応: 3 × 25s + backoffs = 78s max
     // Playwrightはリダイレクトを自動追跡するため、最終URLを確認する
-    await gotoWithRetry(page, 'https://api.r2c.biz/carnation-demo.html', 3, 25_000);
+    await gotoWithRetry(page, `${API_BASE_URL}/carnation-demo.html`, 3, 25_000);
     expect(page.url()).toContain('/carnation-demo/index.html');
     const title = await page.title();
     expect(title).toContain('BROSS新潟');

--- a/tests/e2e/qa-2026-07-08-role-a.spec.ts
+++ b/tests/e2e/qa-2026-07-08-role-a.spec.ts
@@ -1,12 +1,13 @@
 import { test, expect } from '@playwright/test';
 import { gotoWithRetry } from './helpers/gotoRetry';
+import { API_BASE_URL } from './config';
 
 // QA sweep 2026-07-08: previously-uncovered Role A (end-user/anonymous) flows
 // from R2C_UIフローカタログ_2026-07-08.md (A2-3, A2-6, A2-13, A2-14, A3-2, A3-3, A3-5, A3-6, A3-8).
 // Any real failures found here are filed to Asana (RAJIUCE Development, gid 1213607637045514).
 
 const E2E_ENABLED = process.env.E2E_ENABLED === '1' || !!process.env.CI;
-const DEMO_BASE = 'https://api.r2c.biz/carnation-demo';
+const DEMO_BASE = `${API_BASE_URL}/carnation-demo`;
 
 // Asana #1216386757951251 の修正 (novalidate 付与) が https://api.r2c.biz にまだデプロイされて
 // いない場合、A3-2/A3-5.6/A3-8 の「修正後」アサーションは必ず落ちる。デプロイラグの間 CI を

--- a/tests/e2e/qa-2026-07-08-role-b.spec.ts
+++ b/tests/e2e/qa-2026-07-08-role-b.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { ADMIN_BASE_URL } from './config';
 
 // QA sweep 2026-07-08: Role B (client_admin, tenant "carnation") flows from
 // R2C_UIフローカタログ_2026-07-08.md. Read-only / navigation checks only —
@@ -7,7 +8,7 @@ import { test, expect } from '@playwright/test';
 
 const E2E_ENABLED = process.env.E2E_ENABLED === '1' || !!process.env.CI;
 const AUTH_FILE = 'tests/e2e/.auth/user.json';
-const BASE = 'https://admin.r2c.biz';
+const BASE = ADMIN_BASE_URL;
 
 test.describe('QA 2026-07-08 — Role B (client_admin) read-only sweep', () => {
   test.skip(!E2E_ENABLED, 'E2E tests require E2E_ENABLED=1 or CI=true');

--- a/tests/e2e/qa-copilot-preview.spec.ts
+++ b/tests/e2e/qa-copilot-preview.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import fs from 'fs';
+import { ADMIN_BASE_URL } from './config';
 
 // QA: /copilot-preview の実データ接続・super_adminテナントプレビュー回帰テスト — 2026-07-19
 // 本番で以下3件の不具合が実地発見されたため、再発防止として追加:
@@ -14,7 +15,7 @@ import fs from 'fs';
 //   Role C — tests/e2e/.auth/superadmin.json (superadmin.setup.ts, TEST_SUPERADMIN_EMAIL/PASSWORD)
 
 const E2E_ENABLED = process.env.E2E_ENABLED === '1' || !!process.env.CI;
-const ADMIN = 'https://admin.r2c.biz';
+const ADMIN = ADMIN_BASE_URL;
 const USER_AUTH = 'tests/e2e/.auth/user.json';
 const SA_AUTH = 'tests/e2e/.auth/superadmin.json';
 const PREVIEW_TENANT_ID = 'r2c_default';

--- a/tests/e2e/qa-irregular-3roles.spec.ts
+++ b/tests/e2e/qa-irregular-3roles.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { ADMIN_BASE_URL, API_BASE_URL } from './config';
 
 // QA irregular (異常系) sweep — 2026-07-17
 // 3ロールが「イレギュラーな動作」をした場合に、拒むべき操作が正しく拒まれるか / スコープが
@@ -12,8 +13,8 @@ import { test, expect } from '@playwright/test';
 //   Role C — beforeAll で TEST_SUPERADMIN_EMAIL/PASSWORD からログインし superadmin.json を再生成
 
 const E2E_ENABLED = process.env.E2E_ENABLED === '1' || !!process.env.CI;
-const API = 'https://api.r2c.biz';
-const ADMIN = 'https://admin.r2c.biz';
+const API = API_BASE_URL;
+const ADMIN = ADMIN_BASE_URL;
 const DEMO_BASE = `${API}/carnation-demo`;
 const USER_AUTH = 'tests/e2e/.auth/user.json';
 const SA_AUTH = 'tests/e2e/.auth/superadmin.json';

--- a/tests/e2e/qa-preview-scope-leak.spec.ts
+++ b/tests/e2e/qa-preview-scope-leak.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { ADMIN_BASE_URL } from './config';
 
 // 回帰検知用: super_admin の「クライアントビューで見る」プレビュー中に previewTenantId が
 // 正しく使われず、テナントスコープが壊れる/画面が空白になる不具合の恒久テスト群。
@@ -17,7 +18,7 @@ import { test, expect } from '@playwright/test';
 // 消えるため、各ページへは SPA 内リンククリックで遷移する（page.goto は使わない）。
 
 const E2E_ENABLED = process.env.E2E_ENABLED === '1' || !!process.env.CI;
-const ADMIN = 'https://admin.r2c.biz';
+const ADMIN = ADMIN_BASE_URL;
 const SA_AUTH = 'tests/e2e/.auth/superadmin.json';
 const PREVIEW_TENANT = 'carnation';
 const PREVIEW_TENANT_2 = 'lp-demo';

--- a/tests/e2e/responsive.spec.ts
+++ b/tests/e2e/responsive.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { ADMIN_BASE_URL } from './config';
 
 const E2E_ENABLED = process.env.E2E_ENABLED === '1' || !!process.env.CI;
 
@@ -10,7 +11,7 @@ test.describe('Responsive — 390px Mobile Viewport', () => {
   });
 
   test('admin.r2c.biz renders without horizontal overflow at 390px', async ({ page }) => {
-    await page.goto('https://admin.r2c.biz');
+    await page.goto(ADMIN_BASE_URL);
     await page.waitForLoadState('domcontentloaded');
 
     // ページ幅が viewport 幅を超えていないこと（横スクロールなし）
@@ -19,7 +20,7 @@ test.describe('Responsive — 390px Mobile Viewport', () => {
   });
 
   test('admin.r2c.biz critical elements visible at 390px', async ({ page }) => {
-    await page.goto('https://admin.r2c.biz');
+    await page.goto(ADMIN_BASE_URL);
     await page.waitForLoadState('domcontentloaded');
 
     // <main>, <nav>, <header> のいずれかが存在し、画面内に収まっていること
@@ -45,7 +46,7 @@ test.describe('Responsive — 390px Mobile Viewport', () => {
   });
 
   test('touch-target size: interactive elements at 390px (advisory)', async ({ page, browserName }) => {
-    await page.goto('https://admin.r2c.biz');
+    await page.goto(ADMIN_BASE_URL);
     await page.waitForLoadState('domcontentloaded');
 
     // ボタンが存在する場合、高さを計測してアノテーションとして記録

--- a/tests/e2e/superadmin.setup.ts
+++ b/tests/e2e/superadmin.setup.ts
@@ -1,6 +1,7 @@
 import { test as setup } from '@playwright/test';
 import fs from 'fs';
 import path from 'path';
+import { ADMIN_BASE_URL } from './config';
 
 // super_admin 用 storageState 生成（auth.setup.ts の client_admin 版と同方式）。
 // TEST_SUPERADMIN_EMAIL / TEST_SUPERADMIN_PASSWORD が無い場合は空スケルトンを書き、
@@ -19,7 +20,7 @@ setup('authenticate super_admin', async ({ page }) => {
     return;
   }
 
-  await page.goto('https://admin.r2c.biz', { waitUntil: 'domcontentloaded' });
+  await page.goto(ADMIN_BASE_URL, { waitUntil: 'domcontentloaded' });
   await page.waitForTimeout(2000);
   await page.locator('input[type="email"]').waitFor({ timeout: 15000 });
   await page.fill('input[type="email"]', email);

--- a/tests/e2e/visual-regression.spec.ts
+++ b/tests/e2e/visual-regression.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { ADMIN_BASE_URL, API_BASE_URL } from './config';
 
 // Phase C: ビジュアルリグレッションテスト
 // storageState (auth.setup.ts) で認証済み状態で実行される
@@ -12,7 +13,7 @@ test.describe('Visual Regression — Admin UI', () => {
 
   test.beforeEach(async ({ page }) => {
     // storageStateが空（認証情報なし）の場合はスキップ
-    await page.goto('https://admin.r2c.biz');
+    await page.goto(ADMIN_BASE_URL);
     if (page.url().includes('/login')) {
       test.skip();
     }
@@ -20,7 +21,7 @@ test.describe('Visual Regression — Admin UI', () => {
 
   test('dashboard — desktop 1280x800', async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 });
-    await page.goto('https://admin.r2c.biz');
+    await page.goto(ADMIN_BASE_URL);
     await page.waitForLoadState('domcontentloaded');
     await page.waitForTimeout(2000);
     // 動的な要素（時刻・通知バッジ）をマスクして差分を安定化
@@ -37,7 +38,7 @@ test.describe('Visual Regression — Admin UI', () => {
 
   test('dashboard — mobile 390x844', async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
-    await page.goto('https://admin.r2c.biz');
+    await page.goto(ADMIN_BASE_URL);
     await page.waitForLoadState('domcontentloaded');
     await page.waitForTimeout(2000);
     await expect(page).toHaveScreenshot('dashboard-mobile-390.png', {
@@ -53,7 +54,7 @@ test.describe('Visual Regression — Admin UI', () => {
   test('sessions list — desktop 1280x800', async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 });
     // セッション一覧ページ（AI提案ルール含む）
-    await page.goto('https://admin.r2c.biz/admin/sessions');
+    await page.goto(`${ADMIN_BASE_URL}/admin/sessions`);
     await page.waitForLoadState('domcontentloaded');
     await page.waitForTimeout(2000);
     await expect(page).toHaveScreenshot('sessions-desktop.png', {
@@ -73,7 +74,7 @@ test.describe('Visual Regression — Public Pages', () => {
 
   test('carnation-demo index — desktop', async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 });
-    await page.goto('https://api.r2c.biz/carnation-demo/index.html');
+    await page.goto(`${API_BASE_URL}/carnation-demo/index.html`);
     await page.waitForLoadState('networkidle');
     // widget初期化を待つ
     await page.waitForTimeout(2000);
@@ -84,7 +85,7 @@ test.describe('Visual Regression — Public Pages', () => {
 
   test('carnation-demo index — mobile 390px', async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
-    await page.goto('https://api.r2c.biz/carnation-demo/index.html');
+    await page.goto(`${API_BASE_URL}/carnation-demo/index.html`);
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(2000);
     await expect(page).toHaveScreenshot('carnation-demo-mobile-390.png', {

--- a/tests/e2e/widget-animated-avatar-demo.spec.ts
+++ b/tests/e2e/widget-animated-avatar-demo.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { gotoWithRetry } from './helpers/gotoRetry';
+import { API_BASE_URL } from './config';
 
 const E2E_ENABLED = process.env.E2E_ENABLED === '1' || !!process.env.CI;
 
@@ -23,7 +24,7 @@ const E2E_ENABLED = process.env.E2E_ENABLED === '1' || !!process.env.CI;
 test.describe('LPデモウィジェット — アニメアバター/定型応答のコスト制御', () => {
   test.skip(!E2E_ENABLED, 'E2E tests require E2E_ENABLED=1 or CI=true');
 
-  const LP_URL = 'https://api.r2c.biz/lp/';
+  const LP_URL = `${API_BASE_URL}/lp/`;
 
   async function waitForFab(page: import('@playwright/test').Page) {
     await page.waitForFunction(

--- a/tests/e2e/widget-fab-avatar.spec.ts
+++ b/tests/e2e/widget-fab-avatar.spec.ts
@@ -1,4 +1,5 @@
 import { test, expect } from '@playwright/test';
+import { API_BASE_URL } from './config';
 
 const E2E_ENABLED = process.env.E2E_ENABLED === '1' || !!process.env.CI;
 
@@ -15,7 +16,7 @@ test.describe('Widget FAB — Avatar persistence on chat open/close', () => {
 
   // アバター設定済みテナントのデモページ (test 1/2 が使用)
   const AVATAR_DEMO_URL =
-    process.env.E2E_CHAT_TEST_URL || 'https://api.r2c.biz/carnation-demo/index.html';
+    process.env.E2E_CHAT_TEST_URL || `${API_BASE_URL}/carnation-demo/index.html`;
   // 非アバターテナントのページ (test 3 が使用)。CI で実 URL を注入すると非アバター経路を実検証できる。
   // 未指定時はアバター版にフォールバック → test 3 は従来どおり skip される（誤検証を防ぐ）。
   const NON_AVATAR_DEMO_URL = process.env.E2E_NON_AVATAR_TEST_URL || AVATAR_DEMO_URL;

--- a/tests/e2e/widget-mobile.spec.ts
+++ b/tests/e2e/widget-mobile.spec.ts
@@ -1,8 +1,9 @@
 import { test, expect } from '@playwright/test';
 import { gotoWithRetry } from './helpers/gotoRetry';
+import { API_BASE_URL } from './config';
 
 const E2E_ENABLED = process.env.E2E_ENABLED === '1' || !!process.env.CI;
-const DEMO_URL = 'https://api.r2c.biz/carnation-demo/index.html';
+const DEMO_URL = `${API_BASE_URL}/carnation-demo/index.html`;
 
 test.describe('Widget — Mobile iPhone 12 (390px) M1-M4', () => {
   test.skip(!E2E_ENABLED, 'E2E tests require E2E_ENABLED=1 or CI=true');

--- a/tests/e2e/widget.spec.ts
+++ b/tests/e2e/widget.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { gotoWithRetry } from './helpers/gotoRetry';
+import { API_BASE_URL } from './config';
 
 const E2E_ENABLED = process.env.E2E_ENABLED === '1' || !!process.env.CI;
 
@@ -10,7 +11,7 @@ test.describe('Chat Widget — Rendering', () => {
     const errors: string[] = [];
     page.on('pageerror', (err) => errors.push(err.message));
 
-    const response = await gotoWithRetry(page, 'https://api.r2c.biz/carnation-demo/index.html');
+    const response = await gotoWithRetry(page, `${API_BASE_URL}/carnation-demo/index.html`);
 
     // ページ自体は 200 で返る
     expect(response?.status()).toBe(200);
@@ -23,7 +24,7 @@ test.describe('Chat Widget — Rendering', () => {
   });
 
   test('widget.js script tag is present in demo page', async ({ page }) => {
-    await gotoWithRetry(page, 'https://api.r2c.biz/carnation-demo/index.html');
+    await gotoWithRetry(page, `${API_BASE_URL}/carnation-demo/index.html`);
 
     // widget.js の <script> タグが埋め込まれていること
     const widgetScript = page.locator('script[src*="widget.js"]');
@@ -31,7 +32,7 @@ test.describe('Chat Widget — Rendering', () => {
   });
 
   test('widget container or chat button appears in DOM', async ({ page }) => {
-    await gotoWithRetry(page, 'https://api.r2c.biz/carnation-demo/index.html');
+    await gotoWithRetry(page, `${API_BASE_URL}/carnation-demo/index.html`);
 
     // Shadow DOM ホスト要素またはウィジェットコンテナが存在すること
     // widget.js が生成する要素を確認（data-api-key 属性付き script の後に挿入される）


### PR DESCRIPTION
## Summary
- `tests/e2e/config.ts` を新設し、`ADMIN_BASE_URL` / `API_BASE_URL` を `E2E_BASE_URL` / `E2E_API_URL` (未設定時は現行の本番URL) から解決するようにした。
- `playwright.config.ts` を含む16件のE2E spec/setupファイルが `https://admin.r2c.biz` / `https://api.r2c.biz` を直接ハードコードしていた箇所を、すべてこの共通定数経由に置き換えた。
- コメント内で本番ドメインに言及している箇所（デプロイ状況の説明など）はコードではないため変更していない。

## 背景
super_admin E2Eテスト用アカウントのSecrets登録を進める過程で、`E2E_BASE_URL`/`E2E_API_URL` が実際には `playwright.config.ts` の1箇所でしか消費されておらず、将来ステージング環境(Asana 1217045569747485、人間作業主導で構築予定)へE2Eの向き先を切り替える手段が事実上存在しないことが判明した。今回はその前提を作るための純粋なリファクタで、env未設定時は現行と同じ本番URLがデフォルトになるため、今日時点の挙動・CI結果に変化はない。

## Test plan
- [x] `npx tsc --noEmit` — エラーなし
- [x] `npx oxlint tests/e2e` — warning 2件のみ、いずれも本PRの変更行とは無関係の既存警告(未使用変数)であることを diff で確認済み
- [x] `E2E_ENABLED=1 npx playwright test --list` — 17ファイル103テストが正しく列挙されることを確認(インポートエラーなし)
- [x] `bash SCRIPTS/security-scan.sh` — PASS
- [ ] CI上のE2E実行(本番URLへの実リクエストが従来通り成功することの最終確認)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NgWB82fsx7LMjhJqpd1rCx