### PR TITLE
test(e2e): isBootstrapMessage優先順位テスト + B-IRR-3テナントIDドリフト検知を追加

### DIFF
--- a/tests/e2e/helpers/agentChatMock.test.ts
+++ b/tests/e2e/helpers/agentChatMock.test.ts
@@ -84,6 +84,18 @@ describe('isBootstrapMessage — ユーザーがやりそうなイレギュラ�
     // さらに広がるため、あえて緩めない。挙動の固定として記録する。
     expect(isBootstrapMessage('ﾛｸﾞｲﾝしたところです')).toBe(false);
   });
+
+  it('マーカーと他の分岐キーワードが同一メッセージに同居しても true が勝つ(呼び出し側のif分岐順に依存する優先順位を明示固定)', () => {
+    // 呼び出し側(qa-copilot-preview.spec.ts / qa-irregular-3roles.spec.ts)は
+    // 「if (isBootstrapMessage(body.message)) { ... } else if (body.message?.includes('アバターを作りたい')) { ... }」
+    // という順序のif分岐でルーティングしている。isBootstrapMessageは常に最初に
+    // 評価されるため、両方のキーワードを含むメッセージは本来の分岐(アバター作成)
+    // ではなく起動時ブリーフィング応答に誤ルーティングされる。この優先順位は
+    // isBootstrapMessage自体の実装ではなく呼び出し側の分岐順が生む挙動だが、
+    // 将来分岐順が入れ替わった際に気づけるよう、ここで固定しておく。
+    expect(isBootstrapMessage('ログインしたところです。アバターを作りたいです。')).toBe(true);
+    expect(isBootstrapMessage('ログインしたところです。採用してください')).toBe(true);
+  });
 });
 
 describe('isBootstrapMessage — admin-ui 側の BOOTSTRAP_PROMPT とのドリフト検知', () => {

--- a/tests/e2e/tenantIdConsistency.test.ts
+++ b/tests/e2e/tenantIdConsistency.test.ts
@@ -1,0 +1,39 @@
+// tests/e2e/tenantIdConsistency.test.ts
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+// Asana 1217080885072052 の是正で、qa-irregular-3roles.spec.ts の B-IRR-3 が使う
+// OTHER_TENANT_IDS の 'r2c_default' 分は同ファイルの FOREIGN_TENANT 定数参照に
+// 是正済みだが、'lp-demo' 分は spec 間でテナントID定数を共有する仕組みが無いため
+// qa-preview-scope-leak.spec.ts の PREVIEW_TENANT_2 の値を手で複製したままである。
+// この複製は、PREVIEW_TENANT_2 が変わってもコンパイルエラーにもテスト失敗にも
+// ならず気づかれずに乖離する(=B-IRR-3が越境を検知できなくなる)という壊れやすい
+// ポイントであるため、乖離をここで検知する(confirmPolicy.test.ts / agentChatMock.test.ts
+// と同じ、readFileSyncで実ソースを読んで検査するパターン)。
+describe('B-IRR-3 OTHER_TENANT_IDS と他specの実テナントIDとの整合', () => {
+  const IRREGULAR_SPEC_PATH = join(__dirname, 'qa-irregular-3roles.spec.ts');
+  const SCOPE_LEAK_SPEC_PATH = join(__dirname, 'qa-preview-scope-leak.spec.ts');
+
+  it('OTHER_TENANT_IDSがFOREIGN_TENANT参照のまま(r2c_defaultの直書きへ後退していない)', () => {
+    const source = readFileSync(IRREGULAR_SPEC_PATH, 'utf8');
+    const match = source.match(/const OTHER_TENANT_IDS = \[FOREIGN_TENANT,\s*['"]([^'"]+)['"]\]/);
+    expect(match).not.toBeNull();
+  });
+
+  it('OTHER_TENANT_IDSのlp-demo相当分が qa-preview-scope-leak.spec.ts の PREVIEW_TENANT_2 と一致する', () => {
+    const irregularSource = readFileSync(IRREGULAR_SPEC_PATH, 'utf8');
+    const otherTenantMatch = irregularSource.match(
+      /const OTHER_TENANT_IDS = \[FOREIGN_TENANT,\s*['"]([^'"]+)['"]\]/,
+    );
+    expect(otherTenantMatch).not.toBeNull();
+    const duplicatedTenantId = otherTenantMatch![1];
+
+    const scopeLeakSource = readFileSync(SCOPE_LEAK_SPEC_PATH, 'utf8');
+    const previewTenant2Match = scopeLeakSource.match(/const PREVIEW_TENANT_2 = ['"]([^'"]+)['"]/);
+    expect(previewTenant2Match).not.toBeNull();
+    const previewTenant2Value = previewTenant2Match![1];
+
+    expect(duplicatedTenantId).toBe(previewTenant2Value);
+  });
+});


### PR DESCRIPTION
## Summary
- 前回の厳格レビューで「テストの抜け」として指摘した2点に対応するテスト強化(実装コードの変更は無し、テストのみ)。

## 変更内容
1. `tests/e2e/helpers/agentChatMock.test.ts`: `isBootstrapMessage`が他の分岐キーワード(「アバターを作りたい」「採用してください」)と同一メッセージに同居した場合でも常に先勝ちすることを明示固定。
2. `tests/e2e/tenantIdConsistency.test.ts`(新規): B-IRR-3の`OTHER_TENANT_IDS`が
   - `FOREIGN_TENANT`参照のまま(直書きへ後退していない)こと
   - `'lp-demo'`相当分が`qa-preview-scope-leak.spec.ts`の`PREVIEW_TENANT_2`と一致すること
   の両方をドリフト検知する。両ケースとも一時的に壊して実際に落ちることを確認済み。

## Test plan
- [x] `npx jest tests/e2e/helpers/agentChatMock.test.ts tests/e2e/tenantIdConsistency.test.ts` → 18件 pass
- [x] `PREVIEW_TENANT_2`の値を一時的に変更 → 新規テストが確実に失敗することを確認、復元後は再度pass
- [x] `OTHER_TENANT_IDS`を直書きへ一時的に戻す → 新規テストが確実に失敗することを確認、復元後は再度pass
- [x] `npx tsc --noEmit` → 対象ファイルにエラー無し
- [ ] CI(Gate1/Gate3/E2E/gitleaks/security-scan)の結果待ち

🤖 Generated with [Claude Code](https://claude.com/claude-code)