### PR TITLE
fix(e2e): mainマージ直後のCloudflare Pagesデプロイ直撃でAuth setupが失敗する問題を直す

### DIFF
--- a/tests/e2e/auth.setup.ts
+++ b/tests/e2e/auth.setup.ts
@@ -2,6 +2,7 @@ import { test as setup } from '@playwright/test';
 import fs from 'fs';
 import path from 'path';
 import { ADMIN_BASE_URL } from './config';
+import { waitForAppReady } from './helpers/gotoRetry';
 
 const AUTH_FILE = 'tests/e2e/.auth/user.json';
 
@@ -17,8 +18,9 @@ setup('authenticate admin', async ({ page }) => {
     return;
   }
 
-  await page.goto(ADMIN_BASE_URL);
-  await page.locator('input[type="email"]').waitFor({ timeout: 15000 });
+  // Asana 1217048228772841: mainマージ直後のCloudflare Pagesデプロイ直撃で
+  // input[type="email"]が現れない時間帯があるため、再読み込みしながら待つ。
+  await waitForAppReady(page, ADMIN_BASE_URL, 'input[type="email"]');
   await page.fill('input[type="email"]', email);
   await page.fill('input[type="password"]', password);
   await page.locator('button[type="submit"]').click();

--- a/tests/e2e/helpers/gotoRetry.ts
+++ b/tests/e2e/helpers/gotoRetry.ts
@@ -22,3 +22,35 @@ export async function gotoWithRetry(
   }
   throw lastError;
 }
+
+// Asana 1217048228772841: admin.r2c.biz は Cloudflare Pages が main への push で
+// 自動デプロイする。admin-ui を含むPRがマージされた直後は、SPAのバンドルが
+// 差し替わる最中で HTML シェルは200を返すもののクライアント側のレンダリングが
+// 完了せず readySelector が現れない時間帯がある(実測で確認済み)。gotoWithRetry
+// とは別の障害モード(gotoの例外ではなく、goto成功後のレンダリング未完了)なので
+// 単純なリトライ回数増では解決しない。ページを再読み込みしながら段階的に待つ。
+// デプロイ完了までの窓は実測で「数十秒〜」のため、既定は合計90秒・8秒間隔。
+export async function waitForAppReady(
+  page: Page,
+  url: string,
+  readySelector: string,
+  totalBudgetMs = 90_000,
+  perAttemptTimeoutMs = 8_000,
+): Promise<void> {
+  const deadline = Date.now() + totalBudgetMs;
+  let attempt = 0;
+
+  for (;;) {
+    attempt += 1;
+    const isLastAttempt = Date.now() + perAttemptTimeoutMs >= deadline;
+    await page.goto(url, { waitUntil: 'domcontentloaded' });
+    try {
+      await page.locator(readySelector).waitFor({ timeout: perAttemptTimeoutMs });
+      return;
+    } catch (err) {
+      // 最終試行は元のエラーをそのまま投げ直し、失敗理由を分かりやすくする
+      if (isLastAttempt) throw err;
+      console.warn(`⚠️  waitForAppReady: ${readySelector} 未検出(${attempt}回目)。Cloudflare Pages デプロイ直後の可能性 — 再読み込みして待機を継続します`);
+    }
+  }
+}

--- a/tests/e2e/superadmin.setup.ts
+++ b/tests/e2e/superadmin.setup.ts
@@ -2,6 +2,7 @@ import { test as setup } from '@playwright/test';
 import fs from 'fs';
 import path from 'path';
 import { ADMIN_BASE_URL } from './config';
+import { waitForAppReady } from './helpers/gotoRetry';
 
 // super_admin 用 storageState 生成（auth.setup.ts の client_admin 版と同方式）。
 // TEST_SUPERADMIN_EMAIL / TEST_SUPERADMIN_PASSWORD が無い場合は空スケルトンを書き、
