### PR TITLE
debug: temporary CP-B-4 user state diagnostics (do not merge)

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -912,17 +912,6 @@ export default function CopilotPreviewPage() {
     myEpoch: number,
     opts: { hasRestoredConversation: boolean; loadingText: string; force?: boolean },
   ) => {
-    // TEMP DIAGNOSTIC (Asana 1217048227626635, do not merge): JWTを別途デコードした
-    // 診断ログ(PR #680)と、useAuthが実際に解決したReact stateが食い違う可能性を
-    // 切り分けるため、判定に使う値そのものをここで直接ダンプする。
-    // eslint-disable-next-line no-console
-    console.log('[DIAG2] runOnboardingAwareBriefing entry:', JSON.stringify({
-      role: user?.role,
-      tenantId: user?.tenantId,
-      previewMode,
-      previewTenantId,
-      scopedTenantId,
-    }));
     let stage: OnboardingStageFlags | null = null;
     // Asana 1217040568430944(P7): super_adminのクライアントビュー(previewMode)からも
     // オンボーディングの「次の一手」提示を使えるようにする(docs/ONBOARDING_FIRST_LOGIN.md 決定D)。
@@ -965,13 +954,6 @@ export default function CopilotPreviewPage() {
     // 変更せず、admin-ui内のブラウザ単位フラグ(tuningRuleIntro.ts)だけで
     // 「1回きり」を保証する軽量な接続(既存テナント向けの移行導線は別途作らない — 4段階が
     // 全て真になるのは実質的にこのオンボーディングフローを新規に通過したテナントのみ)。
-    // eslint-disable-next-line no-console
-    console.log('[DIAG2] P6-1 gate check:', JSON.stringify({
-      hasStage: !!stage,
-      scopedTenantId,
-      hasShown: scopedTenantId ? hasShownTuningRuleIntro(scopedTenantId) : null,
-      gatePassed: !!(stage && scopedTenantId && !hasShownTuningRuleIntro(scopedTenantId || '')),
-    }));
     if (stage && scopedTenantId && !hasShownTuningRuleIntro(scopedTenantId)) {
       markTuningRuleIntroShown(scopedTenantId);
       push(say(

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -912,6 +912,17 @@ export default function CopilotPreviewPage() {
     myEpoch: number,
     opts: { hasRestoredConversation: boolean; loadingText: string; force?: boolean },
   ) => {
+    // TEMP DIAGNOSTIC (Asana 1217048227626635, do not merge): JWTを別途デコードした
+    // 診断ログ(PR #680)と、useAuthが実際に解決したReact stateが食い違う可能性を
+    // 切り分けるため、判定に使う値そのものをここで直接ダンプする。
+    // eslint-disable-next-line no-console
+    console.log('[DIAG2] runOnboardingAwareBriefing entry:', JSON.stringify({
+      role: user?.role,
+      tenantId: user?.tenantId,
+      previewMode,
+      previewTenantId,
+      scopedTenantId,
+    }));
     let stage: OnboardingStageFlags | null = null;
     // Asana 1217040568430944(P7): super_adminのクライアントビュー(previewMode)からも
     // オンボーディングの「次の一手」提示を使えるようにする(docs/ONBOARDING_FIRST_LOGIN.md 決定D)。
@@ -954,6 +965,13 @@ export default function CopilotPreviewPage() {
     // 変更せず、admin-ui内のブラウザ単位フラグ(tuningRuleIntro.ts)だけで
     // 「1回きり」を保証する軽量な接続(既存テナント向けの移行導線は別途作らない — 4段階が
     // 全て真になるのは実質的にこのオンボーディングフローを新規に通過したテナントのみ)。
+    // eslint-disable-next-line no-console
+    console.log('[DIAG2] P6-1 gate check:', JSON.stringify({
+      hasStage: !!stage,
+      scopedTenantId,
+      hasShown: scopedTenantId ? hasShownTuningRuleIntro(scopedTenantId) : null,
+      gatePassed: !!(stage && scopedTenantId && !hasShownTuningRuleIntro(scopedTenantId || '')),
+    }));
     if (stage && scopedTenantId && !hasShownTuningRuleIntro(scopedTenantId)) {
       markTuningRuleIntroShown(scopedTenantId);
       push(say(

--- a/tests/e2e/qa-copilot-preview.spec.ts
+++ b/tests/e2e/qa-copilot-preview.spec.ts
@@ -221,6 +221,14 @@ test.describe('copilot-preview — Role B (client_admin)', () => {
     // my-tenant(オンボーディング判定)とagent/chatをモックし、実LLM/実carnationデータの
     // 書き換えに依存させない(CP-B-3のコメントと同じ理由)。
     test('CP-B-4 (P6-1): 4段階完了直後の紹介から、旧UIに行かずに指示ルールを作成・確認できる', async ({ page }) => {
+      // TEMP DIAGNOSTIC (Asana 1217048227626635, do not merge): copilot-preview/index.tsx に
+      // 追加した [DIAG2] console.log をブラウザ→NodeのCIログへ転送する。
+      page.on('console', (msg) => {
+        if (msg.text().includes('[DIAG2]')) {
+          // eslint-disable-next-line no-console
+          console.log('[BROWSER]', msg.text());
+        }
+      });
       await page.route('**/v1/admin/my-tenant', (route) =>
         route.fulfill({
           status: 200,

--- a/tests/e2e/qa-copilot-preview.spec.ts
+++ b/tests/e2e/qa-copilot-preview.spec.ts
@@ -221,14 +221,6 @@ test.describe('copilot-preview — Role B (client_admin)', () => {
     // my-tenant(オンボーディング判定)とagent/chatをモックし、実LLM/実carnationデータの
     // 書き換えに依存させない(CP-B-3のコメントと同じ理由)。
     test('CP-B-4 (P6-1): 4段階完了直後の紹介から、旧UIに行かずに指示ルールを作成・確認できる', async ({ page }) => {
-      // TEMP DIAGNOSTIC (Asana 1217048227626635, do not merge): copilot-preview/index.tsx に
-      // 追加した [DIAG2] console.log をブラウザ→NodeのCIログへ転送する。
-      page.on('console', (msg) => {
-        if (msg.text().includes('[DIAG2]')) {
-          // eslint-disable-next-line no-console
-          console.log('[BROWSER]', msg.text());
-        }
-      });
       await page.route('**/v1/admin/my-tenant', (route) =>
         route.fulfill({
           status: 200,
@@ -286,6 +278,34 @@ test.describe('copilot-preview — Role B (client_admin)', () => {
       });
 
       await page.goto(`${ADMIN}/copilot-preview`, { waitUntil: 'domcontentloaded', timeout: 20000 });
+
+      // TEMP DIAGNOSTIC (Asana 1217048227626635, do not merge): admin-ui はE2E実行時点で
+      // 本番デプロイ済みのバンドルがそのまま動くため、ソース側にconsole.logを足しても
+      // このPRブランチの変更としては反映されない(mainマージ後の再デプロイが必要)。
+      // そのためテスト側のpage.evaluate()で実行時のlocalStorage/JWTを直接読む
+      // (PR #680と同じ手法をこのテストの実行タイミングに合わせて再実施する)。
+      await page.waitForTimeout(3000); // bootstrap effect(fetch含む)が走るのを待つ
+      const diag = await page.evaluate(() => {
+        const authRaw = window.localStorage.getItem('sb-rpqrwifbrhlebbelyqog-auth-token');
+        let jwt: unknown = null;
+        try {
+          const parsed = authRaw ? JSON.parse(authRaw) : null;
+          const token = parsed?.access_token as string | undefined;
+          if (token) {
+            const payloadB64 = token.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
+            jwt = JSON.parse(atob(payloadB64));
+          }
+        } catch (e) {
+          jwt = { error: String(e) };
+        }
+        return {
+          jwtAppMetadata: (jwt as any)?.app_metadata,
+          localStorageR2cKeys: Object.keys(window.localStorage).filter((k) => k.startsWith('r2c_')),
+          sessionStorageR2cKeys: Object.keys(window.sessionStorage).filter((k) => k.startsWith('r2c_')),
+        };
+      });
+      // eslint-disable-next-line no-console
+      console.log('[DIAG3]', JSON.stringify(diag));
 
       // 週次ブリーフィングの代わりに、指示ルールの初回紹介が出る
       await expect(page.getByText(/最初のルールを作ってみますか/)).toBeVisible({ timeout: 15000 });


### PR DESCRIPTION
一時診断PR。Asana 1217048227626635 の調査続行用。

PR #680 の診断(JWTを別途デコード)では app_metadata に role/tenant_id が無いと出たが、
同じログの my-tenant 200レスポンスは CP-B-4 自身の page.route() モックの固定値と一致しており、
そのfetch自体は index.tsx:927 の `user?.role === "client_admin"` を通過しないと発生しないはず
という矛盾がある。この診断PRは JWTを別途デコードするのではなく、useAuth が実際に解決した
React state (`user?.role` / `user?.tenantId` / `scopedTenantId`) を判定の瞬間に直接ダンプし、
どちらが実態かを確定させる。

結果を確認したらこのPRはクローズし、ブランチも削除する(#680と同じ運用、do not merge)。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NgWB82fsx7LMjhJqpd1rCx