### PR TITLE
fix: テナント解決の境界値(空白のみ/クエリ汚染)を塞ぎ、保存先パスをテストで固定する

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -1907,6 +1907,49 @@ describe("CopilotPreviewPage — アバター画像候補の生成・採用", ()
       .mock.calls.find(([url]) => String(url).includes("/fal/generate"));
     expect(String(generateCall![0])).toBe("http://localhost:3100/v1/admin/avatar/fal/generate");
   });
+
+  // テナントIDはURLに素で連結している。encodeURIComponent を外すと `&` や `=` が
+  // そのままクエリ構文として解釈され、別のパラメータを注入できてしまう
+  // （例: `a&numImages=99`）。エスケープが実際に効いていることを固定する。
+  it("テナントIDにクエリ構文の文字が含まれていてもエスケープされる", async () => {
+    mockAdoptedThenEndpoints({ generate: () => mockOk({ images: ["https://img/1.png"] }) });
+
+    const generateButton = await sendAndAdopt({
+      ...SUPER_ADMIN_IN_PREVIEW,
+      previewTenantId: "a&b=c d",
+    });
+    fireEvent.click(generateButton);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "これにする" })).toBeTruthy());
+    const url = String(
+      vi.mocked(authFetch).mock.calls.find(([u]) => String(u).includes("/fal/generate"))![0],
+    );
+    expect(url).toBe("http://localhost:3100/v1/admin/avatar/fal/generate?tenant=a%26b%3Dc%20d");
+    // 生のまま連結されていない（=クエリが増えていない）こと
+    expect(new URL(url).searchParams.get("tenant")).toBe("a&b=c d");
+    expect([...new URL(url).searchParams.keys()]).toEqual(["tenant"]);
+  });
+
+  // previewMode に入っているのにテナントが未解決（previewTenantId=null）という
+  // 中間状態がありうる。ここで `?tenant=` を空で送ると、バックエンドは
+  // 「空白のみ/未指定」として400にするので、送らない方が挙動が素直になる。
+  // 空文字を付けて送っていないことを固定する。
+  it("previewMode中でもテナント未解決なら ?tenant= を空で送らない", async () => {
+    mockAdoptedThenEndpoints({ generate: () => mockOk({ images: ["https://img/1.png"] }) });
+
+    const generateButton = await sendAndAdopt({
+      ...SUPER_ADMIN_IN_PREVIEW,
+      previewTenantId: null,
+    });
+    fireEvent.click(generateButton);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "これにする" })).toBeTruthy());
+    const url = String(
+      vi.mocked(authFetch).mock.calls.find(([u]) => String(u).includes("/fal/generate"))![0],
+    );
+    expect(url).toBe("http://localhost:3100/v1/admin/avatar/fal/generate");
+    expect(url).not.toContain("tenant=");
+  });
 });
 
 // POST /match-voice はテキストの候補(id/title/description/score)のみを返し音声

--- a/src/api/admin/avatar/avatarGenerationAuthGuard.test.ts
+++ b/src/api/admin/avatar/avatarGenerationAuthGuard.test.ts
@@ -172,6 +172,61 @@ describe('avatar generation routes — テナント不明時は400、外部API�
       expect(res.status).toBe(400);
       expect(mockFetch).not.toHaveBeenCalled();
     });
+
+    // 空白のみ／複数指定は、テナントとして採用してはいけないが 400 で
+    // 落ちることまで確認しないと「truthy だから通った」に気づけない。
+    it(`${method.toUpperCase()} ${path} — ?tenant=が空白のみ → 400、fetch未呼び出し`, async () => {
+      const app = makeApp({ app_metadata: { role: 'super_admin' }, email: 'sa@t.com' });
+      const res = await (request(app) as any)[method](`${path}?tenant=%20%20`).send(body);
+      expect(res.status).toBe(400);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it(`${method.toUpperCase()} ${path} — ?tenant=を2回指定 → 400、fetch未呼び出し`, async () => {
+      const app = makeApp({ app_metadata: { role: 'super_admin' }, email: 'sa@t.com' });
+      const res = await (request(app) as any)[method](`${path}?tenant=t1&tenant=t2`).send(body);
+      expect(res.status).toBe(400);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+  });
+});
+
+// ── 過剰ブロックしていないことの対検証 ────────────────────────────────────
+// 上の 400 ガードだけを見ていると「常に400を返す」実装でもテストが通ってしまう。
+// テナントが解決できるときは通ること（＝外部APIまで到達すること）を必ず対で押さえる。
+
+describe('avatar generation routes — テナントが解決できれば400にならず外部APIへ到達する', () => {
+  // 外部APIキーが無いと、テナントガードを通過しても手前で 500 になり fetch まで
+  // 到達しない。「ガードを抜けて実処理に入った」ことを見たいので一式用意する
+  // （応答自体は共通 beforeEach の失敗レスポンスのままでよい）。
+  beforeEach(() => {
+    process.env.GROQ_API_KEY = 'test-groq-key';
+    process.env.LEONARDO_API_KEY = 'test-leonardo-key';
+    process.env.FISH_AUDIO_API_KEY = 'test-fish-key';
+    process.env.FAL_KEY = 'test-fal-key';
+  });
+
+  afterEach(() => {
+    delete process.env.GROQ_API_KEY;
+    delete process.env.LEONARDO_API_KEY;
+    delete process.env.FISH_AUDIO_API_KEY;
+    delete process.env.FAL_KEY;
+  });
+
+  TENANT_GUARDED_ENDPOINTS.forEach(({ method, path, body }) => {
+    it(`${method.toUpperCase()} ${path} — super_admin + ?tenant=t1 → 400にならない`, async () => {
+      const app = makeApp({ app_metadata: { role: 'super_admin' }, email: 'sa@t.com' });
+      const res = await (request(app) as any)[method](`${path}?tenant=t1`).send(body);
+      expect(res.status).not.toBe(400);
+      expect(mockFetch).toHaveBeenCalled();
+    });
+
+    it(`${method.toUpperCase()} ${path} — client_admin(自テナントあり) → 400にならない`, async () => {
+      const app = makeApp({ app_metadata: { role: 'client_admin', tenant_id: 't1' }, email: 'ca@t.com' });
+      const res = await (request(app) as any)[method](path).send(body);
+      expect(res.status).not.toBe(400);
+      expect(mockFetch).toHaveBeenCalled();
+    });
   });
 });
 

--- a/src/api/admin/avatar/falGenerationRoutes.test.ts
+++ b/src/api/admin/avatar/falGenerationRoutes.test.ts
@@ -10,8 +10,15 @@ jest.mock("../../../admin/http/supabaseAuthMiddleware", () => ({
   supabaseAuthMiddleware: (_req: any, _res: any, next: any) => next(),
 }));
 
+// 既定は null（＝ストレージ無効。imageUrlをそのまま返す）。
+// 保存先パスを検証する describe だけが mockSupabaseAdmin.current を差し替える。
+// getter 経由にしているのは、ルート側が呼び出し時に supabaseAdmin を読むため、
+// jest.resetModules() を使わずにテスト単位で有効/無効を切り替えられるようにするため。
+const mockSupabaseAdmin: { current: unknown } = { current: null };
 jest.mock("../../../auth/supabaseClient", () => ({
-  supabaseAdmin: null, // ストレージ無効（imageUrlをそのまま返す）
+  get supabaseAdmin() {
+    return mockSupabaseAdmin.current;
+  },
 }));
 
 const mockTrackUsage = jest.fn();
@@ -208,5 +215,140 @@ describe("POST /v1/admin/avatar/fal/generate", () => {
 
     const callBody = JSON.parse(mockFetch.mock.calls[0][1].body);
     expect(callBody.num_images).toBe(4);
+  });
+});
+
+// ── Supabase Storage の保存先 ───────────────────────────────────────────────
+// 上の describe は supabaseAdmin=null でアップロード自体をスキップしており、
+// 保存先パスの組み立て(`${tenantId}/${filename}.${ext}`)が一度も検証されて
+// いなかった。テナントの取り違えで最も重い実害はここ(バケット直下や別テナントの
+// ディレクトリへ全テナントの画像が混在して書き込まれる)なので、supabaseAdmin を
+// 有効にした状態で保存先だけを検証する。
+describe("POST /v1/admin/avatar/fal/generate — Supabase Storage の保存先", () => {
+  const uploadedPaths: string[] = [];
+
+  function makeStorageApp(tenantId: string, role: "client_admin" | "super_admin" = "client_admin") {
+    uploadedPaths.length = 0;
+    mockSupabaseAdmin.current = {
+      storage: {
+        from: () => ({
+          upload: (filePath: string) => {
+            uploadedPaths.push(filePath);
+            return Promise.resolve({ error: null });
+          },
+          getPublicUrl: (filePath: string) => ({
+            data: { publicUrl: `https://cdn.example/${filePath}` },
+          }),
+        }),
+      },
+    };
+
+    const app = express();
+    app.use(express.json());
+    app.use((req: any, _res: any, next: any) => {
+      req.supabaseUser = { app_metadata: { tenant_id: tenantId, role } };
+      req.requestId = "req-store-001";
+      next();
+    });
+    registerFalGenerationRoutes(app);
+    return app;
+  }
+
+  // fal.ai は画像URLを返し、その後 uploadImageFromUrl が各URLを実際に取得する。
+  // 1度目の fetch を fal.ai、以降を画像ダウンロードとして応答させる。
+  function mockFalThenImageDownloads(imageUrls: string[]) {
+    mockFetch.mockImplementation((url: string) => {
+      if (String(url).includes("fal.run")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({
+            images: imageUrls.map((u) => ({ url: u, width: 768, height: 1024 })),
+            seed: 1,
+          }),
+        });
+      }
+      return Promise.resolve({
+        ok: true,
+        arrayBuffer: async () => new ArrayBuffer(8),
+        headers: { get: () => "image/jpeg" },
+      });
+    });
+  }
+
+  // 上の describe の beforeEach/afterEach はこの describe には適用されないため、
+  // FAL_KEY の用意とモックのクリアをここでも行う（クリアし忘れると前のテストの
+  // fetch 呼び出しが残り、「呼ばれていないこと」の検証が通らなくなる）。
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.FAL_KEY = "test-fal-key";
+  });
+
+  afterEach(() => {
+    delete process.env.FAL_KEY;
+    // 他の describe（ストレージ無効前提）へ影響を残さない
+    mockSupabaseAdmin.current = null;
+  });
+
+  it("client_admin: 自テナントのディレクトリ配下に保存される", async () => {
+    mockFalThenImageDownloads(["https://img.fal.media/a.jpg"]);
+
+    const res = await request(makeStorageApp("tenant-a"))
+      .post("/v1/admin/avatar/fal/generate")
+      .send({ prompt: "Professional portrait of a Japanese woman, bust shot, smiling", numImages: 1 });
+
+    expect(res.status).toBe(200);
+    expect(uploadedPaths).toHaveLength(1);
+    expect(uploadedPaths[0]!.startsWith("tenant-a/")).toBe(true);
+  });
+
+  it("super_admin + ?tenant=: 操作対象テナントのディレクトリへ保存される(自分のではなく)", async () => {
+    mockFalThenImageDownloads(["https://img.fal.media/a.jpg", "https://img.fal.media/b.jpg"]);
+
+    const res = await request(makeStorageApp("", "super_admin"))
+      .post("/v1/admin/avatar/fal/generate?tenant=tenant-b")
+      .send({ prompt: "Professional portrait of a Japanese woman, bust shot, smiling", numImages: 2 });
+
+    expect(res.status).toBe(200);
+    expect(uploadedPaths).toHaveLength(2);
+    for (const p of uploadedPaths) expect(p.startsWith("tenant-b/")).toBe(true);
+    // バケット直下（先頭が "/"）に落ちていないこと＝今回の欠陥そのものの回帰ガード
+    for (const p of uploadedPaths) expect(p.startsWith("/")).toBe(false);
+  });
+
+  it("[越権防止] client_adminが?tenant=で他テナントのディレクトリへ書き込めない", async () => {
+    mockFalThenImageDownloads(["https://img.fal.media/a.jpg"]);
+
+    const res = await request(makeStorageApp("tenant-a", "client_admin"))
+      .post("/v1/admin/avatar/fal/generate?tenant=tenant-b")
+      .send({ prompt: "Professional portrait of a Japanese man, bust shot, business suit", numImages: 1 });
+
+    expect(res.status).toBe(200);
+    expect(uploadedPaths[0]!.startsWith("tenant-a/")).toBe(true);
+  });
+
+  it("[空白のみ] ?tenant= が空白だけなら400で止まり、バケットへ一切書き込まない", async () => {
+    // "   " は truthy なので、helper 側で trim していないと 400 ガードを通過して
+    // "   /fal-xxx.jpg" というパスで実際に書き込まれてしまう。
+    mockFalThenImageDownloads(["https://img.fal.media/a.jpg"]);
+
+    const res = await request(makeStorageApp("", "super_admin"))
+      .post("/v1/admin/avatar/fal/generate?tenant=%20%20%20")
+      .send({ prompt: "Professional portrait of a Japanese woman, bust shot, smiling", numImages: 1 });
+
+    expect(res.status).toBe(400);
+    expect(uploadedPaths).toHaveLength(0);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("[クエリ汚染] ?tenant= を2回指定されたら400で止まり、\"a,b\" のようなパスを作らない", async () => {
+    mockFalThenImageDownloads(["https://img.fal.media/a.jpg"]);
+
+    const res = await request(makeStorageApp("", "super_admin"))
+      .post("/v1/admin/avatar/fal/generate?tenant=tenant-a&tenant=tenant-b")
+      .send({ prompt: "Professional portrait of a Japanese woman, bust shot, smiling", numImages: 1 });
+
+    expect(res.status).toBe(400);
+    expect(uploadedPaths).toHaveLength(0);
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 });

--- a/src/api/middleware/roleAuth.test.ts
+++ b/src/api/middleware/roleAuth.test.ts
@@ -313,6 +313,103 @@ describe("resolveEffectiveTenantId", () => {
     const req = mockReq({ query: {} });
     expect(resolveEffectiveTenantId(req)).toBe("");
   });
+
+  // ── 境界値・異常系 ──────────────────────────────────────────────────────
+  // 返り値は trackUsage の請求先テナントと Supabase Storage のパス
+  // (`${tenantId}/${filename}`) の両方に直接入る。string 以外や空白だけの値が
+  // 素通りすると、請求先が実在しないテナントになる/バケットの意図しない場所へ
+  // 書かれる、という形で静かに壊れる。呼び出し側の `if (!tenantId)` ガードは
+  // 空文字しか弾けないため、ここで型と中身を確定させておく必要がある。
+
+  it("[クエリ汚染] ?tenant= を複数回指定されても配列を返さない(Expressは配列にする)", () => {
+    // `?tenant=a&tenant=b` を Express は ['a','b'] としてパースする。
+    // `as string` のキャストは実行時には何も保証しないため、素通りすると
+    // `${tenantId}/...` が "a,b/..." というパスになり、trackUsage の
+    // tenantId にも配列が入る。
+    const req = mockReq({
+      supabaseUser: { app_metadata: { role: "super_admin" } },
+      query: { tenant: ["tenant-a", "tenant-b"] },
+    });
+    const result = resolveEffectiveTenantId(req);
+    expect(typeof result).toBe("string");
+    // 曖昧な指定は採用せず、テナント未指定として扱う(呼び出し側の400ガードに委ねる)
+    expect(result).toBe("");
+  });
+
+  it("[クエリ汚染] ?tenant[x]=y のようなオブジェクト指定も文字列として扱わない", () => {
+    const req = mockReq({
+      supabaseUser: { app_metadata: { role: "super_admin" } },
+      query: { tenant: { x: "y" } },
+    });
+    const result = resolveEffectiveTenantId(req);
+    expect(typeof result).toBe("string");
+    expect(result).toBe("");
+  });
+
+  it("[空白のみ] ?tenant=%20%20 は未指定として扱う(バケット直下に空白ディレクトリを作らない)", () => {
+    // "   " は truthy なので、trimしないと呼び出し側の `if (!tenantId)` を
+    // すり抜けて `"   /fal-xxx.jpg"` というパスで実際に書き込まれてしまう。
+    const req = mockReq({
+      supabaseUser: { app_metadata: { role: "super_admin" } },
+      query: { tenant: "   " },
+    });
+    expect(resolveEffectiveTenantId(req)).toBe("");
+  });
+
+  it("[空白混じり] 前後の空白は落として返す", () => {
+    const req = mockReq({
+      supabaseUser: { app_metadata: { role: "super_admin" } },
+      query: { tenant: "  tenant-b  " },
+    });
+    expect(resolveEffectiveTenantId(req)).toBe("tenant-b");
+  });
+
+  it("[空白のみ] client_admin の JWT テナントが空白だけの場合も未指定として扱う", () => {
+    const req = mockReq({
+      supabaseUser: { app_metadata: { role: "client_admin", tenant_id: "   " } },
+      query: {},
+    });
+    expect(resolveEffectiveTenantId(req)).toBe("");
+  });
+
+  it("[優先順位] super_adminが自身のtenant_idを持っていても ?tenant= が優先される", () => {
+    // R2C運用者のJWTにtenant_idが入っているケース。previewMode中の操作対象は
+    // あくまで ?tenant= 側なので、JWT側に引きずられてはいけない。
+    const req = mockReq({
+      supabaseUser: { app_metadata: { role: "super_admin", tenant_id: "r2c-internal" } },
+      query: { tenant: "tenant-b" },
+    });
+    expect(resolveEffectiveTenantId(req)).toBe("tenant-b");
+  });
+
+  it("[フォールバック] super_adminが?tenant=を空文字で送ったらJWTのtenant_idに落ちる", () => {
+    const req = mockReq({
+      supabaseUser: { app_metadata: { role: "super_admin", tenant_id: "r2c-internal" } },
+      query: { tenant: "" },
+    });
+    expect(resolveEffectiveTenantId(req)).toBe("r2c-internal");
+  });
+
+  it("[越権防止] client_adminには配列汚染も効かず、常に自テナントを返す", () => {
+    const req = mockReq({
+      supabaseUser: { app_metadata: { role: "client_admin", tenant_id: "tenant-a" } },
+      query: { tenant: ["tenant-b", "tenant-c"] },
+    });
+    expect(resolveEffectiveTenantId(req)).toBe("tenant-a");
+  });
+
+  it("[攻撃防止] user_metadata.role='super_admin' では ?tenant= を効かせない", () => {
+    // user_metadata はクライアント制御可能。ここで super_admin と誤認すると
+    // 任意テナントへの課金付け替えが誰でもできてしまう。
+    const req = mockReq({
+      supabaseUser: {
+        app_metadata: { role: "client_admin", tenant_id: "tenant-a" },
+        user_metadata: { role: "super_admin" },
+      },
+      query: { tenant: "tenant-b" },
+    });
+    expect(resolveEffectiveTenantId(req)).toBe("tenant-a");
+  });
 });
 
 // NOTE: requireOwnTenant() ヘルパー削除に伴い、対応する describe ブロックは撤去。

--- a/src/api/middleware/roleAuth.ts
+++ b/src/api/middleware/roleAuth.ts
@@ -123,10 +123,18 @@ export function resolveEffectiveTenantId(req: Request): string {
   const supabaseUser = (req as AuthedReq).supabaseUser;
   const role = safeStringClaim(supabaseUser?.app_metadata?.role);
   const isSuperAdmin = role === "super_admin";
-  const tenantId =
+  const tenantId = (
     safeStringClaim(supabaseUser?.app_metadata?.tenant_id) ||
-    safeStringClaim((supabaseUser as { tenant_id?: string } | undefined)?.tenant_id);
-  return isSuperAdmin ? ((req.query["tenant"] as string) || tenantId) : tenantId;
+    safeStringClaim((supabaseUser as { tenant_id?: string } | undefined)?.tenant_id)
+  ).trim();
+  if (!isSuperAdmin) return tenantId;
+  // `?tenant=a&tenant=b` を Express は配列に、`?tenant[x]=y` はオブジェクトにする。
+  // 返り値は trackUsage の請求先と Storage のパス(`${tenantId}/...`)へそのまま入るため、
+  // string 以外は採用しない（曖昧な指定はテナント未指定として呼び出し側の400へ落とす）。
+  // 空白のみの値も同様に落とす: "   " は truthy で `if (!tenantId)` を通過してしまい、
+  // バケット直下に空白ディレクトリを作って書き込まれる。
+  const fromQuery = safeStringClaim(req.query["tenant"]).trim();
+  return fromQuery || tenantId;
 }
 
 // NOTE: 旧 `requireOwnTenant()` ヘルパーは削除済み（Phase70 / Phase44-46 棚卸し結論）。


