### PR TITLE
fix(admin-ui): 通知ベルの3重マウントを解消する(オフスクリーンrailの非マウント化)

### DIFF
--- a/admin-ui/src/components/AppSidebar.test.tsx
+++ b/admin-ui/src/components/AppSidebar.test.tsx
@@ -1,8 +1,8 @@
 // GID: LP料金表(Growth〜: 会話分析/成約・効果分析)に基づくnav非表示の回帰テスト
-import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { AppSidebar } from "./AppSidebar";
+import { AppSidebar, MobileHeader } from "./AppSidebar";
 import { useAuth } from "../auth/useAuth";
 
 vi.mock("../auth/useAuth", () => ({
@@ -14,12 +14,33 @@ vi.mock("../contexts/ThemeContext", () => ({
 }));
 
 vi.mock("./common/NotificationBell", () => ({
-  NotificationBell: () => <div />,
+  NotificationBell: () => <div data-testid="notification-bell" />,
 }));
 
 vi.mock("./AppSwitcher", () => ({
   default: () => <div />,
 }));
+
+// happy-dom は matchMedia を実装していないため、既存テスト(デスクトップ幅前提)が
+// AppSidebar/MobileHeader の viewport 判定で例外を起こさないよう、既定でデスクトップ
+// (max-width: 767px に非マッチ)としてモックする。モバイル固有のテストは
+// このモックを個別に上書きする。
+function mockMatchMedia(matches: boolean) {
+  window.matchMedia = vi.fn().mockImplementation((query: string) => ({
+    matches,
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  }));
+}
+
+beforeEach(() => {
+  mockMatchMedia(false);
+});
 
 function baseAuth(overrides: Partial<ReturnType<typeof useAuth>>) {
   return {
@@ -210,5 +231,67 @@ describe("AppSidebar — ThemeToggle切り出し後の回帰テスト", () => {
     expect(screen.getByTitle("ライト")).toBeTruthy();
     expect(screen.getByTitle("ダーク")).toBeTruthy();
     expect(screen.getByTitle("自動")).toBeTruthy();
+  });
+});
+
+// 通知ベルの3重マウント回帰テスト(オフスクリーンrailの非マウント化)。
+// .app-sidebar は @media(max-width:767px) で transform: translateX(-100%) されるだけで
+// DOMには残るため、NotificationBell(setIntervalでポーリング)がAppSidebar rail /
+// MobileHeader上部バー / モバイルドロワーの最大3箇所で同時にマウントされ得た。
+describe("AppSidebar / MobileHeader — 通知ベルの3重マウント解消", () => {
+  it("デスクトップ幅: ベルはAppSidebar(rail)の1個のみ描画される", () => {
+    mockMatchMedia(false); // (max-width: 767px) に非マッチ = デスクトップ
+    vi.mocked(useAuth).mockReturnValue(baseAuth({ tenantPlan: "growth" }));
+    renderSidebar();
+
+    expect(screen.getAllByTestId("notification-bell")).toHaveLength(1);
+  });
+
+  it("デスクトップ幅: MobileHeaderはnullを返しベルを持たない(二重ポーリング防止)", () => {
+    mockMatchMedia(false);
+    vi.mocked(useAuth).mockReturnValue(baseAuth({ tenantPlan: "growth" }));
+    const { container } = render(
+      <MemoryRouter>
+        <MobileHeader />
+      </MemoryRouter>,
+    );
+
+    expect(screen.queryAllByTestId("notification-bell")).toHaveLength(0);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("モバイル幅: AppSidebarはnullを返しベルを持たない(オフスクリーンrailの非マウント化)", () => {
+    mockMatchMedia(true); // (max-width: 767px) にマッチ = モバイル
+    vi.mocked(useAuth).mockReturnValue(baseAuth({ tenantPlan: "growth" }));
+    const { container } = renderSidebar();
+
+    expect(screen.queryAllByTestId("notification-bell")).toHaveLength(0);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("モバイル幅: ベルはMobileHeader上部バーの1個のみ描画される", () => {
+    mockMatchMedia(true);
+    vi.mocked(useAuth).mockReturnValue(baseAuth({ tenantPlan: "growth" }));
+    render(
+      <MemoryRouter>
+        <MobileHeader />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getAllByTestId("notification-bell")).toHaveLength(1);
+  });
+
+  it("モバイル幅でドロワーを開いても、ベルは1個のまま(ドロワー側のベルは出さない)", () => {
+    mockMatchMedia(true);
+    vi.mocked(useAuth).mockReturnValue(baseAuth({ tenantPlan: "growth" }));
+    render(
+      <MemoryRouter>
+        <MobileHeader />
+      </MemoryRouter>,
+    );
+
+    fireEvent.click(screen.getByLabelText("メニューを開く"));
+
+    expect(screen.getAllByTestId("notification-bell")).toHaveLength(1);
   });
 });

--- a/admin-ui/src/components/AppSidebar.tsx
+++ b/admin-ui/src/components/AppSidebar.tsx
@@ -1,3 +1,4 @@
+import { useState, useEffect } from "react";
 import { NavLink, useNavigate, useLocation } from "react-router-dom";
 import {
   LayoutDashboard,
@@ -20,6 +21,7 @@ import {
   Headset,
   HelpCircle,
   Sparkles,
+  Menu,
 } from "lucide-react";
 import { useAuth } from "../auth/useAuth";
 import { NotificationBell } from "./common/NotificationBell";
@@ -218,7 +220,10 @@ function SidebarContent({ onClose }: SidebarContentProps) {
           </span>
         </NavLink>
         <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
-          <NotificationBell />
+          {/* onClose はモバイルドロワー呼び出し時のみ渡される。ドロワー展開中は
+              MobileHeader 自身の上部バーに既にベルがあるため、ここでは出さない
+              (両方出すと同一画面に2個同時表示・二重ポーリングになる)。 */}
+          {!onClose && <NotificationBell />}
           {onClose && (
             <button
               onClick={onClose}
@@ -389,9 +394,35 @@ function SidebarContent({ onClose }: SidebarContentProps) {
   );
 }
 
+// admin-ui/src/index.css の @media (max-width: 767px) と同じブレークポイント。
+// .app-sidebar は CSS の transform で画面外に押し出されるだけでDOMには残るため、
+// NotificationBell のようなポーリングを持つ子がオフスクリーンでもマウントされ続ける
+// (デスクトップrail + MobileHeader + モバイルドロワーの最大3重マウント)。
+// JS側でも早期returnし、非表示側を実際に非マウントにする。
+const MOBILE_BREAKPOINT_QUERY = "(max-width: 767px)";
+
+function useIsMobileViewport(): boolean {
+  const [isMobile, setIsMobile] = useState(
+    () => typeof window !== "undefined" && window.matchMedia(MOBILE_BREAKPOINT_QUERY).matches,
+  );
+
+  useEffect(() => {
+    const mql = window.matchMedia(MOBILE_BREAKPOINT_QUERY);
+    const handleChange = () => setIsMobile(mql.matches);
+    handleChange();
+    mql.addEventListener("change", handleChange);
+    return () => mql.removeEventListener("change", handleChange);
+  }, []);
+
+  return isMobile;
+}
+
 // ─── Desktop sidebar ──────────────────────────────────────────────────
 
 export function AppSidebar() {
+  const isMobile = useIsMobileViewport();
+  if (isMobile) return null;
+
   return (
     <aside className="app-sidebar">
       <SidebarContent />
@@ -401,11 +432,10 @@ export function AppSidebar() {
 
 // ─── Mobile sidebar + header ──────────────────────────────────────────
 
-import { useState } from "react";
-import { Menu } from "lucide-react";
-
 export function MobileHeader() {
+  const isMobile = useIsMobileViewport();
   const [open, setOpen] = useState(false);
+  if (!isMobile) return null;
 
   return (
     <>


### PR DESCRIPTION
## Summary
- `.app-sidebar` は `@media(max-width:767px)` で `transform: translateX(-100%)` されるだけでDOMに残り続け、`NotificationBell`(setIntervalポーリング)がAppSidebar(rail)・MobileHeader(上部バー)・モバイルドロワーの最大3箇所で同時にマウントされていた(通知取得APIが3重に発行)
- `AppSidebar`/`MobileHeader` に viewport 判定(`useIsMobileViewport`)を追加し、非表示側は早期returnでnullを返す
- `SidebarContent` のベルは `onClose`(モバイルドロワー呼び出し時のみ渡る)が無い場合のみ描画。ドロワー展開中の二重表示・二重ポーリングも防止
- `App.tsx`・`NotificationBell.tsx` 本体・`index.css` は無変更

## Test plan
- [x] `AppSidebar.test.tsx` に5ケース追加、全18テストpass(happy-domの`matchMedia`未実装対応で既定モックも追加)
  - デスクトップ幅: ベルはrailの1個のみ / MobileHeaderはnull
  - モバイル幅: AppSidebarはnull / ベルはMobileHeader上部バーの1個のみ
  - モバイル幅でドロワーを開いてもベルは1個のまま
- [x] `pnpm typecheck`(backend) / `pnpm lint` パス。admin-ui `tsc -b` は既存の別ファイル(useAuth.test.tsx等13件、AuthContextValue型不一致)で事前から失敗しておりCI非対象(Gate1はbackendのみ)、本PR起因ではないことを確認済み

Asana: https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217083320228441

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xq3XPSpwhHBTrNyoJMhvoa