### PR TITLE
chore(backend): livekit-server-sdk を 2.17.0 に上げ、agent dispatch に restartPolicy を入れる

### DIFF
--- a/package.json
+++ b/package.json
@@ -133,7 +133,7 @@
     "express": "5.1.0",
     "js-yaml": "^4.3.0",
     "jsonwebtoken": "^9.0.3",
-    "livekit-server-sdk": "^2.15.0",
+    "livekit-server-sdk": "^2.17.0",
     "multer": "^2.2.0",
     "pdf-parse": "1.1.1",
     "pdf2pic": "^3.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,8 +55,8 @@ importers:
         specifier: ^9.0.3
         version: 9.0.3
       livekit-server-sdk:
-        specifier: ^2.15.0
-        version: 2.15.0
+        specifier: ^2.17.0
+        version: 2.17.0
       multer:
         specifier: ^2.2.0
         version: 2.2.0
@@ -729,8 +729,8 @@ packages:
       zod-to-json-schema:
         optional: true
 
-  '@livekit/protocol@1.45.1':
-    resolution: {integrity: sha512-sr6p0TwKofHO5KW6kUzjq4hH2de4Al5scQo824xFnyI1XYo0qQn6fTG+bdr+Uj4EedjYAOqjezwUju5OErVIRA==}
+  '@livekit/protocol@1.50.4':
+    resolution: {integrity: sha512-L1uggNQAqyY21smQY8AllyOYbcv9Me9TaxwuLytL1R8ck9nbYPmQLNwEDi3pOFGAMa5F8I2nUi2Jc59W5awxlA==}
 
   '@minimistjs/subarg@1.0.0':
     resolution: {integrity: sha512-Q/ONBiM2zNeYUy0mVSO44mWWKYM3UHuEK43PKIOzJCbvUnPoMH1K+gk3cf1kgnCVJFlWmddahQQCmrmBGlk9jQ==}
@@ -1449,10 +1449,6 @@ packages:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
     engines: {node: '>=6'}
 
-  camelcase-keys@9.1.3:
-    resolution: {integrity: sha512-Rircqi9ch8AnZscQcsA1C47NFdaO3wukpmIRzYcDOrmvgt78hM/sj5pZhZNec2NM12uk5vTwRHZ4anGcrC4ZTg==}
-    engines: {node: '>=16'}
-
   camelcase@5.3.1:
     resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
     engines: {node: '>=6'}
@@ -1460,10 +1456,6 @@ packages:
   camelcase@6.3.0:
     resolution: {integrity: sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==}
     engines: {node: '>=10'}
-
-  camelcase@8.0.0:
-    resolution: {integrity: sha512-8WB3Jcas3swSvjIeA2yvCJ+Miyz5l1ZmB6HFb9R1317dt9LCQoswg/BGrmAmkWVEszSrrg4RwmO46qIm2OEnSA==}
-    engines: {node: '>=16'}
 
   caniuse-lite@1.0.30001759:
     resolution: {integrity: sha512-Pzfx9fOKoKvevQf8oCXoyNRQ5QyxJj+3O0Rqx2V5oxT61KGx8+n6hV/IUyJeifUci2clnmmKVpvtiqRzgiWjSw==}
@@ -2437,8 +2429,8 @@ packages:
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
 
-  livekit-server-sdk@2.15.0:
-    resolution: {integrity: sha512-HmzjWnwEwwShu8yUf7VGFXdc+BuMJR5pnIY4qsdlhqI9d9wDgq+4cdTEHg0NEBaiGnc6PCOBiaTYgmIyVJ0S9w==}
+  livekit-server-sdk@2.17.0:
+    resolution: {integrity: sha512-GWNEQrUD13UwZNrmosyTVFPgeBvSU2lFKGxdA4DaUI5F4sMb1cGeep/PPEE9vvRNELJYpxWS0ImS4gQmovKUDA==}
     engines: {node: '>=18'}
 
   locate-path@5.0.0:
@@ -2508,10 +2500,6 @@ packages:
 
   manage-path@2.0.0:
     resolution: {integrity: sha512-NJhyB+PJYTpxhxZJ3lecIGgh4kwIY2RAh44XvAz9UlqthlQwtPBf62uBVR8XaD8CRuSjQ6TnZH2lNJkbLPZM2A==}
-
-  map-obj@5.0.0:
-    resolution: {integrity: sha512-2L3MIgJynYrZ3TYMriLDLWocz15okFakV6J12HXvMXDHui2x/zgChzg1u9mFFGbbGWE+GsLpQByt4POb9Or+uA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   map-stream@0.1.0:
     resolution: {integrity: sha512-CkYQrPYZfWnu/DAmVCpTSX/xHpKZ80eKh2lAkyA6AJTef6bW+6JpbQZN5rofum7da+SyN1bi5ctTm+lTfcCW3g==}
@@ -2963,10 +2951,6 @@ packages:
 
   quick-format-unescaped@4.0.4:
     resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
-
-  quick-lru@6.1.2:
-    resolution: {integrity: sha512-AAFUA5O1d83pIHEhJwWCq/RQcRukCkn/NSm2QsTEMle5f2hP0ChI2+3Xb051PZCkLryI/Ir1MVKviT2FIloaTQ==}
-    engines: {node: '>=12'}
 
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
@@ -4292,7 +4276,7 @@ snapshots:
       - react
       - react-dom
 
-  '@livekit/protocol@1.45.1':
+  '@livekit/protocol@1.50.4':
     dependencies:
       '@bufbuild/protobuf': 1.10.1
 
@@ -4985,18 +4969,9 @@ snapshots:
 
   callsites@3.1.0: {}
 
-  camelcase-keys@9.1.3:
-    dependencies:
-      camelcase: 8.0.0
-      map-obj: 5.0.0
-      quick-lru: 6.1.2
-      type-fest: 4.41.0
-
   camelcase@5.3.1: {}
 
   camelcase@6.3.0: {}
-
-  camelcase@8.0.0: {}
 
   caniuse-lite@1.0.30001759: {}
 
@@ -6207,11 +6182,10 @@ snapshots:
 
   lines-and-columns@1.2.4: {}
 
-  livekit-server-sdk@2.15.0:
+  livekit-server-sdk@2.17.0:
     dependencies:
       '@bufbuild/protobuf': 1.10.1
-      '@livekit/protocol': 1.45.1
-      camelcase-keys: 9.1.3
+      '@livekit/protocol': 1.50.4
       jose: 5.10.0
 
   locate-path@5.0.0:
@@ -6265,8 +6239,6 @@ snapshots:
       tmpl: 1.0.5
 
   manage-path@2.0.0: {}
-
-  map-obj@5.0.0: {}
 
   map-stream@0.1.0: {}
 
@@ -6697,8 +6669,6 @@ snapshots:
       side-channel: 1.1.0
 
   quick-format-unescaped@4.0.4: {}
-
-  quick-lru@6.1.2: {}
 
   range-parser@1.2.1: {}
 

--- a/src/api/avatar/livekitTokenRoutes.test.ts
+++ b/src/api/avatar/livekitTokenRoutes.test.ts
@@ -27,6 +27,7 @@ jest.mock("livekit-server-sdk", () => ({
   AgentDispatchClient: jest.fn().mockImplementation(() => ({
     createDispatch: mockCreateDispatch,
   })),
+  JobRestartPolicy: { JRP_ON_FAILURE: 0, JRP_NEVER: 1 },
 }));
 
 import { pool } from "../../lib/db";
@@ -351,6 +352,9 @@ describe("POST /api/avatar/room-token", () => {
       // dispatch が呼ばれていることを確認（fire-and-forget のため Promise 解決を待つ）
       await new Promise(resolve => setImmediate(resolve));
       expect(mockCreateDispatch).toHaveBeenCalledTimes(1);
+      // restartPolicy: JRP_ON_FAILURE(=0) が明示指定されていること
+      const dispatchCallArgs = mockCreateDispatch.mock.calls[0];
+      expect(dispatchCallArgs[2]).toEqual({ restartPolicy: 0 });
     });
 
     it("pre_dispatch=false かつ connect=false → dispatch 呼ばれず preDispatchEnabled=false（プラン確認自体スキップ）", async () => {

--- a/src/api/avatar/livekitTokenRoutes.ts
+++ b/src/api/avatar/livekitTokenRoutes.ts
@@ -14,7 +14,7 @@ import crypto from "crypto";
 import type { Express, Request, Response, RequestHandler } from "express";
 import jwt from "jsonwebtoken";
 import { pool } from "../../lib/db";
-import { RoomServiceClient, AgentDispatchClient } from "livekit-server-sdk";
+import { RoomServiceClient, AgentDispatchClient, JobRestartPolicy } from "livekit-server-sdk";
 import type { AuthedRequest } from "../../agent/http/authMiddleware";
 import { logger } from '../../lib/logger';
 import { queryTenantPlan, planHasFeature } from "../../lib/billing/planFeatures";
@@ -76,7 +76,11 @@ async function dispatchAgentToRoom(
   }
 
   // 2. Agent Dispatch
-  const dispatch = await dispatchClient.createDispatch(roomName, "rajiuce-avatar");
+  // restartPolicy: JRP_ON_FAILURE(デフォルト)を明示指定。会話途中で agent job が
+  // 落ちても再起動されるようにする（LiveKit Cloud限定機能。以前は未指定=暗黙のデフォルト依存だった）。
+  const dispatch = await dispatchClient.createDispatch(roomName, "rajiuce-avatar", {
+    restartPolicy: JobRestartPolicy.JRP_ON_FAILURE,
+  });
   logger.info(`[livekitTokenRoutes] Agent dispatched to room: ${roomName} id=${dispatch.id} room=${dispatch.room}`);
 }
 


### PR DESCRIPTION
## 概要
- LiveKit公式最新版調査(2026-08-01)に基づく更新PRの6/6本目。他のavatar-agent系タスク(1〜5)とは独立(バックエンドのみ)、いつマージしてもよい。
- `livekit-server-sdk` を2.15.0 → 2.17.0に上げ、`dispatchAgentToRoom()`の`createDispatch()`に`restartPolicy`を明示指定する。

## 効く理由
- 2.15.3で`createDispatch`に`restartPolicy`オプションが追加(LiveKit Cloud限定)。現状、アバターのagent jobが会話中に落ちても誰も再起動しない。
- `JobRestartPolicy`は`JRP_ON_FAILURE`(デフォルト、失敗時再起動)と`JRP_NEVER`(再起動しない)の2値のみ(@livekit/protocolのenum定義で確認済み)。R2Cの要件「会話途中で落ちたら復帰させたい」に合うのは`JRP_ON_FAILURE`——デフォルトと同じ値だが、意図を明示するため指定した。

## 変更ファイル
- `package.json` — `livekit-server-sdk` `^2.15.0` → `^2.17.0`
- `pnpm-lock.yaml` — Node 20.19.5で`pnpm install`し再生成。差分は`livekit-server-sdk`とその依存(`@livekit/protocol`、間接依存の`camelcase-keys`系)のみに限定されていることを確認済み
- `src/api/avatar/livekitTokenRoutes.ts` — `dispatchAgentToRoom()`の`createDispatch(roomName, "rajiuce-avatar")`呼び出しに`{ restartPolicy: JobRestartPolicy.JRP_ON_FAILURE }`を追加。import文以外は他の箇所は無変更
- `src/api/avatar/livekitTokenRoutes.test.ts` — `jest.mock("livekit-server-sdk")`に`JobRestartPolicy`のモックを追加(追加しないと`JobRestartPolicy.JRP_ON_FAILURE`がundefinedエラーになる)。既存のdispatchテストに`restartPolicy`アサーションを追加、既存30ケースは無変更のまま全パス

## やっていないこと(要求外)
- 2.17.0の`LiveKitAPI`統合クライアントへの移行
- `generateLiveKitToken`のハンドロールJWTを`AccessToken`に置換すること(動機がない、公式のexplicit dispatchを維持)
- token roomConfigディスパッチへの変更(公式はexplicit dispatchを本番推奨、現行が正しい)

## Gate結果
- Gate 1 `pnpm verify`: typecheck / lint(0 errors) / jest 226 suites 3263 tests(livekitTokenRoutes.test.ts 31 tests含む)全パス / admin-ui build成功
- Gate 2 `security-scan.sh`: PASS (CRITICAL/HIGH=0)
- Gate 3 `pnpm build && cd admin-ui && pnpm build`: 成功

## Tier
`src/**`に触れるためTier S = high-risk。**手動merge必須**（auto-merge対象外）。

## Asana
https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217083773150035