### PR TITLE
fix(backend): PATCH /configs/:id の写真アップロードがバケット直下に保存される問題を直す

### DIFF
--- a/src/api/admin/avatar/routes.test.ts
+++ b/src/api/admin/avatar/routes.test.ts
@@ -13,8 +13,14 @@ jest.mock("../../../admin/http/supabaseAuthMiddleware", () => ({
   supabaseAuthMiddleware: (_req: any, _res: any, next: any) => next(),
 }));
 
+// 既定は null（＝ストレージ無効。多くの既存テストはこれで image_url をそのまま扱う）。
+// 保存先パスを検証する describe だけが mockSupabaseAdmin.current を差し替える
+// （falGenerationRoutes.test.ts の「Supabase Storage の保存先」describe、#682と同じパターン）。
+const mockSupabaseAdmin: { current: unknown } = { current: null };
 jest.mock("../../../auth/supabaseClient", () => ({
-  supabaseAdmin: null,
+  get supabaseAdmin() {
+    return mockSupabaseAdmin.current;
+  },
 }));
 
 const mockTenantHasFeature = jest.fn().mockResolvedValue(true);
@@ -629,5 +635,132 @@ describe("resizeForLemonSlice (I-6)", () => {
     const junk = Buffer.from("not-an-image");
     const out = await resizeForLemonSlice(junk);
     expect(out).toBe(junk);
+  });
+});
+
+// --------------------------------------------------------------------------
+// PATCH /v1/admin/avatar/configs/:id — base64画像アップロードの保存先(#P1-A)
+// --------------------------------------------------------------------------
+// このエンドポイントには元々テストが1件も無かった。super_adminのpreviewMode中に
+// ?tenant= を無視して生の(空の)tenantIdでバケット直下に保存していた欠陥
+// (POSTは effectiveTenantId を使うのに、同一ファイル内のPATCHだけ生のtenantIdを
+// 使っていた非対称)を固定する。
+
+const DATA_URL_PNG =
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII=";
+
+describe("PATCH /v1/admin/avatar/configs/:id — 画像アップロードの保存先", () => {
+  const uploadedPaths: string[] = [];
+
+  function makeStorageAdmin() {
+    uploadedPaths.length = 0;
+    return {
+      storage: {
+        createBucket: () => Promise.resolve({ error: null }),
+        from: () => ({
+          upload: (filePath: string) => {
+            uploadedPaths.push(filePath);
+            return Promise.resolve({ error: null });
+          },
+          getPublicUrl: (filePath: string) => ({
+            data: { publicUrl: `https://cdn.example/${filePath}` },
+          }),
+        }),
+      },
+    };
+  }
+
+  beforeEach(() => {
+    mockSupabaseAdmin.current = makeStorageAdmin();
+  });
+
+  afterEach(() => {
+    // 他のdescribe(ストレージ無効前提)へ影響を残さない
+    mockSupabaseAdmin.current = null;
+  });
+
+  it("super_admin + ?tenant=tenant-b → 保存パスが tenant-b/ で始まる", async () => {
+    const dbQuery = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ is_default: false }] }) // is_default チェック
+      .mockResolvedValueOnce({ rows: [{ ...CONFIG_ROW, id: "config-1" }] }); // UPDATE ... RETURNING
+
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "super_admin", ""))
+      .patch("/v1/admin/avatar/configs/config-1?tenant=tenant-b")
+      .send({ image_url: DATA_URL_PNG });
+
+    expect(res.status).toBe(200);
+    expect(uploadedPaths).toHaveLength(1);
+    expect(uploadedPaths[0]!.startsWith("tenant-b/")).toBe(true);
+  });
+
+  it("super_admin で ?tenant= なし → 400でテナント不明として止まり、バケット直下へ一切書き込まない", async () => {
+    // is_default チェックの1回のみ発行され、UPDATEには到達しない
+    const dbQuery = jest.fn().mockResolvedValueOnce({ rows: [{ is_default: false }] });
+
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "super_admin", ""))
+      .patch("/v1/admin/avatar/configs/config-1")
+      .send({ image_url: DATA_URL_PNG });
+
+    // 今回の欠陥そのものの回帰ガード: 修正前は空テナントのまま
+    // "/avatar-xxx.png" というバケット直下パスで実際に書き込まれていた
+    expect(res.status).toBe(400);
+    expect(uploadedPaths).toHaveLength(0);
+    expect(dbQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("[越権防止] client_adminが?tenant=tenant-bを付けても自テナント配下になる", async () => {
+    const dbQuery = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ is_default: false }] })
+      .mockResolvedValueOnce({ rows: [{ ...CONFIG_ROW, id: "config-1" }] });
+
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "client_admin", "tenant-a"))
+      .patch("/v1/admin/avatar/configs/config-1?tenant=tenant-b")
+      .send({ image_url: DATA_URL_PNG });
+
+    expect(res.status).toBe(200);
+    expect(uploadedPaths).toHaveLength(1);
+    expect(uploadedPaths[0]!.startsWith("tenant-a/")).toBe(true);
+  });
+
+  it("base64でない(https URL)場合はStorageを一切触らない(チャットUI採用経路の回帰ガード)", async () => {
+    const dbQuery = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ is_default: false }] })
+      .mockResolvedValueOnce({ rows: [{ ...CONFIG_ROW, id: "config-1" }] });
+
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "super_admin", ""))
+      .patch("/v1/admin/avatar/configs/config-1?tenant=tenant-b")
+      .send({ image_url: "https://img.example/already-hosted.png" });
+
+    expect(res.status).toBe(200);
+    expect(uploadedPaths).toHaveLength(0);
+  });
+
+  it("PATCHのSQL挙動(super_adminの跨テナント更新可)は変えない — WHERE句にtenant_id条件が付かない", async () => {
+    const dbQuery = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ is_default: false }] })
+      .mockResolvedValueOnce({ rows: [{ ...CONFIG_ROW, id: "config-1" }] });
+
+    const db = { query: dbQuery };
+
+    await request(makeApp(db, "super_admin", ""))
+      .patch("/v1/admin/avatar/configs/config-1?tenant=tenant-b")
+      .send({ image_url: DATA_URL_PNG });
+
+    const updateCall = dbQuery.mock.calls.find(
+      ([sql]) => typeof sql === "string" && sql.startsWith("UPDATE avatar_configs"),
+    );
+    expect(updateCall![0]).not.toContain("tenant_id");
   });
 });

--- a/src/api/admin/avatar/routes.ts
+++ b/src/api/admin/avatar/routes.ts
@@ -10,6 +10,7 @@ import multer from 'multer';
 import { logger } from '../../../lib/logger';
 import { trackUsage } from '../../../lib/billing/usageTracker';
 import { tenantHasFeature } from '../../../lib/billing/planFeatures';
+import { resolveEffectiveTenantId } from '../../middleware/roleAuth';
 
 // ---------------------------------------------------------------------------
 // Supabase Storage: base64 data URL → 公開 HTTP URL
@@ -517,10 +518,20 @@ export function registerAvatarConfigRoutes(app: Express, db: any): void {
       }
 
       // base64 data URL → Supabase Storage HTTP URL に変換
+      // super_admin のpreviewMode中は ?tenant= を反映する(他の生成系ルートと同じ
+      // resolveEffectiveTenantId、#682でtrim・型ガード済み)。生の tenantId のままだと
+      // super_adminの空テナントでバケット直下に保存されていた(#P1-A)。この1箇所のみの
+      // 利用で、ファイル全体のextractAuthからの移行はしない(スコープ膨張防止)。
+      // SQLのWHERE句(552-555行、super_adminの跨テナント更新可)は既存仕様のまま変更しない。
       if (data.image_url?.startsWith("data:")) {
+        const storageTenantId = resolveEffectiveTenantId(req);
+        // #P0-3と同じ理由: テナントが解決できないままバケット直下へ書き込まない。
+        if (!storageTenantId) {
+          return res.status(400).json({ error: "テナント情報が取得できません" });
+        }
         const uploaded = await uploadBase64ToStorage(
           data.image_url,
-          tenantId,
+          storageTenantId,
           `avatar-${id}-${Date.now()}`
         );
         if (uploaded) data.image_url = uploaded;


### PR DESCRIPTION
## Summary

Asana: [P1-A](https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217048173089889)

#674〜#677 で生成系4ルートのテナント解決を直したが、同じ欠陥クラスが `routes.ts` の PATCH に残っていた（#682のテスト強化作業中に発見）。同一ファイル内で POST（`body.tenant_id`）は正しくテナントを反映するのに、PATCH は生の `tenantId`（`extractAuth` から）を使っており、super_admin の previewMode 中に `?tenant=` を無視してバケット直下へ全テナント混在で書き込んでいた。

## 実装で見つかった追加の欠陥

タスク本文は「保存先パスのみ直す」ことを想定していましたが、テストを書く過程で **テナントが解決できない場合の400ガードが元々無い** ことも発覚しました。修正前のコードでは、`?tenant=` を送らない super_admin がそのまま base64 をアップロードすると、空テナントのままバケット直下へ実際に書き込まれてしまいます。`#P0-3` と同じ形で外部処理（Storage書き込み）前に400を返すガードを追加しました。

## 変更内容

- `PATCH /v1/admin/avatar/configs/:id` の base64 アップロード直前で `resolveEffectiveTenantId(req)`（#674で導入、#682でtrim・型ガード済み）を使うよう変更
- テナントが解決できない場合は Storage を触る前に400で早期リターン
- **PATCHのSQL（WHERE句、super_adminの跨テナント更新可）は変更していません**（既存の意図された仕様。DELETE/voice-cloneも同規則）

## やっていないこと

- `routes.ts` ファイル全体を `extractAuth` から `resolveEffectiveTenantId` へ移行していません（今回の1箇所のみ、スコープ膨張防止）
- `studio.tsx`（旧UI編集画面）から `?tenant=` を実際に送る配線は今回のスコープ外です。`AvatarCard.tsx` の編集リンクが `?tenant=` をそもそもURLに乗せていないため、この修正だけでは実際の編集フローはまだ繋がりません（`docs/AVATAR_CHAT_MIGRATION.md` §16 に記載済みの既知の残存ギャップ）

## Test plan

- [x] このエンドポイントには元々テストが1件も無かったため、5件を新規追加（`src/api/admin/avatar/routes.test.ts`）: super_admin+`?tenant=`で対象テナント配下に保存 / `?tenant=`なしは400でStorage不到達 / client_adminの越権防止 / https URLはStorageを一切触らない / SQLのWHERE句が変わっていないこと
- [x] `npx jest src/api/admin/avatar/routes.test.ts` — 新規5件 pass。既存の失敗11件（voice-clone系）は `jest.spyOn(global, "fetch")` のローカル環境要因で、本PRの変更とは無関係（本日 #682 で同じ事象を確認済み。CIでのgreenを基準にしてください）
- [x] `npx tsc --noEmit` — エラーなし
- [x] `npx oxlint`（変更ファイル） — 新規警告なし（既存2件は本PR無関係）
- [x] rebase on latest main, no conflicts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StqjjaijseYkGkmG2k5LJ