### PR TITLE
chore: アセット破損をpost-deploy-smokeで検知し、purge手順を文書化する

### DIFF
--- a/SCRIPTS/post-deploy-smoke.sh
+++ b/SCRIPTS/post-deploy-smoke.sh
@@ -61,6 +61,26 @@ fi
 # ── 3. Admin UI (Cloudflare Pages) ────────────────────────────────────────
 check "Admin UI" "$ADMIN_URL"
 
+# ── 3b. Admin UI アセットのCDNキャッシュ破損検知 ───────────────────────
+# PR #487の事故: index.htmlは正しいJSファイル名を参照していたが、CDNの
+# 一部エッジがそのURLに対してHTML(SPAフォールバック)の中身を誤って
+# キャッシュしていた。Content-Typeヘッダは正しくJSを返しつつボディだけ
+# HTMLだったため、ヘッダだけでは検知できない。実ボディの先頭文字を見る。
+admin_html=$(curl -s --max-time 10 "$ADMIN_URL" 2>/dev/null || echo "")
+admin_js_path=$(echo "$admin_html" | grep -oE '/assets/[A-Za-z0-9_.-]+\.js' | head -1)
+if [ -n "$admin_js_path" ]; then
+  admin_js_body_head=$(curl -s --max-time 10 "$ADMIN_URL$admin_js_path" 2>/dev/null | head -c 1)
+  if [ "$admin_js_body_head" = "<" ]; then
+    echo "  ❌ Admin UI asset ($admin_js_path) body starts with '<' — CDNキャッシュ破損の疑い(HTMLが返っている)"
+    FAIL=$((FAIL + 1))
+  else
+    echo "  ✅ Admin UI asset ($admin_js_path) — JS本文を確認"
+    PASS=$((PASS + 1))
+  fi
+else
+  echo "  ⚠️  Admin UI index.html から /assets/*.js を検出できず(スキップ)"
+fi
+
 # ── 4. Demo page ──────────────────────────────────────────────────────────
 check "Demo page" "$API_URL/carnation-demo/index.html"
 

--- a/docs/DEPLOY_CHECKLIST.md
+++ b/docs/DEPLOY_CHECKLIST.md
@@ -159,3 +159,20 @@ ssh root@65.108.159.161 "psql \$DATABASE_URL -f /opt/rajiuce/src/api/admin/feedb
 | PDF アップロード失敗 | `/v1/admin/knowledge/pdf` エンドポイントの実装確認 (Phase27) |
 | DB 接続エラー | `DATABASE_URL` のポート (5432 vs 5434) を VPS で確認 |
 | メモリ不足 | `free -h`, ES ヒープを `ES_JAVA_OPTS=-Xms1g -Xmx1g` に縮小 |
+
+## Admin UI (Cloudflare Pages) のCDNキャッシュ破損時の対応
+
+`admin.r2c.biz` は Cloudflare Pages 配信であり、`bash SCRIPTS/deploy-vps.sh` では更新されない
+（main push → Pages 自動ビルド）。したがって「Admin UI が起動しない」原因が
+デプロイ漏れではなくCDNキャッシュ破損（PR #487で実際に発生、`/assets/*.js` の
+URLに対しHTMLの中身が誤ってキャッシュされる事故）の場合、VPS側の対処では直らない。
+
+`bash SCRIPTS/post-deploy-smoke.sh` の「Admin UI asset」チェックがこの破損を自動検知する
+（`index.html` が参照する `/assets/*.js` の実ボディ先頭が `<` かどうかを見る。
+Content-Typeヘッダだけでは検知できない点に注意）。
+
+1. **対象URLの特定**: smoke test の出力、または `curl -s https://admin.r2c.biz | grep -oE '/assets/[A-Za-z0-9_.-]+\.js'` で破損している資産のパスを確認する。
+2. **Cloudflareキャッシュパージ**: Cloudflare ダッシュボード（該当ゾーン → Caching → Configuration → Purge Cache）から、特定したURL（`https://admin.r2c.biz/assets/xxxxx.js` 等）を個別パージする。ゾーン全体のパージは他のテナントへの影響が大きいため、まずは対象URLのみに絞る。
+3. **再検証**: `bash SCRIPTS/post-deploy-smoke.sh` を再実行し、「Admin UI asset」チェックが ✅ になることを確認する。
+
+なお `admin-ui/index.html` には自動復旧の仕組みが入っており（起動エラー検知時にキャッシュバスター付きで1回だけ再取得を試みる）、多くの場合はユーザー側で自然に復旧する。上記の手順は自動復旧後も破損が継続する場合、またはsmoke testで能動的に検知した場合の人手対応。


### PR DESCRIPTION
## Summary
- PR #487のCDNキャッシュ破損事故(本番の管理画面が起動不能)は、人間が別作業中に偶然発見するまで検知できていなかった。Content-Typeヘッダは正しくJSを返しつつボディだけHTMLが返る事故のため、ヘッダのみのチェックでは検知不能
- `post-deploy-smoke.sh` に、Admin UIの`index.html`が参照する`/assets/*.js`を実際に取得し、本文が`<`で始まっていない(=HTMLが返っていない)ことを検証するチェックを追加
- `DEPLOY_CHECKLIST.md` に、`admin.r2c.biz`はCloudflare Pages配信でありdeploy-vps.shでは更新されない旨と、破損検知時のpurge手順(対象URL特定→Cloudflareキャッシュパージ→再検証)を追記

## Test plan
- [x] `bash -n SCRIPTS/post-deploy-smoke.sh` で構文チェックOK
- [x] 新しい検知ロジックを本番(`https://admin.r2c.biz`)に対して手動実行し、`/assets/index-Bifgu1BC.js`の検出とJS本文確認が正しく動作することを確認済み(現在は破損していないため正常系のみ確認、異常系はロジックレビューで担保)
- 新規スクリプト・cron・launchdは追加していない(既存の`post-deploy-smoke.sh`に追記のみ)

Asana: https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217083320230250

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xq3XPSpwhHBTrNyoJMhvoa