### PR TITLE
test: オンボーディング是正(A-D)の壊れやすい箇所を追加検証する

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -2729,6 +2729,34 @@ describe("CopilotPreviewPage — 会話の復元(sessionStorage)", () => {
     expect(screen.queryByText("今週も順調です。")).toBeNull();
   });
 
+  // N-1隣接(テスト強化パス): hasDraftFaqはfetchOnboardingStageStatus内の別クエリ由来で、
+  // industryAnsweredとは独立に決まる値。理論上あり得ないはずの組み合わせ(業種未回答なのに
+  // 下書きが存在する)でも、nextIncompleteStageが段階順序を守り業種チップを優先することを
+  // 防御的に固定する(hasDraftFaqがindustry_answeredの判定を誤って飛び越さないこと)。
+  it("N-1隣接: 業種未回答のままhasDraftFaq=trueでも、下書き確認ではなく業種チップが優先される", async () => {
+    vi.mocked(restoreChatSession).mockReturnValue(null);
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (isBadgeUrl(url)) return mockEmptyBadges();
+      if (String(url).includes("/v1/admin/my-tenant")) {
+        return mockOk({
+          onboarding_stage: {
+            industryAnswered: false,
+            knowledgePublished: false,
+            widgetInstalled: false,
+            firstConversation: false,
+            hasDraftFaq: true,
+          },
+        });
+      }
+      return mockOk({ reply: "今週も順調です。", actions: [] });
+    });
+
+    renderPage();
+
+    expect(await screen.findByText(/どんな業種ですか/)).toBeTruthy();
+    expect(screen.queryByText("下書きを見る")).toBeNull();
+  });
+
   // X-6(docs/ONBOARDING_FIRST_LOGIN.md §7.3、オンボ 是正D-2): ログアウト→再ログインの
   // 想定(復元なし+未完了+client_admin)。サーバ側の段階だけから正しく復元されることを
   // N-1と同じ入力組み合わせで固定する(実装上はmy-tenantを毎回叩くだけなので安全域だが、

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -6618,6 +6618,85 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(res.body.actions[0].result).toContain('4件、下書きとして登録しました');
     });
 
