### PR TITLE
debug: temporary CP-B-4 diagnostics (do not merge)

### DIFF
--- a/tests/e2e/qa-copilot-preview.spec.ts
+++ b/tests/e2e/qa-copilot-preview.spec.ts
@@ -294,6 +294,20 @@ test.describe('copilot-preview — Role B (client_admin)', () => {
       console.log('[DIAG] responses:', JSON.stringify(diagResponses, null, 2));
       console.log('[DIAG] localStorage keys:', await page.evaluate(() => Object.keys(window.localStorage)));
       console.log('[DIAG] body text:', (await page.textContent('body'))?.slice(0, 1500));
+      console.log('[DIAG] jwt payload:', await page.evaluate(() => {
+        try {
+          const key = Object.keys(window.localStorage).find((k) => k.includes('auth-token'));
+          if (!key) return 'NO_AUTH_TOKEN_KEY';
+          const raw = window.localStorage.getItem(key);
+          const parsed = JSON.parse(raw || '{}');
+          const accessToken = parsed?.access_token as string | undefined;
+          if (!accessToken) return 'NO_ACCESS_TOKEN';
+          const payloadB64 = accessToken.split('.')[1];
+          return JSON.parse(atob(payloadB64.replace(/-/g, '+').replace(/_/g, '/')));
+        } catch (e) {
+          return 'ERROR: ' + String(e);
+        }
+      }));
 
       // 週次ブリーフィングの代わりに、指示ルールの初回紹介が出る
       await expect(page.getByText(/最初のルールを作ってみますか/)).toBeVisible({ timeout: 15000 });

--- a/tests/e2e/qa-copilot-preview.spec.ts
+++ b/tests/e2e/qa-copilot-preview.spec.ts
@@ -277,7 +277,23 @@ test.describe('copilot-preview — Role B (client_admin)', () => {
         return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ reply: '了解しました。', actions: [] }) });
       });
 
+      // DIAGNOSTIC (temporary, to be reverted): capture my-tenant/agent-chat responses and
+      // localStorage state to debug why the P6-1 intro nudge doesn't appear in CI.
+      const diagResponses: string[] = [];
+      page.on('response', (res) => {
+        const u = res.url();
+        if (u.includes('my-tenant') || u.includes('agent/chat')) {
+          res.text().then((body) => {
+            diagResponses.push(`${res.status()} ${u} :: ${body.slice(0, 300)}`);
+          }).catch(() => {});
+        }
+      });
+
       await page.goto(`${ADMIN}/copilot-preview`, { waitUntil: 'domcontentloaded', timeout: 20000 });
+      await page.waitForTimeout(5000);
+      console.log('[DIAG] responses:', JSON.stringify(diagResponses, null, 2));
+      console.log('[DIAG] localStorage keys:', await page.evaluate(() => Object.keys(window.localStorage)));
+      console.log('[DIAG] body text:', (await page.textContent('body'))?.slice(0, 1500));
 
       // 週次ブリーフィングの代わりに、指示ルールの初回紹介が出る
       await expect(page.getByText(/最初のルールを作ってみますか/)).toBeVisible({ timeout: 15000 });


### PR DESCRIPTION
一時的な調査用PR。CP-B-4のP6-1初回紹介チップが本番で出ない原因調査のため、CIログにレスポンス内容とlocalStorage状態をダンプする。原因判明後にクローズ・ブランチ削除する(マージしない)。