### PR TITLE
feat(admin-ui): 新規テナントが旧UIに行かずに指示ルールを完結できるようにする(P6-1)

### DIFF
--- a/admin-ui/src/lib/tuningRuleIntro.test.ts
+++ b/admin-ui/src/lib/tuningRuleIntro.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { hasShownTuningRuleIntro, markTuningRuleIntroShown } from "./tuningRuleIntro";
+
+// このプロジェクトのvitest環境(happy-dom)は window.localStorage を提供しないため、
+// テスト用に最小限のMap実装で補う(chatFirstDefault.test.tsと同じパターン)。
+function installFakeLocalStorage() {
+  const store = new Map<string, string>();
+  const fakeStorage = {
+    getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+    setItem: (k: string, v: string) => void store.set(k, v),
+    removeItem: (k: string) => void store.delete(k),
+    clear: () => void store.clear(),
+  };
+  Object.defineProperty(window, "localStorage", { value: fakeStorage, configurable: true });
+}
+
+describe("tuningRuleIntro (P6-1: 新規テナントの指示ルール初回紹介、1回きりフラグ)", () => {
+  beforeEach(() => {
+    installFakeLocalStorage();
+  });
+
+  it("既定(未設定)では未紹介", () => {
+    expect(hasShownTuningRuleIntro("tenant-a")).toBe(false);
+  });
+
+  it("markTuningRuleIntroShown 後は紹介済みになる", () => {
+    markTuningRuleIntroShown("tenant-a");
+    expect(hasShownTuningRuleIntro("tenant-a")).toBe(true);
+  });
+
+  it("テナント単位で分かれる(片方だけ紹介済みでも他方には影響しない)", () => {
+    markTuningRuleIntroShown("tenant-a");
+    expect(hasShownTuningRuleIntro("tenant-a")).toBe(true);
+    expect(hasShownTuningRuleIntro("tenant-b")).toBe(false);
+  });
+
+  it("localStorageが例外を投げても(プライベートブラウズ等)静かにfalseへフォールバックする", () => {
+    Object.defineProperty(window, "localStorage", {
+      value: {
+        getItem: () => {
+          throw new Error("private mode");
+        },
+        setItem: () => {
+          throw new Error("private mode");
+        },
+      },
+      configurable: true,
+    });
+
+    expect(hasShownTuningRuleIntro("tenant-a")).toBe(false);
+    expect(() => markTuningRuleIntroShown("tenant-a")).not.toThrow();
+  });
+});

--- a/admin-ui/src/lib/tuningRuleIntro.ts
+++ b/admin-ui/src/lib/tuningRuleIntro.ts
@@ -1,0 +1,24 @@
+// admin-ui/src/lib/tuningRuleIntro.ts
+// P6-1: 新規テナントが4段階のオンボーディングを完了した直後、指示ルールの存在に
+// 気づけるよう一度だけ紹介する。backend の onboardingStage.ts(単一の情報源)は
+// 変更せず、admin-ui 側のブラウザ単位フラグだけで「1回きり」を保証する軽量な接続。
+// テナント単位で分ける(super_adminが複数テナントをプレビューしても混ざらないように)。
+
+const KEY_PREFIX = "r2c_tuning_rule_intro_shown_";
+
+export function hasShownTuningRuleIntro(tenantId: string): boolean {
+  try {
+    return typeof window !== "undefined" && window.localStorage.getItem(KEY_PREFIX + tenantId) === "true";
+  } catch {
+    return false;
+  }
+}
+
+export function markTuningRuleIntroShown(tenantId: string): void {
+  try {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(KEY_PREFIX + tenantId, "true");
+  } catch {
+    // localStorage無効環境(プライベートブラウズ等)では静かに無視(次回また出るだけで実害は無い)
+  }
+}

--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -1272,6 +1272,33 @@ describe("CopilotPreviewPage — 構造化カード(card)からの描画", () =>
     expect(screen.queryByText("優先度")).toBeNull();
   });
 
+  // P6-1: 新規テナントが最初にこのカードを開いた時、技術的な「0件」表示にせず
+  // 何ができるか+最初の一手を示す。
+  it("P6-1: get_tuning_rules: 0件の場合は空表示ではなく説明と「最初のルールを作ってみる」ボタンが出る", async () => {
+    mockAgent({
+      reply: "まだ指示ルールはありません。",
+      actions: [
+        {
+          tool: "get_tuning_rules",
+          result: "指示ルールはまだありません。",
+          card: { kind: "tuning_rules_list", totalCount: 0, rules: [] },
+        },
+      ],
+    });
+
+    await send("指示ルールの状況を教えて");
+
+    expect(await screen.findByText(/AIチャットボットの受け答えを1つずつ細かく調整できます/)).toBeTruthy();
+    const chip = screen.getByRole("button", { name: "🎛️ 最初のルールを作ってみる" });
+    expect(chip).toBeTruthy();
+
+    fireEvent.click(chip);
+
+    await waitFor(() =>
+      expect(screen.getByText("指示ルールを初めて作ります。何をどう伝えればいいか教えてください")).toBeTruthy(),
+    );
+  });
+
   // P4-1: AI提案ルールの承認/却下と根拠提示
   it("get_tuning_rules: AI提案(未承認)には出所バッジと承認/却下ボタン、根拠が表示される", async () => {
     mockAgent({
@@ -2702,6 +2729,97 @@ describe("CopilotPreviewPage — 会話の復元(sessionStorage)", () => {
       { role: "user", content: "営業時間を教えて" },
       { role: "assistant", content: "今週も順調です。" },
     ]);
+  });
+});
+
+// P6-1: 4段階のオンボーディングが全て完了した直後、指示ルールの初回体験へ
+// 一度だけ接続する軽量な導線(admin-ui内のlocalStorageフラグのみ。backendの
+// onboardingStage.tsは変更しない)。
+describe("CopilotPreviewPage — 指示ルールの初回紹介(P6-1)", () => {
+  const ALL_STAGES_COMPLETE = {
+    industryAnswered: true,
+    knowledgePublished: true,
+    widgetInstalled: true,
+    firstConversation: true,
+  };
+
+  // happy-dom は window.localStorage を提供しないため、Mapベースの最小実装で補う
+  // (chat_first_toggle のテストと同じパターン)。
+  function installFakeLocalStorage() {
+    const store = new Map<string, string>();
+    Object.defineProperty(window, "localStorage", {
+      configurable: true,
+      value: {
+        getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+        setItem: (k: string, v: string) => void store.set(k, v),
+        removeItem: (k: string) => void store.delete(k),
+        clear: () => void store.clear(),
+      },
+    });
+  }
+
+  beforeEach(() => {
+    installFakeLocalStorage();
+    vi.mocked(authFetch).mockReset();
+    mockNavigate.mockReset();
+    vi.mocked(restoreChatSession).mockReturnValue(null);
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (isBadgeUrl(url)) return mockEmptyBadges();
+      if (String(url).includes("/v1/admin/my-tenant")) {
+        return mockOk({ onboarding_stage: ALL_STAGES_COMPLETE });
+      }
+      return mockOk({ reply: "今週も順調です。", actions: [] });
+    });
+  });
+
+  it("4段階完了・未紹介・新規起動(復元なし) → 週次ブリーフィングの代わりに紹介メッセージが一度出る", async () => {
+    renderPage();
+
+    expect(await screen.findByText(/最初のルールを作ってみますか/)).toBeTruthy();
+    expect(screen.getByText("🎛️ 作ってみる")).toBeTruthy();
+    expect(screen.getByText("あとで")).toBeTruthy();
+    // 通常の週次ブリーフィングには進まない(このターンでは agent/chat を呼ばない)
+    const urls = vi.mocked(authFetch).mock.calls.map((c) => String(c[0]));
+    expect(urls.some((u) => u.includes("/v1/admin/agent/chat"))).toBe(false);
+    expect(window.localStorage.getItem("r2c_tuning_rule_intro_shown_tenant-a")).toBe("true");
+  });
+
+  it("「🎛️ 作ってみる」を押すと、指示ルール作成を依頼する自然文が実送信される", async () => {
+    renderPage();
+    const chip = await screen.findByRole("button", { name: "🎛️ 作ってみる" });
+
+    fireEvent.click(chip);
+
+    await waitFor(() =>
+      expect(screen.getByText("指示ルールを初めて作ります。何をどう伝えればいいか教えてください")).toBeTruthy(),
+    );
+  });
+
+  it("既に紹介済み(localStorageフラグあり) → 紹介メッセージは出ず、通常どおり週次ブリーフィングが走る", async () => {
+    window.localStorage.setItem("r2c_tuning_rule_intro_shown_tenant-a", "true");
+
+    renderPage();
+
+    expect(await screen.findByText("今週も順調です。")).toBeTruthy();
+    expect(screen.queryByText(/最初のルールを作ってみますか/)).toBeNull();
+  });
+
+  it("previewMode中のsuper_adminは対象テナントごとにフラグが分かれる", async () => {
+    // previewMode中はmy-tenantではなく/v1/admin/tenants/:idでオンボーディング判定する
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (isBadgeUrl(url)) return mockEmptyBadges();
+      if (String(url).includes("/v1/admin/tenants/tenant-preview")) {
+        return mockOk({ onboarding_stage: ALL_STAGES_COMPLETE });
+      }
+      return mockOk({ reply: "今週も順調です。", actions: [] });
+    });
+
+    renderPage(SUPER_ADMIN_IN_PREVIEW);
+
+    expect(await screen.findByText(/最初のルールを作ってみますか/)).toBeTruthy();
+    expect(window.localStorage.getItem("r2c_tuning_rule_intro_shown_tenant-preview")).toBe("true");
+    // client_admin(tenant-a)側のフラグには影響しない
+    expect(window.localStorage.getItem("r2c_tuning_rule_intro_shown_tenant-a")).toBeNull();
   });
 });
 

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -21,6 +21,7 @@ import {
   saveChatSession,
 } from "../../lib/chatSessionStore";
 import { priorityToTier } from "../../lib/tuningPriority";
