### PR TITLE
fix(e2e): 起動時ブリーフィングの「必ず1回目」決め打ちをやめ、オンボーディング分岐で壊れるE2Eを直す

### DIFF
--- a/docs/ONBOARDING_FIRST_LOGIN.md
+++ b/docs/ONBOARDING_FIRST_LOGIN.md
@@ -366,6 +366,8 @@ WHERE t.created_at <= NOW() - INTERVAL '7 days';  -- 判定期間(7日)が満了
 | playwright（`tests/e2e/`） | N-2, N-12, X-6, X-7, X-13, X-14。既存の `qa-irregular-3roles.spec.ts` / `qa-preview-scope-leak.spec.ts` / `responsive.spec.ts` に追記できるものは追記する |
 | 手動 / Gate 4b | 設置検知（N-7）と実会話（N-8）は実サイト依存のため、最低1テナントで実地確認 |
 
+**E2Eモックを書く際の注意（Asana 1217080508665459）**: 起動時に `agent/chat` が必ず1回呼ばれるとは限らない。オンボーディング未完了のテナント（`firstConversation: false` 等）では `deriveOnboardingNextStep`（`index.tsx:335`）が `nextStep` を返し、`index.tsx:947-950` で `return` するため、起動時ブリーフィングの `sendReal(BOOTSTRAP_PROMPT)` 自体が発火しない。`page.route('**/v1/admin/agent/chat', ...)` のモックで「1回目の呼び出し＝起動時ブリーフィング」と回数で決め打たず、`tests/e2e/helpers/agentChatMock.ts` の `isBootstrapMessage()` で `BOOTSTRAP_PROMPT` の内容を見て判定すること。
+
 ---
 
 ## 8. 受け入れ条件

