### PR TITLE
refactor(e2e): carnation-demo URL合成の重複をconfig.tsの派生定数に集約する

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,8 +10,8 @@ on:
       - 'tests/e2e/**'
       - 'playwright.config.ts'
 
-# E2E は playwright.config.ts の baseURL(https://admin.r2c.biz)経由で本番環境を直接叩く
-# (専用のstaging環境やサーバ起動ステップが無いため)。並行PRが同時にE2Eを走らせると
+# E2E は tests/e2e/config.ts の ADMIN_BASE_URL/API_BASE_URL(既定値は本番)経由で
+# 本番環境を直接叩く(専用のstaging環境やサーバ起動ステップが無いため)。並行PRが同時にE2Eを走らせると
 # 本番へのリクエストがレート制限(429)に達し、PRの内容と無関係にCIが赤くなる事象が
 # 確認された(GID 1216947610263309)。E2Eジョブを1本ずつ直列実行させることで回避する。
 # cancel-in-progress は必ず false — 後から来たPRのE2Eが先行PRの実行中E2Eをキャンセルして

--- a/tests/e2e/config.test.ts
+++ b/tests/e2e/config.test.ts
@@ -1,6 +1,6 @@
 // tests/e2e/config.test.ts
 
-import { resolveE2eBaseUrls, ADMIN_BASE_URL, API_BASE_URL } from './config';
+import { resolveE2eBaseUrls, ADMIN_BASE_URL, API_BASE_URL, DEMO_BASE_URL, DEMO_INDEX_URL } from './config';
 
 describe('resolveE2eBaseUrls', () => {
   it('env未設定 → 本番URLがデフォルトになる', () => {
@@ -64,5 +64,20 @@ describe('ADMIN_BASE_URL / API_BASE_URL', () => {
   it('本番URLの文字列としてexportされている(export名の消失検知)', () => {
     expect(ADMIN_BASE_URL).toMatch(/^https:\/\//);
     expect(API_BASE_URL).toMatch(/^https:\/\//);
+  });
+});
+
+describe('DEMO_BASE_URL / DEMO_INDEX_URL', () => {
+  it('DEMO_BASE_URL が API_BASE_URL + "/carnation-demo" になる', () => {
+    expect(DEMO_BASE_URL).toBe(`${API_BASE_URL}/carnation-demo`);
+  });
+
+  it('DEMO_INDEX_URL が DEMO_BASE_URL + "/index.html" になる', () => {
+    expect(DEMO_INDEX_URL).toBe(`${DEMO_BASE_URL}/index.html`);
+  });
+
+  it('末尾スラッシュ付きのAPI_BASE_URLでも // が混入しない(合成後のパス部分に二重スラッシュが無い)', () => {
+    const path = DEMO_INDEX_URL.replace(/^https?:\/\//, '');
+    expect(path).not.toContain('//');
   });
 });

--- a/tests/e2e/config.ts
+++ b/tests/e2e/config.ts
@@ -50,3 +50,8 @@ const { adminBaseUrl, apiBaseUrl } = resolveE2eBaseUrls();
 
 export const ADMIN_BASE_URL = adminBaseUrl;
 export const API_BASE_URL = apiBaseUrl;
+
+// carnation-demo(社内デモ用テナント)のURL。複数のspecが同じパスを個別に
+// 組み立てていた重複を解消するための派生定数。
+export const DEMO_BASE_URL = `${API_BASE_URL}/carnation-demo`;
+export const DEMO_INDEX_URL = `${DEMO_BASE_URL}/index.html`;

--- a/tests/e2e/phase65-demo.spec.ts
+++ b/tests/e2e/phase65-demo.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect } from '@playwright/test';
 import { gotoWithRetry } from './helpers/gotoRetry';
-import { API_BASE_URL } from './config';
+import { API_BASE_URL, DEMO_BASE_URL } from './config';
 
 const E2E_ENABLED = process.env.E2E_ENABLED === '1' || !!process.env.CI;
-const DEMO_BASE = `${API_BASE_URL}/carnation-demo`;
+const DEMO_BASE = DEMO_BASE_URL;
 
 test.describe('Phase65 carnation-demo サイト', () => {
   test.skip(!E2E_ENABLED, 'E2E tests require E2E_ENABLED=1 or CI=true');

--- a/tests/e2e/qa-2026-07-08-role-a.spec.ts
+++ b/tests/e2e/qa-2026-07-08-role-a.spec.ts
@@ -1,13 +1,13 @@
 import { test, expect } from '@playwright/test';
 import { gotoWithRetry } from './helpers/gotoRetry';
-import { API_BASE_URL } from './config';
+import { DEMO_BASE_URL } from './config';
 
 // QA sweep 2026-07-08: previously-uncovered Role A (end-user/anonymous) flows
 // from R2C_UIフローカタログ_2026-07-08.md (A2-3, A2-6, A2-13, A2-14, A3-2, A3-3, A3-5, A3-6, A3-8).
 // Any real failures found here are filed to Asana (RAJIUCE Development, gid 1213607637045514).
 
 const E2E_ENABLED = process.env.E2E_ENABLED === '1' || !!process.env.CI;
-const DEMO_BASE = `${API_BASE_URL}/carnation-demo`;
+const DEMO_BASE = DEMO_BASE_URL;
 
 // Asana #1216386757951251 の修正 (novalidate 付与) が https://api.r2c.biz にまだデプロイされて
 // いない場合、A3-2/A3-5.6/A3-8 の「修正後」アサーションは必ず落ちる。デプロイラグの間 CI を

--- a/tests/e2e/qa-irregular-3roles.spec.ts
+++ b/tests/e2e/qa-irregular-3roles.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { ADMIN_BASE_URL, API_BASE_URL } from './config';
+import { ADMIN_BASE_URL, API_BASE_URL, DEMO_BASE_URL } from './config';
 
 // QA irregular (異常系) sweep — 2026-07-17
 // 3ロールが「イレギュラーな動作」をした場合に、拒むべき操作が正しく拒まれるか / スコープが
@@ -15,7 +15,7 @@ import { ADMIN_BASE_URL, API_BASE_URL } from './config';
 const E2E_ENABLED = process.env.E2E_ENABLED === '1' || !!process.env.CI;
 const API = API_BASE_URL;
 const ADMIN = ADMIN_BASE_URL;
-const DEMO_BASE = `${API}/carnation-demo`;
+const DEMO_BASE = DEMO_BASE_URL;
 const USER_AUTH = 'tests/e2e/.auth/user.json';
 const SA_AUTH = 'tests/e2e/.auth/superadmin.json';
 const OWN_TENANT = 'carnation';

--- a/tests/e2e/visual-regression.spec.ts
+++ b/tests/e2e/visual-regression.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { ADMIN_BASE_URL, API_BASE_URL } from './config';
+import { ADMIN_BASE_URL, DEMO_INDEX_URL } from './config';
 
 // Phase C: ビジュアルリグレッションテスト
 // storageState (auth.setup.ts) で認証済み状態で実行される
@@ -74,7 +74,7 @@ test.describe('Visual Regression — Public Pages', () => {
 
   test('carnation-demo index — desktop', async ({ page }) => {
     await page.setViewportSize({ width: 1280, height: 800 });
-    await page.goto(`${API_BASE_URL}/carnation-demo/index.html`);
+    await page.goto(DEMO_INDEX_URL);
     await page.waitForLoadState('networkidle');
     // widget初期化を待つ
     await page.waitForTimeout(2000);
@@ -85,7 +85,7 @@ test.describe('Visual Regression — Public Pages', () => {
 
   test('carnation-demo index — mobile 390px', async ({ page }) => {
     await page.setViewportSize({ width: 390, height: 844 });
-    await page.goto(`${API_BASE_URL}/carnation-demo/index.html`);
+    await page.goto(DEMO_INDEX_URL);
     await page.waitForLoadState('networkidle');
     await page.waitForTimeout(2000);
     await expect(page).toHaveScreenshot('carnation-demo-mobile-390.png', {

--- a/tests/e2e/widget-fab-avatar.spec.ts
+++ b/tests/e2e/widget-fab-avatar.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from '@playwright/test';
-import { API_BASE_URL } from './config';
+import { DEMO_INDEX_URL } from './config';
 
 const E2E_ENABLED = process.env.E2E_ENABLED === '1' || !!process.env.CI;
 
@@ -16,7 +16,7 @@ test.describe('Widget FAB — Avatar persistence on chat open/close', () => {
 
   // アバター設定済みテナントのデモページ (test 1/2 が使用)
   const AVATAR_DEMO_URL =
-    process.env.E2E_CHAT_TEST_URL || `${API_BASE_URL}/carnation-demo/index.html`;
+    process.env.E2E_CHAT_TEST_URL || DEMO_INDEX_URL;
   // 非アバターテナントのページ (test 3 が使用)。CI で実 URL を注入すると非アバター経路を実検証できる。
   // 未指定時はアバター版にフォールバック → test 3 は従来どおり skip される（誤検証を防ぐ）。
   const NON_AVATAR_DEMO_URL = process.env.E2E_NON_AVATAR_TEST_URL || AVATAR_DEMO_URL;

--- a/tests/e2e/widget-mobile.spec.ts
+++ b/tests/e2e/widget-mobile.spec.ts
@@ -1,9 +1,9 @@
 import { test, expect } from '@playwright/test';
 import { gotoWithRetry } from './helpers/gotoRetry';
-import { API_BASE_URL } from './config';
+import { DEMO_INDEX_URL } from './config';
 
 const E2E_ENABLED = process.env.E2E_ENABLED === '1' || !!process.env.CI;
-const DEMO_URL = `${API_BASE_URL}/carnation-demo/index.html`;
+const DEMO_URL = DEMO_INDEX_URL;
 
 test.describe('Widget — Mobile iPhone 12 (390px) M1-M4', () => {
   test.skip(!E2E_ENABLED, 'E2E tests require E2E_ENABLED=1 or CI=true');

--- a/tests/e2e/widget.spec.ts
+++ b/tests/e2e/widget.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { gotoWithRetry } from './helpers/gotoRetry';
-import { API_BASE_URL } from './config';
+import { DEMO_INDEX_URL } from './config';
 
 const E2E_ENABLED = process.env.E2E_ENABLED === '1' || !!process.env.CI;
 
@@ -11,7 +11,7 @@ test.describe('Chat Widget — Rendering', () => {
     const errors: string[] = [];
     page.on('pageerror', (err) => errors.push(err.message));
 
-    const response = await gotoWithRetry(page, `${API_BASE_URL}/carnation-demo/index.html`);
+    const response = await gotoWithRetry(page, DEMO_INDEX_URL);
 
     // ページ自体は 200 で返る
     expect(response?.status()).toBe(200);
@@ -24,7 +24,7 @@ test.describe('Chat Widget — Rendering', () => {
   });
 
   test('widget.js script tag is present in demo page', async ({ page }) => {
-    await gotoWithRetry(page, `${API_BASE_URL}/carnation-demo/index.html`);
+    await gotoWithRetry(page, DEMO_INDEX_URL);
 
     // widget.js の <script> タグが埋め込まれていること
     const widgetScript = page.locator('script[src*="widget.js"]');
@@ -32,7 +32,7 @@ test.describe('Chat Widget — Rendering', () => {
   });
 
   test('widget container or chat button appears in DOM', async ({ page }) => {
-    await gotoWithRetry(page, `${API_BASE_URL}/carnation-demo/index.html`);
+    await gotoWithRetry(page, DEMO_INDEX_URL);
 
     // Shadow DOM ホスト要素またはウィジェットコンテナが存在すること
     // widget.js が生成する要素を確認（data-api-key 属性付き script の後に挿入される）


### PR DESCRIPTION
## Summary
- `tests/e2e/config.ts` に `DEMO_BASE_URL`(`${API_BASE_URL}/carnation-demo`) / `DEMO_INDEX_URL`(`${DEMO_BASE_URL}/index.html`) を派生定数として追加。
- 7ファイル・7箇所以上に個別重複していた `${API_BASE_URL}/carnation-demo` 系のURL組み立てを、上記の派生定数を参照する形に統一した: `phase65-demo.spec.ts`, `qa-2026-07-08-role-a.spec.ts`, `qa-irregular-3roles.spec.ts`, `widget-mobile.spec.ts`, `widget-fab-avatar.spec.ts`, `widget.spec.ts`, `visual-regression.spec.ts`。
- 各specのローカル定数名(`DEMO_BASE`/`DEMO_URL`等)はそのまま維持し、初期化子のみを差し替えたため、本文の参照箇所(最大10箇所/ファイル)には一切触れていない。
- `phase65-demo.spec.ts:91` の「旧URL `/carnation-demo.html` への301リダイレクト」を検証する専用URLは意図的に対象外とし、`API_BASE_URL` 合成のまま残した(デモのベースパスではなく別物のため、巻き込むとテストの意味が消える)。
- `.github/workflows/e2e.yml` の陳腐化していたコメント(URLが `config.ts` に集約された後もハードコードされたままだった記述)のみ更新。ロジックは不変。
- `tests/e2e/config.test.ts` に派生定数のテストを3件追加。

## 前提
先行PR #673(E2E設定のJest収集ガード + `resolveE2eBaseUrls` 純粋関数化)がマージ済みであること。

## Test plan
- [x] `npx tsc --noEmit` — エラーなし(未使用importも無し)
- [x] `npx oxlint tests/e2e` — warning 2件のみ、いずれも本PRと無関係の既存警告
- [x] `npx jest tests/e2e/config.test.ts` — 11件全てpass(派生定数の新規3件含む)
- [x] `E2E_ENABLED=1 npx playwright test --list` — Total: 103 tests in 17 files(純粋なリファクタのため変化なし)
- [x] `rg -n "carnation-demo" tests/e2e/*.spec.ts` — 残存箇所は全てテスト名/describe名/リダイレクト検証専用URL/スクリーンショット名のみで、URL組み立ての重複・置換漏れ・誤置換は無いことを確認
- [x] `bash SCRIPTS/security-scan.sh` — PASS
- [ ] CI上のE2E実行(本番URLへの実リクエストが従来通り成功することの最終確認)

## Asana
https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217046393105227

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NgWB82fsx7LMjhJqpd1rCx