@@ -20,9 +21,10 @@ setup('authenticate super_admin', async ({ page }) => {
     return;
   }
 
-  await page.goto(ADMIN_BASE_URL, { waitUntil: 'domcontentloaded' });
-  await page.waitForTimeout(2000);
-  await page.locator('input[type="email"]').waitFor({ timeout: 15000 });
+  // Asana 1217048228772841: mainマージ直後のCloudflare Pagesデプロイ直撃で
+  // input[type="email"]が現れない時間帯があるため、再読み込みしながら待つ
+  // (auth.setup.tsのclient_admin版と同方式)。
+  await waitForAppReady(page, ADMIN_BASE_URL, 'input[type="email"]');
   await page.fill('input[type="email"]', email);
   await page.fill('input[type="password"]', password);
   await page.locator('button[type="submit"]').click();


### PR DESCRIPTION
## Summary

Asana: [CI Auth setup タイミング](https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217048228772841)

タスク本文が挙げた4つの対応候補のうち、**案1（readiness待ちを追加する）**を採用しました。CIワークフロー構造（`e2e.yml`のconcurrency設計等）を変えず、最も的を絞った可逆的な変更です。

## 原因（実測で特定済み・タスク本文より）

admin.r2c.biz は Cloudflare Pages が main への push で自動デプロイします。admin-ui を含むPRのマージ直後は、SPAのバンドルが差し替わる最中で HTML シェル(1.4KB程度)は200を返すもののクライアント側のレンダリングが完了せず `input[type="email"]` が現れない時間帯があります。

自然実験（同一コミットで結果が分かれた）で裏付け済み: マージ24秒後に開始したE2Eは失敗、90秒後に開始した別実行は通過、同一コミットのまま後で再実行すると通過。`playwright.config.ts` の `retries:1` は同じタイムアウト値で2回とも同じ理由で落ちるため、単純なリトライ回数増では解決しません。

## 変更内容

- `tests/e2e/helpers/gotoRetry.ts` に `waitForAppReady()` を追加。ページを再読み込みしながら段階的に待つ（合計90秒・8秒間隔）。既存の `gotoWithRetry()`（goto自体の例外をリトライ）とは別の障害モード（goto成功後のレンダリング未完了）のため、同じヘルパーファイル内に別関数として追加しました
- `auth.setup.ts`（client_admin）・`superadmin.setup.ts`（super_admin）の両方に適用。**`superadmin.setup.ts` は既存の `waitForTimeout(2000)` による場当たり的な待機を同じ仕組みに置換**しています（同一バグクラスが2ファイルに存在していたため、片方だけ直すと不自然という判断です）

## やっていないこと（他の候補案）

- 案2（Auth setupステップ単位のリトライ）: 案1と違い無駄な待ちが増えるため採用せず
- 案3（Cloudflare Pagesのデプロイ完了を待つworkflow_run連携）: `e2e.yml` の設計変更を伴い、タスク本文が指摘する「concurrency: e2e-production の直列化」も併せて設計が必要になる大きめの変更のため、今回は見送り。将来的にこの問題が再発する場合は検討してください
- 案4（何もしない・再実行運用の明文化）: タスク本文の通り、再実行が通りにくい構造的問題（concurrency直列化・待機runのcancel）があるため実質的な解決にならないと判断し不採用

## Test plan

- [x] `npx tsc --noEmit` — エラーなし
- [x] `npx oxlint`（変更ファイル） — エラーなし
- [x] `npx playwright test tests/e2e/auth.setup.ts tests/e2e/superadmin.setup.ts --list` — 2ファイルとも正しくパースされることを確認
- [x] rebase on latest main, no conflicts
- [ ] 受け入れ条件「admin-uiを含むPRがmainにマージされた直後(60秒以内)にE2Eが開始されても、Auth setupが安定して通ること」は、実際にmainマージ直後のタイミングでのCI実行結果で確認が必要です。次にadmin-ui変更を含むPRがマージされた直後にE2Eが走るタイミングで結果を確認してください

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StqjjaijseYkGkmG2k5LJ