### PR TITLE
fix(admin-ui): 会話一覧の成果バッジを既存の意匠規約に揃え、テストの欠落フィールドを補完する

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -546,7 +546,7 @@ describe("CopilotPreviewPage — 構造化カード(card)からの描画", () =>
           card: {
             kind: "chat_session_list",
             total: 1,
-            sessions: [{ shortId: "sess-aaa", startedAt: "2026-07-17T10:00:00Z", messageCount: 4, preview: "送料はいくらですか" }],
+            sessions: [{ shortId: "sess-aaa", startedAt: "2026-07-17T10:00:00Z", messageCount: 4, preview: "送料はいくらですか", outcome: null }],
           },
         },
       ],
@@ -608,7 +608,7 @@ describe("CopilotPreviewPage — 構造化カード(card)からの描画", () =>
               card: {
                 kind: "chat_session_list",
                 total: 1,
-                sessions: [{ shortId: "sess-aaa", startedAt: "2026-07-17T10:00:00Z", messageCount: 4, preview: "送料はいくらですか" }],
+                sessions: [{ shortId: "sess-aaa", startedAt: "2026-07-17T10:00:00Z", messageCount: 4, preview: "送料はいくらですか", outcome: null }],
               },
             },
           ],

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -2264,7 +2264,7 @@ function CardView({
               <div style={{ fontSize: 12.5, color: "var(--muted-foreground)" }}>
                 {s.startedAt.slice(0, 10)} ・ {s.messageCount}件
                 {s.outcome && (
-                  <span style={{ marginLeft: 8, padding: "1px 8px", borderRadius: 999, fontSize: 11.5, fontWeight: 600, background: "rgba(34,197,94,0.15)", color: "#16a34a" }}>
+                  <span style={{ marginLeft: 8, padding: "1px 8px", borderRadius: 999, fontSize: 12.5, fontWeight: 600, background: "rgba(34,197,94,0.15)", border: "1px solid rgba(34,197,94,0.3)", color: "#16a34a" }}>
                     {s.outcome}
                   </span>
                 )}


### PR DESCRIPTION
Asana: 1217045576183929

## Summary

### 1. バッジ意匠の一点物化を解消
成果バッジは**色は既存の「成功」配色と一致**していた（`rgba(34,197,94,*)` / `#16a34a`、他に3箇所で使用）が、構造が一点物だった:

- ファイル内の他の全てのピル型バッジ（`RailCountBadge`、評価軸バッジ）は半透明背景に対応する `border` を必ず持つのに、これだけ `border` が無い
- `fontSize` が 11.5 で、バッジ群（12.5〜14.5）の中で最小

`border` を追加し `fontSize` を 12.5 に揃えた。**色は変更していない**（既存の成功配色で正しいため）。新しい見た目を発明せず、既存規約への機械的整合のみ。

### 2. テストフィクスチャの `outcome` 欠落を補完
`chat_session_list` フィクスチャ3箇所のうち2箇所が `outcome` キー自体を持っていなかった。`mockAgent` の引数が `unknown` 型のため型検査で検出されず、実行時は `undefined` → falsy でバッジが出ないだけで静かに通っていた。

`mockAgent` の型を締める案は採っていない（一部のテストが意図的に不完全なカードを渡してフォールバック挙動を検証しており、`unknown` は意図的な緩さのため）。

## Test plan
- [x] `npx tsc --noEmit`（admin-ui）
- [x] `npx oxlint admin-ui/src --max-warnings 63`
- [x] `index.test.tsx` フルファイル 142件通過
- [x] **全21 describe を `-t` で単独実行し全通過**（このファイルは過去に単独実行不可のレース問題があったため）
- [x] `vite build` 成功

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UpYM4tvAGHfu4vc9NQqPfY