### PR TITLE
fix(admin-ui): 新旧UIの生成系呼び出しに previewMode のテナントを載せる

### DIFF
--- a/admin-ui/src/pages/admin/avatar/studio.tsx
+++ b/admin-ui/src/pages/admin/avatar/studio.tsx
@@ -149,8 +149,13 @@ export default function AvatarStudioPage() {
     setImageDescError(null);
     setGeneratingImage(true);
     setError(null);
+    // super_admin 用: URL ?tenant= でテナントを指定(line 350 と同じ既存パターン)。
+    // 付けないとバックエンドが自身の(空の)テナントで課金してしまう。
+    const generateImageUrl = isSuperAdmin && tenantQueryParam
+      ? `${API_BASE}/v1/admin/avatar/generate-image?tenant=${encodeURIComponent(tenantQueryParam)}`
+      : `${API_BASE}/v1/admin/avatar/generate-image`;
     try {
-      const res = await authFetch(`${API_BASE}/v1/admin/avatar/generate-image`, {
+      const res = await authFetch(generateImageUrl, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ description: imageDesc }),
@@ -216,8 +221,12 @@ export default function AvatarStudioPage() {
     if (isDefault || !voiceDesc.trim() || matchingVoice) return;
     setMatchingVoice(true);
     setError(null);
+    // super_admin 用: URL ?tenant= でテナントを指定(generateImageUrl と同じ理由)。
+    const matchVoiceUrl = isSuperAdmin && tenantQueryParam
+      ? `${API_BASE}/v1/admin/avatar/match-voice?tenant=${encodeURIComponent(tenantQueryParam)}`
+      : `${API_BASE}/v1/admin/avatar/match-voice`;
     try {
-      const res = await authFetch(`${API_BASE}/v1/admin/avatar/match-voice`, {
+      const res = await authFetch(matchVoiceUrl, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ description: voiceDesc }),
@@ -252,8 +261,12 @@ export default function AvatarStudioPage() {
     if (isDefault || !promptRules.trim() || generatingPrompt) return;
     setGeneratingPrompt(true);
     setError(null);
+    // super_admin 用: URL ?tenant= でテナントを指定(generateImageUrl と同じ理由)。
+    const generatePromptUrl = isSuperAdmin && tenantQueryParam
+      ? `${API_BASE}/v1/admin/avatar/generate-prompt?tenant=${encodeURIComponent(tenantQueryParam)}`
+      : `${API_BASE}/v1/admin/avatar/generate-prompt`;
     try {
-      const res = await authFetch(`${API_BASE}/v1/admin/avatar/generate-prompt`, {
+      const res = await authFetch(generatePromptUrl, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ rules: promptRules }),

--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -1629,7 +1629,7 @@ describe("CopilotPreviewPage — アバター画像候補の生成・採用", ()
     let agentCalls = 0;
     vi.mocked(authFetch).mockImplementation((url: string) => {
       if (isBadgeUrl(url)) return mockEmptyBadges();
-      if (String(url).includes("/v1/admin/my-tenant")) {
+      if (String(url).includes("/v1/admin/my-tenant") || String(url).includes("/v1/admin/tenants/tenant-preview")) {
         return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
       }
       if (isUnreadFeedbackUrl(url)) return mockNoFeedbackReplies();
@@ -1657,8 +1657,8 @@ describe("CopilotPreviewPage — アバター画像候補の生成・採用", ()
     });
   }
 
-  async function sendAndAdopt() {
-    renderPage();
+  async function sendAndAdopt(authOverrides: Partial<ReturnType<typeof useAuth>> = {}) {
+    renderPage(authOverrides);
     // 起動時ブリーフィングのタイプライター演出が完了する(sendingがfalseへ確定する)まで待つ。
     // 早すぎるタイミングでdisabled判定すると、演出中にsendingが再びtrueへ倒れる前の
     // 初期レンダー(sending初期値false)を素通りしてしまい、直後のクリックが disabled な
@@ -1849,6 +1849,37 @@ describe("CopilotPreviewPage — アバター画像候補の生成・採用", ()
     expect(JSON.parse(String((patchCalls[0]![1] as RequestInit).body))).toEqual({ image_url: "https://img/1-a.png" });
     expect(JSON.parse(String((patchCalls[1]![1] as RequestInit).body))).toEqual({ image_url: "https://img/2-b.png" });
   });
+
+  // previewMode(super_adminのクライアントビュー)中は ?tenant= を付けないと、
+  // バックエンドが super_admin 自身の(空の)テナントで課金・保存してしまう(#P0-2)。
+  // uploadUrl(book-pdf)と同じ既存パターンを生成系にも適用したことの固定。
+  it("previewMode中は fal/generate に ?tenant=<プレビュー対象テナント> が付く", async () => {
+    mockAdoptedThenEndpoints({ generate: () => mockOk({ images: ["https://img/1.png"] }) });
+
+    const generateButton = await sendAndAdopt(SUPER_ADMIN_IN_PREVIEW);
+    fireEvent.click(generateButton);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "これにする" })).toBeTruthy());
+    const generateCall = vi
+      .mocked(authFetch)
+      .mock.calls.find(([url]) => String(url).includes("/fal/generate"));
+    expect(String(generateCall![0])).toBe(
+      "http://localhost:3100/v1/admin/avatar/fal/generate?tenant=tenant-preview",
+    );
+  });
+
+  it("previewModeでない通常のclient_adminでは ?tenant= が付かない(越権にならない)", async () => {
+    mockAdoptedThenEndpoints({ generate: () => mockOk({ images: ["https://img/1.png"] }) });
+
+    const generateButton = await sendAndAdopt();
+    fireEvent.click(generateButton);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "これにする" })).toBeTruthy());
+    const generateCall = vi
+      .mocked(authFetch)
+      .mock.calls.find(([url]) => String(url).includes("/fal/generate"));
+    expect(String(generateCall![0])).toBe("http://localhost:3100/v1/admin/avatar/fal/generate");
+  });
 });
 
 // POST /match-voice はテキストの候補(id/title/description/score)のみを返し音声
@@ -1865,7 +1896,7 @@ describe("CopilotPreviewPage — アバターの声の選択・採用", () => {
     let agentCalls = 0;
     vi.mocked(authFetch).mockImplementation((url: string) => {
       if (isBadgeUrl(url)) return mockEmptyBadges();
-      if (String(url).includes("/v1/admin/my-tenant")) {
+      if (String(url).includes("/v1/admin/my-tenant") || String(url).includes("/v1/admin/tenants/tenant-preview")) {
         return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
       }
       if (isUnreadFeedbackUrl(url)) return mockNoFeedbackReplies();
@@ -1895,8 +1926,8 @@ describe("CopilotPreviewPage — アバターの声の選択・採用", () => {
     });
   }
 
-  async function sendAndFindVoiceButton() {
-    renderPage();
+  async function sendAndFindVoiceButton(authOverrides: Partial<ReturnType<typeof useAuth>> = {}) {
+    renderPage(authOverrides);
     await waitFor(() => expect(screen.getByText("今週も順調です。")).toBeTruthy());
     await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
     fireEvent.change(getComposer(), { target: { value: "採用してください" } });
@@ -2040,6 +2071,36 @@ describe("CopilotPreviewPage — アバターの声の選択・採用", () => {
     for (const btn of remaining) expect((btn as HTMLButtonElement).disabled).toBe(true);
     // 「これに決定」は1件だけ(誤って複数がハイライトされていない)
     expect(screen.getAllByRole("button", { name: "これに決定" }).length).toBe(1);
+  });
+
+  // previewMode中は ?tenant= を付けないと、バックエンドが super_admin 自身の
+  // (空の)テナントで課金してしまう(generateAvatarCandidatesと同じ理由、#P0-2)。
+  it("previewMode中は match-voice に ?tenant=<プレビュー対象テナント> が付く", async () => {
+    mockAdoptedThenVoiceEndpoints({});
+
+    const voiceButton = await sendAndFindVoiceButton(SUPER_ADMIN_IN_PREVIEW);
+    fireEvent.click(voiceButton);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "この声にする" })).toBeTruthy());
+    const matchCall = vi
+      .mocked(authFetch)
+      .mock.calls.find(([url]) => String(url).includes("/match-voice"));
+    expect(String(matchCall![0])).toBe(
+      "http://localhost:3100/v1/admin/avatar/match-voice?tenant=tenant-preview",
+    );
+  });
+
+  it("previewModeでない通常のclient_adminでは match-voice に ?tenant= が付かない(越権にならない)", async () => {
+    mockAdoptedThenVoiceEndpoints({});
+
+    const voiceButton = await sendAndFindVoiceButton();
+    fireEvent.click(voiceButton);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "この声にする" })).toBeTruthy());
+    const matchCall = vi
+      .mocked(authFetch)
+      .mock.calls.find(([url]) => String(url).includes("/match-voice"));
+    expect(String(matchCall![0])).toBe("http://localhost:3100/v1/admin/avatar/match-voice");
   });
 });
 

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -1322,8 +1322,15 @@ export default function CopilotPreviewPage() {
       background: "simple",
     });
 