### PR DESCRIPTION
## Summary

#674〜#677 で入れたテナント解決に対してテストを強化したところ、**400ガードを素通りする経路が2つ**見つかったため、テスト追加と併せて塞ぎます。「通るだけのテスト」ではなく、修正前に実際に落ちることを確認した回帰ガードのみ入れています（後述）。

## 見つかった欠陥（いずれも修正済み）

### 1. 空白のみの `?tenant=` が400ガードを素通りする
`"   "` は truthy なので #676 で入れた `if (!tenantId)` を通過し、Supabase Storage に **`"   /fal-xxx.jpg"` というパスで実際に書き込まれ**、`trackUsage` も `"   "` で計上されていました。#676 の意図（テナント不明なら外部APIを呼ぶ前に止める）が空白入力で無効化される状態でした。

### 2. `?tenant=` の複数指定・オブジェクト指定が string として素通りする
`?tenant=a&tenant=b` を Express は**配列**にしますが、`req.query["tenant"] as string` のキャストは実行時に何も保証しません。結果、保存先パスが `"a,b/..."` になり、請求先テナントにも配列が入っていました。`?tenant[x]=y` も同様。

**修正**: `resolveEffectiveTenantId` で `safeStringClaim`（string 以外を弾く既存ヘルパー）を通し、`.trim()` する。曖昧な指定は未指定として扱い、呼び出し側の400へ落とす。