+import { hasShownTuningRuleIntro, markTuningRuleIntroShown } from "../../lib/tuningRuleIntro";
 import {
   AGENT_CHAT_AUTH_REQUIRED_MESSAGE,
   AGENT_CHAT_HISTORY_MAX_ENTRIES,
@@ -929,6 +930,23 @@ export default function CopilotPreviewPage() {
 
     if (nextStep) {
       push(say(nextStep.text, nextStep.chips));
+      return;
+    }
+
+    // P6-1: 新規テナントが指示ルールの存在に気づけるよう、4段階のオンボーディングが
+    // 全て完了した直後に一度だけ紹介する。backendのonboardingStage.ts(単一の情報源)は
+    // 変更せず、admin-ui内のブラウザ単位フラグ(tuningRuleIntro.ts)だけで
+    // 「1回きり」を保証する軽量な接続(既存テナント向けの移行導線は別途作らない — 4段階が
+    // 全て真になるのは実質的にこのオンボーディングフローを新規に通過したテナントのみ)。
+    if (stage && scopedTenantId && !hasShownTuningRuleIntro(scopedTenantId)) {
+      markTuningRuleIntroShown(scopedTenantId);
+      push(say(
+        "指示ルールも使えます。お客様への受け答えを1つずつAIチャットボットに教えられる機能です。最初のルールを作ってみますか？",
+        [
+          { label: "🎛️ 作ってみる", action: "__real:指示ルールを初めて作ります。何をどう伝えればいいか教えてください", tone: "primary" },
+          { label: "あとで", action: "__real:あとでにします", tone: "ghost" },
+        ],
+      ));
       return;
     }
 
@@ -2111,6 +2129,26 @@ function CardView({
         </CardShell>
       );
     case "rulesList":
+      // P6-1: 新規テナントが最初にこのカードを開いた時、0件をそのまま出すと
+      // 「技術的な空表示」になり何をすればいいか分からない。何ができるか(具体例)と
+      // 最初の一手(チップ)を添える。
+      if (card.totalCount === 0) {
+        return (
+          <CardShell hd={<><span>🎛️</span>指示ルールはまだありません</>}>
+            <div style={{ fontSize: 14.5, color: "var(--foreground)" }}>
+              指示ルールを使うと、「保証について聞かれたら2年とお伝えする」のように、AIチャットボットの受け答えを1つずつ細かく調整できます。
+            </div>
+            {onSendReal && (
+              <button
+                onClick={() => onSendReal("__real:指示ルールを初めて作ります。何をどう伝えればいいか教えてください")}
+                style={{ alignSelf: "flex-start", fontSize: 13.5, fontWeight: 700, padding: "9px 16px", borderRadius: 10, cursor: "pointer", border: "none", background: AGENT, color: "#fff", minHeight: 44 }}
+              >
+                🎛️ 最初のルールを作ってみる
+              </button>
+            )}
+          </CardShell>
+        );
+      }
       return (
         <CardShell hd={<><span>🎛️</span>指示ルール一覧（{card.totalCount}件）</>}>
           {card.rules.map((r) => {

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -535,7 +535,7 @@ export default function CopilotPreviewPage() {
   // super_adminがテナントプレビュー中の場合、対象テナントIDをtargetTenantIdとしてAPIに渡す
   // (他画面のescalations/knowledge-gaps等と同じパターン)。client_adminは自身のJWT由来の
   // tenantIdがサーバー側で使われるため、previewMode=falseのままで問題ない。
-  const { user, isSuperAdmin, previewMode, previewTenantId, enterPreview, logout } = useAuth();
+  const { user, isSuperAdmin, previewMode, previewTenantId, enterPreview, logout, isLoading: authLoading } = useAuth();
   const navigate = useNavigate();
   // super_adminがプレビューに入っていない場合、テナントが特定できないため
   // ほぼ全てのツールが「テナントが特定できません」になり会話が行き止まりになる。
@@ -971,6 +971,13 @@ export default function CopilotPreviewPage() {
     // 「テナントが特定できません」で埋まるだけのため）。選択してpreviewModeに
     // 入った時点でこのeffectが再評価され、通常どおりブリーフィングが走る。
     if (needsTenantSelection) return;
+    // P6-1で発見(既存の潜在バグ): /copilot-previewはRequireAuth外の隔離ルートのため、
+    // useAuth()のセッション確認(非同期)が終わる前に user=null のままこのeffectが
+    // 走ってしまうことがある。user未確定のままだとscopedTenantIdが空になり、
+    // オンボーディング段階(stage)判定そのものが飛ばされて通常の週次ブリーフィングに
+    // フォールバックしていた(既存の4段階次の一手が出ないことがある、同一の原因)。
+    // needsTenantSelectionと同じ理由でauth確認が終わるまで待つ。
+    if (authLoading) return;
     if (bootstrapped.current) return;
     bootstrapped.current = true;
 
@@ -989,7 +996,7 @@ export default function CopilotPreviewPage() {
       loadingText: "ログイン、お疲れさまです。今週の実データを確認しています…",
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [needsTenantSelection]);
+  }, [needsTenantSelection, authLoading]);
 
   // super_adminがプレビュー中に別テナントへenterPreviewする経路(AppSwitcher/テナント詳細の
   // 「クライアントビューで見る」等)を検知し、会話を初期化して新テナントの週次ブリーフィングを

--- a/tests/e2e/qa-copilot-preview.spec.ts
+++ b/tests/e2e/qa-copilot-preview.spec.ts
@@ -215,6 +215,90 @@ test.describe('copilot-preview — Role B (client_admin)', () => {
       const body = (await page.textContent('body')) ?? '';
       expect(body).not.toContain(NO_TENANT_MSG);
     });
+
+    // P6-1: 新規テナントが旧UI /admin/tuning に一度も行かずに、指示ルールの初回紹介 →
+    // 提案 → 保存 → 一覧確認まで /copilot-preview だけで完結できることの受け入れ確認。
+    // my-tenant(オンボーディング判定)とagent/chatをモックし、実LLM/実carnationデータの
+    // 書き換えに依存させない(CP-B-3のコメントと同じ理由)。
+    test('CP-B-4 (P6-1): 4段階完了直後の紹介から、旧UIに行かずに指示ルールを作成・確認できる', async ({ page }) => {
+      await page.route('**/v1/admin/my-tenant', (route) =>
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            onboarding_stage: { industryAnswered: true, knowledgePublished: true, widgetInstalled: true, firstConversation: true },
+          }),
+        }),
+      );
+      await page.route('**/v1/admin/agent/chat', async (route) => {
+        const body = JSON.parse(route.request().postData() || '{}') as { message?: string };
+        if (body.message?.includes('指示ルールを初めて作ります')) {
+          return route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              reply: '提案:\nトリガー: 保証\n対応方針: 保証期間は2年とお伝えする\n優先度: 5\nこの内容でよいか確認し、同意が得られたら保存します。',
+              actions: [{
+                tool: 'suggest_tuning_rule',
+                result: '提案:\nトリガー: 保証\n対応方針: 保証期間は2年とお伝えする\n優先度: 5',
+                card: { kind: 'tuning_rule_draft', triggerPattern: '保証', expectedBehavior: '保証期間は2年とお伝えする', priority: 5 },
+              }],
+            }),
+          });
+        }
+        if (body.message === '保存してください') {
+          return route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              reply: '保存しました。',
+              actions: [{ tool: 'save_tuning_rule', result: '指示ルールを保存しました（ID: 999）: 「保証」→ 保証期間は2年とお伝えする' }],
+            }),
+          });
+        }
+        if (body.message === '指示ルールの状況を教えて') {
+          return route.fulfill({
+            status: 200,
+            contentType: 'application/json',
+            body: JSON.stringify({
+              reply: '1件あります。',
+              actions: [{
+                tool: 'get_tuning_rules',
+                result: '指示ルール一覧（1件、うち有効1件・無効0件）です。',
+                card: {
+                  kind: 'tuning_rules_list',
+                  totalCount: 1,
+                  rules: [{ id: 999, triggerPattern: '保証', expectedBehavior: '保証期間は2年とお伝えする', priority: 5, isActive: true, source: 'manual', status: null, evidence: null }],
+                },
+              }],
+            }),
+          });
+        }
+        return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ reply: '了解しました。', actions: [] }) });
+      });
+
+      await page.goto(`${ADMIN}/copilot-preview`, { waitUntil: 'domcontentloaded', timeout: 20000 });
+
+      // 週次ブリーフィングの代わりに、指示ルールの初回紹介が出る
+      await expect(page.getByText(/最初のルールを作ってみますか/)).toBeVisible({ timeout: 15000 });
+      await page.getByRole('button', { name: '🎛️ 作ってみる' }).click();
+
+      // 提案 → 保存(チップ経由)
+      await expect(page.getByText('保証期間は2年とお伝えする')).toBeVisible({ timeout: 10000 });
+      await page.getByRole('button', { name: '保存して' }).click();
+      await expect(page.getByText('保存しました。', { exact: true })).toBeVisible({ timeout: 10000 });
+
+      // 一覧で作成したルールを確認できる(旧UI /admin/tuning への誘導は出ない)
+      const composer = page.getByPlaceholder(/指示ルール/);
+      const send = page.getByLabel('送信');
+      await composer.fill('指示ルールの状況を教えて');
+      await send.click();
+      await expect(page.getByText('指示ルール一覧（1件）', { exact: false })).toBeVisible({ timeout: 10000 });
+      expect((await page.textContent('body')) ?? '').not.toContain('/admin/tuning');
+
+      const bodyScrollWidth = await page.evaluate(() => document.body.scrollWidth);
+      expect(bodyScrollWidth).toBeLessThanOrEqual(400); // 10px tolerance
+    });
   });
 });
 

--- a/tests/e2e/qa-irregular-3roles.spec.ts
+++ b/tests/e2e/qa-irregular-3roles.spec.ts
@@ -305,6 +305,99 @@ test.describe('Irregular — Role B (client_admin RBAC/tenant boundary)', () => 
     expect(await page.getByRole('button', { name: '採用して' }).count()).toBe(0);
     expect(mock.countMessage('採用してください')).toBe(1);
   });
+
+  // P6-1: アバターと同じ理由(実LLM/実carnationデータの書き換えに依存させない)で
+  // suggest_tuning_rule/save_tuning_ruleをモックする。
+  async function mockTuningRuleFlowUpToDraft(page: any) {
+    let saveCalls = 0;
+    const sentMessages: string[] = [];
+    let bootstrapDone = false;
+    await page.route('**/v1/admin/agent/chat', async (route: any) => {
+      const body = JSON.parse(route.request().postData() || '{}') as { message?: string };
+      sentMessages.push(body.message ?? '');
+      if (!bootstrapDone) {
+        bootstrapDone = true;
+        return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ reply: '今週も順調です。', actions: [] }) });
+      }
+      if (body.message?.includes('保証について聞かれたら')) {
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            reply: 'こう提案します。保存してよいですか？',
+            actions: [{
+              tool: 'suggest_tuning_rule',
+              result: '提案:\nトリガー: 保証\n対応方針: 保証期間は2年とお伝えする\n優先度: 5',
+              card: { kind: 'tuning_rule_draft', triggerPattern: '保証', expectedBehavior: '保証期間は2年とお伝えする', priority: 5 },
+            }],
+          }),
+        });
+      }
+      if (body.message === '保存してください') {
+        saveCalls += 1;
+        return route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            reply: '保存しました。',
+            actions: [{ tool: 'save_tuning_rule', result: '指示ルールを保存しました（ID: 999）: 「保証」→ 保証期間は2年とお伝えする' }],
+          }),
+        });
+      }
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ reply: '了解しました。', actions: [] }) });
+    });
+    return { saveCallCount: () => saveCalls, sentMessages };
+  }
+
+  // GID: 指示ルールの下書き提案チップ(保存して/やめておく)を連打しても、二重保存されない
+  // (アバターの採用チップ連打(B-IRR-6)と同じ仕組み・同じ検証)。
+  test('B-IRR-7 (P6-1): 指示ルールの「保存して」チップを連打しても保存は1回しか実行されない', async ({ page }) => {
+    const mock = await mockTuningRuleFlowUpToDraft(page);
+
+    await page.goto(`${ADMIN}/copilot-preview`, { waitUntil: 'domcontentloaded', timeout: 20000 });
+    await page.waitForTimeout(2000);
+
+    const composer = page.getByPlaceholder(/指示ルール/);
+    const send = page.getByLabel('送信');
+    await composer.fill('保証について聞かれたら2年と答えて');
+    await send.click();
+    const saveChip = page.getByRole('button', { name: '保存して' });
+    await saveChip.waitFor({ timeout: 10000 });
+
+    // 連打(2回)。1回目のクリックでチップは使用済みになり消えるため、2回目は同じ要素に当たらない想定。
+    await saveChip.click();
+    await saveChip.click({ timeout: 1000 }).catch(() => {});
+
+    await expect(page.getByText('保存しました。', { exact: true })).toBeVisible({ timeout: 10000 });
+    expect(await page.getByRole('button', { name: '保存して' }).count()).toBe(0);
+    expect(mock.saveCallCount()).toBe(1);
+  });
+
+  // GID: 下書き(保存して/やめておくチップ提示中)にリロードしても、sessionStorage復元で
+  // 会話とチップが機能したまま続けられる(アバターの生成完了後リロード(B-IRR-5)と対の
+  // シナリオ: こちらは「まだ何も書き込まれていない下書き段階」でのリロード)。
+  test('B-IRR-8 (P6-1): 指示ルールの下書き提示中にリロードしても会話が復元し、保存を続けられる', async ({ page }) => {
+    const mock = await mockTuningRuleFlowUpToDraft(page);
+
+    await page.goto(`${ADMIN}/copilot-preview`, { waitUntil: 'domcontentloaded', timeout: 20000 });
+    await page.waitForTimeout(2000);
+
+    const composer = page.getByPlaceholder(/指示ルール/);
+    const send = page.getByLabel('送信');
+    await composer.fill('保証について聞かれたら2年と答えて');
+    await send.click();
+    await page.getByRole('button', { name: '保存して' }).waitFor({ timeout: 10000 });
+
+    // 会話保存(chatSessionStore)のデバウンス分の余裕を持って待つ(B-IRR-5と同じ理由)
+    await page.waitForTimeout(800);
+    await page.reload({ waitUntil: 'domcontentloaded', timeout: 20000 });
+    await page.waitForTimeout(1500);
+
+    await expect(page.getByRole('button', { name: '保存して' })).toBeVisible({ timeout: 10000 });
+    await page.getByRole('button', { name: '保存して' }).click();
+    await expect(page.getByText('保存しました。', { exact: true })).toBeVisible({ timeout: 10000 });
+    expect(mock.saveCallCount()).toBe(1);
+  });
 });
 
 // ───────────────────────────────────────────────────────────────────────────