+    // X-2強化(テスト強化パス): 上のテストは完全一致(文字列同一)でのスキップしか検証して
+    // いない。実運用では表記ゆれ(「営業時間は？」等のパラフレーズ)が既存FAQ側に
+    // あることの方が多く、bigramSimilarity(閾値0.6)による近似一致判定が実際に
+    // 効いているかどうかは別軸の懸念。faqImport.ts のdocstring例(「営業時間は」vs
+    // 「営業時間を教えてください」→0.75)をそのまま使い、完全一致ではないが
+    // 閾値を超えるケースでもスキップされることを固定する。
+    it('X-2強化: 完全一致ではないパラフレーズ(表記ゆれ)でも類似度閾値を超えれば重複スキップされる', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-ind-dup1b', 'import_industry_faq_templates', { industry: 'beauty', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('登録しました。'));
+
+      // 「営業時間を教えてください」テンプレとは文字列として不一致だが、bigram類似度は
+      // 閾値(0.6)を超える(faqImport.tsのdocstring例と同じペア)
+      mockFetchExistingQuestions.mockResolvedValueOnce(['営業時間は']);
+      for (let i = 0; i < 4; i++) {
+        mockQuery.mockResolvedValueOnce({
+          rows: [{ id: 210 + i, question: `dup-q${i}`, answer: `dup-a${i}`, is_published: false }],
+        });
+      }
+      mockQuery.mockResolvedValueOnce({ rows: [] }); // UPDATE tenants
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '登録して', sessionId: 'sess-ind-dup1b' });
+
+      expect(res.status).toBe(200);
+      const insertCalls = mockQuery.mock.calls.filter(([sql]) => String(sql).includes('INSERT INTO faq_docs'));
+      expect(insertCalls).toHaveLength(4);
+      // 完全一致でスキップされたのなら偶然一致しただけの可能性が残るため、
+      // 実際にINSERTされた4件の中に「営業時間を教えてください」が含まれないことも確認する
+      expect(insertCalls.some(([, params]) => (params as unknown[])[1] === '営業時間を教えてください')).toBe(false);
+      expect(res.body.actions[0].result).toContain('4件、下書きとして登録しました');
+    });
+
+    // X-1関連(テスト強化パス): オンボ 是正A-2で「あとで」時点で業種を先に保存する
+    // ようにしたため、ユーザーが一度業種を選んでから気が変わり、確認前に別の業種で
+    // 確定するケースが新たに起こりうる(以前は業種未保存だったため起こり得なかった
+    // 状態遷移)。最終的な業種は「確定時に指定した値」で上書きされ、投入される
+    // FAQも確定時の業種のテンプレになることを固定する。
+    it('X-1関連: 「あとで」で業種Aを保存した後、別の業種Bで確定すると業種Bのテンプレが登録され業種もBで上書きされる', async () => {
+      // 1ターン目: 美容室を選んで「あとで」(confirmed=false) → onboarding_industry='beauty'を保存
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-ind-switch1', 'import_industry_faq_templates', { industry: 'beauty', confirmed: false }))
+        .mockResolvedValueOnce(makeGroqResponse('こちらでよろしいですか？'));
+      mockQuery.mockResolvedValueOnce({ rows: [] }); // UPDATE tenants(業種のみ、fire-and-forget)
+
+      const res1 = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '美容室です', sessionId: 'sess-ind-switch1' });
+      expect(res1.status).toBe(200);
+      await new Promise((r) => setTimeout(r, 0));
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE tenants SET onboarding_industry'),
+        ['beauty', 'tenant-abc'],
+      );
+
+      // 2ターン目: 気が変わって飲食を選び直し、そのまま確定(confirmed=true)
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-ind-switch2', 'import_industry_faq_templates', { industry: 'food', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('登録しました。'));
+      for (let i = 0; i < 5; i++) {
+        mockQuery.mockResolvedValueOnce({
+          rows: [{ id: 220 + i, question: `food-q${i}`, answer: `food-a${i}`, is_published: false }],
+        });
+      }
+      mockQuery.mockResolvedValueOnce({ rows: [] }); // UPDATE tenants(最終確定)
+
+      const res2 = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '登録して', sessionId: 'sess-ind-switch2' });
+
+      expect(res2.status).toBe(200);
+      expect(res2.body.actions[0].result).toContain('5件、下書きとして登録しました');
+      expect(mockQuery).toHaveBeenLastCalledWith(
+        expect.stringContaining('UPDATE tenants SET onboarding_industry'),
+        ['food', 'tenant-abc'],
+      );
+    });
+
     it('X-2: 業種テンプレ5件すべてが既に登録済みなら1件もINSERTせず、段階も進めない(重複のみメッセージ)', async () => {
       mockFetch
         .mockResolvedValueOnce(toolCallResponse('call-ind-dup2', 'import_industry_faq_templates', { industry: 'beauty', confirmed: true }))
@@ -6901,6 +6980,65 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(updateCall).toBeDefined();
       expect(String(updateCall![0])).toContain('tenant_id = $1');
       expect(updateCall![1]).toEqual(['tenant-abc']);
+    });
+
+    // silent cap境界値(テスト強化パス、オンボ 是正D-1の境界)。総件数がLIMIT(20)ちょうどの
+    // 場合と、1件超過(21件)の場合とで「残りN件」文言の有無が正しく切り替わることを固定する。
+    // これまでのテストは0件・少数件でしか総件数分岐を検証しておらず、実際にLIMITへ
+    // 到達するケース(このsilent capが本来意味を持つ場面)が未検証だった。
+    it('境界値: 下書き総数がちょうど20件(LIMIT一致)なら「残り」文言は出ない', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-pub-b20', 'publish_faq_drafts', { confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('公開しました。'));
+      const rows = Array.from({ length: 20 }, (_, i) => ({ id: i + 1, question: `Q${i}`, answer: `A${i}` }));
+      mockQuery
+        .mockResolvedValueOnce({ rows })
+        .mockResolvedValueOnce({ rows: [{ cnt: 0 }] }); // 公開後の残件数= 0
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '公開して', sessionId: 'sess-pub-b20' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('20件のFAQを公開しました');
+      expect(res.body.actions[0].result).not.toContain('残り');
+    });
+
+    it('境界値: 下書き総数が21件(LIMIT超過)なら公開は20件のみ・「残り1件は次回以降」を明示する', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-pub-b21', 'publish_faq_drafts', { confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('公開しました。'));
+      const rows = Array.from({ length: 20 }, (_, i) => ({ id: i + 1, question: `Q${i}`, answer: `A${i}` }));
+      mockQuery
+        .mockResolvedValueOnce({ rows })
+        .mockResolvedValueOnce({ rows: [{ cnt: 1 }] }); // 公開後もまだ1件残っている(21件目)
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '公開して', sessionId: 'sess-pub-b21' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('20件のFAQを公開しました');
+      expect(res.body.actions[0].result).toContain('残り1件は次回以降に公開できます');
+    });
+
+    // confirmed=false側の総件数境界(一覧提示時)も同様に固定する。
+    it('境界値: 一覧提示時、下書き総数が21件なら「総21件あります。うち新しい20件」と表示する', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-pub-list21', 'publish_faq_drafts', { confirmed: false }))
+        .mockResolvedValueOnce(makeGroqResponse('こちらを公開しますか？'));
+      const rows = Array.from({ length: 20 }, (_, i) => ({ id: i + 1, question: `Q${i}`, answer: `A${i}` }));
+      mockQuery
+        .mockResolvedValueOnce({ rows })
+        .mockResolvedValueOnce({ rows: [{ cnt: 21 }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '下書きを見せて', sessionId: 'sess-pub-list21' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('総21件あります');
+      expect(res.body.actions[0].result).toContain('うち新しい20件');
     });
 
     it('super_adminがtargetTenantId指定で代行実行した場合はactor:delegatedで記録される', async () => {

--- a/src/api/admin/agent/onboardingStage.test.ts
+++ b/src/api/admin/agent/onboardingStage.test.ts
@@ -86,6 +86,22 @@ describe('deriveOnboardingStage', () => {
       };
       expect(deriveOnboardingStage(facts)).toBeNull();
     });
+
+    // 上のテストは hasDraftFaq: false 固定だった。hasDraftFaq は他の4フラグとは別経路
+    // (fetchOnboardingStageStatusの別クエリ)から来るため、これがtrueの組み合わせでも
+    // カットオフが優先されることを別途固定する(値の見落としで片方だけ対象外判定が
+    // 抜ける、というリグレッションを防ぐ)。
+    it('カットオフより前は hasDraftFaq=true(下書きあり)でも null を返す', () => {
+      const facts: OnboardingStageFacts = {
+        tenantCreatedAt: '2020-01-01T00:00:00Z',
+        onboardingIndustry: null,
+        onboardingWidgetSeenAt: null,
+        hasPublishedFaq: false,
+        hasRealConversation: false,
+        hasDraftFaq: true,
+      };
+      expect(deriveOnboardingStage(facts)).toBeNull();
+    });
   });
 
   it('onboardingWidgetSeenAt が文字列(DBからのタイムスタンプ)でも true になる', () => {


### PR DESCRIPTION
## Summary
是正A-1〜D-2(#662/#665/#672/#679)に対するテスト強化。**実装は変更していない(テストのみ、3ファイル)**。

## 追加したテスト
- **X-2強化**: 既存の重複スキップテストは完全一致(文字列同一)しか検証しておらず、実運用で起きやすい表記ゆれ(パラフレーズ)によるbigram類似度の近似一致が実際に効いているかは未検証だった。`faqImport.ts`のdocstring例と同じペア(「営業時間は」vs「営業時間を教えてください」)で固定。
- **業種の心変わり**: オンボ 是正A-2で「あとで」時点で業種を先に保存するようにしたため、一度業種を選んでから確認前に別の業種で確定する新しい状態遷移が起こりうるようになった(以前は業種未保存だったため起こり得なかった)。最終的に確定時の業種で上書きされることを固定。
- **publish_faq_draftsのsilent cap境界値**: 総件数がLIMIT(20)ちょうど・21件(超過1件)の場合の「残りN件」文言の有無を固定。これまで0件・少数件でしか総件数分岐を検証しておらず、silent capが本来意味を持つ境界そのものが未検証だった。
- **カットオフ×hasDraftFaq**: `hasDraftFaq`は`fetchOnboardingStageStatus`内の別クエリ由来で他4フラグと独立に決まるため、カットオフ判定がこの値の組み合わせでも正しく無条件に優先されることを別途固定。
- **N-1隣接**: 業種未回答のまま`hasDraftFaq=true`という理論上あり得ない組み合わせでも、`nextIncompleteStage`が段階順序を守り業種チップを優先することを防御的に固定。

## テストでカバーできていないリスク(指摘)
- **TOCTOU(publish_faq_drafts)**: 確認時の一覧と実際の公開対象の完全一致は保証されない。ID固定はLLMへの往復に依存し誤動作リスクの方が大きいと判断し、意図的に未対応・未テスト(D-1で判断済み)。
- **E-4(既知の挙動)**: FAQ本体は全件成功してもUPDATE tenantsだけが失敗すると、次回ログインで「初めまして」が再生される狭いウィンドウが残る(D-2で特性テスト済み、修正はプロダクト判断待ち)。
- **業種確定の同時多発リクエスト(新規発見)**: `import_industry_faq_templates`の重複判定はリクエスト単位の`fetchExistingQuestions`に閉じており、真に同時(並行)な2つのconfirmed=trueリクエストが重なった場合はTOCTOUと同種の二重登録リスクが残る。単一ユーザーの連打はフロント側の`chipsUsed`ガードで防げるが、サーバ側の排他制御ではない。
- **admin/index.tsx(AdminDashboard)**: オンボ 是正C-1でモーダル配線を削除したが、このページ自体のテストファイルは元々存在せず(pre-existing gap)、削除後も新規作成していない。tscでの参照整合性のみ確認済み。
- **previewMode時のuseAuth.onboardingStage**: 意図的にnull固定(実際の段階取得はcopilot-preview側の自前fetchに委ねている)。他に消費者がいないことは確認済みだが、将来この値を別の場所で使い始めた場合にpreviewModeだけ機能しない、というドリフトの芽は残る。

## Test plan
- [x] `npx tsc --noEmit`(backend clean)
- [x] `cd admin-ui && npx tsc -b`(既存ベースライン13件のまま)
- [x] `npx oxlint src admin-ui/src --max-warnings 63`(exit 0)
- [x] `agentRoutes.test.ts` + `onboardingStage.test.ts`: 398/398
- [x] `copilot-preview/index.test.tsx` + `landingDecision.test.ts`: 176/176
- [x] `bash SCRIPTS/dead-code-check.sh`(既存無関係の4件のみ)
- [x] `bash SCRIPTS/security-scan.sh`(PASS, 0 critical/high)

https://claude.ai/code/session_0177MCsC7jN3a51F7TdaW9vH