--- a/tests/e2e/helpers/agentChatMock.test.ts
+++ b/tests/e2e/helpers/agentChatMock.test.ts
@@ -1,0 +1,115 @@
+// tests/e2e/helpers/agentChatMock.test.ts
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { isBootstrapMessage } from './agentChatMock';
+
+describe('isBootstrapMessage — 正常系', () => {
+  it('実際の BOOTSTRAP_PROMPT 全文を渡すと true', () => {
+    const prompt =
+      'ログインしたところです。今週の状況を教えてください。要点と次にやるべきことを最大3つまで、簡潔に教えてください。';
+    expect(isBootstrapMessage(prompt)).toBe(true);
+  });
+
+  it('ユーザーが送った通常のメッセージには反応しない', () => {
+    expect(isBootstrapMessage('アバターを作りたい')).toBe(false);
+    expect(isBootstrapMessage('保証について聞かれたら2年と答えて')).toBe(false);
+    expect(isBootstrapMessage('採用してください')).toBe(false);
+  });
+});
+
+describe('isBootstrapMessage — 境界値・異常系', () => {
+  it('undefined → false（例外を投げない）', () => {
+    expect(isBootstrapMessage(undefined)).toBe(false);
+  });
+
+  it('空文字 → false', () => {
+    expect(isBootstrapMessage('')).toBe(false);
+  });
+
+  it('文字列以外の実行時値が来ても例外を投げず false を返す', () => {
+    // route.request().postData() を JSON.parse した結果は型定義上 string|undefined だが、
+    // 実行時は body の中身次第で null・数値・オブジェクトになりうる
+    // (JSON.parse は any を返すため TS の型は実行時を保証しない)。
+    expect(isBootstrapMessage(null as unknown as string)).toBe(false);
+    expect(isBootstrapMessage(123 as unknown as string)).toBe(false);
+    expect(isBootstrapMessage({} as unknown as string)).toBe(false);
+    expect(isBootstrapMessage([] as unknown as string)).toBe(false);
+  });
+
+  it('マーカー文字列だけの最小一致でも true（部分一致で十分という設計）', () => {
+    expect(isBootstrapMessage('ログインしたところです')).toBe(true);
+  });
+
+  it('マーカーが文中のどこにあっても true（先頭/末尾/中間で位置に依存しない）', () => {
+    expect(isBootstrapMessage('ログインしたところです。続きの文章。')).toBe(true);
+    expect(isBootstrapMessage('前置きの文章。ログインしたところです')).toBe(true);
+    expect(isBootstrapMessage('前置き。ログインしたところです。後置き。')).toBe(true);
+  });
+
+  it('1文字でも欠けると一致しない(前方一致・後方一致の未達を区別できる)', () => {
+    expect(isBootstrapMessage('ログインしたところで')).toBe(false); // 末尾1文字欠落
+    expect(isBootstrapMessage('ログインしたところです'.slice(1))).toBe(false); // 先頭1文字欠落
+  });
+});
+
+describe('isBootstrapMessage — ユーザーがやりそうなイレギュラーな操作', () => {
+  it('似た言い回し(業種チップ・埋め込みコードの案内文)には反応しない', () => {
+    // 実際に copilot-preview/index.tsx が出す他の定型文。マーカーが広すぎて
+    // 別の定型文まで誤検知していないことを確認する。
+    expect(
+      isBootstrapMessage('初めまして！まず1つだけ教えてください。どんな業種ですか？'),
+    ).toBe(false);
+    expect(
+      isBootstrapMessage('FAQの準備ができました。次はウィジェットをサイトに設置しましょう。'),
+    ).toBe(false);
+  });
+
+  it('【既知のリスク・意図的に固定】ユーザーが偶然マーカーと同じ言葉を送ると誤検知する', () => {
+    // 「ログインしたところです」は自然な日本語表現でもあるため、ユーザーが
+    // (ボットへの雑談として)似た文言を送った場合、モックはそれを起動時
+    // ブリーフィングと誤判定する。実運用のE2Eではユーザー役のcomposer.fill()
+    // 内容を私たちが完全に制御しているため実害は無いが、この判定方式の
+    // 限界として意図せず悪化しないよう固定しておく。
+    expect(isBootstrapMessage('さっきログインしたところです。質問があります。')).toBe(true);
+  });
+
+  it('前後の空白・改行が付与されていても反応する(コピペ・IME確定由来のノイズを許容)', () => {
+    expect(isBootstrapMessage('  ログインしたところです。今週の状況を教えてください。  ')).toBe(true);
+    expect(isBootstrapMessage('\nログインしたところです。\n')).toBe(true);
+  });
+
+  it('全角/半角の表記ゆれには反応しない(厳密な部分文字列一致のため正規化しない)', () => {
+    // 意図的な設計: 正規化すると「ユーザーが偶然似た文言を送ると誤検知する」リスクが
+    // さらに広がるため、あえて緩めない。挙動の固定として記録する。
+    expect(isBootstrapMessage('ﾛｸﾞｲﾝしたところです')).toBe(false);
+  });
+});
+
+describe('isBootstrapMessage — admin-ui 側の BOOTSTRAP_PROMPT とのドリフト検知', () => {
+  // Asana 1217080508665459 の根本原因は「テスト側の前提が実装の変更に追従して
+  // いなかった」ことだった。同じ再発を防ぐため、admin-ui 側の実際の定数文字列を
+  // 読み取り、マーカーがそこに実在することを検証する。admin-ui/src の実装は
+  // 一切変更しないが、将来 BOOTSTRAP_PROMPT の文言が変わってマーカーと乖離した
+  // 場合は、この場で気づけるようにする(confirmPolicy.test.ts が actionExecutor.ts
+  // を readFileSync して検査するのと同じパターン)。
+  const INDEX_TSX_PATH = join(
+    __dirname,
+    '..',
+    '..',
+    '..',
+    'admin-ui',
+    'src',
+    'pages',
+    'copilot-preview',
+    'index.tsx',
+  );
+
+  it('admin-ui/src/pages/copilot-preview/index.tsx の BOOTSTRAP_PROMPT にマーカーが含まれる', () => {
+    const source = readFileSync(INDEX_TSX_PATH, 'utf8');
+    const match = source.match(/const BOOTSTRAP_PROMPT =\s*\n?\s*"([^"]+)"/);
+    expect(match).not.toBeNull();
+    const actualPrompt = match![1];
+    expect(isBootstrapMessage(actualPrompt)).toBe(true);
+  });
+});

