### PR TITLE
fix: セッション短縮IDの大文字小文字を区別せず解決できるようにする

### DIFF
--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -177,8 +177,16 @@ export async function resolveSessionByShortId(
   if (!shortId) {
     return { ok: false, message: 'セッションIDを指定してください' };
   }
+  // session_id は生成時から常に小文字（ウィジェット側の crypto.randomUUID() と
+  // 手動フォールバック(toString(16))、サーバ側の randomUUID() のいずれも小文字を返す）。
+  // 一方 Postgres の LIKE は大文字小文字を区別するため、ユーザーがコピペ時に
+  // 大文字化されたIDや、LLMが整形し直したIDを渡すと、実在するセッションが
+  // 「見つかりません」になり存在しないIDと区別が付かなかった。照合用だけ小文字に
+  // 正規化する（SQL を ILIKE に変えないのは、インデックスを効かせたままにするため）。
+  // 表示用の shortId は入力のまま残し、エラー文にはユーザーが打った文字列を返す。
+  //
   // LIKE のワイルドカードを無効化し、意図しない広域一致を防ぐ（Postgres の既定エスケープ文字は \）
-  const prefix = shortId.replace(/[\\%_]/g, (c) => `\\${c}`);
+  const prefix = shortId.toLowerCase().replace(/[\\%_]/g, (c) => `\\${c}`);
 
   const result = await db.query<{ id: string; session_id: string }>(
     `SELECT id, session_id FROM chat_sessions

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -4362,6 +4362,50 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(params[1]).toBe(expectedPrefix);
     });
 
+    // session_id は生成時から常に小文字だが Postgres の LIKE は大文字小文字を区別する。
+    // コピペ時の自動大文字化やLLMによる整形で大文字が混ざると、実在するセッションが
+    // 「見つかりません」になり、存在しないIDと区別が付かなかった。
+    it.each([
+      ['A1B2C3D4', '全て大文字'],
+      ['A1b2C3d4', '大文字小文字の混在'],
+      ['  A1B2C3D4  ', '大文字 + 前後の空白'],
+    ])('session_id=%p (%s) でも実在セッションを解決できる', async (rawInput) => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-cm-case', 'get_chat_session_messages', { session_id: rawInput }))
+        .mockResolvedValueOnce(makeGroqResponse('会話内容はこちらです。'));
+
+      seedSessions([OWN_SESSION]);
+      mockGetMessages.mockResolvedValueOnce([
+        { id: 1, role: 'user', content: '送料はいくらですか', metadata: {}, created_at: '2026-07-17T10:00:00Z' },
+      ]);
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '会話を見せて', sessionId: `sess-cm-case-${encodeURIComponent(rawInput)}` });
+
+      // 小文字へ正規化された前方一致でDBに問い合わせている
+      const [, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+      expect(params[1]).toBe('a1b2c3d4');
+      // 「見つかりません」で終わらず、実際に本文を取得できている
+      expect(mockGetMessages).toHaveBeenCalledWith({ sessionDbId: 'db-sess-own', tenantId: 'tenant-abc' });
+      expect(res.body.actions[0].result).toContain('送料はいくらですか');
+    });
+
+    it('大文字のIDが見つからない場合、エラー文にはユーザーが入力した表記をそのまま返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-cm-case-nf', 'get_chat_session_messages', { session_id: 'ZZZZZZZZ' }))
+        .mockResolvedValueOnce(makeGroqResponse('見つかりませんでした。'));
+
+      seedSessions([OWN_SESSION]);
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '会話を見せて', sessionId: 'sess-cm-case-nf' });
+
+      // 正規化後の小文字ではなく、打った文字列を見せる(どのIDを試したか分かるように)
+      expect(res.body.actions[0].result).toContain('ZZZZZZZZ');
+    });
+
     it('getMessages が例外を投げても500にならず、失敗を伝える(本文は漏らさない)', async () => {
       mockFetch
         .mockResolvedValueOnce(toolCallResponse('call-cm-err', 'get_chat_session_messages', { session_id: 'a1b2c3d4' }))


### PR DESCRIPTION
Asana: 1217045576187890

## Summary
`resolveSessionByShortId` は素の `LIKE`（`ILIKE` ではない）で前方一致を取り、入力側にも正規化が無かった。Postgres の `LIKE` は既定の照合順序で大文字小文字を区別するため、**コピペ時の自動大文字化やLLMによる整形で大文字が混ざると、実在するセッションが「見つかりません」になり、存在しないIDと区別が付かなかった。**

影響を受けるのは `resolveSessionByShortId` を経由する8ツール（`get_chat_session_messages` / `delete_chat_session` / `get_session_outcome` / `record_session_outcome` / `get_conversation_evaluation` / `reply_to_escalation` / `resolve_escalation` / `get_legacy_ui_link`）。

## 手順1: 生成元の検証結果（タスクで必須とされていた前提確認）

| 生成元 | 出力 |
|---|---|
| ウィジェット `crypto.randomUUID()` (`widget.js:2996,3004`) | lowercase（仕様） |
| ウィジェットのフォールバック `toString(16)` (`widget.js:1068`) | lowercase |
| サーバ `randomUUID()` (`src/api/chat/route.ts:140`) | lowercase |

**常に小文字**と確認できたため、手順2-A（入力側の正規化）を採用。SQL を `ILIKE` に変える必要はなく、インデックスを効かせたまま維持できる。

## 実装
本番コードの変更は**1行**（`shortId.toLowerCase().replace(...)`）。残りはコメントとテスト。

エラー文に出す `shortId` は入力のまま残し、ユーザーが打った表記をそのまま返す（どのIDを試したのか分かるように）。LIKEワイルドカードのエスケープ順序は変えていない。

## テストが本当にバグを捕まえることの確認
`toLowerCase()` を一時的に外すと**追加した3件が落ちる**ことを確認済み。素通りするテストではない。

## Test plan
- [x] `npx tsc --noEmit` / `npx oxlint src admin-ui/src --max-warnings 63`
- [x] 新規4件（全大文字 / 大小混在 / 大文字+前後空白 / 見つからない場合は入力表記を返す）通過
- [x] 既存のLIKEワイルドカードエスケープ回帰テストが通過
- [ ] **フルスイートのローカル1発クリーンパスは未取得** — 下記参照

> ⚠️ 検証環境について正直に記載します。このマシンは並行レーンが多くエフェメラルポートが枯渇しており（`TIME_WAIT` が 15,000〜16,500 で macOS の約16,384ポートをほぼ使い切り）、supertest が bind できず `EADDRNOTAVAIL` / 5003msタイムアウトが多発します。実行ごとに **異なるテストが** 落ち（348/349 → 347/349 → 268/349 → 189/349 → 347/349）、落ちたテストは単独実行では必ず通ります。リグレッションではないと判断していますが、ローカルで349/349の1発クリアは取れていません。**CIのGate 1（クリーンマシン）での結果を最終確認とします。**

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UpYM4tvAGHfu4vc9NQqPfY