+    // previewMode(super_adminのクライアントビュー)中は操作対象テナントを
+    // ?tenant= で明示する。付けないとバックエンドが自身の(空の)テナントで
+    // 課金・保存してしまう(uploadUrl と同じ既存パターン、#P0-2)。
+    const generateUrl = isSuperAdmin && scopedTenantId
+      ? `${API_BASE}/v1/admin/avatar/fal/generate?tenant=${encodeURIComponent(scopedTenantId)}`
+      : `${API_BASE}/v1/admin/avatar/fal/generate`;
+
     try {
-      const res = await authFetch(`${API_BASE}/v1/admin/avatar/fal/generate`, {
+      const res = await authFetch(generateUrl, {
         method: "POST",
         body: JSON.stringify({ prompt, numImages: 4 }),
       });
@@ -1389,8 +1396,14 @@ export default function CopilotPreviewPage() {
     const boundedDescription = description.slice(0, 300);
     push({ id: cardId, role: "ai", card: { kind: "avatarVoiceCandidates", configId, description: boundedDescription, status: "matching" } });
 
+    // previewMode中は操作対象テナントを ?tenant= で明示する(generateAvatarCandidates
+    // と同じ理由、#P0-2)。
+    const matchVoiceUrl = isSuperAdmin && scopedTenantId
+      ? `${API_BASE}/v1/admin/avatar/match-voice?tenant=${encodeURIComponent(scopedTenantId)}`
+      : `${API_BASE}/v1/admin/avatar/match-voice`;
+
     try {
-      const res = await authFetch(`${API_BASE}/v1/admin/avatar/match-voice`, {
+      const res = await authFetch(matchVoiceUrl, {
         method: "POST",
         body: JSON.stringify({ description: boundedDescription }),
       });

--- a/src/api/admin/avatar/falGenerationRoutes.test.ts
+++ b/src/api/admin/avatar/falGenerationRoutes.test.ts
@@ -24,11 +24,11 @@ global.fetch = mockFetch;
 
 // ── ヘルパー ──────────────────────────────────────────────────────────────────
 
-function makeApp(tenantId = "tenant-a") {
+function makeApp(tenantId = "tenant-a", role: "client_admin" | "super_admin" = "client_admin") {
   const app = express();
   app.use(express.json());
   app.use((req: any, _res: any, next: any) => {
-    req.supabaseUser = { app_metadata: { tenant_id: tenantId, role: 'client_admin' } };
+    req.supabaseUser = { app_metadata: { tenant_id: tenantId, role } };
     req.requestId = "req-test-001";
     next();
   });
@@ -94,6 +94,42 @@ describe("POST /v1/admin/avatar/fal/generate", () => {
         featureUsed: "avatar_config_image",
         imageCount: 4,
       }),
+    );
+  });
+
+  // previewMode(super_adminのクライアントビュー)中、app_metadata.tenant_id が空の
+  // super_adminがそのまま生成すると trackUsage が空テナントで計上され、Supabase
+  // Storageのパス(uploadImageFromUrlの第2引数=同じtenantId変数)もバケット直下に
+  // 書き込まれていた(#P0-1)。?tenant= を effective tenantId として使うことを固定する。
+  it("super_adminが?tenant=で操作対象テナントを指定すると、そのテナントでusage_logsに計上される", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => FAL_OK_RESPONSE,
+    });
+
+    const res = await request(makeApp("", "super_admin"))
+      .post("/v1/admin/avatar/fal/generate?tenant=tenant-b")
+      .send({ prompt: "Professional portrait of a Japanese woman, bust shot, smiling" });
+
+    expect(res.status).toBe(200);
+    expect(mockTrackUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ tenantId: "tenant-b" }),
+    );
+  });
+
+  it("client_adminが?tenant=を付けても無視され、JWTの自テナントで計上される(越権防止)", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => FAL_OK_RESPONSE,
+    });
+
+    const res = await request(makeApp("tenant-a", "client_admin"))
+      .post("/v1/admin/avatar/fal/generate?tenant=tenant-b")
+      .send({ prompt: "Professional portrait of a Japanese man, bust shot, business suit" });
+
+    expect(res.status).toBe(200);
+    expect(mockTrackUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ tenantId: "tenant-a" }),
     );
   });
 

--- a/src/api/admin/avatar/falGenerationRoutes.ts
+++ b/src/api/admin/avatar/falGenerationRoutes.ts
@@ -7,7 +7,7 @@ import { supabaseAuthMiddleware } from "../../../admin/http/supabaseAuthMiddlewa
 import { supabaseAdmin } from "../../../auth/supabaseClient";
 import { logger } from "../../../lib/logger";
 import { trackUsage } from "../../../lib/billing/usageTracker";
-import { roleAuthMiddleware, requireRole, type AuthedReq } from "../../middleware/roleAuth";
+import { roleAuthMiddleware, requireRole, resolveEffectiveTenantId, type AuthedReq } from "../../middleware/roleAuth";
 
 type AuthReq = Request & { supabaseUser?: Record<string, unknown>; requestId?: string };
 
@@ -92,9 +92,7 @@ export function registerFalGenerationRoutes(app: Express): void {
 
       const { prompt, numImages } = parsed.data;
 
-      const su = (req as AuthReq).supabaseUser;
-      const suMeta = su?.app_metadata as Record<string, unknown> | undefined;
-      const tenantId = (suMeta?.tenant_id as string) ?? "";
+      const tenantId = resolveEffectiveTenantId(req);
       const requestId = (req as AuthReq).requestId ?? crypto.randomUUID();
 
       const falKey = process.env.FAL_KEY?.trim();

--- a/src/api/admin/avatar/generationRoutes.ts
+++ b/src/api/admin/avatar/generationRoutes.ts
@@ -8,7 +8,7 @@ import type { Express, NextFunction, Request, Response } from "express";
 type AvatarReq = Request & { supabaseUser?: Record<string, unknown>; requestId?: string };
 import { z } from "zod";
 import { supabaseAuthMiddleware } from "../../../admin/http/supabaseAuthMiddleware";
-import { roleAuthMiddleware, requireRole, type AuthedReq } from "../../middleware/roleAuth";
+import { roleAuthMiddleware, requireRole, resolveEffectiveTenantId, type AuthedReq } from "../../middleware/roleAuth";
 import { trackUsage } from "../../../lib/billing/usageTracker";
 import { logger } from '../../../lib/logger';
 import { containsBannedWord } from '../../../lib/contentGuard';
@@ -112,10 +112,7 @@ export function registerAvatarGenerationRoutes(app: Express, _db: any): void {
         return res.status(400).json({ error: "このプロンプトにはビジネスに不適切な表現が含まれています" });
       }
 
-      const su = (req as AvatarReq).supabaseUser;
-      const suMeta = (su?.app_metadata as Record<string, unknown> | undefined);
-      const tenantId: string =
-        suMeta?.tenant_id as string ?? su?.tenant_id as string ?? "";
+      const tenantId: string = resolveEffectiveTenantId(req);
       const requestId: string =
         (req as AvatarReq).requestId ?? crypto.randomUUID();
 
@@ -256,10 +253,7 @@ Output ONLY the English prompt, nothing else.`,
       }
 
       const { description } = parsed.data;
-      const su = (req as AvatarReq).supabaseUser;
-      const suMeta = (su?.app_metadata as Record<string, unknown> | undefined);
-      const tenantId: string =
-        suMeta?.tenant_id as string ?? su?.tenant_id as string ?? "";
+      const tenantId: string = resolveEffectiveTenantId(req);
       const requestId: string =
         (req as AvatarReq).requestId ?? crypto.randomUUID();
 
@@ -386,10 +380,7 @@ JSONのみ返してください。`,
       }
 
       const { rules } = parsed.data;
-      const su = (req as AvatarReq).supabaseUser;
-      const suMeta = (su?.app_metadata as Record<string, unknown> | undefined);
-      const tenantId: string =
-        suMeta?.tenant_id as string ?? su?.tenant_id as string ?? "";
+      const tenantId: string = resolveEffectiveTenantId(req);
       const requestId: string =
         (req as AvatarReq).requestId ?? crypto.randomUUID();
 

--- a/src/api/middleware/roleAuth.test.ts
+++ b/src/api/middleware/roleAuth.test.ts
@@ -4,6 +4,7 @@ import type { NextFunction, Request, Response } from "express";
 import {
   roleAuthMiddleware,
   requireRole,
+  resolveEffectiveTenantId,
   type AuthenticatedUser,
 } from "./roleAuth";
 
@@ -264,6 +265,53 @@ describe("requireRole", () => {
 
     expect(res.status).toHaveBeenCalledWith(403);
     expect(next).not.toHaveBeenCalled();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// resolveEffectiveTenantId
+// ---------------------------------------------------------------------------
+// アバター生成系4ルート(fal/generate, generate-image, match-voice,
+// generate-prompt)が個別に app_metadata.tenant_id のみを見ており、
+// super_adminのpreviewMode中に ?tenant= を無視して空テナントで課金・
+// ストレージ書き込みしていた欠陥の是正で導入。routes.ts:647 の既存パターンを
+// 共有ヘルパーとして切り出したもの。
+describe("resolveEffectiveTenantId", () => {
+  it("super_adminは?tenant=クエリで操作対象テナントを上書きできる", () => {
+    const req = mockReq({
+      supabaseUser: { app_metadata: { role: "super_admin" } },
+      query: { tenant: "tenant-b" },
+    });
+    expect(resolveEffectiveTenantId(req)).toBe("tenant-b");
+  });
+
+  it("super_adminが?tenant=を付けなければ従来通り空文字のまま(400ガードは別レイヤーの責務)", () => {
+    const req = mockReq({
+      supabaseUser: { app_metadata: { role: "super_admin" } },
+      query: {},
+    });
+    expect(resolveEffectiveTenantId(req)).toBe("");
+  });
+
+  it("[越権防止] client_adminが?tenant=を付けても無視され、JWTの自テナントが使われる", () => {
+    const req = mockReq({
+      supabaseUser: { app_metadata: { role: "client_admin", tenant_id: "tenant-a" } },
+      query: { tenant: "tenant-b" },
+    });
+    expect(resolveEffectiveTenantId(req)).toBe("tenant-a");
+  });
+
+  it("client_adminは?tenant=なしなら自テナントをそのまま使う", () => {
+    const req = mockReq({
+      supabaseUser: { app_metadata: { role: "client_admin", tenant_id: "tenant-a" } },
+      query: {},
+    });
+    expect(resolveEffectiveTenantId(req)).toBe("tenant-a");
+  });
+
+  it("supabaseUserが無ければ空文字を返す(anonymous)", () => {
+    const req = mockReq({ query: {} });
+    expect(resolveEffectiveTenantId(req)).toBe("");
   });
 });
 

--- a/src/api/middleware/roleAuth.ts
+++ b/src/api/middleware/roleAuth.ts
@@ -113,6 +113,22 @@ export function requireRole(...roles: UserRole[]) {
   };
 }
 
+/**
+ * super_admin のプレビュー中は ?tenant= クエリでの上書きを許可し、それ以外は
+ * JWT の app_metadata.tenant_id をそのまま使う。src/api/admin/avatar/routes.ts:647
+ * の既存パターンを共有ヘルパーとして切り出したもの（生成系ルートが個別に
+ * app_metadata.tenant_id のみを見て ?tenant= を無視していた漏れの是正で導入）。
+ */
+export function resolveEffectiveTenantId(req: Request): string {
+  const supabaseUser = (req as AuthedReq).supabaseUser;
+  const role = safeStringClaim(supabaseUser?.app_metadata?.role);
+  const isSuperAdmin = role === "super_admin";
+  const tenantId =
+    safeStringClaim(supabaseUser?.app_metadata?.tenant_id) ||
+    safeStringClaim((supabaseUser as { tenant_id?: string } | undefined)?.tenant_id);
+  return isSuperAdmin ? ((req.query["tenant"] as string) || tenantId) : tenantId;
+}
+
 // NOTE: 旧 `requireOwnTenant()` ヘルパーは削除済み（Phase70 / Phase44-46 棚卸し結論）。
 // テナント分離は各 per-tenant ルート内で個別に実装されている等価ロジックで担保されており、
 // 一律ミドルウェアの再配線は不要と確認した。代表例:

--- a/tests/e2e/qa-preview-scope-leak.spec.ts
+++ b/tests/e2e/qa-preview-scope-leak.spec.ts
@@ -181,4 +181,89 @@ test.describe('Preview scope leak (known bug) — escalations が preview テナ
     const body = (await page.textContent('body')) ?? '';
     expect(body).not.toContain('テナントが特定できません');
   });
