### PR TITLE
fix(e2e): B-IRR-3 がテナント越境を一度も検証できていなかった問題を直す

### DIFF
--- a/tests/e2e/qa-irregular-3roles.spec.ts
+++ b/tests/e2e/qa-irregular-3roles.spec.ts
@@ -159,13 +159,33 @@ test.describe('Irregular — Role B (client_admin RBAC/tenant boundary)', () => 
     expect(foreignLeak).toBe(false);
   });
 
+  // Asana 1217080725079367: 旧実装は select 要素の全件カウントが0であることだけを
+  // 見ていたが、/admin/knowledge/books はリダイレクトスタブ(books.tsx、13行)のため
+  // role=anonymous(JWT修正前)だと画面自体が退化描画され select が無いだけでも
+  // このテストは通っていた。つまり越境を一度も検証できていなかった。
+  // 画面が実際に描画されたことを先に確認したうえで、描画された select の選択肢に
+  // 自テナント(carnation)以外のテナントIDが含まれないことを検証する。
   test('B-IRR-3: 判明済みギャップ /admin/knowledge/books へ直URL到達しても他テナント選択UIは出ない', async ({ page }) => {
     const { res } = await gotoAdmin(page, '/admin/knowledge/books');
     // RequireAuth のため到達自体は許容され得る。実害＝クロステナント選択/データが出ないことを確認。
     test.info().annotations.push({ type: 'final-url', description: page.url() });
     test.info().annotations.push({ type: 'status', description: String(res?.status()) });
-    const selectCount = await page.locator('select').count();
-    expect(selectCount).toBe(0); // テナント横断セレクタが出ない＝越境ビュー無し
+
+    // books.tsx は /admin/knowledge へリダイレクトするだけのスタブ。画面が実際に
+    // 描画されたことをまず確認する(描画されていなければ select が0件でも無意味)。
+    await expect(page.getByText('AIの知識データ').first()).toBeVisible({ timeout: 10000 });
+
+    const optionValues = await page.locator('select option').evaluateAll((opts) =>
+      opts.map((o) => (o as HTMLOptionElement).value),
+    );
+    test.info().annotations.push({ type: 'select-option-values', description: JSON.stringify(optionValues) });
+
+    // このリポジトリの他specが使う実在の他テナントID(qa-preview-scope-leak.spec.ts の
+    // PREVIEW_TENANT_2 / PREVIEW_TENANT_ID)。仮に他テナント選択UIが実装されて
+    // 選択肢に混入すればこのアサーションで落ちる(単なる0件カウントには戻さない)。
+    const OTHER_TENANT_IDS = ['lp-demo', 'r2c_default'];
+    const foreignOptions = optionValues.filter((v) => OTHER_TENANT_IDS.includes(v));
+    expect(foreignOptions).toEqual([]);
   });
 
   // GID 1217040818410419(2026-07-31): 「書籍/PDFはR2C運用限定」の実装反映。

--- a/tests/e2e/qa-irregular-3roles.spec.ts
+++ b/tests/e2e/qa-irregular-3roles.spec.ts
@@ -180,10 +180,12 @@ test.describe('Irregular — Role B (client_admin RBAC/tenant boundary)', () => 
     );
     test.info().annotations.push({ type: 'select-option-values', description: JSON.stringify(optionValues) });
 
-    // このリポジトリの他specが使う実在の他テナントID(qa-preview-scope-leak.spec.ts の
-    // PREVIEW_TENANT_2 / PREVIEW_TENANT_ID)。仮に他テナント選択UIが実装されて
-    // 選択肢に混入すればこのアサーションで落ちる(単なる0件カウントには戻さない)。
-    const OTHER_TENANT_IDS = ['lp-demo', 'r2c_default'];
+    // r2c_defaultは本ファイル冒頭のFOREIGN_TENANTを再利用(値の二重管理を避ける)。
+    // lp-demoはqa-preview-scope-leak.spec.tsのPREVIEW_TENANT_2と同値だが、
+    // spec間でテナントID定数を共有する仕組みが無いため手動で複製している。
+    // 仮に他テナント選択UIが実装されて選択肢に混入すればこのアサーションで落ちる
+    // (単なる0件カウントには戻さない)。
+    const OTHER_TENANT_IDS = [FOREIGN_TENANT, 'lp-demo'];
     const foreignOptions = optionValues.filter((v) => OTHER_TENANT_IDS.includes(v));
     expect(foreignOptions).toEqual([]);
   });


### PR DESCRIPTION
## Summary

Asana: [P1](https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217080725079367)
Stacked on: #688（P0）。**P0マージ後に、baseをmainへ変更してレビューしてください。**

[P0](https://github.com/milechy/commerce-faq-tasks/pull/688) の後始末で、B-IRR-3 が JWT修正の副作用で失敗するようになったのを調査した結果、**このテストは一度も意図した検証をできていなかった**ことが判明しました。

## 見つかった問題

`page.locator('select').count()` が0であることだけを断定していましたが、`/admin/knowledge/books` は `/admin/knowledge` へ飛ぶだけの13行のリダイレクトスタブ（`books.tsx`）です。JWT修正前は `role=anonymous` で画面が退化描画され、select が無いだけでこのテストは通っていました。つまり**越境を一度も検証できていませんでした**。

## 変更内容

- 画面が実際に描画されたこと（「AIの知識データ」の見出し）を先に確認する
- 描画された `select` の `option` 値を実際に見て、自テナント（carnation）以外の実在テナントID（`lp-demo`, `r2c_default` — 他specが使う実在ID）が選択肢に含まれないことを検証する。仮に他テナント選択UIが実装されて混入すればこのアサーションで落ちる形にし、単なる0件カウントには戻していません

## やっていないこと

- `admin-ui` 側のコード（`books.tsx` のリダイレクト挙動、`KnowledgeListTab` の並び順セレクタ）は変更していません。並び順セレクタは正当なUIで、テストの都合で消しません

## Test plan

- [x] `npx tsc --noEmit` — エラーなし
- [x] `npx oxlint`（変更ファイル） — エラーなし
- [x] `npx playwright test tests/e2e/qa-irregular-3roles.spec.ts --list` — パース確認OK
- [ ] E2Eは本番直叩きのためローカル実行不可。**CIの結果が唯一の検証手段**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018StqjjaijseYkGkmG2k5LJ