### PR TITLE
test(e2e): E2E設定レイヤの壊れやすい経路を突くテストを追加し、値の正規化・検証を強化する

### DIFF
--- a/tests/e2e/config.test.ts
+++ b/tests/e2e/config.test.ts
@@ -1,13 +1,18 @@
 // tests/e2e/config.test.ts
 
-import { resolveE2eBaseUrls, ADMIN_BASE_URL, API_BASE_URL, DEMO_BASE_URL, DEMO_INDEX_URL } from './config';
+import {
+  resolveE2eBaseUrls,
+  ADMIN_BASE_URL,
+  API_BASE_URL,
+  DEMO_BASE_URL,
+  DEMO_INDEX_URL,
+} from './config';
 
-describe('resolveE2eBaseUrls', () => {
+const PROD = { adminBaseUrl: 'https://admin.r2c.biz', apiBaseUrl: 'https://api.r2c.biz' };
+
+describe('resolveE2eBaseUrls — 正常系', () => {
   it('env未設定 → 本番URLがデフォルトになる', () => {
-    expect(resolveE2eBaseUrls({})).toEqual({
-      adminBaseUrl: 'https://admin.r2c.biz',
-      apiBaseUrl: 'https://api.r2c.biz',
-    });
+    expect(resolveE2eBaseUrls({})).toEqual(PROD);
   });
 
   it('両方設定時 → 両方とも上書きされる', () => {
@@ -22,41 +27,175 @@ describe('resolveE2eBaseUrls', () => {
     });
   });
 
-  it('E2E_BASE_URL のみ設定 → throw する', () => {
+  it('管理画面とAPIが同一ホストでも許容される(単一ホスト構成のステージング)', () => {
+    expect(
+      resolveE2eBaseUrls({
+        E2E_BASE_URL: 'https://staging.example.com',
+        E2E_API_URL: 'https://staging.example.com',
+      }),
+    ).toEqual({
+      adminBaseUrl: 'https://staging.example.com',
+      apiBaseUrl: 'https://staging.example.com',
+    });
+  });
+
+  it('http(ローカル/自前ステージング)も許容される — https限定にしない', () => {
+    expect(
+      resolveE2eBaseUrls({
+        E2E_BASE_URL: 'http://localhost:5173',
+        E2E_API_URL: 'http://localhost:3100',
+      }),
+    ).toEqual({
+      adminBaseUrl: 'http://localhost:5173',
+      apiBaseUrl: 'http://localhost:3100',
+    });
+  });
+
+  it('パス付きのbase URL(サブパス配信)でもパスが保持される', () => {
+    expect(
+      resolveE2eBaseUrls({
+        E2E_BASE_URL: 'https://example.com/admin-app',
+        E2E_API_URL: 'https://example.com/api',
+      }).apiBaseUrl,
+    ).toBe('https://example.com/api');
+  });
+
+  it('大文字スキーム(HTTPS://)も受け付ける', () => {
+    expect(
+      resolveE2eBaseUrls({
+        E2E_BASE_URL: 'HTTPS://staging-admin.example.com',
+        E2E_API_URL: 'HTTPS://staging-api.example.com',
+      }).adminBaseUrl,
+    ).toBe('HTTPS://staging-admin.example.com');
+  });
+});
+
+describe('resolveE2eBaseUrls — 片側のみ設定(向き先の食い違い防止)', () => {
+  it('E2E_BASE_URL のみ設定 → 欠けている側の変数名を含めて throw する', () => {
     expect(() => resolveE2eBaseUrls({ E2E_BASE_URL: 'https://staging-admin.example.com' })).toThrow(
       /E2E_API_URL/,
     );
   });
 
-  it('E2E_API_URL のみ設定 → throw する', () => {
+  it('E2E_API_URL のみ設定 → 欠けている側の変数名を含めて throw する', () => {
     expect(() => resolveE2eBaseUrls({ E2E_API_URL: 'https://staging-api.example.com' })).toThrow(
       /E2E_BASE_URL/,
     );
   });
 
-  it('末尾スラッシュ付き(E2E_BASE_URL)が正規化される', () => {
+  // 「片方を空文字にすれば無効化できる」と誤解した操作。空文字は未設定と同義に倒れるため
+  // 「もう片方だけ設定された」状態になり、本番混在ではなく throw で止まる必要がある。
+  it('片方が空文字・もう片方が実URL → 未設定扱いになり throw する(本番と混在させない)', () => {
+    expect(() =>
+      resolveE2eBaseUrls({ E2E_BASE_URL: '', E2E_API_URL: 'https://staging-api.example.com' }),
+    ).toThrow(/E2E_BASE_URL/);
+  });
+
+  // 空白のみの値は「見た目は設定済み・実質未設定」。trim しないと truthy のまま通過し、
+  // 片側ガードもすり抜けて adminBaseUrl='   ' のまま全specへ配られてしまう。
+  it('片方が空白のみ・もう片方が実URL → 空白は未設定扱いになり throw する', () => {
+    expect(() =>
+      resolveE2eBaseUrls({ E2E_BASE_URL: '   ', E2E_API_URL: 'https://staging-api.example.com' }),
+    ).toThrow(/E2E_BASE_URL/);
+  });
+
+  it('両方とも空白のみ → 両方未設定扱いで本番にフォールバックする(throwしない)', () => {
+    expect(resolveE2eBaseUrls({ E2E_BASE_URL: '  ', E2E_API_URL: '\n' })).toEqual(PROD);
+  });
+
+  it('両方未設定は正常系(throwしない)', () => {
+    expect(() => resolveE2eBaseUrls({})).not.toThrow();
+  });
+});
+
+describe('resolveE2eBaseUrls — 値の正規化', () => {
+  it('空文字列は本番にフォールバックする', () => {
+    expect(resolveE2eBaseUrls({ E2E_BASE_URL: '', E2E_API_URL: '' })).toEqual(PROD);
+  });
+
+  // CI Secrets / .env は末尾に改行が混入しやすい。trim しないと
+  // `https://example.com\n/health` のような一見正しく見えるURLになる。
+  it.each([
+    ['末尾改行', 'https://staging-admin.example.com\n', 'https://staging-api.example.com\n'],
+    ['末尾スペース', 'https://staging-admin.example.com ', 'https://staging-api.example.com '],
+    ['前後スペース', '  https://staging-admin.example.com  ', '  https://staging-api.example.com  '],
+    ['タブ+CRLF', '\thttps://staging-admin.example.com\r\n', '\thttps://staging-api.example.com\r\n'],
+  ])('%s は trim される', (_label, admin, api) => {
+    expect(resolveE2eBaseUrls({ E2E_BASE_URL: admin, E2E_API_URL: api })).toEqual({
+      adminBaseUrl: 'https://staging-admin.example.com',
+      apiBaseUrl: 'https://staging-api.example.com',
+    });
+  });
+
+  it('末尾スラッシュが1つでも複数でも除去される', () => {
     expect(
       resolveE2eBaseUrls({
         E2E_BASE_URL: 'https://staging-admin.example.com/',
-        E2E_API_URL: 'https://staging-api.example.com',
+        E2E_API_URL: 'https://staging-api.example.com///',
+      }),
+    ).toEqual({
+      adminBaseUrl: 'https://staging-admin.example.com',
+      apiBaseUrl: 'https://staging-api.example.com',
+    });
+  });
+
+  it('末尾スラッシュとその後ろの空白が併存しても両方除去される', () => {
+    expect(
+      resolveE2eBaseUrls({
+        E2E_BASE_URL: 'https://staging-admin.example.com/ ',
+        E2E_API_URL: 'https://staging-api.example.com/ ',
       }).adminBaseUrl,
     ).toBe('https://staging-admin.example.com');
   });
 
-  it('末尾スラッシュ付き(E2E_API_URL)が正規化される', () => {
-    expect(
-      resolveE2eBaseUrls({
-        E2E_BASE_URL: 'https://staging-admin.example.com',
-        E2E_API_URL: 'https://staging-api.example.com/',
-      }).apiBaseUrl,
-    ).toBe('https://staging-api.example.com');
+  // これが破れると DEMO_BASE_URL の合成で `//carnation-demo` が生まれる。
+  // 個別ケースではなく不変条件として押さえる。
+  it.each([
+    'https://a.example.com',
+    'https://a.example.com/',
+    'https://a.example.com///',
+    'https://a.example.com/sub/',
+    'https://a.example.com/sub  ',
+  ])('戻り値は末尾スラッシュを持たない: %s', (input) => {
+    const { adminBaseUrl, apiBaseUrl } = resolveE2eBaseUrls({
+      E2E_BASE_URL: input,
+      E2E_API_URL: input,
+    });
+    expect(adminBaseUrl.endsWith('/')).toBe(false);
+    expect(apiBaseUrl.endsWith('/')).toBe(false);
+  });
+});
+
+describe('resolveE2eBaseUrls — URLとして壊れた値の早期検出', () => {
+  // 検証が無いと、これらが黙って103テスト全部に配られ「向き先が壊れている」と
+  // 気付けないまま原因不明の失敗が並ぶ。
+  it.each([
+    ['スラッシュのみ', '/'],
+    ['スキーム無し', 'not-a-url'],
+    ['ホスト名なし', 'https://'],
+    ['対応外スキーム', 'ftp://example.com'],
+    ['相対パス', '/admin'],
+    ['スキームのtypo', 'htps://example.com'],
+  ])('%s は throw する', (_label, bad) => {
+    expect(() => resolveE2eBaseUrls({ E2E_BASE_URL: bad, E2E_API_URL: bad })).toThrow(/URL/);
   });
 
-  it('空文字列は本番にフォールバックする', () => {
-    expect(resolveE2eBaseUrls({ E2E_BASE_URL: '', E2E_API_URL: '' })).toEqual({
-      adminBaseUrl: 'https://admin.r2c.biz',
-      apiBaseUrl: 'https://api.r2c.biz',
-    });
+  it('壊れているのがAPI側だけでも、どちらの変数かを名指しして throw する', () => {
+    expect(() =>
+      resolveE2eBaseUrls({ E2E_BASE_URL: 'https://ok.example.com', E2E_API_URL: 'not-a-url' }),
+    ).toThrow(/E2E_API_URL/);
+  });
+
+  it('壊れているのが管理画面側だけでも、どちらの変数かを名指しして throw する', () => {
+    expect(() =>
+      resolveE2eBaseUrls({ E2E_BASE_URL: 'not-a-url', E2E_API_URL: 'https://ok.example.com' }),
+    ).toThrow(/E2E_BASE_URL/);
+  });
+
+  it('エラーメッセージに実際の解決値が含まれる(原因特定を早めるため)', () => {
+    expect(() =>
+      resolveE2eBaseUrls({ E2E_BASE_URL: 'not-a-url', E2E_API_URL: 'https://ok.example.com' }),
+    ).toThrow(/not-a-url/);
   });
 });
 
@@ -64,6 +203,11 @@ describe('ADMIN_BASE_URL / API_BASE_URL', () => {
   it('本番URLの文字列としてexportされている(export名の消失検知)', () => {
     expect(ADMIN_BASE_URL).toMatch(/^https:\/\//);
     expect(API_BASE_URL).toMatch(/^https:\/\//);
+  });
+
+  it('末尾スラッシュを持たない(パス連結で // を作らない)', () => {
+    expect(ADMIN_BASE_URL.endsWith('/')).toBe(false);
+    expect(API_BASE_URL.endsWith('/')).toBe(false);
   });
 });
 
@@ -76,8 +220,14 @@ describe('DEMO_BASE_URL / DEMO_INDEX_URL', () => {
     expect(DEMO_INDEX_URL).toBe(`${DEMO_BASE_URL}/index.html`);
   });
 
-  it('末尾スラッシュ付きのAPI_BASE_URLでも // が混入しない(合成後のパス部分に二重スラッシュが無い)', () => {
-    const path = DEMO_INDEX_URL.replace(/^https?:\/\//, '');
+  it('パス部分に二重スラッシュを含まない', () => {
+    const path = DEMO_INDEX_URL.replace(/^https?:\/\//i, '');
     expect(path).not.toContain('//');
+  });
+
+  // spec側は DEMO_BASE_URL に対して `${DEMO_BASE}/inquiry.html` のように
+  // 先頭スラッシュ付きで連結する。ここが末尾スラッシュを持つと `//inquiry.html` になる。
+  it('DEMO_BASE_URL は末尾スラッシュを持たない(spec側の連結規約)', () => {
+    expect(DEMO_BASE_URL.endsWith('/')).toBe(false);
   });
 });

--- a/tests/e2e/config.ts
+++ b/tests/e2e/config.ts
@@ -13,17 +13,37 @@ function stripTrailingSlash(url: string): string {
 }
 
 /**
+ * 解決後のURLが実際に到達可能な形をしているか検証する。
+ * ここを通さないと、'/' や 'not-a-url' のような値が黙って全specに配られ、
+ * 103テストが原因不明の失敗を起こす(向き先の誤りだと気付けない)。
+ * ローカル/自前ステージングは http のことがあるため https 限定にはしない。
+ */
+function assertUsableBaseUrl(value: string, envName: string): string {
+  if (!/^https?:\/\/./i.test(value)) {
+    throw new Error(
+      `${envName} の値が URL として解釈できません(解決結果: ${JSON.stringify(value)})。` +
+        'http:// または https:// で始まるホスト名付きのURLを指定してください。',
+    );
+  }
+  return value;
+}
+
+/**
  * env から E2E の向き先を解決する(純粋関数)。src/lib/traffic/trafficSource.ts の
  * resolveTrafficSource と同じ形(入力を引数で受ける純粋関数)に合わせている。
  *
  * 片方だけ設定された場合は throw する: 管理画面はステージング・APIは本番、という
  * 混在状態が無警告で成立するのを防ぐため。
+ *
+ * 値は trim してから判定する: CI の Secrets や .env 経由の値は末尾に改行や空白が
+ * 混入しやすく、trim しないと `https://example.com\n/health` のような
+ * 一見正しく見えるURLになって原因特定が困難になるため。
  */
 export function resolveE2eBaseUrls(
   env: NodeJS.ProcessEnv = process.env,
 ): { adminBaseUrl: string; apiBaseUrl: string } {
-  const rawAdmin = env.E2E_BASE_URL || '';
-  const rawApi = env.E2E_API_URL || '';
+  const rawAdmin = (env.E2E_BASE_URL || '').trim();
+  const rawApi = (env.E2E_API_URL || '').trim();
 
   if (rawAdmin && !rawApi) {
     throw new Error(
@@ -41,8 +61,14 @@ export function resolveE2eBaseUrls(
   }
 
   return {
-    adminBaseUrl: stripTrailingSlash(rawAdmin || 'https://admin.r2c.biz'),
-    apiBaseUrl: stripTrailingSlash(rawApi || 'https://api.r2c.biz'),
+    adminBaseUrl: assertUsableBaseUrl(
+      stripTrailingSlash(rawAdmin || 'https://admin.r2c.biz'),
+      'E2E_BASE_URL',
+    ),
+    apiBaseUrl: assertUsableBaseUrl(
+      stripTrailingSlash(rawApi || 'https://api.r2c.biz'),
+      'E2E_API_URL',
+    ),
   };
 }
 

--- a/tests/e2e/playwrightConfig.test.ts
+++ b/tests/e2e/playwrightConfig.test.ts
@@ -1,0 +1,93 @@
+// tests/e2e/playwrightConfig.test.ts
+//
+// playwright.config.ts の testMatch ガードが外れていないことを Gate 1(1分)で検知する。
+//
+// なぜ必要か:
+//   testDir が './tests/e2e' である一方、tests/ 配下は Jest と Playwright の二重所有。
+//   Playwright の既定 testMatch は *.spec.ts だけでなく *.test.ts にも一致するため、
+//   ガードが外れると Playwright が本ファイルや config.test.ts を読み込み、
+//   `ReferenceError: describe is not defined` で収集が落ちて 103 テストが 0 件になる
+//   (実測確認済み。exit code 1 なので CI は赤くなるが、原因が分かりにくく E2E の
+//   3分半を消費してから失敗する)。ここで pin しておけば Gate 1 が即座に落ちる。
+//
+// なぜ import ではなく正規表現を抽出しているか:
+//   playwright.config.ts は `@playwright/test` を import しており、Jest 内で読み込むと
+//   expect の内部シンボルが衝突して `TypeError: Cannot redefine property:
+//   Symbol($$jest-matchers-object)` になる(実測確認済み)。そのためソースから
+//   正規表現リテラルを取り出し、実際にファイル名へ適用して挙動を検証する。
+
+import fs from 'fs';
+import path from 'path';
+
+const CONFIG_PATH = path.resolve(__dirname, '../../playwright.config.ts');
+const source = fs.readFileSync(CONFIG_PATH, 'utf8');
+
+/** ソース中の `testMatch: /.../flags` から RegExp を復元する。 */
+function extractTestMatchRegexes(text: string): RegExp[] {
+  const literals = text.match(/testMatch:\s*\/(?:[^/\\\n]|\\.)+\/[gimsuy]*/g) ?? [];
+  return literals.map((literal) => {
+    const body = literal.replace(/^testMatch:\s*\//, '');
+    const lastSlash = body.lastIndexOf('/');
+    return new RegExp(body.slice(0, lastSlash), body.slice(lastSlash + 1));
+  });
+}
+
+/** projects: より前 = トップレベル設定。 */
+const topLevelSection = source.slice(0, source.indexOf('projects:'));
+
+const JEST_OWNED_FILES = [
+  'tests/e2e/config.test.ts',
+  'tests/e2e/playwrightConfig.test.ts',
+  'config.test.ts',
+];
+
+describe('playwright.config.ts — testMatch ガード', () => {
+  it('トップレベルに testMatch が定義されている(ガードの存在)', () => {
+    expect(extractTestMatchRegexes(topLevelSection)).toHaveLength(1);
+  });
+
+  describe('トップレベル testMatch の挙動', () => {
+    const [topLevel] = extractTestMatchRegexes(topLevelSection);
+
+    it.each(JEST_OWNED_FILES)('Jest所有の %s に一致しない', (file) => {
+      expect(topLevel.test(file)).toBe(false);
+    });
+
+    it.each([
+      'tests/e2e/widget.spec.ts',
+      'tests/e2e/qa-irregular-3roles.spec.ts',
+      'tests/e2e/visual-regression.spec.ts',
+    ])('Playwright所有の %s には一致する', (file) => {
+      expect(topLevel.test(file)).toBe(true);
+    });
+
+    it.each(['tests/e2e/auth.setup.ts', 'tests/e2e/superadmin.setup.ts'])(
+      'storageState生成の %s には一致する(除外すると認証が走らずRole B/Cが全skipになる)',
+      (file) => {
+        expect(topLevel.test(file)).toBe(true);
+      },
+    );
+  });
+
+  // Playwright ではプロジェクト個別の testMatch がトップレベルを上書きする。
+  // 将来どのプロジェクトに testMatch が足されても、*.test.ts を拾い直さないことを保証する。
+  it('ファイル内のどの testMatch も Jest所有の *.test.ts に一致しない', () => {
+    const all = extractTestMatchRegexes(source);
+    expect(all.length).toBeGreaterThanOrEqual(1);
+
+    const offenders = all.flatMap((re) =>
+      JEST_OWNED_FILES.filter((f) => re.test(f)).map((f) => `${String(re)} matches ${f}`),
+    );
+    expect(offenders).toEqual([]);
+  });
+
+  // chromium プロジェクトは testMatch を持たずトップレベルを継承することが前提。
+  // ここに testMatch が足されるとガードが実質無効化されるため、変更時に気付けるようにする。
+  it('chromium プロジェクトは testMatch を持たない(トップレベルのガードを継承する)', () => {
+    const chromiumSection = source.slice(source.indexOf("name: 'chromium'"));
+    const untilNextProject = chromiumSection.slice(0, chromiumSection.indexOf('},'));
+    // 行コメント内の「testMatch」への言及を拾わないよう、コメントを除去してからキーを探す。
+    const codeOnly = untilNextProject.replace(/\/\/[^\n]*/g, '');
+    expect(codeOnly).not.toMatch(/\btestMatch\s*:/);
+  });
+});


### PR DESCRIPTION
## Summary
既存テスト(11件)が薄く、実測で4件の欠陥が素通りすることを確認したため、テストで固定した上で最小限の修正を入れた。テストは 11件 → 50件。

### 発見した欠陥(いずれも実測で確認)
| # | 入力 | 修正前の結果 | 現実に起きる経路 |
|---|---|---|---|
| 1 | `https://x.com\n` | そのまま採用 → `https://x.com\n/health` | CI Secrets / `.env` の末尾改行 |
| 2 | `'   '`(空白のみ) | truthy扱い → 片側ガードもすり抜け `adminBaseUrl='   '` | 値を消したつもりの空白残し |
| 3 | `'/'` | `''` に潰れ、相対URLとして解決 | 手入力ミス |
| 4 | `not-a-url` / `ftp://x` | 素通りして103テスト全部に配布 | URLの貼り間違い |

`.trim()` と `assertUsableBaseUrl()` を追加して解消。**ローカル/自前ステージングを想定し `http://` は許容**(https限定にしない)。

### ガード自体を守るテストが無かった問題
`playwright.config.ts` の `testMatch` ガード(E2E全滅を防ぐ要)には自動検知が一切無かった。`tests/e2e/playwrightConfig.test.ts` を追加し、以下3経路を検知する:
- ガードが削除される
- ガードが緩められて `.test.ts` を再び拾う
- プロジェクト側 `testMatch` で上書きされる(Playwrightではプロジェクト側が優先される)

`@playwright/test` は Jest 内で import すると `Symbol($$jest-matchers-object)` が衝突する(実測)ため、ソースから正規表現リテラルを抽出し**実際にファイル名へ適用して**挙動を検証している。

## Mutation テスト(「通るだけのテスト」でないことの確認)
意図的に5種類の変更を注入し、全て検知されることを確認:

| 注入した変更 | 結果 |
|---|---|
| `.trim()` を削除 | 6件 failed |
| URL検証を削除 | 9件 failed |
| top-level `testMatch` を削除 | 8件 failed |
| `testMatch` を `.test.ts` も拾うよう緩める | 4件 failed |
| chromium プロジェクトに `testMatch` を追加 | 2件 failed |

## Test plan
- [x] `npx jest tests/e2e/config.test.ts tests/e2e/playwrightConfig.test.ts` — 50件全pass
- [x] `npx tsc --noEmit` — エラーなし
- [x] `npx oxlint tests/e2e` — warning 2件のみ、いずれも本PRと無関係の既存警告
- [x] `E2E_ENABLED=1 npx playwright test --list` — **108 tests in 17 files**。新規 `.test.ts` を追加してもファイル数17のまま=ガードが機能。108という数はpristineな`origin/main`でも同一であることを別worktreeで実測確認済み(他レーンのマージによる増加で、本PR起因ではない)
- [x] 各プロジェクト: setup 1/1、superadmin-setup 1/1、admin-ui 7/3、visual-regression 6/2 — 変化なし
- [x] `bash SCRIPTS/security-scan.sh` — PASS
- [x] フルJestスイート: 6スイート失敗。うち `src/api/admin/avatar/routes.test.ts` の11件は **pristineな`origin/main`でも同一に失敗する既存の失敗**であることを別worktreeで確認済み(本PRは`tests/e2e/`以外を触っていない)

## 残存リスク(本PRでは対応せず)
- `resolveE2eBaseUrls` はモジュール読込時にも実行されるため、不正値だと**全specがimport時にthrow**する。Playwrightは収集エラーで exit 1 になるため CI は赤くなる(実測確認済み)が、エラーの出方は分かりにくい。
- `E2E_CHAT_TEST_URL` / `E2E_NON_AVATAR_TEST_URL`(widget-fab-avatar.spec.ts 固有)は今回の検証・正規化を経由しない別系統のまま。ステージング移行時に整理すべき。

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NgWB82fsx7LMjhJqpd1rCx