+
+  // C-LEAK-5: /copilot-preview の画像生成(fal/generate)・声検索(match-voice)は
+  // エージェントツール経由でなくチャットUIから直接fetchするため、C-LEAK-4の
+  // targetTenantId自動付与の対象外(#P0-2で発見・是正)。previewMode中に
+  // ?tenant=<プレビュー対象テナント> が付かないと、fal.ai/Fish Audioの実費用が
+  // 操作対象テナントではなくsuper_admin自身に誤課金される。
+  // agent/chatは実LLMのツール選択に依存させると、carnationの実際のアバター
+  // 保有状況次第で見本提案が出ない(既に採用済み等)フローに揺れうるため、
+  // qa-copilot-preview.spec.ts の CP-B-3 と同じ理由でモックし決定論的にする。
+  // fal/generate・match-voiceも同じ理由(実課金)でモックし、送信URLだけを検証する。
+  test('C-LEAK-5: carnation プレビュー中、fal/generate・match-voiceのURLに?tenant=が付与される', async ({
+    page,
+  }) => {
+    let chatCalls = 0;
+    await page.route('**/v1/admin/agent/chat', async (route) => {
+      chatCalls += 1;
+      if (chatCalls === 1) {
+        return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ reply: '今週も順調です。', actions: [] }) });
+      }
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          reply: '採用しました。',
+          actions: [{
+            tool: 'adopt_avatar_preset',
+            result: 'アバター「Haruka」を採用しました。まだ公開はされていません。',
+            card: { kind: 'avatar_adopted', configId: 'cfg-leak5-1', name: 'Haruka', imageUrl: null, description: 'とても丁寧な性格です。' },
+          }],
+        }),
+      });
+    });
+
+    let generateUrl: string | null = null;
+    let matchVoiceUrl: string | null = null;
+    await page.route('**/v1/admin/avatar/fal/generate*', (route) => {
+      generateUrl = route.request().url();
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ images: ['https://img.example/1.png'] }),
+      });
+    });
+    await page.route('**/v1/admin/avatar/match-voice*', (route) => {
+      matchVoiceUrl = route.request().url();
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ recommendations: [{ id: 'voice-e2e-1', title: 'Haruka Voice', description: '明るい声', score: 0.9 }] }),
+      });
+    });
+
+    // 1. テナント詳細を開き、プレビュー投入
+    await page.goto(`${ADMIN}/admin/tenants/${PREVIEW_TENANT}`, { waitUntil: 'domcontentloaded' });
+    const previewBtn = page.getByRole('button', { name: /クライアントビューで見る/ });
+    await previewBtn.waitFor({ timeout: 15000 });
+    await previewBtn.click();
+    await expect(page.getByText(/プレビューモード|元に戻す/).first()).toBeVisible({ timeout: 10000 });
+
+    // 2. SPA内リンククリックでチャットへ(C-LEAK-4と同じ理由でpage.gotoは使わない)
+    await page.getByText('AIチャットに戻る').first().click();
+    await page.waitForURL((url) => url.pathname === '/copilot-preview', { timeout: 15000 });
+    await page.waitForResponse((r) => r.url().includes('/v1/admin/agent/chat') && r.request().method() === 'POST', { timeout: 20000 });
+
+    // 3. アバターを採用済みの状態にする(agent/chatはモック済みなので実LLMの揺れなし)
+    const composer = page.getByPlaceholder(/指示ルール/);
+    const send = page.getByLabel('送信');
+    await composer.fill('採用してください');
+    await send.click();
+    const generateBtn = page.getByRole('button', { name: '画像を新しく生成する' }).first();
+    await generateBtn.waitFor({ timeout: 15000 });
+
+    // 4. 画像生成・声探しボタンをクリックしてモックへのリクエストURLを捕捉
+    await generateBtn.click();
+    await page.waitForTimeout(1000);
+    const voiceBtn = page.getByRole('button', { name: '声を探す' }).first();
+    await voiceBtn.waitFor({ timeout: 10000 });
+    await voiceBtn.click();
+    await page.waitForTimeout(1000);
+
+    test.info().annotations.push({ type: 'fal-generate-url', description: String(generateUrl) });
+    test.info().annotations.push({ type: 'match-voice-url', description: String(matchVoiceUrl) });
+    expect(generateUrl).toContain(`tenant=${PREVIEW_TENANT}`);
+    expect(matchVoiceUrl).toContain(`tenant=${PREVIEW_TENANT}`);
+  });
 });


### PR DESCRIPTION
## Summary

Asana: [P0-2](https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217046308116781)
Stacked on: #674 (P0-1) — このPRは P0-1 の上に積んでいます。**P0-1マージ後に、baseをmainへ変更してレビューしてください。**

[P0-1](https://github.com/milechy/commerce-faq-tasks/pull/674) でバックエンドが `?tenant=` を受け付けるようになったので、実際に送る側(フロント)を直す。

super_admin がクライアントビュー(previewMode)で画像生成・声検索を行うと、同じファイル内の `uploadUrl`(book-pdf)は `?tenant=` を送っているのに、生成系2エンドポイント(`fal/generate`・`match-voice`)は送っていなかった。新UI(copilot-preview)・旧UI(studio.tsx)の両方に同じ穴があった。

## 変更内容

- `admin-ui/src/pages/copilot-preview/index.tsx` — `generateAvatarCandidates`・`matchAvatarVoice` のfetch先に、既存の `uploadUrl` と同じ `isSuperAdmin && scopedTenantId` パターンで `?tenant=` を付与
- `admin-ui/src/pages/admin/avatar/studio.tsx` — 同じ3エンドポイント(`generate-image`/`match-voice`/`generate-prompt`)に、既存の `tenantQueryParam`(line 350に既にある「super_admin用: URL ?tenant= でテナントを指定」コメントと同じ値)を適用

## やっていないこと(範囲外・別ギャップ)

- `studio.tsx` の編集(`isEdit`)導線は `AvatarCard.tsx` からの遷移時に `?tenant=` をそもそもURLに乗せていない(新規作成導線の `AvatarTab.tsx` は乗せている)。今回追加した3エンドポイントの `?tenant=` 付与ロジック自体は正しいが、編集画面ではこのURLパラメータが最初から無いため無効化される。既存の別ギャップとして残し、深追いしない

## Test plan

- [x] `admin-ui/src/pages/copilot-preview/index.test.tsx` に previewMode中/非previewMode中それぞれで `?tenant=` の有無を検証するテストを追加(画像生成・声検索の両方)
- [x] `npx vitest run src/pages/copilot-preview/index.test.tsx` — 151/151 pass
- [x] `tests/e2e/qa-preview-scope-leak.spec.ts` に C-LEAK-5 追加(previewMode中、fal/generate・match-voiceのURLに実際に `?tenant=` が付くことを本番相当環境で検証。agent/chat・fal/generate・match-voiceはCP-B-3と同じ理由でモック)。E2Eは本番(admin.r2c.biz)直叩きのためこの環境では実行できず、CIでの実行結果を確認してください
- [x] `npx tsc --noEmit`(バックエンド)/ `npx tsc -b`(admin-ui) — 変更ファイルにエラーなし(admin-ui側の既存25件のエラーは本PR無関係の別レーン由来、baseline比較で確認済み)
- [x] `npx oxlint` — エラーなし
- [x] studio.tsx用の単体テストファイルは存在せず、プランでも新規テストファイル作成を認めていないため作成していません(コードレビュー + 型チェックのみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StqjjaijseYkGkmG2k5LJ