### PR TITLE
fix(e2e): tests/e2e配下のJest収集事故を防ぎ、config.tsの向き先解決を堅牢化する

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,6 +5,10 @@ const AUTH_FILE = 'tests/e2e/.auth/user.json';
 
 export default defineConfig({
   testDir: './tests/e2e',
+  // tests/ 配下は Jest と Playwright の二重所有。*.test.ts は Jest の領域であり、
+  // Playwrightが拾うと収集エラー(ReferenceError: describe is not defined)で
+  // E2E全件が0件になるため、ここで .spec.ts / .setup.ts のみに限定する。
+  testMatch: /\.(spec|setup)\.ts$/,
   timeout: 30000,
   retries: 1,
   use: {

--- a/tests/e2e/config.test.ts
+++ b/tests/e2e/config.test.ts
@@ -1,0 +1,68 @@
+// tests/e2e/config.test.ts
+
+import { resolveE2eBaseUrls, ADMIN_BASE_URL, API_BASE_URL } from './config';
+
+describe('resolveE2eBaseUrls', () => {
+  it('env未設定 → 本番URLがデフォルトになる', () => {
+    expect(resolveE2eBaseUrls({})).toEqual({
+      adminBaseUrl: 'https://admin.r2c.biz',
+      apiBaseUrl: 'https://api.r2c.biz',
+    });
+  });
+
+  it('両方設定時 → 両方とも上書きされる', () => {
+    expect(
+      resolveE2eBaseUrls({
+        E2E_BASE_URL: 'https://staging-admin.example.com',
+        E2E_API_URL: 'https://staging-api.example.com',
+      }),
+    ).toEqual({
+      adminBaseUrl: 'https://staging-admin.example.com',
+      apiBaseUrl: 'https://staging-api.example.com',
+    });
+  });
+
+  it('E2E_BASE_URL のみ設定 → throw する', () => {
+    expect(() => resolveE2eBaseUrls({ E2E_BASE_URL: 'https://staging-admin.example.com' })).toThrow(
+      /E2E_API_URL/,
+    );
+  });
+
+  it('E2E_API_URL のみ設定 → throw する', () => {
+    expect(() => resolveE2eBaseUrls({ E2E_API_URL: 'https://staging-api.example.com' })).toThrow(
+      /E2E_BASE_URL/,
+    );
+  });
+
+  it('末尾スラッシュ付き(E2E_BASE_URL)が正規化される', () => {
+    expect(
+      resolveE2eBaseUrls({
+        E2E_BASE_URL: 'https://staging-admin.example.com/',
+        E2E_API_URL: 'https://staging-api.example.com',
+      }).adminBaseUrl,
+    ).toBe('https://staging-admin.example.com');
+  });
+
+  it('末尾スラッシュ付き(E2E_API_URL)が正規化される', () => {
+    expect(
+      resolveE2eBaseUrls({
+        E2E_BASE_URL: 'https://staging-admin.example.com',
+        E2E_API_URL: 'https://staging-api.example.com/',
+      }).apiBaseUrl,
+    ).toBe('https://staging-api.example.com');
+  });
+
+  it('空文字列は本番にフォールバックする', () => {
+    expect(resolveE2eBaseUrls({ E2E_BASE_URL: '', E2E_API_URL: '' })).toEqual({
+      adminBaseUrl: 'https://admin.r2c.biz',
+      apiBaseUrl: 'https://api.r2c.biz',
+    });
+  });
+});
+
+describe('ADMIN_BASE_URL / API_BASE_URL', () => {
+  it('本番URLの文字列としてexportされている(export名の消失検知)', () => {
+    expect(ADMIN_BASE_URL).toMatch(/^https:\/\//);
+    expect(API_BASE_URL).toMatch(/^https:\/\//);
+  });
+});

--- a/tests/e2e/config.ts
+++ b/tests/e2e/config.ts
@@ -7,5 +7,46 @@
 // ステージング環境が用意でき次第(Asana 1217045569747485 が前提条件)、
 // E2E_BASE_URL / E2E_API_URL を CI/ローカルで設定するだけで向き先を切り替えられるように、
 // 各 spec はこの定数を経由し、URL を直接ハードコードしない。
-export const ADMIN_BASE_URL = process.env.E2E_BASE_URL || 'https://admin.r2c.biz';
-export const API_BASE_URL = process.env.E2E_API_URL || 'https://api.r2c.biz';
+
+function stripTrailingSlash(url: string): string {
+  return url.replace(/\/+$/, '');
+}
+
+/**
+ * env から E2E の向き先を解決する(純粋関数)。src/lib/traffic/trafficSource.ts の
+ * resolveTrafficSource と同じ形(入力を引数で受ける純粋関数)に合わせている。
+ *
+ * 片方だけ設定された場合は throw する: 管理画面はステージング・APIは本番、という
+ * 混在状態が無警告で成立するのを防ぐため。
+ */
+export function resolveE2eBaseUrls(
+  env: NodeJS.ProcessEnv = process.env,
+): { adminBaseUrl: string; apiBaseUrl: string } {
+  const rawAdmin = env.E2E_BASE_URL || '';
+  const rawApi = env.E2E_API_URL || '';
+
+  if (rawAdmin && !rawApi) {
+    throw new Error(
+      'E2E_BASE_URL のみが設定され、E2E_API_URL が未設定です。' +
+        '管理画面とAPIの向き先が食い違う(例: 管理画面はステージング・APIは本番)状態を' +
+        '防ぐため、両方を設定するか両方とも未設定のままにしてください。',
+    );
+  }
+  if (rawApi && !rawAdmin) {
+    throw new Error(
+      'E2E_API_URL のみが設定され、E2E_BASE_URL が未設定です。' +
+        '管理画面とAPIの向き先が食い違う(例: 管理画面はステージング・APIは本番)状態を' +
+        '防ぐため、両方を設定するか両方とも未設定のままにしてください。',
+    );
+  }
+
+  return {
+    adminBaseUrl: stripTrailingSlash(rawAdmin || 'https://admin.r2c.biz'),
+    apiBaseUrl: stripTrailingSlash(rawApi || 'https://api.r2c.biz'),
+  };
+}
+
+const { adminBaseUrl, apiBaseUrl } = resolveE2eBaseUrls();
+
+export const ADMIN_BASE_URL = adminBaseUrl;
+export const API_BASE_URL = apiBaseUrl;


### PR DESCRIPTION
## Summary
- `playwright.config.ts` に top-level `testMatch: /\.(spec|setup)\.ts$/` を追加。tests/e2e配下にJest形式のテスト(`*.test.ts`)を置くとPlaywrightのデフォルトtestMatchがそれを拾ってしまい、`ReferenceError: describe is not defined` でE2E全103テストが0件になることを実測で確認(再現用ファイルは確認後に削除済み)。このガードにより `.spec.ts` / `.setup.ts` のみに限定する。
- `tests/e2e/config.ts` の `ADMIN_BASE_URL` / `API_BASE_URL` を、env を引数で受ける純粋関数 `resolveE2eBaseUrls()` から導出する形に変更。`src/lib/traffic/trafficSource.ts` の `resolveTrafficSource()` と同じ既存イディオムに追従。
  - 片方のみのenv設定(`E2E_BASE_URL`だけ/`E2E_API_URL`だけ)は throw する(管理画面とAPIの向き先が食い違う無警告状態を防止)
  - 末尾スラッシュを正規化
  - 空文字列は従来通り本番にフォールバック
  - export名 `ADMIN_BASE_URL` / `API_BASE_URL` は不変(17ファイルの呼び出し側は無変更)
- `tests/e2e/config.test.ts` を新規作成。上記の挙動をJestでカバー。

## 背景
PR #666 で `config.ts` が17個のE2Eファイル全ての向き先を決める単一の制御点になったが、テストが1つも無かった。最も自然な置き場所である `tests/e2e/config.test.ts` を試したところ、Playwrightの収集エラーでE2E全体が壊れることが判明したため、まずこのガードを入れてから回帰テストを追加した。

## Test plan
- [x] `npx tsc --noEmit` — エラーなし
- [x] `npx oxlint tests/e2e` — warning 2件のみ、いずれも本PRの変更行と無関係の既存警告
- [x] `npx jest tests/e2e/config.test.ts` — 8件全てpass
- [x] `E2E_ENABLED=1 npx playwright test --list` — Total: 103 tests in 17 files (`config.test.ts` 追加後も変化なし)
- [x] `--project=setup` → 1/1、`--project=superadmin-setup` → 1/1、`--project=admin-ui` → 7/3、`--project=visual-regression` → 6/2 (いずれもtestMatch変更前と同一)
- [x] `bash SCRIPTS/security-scan.sh` — PASS
- [x] フルJestスイート実行 — 13スイート失敗はいずれも本PR変更ファイルと無関係(`EADDRNOTAVAIL`、本機のephemeralポート枯渇による既知の環境要因。`netstat`で22009件のTIME_WAITを確認)
- [ ] CI上のE2E実行(本番URLへの実リクエストが従来通り成功することの最終確認)

## Asana
https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217068919748097

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NgWB82fsx7LMjhJqpd1rCx