### PR TITLE
fix: セッション削除時に、記録済みの成果を監査ログへ残す

### DIFF
--- a/src/api/admin/chat-history/deleteSession.test.ts
+++ b/src/api/admin/chat-history/deleteSession.test.ts
@@ -757,4 +757,85 @@ describe("deleteSessionRepository: lock_timeout / ROLLBACK 整合性", () => {
     expect(rollbackCalls).toHaveLength(1);
     expect(mockRelease).toHaveBeenCalledTimes(1);
   });
+
+  // ── 削除時に失われる成果(outcome)の監査記録 ─────────────────────────────
+  // outcome は独立テーブルではなく chat_sessions の列のため、行の削除と同時に
+  // 失われる。agent の record_session_outcome と delete_chat_session を同一ターンで
+  // 実行すると、記録した直後に無音で消える経路が実在する。削除の監査ログに
+  // 残しておかないと、後から「何が記録されていたか」を追う手段が無くなる。
+  function seedSuccessfulDelete(sessionRow: Record<string, unknown>) {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // BEGIN
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // SET LOCAL lock_timeout
+      .mockResolvedValueOnce({ rows: [sessionRow], rowCount: 1 }) // SELECT FOR UPDATE
+      .mockResolvedValueOnce({ rows: [{ cnt: "3" }], rowCount: 1 }) // COUNT messages
+      .mockResolvedValueOnce({ rows: [{ cnt: "0" }], rowCount: 1 }) // COUNT orders
+      .mockResolvedValueOnce({ rows: [{ id: "sess-uuid-1" }], rowCount: 1 }) // DELETE RETURNING
+      .mockResolvedValue({ rows: [], rowCount: 0 }); // INSERT audit_logs / COMMIT
+  }
+
+  function auditMetadata(): Record<string, unknown> {
+    const insertCall = mockQuery.mock.calls.find(
+      (c) => typeof c[0] === "string" && (c[0] as string).includes("INSERT INTO audit_logs"),
+    );
+    expect(insertCall).toBeTruthy();
+    // metadata は INSERT の7番目のパラメータ（JSON文字列）
+    return JSON.parse((insertCall![1] as unknown[])[6] as string) as Record<string, unknown>;
+  }
+
+  it("成果が記録済みのセッションを削除すると、その値が監査ログに残る", async () => {
+    seedSuccessfulDelete({
+      id: "sess-uuid-1",
+      tenant_id: "tenant-a",
+      outcome: "購入完了",
+      outcome_recorded_at: "2026-07-31T10:00:00Z",
+    });
+
+    await realDeleteSession(BASE_PARAMS);
+
+    expect(auditMetadata()).toEqual(
+      expect.objectContaining({
+        deleted_outcome: { outcome: "購入完了", recorded_at: "2026-07-31T10:00:00Z" },
+      }),
+    );
+  });
+
+  it("成果が未記録(null)なら監査ログに余計なフィールドを足さない", async () => {
+    seedSuccessfulDelete({
+      id: "sess-uuid-1",
+      tenant_id: "tenant-a",
+      outcome: null,
+      outcome_recorded_at: null,
+    });
+
+    await realDeleteSession(BASE_PARAMS);
+
+    const metadata = auditMetadata();
+    expect(metadata).not.toHaveProperty("deleted_outcome");
+    // 既存の形(reason + affected_counts)が変わっていないこと
+    expect(metadata).toEqual({
+      reason: "test reason here",
+      affected_counts: { chat_messages: 3, option_orders_nulled: 0 },
+    });
+  });
+
+  it.each([
+    ["tenant スコープ", { kind: "tenant" as const, tenantId: "tenant-a" }],
+    ["global スコープ", { kind: "global" as const }],
+  ])("%s の SELECT でも outcome を読む(super_admin経路の取りこぼし防止)", async (_label, scope) => {
+    seedSuccessfulDelete({
+      id: "sess-uuid-1",
+      tenant_id: "tenant-a",
+      outcome: "離脱",
+      outcome_recorded_at: "2026-07-31T10:00:00Z",
+    });
+
+    await realDeleteSession({ ...BASE_PARAMS, scope });
+
+    const selectCall = mockQuery.mock.calls.find(
+      (c) => typeof c[0] === "string" && (c[0] as string).includes("FOR UPDATE"),
+    );
+    expect(selectCall![0] as string).toContain("outcome");
+    expect(auditMetadata()).toHaveProperty("deleted_outcome");
+  });
 });

