### PR TITLE
chore(avatar-agent): livekit-agents を 1.5.17 → 1.6.7 に上げる（バージョンのみ）

### DIFF
--- a/avatar-agent/requirements.txt
+++ b/avatar-agent/requirements.txt
@@ -1,7 +1,7 @@
 # Direct dependencies — pinned via `pip freeze` on VPS 2026-04-21
 # To update: pip install -U <package> && pip freeze > /tmp/freeze.txt, then update this file
 # DO NOT use >= constraints — they allow silent version drift that breaks livekit-agents compatibility
-livekit-agents[lemonslice,openai]==1.5.17
+livekit-agents[lemonslice,openai]==1.6.7
 fish-audio-sdk==1.3.0
 groq==1.2.0
 httpx==0.28.1


### PR DESCRIPTION
## 概要
- LiveKit公式最新版調査(2026-08-01)に基づく更新PRの2/6本目。avatar-agentのlivekit-agentsをバンプする。
- `requirements.txt`の1行のみ変更。`agent.py`は無変更。

## なぜバージョンのみ分離するか
- avatar-agentのPythonはCIで一切テストされない(pnpm verifyにpytestは無い)。実機デプロイでの検証が唯一のゲート。
- speak()ファネル導入(3/7)やfishaudioプラグイン置換(5/7)と混ぜると、実機で不具合が出た際に「バージョンか実装か」を切り分けられなくなる。1PR1変数の方針。

## agent.pyを触らなくてよい理由(調査済み)
- `AgentSession(llm=, tts=, user_away_timeout=None)`は1.6.7でも有効(user_away_timeoutは現行mainにも存在、デフォルト15.0)。
- 1.6.1で`turn_detection`/`preemptive_generation`等が`turn_handling=TurnHandlingOptions(...)`へ移行し非推奨化されたが、R2Cは1つも使っていない。
- 1.6.4の警告「1.5.14〜1.6.3でSTT+agent handoffが壊れる」はR2CがSTT未使用のため非該当。

## ローカル確認
venvで`pip install -r requirements.txt`が解決し、`livekit.agents`/`livekit.plugins.lemonslice`/`livekit.plugins.openai`のimportに成功、`livekit-agents==1.6.7`を確認済み。

## Gate結果
- Gate 1 `pnpm verify`: この変更(requirements.txt)はCI検査対象外。typecheck/lint/jest全パス(既存の226 suites 3263 tests、無変更)。

## デプロイ・実機確認
「[LiveKit更新 7/7] 人間作業」タスクの波2で実施(`bash SCRIPTS/deploy-vps.sh`でvenv再構築 → pm2ログで`SESSION STARTED`確認 → 会話1往復確認)。

## Asana
https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217084040142070