### PR TITLE
docs: 直接fetch経路のテナントスコープ漏れを再発防止ルールとして明文化する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,6 +189,15 @@ R2C は、テナント（店舗・EC事業者）のサイトに1行で埋め込�
 17. **チャットに出す集計値をLLMの生成文のまま表示する。** 数値・期間・件数はサーバが構造化データ
     （card）として返し、LLMは解釈・提案のみを担う。丸め・省略・語り換えが構造的に起こり得るため
     （例: `get_weekly_briefing`。詳細: `docs/WEEKLY_SUMMARY_REQUIREMENTS.md`）。
+18. **チャットUIからバックエンドを直接fetchする経路を足すとき、previewMode中のテナントスコープ
+    (`?tenant=`)を載せ忘れる。** エージェントツール経由の呼び出しは `targetTenantId` が自動で載るが、
+    直接fetch（`generateAvatarCandidates`・`matchAvatarVoice`・`uploadUrl`のような、500字制約や
+    外部API呼び出しでツール経由にできない処理）は自分で載せる必要があり、この非対称を知らないまま
+    新しい直接fetch経路を足すと静かに漏れる。載せ忘れると、費用と保存先が操作対象テナントではなく
+    super_admin自身の（空の）テナントに紐づき、画面上は正常に見えるためQAで気づけない
+    （実例: `falGenerationRoutes.ts`/`generationRoutes.ts` の生成系4ルート。
+    `escalations`/`tuning`/`knowledge`/テストチャットでも過去に同根の修正が4回ある再発パターン。
+    PR #481/#483、および #P0-1〜#P0-3）。
 
 ## テストの最低ライン
 

--- a/docs/AVATAR_CHAT_MIGRATION.md
+++ b/docs/AVATAR_CHAT_MIGRATION.md
@@ -613,3 +613,28 @@ SELECT
 | クローズ判定を開始してよいか | **開始不可**。V が8週連続で成立するまでは、C1〜C3・ファネルの数値が仮に良好でも判定材料として使わない（`docs/LEGACY_UI_SUNSET.md` §2.3 の規約どおり） |
 
 **次のアクション**: 2026-09-25 以降（または本番DBに接続できるようになった時点でまず§14-Aを実行し8週連続成立を確認してから）、§14 の B〜E を実行し、本ドキュメントに実測値を追記した上でクローズ判定に進む。