@@ -392,6 +485,30 @@ test.describe('Irregular — Role C (super_admin cross-tenant & preview)', () =>
     const composer = page.getByPlaceholder(/指示ルール/);
     const send = page.getByLabel('送信');
     await composer.fill('アバターを有効化してください');
+    const chatResP = page.waitForResponse(
+      (res) => res.url().includes('/v1/admin/agent/chat') && res.request().method() === 'POST',
+      { timeout: 20000 },
+    );
+    await send.click();
+    await chatResP;
+    await page.waitForTimeout(1500);
+
+    const body = (await page.textContent('body')) ?? '';
+    expect(body).toContain('テナントが特定できません');
+  });
+
+  // P6-1: C-IRR-5(activate_avatar)と同型。suggest_tuning_rule/save_tuning_ruleも
+  // tenantId未解決の場合、Groq呼び出し・DB読み書きの手前で拒否される(実backendに安全に実行できる)。
+  test('C-IRR-6 (P6-1): super_adminがpreview未選択のまま指示ルールの作成・保存を指示すると拒否される', async ({ page }) => {
+    await page.goto(`${ADMIN}/copilot-preview`, { waitUntil: 'domcontentloaded', timeout: 20000 });
+    await page
+      .waitForResponse((res) => res.url().includes('/v1/admin/agent/chat') && res.request().method() === 'POST', { timeout: 20000 })
+      .catch(() => {});
+    await page.waitForTimeout(2000);
+
+    const composer = page.getByPlaceholder(/指示ルール/);
+    const send = page.getByLabel('送信');
+    await composer.fill('「保証について聞かれたら2年と答えて」という指示ルールを作って保存してください');
     const chatResP = page.waitForResponse(
       (res) => res.url().includes('/v1/admin/agent/chat') && res.request().method() === 'POST',
       { timeout: 20000 },


### PR DESCRIPTION
## Summary
- `/copilot-preview` の指示ルール一覧(0件)を、技術的な「0件」表示ではなく「何ができるか(具体例)+最初の一手」を示す空状態にした。
- 既存4段階オンボーディング(業種選択→FAQ公開→ウィジェット設置→初回会話)が全て完了した直後、指示ルールの存在に気づけるよう一度だけ紹介する導線を追加(admin-ui内のブラウザ単位localStorageフラグのみで「1回きり」を保証、backendのonboardingStage.tsは変更しない軽量な接続)。
- `get_legacy_ui_link`のtuning案内ゲート(タスク当初案の項目3)は、grepで確認した結果 `'tuning'` というfeatureキー自体がすでに存在しない(チャット完結化に伴い過去に撤去済み)ため対応不要と判明。コード変更なし。

## 設計判断
オンボーディング接続の実装深さ(admin-uiのみの軽量ローカルフラグ vs backendのonboardingStage.tsに5段階目を追加する本格版)はユーザーに確認し、軽量版を選択(既存の共有onboarding機構への変更を避け、他レーンの実装済み4段階システムに影響を与えないため)。

## 既知のCI失敗(E2E) — マージ前に必ずお読みください
`CP-B-4 (P6-1)` はこのリポジトリのE2Eがステージング無しで本番(`admin.r2c.biz`)を直接叩く方式のため、**このPRのコードが本番に反映されるまで構造的に必ず失敗します**(P5-1/P5-2は同一PR内に新機能のE2Eを含めなかったためこの問題を踏んでいませんでした)。
- Gate 1(typecheck+lint+test)/ Gate 3(admin-ui build)/ security-scan / gitleaks: PASS
- E2E: `CP-B-4` のみ FAIL(未デプロイのため紹介メッセージが出ない。ローカルで実際に本番へ向けて再現・原因確認済み)
- イレギュラー操作3件(`B-IRR-7`/`B-IRR-8`/`C-IRR-6`)は既存の指示ルール機能を検証するだけなので影響を受けずPASS

対応方針はユーザーと相談の上、CP-B-4を残したまま手動マージし、マージ・デプロイ後に`gh pr checks`またはワークフロー再実行で再検証する方針に決定。

## 副次的な発見・修正(このPRに含む)
E2Eでの再現調査中、`/copilot-preview`(RequireAuth外の隔離ルート)で`useAuth()`の非同期セッション確認(`isLoading`)が終わる前に起動時ブリーフィングのeffectが走り、`user`未確定のまま`scopedTenantId`が空になってオンボーディング段階(stage)判定そのものが飛ばされる既存のレース条件を発見・修正した。これは既存の4段階「次の一手」・本PRの指示ルール初回紹介の両方に影響する(`needsTenantSelection`と同じ理由で`isLoading`完了まで待つよう修正)。

## Test plan
- [x] `npx tsc --noEmit -p .` / `npx tsc -b`(admin-ui) いずれもエラー無し
- [x] 新規: `admin-ui/src/lib/tuningRuleIntro.ts` + `.test.ts`(1回きりフラグ、テナント単位分離、localStorage例外時のfail-safe)
- [x] `copilot-preview/index.test.tsx` に追加:
  - 0件時の空状態(説明文+「🎛️ 最初のルールを作ってみる」ボタン、送信内容)
  - 4段階完了直後の紹介メッセージ(週次ブリーフィングへは進まない)/ 既紹介時のフォールバック / previewMode中のsuper_adminのテナント別フラグ分離
- [x] E2E: `qa-copilot-preview.spec.ts`(390pxモバイル)に CP-B-4 追加 — 紹介→提案→保存→一覧確認まで旧UIへの誘導無しで完走
- [x] E2E: `qa-irregular-3roles.spec.ts` にイレギュラー操作3件追加 — B-IRR-7(保存チップ連打)/ B-IRR-8(下書き提示中のリロード)/ C-IRR-6(preview外super_adminからの保存指示拒否)。いずれも実LLM/実carnationデータの書き換えに依存させないようagent/chat・my-tenantをモック(CP-B-3の既存方針を踏襲)
- [x] `oxlint` clean / `dead-code-check`(既存のnotionSchemas.ts未使用exportのみ、本PR無関係) / `security-scan` PASS
- [x] フロントエンド全体テスト 151/151 pass

Tier S(admin-ui/src変更)のためhkobayashiの手動マージが必要です。
Asana: 1217040717654962
