### PR TITLE
fix: テンプレ二重登録・silent cap・停止テナント検知漏れを直し、主経路のテスト抜けを埋める(オンボ 是正D-1/D-2)

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -2613,6 +2613,61 @@ describe("CopilotPreviewPage — 会話の復元(sessionStorage)", () => {
     expect(screen.queryByText("埋め込みコードを見る")).toBeNull();
   });
 
+  // N-1本体(docs/ONBOARDING_FIRST_LOGIN.md §7.1、オンボ 是正D-2): 決定Aの主経路
+  // (テナント本人の初回ログイン・会話復元なし・client_admin)が、これまでpreviewMode
+  // (super_admin代行)の1件でしか肯定検証されておらず、丸ごと未検証だった。
+  it("N-1: client_adminが復元なし・未完了で起動すると、業種チップ付き挨拶が出る(決定Aの主経路)", async () => {
+    vi.mocked(restoreChatSession).mockReturnValue(null);
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (isBadgeUrl(url)) return mockEmptyBadges();
+      if (String(url).includes("/v1/admin/my-tenant")) {
+        return mockOk({
+          onboarding_stage: {
+            industryAnswered: false,
+            knowledgePublished: false,
+            widgetInstalled: false,
+            firstConversation: false,
+            hasDraftFaq: false,
+          },
+        });
+      }
+      return mockOk({ reply: "今週も順調です。", actions: [] });
+    });
+
+    renderPage();
+
+    expect(await screen.findByText(/どんな業種ですか/)).toBeTruthy();
+    // 通常の週次ブリーフィングには進まない(業種未回答の間はブリーフィングより優先)
+    expect(screen.queryByText("今週も順調です。")).toBeNull();
+  });
+
+  // X-6(docs/ONBOARDING_FIRST_LOGIN.md §7.3、オンボ 是正D-2): ログアウト→再ログインの
+  // 想定(復元なし+未完了+client_admin)。サーバ側の段階だけから正しく復元されることを
+  // N-1と同じ入力組み合わせで固定する(実装上はmy-tenantを毎回叩くだけなので安全域だが、
+  // 復元経路を「重いので省略」に変えた瞬間に壊れる回帰を検出する)。
+  it("X-6: ログアウト後の再ログイン相当(復元なし)でも、サーバ側の段階から次の一手が復元される", async () => {
+    vi.mocked(restoreChatSession).mockReturnValue(null);
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (isBadgeUrl(url)) return mockEmptyBadges();
+      if (String(url).includes("/v1/admin/my-tenant")) {
+        return mockOk({
+          onboarding_stage: {
+            industryAnswered: true,
+            knowledgePublished: true,
+            widgetInstalled: false,
+            firstConversation: false,
+            hasDraftFaq: false,
+          },
+        });
+      }
+      return mockOk({ reply: "今週も順調です。", actions: [] });
+    });
+
+    renderPage();
+
+    expect(await screen.findByText(/ウィジェットをサイトに設置しましょう/)).toBeTruthy();
+  });
+
   // E-1(docs/ONBOARDING_FIRST_LOGIN.md §7.2): my-tenant取得失敗時、詰まらず週次ブリーフィングへ
   // フォールバックする。会話が復元されない(=新規起動)パスで検証する。
   it("E-1: my-tenant取得が例外を投げても、詰まらず週次ブリーフィングにフォールバックする", async () => {

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -20,6 +20,9 @@ import {
   generateScrapeFaqPreview,
   commitTextFaqs,
   commitScrapeFaqs,
+  fetchExistingQuestions,
+  bigramSimilarity,
+  DUPLICATE_THRESHOLD,
 } from '../../../lib/knowledge/faqImport';
 import {
   setStagedFaqImport,
@@ -710,8 +713,21 @@ export async function executeToolCall(
       }
 
       try {
+        // オンボ 是正D-1: 生INSERTで既存質問との重複判定を一切していなかったため、
+        // 業種チップ連打・2業種連続選択・「登録して」の複数回送信で同じテンプレが
+        // 素直に二重登録されていた(X-2)。commitTextFaqs が使う既存の重複判定
+        // (bigram類似度)をここでも通す。
+        const existingQuestionsAtCommit = await fetchExistingQuestions(db, tenantId);
         let inserted = 0;
+        let skipped = 0;
         for (const t of templates) {
+          const isDuplicate = existingQuestionsAtCommit.some(
+            (q) => bigramSimilarity(t.question, q) >= DUPLICATE_THRESHOLD,
+          );
+          if (isDuplicate) {
+            skipped++;
+            continue;
+          }
           try {
             const result = await db.query(
               `INSERT INTO faq_docs (tenant_id, question, answer, category, is_published)
@@ -725,6 +741,7 @@ export async function executeToolCall(
               faq_id: row.id,
             });
             upsertToEsAsync(tenantId, row.id, row.question, row.answer, row.is_published);
+            existingQuestionsAtCommit.push(row.question);
             inserted++;
           } catch (err) {
             logger.warn('[actionExecutor] import_industry_faq_templates insert failed', err);
@@ -734,7 +751,13 @@ export async function executeToolCall(
         // オンボ 是正A-2: 0件成功なら段階を進めない(要件どおり「登録しました」を返さない)。
         // 以前はinsertedの値に関わらずUPDATEと成功文言を返しており、全INSERT失敗時でも
         // industryAnswered=trueかつ下書き0件のまま stage2 で永久にループしていた。
+        // 全件が重複スキップだった場合も同様に扱う(段階は既に進んでいるはずのため)。
         if (inserted === 0) {
+          if (skipped > 0) {
+            return truncate(
+              `「${label}」向けのFAQはすべて登録済みでした(重複のため${skipped}件をスキップしました)。`,
+            );
+          }
           return truncate(
             `「${label}」向けのFAQの登録に失敗しました。時間をおいてもう一度お試しください。`,
           );
@@ -770,17 +793,30 @@ export async function executeToolCall(
 
       if (!confirmed) {
         try {
-          const draftResult = await db.query(
-            `SELECT id, question, answer FROM faq_docs WHERE tenant_id = $1 AND is_published = false ORDER BY id LIMIT 20`,
-            [tenantId],
-          );
+          // オンボ 是正D-1: LIMIT 20 のsilent cap対策。25件あっても「20件あります」とだけ
+          // 表示すると実数と食い違う(CLAUDE.mdの「silent capを作らない」方針に反する)ため、
+          // 総件数を別途取得して超過分を明示する。
+          const [draftResult, countResult] = await Promise.all([
+            db.query(
+              `SELECT id, question, answer FROM faq_docs WHERE tenant_id = $1 AND is_published = false ORDER BY id DESC LIMIT 20`,
+              [tenantId],
+            ),
+            db.query(
+              `SELECT COUNT(*)::int AS cnt FROM faq_docs WHERE tenant_id = $1 AND is_published = false`,
+              [tenantId],
+            ),
+          ]);
           const drafts = draftResult.rows as { id: number; question: string; answer: string }[];
+          const totalDrafts = (countResult.rows[0] as { cnt: number } | undefined)?.cnt ?? drafts.length;
           if (drafts.length === 0) {
             return truncate('公開できる下書きのFAQはありません');
           }
           const lines = drafts.map((d, i) => `${i + 1}. Q: ${d.question} / A: ${d.answer}`);
+          const countLine = totalDrafts > drafts.length
+            ? `下書き（未公開）のFAQが総${totalDrafts}件あります。うち新しい${drafts.length}件:\n`
+            : `下書き（未公開）のFAQが${drafts.length}件あります:\n`;
           return truncate(
-            `下書き（未公開）のFAQが${drafts.length}件あります:\n` +
+            countLine +
             lines.join('\n') +
             `\nよろしければ公開しますか？（公開後も自由に編集・非公開に戻せます）`,
           );
@@ -791,10 +827,18 @@ export async function executeToolCall(
       }
 
       try {
+        // オンボ 是正D-1: 確認時の一覧提示と同じ ORDER BY id DESC(新しい順)に揃える。
+        // ASC(古い順)のままだと、既存テナントが使った場合に「意図的に非公開のままに
+        // していた古いFAQ」が新しいオンボ由来の下書きより先に公開されてしまう。
+        //
+        // TOCTOU(確認時の一覧と実際の公開対象の集合が完全一致する保証が無い)は既知の
+        // トレードオフとして残す: 対象IDをLLM往復で固定する設計は、このツールが意図的に
+        // TTLステージングを持たない設計(X-10、docs/ONBOARDING_FIRST_LOGIN.md)と衝突し、
+        // LLMがID配列を正しく往復できない場合に誤動作するリスクの方が大きいと判断した。
         const result = await db.query(
           `UPDATE faq_docs SET is_published = true, updated_at = NOW()
            WHERE id IN (
-             SELECT id FROM faq_docs WHERE tenant_id = $1 AND is_published = false ORDER BY id LIMIT 20
+             SELECT id FROM faq_docs WHERE tenant_id = $1 AND is_published = false ORDER BY id DESC LIMIT 20
            )
            RETURNING id, question, answer, is_excluded_from_search`,
           [tenantId],
@@ -809,7 +853,18 @@ export async function executeToolCall(
         if (rows.length === 0) {
           return truncate('公開できる下書きのFAQはありません');
         }
-        return truncate(`${rows.length}件のFAQを公開しました`);
+        // オンボ 是正D-1: 残件数を明示する(公開後も「20件公開しました」だけでは
+        // 残りの下書きの存在が伝わらない)。
+        const remainingResult = await db.query(
+          `SELECT COUNT(*)::int AS cnt FROM faq_docs WHERE tenant_id = $1 AND is_published = false`,
+          [tenantId],
+        ).catch(() => null);
+        const remaining = (remainingResult?.rows[0] as { cnt: number } | undefined)?.cnt ?? 0;
+        return truncate(
+          remaining > 0
+            ? `${rows.length}件のFAQを公開しました(残り${remaining}件は次回以降に公開できます)`
+            : `${rows.length}件のFAQを公開しました`,
+        );
       } catch (err) {
         logger.warn('[actionExecutor] publish_faq_drafts failed', err);
         return truncate('FAQの公開に失敗しました');

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -91,12 +91,24 @@ const mockGenerateTextFaqPreview = jest.fn();
 const mockGenerateScrapeFaqPreview = jest.fn();
 const mockCommitTextFaqs = jest.fn();
 const mockCommitScrapeFaqs = jest.fn();
-jest.mock('../../../lib/knowledge/faqImport', () => ({
-  generateTextFaqPreview: (...args: any[]) => mockGenerateTextFaqPreview(...args),
-  generateScrapeFaqPreview: (...args: any[]) => mockGenerateScrapeFaqPreview(...args),
-  commitTextFaqs: (...args: any[]) => mockCommitTextFaqs(...args),
-  commitScrapeFaqs: (...args: any[]) => mockCommitScrapeFaqs(...args),
-}));
+// オンボ 是正D-1: import_industry_faq_templates が既存質問との重複判定に
+// fetchExistingQuestions/bigramSimilarity/DUPLICATE_THRESHOLD を使うようになったため、
+// 一部モックのままだと undefined 呼び出しで同期例外になる。bigramSimilarity/
+// DUPLICATE_THRESHOLD は純関数/定数なので実物を使い、DB依存のfetchExistingQuestionsのみ
+// モックする(既定は「重複無し」= 空配列。個別テストで上書き可能)。
+const mockFetchExistingQuestions = jest.fn();
+jest.mock('../../../lib/knowledge/faqImport', () => {
+  const actual = jest.requireActual('../../../lib/knowledge/faqImport');
+  return {
+    generateTextFaqPreview: (...args: any[]) => mockGenerateTextFaqPreview(...args),
+    generateScrapeFaqPreview: (...args: any[]) => mockGenerateScrapeFaqPreview(...args),
+    commitTextFaqs: (...args: any[]) => mockCommitTextFaqs(...args),
+    commitScrapeFaqs: (...args: any[]) => mockCommitScrapeFaqs(...args),
+    fetchExistingQuestions: (...args: any[]) => mockFetchExistingQuestions(...args),
+    bigramSimilarity: actual.bigramSimilarity,
+    DUPLICATE_THRESHOLD: actual.DUPLICATE_THRESHOLD,
+  };
+});
 
 // suggest_engagement_rule が使う依存をモック
 const mockSuggestEngagementRuleFromText = jest.fn();
@@ -309,6 +321,8 @@ describe('POST /v1/admin/agent/chat', () => {
     mockSearchKnowledgeForSuggestion.mockResolvedValue({ results: [] });
     mockFormatKnowledgeContext.mockReturnValue('');
     mockCheckSaiMonthlyCostCeiling.mockResolvedValue({ ok: true });
+    // オンボ 是正D-1: jest.resetAllMocks() で既定実装([]を返す)も消えるため再設定する
+    mockFetchExistingQuestions.mockResolvedValue([]);
     // knowledgeImportStaging はモックしない実物のモジュールなので、
     // jest.resetAllMocks() では消えないプロセス内Mapをテストごとに明示的にリセットする。
     __resetKnowledgeImportStagingForTest();
@@ -6576,6 +6590,95 @@ describe('POST /v1/admin/agent/chat', () => {
       ]);
     });
 
+    // X-2(docs/ONBOARDING_FIRST_LOGIN.md §7.3、オンボ 是正D-1): 業種チップ連打・
+    // 「登録して」の複数回送信で、既存の重複判定(commitTextFaqsのbigram類似度)を
+    // 一切経由せずテンプレを素直に二重登録していた。既に同一質問が登録済みならスキップする。
+    it('X-2: 既に同一のテンプレ質問が登録済みなら重複スキップし、二重登録しない', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-ind-dup1', 'import_industry_faq_templates', { industry: 'beauty', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('登録しました。'));
+
+      // 5件中、最初の1件(「営業時間を教えてください」)が既に登録済みという想定
+      mockFetchExistingQuestions.mockResolvedValueOnce(['営業時間を教えてください']);
+      for (let i = 0; i < 4; i++) {
+        mockQuery.mockResolvedValueOnce({
+          rows: [{ id: 200 + i, question: `dup-q${i}`, answer: `dup-a${i}`, is_published: false }],
+        });
+      }
+      mockQuery.mockResolvedValueOnce({ rows: [] }); // UPDATE tenants
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '登録して', sessionId: 'sess-ind-dup1' });
+
+      expect(res.status).toBe(200);
+      // 重複した1件を除く4件だけがINSERTされる
+      const insertCalls = mockQuery.mock.calls.filter(([sql]) => String(sql).includes('INSERT INTO faq_docs'));
+      expect(insertCalls).toHaveLength(4);
+      expect(res.body.actions[0].result).toContain('4件、下書きとして登録しました');
+    });
+
+    it('X-2: 業種テンプレ5件すべてが既に登録済みなら1件もINSERTせず、段階も進めない(重複のみメッセージ)', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-ind-dup2', 'import_industry_faq_templates', { industry: 'beauty', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('登録済みです。'));
+
+      mockFetchExistingQuestions.mockResolvedValueOnce([
+        '営業時間を教えてください',
+        '予約は必要ですか？',
+        '初めてでも大丈夫ですか？',
+        'クーポンや割引はありますか？',
+        '駐車場はありますか？',
+      ]);
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '登録して', sessionId: 'sess-ind-dup2' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery.mock.calls.some(([sql]) => String(sql).includes('INSERT INTO faq_docs'))).toBe(false);
+      expect(mockQuery.mock.calls.some(([sql]) => String(sql).includes('UPDATE tenants'))).toBe(false);
+      expect(res.body.actions[0].result).toContain('すべて登録済みでした');
+      expect(recordedMetrics('onboarding_stage_reached')).toEqual([]);
+    });
+
+    // E-4(docs/ONBOARDING_FIRST_LOGIN.md §7.2、オンボ 是正D-2): FAQ本体のINSERTは
+    // 全件成功しているのに、直後の UPDATE tenants(onboarding_industry/completed_at)
+    // だけが失敗した場合の挙動を固定する。現状は .catch(warn) で握り潰し成功文言を
+    // 返す実装のまま(このタスクはテスト追加のみで実装は変更しない)。UPDATE失敗時は
+    // onboarding_industry が更新されないため、次回ログインで「初めまして」が
+    // 再生される既知の狭い窓が残る(A-2の詰まりとは別、より稀なケース)。
+    it('E-4(既知の挙動): FAQ本体は全件成功してもUPDATE tenantsが失敗すると、次回onboarding_industryは更新されないまま', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-ind-e4', 'import_industry_faq_templates', { industry: 'beauty', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('登録しました。'));
+
+      for (let i = 0; i < 5; i++) {
+        mockQuery.mockResolvedValueOnce({
+          rows: [{ id: 300 + i, question: `e4-q${i}`, answer: `e4-a${i}`, is_published: false }],
+        });
+      }
+      mockQuery.mockRejectedValueOnce(new Error('UPDATE tenants connection lost'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '登録して', sessionId: 'sess-ind-e4' });
+
+      expect(res.status).toBe(200);
+      // 現状の実装: FAQは登録済みなのに成功文言を返す(UPDATE失敗はチャット応答に現れない)
+      expect(res.body.actions[0].result).toContain('5件、下書きとして登録しました');
+      // メトリクスは result の文言一致で判定するため、UPDATE失敗でも発火する
+      // (このメトリクス自体はFAQ登録の成功を表しており、onboarding_industry永続化とは別軸)
+      expect(recordedMetrics('onboarding_stage_reached')).toEqual([
+        {
+          metricName: 'onboarding_stage_reached',
+          tenantId: 'tenant-abc',
+          labels: { stage: 'industry_answered', actor: 'self', surface: 'unknown' },
+          value: 1,
+        },
+      ]);
+    });
+
     it('confirmed=false(一覧提示のみ)では段階到達メトリクスを記録しない', async () => {
       mockFetch
         .mockResolvedValueOnce(toolCallResponse('call-ind-4', 'import_industry_faq_templates', { industry: 'beauty', confirmed: false }))
@@ -6682,9 +6785,12 @@ describe('POST /v1/admin/agent/chat', () => {
         .mockResolvedValueOnce(toolCallResponse('call-pub-1', 'publish_faq_drafts', { confirmed: false }))
         .mockResolvedValueOnce(makeGroqResponse('こちらを公開しますか？'));
 
-      mockQuery.mockResolvedValueOnce({
-        rows: [{ id: 1, question: 'Q1', answer: 'A1' }, { id: 2, question: 'Q2', answer: 'A2' }],
-      });
+      // オンボ 是正D-1: 一覧提示は draft本体 + 総件数(COUNT)を並行取得する(Promise.all)。
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [{ id: 1, question: 'Q1', answer: 'A1' }, { id: 2, question: 'Q2', answer: 'A2' }],
+        })
+        .mockResolvedValueOnce({ rows: [{ cnt: 2 }] }); // COUNT(*)
 
       const res = await request(makeApp(CLIENT_ADMIN_USER))
         .post('/v1/admin/agent/chat')
@@ -6704,7 +6810,9 @@ describe('POST /v1/admin/agent/chat', () => {
         .mockResolvedValueOnce(toolCallResponse('call-pub-2', 'publish_faq_drafts', { confirmed: false }))
         .mockResolvedValueOnce(makeGroqResponse('下書きはありませんでした。'));
 
-      mockQuery.mockResolvedValueOnce({ rows: [] });
+      mockQuery
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [{ cnt: 0 }] });
 
       const res = await request(makeApp(CLIENT_ADMIN_USER))
         .post('/v1/admin/agent/chat')
@@ -6719,9 +6827,11 @@ describe('POST /v1/admin/agent/chat', () => {
         .mockResolvedValueOnce(toolCallResponse('call-pub-3', 'publish_faq_drafts', { confirmed: true }))
         .mockResolvedValueOnce(makeGroqResponse('公開しました。'));
 
-      mockQuery.mockResolvedValueOnce({
-        rows: [{ id: 1, question: 'Q1', answer: 'A1' }, { id: 2, question: 'Q2', answer: 'A2' }],
-      });
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [{ id: 1, question: 'Q1', answer: 'A1' }, { id: 2, question: 'Q2', answer: 'A2' }],
+        })
+        .mockResolvedValueOnce({ rows: [{ cnt: 0 }] }); // オンボ 是正D-1: 残件数取得
 
       const res = await request(makeApp(CLIENT_ADMIN_USER))
         .post('/v1/admin/agent/chat')
@@ -6751,12 +6861,14 @@ describe('POST /v1/admin/agent/chat', () => {
         .mockResolvedValueOnce(toolCallResponse('call-pub-3b', 'publish_faq_drafts', { confirmed: true }))
         .mockResolvedValueOnce(makeGroqResponse('公開しました。'));
 
-      mockQuery.mockResolvedValueOnce({
-        rows: [
-          { id: 1, question: 'Q1', answer: 'A1', is_excluded_from_search: true },
-          { id: 2, question: 'Q2', answer: 'A2', is_excluded_from_search: false },
-        ],
-      });
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [
+            { id: 1, question: 'Q1', answer: 'A1', is_excluded_from_search: true },
+            { id: 2, question: 'Q2', answer: 'A2', is_excluded_from_search: false },
+          ],
+        })
+        .mockResolvedValueOnce({ rows: [{ cnt: 0 }] }); // オンボ 是正D-1: 残件数取得
 
       const res = await request(makeApp(CLIENT_ADMIN_USER))
         .post('/v1/admin/agent/chat')
@@ -6769,14 +6881,38 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(mockUpsertToEsAsync).toHaveBeenCalledWith('tenant-abc', 2, 'Q2', 'A2', true, false);
     });
 
+    // オンボ 是正D-2: X-16(chat_sessionsのテナント境界)はSQL文字列レベルで固定されて
+    // いるのに、publish_faq_draftsのサブクエリのtenant_id境界は未検証だった。
+    // モックはrowCountを返すだけなので、この条件が外れて全テナント横断で公開されても
+    // 他のテストは緑のまま検出できなかった。
+    it('オンボ 是正D-2: UPDATE faq_docsのサブクエリにtenant_id境界が残っている(SQL文字列検証)', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-pub-boundary', 'publish_faq_drafts', { confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('公開しました。'));
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ id: 1, question: 'Q1', answer: 'A1' }] })
+        .mockResolvedValueOnce({ rows: [{ cnt: 0 }] });
+
+      await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '公開して', sessionId: 'sess-pub-boundary' });
+
+      const updateCall = mockQuery.mock.calls.find(([sql]) => String(sql).includes('UPDATE faq_docs SET is_published = true'));
+      expect(updateCall).toBeDefined();
+      expect(String(updateCall![0])).toContain('tenant_id = $1');
+      expect(updateCall![1]).toEqual(['tenant-abc']);
+    });
+
     it('super_adminがtargetTenantId指定で代行実行した場合はactor:delegatedで記録される', async () => {
       mockFetch
         .mockResolvedValueOnce(toolCallResponse('call-pub-4', 'publish_faq_drafts', { confirmed: true }))
         .mockResolvedValueOnce(makeGroqResponse('公開しました。'));
 
-      mockQuery.mockResolvedValueOnce({
-        rows: [{ id: 1, question: 'Q1', answer: 'A1' }],
-      });
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [{ id: 1, question: 'Q1', answer: 'A1' }],
+        })
+        .mockResolvedValueOnce({ rows: [{ cnt: 0 }] }); // オンボ 是正D-1: 残件数取得
 
       const res = await request(makeApp(SUPER_ADMIN_USER))
         .post('/v1/admin/agent/chat')
@@ -6818,9 +6954,11 @@ describe('POST /v1/admin/agent/chat', () => {
         .mockResolvedValueOnce(makeGroqResponse('下書きが見つかりました。'));
 
       // 「何日も前に作られた」ことをシミュレートしても、SELECT自体に時間条件は無いので拾える
-      mockQuery.mockResolvedValueOnce({
-        rows: [{ id: 1, question: '何日も前に作られた下書き', answer: 'A' }],
-      });
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [{ id: 1, question: '何日も前に作られた下書き', answer: 'A' }],
+        })
+        .mockResolvedValueOnce({ rows: [{ cnt: 1 }] }); // COUNT(*)
 
       const res = await request(makeApp(CLIENT_ADMIN_USER))
         .post('/v1/admin/agent/chat')
@@ -8030,9 +8168,11 @@ describe('POST /v1/admin/agent/chat', () => {
       mockFetch
         .mockResolvedValueOnce(toolCallResponse('call-au-ob3', 'publish_faq_drafts', { confirmed: true }))
         .mockResolvedValueOnce(makeGroqResponse('公開しました。'));
-      mockQuery.mockResolvedValueOnce({
-        rows: [{ id: 1, question: 'Q1', answer: 'A1' }],
-      });
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [{ id: 1, question: 'Q1', answer: 'A1' }],
+        })
+        .mockResolvedValueOnce({ rows: [{ cnt: 0 }] }); // オンボ 是正D-1: 残件数取得
 
       const res = await request(makeApp(AUDIT_USER))
         .post('/v1/admin/agent/chat')

--- a/src/api/admin/agent/toolDefinitions.ts
+++ b/src/api/admin/agent/toolDefinitions.ts
@@ -199,7 +199,9 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
             description: 'ユーザーの明確な同意を得た場合のみ true',
           },
         },
-        required: ['industry'],
+        // オンボ 是正D-1: publish_faq_drafts側は confirmed が required なのに、
+        // ここは industry だけが required で非対称だった。同じ確認ゲート付きツールとして揃える。
+        required: ['industry', 'confirmed'],
       },
     },
   },

--- a/src/api/admin/tenants/migration_onboarding.sql
+++ b/src/api/admin/tenants/migration_onboarding.sql
@@ -1,6 +1,10 @@
 -- GID 1216274591838389: 初回ログイン時の1問オンボーディング(業種質問→FAQテンプレート提案)
 -- onboarding_industry: 回答した業種キー(auto/beauty/food/realestate/retail/other)。NULL=未回答。
--- onboarding_completed_at: オンボーディング完了日時。NULL=未完了(ダッシュボードでモーダル表示対象)。
+-- onboarding_completed_at: 業種質問への回答日時。NULL=未回答(ダッシュボードでモーダル表示対象)。
+-- 【オンボ 是正D-1で訂正】列名・当初コメントは「完了」だが、実際は業種回答(旧・単一問オンボの
+-- 完了)時点で更新される。新4段階モデル(onboarding_stage、onboardingStage.ts)導入後の
+-- 「全段階完了」とは別概念であり、両者は独立に管理されている。列名は変更していない
+-- (DBスキーマ変更は人間承認が必要なため、コメント訂正のみ)。
 ALTER TABLE tenants ADD COLUMN IF NOT EXISTS onboarding_industry TEXT;
 ALTER TABLE tenants ADD COLUMN IF NOT EXISTS onboarding_completed_at TIMESTAMPTZ;
 

--- a/src/lib/onboardingWidgetSeen.ts
+++ b/src/lib/onboardingWidgetSeen.ts
@@ -18,8 +18,11 @@ import { logger } from "./logger";
 
 export async function recordWidgetSeenOnce(db: Pool, tenantId: string): Promise<void> {
   try {
+    // オンボ 是正D-1: is_active 条件が無く、停止中テナントのAPIキーでもウィジェット
+    // 設置検知が立ってしまっていた(呼び出し元 src/index.ts では is_active チェックより
+    // 前にこの関数を呼ぶため、ここ自体に条件を持たせる必要がある)。
     await db.query(
-      "UPDATE tenants SET onboarding_widget_seen_at = NOW() WHERE id = $1 AND onboarding_widget_seen_at IS NULL",
+      "UPDATE tenants SET onboarding_widget_seen_at = NOW() WHERE id = $1 AND onboarding_widget_seen_at IS NULL AND is_active = true",
       [tenantId],
     );
   } catch (err) {

--- a/tests/api/admin/tenants/routes.test.ts
+++ b/tests/api/admin/tenants/routes.test.ts
@@ -295,6 +295,35 @@ describe("Tenant Admin Routes", () => {
         expect(String(chatSessionsCall[0])).toContain(`metadata->>'source' = 'user'`);
       });
 
+      // オンボ 是正D-2: X-16はchat_sessionsのテナント境界をSQL文字列レベルで固定して
+      // いるのに、knowledgePublished判定のis_published条件は未検証で非対称だった
+      // (この条件が外れて「下書きでも公開済み扱い」になっても既存テストは全て緑のまま)。
+      it("オンボ 是正D-2: knowledgePublished判定クエリは is_published を条件に含む(SQL文字列検証)", async () => {
+        mockDb.query
+          .mockResolvedValueOnce({
+            rows: [{
+              id: "tenant1", name: "Test", features: {}, lemonslice_agent_id: null, conversion_types: [],
+              onboarding_industry: "beauty", onboarding_widget_seen_at: null,
+              created_at: "2026-08-01T00:00:00.000Z",
+            }],
+            rowCount: 1,
+          })
+          .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // checkHasR2c2
+          .mockResolvedValueOnce({ rows: [{ published_count: "0", draft_count: "0" }], rowCount: 1 }) // faq_docs
+          .mockResolvedValueOnce({ rows: [], rowCount: 0 }); // chat_sessions
+
+        await request(app)
+          .get("/v1/admin/my-tenant")
+          .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`);
+
+        const faqDocsCall = mockDb.query.mock.calls.find(([sql]: [string]) =>
+          String(sql).includes("FROM faq_docs"),
+        );
+        expect(faqDocsCall).toBeDefined();
+        expect(String(faqDocsCall[0])).toContain("is_published");
+        expect(String(faqDocsCall[0])).toContain("tenant_id = $1");
+      });
+
       // X-14(docs/ONBOARDING_FIRST_LOGIN.md §7.3): super_adminの代行(previewMode)でも
       // client_admin本人でも、段階の導出は同じクエリ・同じ判定になる(actorによる分岐が無い)。
       // tenants テーブル自体に actor 列が無いため、代行で設定した状態はテナント本人からも
@@ -348,6 +377,31 @@ describe("Tenant Admin Routes", () => {
         expect(res.status).toBe(200);
         expect(res.body.onboarding_stage.knowledgePublished).toBe(false);
         expect(res.body.onboarding_stage.industryAnswered).toBe(true);
+      });
+
+      // オンボ 是正D-2: フェイルセーフはfaq_docs失敗のみ検証済みで、chat_sessions失敗が
+      // 非対称に未検証だった。
+      it("chat_sessions クエリが失敗しても my-tenant 応答全体は壊れない(フェイルセーフ)", async () => {
+        mockDb.query
+          .mockResolvedValueOnce({
+            rows: [{
+              id: "tenant1", name: "Test", features: {}, lemonslice_agent_id: null, conversion_types: [],
+              onboarding_industry: "beauty", onboarding_completed_at: null, onboarding_widget_seen_at: null,
+              created_at: "2026-08-01T00:00:00.000Z",
+            }],
+            rowCount: 1,
+          })
+          .mockResolvedValueOnce({ rows: [], rowCount: 0 }) // checkHasR2c2
+          .mockResolvedValueOnce({ rows: [{ published_count: "1", draft_count: "0" }], rowCount: 1 }) // faq_docs: 成功
+          .mockRejectedValueOnce(new Error("connection lost")); // chat_sessions 失敗
+
+        const res = await request(app)
+          .get("/v1/admin/my-tenant")
+          .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`);
+
+        expect(res.status).toBe(200);
+        expect(res.body.onboarding_stage.firstConversation).toBe(false);
+        expect(res.body.onboarding_stage.knowledgePublished).toBe(true);
       });
 
       // オンボ 是正A-1: P6マージ前(4段階モデル導入前)に作られたテナントは


### PR DESCRIPTION
## Summary
Asana: 1217044956242416 / 1217045056806827

**このPRは #665(オンボ 是正B-1/B-2、さらにその下に#662 A-1/A-2/A-3)の上に積んだスタックPRです。#662→#665の順にmainへマージされたら、baseをmainに retarget します(docs/PR_MERGE_RULES.md の規約どおり)。**

### D-1: 堅牢性
- **X-2 テンプレ二重登録**: `import_industry_faq_templates` が生INSERTで既存質問との重複判定を一切していなかった。`commitTextFaqs` と同じ `fetchExistingQuestions` + `bigramSimilarity`(既存関数の再利用、新規ロジックなし)を通し、業種チップ連打・複数回送信での二重登録を防ぐ。全件重複時は「すべて登録済みでした」を返し段階も進めない。
- **silent cap**: `publish_faq_drafts` の `LIMIT 20` で実件数と表示件数が食い違っていた(CLAUDE.mdの「silent capを作らない」方針に反する)。`COUNT(*)` で総件数を取得し「総N件中20件」「残りM件は次回以降に公開できます」を明示。
- **公開順序**: `ORDER BY id` を `DESC`(新しい順)に変更。既存テナントが使った場合、意図的に非公開のままにしていた古いFAQが新しいオンボ由来の下書きより先に公開される問題を解消。
- **TOCTOU(意図的に対応見送り)**: 確認時の一覧と実際の公開対象IDを完全一致させる設計(LLMへのID往復)は、このツールが意図的にTTLステージングを持たない設計(X-10、docs/ONBOARDING_FIRST_LOGIN.md)と衝突し、LLMがID配列を正しく往復できない場合の誤動作リスクの方が大きいと判断し見送った。コードコメントで明示。
- **停止テナント検知漏れ**: `recordWidgetSeenOnce` に `is_active = true` を追加。停止中テナントでもウィジェット設置検知が立っていた。
- `toolDefinitions.ts`: `import_industry_faq_templates` の `required` に `confirmed` を追加(`publish_faq_drafts` 側とだけ非対称だった)。
- `onboarding_completed_at` のコメントを実態(業種回答日時、全段階完了ではない)に訂正。DBスキーマ変更は無し(コメントのみ)。

### D-2: テスト補強
- **N-1本体**: 決定Aの主経路(client_admin・復元なし・未完了)が previewMode の1件でしか肯定検証されておらず丸ごと未検証だった。
- **X-6**: ログアウト→再ログイン相当(復元なし+未完了+client_admin)。
- **E-4**: `UPDATE tenants` 失敗時の挙動を固定(既知の狭いウィンドウとして特性テスト、実装は変更せず)。
- fail-safe非対称: `chat_sessions` クエリ失敗時のフェイルセーフ(`faq_docs`側のみ既存検証だった)。
- SQL境界の非対称: `publish_faq_drafts` サブクエリの `tenant_id = $1`、`knowledgePublished` 判定の `is_published` がSQL文字列レベルで検証されていなかった(X-16は`chat_sessions`のテナント境界のみ検証済みだった)。

## 変更ファイル
- `src/api/admin/agent/actionExecutor.ts` — 重複スキップ、silent cap明示、ORDER BY DESC
- `src/lib/onboardingWidgetSeen.ts` — `is_active` 条件追加
- `src/api/admin/agent/toolDefinitions.ts` — required対称化
- `src/api/admin/tenants/migration_onboarding.sql` — コメント訂正(スキーマ変更なし)
- テスト: `agentRoutes.test.ts`(X-2/E-4/SQL境界、+ `fetchExistingQuestions` の部分モック化) / `tests/api/admin/tenants/routes.test.ts`(SQL境界・fail-safe対称化) / `copilot-preview/index.test.tsx`(N-1/X-6)

## Test plan
- [x] `npx tsc --noEmit`(backend clean)
- [x] `cd admin-ui && npx tsc -b`(既存ベースライン13件のまま)
- [x] `npx oxlint src admin-ui/src --max-warnings 63`(exit 0)
- [x] 変更ファイルのjest/vitestが全パス(agentRoutes・tenants/routes・onboardingWidgetSeen・copilot-preview 140/140、いずれも高負荷環境下の無関係テストの一時的タイムアウトを除き全パス。**pristine origin/mainでも同一の非決定的フレーキー(別の無関係テストがランダムに失敗)を確認し、既存環境要因と特定済み**)
- [x] `bash SCRIPTS/dead-code-check.sh`(既存無関係の4件のみ)
- [x] `bash SCRIPTS/security-scan.sh`(PASS, 0 critical/high)

https://claude.ai/code/session_0177MCsC7jN3a51F7TdaW9vH