--- a/src/api/admin/chat-history/deleteSessionRepository.ts
+++ b/src/api/admin/chat-history/deleteSessionRepository.ts
@@ -48,10 +48,19 @@ export async function deleteSession(
     // FOR UPDATE で並行削除との競合を防ぐ
     const scope = params.scope;
     const isTenantScoped = scope.kind === "tenant";
-    const sessionResult = await client.query<{ id: string; tenant_id: string }>(
+    // outcome も併せて読むのは、削除後に「この会話にどんな成果が記録されていたか」を
+    // 追跡する手段が他に無いため。outcome は独立テーブルではなく chat_sessions の列で、
+    // 行の削除と同時に失われる(agent の record_session_outcome と delete_chat_session を
+    // 同一ターンで実行すると、記録直後に無音で消える経路が実在する)。
+    const sessionResult = await client.query<{
+      id: string;
+      tenant_id: string;
+      outcome: string | null;
+      outcome_recorded_at: string | null;
+    }>(
       isTenantScoped
-        ? `SELECT id, tenant_id FROM chat_sessions WHERE id = $1 AND tenant_id = $2 FOR UPDATE`
-        : `SELECT id, tenant_id FROM chat_sessions WHERE id = $1 FOR UPDATE`,
+        ? `SELECT id, tenant_id, outcome, outcome_recorded_at FROM chat_sessions WHERE id = $1 AND tenant_id = $2 FOR UPDATE`
+        : `SELECT id, tenant_id, outcome, outcome_recorded_at FROM chat_sessions WHERE id = $1 FOR UPDATE`,
       isTenantScoped && scope.kind === "tenant"
         ? [params.sessionDbId, scope.tenantId]
         : [params.sessionDbId],
@@ -100,12 +109,22 @@ export async function deleteSession(
     }
 
     // 5. audit_logs 記録（削除成功が証明された後のみ）
+    // 成果が記録済みだった場合のみ deleted_outcome を足す。未記録(null)のときに
+    // 空のフィールドを増やすと、既存の監査ログとの差分が読みにくくなるため付けない。
     const metadata = {
       reason: params.reason,
       affected_counts: {
         chat_messages: msgCount,
         option_orders_nulled: orderCount,
       },
+      ...(session.outcome
+        ? {
+            deleted_outcome: {
+              outcome: session.outcome,
+              recorded_at: session.outcome_recorded_at,
+            },
+          }
+        : {}),
     };
 
     await client.query(


### PR DESCRIPTION
Asana: 1217045596409179

## Summary
`outcome` / `outcome_recorded_at` は独立テーブルではなく `chat_sessions` の列のため、行の削除と同時に失われる。

agent の `record_session_outcome` と `delete_chat_session` を同一ターンで実行した場合（ユーザーが「成果を記録して、それと削除して」と一度に同意すると Groq が同一hopで両方の tool_calls を返しうる）、記録した直後に無音で消える。削除の監査ログには `reason` と `affected_counts` しか残らず、SELECT も `id, tenant_id` しか読んでいなかったため、**後から何が記録されていたかを追う手段が無かった**。

## 実装

行ロック用の既存 SELECT に `outcome, outcome_recorded_at` を追加（新しいクエリは書かない）。記録済みだった場合のみ監査メタデータに `deleted_outcome` として残す。未記録（null）のときは既存のメタデータ形のままにして、無意味なフィールドを増やさない。

tenant スコープと global スコープ（super_admin経路）の**両方**の SELECT を対象にし、片方だけ直す取りこぼしをテストで固定した。

## 同一ターン連鎖のブロックは実装していません（意図的）

「成果を記録してから削除する」は正当な操作であり、ブロックは製品挙動として疑問がある。実害は消えた成果が追跡不能になることなので、**止めるのではなく記録する**方が正しい対処と判断した。この判断はAsanaタスクにも明記済み。

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx oxlint src admin-ui/src --max-warnings 63`
- [x] `src/api/admin/chat-history` 配下 64件通過（新規4件含む）
- [x] 既存の監査ログ・ROLLBACK整合性テストが1件も壊れていない

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UpYM4tvAGHfu4vc9NQqPfY