### PR TITLE
fix(avatar-agent): update_agent_prompt のイベント名が誤っており表情切替が動いていない欠陥を直す

### DIFF
--- a/avatar-agent/agent.py
+++ b/avatar-agent/agent.py
@@ -75,11 +75,30 @@ STATE_AGENT_PROMPTS = {
 }
 
 
+# LemonSlice Session Control API が受け付けるイベント名の全量（2026-08-01 公式ドキュメント確認済み）。
+# https://lemonslice.com/docs/api-reference/control-session
+# 未知の名前は HTTP 400 になるが、control_lemonslice() は fire-and-forget で warning に
+# 落とすだけのため、誤字（例: アンダースコア表記）があっても無音で失敗し気づけない
+# （update_agent_prompt の誤字で I-4 表情切替が実装以来動いていなかった実例がある）。
+# 送信前にここで弾き、誤字と本物の障害を区別できるようにする。
+LEMONSLICE_CONTROL_EVENTS = frozenset({
+    "terminate",
+    "update-image",
+    "update-agent-prompt",
+    "update-idle-prompt",
+    "pose-trigger",
+    "reset-idle-timeout",
+})
+
+
 async def control_lemonslice(event: str, **kwargs) -> bool:
     """LemonSlice Control API への fire-and-forget ラッパー（失敗は warning のみ・non-fatal）。
 
     注意: session_id / API キーはログに出さないこと。
     """
+    if event not in LEMONSLICE_CONTROL_EVENTS:
+        logger.error(f"[lemonslice-control] unknown event name (typo?): {event!r}")
+        return False
     if not _lemonslice_session_id:
         logger.debug("[lemonslice-control] session_id not available, skipping")
         return False
@@ -604,7 +623,7 @@ async def entrypoint(ctx: agents.JobContext) -> None:
                 if prompt:
                     logger.info(f"[data_channel] state_change received: state={state}")
                     asyncio.create_task(
-                        control_lemonslice("update_agent_prompt", agent_prompt=prompt)
+                        control_lemonslice("update-agent-prompt", agent_prompt=prompt)
                     )
                 else:
                     logger.debug(f"[data_channel] state_change with unknown state, skipping: {state!r}")

--- a/avatar-agent/test_lemonslice_control.py
+++ b/avatar-agent/test_lemonslice_control.py
@@ -1,0 +1,53 @@
+"""
+control_lemonslice() / LEMONSLICE_CONTROL_EVENTS のユニットテスト。
+
+背景: agent.py はかつて control_lemonslice("update_agent_prompt", ...) という
+アンダースコア表記の誤字を送っていた（正しくは update-agent-prompt）。
+LemonSlice Control API は未知の event 値に HTTP 400 を返すが、control_lemonslice()
+は fire-and-forget で warning に落とすだけのため、この誤字は I-4 表情切替が
+実装以来一度も動いていないことに誰も気づけない、という形で長期間残っていた。
+このテストは同種の再発を検出する。
+"""
+
+import asyncio
+
+from agent import LEMONSLICE_CONTROL_EVENTS, control_lemonslice
+
+
+class TestLemonsliceControlEvents:
+    def test_known_events_are_hyphenated(self):
+        # LemonSlice 公式ドキュメント(2026-08-01確認)の6イベントと完全一致すること。
+        assert LEMONSLICE_CONTROL_EVENTS == {
+            "terminate",
+            "update-image",
+            "update-agent-prompt",
+            "update-idle-prompt",
+            "pose-trigger",
+            "reset-idle-timeout",
+        }
+
+    def test_no_underscore_variants_are_allowed(self):
+        # アンダースコア表記は LemonSlice API 側に存在しない。再発防止の直接的なガード。
+        for event in LEMONSLICE_CONTROL_EVENTS:
+            assert "_" not in event, f"{event!r} contains underscore, expected hyphen"
+
+
+class TestControlLemonsliceRejectsUnknownEvents:
+    def test_unknown_event_returns_false_without_session_id(self):
+        # session_id 未設定でも、まず event 名の allowlist チェックで弾かれることを確認する
+        # (ここで False が返るのが「未知の名前だから」であって「session_id が無いから」
+        #  ではないことは、既知イベントでも同条件で False になる次のテストと対比して保証する)。
+        result = asyncio.run(control_lemonslice("update_agent_prompt", agent_prompt="x"))
+        assert result is False
+
+    def test_known_event_without_session_id_also_returns_false(self):
+        # session_id 未設定時の早期returnはevent名に関わらず起こる、という前提の確認。
+        # (このモジュールはグローバルセッション状態を持つため、テスト実行順に依存しない
+        #  よう session_id が未設定であることをテスト側で強制しない — entrypoint実行前は
+        #  常に None のため、テスト環境では自然にこの前提が満たされる)
+        result = asyncio.run(control_lemonslice("update-agent-prompt", agent_prompt="x"))
+        assert result is False
+
+    def test_completely_unknown_event_name_returns_false(self):
+        result = asyncio.run(control_lemonslice("viseme", phoneme="aa"))
+        assert result is False


### PR DESCRIPTION
## Summary
- LemonSlice Session Control API のイベント名は `update-agent-prompt`(ハイフン)だが、`agent.py:626` は `update_agent_prompt`(アンダースコア)を送っていた
- 不正な event 値は HTTP 400 を返すが `control_lemonslice()` は fire-and-forget で warning に落とすだけのため、I-4(SalesFlowの状態変化に応じた表情プロンプト差し替え)は実装以来一度も機能していなかった
- 出典(2026-08-01 公式ドキュメント確認): https://lemonslice.com/docs/api-reference/control-session — サポートされるイベントは `terminate` / `update-image` / `update-agent-prompt` / `update-idle-prompt` / `pose-trigger` / `reset-idle-timeout` の6種のみ
- 再発防止として `control_lemonslice()` に allowlist 検証を追加。未知のevent名は送信前に `logger.error` で明示的に落とす(従来は誤字と本物の障害が区別できなかった)

## Test plan
- [x] `avatar-agent/test_lemonslice_control.py` を新規追加、既存 `test_emotion_tags.py` と全16テストpass(scratch venvで実行確認)
  - `LEMONSLICE_CONTROL_EVENTS` が公式6イベントと完全一致
  - アンダースコア表記が allowlist に含まれないことを直接ガード
  - 旧バグの引数(`update_agent_prompt`)を渡すと `False` が返る回帰テスト

Asana: https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217083718130331

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xq3XPSpwhHBTrNyoJMhvoa