### PR TITLE
feat: カテゴリ変化でアバターの見た目・人格を切り替える(widget → agent配線)

### DIFF
--- a/avatar-agent/agent.py
+++ b/avatar-agent/agent.py
@@ -485,7 +485,15 @@ async def entrypoint(ctx: agents.JobContext) -> None:
         effective_emotion_tags = []
     effective_emotion_tags = [str(t) for t in effective_emotion_tags if t]
 
-    logger.info(f"[entrypoint] effective config: voice_id={effective_reference_id!r}, agent_id={effective_agent_id!r}, image_url={'set' if effective_image_url else 'none'}, custom_prompt={'yes' if avatar_config and avatar_config.get('personality_prompt') else 'no'}, emotion_tags={len(effective_emotion_tags)} {effective_emotion_tags}")
+    # LemonSliceペルソナスワップ: カテゴリ名 → {image_url, agent_prompt, idle_prompt, voice_id}
+    # のマップ（migration_category_persona.sql の avatar_configs.category_persona_map、JSONB）。
+    # 未設定テナントは {} のまま（category_change を受けても何もしない）。
+    category_persona_map = (avatar_config.get("category_persona_map") if avatar_config else None) or {}
+    if not isinstance(category_persona_map, dict):
+        logger.warning(f"[entrypoint] category_persona_map is not a dict, ignoring: {type(category_persona_map)}")
+        category_persona_map = {}
+
+    logger.info(f"[entrypoint] effective config: voice_id={effective_reference_id!r}, agent_id={effective_agent_id!r}, image_url={'set' if effective_image_url else 'none'}, custom_prompt={'yes' if avatar_config and avatar_config.get('personality_prompt') else 'no'}, emotion_tags={len(effective_emotion_tags)} {effective_emotion_tags}, category_personas={len(category_persona_map)}")
 
     fish_tts = FishAudioTTS(
         api_key=os.environ["FISH_AUDIO_API_KEY"],
@@ -608,6 +616,36 @@ async def entrypoint(ctx: agents.JobContext) -> None:
                     )
                 else:
                     logger.debug(f"[data_channel] state_change with unknown state, skipping: {state!r}")
+            elif msg_type == "category_change":
+                # LemonSliceペルソナスワップ: 話題カテゴリの変化に応じて見た目・人格・声を
+                # 切り替える（LiveKit接続は維持したまま、fire-and-forget）。
+                category = msg.get("category")
+                persona = (
+                    category_persona_map.get(category)
+                    if isinstance(category, str) and isinstance(category_persona_map, dict)
+                    else None
+                )
+                if isinstance(persona, dict):
+                    logger.info(f"[data_channel] category_change received: category={category}")
+                    if persona.get("image_url"):
+                        asyncio.create_task(
+                            control_lemonslice("update-image", image_url=persona["image_url"])
+                        )
+                    if persona.get("agent_prompt"):
+                        asyncio.create_task(
+                            control_lemonslice("update-agent-prompt", agent_prompt=persona["agent_prompt"])
+                        )
+                    if persona.get("idle_prompt"):
+                        asyncio.create_task(
+                            control_lemonslice("update-idle-prompt", idle_prompt=persona["idle_prompt"])
+                        )
+                    if persona.get("voice_id"):
+                        # 次回 TTS 合成から声を切り替える。FishAudioTTS.synthesize() は
+                        # 呼び出しのたびに self._reference_id を読むため、インスタンス属性を
+                        # 直接更新するだけで反映される（TTSインスタンスの再生成は不要）。
+                        fish_tts._reference_id = persona["voice_id"]
+                else:
+                    logger.debug(f"[data_channel] category_change with unmapped category, skipping: {category!r}")
             elif msg_type == "widget_connected":
                 logger.info("[data_channel] widget_connected received")
                 # 挨拶は AgentSession が自動的に行うため、手動呼び出し不要

--- a/public/widget.js
+++ b/public/widget.js
@@ -1063,6 +1063,7 @@
   var lastAvatarImageUrl = null; // 最後に確認されたアバター画像URL（closePanel時のフォールバック）
   var avatarInactivityTimer = null;
   var AVATAR_INACTIVITY_MS = 33000; // 大表示非アクティブタイムアウト（33秒）
+  var lastRagCategory = null;    // LemonSliceペルソナスワップ: 直近送信した話題カテゴリ（変化時のみ送信）
 
   var conversationId = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
     var r = Math.random() * 16 | 0;
@@ -2564,6 +2565,21 @@
               }
             } catch (e) {
               console.warn('[FAQ Widget] state_change send error:', e && (e.message || e));
+            }
+          }
+          // LemonSliceペルソナスワップ: 話題カテゴリが変化した時だけ通知する
+          // （同じカテゴリが続く間は毎回送らない。接続は切らずに見た目・人格だけ切り替える）
+          if (json.data && typeof json.data.ragCategory === 'string' && json.data.ragCategory !== lastRagCategory) {
+            lastRagCategory = json.data.ragCategory;
+            try {
+              var categoryEncoder = new TextEncoder();
+              var categoryPayload = categoryEncoder.encode(JSON.stringify({ type: 'category_change', category: json.data.ragCategory }));
+              var categoryPromise = lkRoom.localParticipant.publishData(categoryPayload, { reliable: true });
+              if (categoryPromise && typeof categoryPromise.catch === 'function') {
+                categoryPromise.catch(function (err) { console.warn('[FAQ Widget] category_change publishData rejected:', err && (err.message || err)); });
+              }
+            } catch (e) {
+              console.warn('[FAQ Widget] category_change send error:', e && (e.message || e));
             }
           }
         }

--- a/src/api/internal/avatarConfigRoutes.test.ts
+++ b/src/api/internal/avatarConfigRoutes.test.ts
@@ -164,4 +164,25 @@ describe("GET /api/internal/avatar-config", () => {
       expect(res.body.config).toBeNull();
     });
   });
+
+  describe("LemonSliceペルソナスワップ: category_persona_map の伝搬", () => {
+    it("SELECT句に category_persona_map が含まれる（avatar-agentがカテゴリ別ペルソナを取得できる）", async () => {
+      const mockQuery = mockPool([AVATAR_ROW]);
+      await request(makeApp())
+        .get("/api/internal/avatar-config?tenantId=r2c_default")
+        .set("X-Internal-Request", "1");
+
+      const sql: string = mockQuery.mock.calls[0][0];
+      expect(sql).toContain("category_persona_map");
+    });
+
+    it("category_persona_map を含む行がそのまま config として返る", async () => {
+      mockPool([{ ...AVATAR_ROW, category_persona_map: { fashion: { agent_prompt: "stylish" } } }]);
+      const res = await request(makeApp())
+        .get("/api/internal/avatar-config?tenantId=r2c_default")
+        .set("X-Internal-Request", "1");
+
+      expect(res.body.config.category_persona_map).toEqual({ fashion: { agent_prompt: "stylish" } });
+    });
+  });
 });

--- a/src/api/internal/avatarConfigRoutes.ts
+++ b/src/api/internal/avatarConfigRoutes.ts
@@ -25,7 +25,7 @@ export function registerInternalAvatarConfigRoutes(app: Express): void {
     const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
     const avatarConfigId = _rawConfigId && UUID_RE.test(_rawConfigId) ? _rawConfigId : undefined;
 
-    const COLS = "voice_id, personality_prompt, emotion_tags, lemonslice_agent_id, behavior_description, avatar_provider, image_url, agent_prompt, agent_idle_prompt";
+    const COLS = "voice_id, personality_prompt, emotion_tags, lemonslice_agent_id, behavior_description, avatar_provider, image_url, agent_prompt, agent_idle_prompt, category_persona_map";
 
     try {
       const pool = getPool();


### PR DESCRIPTION
## Summary
- 会話の話題カテゴリ(`ragCategory`)が変化した時、LiveKit接続を切らずにLemonSliceアバターの見た目・人格・声を切り替えるLemonSliceペルソナスワップ機能の実配線
- `public/widget.js`: `state_change`送信ブロックに相乗りし、`ragCategory`が前回と異なる時だけ`category_change`をDataChannel経由でagentへ送信(第2の送信経路は作らない)
- `avatar-agent/agent.py`: `on_data_received`に`category_change`を追加。`category_persona_map`から該当カテゴリのペルソナを引き、`update-image`/`update-agent-prompt`/`update-idle-prompt`を発火(ハイフン区切りの正しいイベント名)。`voice_id`は`fish_tts`インスタンスの`_reference_id`を直接更新し次回TTS合成から反映
- `src/api/internal/avatarConfigRoutes.ts`: SELECT句(`COLS`)に`category_persona_map`が欠けており、migration適用後もagent.pyに列が届かない欠陥を実装時の実機照合で発見・修正(計画時は2ファイルの見積もりだったが、実際には3ファイル目の修正が必要だった)

## 前提(マージ順)
以下3PRがマージされていることが前提です(未マージのまま本PRを先にマージすると、`update_agent_prompt`の誤字を複製する/`ragCategory`が存在しない/`category_persona_map`列が無い状態になります):
- #698 [ペルソナ1/4] ragCategory
- #699 [ペルソナ2/4] migration(本番適用は別途人間作業)
- #697 [LemonSlice P0バグ] update-agent-prompt修正

## Test plan
- [x] `avatar-agent`: `python -c "import agent"` で構文・importエラーなし、既存`test_emotion_tags.py`全11件pass(scratch venv)
- [x] `avatarConfigRoutes.test.ts`に2ケース追加(SELECT句に`category_persona_map`を含む/該当行がそのまま`config`として返る)、全10テストpass
- [x] `pnpm typecheck` / `pnpm lint` パス

Asana: https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217101190645169

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xq3XPSpwhHBTrNyoJMhvoa