## 追加したテスト

### `src/api/middleware/roleAuth.test.ts`（+9件）
境界値・異常系。配列/オブジェクト汚染、空白のみ、前後空白のトリム、`?tenant=` とJWTの優先順位、空文字時のフォールバック、client_admin への配列汚染が効かないこと、`user_metadata.role` 偽装で `?tenant=` を効かせないこと。

### `src/api/admin/avatar/falGenerationRoutes.test.ts`（+5件）
**Supabase Storage の保存先パスを初めて検証**。既存テストは `supabaseAdmin: null` でアップロード自体をスキップしており、今回の欠陥で**最も重い実害（バケット直下への全テナント混在書き込み）が完全にノーガード**でした。`supabaseAdmin` を有効化できるよう mock を可変ホルダー化し（既定 `null` のまま＝既存テストの挙動は不変）、自テナント配下に入ること・super_admin が操作対象テナント配下に入ること・client_admin が越権できないこと・空白/汚染時は書き込みが1件も発生しないことを固定。

### `src/api/admin/avatar/avatarGenerationAuthGuard.test.ts`（+16件）
4ルート×（空白のみ→400 / 複数指定→400）に加え、**過剰ブロックの対検証**を追加。「常に400を返す」実装でも既存テストは通ってしまうため、テナントが解決できる場合はガードを抜けて実処理（外部API呼び出し）まで到達することを4ルート分そろえました。

### `admin-ui/src/pages/copilot-preview/index.test.tsx`（+2件）
- テナントIDに `&` `=` 空白が含まれてもエスケープされ、**クエリを注入できない**こと（`encodeURIComponent` を外すと落ちる）
- previewMode 中でもテナント未解決なら**空の `?tenant=` を送らない**こと

## テストが空振りでないことの確認

`resolveEffectiveTenantId` の修正のみを一時的に戻して実行し、**7件が失敗**することを確認済み（helper単体5件 + Storage結合2件）。残りは既存挙動の固定・過剰ブロック検証です。

## Test plan

- [x] `npx jest src/api/middleware/roleAuth.test.ts` — 29/29 pass
- [x] `npx jest src/api/admin/avatar/falGenerationRoutes.test.ts` — 15/15 pass
- [x] `npx jest src/api/admin/avatar/avatarGenerationAuthGuard.test.ts` — 70/70 pass
- [x] `npx vitest run src/pages/copilot-preview/index.test.tsx` — 158/158 pass
- [x] `npx tsc --noEmit` / `npx oxlint` — エラーなし
- [x] rebase on latest main, no conflicts
- [ ] `src/api/admin/avatar/routes.test.ts` の voice-clone 11件はローカルで失敗しますが、**本PR無関係**です。`routes.test.ts`/`routes.ts` は未変更（`git diff origin/main` で0件）かつ `routes.ts` は `resolveEffectiveTenantId` を使っていません。失敗理由は `jest.spyOn(global, "fetch")` の `Property 'fetch' does not exist in the provided object` で、ローカル実行環境側の要因です（main は CI で green）。CIでの結果を確認してください

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StqjjaijseYkGkmG2k5LJ