### PR TITLE
chore(db): avatar_configs に category_persona_map を追加する migration を用意する

### DIFF
--- a/docs/DEPLOY_CHECKLIST.md
+++ b/docs/DEPLOY_CHECKLIST.md
@@ -113,6 +113,7 @@ VITE_SUPABASE_ANON_KEY=YOUR_ANON_KEY
 | `src/api/admin/feedback/migration_feedback.sql` | feedback_messages テーブル初期作成 | ✅ |
 | `src/api/admin/feedback/migration_feedback_flagged.sql` | flagged_for_improvement カラム追加 + インデックス | 要適用 |
 | `src/api/admin/tenants/migration_phase_a.sql` | Phase A Day 2: tenants GA4/PostHog拡張 + notification_preferences + ga4_connection_logs + ga4_test_history + conversion_attributions拡張 | 要適用 |
+| `src/api/admin/avatar/migration_category_persona.sql` | LemonSliceペルソナスワップ: avatar_configs に category_persona_map(JSONB)追加 | 要適用 |
 
 ### Phase A Day 2 migration 実行手順
 

--- a/src/api/admin/avatar/migration_category_persona.sql
+++ b/src/api/admin/avatar/migration_category_persona.sql
@@ -1,0 +1,10 @@
+-- LemonSliceペルソナスワップ: 商品カテゴリごとのペルソナ定義
+-- キーはカテゴリ名(queryPlanner.ts の filters.category 準拠、例: "product" "returns" 等の
+-- 業種依存語彙をテナントが独自定義)、値は LemonSlice Session Control API に渡すペルソナ定義。
+ALTER TABLE avatar_configs
+  ADD COLUMN IF NOT EXISTS category_persona_map JSONB DEFAULT '{}'::jsonb;
+
+COMMENT ON COLUMN avatar_configs.category_persona_map IS
+  'カテゴリ名 → {image_url, agent_prompt, idle_prompt, voice_id} のマップ。' ||
+  '会話中の話題カテゴリ変化に応じて LemonSlice Control API (update-image / update-agent-prompt / ' ||
+  'update-idle-prompt) でアバターの見た目・人格・声を切り替える際に参照する。';


### PR DESCRIPTION
## Summary
- LemonSliceペルソナスワップ機能([ペルソナ3/4] GID 1217101190645169)が必要とする列を追加する migration ファイルを新規作成
- 既存の `migration_anam_fields.sql` / `migration_agent_prompt.sql` と同じ場所・同じ `ADD COLUMN IF NOT EXISTS` パターン
- `docs/DEPLOY_CHECKLIST.md` の DB マイグレーション一覧に追記

## 未適用
**このPRは migration ファイルの追加のみで、本番DBへの適用は含まれません。**適用は人間が手動実行してください(CLAUDE.md 禁止事項8: migration の自動実行禁止)。

## Test plan
- [x] 既存 migration ファイルと同一パターンの `ALTER TABLE ... ADD COLUMN IF NOT EXISTS` + `COMMENT ON COLUMN`(ローカルDB未起動のため直接実行検証はできず、構造比較で確認)
- [x] `pnpm typecheck` / `pnpm lint` パス(コード変更なし)

Asana: https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217083837034127

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xq3XPSpwhHBTrNyoJMhvoa