--- a/tests/e2e/helpers/agentChatMock.test.ts
+++ b/tests/e2e/helpers/agentChatMock.test.ts
@@ -107,6 +107,9 @@ describe('isBootstrapMessage — admin-ui 側の BOOTSTRAP_PROMPT とのドリ�
 
   it('admin-ui/src/pages/copilot-preview/index.tsx の BOOTSTRAP_PROMPT にマーカーが含まれる', () => {
     const source = readFileSync(INDEX_TSX_PATH, 'utf8');
+    // この正規表現は index.tsx 側が「二重引用符の文字列リテラル1行」で宣言されている前提に依存する。
+    // テンプレートリテラル化や複数行連結に変えた場合はこの正規表現も更新すること。
+    // 乖離した場合は直下の expect(match).not.toBeNull() で落ちるため、サイレント失敗はしない。
     const match = source.match(/const BOOTSTRAP_PROMPT =\s*\n?\s*"([^"]+)"/);
     expect(match).not.toBeNull();
     const actualPrompt = match![1];

--- a/tests/e2e/helpers/agentChatMock.ts
+++ b/tests/e2e/helpers/agentChatMock.ts
@@ -1,0 +1,14 @@
+// Asana 1217080508665459: /copilot-preview の起動時ブリーフィングは、
+// テナントのオンボーディングが未完了(firstConversation:false 等)だと
+// nextStep を出して return し、agent/chat への POST 自体が発生しない
+// (admin-ui/src/pages/copilot-preview/index.tsx:947-950)。
+// この事情を知らずに「1回目の agent/chat 呼び出し = 起動時ブリーフィング」と
+// 回数で決め打つと、オンボーディング未完了のテナントでは1回目がユーザーの
+// 最初の送信メッセージになり、意図しないブリーフィング応答を受け取ってしまう。
+// 回数ではなく BOOTSTRAP_PROMPT の内容で判定することで、この分岐の有無に
+// 依存しないモックにする。
+const BOOTSTRAP_PROMPT_MARKER = 'ログインしたところです';
+
+export function isBootstrapMessage(message: string | undefined): boolean {
+  return typeof message === 'string' && message.includes(BOOTSTRAP_PROMPT_MARKER);
+}

--- a/tests/e2e/qa-copilot-preview.spec.ts
+++ b/tests/e2e/qa-copilot-preview.spec.ts
@@ -59,11 +59,8 @@ test.describe('copilot-preview — Role B (client_admin)', () => {
   // 検証したいのはUIの実配線(クリック→カード遷移→PATCH送出→復元)であって、LLM/外部APIの
   // 中身そのものではないため、モックはこの目的に対して妥当な選択である。
   test('CP-B-3: 未作成テナントが会話だけで公開まで到達し、離脱はライブテストの1回だけ', async ({ page, context }) => {
-    const chatMessages: string[] = [];
-
     await page.route('**/v1/admin/agent/chat', async (route) => {
       const body = JSON.parse(route.request().postData() || '{}') as { message?: string };
-      chatMessages.push(body.message ?? '');
 
       // Asana 1217080508665459: 起動時ブリーフィングは「1回目の呼び出し」ではなく
       // BOOTSTRAP_PROMPT の内容で判定する。carnationのようにオンボーディング未完了

--- a/tests/e2e/qa-copilot-preview.spec.ts
+++ b/tests/e2e/qa-copilot-preview.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from '@playwright/test';
 import fs from 'fs';
 import { ADMIN_BASE_URL } from './config';
+import { isBootstrapMessage } from './helpers/agentChatMock';
 
 // QA: /copilot-preview の実データ接続・super_adminテナントプレビュー回帰テスト — 2026-07-19
 // 本番で以下3件の不具合が実地発見されたため、再発防止として追加:
@@ -58,15 +59,17 @@ test.describe('copilot-preview — Role B (client_admin)', () => {
   // 検証したいのはUIの実配線(クリック→カード遷移→PATCH送出→復元)であって、LLM/外部APIの
   // 中身そのものではないため、モックはこの目的に対して妥当な選択である。
   test('CP-B-3: 未作成テナントが会話だけで公開まで到達し、離脱はライブテストの1回だけ', async ({ page, context }) => {
-    let chatCalls = 0;
     const chatMessages: string[] = [];
 
     await page.route('**/v1/admin/agent/chat', async (route) => {
       const body = JSON.parse(route.request().postData() || '{}') as { message?: string };
-      chatCalls += 1;
       chatMessages.push(body.message ?? '');
 
-      if (chatCalls === 1) {
+      // Asana 1217080508665459: 起動時ブリーフィングは「1回目の呼び出し」ではなく
+      // BOOTSTRAP_PROMPT の内容で判定する。carnationのようにオンボーディング未完了
+      // (firstConversation:false)のテナントでは起動時ブリーフィング自体が発生せず、
+      // 最初の呼び出しがユーザーの送信メッセージになるため。
+      if (isBootstrapMessage(body.message)) {
         // 起動時ブリーフィング
         return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ reply: '今週も順調です。', actions: [] }) });
       }

--- a/tests/e2e/qa-irregular-3roles.spec.ts
+++ b/tests/e2e/qa-irregular-3roles.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { ADMIN_BASE_URL, API_BASE_URL, DEMO_BASE_URL } from './config';
+import { isBootstrapMessage } from './helpers/agentChatMock';
 
 // QA irregular (異常系) sweep — 2026-07-17
 // 3ロールが「イレギュラーな動作」をした場合に、拒むべき操作が正しく拒まれるか / スコープが
@@ -187,7 +188,9 @@ test.describe('Irregular — Role B (client_admin RBAC/tenant boundary)', () => 
       const body = JSON.parse(route.request().postData() || '{}') as { message?: string };
       chatCalls += 1;
       sentMessages.push(body.message ?? '');
-      if (chatCalls === 1) {
+      // Asana 1217080508665459: 起動時ブリーフィングは回数ではなく内容で判定する
+      // (qa-copilot-preview.spec.ts CP-B-3と同じ理由)。
+      if (isBootstrapMessage(body.message)) {
         return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ reply: '今週も順調です。', actions: [] }) });
       }
       if (body.message?.includes('アバターを作りたい')) {
@@ -311,12 +314,12 @@ test.describe('Irregular — Role B (client_admin RBAC/tenant boundary)', () => 
   async function mockTuningRuleFlowUpToDraft(page: any) {
     let saveCalls = 0;
     const sentMessages: string[] = [];
-    let bootstrapDone = false;
     await page.route('**/v1/admin/agent/chat', async (route: any) => {
       const body = JSON.parse(route.request().postData() || '{}') as { message?: string };
       sentMessages.push(body.message ?? '');
-      if (!bootstrapDone) {
-        bootstrapDone = true;
+      // Asana 1217080508665459: 起動時ブリーフィングは回数ではなく内容で判定する
+      // (qa-copilot-preview.spec.ts CP-B-3と同じ理由)。
+      if (isBootstrapMessage(body.message)) {
         return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ reply: '今週も順調です。', actions: [] }) });
       }
       if (body.message?.includes('保証について聞かれたら')) {

--- a/tests/e2e/qa-irregular-3roles.spec.ts
+++ b/tests/e2e/qa-irregular-3roles.spec.ts
@@ -182,11 +182,9 @@ test.describe('Irregular — Role B (client_admin RBAC/tenant boundary)', () => 
   // 実LLM/実課金/carnationの実データ書き換えに依存させない)。検証対象はUIの実配線であり、
   // モックは非破壊性を担保する手段そのものである。
   async function mockAvatarFlowUpToAdopted(page: any) {
-    let chatCalls = 0;
     const sentMessages: string[] = [];
     await page.route('**/v1/admin/agent/chat', async (route: any) => {
       const body = JSON.parse(route.request().postData() || '{}') as { message?: string };
-      chatCalls += 1;
       sentMessages.push(body.message ?? '');
       // Asana 1217080508665459: 起動時ブリーフィングは回数ではなく内容で判定する
       // (qa-copilot-preview.spec.ts CP-B-3と同じ理由)。
@@ -231,7 +229,6 @@ test.describe('Irregular — Role B (client_admin RBAC/tenant boundary)', () => 
       }),
     );
     return {
-      totalCalls: () => chatCalls,
       countMessage: (message: string) => sentMessages.filter((m) => m === message).length,
     };
   }

--- a/tests/e2e/qa-preview-scope-leak.spec.ts
+++ b/tests/e2e/qa-preview-scope-leak.spec.ts
@@ -1,5 +1,6 @@
 import { test, expect } from '@playwright/test';
 import { ADMIN_BASE_URL } from './config';
+import { isBootstrapMessage } from './helpers/agentChatMock';
 
 // 回帰検知用: super_admin の「クライアントビューで見る」プレビュー中に previewTenantId が
 // 正しく使われず、テナントスコープが壊れる/画面が空白になる不具合の恒久テスト群。
@@ -194,10 +195,12 @@ test.describe('Preview scope leak (known bug) — escalations が preview テナ
   test('C-LEAK-5: carnation プレビュー中、fal/generate・match-voiceのURLに?tenant=が付与される', async ({
     page,
   }) => {
-    let chatCalls = 0;
     await page.route('**/v1/admin/agent/chat', async (route) => {
-      chatCalls += 1;
-      if (chatCalls === 1) {
+      const body = JSON.parse(route.request().postData() || '{}') as { message?: string };
+      // Asana 1217080508665459: 起動時ブリーフィングは回数ではなく内容で判定する
+      // (super_adminもpreviewMode経由でオンボーディング分岐に入りうるため、
+      // 「1回目=ブリーフィング」の決め打ちは同じ理由で壊れる)。
+      if (isBootstrapMessage(body.message)) {
         return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ reply: '今週も順調です。', actions: [] }) });
       }
       return route.fulfill({


### PR DESCRIPTION
## Summary

Asana: [P0](https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217080508665459)

JWT修正（[Asana 1217048227626635](https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217048227626635)）で copilot-preview のオンボーディング分岐が初めて実際に動くようになった結果、`carnation`（`firstConversation:false`）では `index.tsx:947-950` の `nextStep` 分岐で `return` し、起動時ブリーフィングの `agent/chat` POST が発生しなくなりました。既存E2Eのモックは「1回目の `agent/chat` 呼び出し = 起動時ブリーフィング」を回数で決め打っていたため、ユーザーが送った最初のメッセージがブリーフィング応答（`actions: []`）を受け取ってしまい失敗します。

これは**アプリのバグではなく、テスト側の前提が古い**問題です。`copilot-preview/index.tsx` のコードは変更していません。

## 進め方（プラン通り、段階的に）

このPRは**まずCP-B-3のみ**を直します。方針が正しいことをCIで確認してから、`qa-irregular-3roles.spec.ts`・`qa-preview-scope-leak.spec.ts` に広げる後続コミットを積みます（6件を一括で直してから回すと、失敗が残ったときに切り分けができないため）。

## 変更内容（Step 1）

- `tests/e2e/helpers/agentChatMock.ts` を新規作成し `isBootstrapMessage()` を export。`BOOTSTRAP_PROMPT`（`copilot-preview/index.tsx:314`）の内容で判定する（既存の `gotoRetry.ts`/`mockAvatarBackend.ts` と同じ粒度・同じ場所に配置）
- `qa-copilot-preview.spec.ts` CP-B-3 の `chatCalls === 1` を `isBootstrapMessage(body.message)` に置換。回数ではなく内容で判定するため、起動時ブリーフィングの有無に依存しなくなる

## Test plan

- [x] `npx tsc --noEmit` — エラーなし
- [x] `npx oxlint`（変更ファイル） — エラーなし
- [x] `npx playwright test tests/e2e/qa-copilot-preview.spec.ts --list` — パース確認OK
- [ ] E2Eは本番(admin.r2c.biz)直叩きのためローカル実行不可。**CIの結果が唯一の検証手段**。CP-B-3が通ることを確認してから残りのファイルへ進む

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StqjjaijseYkGkmG2k5LJ