### PR TITLE
Fish TTSモデルをenv化し原価を実モデルに連動させる

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -124,6 +124,8 @@ LIVEKIT_ACCESS_TOKEN=
 LIVEKIT_ROOM_PREFIX=r2c-
 FISH_AUDIO_API_KEY=your-fish-audio-key
 FISH_AUDIO_REFERENCE_ID=
+# 無料期間(2026-08-31まで)は s2.1-pro-free。有料切替時は s2.1-pro に変更(agent.py側にも同じ値を設定)
+FISH_AUDIO_TTS_MODEL=s2.1-pro-free
 ANAM_API_KEY=
 LEONARDO_API_KEY=
 # LemonSlice (アバター配信サービス)

--- a/avatar-agent/agent.py
+++ b/avatar-agent/agent.py
@@ -203,7 +203,7 @@ async def _report_groq_usage(
 
 # --- Fish Audio TTS ---
 
-async def _report_tts_usage(tenant_id: str, tts_text_bytes: int) -> None:
+async def _report_tts_usage(tenant_id: str, tts_text_bytes: int, tts_model: str) -> None:
     """TTS使用量をRAJIUCE APIに非同期レポート（fire-and-forget）。"""
     api_url = os.environ.get("RAJIUCE_API_URL", "http://localhost:3100")
     try:
@@ -211,10 +211,10 @@ async def _report_tts_usage(tenant_id: str, tts_text_bytes: int) -> None:
             await http_session.post(
                 f"{api_url}/api/internal/usage",
                 headers={"X-Internal-Request": "1", "Content-Type": "application/json"},
-                json={"tenantId": tenant_id, "ttsTextBytes": tts_text_bytes},
+                json={"tenantId": tenant_id, "ttsTextBytes": tts_text_bytes, "ttsModel": tts_model},
                 timeout=aiohttp.ClientTimeout(total=5),
             )
-        logger.debug(f"[usage] TTS usage reported: tenant={tenant_id} bytes={tts_text_bytes}")
+        logger.debug(f"[usage] TTS usage reported: tenant={tenant_id} bytes={tts_text_bytes} model={tts_model}")
     except Exception as e:
         logger.warning(f"[usage] TTS usage report failed (non-critical): {e}")
 
@@ -343,9 +343,10 @@ class FishAudioChunkedStream(agents_tts.ChunkedStream):
             stream=False,
         )
         try:
+            tts_model = os.environ.get("FISH_AUDIO_TTS_MODEL", "s2.1-pro-free")
             request_body = {
                 "text": self._input_text,
-                "model": "s2.1-pro-free",  # Phase A: S2.1 Pro (Free) 明示指定（デフォルト依存を排除、低遅延+多言語）
+                "model": tts_model,
                 "format": "mp3",   # Fish Audio デフォルト形式。WAV より確実。
                 "normalize": True,
                 "latency": "balanced",
@@ -395,7 +396,7 @@ class FishAudioChunkedStream(agents_tts.ChunkedStream):
             # 使用量レポート（fire-and-forget）
             if self._tenant_id:
                 tts_bytes = len(self._input_text.encode("utf-8"))
-                asyncio.ensure_future(_report_tts_usage(self._tenant_id, tts_bytes))
+                asyncio.ensure_future(_report_tts_usage(self._tenant_id, tts_bytes, tts_model))
         except Exception as e:
             logger.error(f"[TTS] Exception in _run: {type(e).__name__}: {e}")
 

--- a/src/api/avatar/fishTtsRoutes.test.ts
+++ b/src/api/avatar/fishTtsRoutes.test.ts
@@ -64,6 +64,7 @@ describe("POST /api/avatar/tts", () => {
     savedEnv = { ...process.env };
     process.env.FISH_AUDIO_API_KEY = "test-fish-key";
     delete process.env.FISH_AUDIO_REFERENCE_ID;
+    delete process.env.FISH_AUDIO_TTS_MODEL;
     mockQuery.mockReset();
     mockFetch.mockReset();
   });
@@ -153,6 +154,31 @@ describe("POST /api/avatar/tts", () => {
 
     expect(res.status).toBe(200);
     expect(sentBody().reference_id).toBe("env-voice-456");
+  });
+
+  it("GID 1217083837550852: env FISH_AUDIO_TTS_MODEL 未設定時は s2.1-pro-free を使う", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    mockFishAudioOk();
+
+    const res = await request(makeApp("tenant-a"))
+      .post("/api/avatar/tts")
+      .send({ text: "こんにちは" });
+
+    expect(res.status).toBe(200);
+    expect(sentBody().model).toBe("s2.1-pro-free");
+  });
+
+  it("GID 1217083837550852: env FISH_AUDIO_TTS_MODEL 設定時はその値を Fish への body に使う", async () => {
+    process.env.FISH_AUDIO_TTS_MODEL = "s2.1-pro";
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    mockFishAudioOk();
+
+    const res = await request(makeApp("tenant-a"))
+      .post("/api/avatar/tts")
+      .send({ text: "こんにちは" });
+
+    expect(res.status).toBe(200);
+    expect(sentBody().model).toBe("s2.1-pro");
   });
 
   it("テナント越境防止: body の voiceId は無視され DB 解決値が優先される", async () => {

--- a/src/api/avatar/fishTtsRoutes.ts
+++ b/src/api/avatar/fishTtsRoutes.ts
@@ -45,6 +45,8 @@ export function registerFishTtsRoutes(app: Express, apiStack: RequestHandler[]):
       logger.warn({ err, tenantId }, '[fishTts] voice_id resolve failed — env fallback');
     }
 
+    const ttsModel = process.env.FISH_AUDIO_TTS_MODEL?.trim() || 's2.1-pro-free';
+
     try {
       const fishRes = await fetch(FISH_AUDIO_API, {
         method: 'POST',
@@ -54,7 +56,7 @@ export function registerFishTtsRoutes(app: Express, apiStack: RequestHandler[]):
         },
         body: JSON.stringify({
           text: text,
-          model: 's2.1-pro-free',
+          model: ttsModel,
           ...(referenceId ? { reference_id: referenceId } : {}),
           format: 'mp3',
           latency: 'balanced',
@@ -86,11 +88,12 @@ export function registerFishTtsRoutes(app: Express, apiStack: RequestHandler[]):
       trackUsage({
         tenantId,
         requestId: (req as any).requestId ?? `tts-${Date.now()}`,
-        model: 'fish-audio-s2.1-pro-free',
+        model: `fish-audio-${ttsModel}`,
         inputTokens: 0,
         outputTokens: 0,
         featureUsed: 'voice',
         ttsTextBytes: Buffer.byteLength(text, 'utf8'),
+        ttsModel,
       });
 
     } catch (err) {

--- a/src/api/internal/usageRoutes.test.ts
+++ b/src/api/internal/usageRoutes.test.ts
@@ -110,6 +110,28 @@ describe("POST /api/internal/usage", () => {
     );
   });
 
+  it("GID 1217083837550852: 既知のttsModelはtrackUsageにそのまま渡る", async () => {
+    await request(makeApp())
+      .post("/api/internal/usage")
+      .set("X-Internal-Request", "1")
+      .send({ tenantId: "tenant-abc", ttsTextBytes: 100, ttsModel: "s2.1-pro-free" });
+
+    expect(mockTrackUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ ttsModel: "s2.1-pro-free" }),
+    );
+  });
+
+  it("GID 1217083837550852: allowlist外のttsModel（なりすまし試行）はundefinedにフォールバックされ原価計算に到達しない", async () => {
+    await request(makeApp())
+      .post("/api/internal/usage")
+      .set("X-Internal-Request", "1")
+      .send({ tenantId: "tenant-abc", ttsTextBytes: 100, ttsModel: "free-model-that-does-not-exist" });
+
+    expect(mockTrackUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ ttsModel: undefined }),
+    );
+  });
+
   it("requestId省略時は自動生成される", async () => {
     await request(makeApp())
       .post("/api/internal/usage")

--- a/src/api/internal/usageRoutes.ts
+++ b/src/api/internal/usageRoutes.ts
@@ -4,12 +4,13 @@
 //   認証: X-Internal-Request: 1（Prometheusメトリクスと同じ方式）
 //   avatar-agent/agent.py からTTS/Avatar使用量を受信してDBに記録する。
 //
-// Body: { tenantId, requestId?, ttsTextBytes?, avatarCredits?, avatarSessionMs? }
+// Body: { tenantId, requestId?, ttsTextBytes?, ttsModel?, avatarCredits?, avatarSessionMs? }
 
 import { GROQ_VERSATILE_70B } from '../../config/groqModels';
 import type { Express, Request, Response } from 'express';
 import { INTERNAL_REQUEST_HEADER } from '../../lib/metrics/kpiDefinitions';
 import { trackUsage, type FeatureUsed } from '../../lib/billing/usageTracker';
+import { FISH_AUDIO_KNOWN_TTS_MODELS } from '../../lib/billing/costCalculator';
 import { internalNetworkOnly } from '../middleware/internalNetworkOnly';
 
 const ALLOWED_FEATURES: readonly FeatureUsed[] = ['avatar', 'voice'];
@@ -21,7 +22,7 @@ export function registerInternalUsageRoutes(app: Express): void {
     }
 
     const body = req.body ?? {};
-    const { tenantId, requestId, ttsTextBytes, avatarCredits, avatarSessionMs, inputTokens, outputTokens, model, featureUsed } = body;
+    const { tenantId, requestId, ttsTextBytes, ttsModel, avatarCredits, avatarSessionMs, inputTokens, outputTokens, model, featureUsed } = body;
 
     if (!tenantId || typeof tenantId !== 'string') {
       return res.status(400).json({ error: 'tenantId required' });
@@ -47,6 +48,10 @@ export function registerInternalUsageRoutes(app: Express): void {
       featureUsed: resolvedFeature,
       ttsTextBytes:
         typeof ttsTextBytes === 'number' && ttsTextBytes >= 0 ? ttsTextBytes : undefined,
+      ttsModel:
+        typeof ttsModel === 'string' && FISH_AUDIO_KNOWN_TTS_MODELS.includes(ttsModel)
+          ? ttsModel
+          : undefined,
       avatarCredits:
         typeof avatarCredits === 'number' && avatarCredits >= 0 ? avatarCredits : undefined,
       avatarSessionMs:

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -95,6 +95,7 @@ const envSchema = z.object({
   ANAM_API_KEY: z.string().optional(),
   FISH_AUDIO_API_KEY: z.string().optional(),
   FISH_AUDIO_REFERENCE_ID: z.string().optional(),
+  FISH_AUDIO_TTS_MODEL: z.string().optional(),
   LEONARDO_API_KEY: z.string().optional(),
   LIVEKIT_URL: z.string().optional(),
   LIVEKIT_WS_URL: z.string().optional(),

--- a/src/lib/billing/costCalculator.test.ts
+++ b/src/lib/billing/costCalculator.test.ts
@@ -6,6 +6,7 @@ import {
   calculateBillingAmountCents,
   calculateTTSCostCents,
   calculateAvatarCostCents,
+  fishTtsCostPerByteUsd,
   normalizeModelKey,
   LLM_COSTS,
   SERVER_COST_PER_REQUEST_USD,
@@ -426,6 +427,48 @@ describe('calculateBillingAmountCents with TTS/Avatar', () => {
     });
     expect(result).toBeGreaterThanOrEqual(7500);
     expect(Number.isInteger(result)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GID 1217083837550852: fishTtsCostPerByteUsd / ttsModel 連動
+// ---------------------------------------------------------------------------
+describe('fishTtsCostPerByteUsd', () => {
+  it('s2.1-pro-free は無料(0)', () => {
+    expect(fishTtsCostPerByteUsd('s2.1-pro-free')).toBe(0);
+  });
+
+  it('s2.1-pro は有料単価($15/M byte)', () => {
+    expect(fishTtsCostPerByteUsd('s2.1-pro')).toBe(FISH_AUDIO_COST_PER_BYTE_USD);
+  });
+
+  it('未知のモデル名は有料単価にフォールバックする', () => {
+    expect(fishTtsCostPerByteUsd('unknown-model')).toBe(FISH_AUDIO_COST_PER_BYTE_USD);
+  });
+
+  it('モデル省略時は有料単価にフォールバックする(既存呼び出し元との後方互換)', () => {
+    expect(fishTtsCostPerByteUsd(undefined)).toBe(FISH_AUDIO_COST_PER_BYTE_USD);
+  });
+});
+
+describe('calculateBillingAmountCents: ttsModel', () => {
+  it('ttsModel=s2.1-pro-free のとき ttsTextBytes があってもTTS分は0円', () => {
+    const withFreeModel = calculateBillingAmountCents({
+      model: 'llama-3.1-8b-instant', inputTokens: 0, outputTokens: 0,
+      ttsTextBytes: 1_000_000, ttsModel: 's2.1-pro-free',
+    });
+    const withoutTts = calculateBillingAmountCents({
+      model: 'llama-3.1-8b-instant', inputTokens: 0, outputTokens: 0,
+    });
+    expect(withFreeModel).toBe(withoutTts);
+  });
+
+  it('ttsModel未指定時は既存どおり有料単価で計上される（後方互換）', () => {
+    const withoutModel = calculateBillingAmountCents({
+      model: 'llama-3.1-8b-instant', inputTokens: 0, outputTokens: 0,
+      ttsTextBytes: 1_000_000,
+    });
+    expect(withoutModel).toBeGreaterThanOrEqual(1500);
   });
 });
 

--- a/src/lib/billing/costCalculator.ts
+++ b/src/lib/billing/costCalculator.ts
@@ -57,6 +57,27 @@ export const NON_BILLABLE_FEATURES: ReadonlySet<string> = new Set([
 /** Phase40: Fish Audio TTS単価: $15.00 / 1M UTF-8バイト */
 export const FISH_AUDIO_COST_PER_BYTE_USD = 15.0 / 1_000_000;
 
+/**
+ * GID 1217083837550852: Fish Audio TTSはモデルによって単価が異なる
+ * （s2.1-pro-free は無料期間中のみ $0）。実際に使ったモデル名は
+ * trackUsage 呼び出し元（fishTtsRoutes.ts / agent.py）が申告する。
+ * 未知のモデル名や省略時は既存の FISH_AUDIO_COST_PER_BYTE_USD（有料単価）にフォールバックする。
+ */
+const FISH_AUDIO_MODEL_COST_PER_BYTE_USD: Record<string, number> = {
+  's2.1-pro-free': 0,
+  's2.1-pro': FISH_AUDIO_COST_PER_BYTE_USD,
+  's2-pro': FISH_AUDIO_COST_PER_BYTE_USD,
+  's1': FISH_AUDIO_COST_PER_BYTE_USD,
+};
+
+/** 既知のFish Audio TTSモデルID一覧（外部境界での allowlist 検証に使う単一の情報源） */
+export const FISH_AUDIO_KNOWN_TTS_MODELS: readonly string[] = Object.keys(FISH_AUDIO_MODEL_COST_PER_BYTE_USD);
+
+export function fishTtsCostPerByteUsd(model?: string): number {
+  if (!model) return FISH_AUDIO_COST_PER_BYTE_USD;
+  return FISH_AUDIO_MODEL_COST_PER_BYTE_USD[model] ?? FISH_AUDIO_COST_PER_BYTE_USD;
+}
+
 /** Phase40: Lemonslice単価: $7.00 / 1000クレジット */
 export const LEMONSLICE_COST_PER_CREDIT_USD = 7.0 / 1_000;
 
@@ -132,6 +153,8 @@ export interface UsageRecord {
   marginOverride?: number;
   /** Phase40: Fish Audio TTSに送ったテキストのUTF-8バイト数 */
   ttsTextBytes?: number;
+  /** GID 1217083837550852: 実際に使用したFish Audio TTSモデル名（単価の決定に使う） */
+  ttsModel?: string;
   /** Phase40: Lemonsliceのクレジット消費量 */
   avatarCredits?: number;
   /** Phase40: LiveKitセッション時間（ミリ秒） */
@@ -280,7 +303,7 @@ export function calculateBillingAmountCents(usage: UsageRecord): number {
   const margin   = usage.marginOverride ?? (isEndUser ? MARGIN_MULTIPLIER : 1);
   // 本行の LLM コスト + 同一リクエスト内の追加 LLM 呼び出し（planner 等）をモデル別実レートで合算。
   const llmUSD   = _calculateLLMCostUSD(usage) + _sumExtraLlmUsd(usage.extraLlmUsages);
-  const ttsUSD   = (usage.ttsTextBytes  ?? 0) * FISH_AUDIO_COST_PER_BYTE_USD;
+  const ttsUSD   = (usage.ttsTextBytes  ?? 0) * fishTtsCostPerByteUsd(usage.ttsModel);
   const avtrUSD  = (usage.avatarCredits ?? 0) * LEMONSLICE_COST_PER_CREDIT_USD;
   const imgUSD   = (usage.imageCount    ?? 0) * IMAGE_GENERATION_COST_USD;
   const anamUSD  = (usage.anam_session_seconds ?? 0) > 0

--- a/src/lib/billing/usageTracker.ts
+++ b/src/lib/billing/usageTracker.ts
@@ -23,6 +23,8 @@ export interface TrackUsageParams {
   marginOverride?: number;
   /** Phase40: Fish Audio TTSに送ったテキストのUTF-8バイト数 */
   ttsTextBytes?: number;
+  /** GID 1217083837550852: 実際に使用したFish Audio TTSモデル名（原価計算にのみ使う。DB列は追加しない） */
+  ttsModel?: string;
   /** Phase40: Lemonsliceのクレジット消費量 */
   avatarCredits?: number;
   /** Phase40: LiveKitセッション時間（ミリ秒） */
@@ -83,7 +85,7 @@ async function _insertUsageLog(params: TrackUsageParams): Promise<void> {
 
   const {
     tenantId, requestId, model, inputTokens, outputTokens,
-    featureUsed, marginOverride, ttsTextBytes, avatarCredits, avatarSessionMs, imageCount,
+    featureUsed, marginOverride, ttsTextBytes, ttsModel, avatarCredits, avatarSessionMs, imageCount,
     anam_session_seconds, extraLlmUsages, saiAgentSteps,
     ocrPages, asrRequestCount, magnificUpscaleCount, fluxImageCount, lemonsliceRegistrationCount,
     billable,
@@ -111,7 +113,7 @@ async function _insertUsageLog(params: TrackUsageParams): Promise<void> {
     costLlmCents   = calculateLLMCostCents({ model, inputTokens, outputTokens, extraLlmUsages });
     costTotalCents = calculateBillingAmountCents({
       model, inputTokens, outputTokens, marginOverride,
-      ttsTextBytes, avatarCredits, avatarSessionMs,
+      ttsTextBytes, ttsModel, avatarCredits, avatarSessionMs,
       featureUsed, imageCount, anam_session_seconds, extraLlmUsages, saiAgentSteps,
       ocrPages, asrRequestCount, magnificUpscaleCount, fluxImageCount, lemonsliceRegistrationCount,
     });


### PR DESCRIPTION
## Summary
- s2.1-pro-free（無料、DPA保証なし、期限2026-08-31）がコードにハードコードされており、有料モデルへの切替がコード変更を要していた問題を是正
- FISH_AUDIO_TTS_MODEL env変数でモデルを切替可能にした（既定値は現行同様 s2.1-pro-free、本番挙動は変わらない）
- 実際に使用したモデル名をtrackUsageに渡し、原価計算をモデル別単価（free=0 / pro=$15/M byte）に連動させた（従来は実費0円のfreeモデルでも有料単価で計上していた）
- DB migrationなし（原価計算専用のフィールド追加のみ、INSERT列は不変）

## Asana
子タスク: https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217083837550852
親: https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217083837119126

## Test plan
- [x] pnpm typecheck: 0 errors
- [x] pnpm lint: 0 (59 pre-existing warnings, threshold 63)
- [x] pnpm test: 3273 tests pass（既存の無関係な1テストが並列実行環境で断続的にflakyになる既知事象。origin/mainベースラインでも同一頻度で再現することを別途確認済み、本PRの変更とは無関係）
- [x] Gate 1.5 dead-code-check: 新規dead exportsなし
- [x] Gate 2 security-scan: CRITICAL/HIGH 0
- [x] Gate 3 build: 0 errors（admin-ui未変更のためadmin-ui buildは対象外）

## 本番切替について
本PRは切替の準備のみ。VPS envをs2.1-proへ実際に切り替えるかの意思決定と実施は別タスク（人間作業、期限2026-08-31）: https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217083993478138

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdBRSsTu4YNWBDTpgzqz2c