+
+## 16. previewMode中のテナントスコープ漏れ（発見・是正、#P0-1〜#P0-3）
+
+実装完了後の厳格レビューで、super_adminのクライアントビュー(previewMode)中に画像生成・声検索を行うと、操作対象テナントではなく super_admin 自身の（空の）テナントに課金・保存されるバグが発覚した。
+
+**発見時の想定と実態の差分**: 当初のレビュー指摘は「`fal/generate`・`match-voice` の2エンドポイントで課金先を誤る」だったが、調査の結果:
+
+- 対象は2本ではなく **`fal/generate`・`generate-image`・`match-voice`・`generate-prompt` の4本**。`src/api/admin/avatar/` 配下の生成系ルートが同じ2行（`app_metadata.tenant_id` を直接読むだけで `?tenant=` クエリを無視）を共有していた
+- 被害は課金の誤計上だけでなく **Supabase Storageのパス破壊**。`falGenerationRoutes.ts` の `uploadImageFromUrl` は `filePath = ${tenantId}/${filename}.${ext}` を組むため、`tenantId` が空だと生成画像がバケット直下に全テナント混在で書き込まれていた
+- これはチャットUI移行で作り込んだバグではなく **旧UI時代から存在する既存バグ**。旧UI(`studio.tsx`)のCRUD系(`/configs`)には `?tenant=` 対応があるのに、生成系4本には無かった
+- 同種の「previewMode中のテナントスコープ漏れ」は `escalations`/`tuning`/`knowledge`/テストチャット（PR #481/#483 等）で過去に**4回**修正されている再発パターンであり、根本原因は本ドキュメントの以下の非対称にある
+
+**根本原因**: エージェントツール経由の呼び出しは `targetTenantId` が自動で載るが、画像生成・声検索のような「500字応答制約や外部API呼び出しでツール経由にできない処理」（§10参照）はチャットUIから直接fetchしており、この直接fetch経路には自動付与の仕組みがない。この非対称を知らないまま新しい直接fetch経路を追加すると、`?tenant=` の付与を個別に実装し忘れやすい。
+
+**対応（3段階、この順序でしか安全に適用できない）**:
+
+1. **P0-1**（バックエンド）: `src/api/middleware/roleAuth.ts` に `resolveEffectiveTenantId()` を追加し、4ルートで共通利用。super_adminの `?tenant=` を受け付けるが、まだ400ガードは入れない
+2. **P0-2**（フロント・新旧UI）: `copilot-preview/index.tsx`・`studio.tsx` の生成系呼び出しに `?tenant=` を実際に送らせる
+3. **P0-3**（バックエンド）: テナントが解決できない場合、外部API呼び出し前に400で早期リターン。P0-1/P0-2完了後でないと、まだ `?tenant=` を送っていない経路（当時の旧UI）を新たに壊す
+
+**やっていないこと（既知の残存ギャップ）**:
+
+- `studio.tsx` の編集(`isEdit`)導線は `AvatarCard.tsx` からの遷移時に `?tenant=` をそもそもURLに乗せていない（新規作成導線の `AvatarTab.tsx` は乗せている）。P0-2で追加した `?tenant=` 付与ロジック自体は正しいが、編集画面ではこのURLパラメータが最初から無いため無効化される
+- `generate-premium`（`premiumGenerationRoutes.ts`）にも同じ脆弱パターン（`su?.app_metadata?.tenant_id` を直接見て `?tenant=` 未対応）が存在することを確認したが、P0-1〜P0-3のスコープが明示的に4ルートに限定されていたため対象外。別タスクとして起票が必要
+- レート制限・利用回数上限は追加していない。従量課金のプロダクトのため、守るべきは `trackUsage` の正しい計上と費用の事前明示であり、上限を設ける必要はない（CLAUDE.md 項目10参照）


### PR DESCRIPTION
## Summary

Asana: [P2](https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217046308466975)
Stacked on: #676 (P0-3) → #675 (P0-2) → #674 (P0-1)。**先行3PRマージ後に、baseをmainへ変更してレビューしてください。**

previewMode中のテナントスコープ漏れは `escalations`/`tuning`/`knowledge`/テストチャット(PR #481/#483等)で過去に4回、今回のアバター生成系4ルート(#P0-1〜#P0-3)で5回目の再発だった。根本原因は「エージェントツール経由の呼び出しは `targetTenantId` が自動で載るが、直接fetch経路には自動付与の仕組みがない」という非対称。この非対称自体がCLAUDE.mdに書かれていなかったため明文化する。

コード変更は含まれません(docsのみ)。

## 変更内容

- `CLAUDE.md` — 「絶対にやってはいけないこと」の項目18として、直接fetch経路を足すときは`?tenant=`を必ず載せる旨を追記(既存項目1・10の隣接ルールとして、新規セクションは作らず既存節に追記)
- `docs/AVATAR_CHAT_MIGRATION.md` — §16として発見経緯(レビュー指摘の当初想定「2エンドポイント」が調査で「4エンドポイント+ストレージ破壊」と判明した経緯を含む)・対応3段階(P0-1→P0-2→P0-3の順序)・残存ギャップ(studio.tsx編集導線, generate-premium, レート制限を追加しない方針)を追記

## Test plan

- コード変更なし。docs追記のみ
- 既存節の中に収まっており新規節を作りすぎていないことを確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StqjjaijseYkGkmG2k5LJ