### PR TITLE
docs: CLAUDE.md の指示ルール記述2件が実装と乖離しているのを是正する

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,7 @@ R2C は、テナント（店舗・EC事業者）のサイトに1行で埋め込�
 
 | やりたいこと | 置き場所（既存） |
 |---|---|
-| ルールの発火条件の判定 | `src/agent/tools/synthesisTool.ts` の `matchesTriggerPattern` |
+| ルールの発火条件の判定 | `src/api/admin/tuning/triggerMatching.ts` の `matchesTriggerPattern` |
 | ルールのプロンプト注入 | `src/api/admin/tuning/tuningRulesRepository.ts` の `buildTuningPromptSection` |
 | 優先度の3段階表現 | `admin-ui/src/lib/tuningPriority.ts`（閾値・代表値を他所に書かない） |
 
@@ -155,7 +155,7 @@ R2C は、テナント（店舗・EC事業者）のサイトに1行で埋め込�
 5. **エンドユーザーに出る内容を、テナントの確認なしで公開する。**
    テンプレート・自動生成の知識は `is_published = false` で投入し、確認後に公開する。
    **指示ルールも同じ**: AI が自動生成した `tuning_rules`（Judge 由来）は必ず `is_active = false` で INSERT する。
-   列を省略するとスキーマ既定 `DEFAULT true` が効いて即座に本番の応答方針へ入る（`src/agent/judge/evaluationAnalyzer.ts` が現に違反）。
+   列を省略するとスキーマ既定 `DEFAULT true` が効いて即座に本番の応答方針へ入る（`src/agent/judge/evaluationAnalyzer.ts` は現在この通り `is_active = false` を明示している。省略する変更をしない）。
    逆に `migration.sql` の `DEFAULT` 自体は、既存データへの影響を評価せずに変えない。
 6. **同じ関心事を2ファイルに複製したまま片方だけ直す。**
    既知の重複: 業種テンプレ（`src/api/admin/agent/industryFaqTemplates.ts` と

--- a/docs/TUNING_RULE_CHAT_REQUIREMENTS.md
+++ b/docs/TUNING_RULE_CHAT_REQUIREMENTS.md
@@ -182,7 +182,7 @@ D7の実装で最も壊れやすい。**要件として先に固定する。**
 
 | 変えるもの | 置き場所（ここ以外に作らない） |
 |---|---|
-| 一致判定 | `src/agent/tools/synthesisTool.ts` の `matchesTriggerPattern` |
+| 一致判定 | `src/api/admin/tuning/triggerMatching.ts` の `matchesTriggerPattern` |
 | プロンプト注入（採用済み返答を含む） | `src/api/admin/tuning/tuningRulesRepository.ts` の `buildTuningPromptSection` |
 | ツール定義 / 実行 | `toolDefinitions.ts` / `actionExecutor.ts` の該当 case |
 | 確認ゲートの分類 | `src/api/admin/agent/confirmPolicy.ts`（新ツールは必ずどちらかの表へ。網羅性は `confirmPolicy.test.ts` が機械検出） |


### PR DESCRIPTION
## Summary
- `matchesTriggerPattern` の置き場所が誤っていた。CLAUDE.mdは「`synthesisTool.ts` の `matchesTriggerPattern`」と記載していたが、実際は `src/api/admin/tuning/triggerMatching.ts` に分離済み(`synthesisTool.ts`はそこからimportしているだけ)。`docs/TUNING_RULE_CHAT_REQUIREMENTS.md` §7.2 の表も同じ誤りを持つためあわせて直す
- `evaluationAnalyzer.ts` の `is_active` 違反はもう存在しない。実際は同ファイル144-149行のINSERTが `is_active=false` を明示済み。ルール本体(承認なしに `is_active=true` にしない)は残し、現状記述だけを削る

いずれもコード自体は変更しない。実機照合(grep)で確認済み。

## Test plan
- [x] docsのみの変更、コード変更なし
- Gate 2.5(Codex review)はdocsのみのためスキップ対象(CLAUDE.md)

Asana: https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217083269327313

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xq3XPSpwhHBTrNyoJMhvoa