### PR TITLE
fix: アバター生成系4ルートが super_admin プレビュー中のテナント指定を受け付けるようにする

### DIFF
--- a/src/api/admin/avatar/falGenerationRoutes.test.ts
+++ b/src/api/admin/avatar/falGenerationRoutes.test.ts
@@ -24,11 +24,11 @@ global.fetch = mockFetch;
 
 // ── ヘルパー ──────────────────────────────────────────────────────────────────
 
-function makeApp(tenantId = "tenant-a") {
+function makeApp(tenantId = "tenant-a", role: "client_admin" | "super_admin" = "client_admin") {
   const app = express();
   app.use(express.json());
   app.use((req: any, _res: any, next: any) => {
-    req.supabaseUser = { app_metadata: { tenant_id: tenantId, role: 'client_admin' } };
+    req.supabaseUser = { app_metadata: { tenant_id: tenantId, role } };
     req.requestId = "req-test-001";
     next();
   });
@@ -94,6 +94,42 @@ describe("POST /v1/admin/avatar/fal/generate", () => {
         featureUsed: "avatar_config_image",
         imageCount: 4,
       }),
+    );
+  });
+
+  // previewMode(super_adminのクライアントビュー)中、app_metadata.tenant_id が空の
+  // super_adminがそのまま生成すると trackUsage が空テナントで計上され、Supabase
+  // Storageのパス(uploadImageFromUrlの第2引数=同じtenantId変数)もバケット直下に
+  // 書き込まれていた(#P0-1)。?tenant= を effective tenantId として使うことを固定する。
+  it("super_adminが?tenant=で操作対象テナントを指定すると、そのテナントでusage_logsに計上される", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => FAL_OK_RESPONSE,
+    });
+
+    const res = await request(makeApp("", "super_admin"))
+      .post("/v1/admin/avatar/fal/generate?tenant=tenant-b")
+      .send({ prompt: "Professional portrait of a Japanese woman, bust shot, smiling" });
+
+    expect(res.status).toBe(200);
+    expect(mockTrackUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ tenantId: "tenant-b" }),
+    );
+  });
+
+  it("client_adminが?tenant=を付けても無視され、JWTの自テナントで計上される(越権防止)", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => FAL_OK_RESPONSE,
+    });
+
+    const res = await request(makeApp("tenant-a", "client_admin"))
+      .post("/v1/admin/avatar/fal/generate?tenant=tenant-b")
+      .send({ prompt: "Professional portrait of a Japanese man, bust shot, business suit" });
+
+    expect(res.status).toBe(200);
+    expect(mockTrackUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ tenantId: "tenant-a" }),
     );
   });
 

--- a/src/api/admin/avatar/falGenerationRoutes.ts
+++ b/src/api/admin/avatar/falGenerationRoutes.ts
@@ -7,7 +7,7 @@ import { supabaseAuthMiddleware } from "../../../admin/http/supabaseAuthMiddlewa
 import { supabaseAdmin } from "../../../auth/supabaseClient";
 import { logger } from "../../../lib/logger";
 import { trackUsage } from "../../../lib/billing/usageTracker";
-import { roleAuthMiddleware, requireRole, type AuthedReq } from "../../middleware/roleAuth";
+import { roleAuthMiddleware, requireRole, resolveEffectiveTenantId, type AuthedReq } from "../../middleware/roleAuth";
 
 type AuthReq = Request & { supabaseUser?: Record<string, unknown>; requestId?: string };
 
@@ -92,9 +92,7 @@ export function registerFalGenerationRoutes(app: Express): void {
 
       const { prompt, numImages } = parsed.data;
 
-      const su = (req as AuthReq).supabaseUser;
-      const suMeta = su?.app_metadata as Record<string, unknown> | undefined;
-      const tenantId = (suMeta?.tenant_id as string) ?? "";
+      const tenantId = resolveEffectiveTenantId(req);
       const requestId = (req as AuthReq).requestId ?? crypto.randomUUID();
 
       const falKey = process.env.FAL_KEY?.trim();

--- a/src/api/admin/avatar/generationRoutes.ts
+++ b/src/api/admin/avatar/generationRoutes.ts
@@ -8,7 +8,7 @@ import type { Express, NextFunction, Request, Response } from "express";
 type AvatarReq = Request & { supabaseUser?: Record<string, unknown>; requestId?: string };
 import { z } from "zod";
 import { supabaseAuthMiddleware } from "../../../admin/http/supabaseAuthMiddleware";
-import { roleAuthMiddleware, requireRole, type AuthedReq } from "../../middleware/roleAuth";
+import { roleAuthMiddleware, requireRole, resolveEffectiveTenantId, type AuthedReq } from "../../middleware/roleAuth";
 import { trackUsage } from "../../../lib/billing/usageTracker";
 import { logger } from '../../../lib/logger';
 import { containsBannedWord } from '../../../lib/contentGuard';
@@ -112,10 +112,7 @@ export function registerAvatarGenerationRoutes(app: Express, _db: any): void {
         return res.status(400).json({ error: "このプロンプトにはビジネスに不適切な表現が含まれています" });
       }
 
-      const su = (req as AvatarReq).supabaseUser;
-      const suMeta = (su?.app_metadata as Record<string, unknown> | undefined);
-      const tenantId: string =
-        suMeta?.tenant_id as string ?? su?.tenant_id as string ?? "";
+      const tenantId: string = resolveEffectiveTenantId(req);
       const requestId: string =
         (req as AvatarReq).requestId ?? crypto.randomUUID();
 
@@ -256,10 +253,7 @@ Output ONLY the English prompt, nothing else.`,
       }
 
       const { description } = parsed.data;
-      const su = (req as AvatarReq).supabaseUser;
-      const suMeta = (su?.app_metadata as Record<string, unknown> | undefined);
-      const tenantId: string =
-        suMeta?.tenant_id as string ?? su?.tenant_id as string ?? "";
+      const tenantId: string = resolveEffectiveTenantId(req);
       const requestId: string =
         (req as AvatarReq).requestId ?? crypto.randomUUID();
 
@@ -386,10 +380,7 @@ JSONのみ返してください。`,
       }
 
       const { rules } = parsed.data;
-      const su = (req as AvatarReq).supabaseUser;
-      const suMeta = (su?.app_metadata as Record<string, unknown> | undefined);
-      const tenantId: string =
-        suMeta?.tenant_id as string ?? su?.tenant_id as string ?? "";
+      const tenantId: string = resolveEffectiveTenantId(req);
       const requestId: string =
         (req as AvatarReq).requestId ?? crypto.randomUUID();
 

--- a/src/api/middleware/roleAuth.test.ts
+++ b/src/api/middleware/roleAuth.test.ts
@@ -4,6 +4,7 @@ import type { NextFunction, Request, Response } from "express";
 import {
   roleAuthMiddleware,
   requireRole,
+  resolveEffectiveTenantId,
   type AuthenticatedUser,
 } from "./roleAuth";
 
@@ -264,6 +265,53 @@ describe("requireRole", () => {
 
     expect(res.status).toHaveBeenCalledWith(403);
     expect(next).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveEffectiveTenantId
+// ---------------------------------------------------------------------------
+// アバター生成系4ルート(fal/generate, generate-image, match-voice,
+// generate-prompt)が個別に app_metadata.tenant_id のみを見ており、
+// super_adminのpreviewMode中に ?tenant= を無視して空テナントで課金・
+// ストレージ書き込みしていた欠陥の是正で導入。routes.ts:647 の既存パターンを
+// 共有ヘルパーとして切り出したもの。
+describe("resolveEffectiveTenantId", () => {
+  it("super_adminは?tenant=クエリで操作対象テナントを上書きできる", () => {
+    const req = mockReq({
+      supabaseUser: { app_metadata: { role: "super_admin" } },
+      query: { tenant: "tenant-b" },
+    });
+    expect(resolveEffectiveTenantId(req)).toBe("tenant-b");
+  });
+
+  it("super_adminが?tenant=を付けなければ従来通り空文字のまま(400ガードは別レイヤーの責務)", () => {
+    const req = mockReq({
+      supabaseUser: { app_metadata: { role: "super_admin" } },
+      query: {},
+    });
+    expect(resolveEffectiveTenantId(req)).toBe("");
+  });
+
+  it("[越権防止] client_adminが?tenant=を付けても無視され、JWTの自テナントが使われる", () => {
+    const req = mockReq({
+      supabaseUser: { app_metadata: { role: "client_admin", tenant_id: "tenant-a" } },
+      query: { tenant: "tenant-b" },
+    });
+    expect(resolveEffectiveTenantId(req)).toBe("tenant-a");
+  });
+
+  it("client_adminは?tenant=なしなら自テナントをそのまま使う", () => {
+    const req = mockReq({
+      supabaseUser: { app_metadata: { role: "client_admin", tenant_id: "tenant-a" } },
+      query: {},
+    });
+    expect(resolveEffectiveTenantId(req)).toBe("tenant-a");
+  });
+
+  it("supabaseUserが無ければ空文字を返す(anonymous)", () => {
+    const req = mockReq({ query: {} });
+    expect(resolveEffectiveTenantId(req)).toBe("");
   });
 });
 

--- a/src/api/middleware/roleAuth.ts
+++ b/src/api/middleware/roleAuth.ts
@@ -113,6 +113,22 @@ export function requireRole(...roles: UserRole[]) {
   };
 }
 
+/**
+ * super_admin のプレビュー中は ?tenant= クエリでの上書きを許可し、それ以外は
+ * JWT の app_metadata.tenant_id をそのまま使う。src/api/admin/avatar/routes.ts:647
+ * の既存パターンを共有ヘルパーとして切り出したもの（生成系ルートが個別に
+ * app_metadata.tenant_id のみを見て ?tenant= を無視していた漏れの是正で導入）。
+ */
+export function resolveEffectiveTenantId(req: Request): string {
+  const supabaseUser = (req as AuthedReq).supabaseUser;
+  const role = safeStringClaim(supabaseUser?.app_metadata?.role);
+  const isSuperAdmin = role === "super_admin";
+  const tenantId =
+    safeStringClaim(supabaseUser?.app_metadata?.tenant_id) ||
+    safeStringClaim((supabaseUser as { tenant_id?: string } | undefined)?.tenant_id);
+  return isSuperAdmin ? ((req.query["tenant"] as string) || tenantId) : tenantId;
+}
+
 // NOTE: 旧 `requireOwnTenant()` ヘルパーは削除済み（Phase70 / Phase44-46 棚卸し結論）。
 // テナント分離は各 per-tenant ルート内で個別に実装されている等価ロジックで担保されており、
 // 一律ミドルウェアの再配線は不要と確認した。代表例:


### PR DESCRIPTION
## Summary

Asana: [P0-1](https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217046358914915)

super_admin がクライアントビュー(previewMode)で操作すると、`fal/generate`・`generate-image`・`match-voice`・`generate-prompt` の生成系4ルートが `app_metadata.tenant_id`（super_adminは空文字）のみを見て `?tenant=` による操作対象テナント指定を無視していた。結果:

- `trackUsage()` の計上先テナントが操作対象ではなく空テナントになる（従量課金の誤計上）
- `fal/generate` のSupabase Storageアップロード先パスが `tenantId/filename.ext` を組むため、`tenantId=""` だとバケット直下に全テナント混在で書き込まれる

これはチャットUI移行で作り込んだバグではなく、旧UI時代から存在する既存バグ（CRUD系 `routes.ts` には `?tenant=` 対応済みだが生成系4本だけ漏れていた）。過去に同根の修正が4回ある再発パターン（PR #481/#483等）。

## 変更内容

- `src/api/middleware/roleAuth.ts` — `resolveEffectiveTenantId(req)` を新規export。`routes.ts:647` に既にある `isSuperAdmin ? (?tenant= || tenantId) : tenantId` パターンをそのまま共有ヘルパー化(新しい書き方は発明していない)
- `src/api/admin/avatar/falGenerationRoutes.ts` / `generationRoutes.ts` — 4ルートのtenantId導出を `resolveEffectiveTenantId(req)` に置換

## やっていないこと(意図的・後続タスクで対応)

- 空テナント時の400ガードは**今回入れていない**。まだフロント(新旧UI)が `?tenant=` を送っていないため、先に400を返すと旧UI(studio.tsx)のsuper_admin操作が新たに壊れる。順序: このPR → [P0-2](https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217046308116781)(新旧UIが`?tenant=`を送るようにする) → [P0-3](https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217046393490238)(400ガード)
- 既存10箇所以上ある同種パターンの一斉置換はしない(スコープ膨張防止)。今回触った4本のみ

## Test plan

- [x] `src/api/middleware/roleAuth.test.ts` に `resolveEffectiveTenantId` の単体テスト追加(super_adminの上書き/未指定、client_adminの越権防止、supabaseUserなし)
- [x] `src/api/admin/avatar/falGenerationRoutes.test.ts` に super_admin+`?tenant=`でtrackUsageが対象テナントになること、client_adminが`?tenant=`を付けても無視されJWTの自テナントが使われることを追加
- [x] `npx jest src/api/middleware/roleAuth.test.ts src/api/admin/avatar/falGenerationRoutes.test.ts src/api/admin/avatar/avatarGenerationAuthGuard.test.ts` — 79/79 pass
- [x] `npx tsc --noEmit` — エラーなし
- [x] `npx oxlint` (変更ファイル) — エラーなし
- [x] rebase on latest main, no conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StqjjaijseYkGkmG2k5LJ