### PR TITLE
feat(api): 応答に ragCategory を返し、カテゴリをクライアントへ届ける

### DIFF
--- a/src/agent/dialog/dialogAgent.test.ts
+++ b/src/agent/dialog/dialogAgent.test.ts
@@ -71,6 +71,7 @@ const baseOrchestrated = {
   gapSignal: undefined,
   llmUsage: { prompt_tokens: 0, completion_tokens: 0 },
   ragSources: undefined,
+  category: undefined,
 };
 
 beforeEach(() => {
@@ -176,5 +177,40 @@ describe("runDialogTurn — Phase73 productCard", () => {
     // エラーは握りつぶされ productCard なしで応答
     expect(result.productCard).toBeUndefined();
     expect(result.answer).toBe("おすすめ"); // salesFlow.prompt が適用される
+  });
+});
+
+describe("runDialogTurn — LemonSliceペルソナスワップ ragCategory", () => {
+  it("orchestrator の category が meta.ragCategory にそのまま転送される", async () => {
+    mockOrchestrator.mockResolvedValue({ ...baseOrchestrated, category: "fashion" });
+    mockSalesFlow.mockResolvedValue({
+      nextStage: undefined,
+      prompt: undefined,
+      meta: {} as any,
+    });
+
+    const result = await runDialogTurn({
+      sessionId: "test-session-category",
+      tenantId: "test-tenant",
+      message: "このジャケットに合うスカートは？",
+    });
+
+    expect(result.meta?.ragCategory).toBe("fashion");
+  });
+
+  it("orchestrator が category を返さない場合 meta.ragCategory は undefined", async () => {
+    mockSalesFlow.mockResolvedValue({
+      nextStage: undefined,
+      prompt: undefined,
+      meta: {} as any,
+    });
+
+    const result = await runDialogTurn({
+      sessionId: "test-session-no-category",
+      tenantId: "test-tenant",
+      message: "こんにちは",
+    });
+
+    expect(result.meta?.ragCategory).toBeUndefined();
   });
 });

--- a/src/agent/dialog/dialogAgent.ts
+++ b/src/agent/dialog/dialogAgent.ts
@@ -207,6 +207,7 @@ export async function runDialogTurn(
       // 別モデル単価のため、合算せず各モデルを実レートで別 usage_log として課金する。
       plannerLlmUsages: multiStepPlan.llmUsages,
       ragSources: orchestrated.ragSources,
+      ragCategory: orchestrated.category,
     },
   };
 

--- a/src/agent/dialog/types.ts
+++ b/src/agent/dialog/types.ts
@@ -130,6 +130,8 @@ export interface DialogTurnMeta {
   plannerLlmUsages?: Array<{ model: string; prompt_tokens: number; completion_tokens: number }>;
   /** Phase68: 応答生成に使用された RAG チャンク */
   ragSources?: import("../types").RagSource[];
+  /** LemonSliceペルソナスワップ: queryPlanner が推定した質問カテゴリ（アバター見た目・人格切替用） */
+  ragCategory?: string;
 }
 
 /** Phase73: recommend ステージで乗せる商品カード情報 */

--- a/src/agent/flow/dialogOrchestrator.ts
+++ b/src/agent/flow/dialogOrchestrator.ts
@@ -31,6 +31,8 @@ export interface OrchestratorResult {
   llmUsage?: { prompt_tokens: number; completion_tokens: number }
   /** Phase68: 応答生成に使用された RAG チャンク */
   ragSources?: RagSource[]
+  /** LemonSliceペルソナスワップ: queryPlanner が推定した質問カテゴリ */
+  category?: string
 }
 
 /**
@@ -121,5 +123,6 @@ export async function runDialogOrchestrator(
     gapSignal: searchResult.gapSignal,
     llmUsage: searchResult.llmUsage,
     ragSources: searchResult.ragSources,
+    category: searchResult.category,
   }
 }

--- a/src/agent/flow/searchAgent.ts
+++ b/src/agent/flow/searchAgent.ts
@@ -244,6 +244,7 @@ export async function runSearchAgent(
     steps,
     ragStats,
     ragSources,
+    category: typeof plan.filters?.category === "string" ? plan.filters.category : undefined,
     gapSignal: synth.gapSignal,
     // Subtask 3: synthesis が usage を返さない場合（GROQ キー無し / fallback / エラー）でも
     // 既に消費済みの embedding トークンを課金に残すため、llmUsage は常に返す。

--- a/src/agent/types.ts
+++ b/src/agent/types.ts
@@ -78,6 +78,8 @@ export interface AgentSearchResponse {
   };
   /** Phase68: 応答生成に使用された RAG チャンク（rerank 後の topK） */
   ragSources?: RagSource[];
+  /** LemonSliceペルソナスワップ: queryPlanner が推定した質問カテゴリ（filters.category） */
+  category?: string;
   gapSignal?: { hitCount: number; topScore: number };
   /** Phase53: Groq API実トークン数 */
   llmUsage?: { prompt_tokens: number; completion_tokens: number };

--- a/src/api/chat/route.ts
+++ b/src/api/chat/route.ts
@@ -278,6 +278,8 @@ export function createChatHandler(logger: Logger) {
         timestamp: Date.now(),
         tenantId,
         flowState,
+        // LemonSliceペルソナスワップ: queryPlanner が推定した質問カテゴリ（アバター見た目・人格切替用）
+        ragCategory: result.meta?.ragCategory,
         // Phase73: recommend ステージで productCard が設定されていれば転送
         ...(result.productCard ? { productCard: result.productCard } : {}),
       };

--- a/src/types/contracts.ts
+++ b/src/types/contracts.ts
@@ -37,6 +37,8 @@ export interface ChatMessage {
     | "propose"
     | "recommend"
     | "close";
+  /** LemonSliceペルソナスワップ: queryPlanner が推定した質問カテゴリ（アバター見た目・人格切替用） */
+  ragCategory?: string;
   /** Phase73: recommend ステージ時に設定される商品カード情報 */
   productCard?: {
     product_id: string;


### PR DESCRIPTION
## Summary
- `queryPlanner.ts` が既に算出しているカテゴリ推定(`plan.filters.category`)が、検索パイプラインのどの層にも露出せず discard されていた(`searchAgent` → `dialogOrchestrator` → `dialogAgent` の3層で捨てられていた)
- 事前調査時のプラン(前回セッション)は「queryPlanner の category が既に応答に載っている」前提だったが、実装時に実機照合したところ誤りだったため、既存の `gapSignal`/`ragSources` と同じ配線パターンで6ファイルを通して修正した
- LemonSliceペルソナスワップ機能([ペルソナ3/4] GID 1217101190645169)の土台

## 変更ファイル
- `src/agent/types.ts`: `AgentSearchResponse` に `category` を追加
- `src/agent/flow/searchAgent.ts`: `plan.filters.category` を返却
- `src/agent/flow/dialogOrchestrator.ts`: `OrchestratorResult` に `category` を追加・転送
- `src/agent/dialog/types.ts`: `DialogTurnMeta` に `ragCategory` を追加
- `src/agent/dialog/dialogAgent.ts`: `meta.ragCategory` に `orchestrated.category` を設定
- `src/api/chat/route.ts`: `ChatMessage.ragCategory` に `result.meta.ragCategory` を設定
- `src/types/contracts.ts`: `ChatMessage.ragCategory` の型定義を追加

`queryPlanner.ts` / `multiStepPlanner.ts` は無変更。widget側はこのPRでは触らない(段階3で配線)。

## Test plan
- [x] `dialogAgent.test.ts` に2ケース追加(category が meta.ragCategory に転送される / 未指定時は undefined)、全6テストpass
- [x] `pnpm typecheck` / `pnpm lint` パス
- [x] `pnpm test` を複数回実行し、既知のNode v26環境要因の失敗(`avatar/routes.test.ts` 11件)以外に固定的な失敗が無いことを確認。フルスイート実行時に稀に別テストが1件flakeするが、**未修正のmainブランチでも同一条件・同一パターンで再現する**ことを確認済み(本PR起因ではない、環境のリソース競合)

Asana: https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217083837034191

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xq3XPSpwhHBTrNyoJMhvoa