### PR TITLE
fix(backend): テナント不明のままアバター画像を生成・保存できないようにする

### DIFF
--- a/src/api/admin/avatar/avatarGenerationAuthGuard.test.ts
+++ b/src/api/admin/avatar/avatarGenerationAuthGuard.test.ts
@@ -157,6 +157,24 @@ describe('avatar generation routes — fail-closed: client_admin without tenant_
   });
 });
 
+// ── テナント解決: super_adminが?tenant=を付けないと400(外部API未呼び出し) ──
+// generate-premium(premiumGenerationRoutes.ts)は #P0-1〜#P0-3 のスコープ外
+// (同じ脆弱パターンが存在するが、別タスクとして扱う。ここでは対象外にする)。
+const TENANT_GUARDED_ENDPOINTS = GENERATION_ENDPOINTS.filter(
+  (e) => e.path !== '/v1/admin/avatar/generate-premium'
+);
+
+describe('avatar generation routes — テナント不明時は400、外部APIを呼ばない', () => {
+  TENANT_GUARDED_ENDPOINTS.forEach(({ method, path, body }) => {
+    it(`${method.toUpperCase()} ${path} — super_adminが?tenant=なし → 400、fetch未呼び出し`, async () => {
+      const app = makeApp({ app_metadata: { role: 'super_admin' }, email: 'sa@t.com' });
+      const res = await (request(app) as any)[method](path).send(body);
+      expect(res.status).toBe(400);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+});
+
 // ── allow-path: 認可通過時にログが出ないこと ─────────────────────────────────
 
 describe('avatar generation routes — allow-path: no authz warn on success', () => {

--- a/src/api/admin/avatar/falGenerationRoutes.test.ts
+++ b/src/api/admin/avatar/falGenerationRoutes.test.ts
@@ -133,6 +133,19 @@ describe("POST /v1/admin/avatar/fal/generate", () => {
     );
   });
 
+  // super_adminが previewMode に入らず ?tenant= も付けずに叩くと、テナントが
+  // 解決できないまま fal.ai を呼び、バケット直下に書き込み・空テナントに課金
+  // していた(#P0-1で発覚)。#P0-3: 外部APIを呼ぶ前に400で早期リターンする。
+  it("super_adminが?tenant=を付けないとテナント不明で400になり、fal.aiを呼ばない", async () => {
+    const res = await request(makeApp("", "super_admin"))
+      .post("/v1/admin/avatar/fal/generate")
+      .send({ prompt: "Professional portrait of a Japanese woman, bust shot, smiling" });
+
+    expect(res.status).toBe(400);
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
+
   it("生成に失敗した場合は計上しない", async () => {
     mockFetch.mockResolvedValueOnce({
       ok: false,

--- a/src/api/admin/avatar/falGenerationRoutes.ts
+++ b/src/api/admin/avatar/falGenerationRoutes.ts
@@ -93,6 +93,9 @@ export function registerFalGenerationRoutes(app: Express): void {
       const { prompt, numImages } = parsed.data;
 
       const tenantId = resolveEffectiveTenantId(req);
+      if (!tenantId) {
+        return res.status(400).json({ error: "テナント情報が取得できません" });
+      }
       const requestId = (req as AuthReq).requestId ?? crypto.randomUUID();
 
       const falKey = process.env.FAL_KEY?.trim();

--- a/src/api/admin/avatar/generationRoutes.ts
+++ b/src/api/admin/avatar/generationRoutes.ts
@@ -113,6 +113,9 @@ export function registerAvatarGenerationRoutes(app: Express, _db: any): void {
       }
 
       const tenantId: string = resolveEffectiveTenantId(req);
+      if (!tenantId) {
+        return res.status(400).json({ error: "テナント情報が取得できません" });
+      }
       const requestId: string =
         (req as AvatarReq).requestId ?? crypto.randomUUID();
 
@@ -254,6 +257,9 @@ Output ONLY the English prompt, nothing else.`,
 
       const { description } = parsed.data;
       const tenantId: string = resolveEffectiveTenantId(req);
+      if (!tenantId) {
+        return res.status(400).json({ error: "テナント情報が取得できません" });
+      }
       const requestId: string =
         (req as AvatarReq).requestId ?? crypto.randomUUID();
 
@@ -381,6 +387,9 @@ JSONのみ返してください。`,
 
       const { rules } = parsed.data;
       const tenantId: string = resolveEffectiveTenantId(req);
+      if (!tenantId) {
+        return res.status(400).json({ error: "テナント情報が取得できません" });
+      }
       const requestId: string =
         (req as AvatarReq).requestId ?? crypto.randomUUID();
 


### PR DESCRIPTION
## Summary

Asana: [P0-3](https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217046393490238)
Stacked on: #675 (P0-2) → #674 (P0-1)。**P0-1/P0-2マージ後に、baseをmainへ変更してレビューしてください。**

P0-1/P0-2 で全ての呼び出し元が `?tenant=` を送るようになった。このPRは、送り忘れた経路が将来また現れても静かに壊れない(空テナントで課金・保存される)ようにする最後の砦として、テナントが解決できない場合は外部API(fal.ai/Fish Audio/Groq)を呼ぶ前に400で早期リターンする。

対象: `fal/generate`・`generate-image`・`match-voice`・`generate-prompt` の4ルート。

## やっていないこと

- 利用回数・レート制限は追加していません。従量課金のプロダクトなので上限を設ける理由がなく、守るべきは `trackUsage` の正しい計上と費用の事前明示です
- `generate-premium`(`premiumGenerationRoutes.ts`)にも同じ脆弱パターン(`su?.app_metadata?.tenant_id` を直接見て `?tenant=` 未対応)が存在することを確認しましたが、P0-1〜P0-3のスコープが明示的に4ルートに限定されていたため対象外にしています。別タスクとして起票が必要です

## Test plan

- [x] `falGenerationRoutes.test.ts` — super_adminが`?tenant=`を付けない → 400、`fal.ai`のfetchが1度も呼ばれないことを検証
- [x] `avatarGenerationAuthGuard.test.ts` — 対象4エンドポイント全てで同様に400・外部API未呼び出しを検証(generate-premiumは対象外として明示的に除外)
- [x] `npx jest src/api/admin/avatar/falGenerationRoutes.test.ts src/api/admin/avatar/avatarGenerationAuthGuard.test.ts src/api/middleware/roleAuth.test.ts` — 84/84 pass
- [x] `npx jest src/api/admin/avatar`(フルディレクトリ) — 対象2ファイルは全green。他ファイル(`routes.test.ts`)の12件失敗は本PR無関係の既知flaky(ローカル環境のリソース逼迫。単体実行では毎回green、失敗内容も本PRが触れていない`voice-clone`/`ALLOWED_ROLES whitelist`)
- [x] `npx tsc --noEmit` — エラーなし
- [x] `npx oxlint`(変更ファイル) — エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StqjjaijseYkGkmG2k5LJ