### PR TITLE
fix(widget): closePanel の disconnect を除去し、パネルを閉じてもアバターを維持する

### DIFF
--- a/public/widget.js
+++ b/public/widget.js
@@ -2263,23 +2263,9 @@
     _fabRestored = true; // 以降の非同期resetFabIcon呼び出しをブロック
     emitToHost('widget:closed', {});
     capturePostHog('widget_closed', {});
-    // LiveKit Room を切断（次回開閉時に新規接続で安定化）。
-    // disconnect() は非同期なので、完了前に __rajiuceRoom を null化しても
-    // 次の connectLiveKit() が正しく待てるよう window.__rajiuceRoomDisconnecting に
-    // Promise を残しておく（GID: パネル高速開閉時のreconnect race fix）。
-    if (window.__rajiuceRoom) {
-      var _closingRoom = window.__rajiuceRoom;
-      window.__rajiuceRoom = null;
-      try {
-        _intentionalDisconnect = true;
-        var _closeDp = _closingRoom.disconnect();
-        window.__rajiuceRoomDisconnecting = (_closeDp && typeof _closeDp.then === 'function')
-          ? _closeDp.catch(function () {})
-          : Promise.resolve();
-      } catch (_e) {
-        window.__rajiuceRoomDisconnecting = Promise.resolve();
-      }
-    }
+    // PiP常駐: LiveKit Room はここでは切断しない。パネルを閉じてもFABでアバター
+    // 映像を表示し続け、再度開いた時に接続待ち(1〜3秒)なしで再開できるようにする
+    // （真の終了経路は cleanupLiveKit() — beforeunload / FaqWidget.destroy()）。
     // アバターUI要素を同期的にクリーンアップ
     // （Disconnected イベントは非同期のため、ここで先に削除しておく）
     var _cpClose = avatarArea.querySelectorAll('.avatar-close-btn');

--- a/tests/e2e/widget-fab-avatar.spec.ts
+++ b/tests/e2e/widget-fab-avatar.spec.ts
@@ -141,6 +141,55 @@ test.describe('Widget FAB — Avatar persistence on chat open/close', () => {
     }
   });
 
+  test('PiP: closePanel() no longer disconnects window.__rajiuceRoom', async ({ page }) => {
+    // 回帰ガード: closePanel() が LiveKit Room を切断する実装に戻っていないことを検証する。
+    // window.__rajiuceRoom は connectLiveKit() 実行時に room.connect() の成否を待たず
+    // 同期的に設定される(widget.js: window.__rajiuceRoom = room)ため、
+    // モックのLiveKit URL(wss://e2e-mock.invalid、実際には接続できない)でも
+    // 「closePanelがnull化するかどうか」だけは確認できる。
+    await mockAvatarBackend(page);
+    const resp = await page.goto(AVATAR_DEMO_URL);
+    expect(resp?.status()).toBe(200);
+
+    await page.waitForFunction(
+      () => {
+        const host = document.getElementById('faq-chat-widget-host') as HTMLElement | null;
+        return !!host?.shadowRoot?.querySelector('.fab');
+      },
+      { timeout: 8000 }
+    );
+    await page.waitForTimeout(3000);
+
+    const fabInitial = await getFabState(page);
+    if (!fabInitial || !(fabInitial.hasImg || fabInitial.hasVideo)) {
+      test.skip(); // No avatar configured — connectLiveKit() が走らないため対象外
+      return;
+    }
+
+    // パネルを開く(connectLiveKit()がwindow.__rajiuceRoomを同期的にセットする)
+    await page.evaluate(() => {
+      const host = document.getElementById('faq-chat-widget-host') as HTMLElement | null;
+      host?.shadowRoot?.querySelector<HTMLButtonElement>('.fab')?.click();
+    });
+    await page.waitForTimeout(500);
+
+    const roomAfterOpen = await page.evaluate(() => !!(window as any).__rajiuceRoom);
+    if (!roomAfterOpen) {
+      test.skip(); // このページ/実行環境ではRoomが生成されなかった
+      return;
+    }
+
+    // パネルを閉じる
+    await page.evaluate(() => {
+      const host = document.getElementById('faq-chat-widget-host') as HTMLElement | null;
+      host?.shadowRoot?.querySelector<HTMLButtonElement>('.close-btn')?.click();
+    });
+    await page.waitForTimeout(500);
+
+    const roomAfterClose = await page.evaluate(() => !!(window as any).__rajiuceRoom);
+    expect(roomAfterClose).toBe(true); // PiP: 閉じてもRoomは保持される(nullにならない)
+  });
+
   test('FAB shows chat SVG icon for non-avatar tenant (demo page without avatar)', async ({ page }) => {
     // NON_AVATAR_DEMO_URL 未指定時は AVATAR_DEMO_URL(アバター設定済み実ページ)にフォールバックする。
     // その場合のみモックが必要 — 真の非アバターテナントは backend 側で avatarEnabled=false により


### PR DESCRIPTION
## Summary
- パネルを閉じるたびにLiveKit Roomが切断され、再度開くと1〜3秒の再接続待ちが発生していた
- `closePanel()`の disconnect ブロックを削除し、Roomを保持したままFABでアバター映像を表示し続ける(PiP常駐)ようにする
- 受け皿となる`openPanel()`の「Room接続中ならavatarAreaを再表示するだけ」の分岐、`connectLiveKit()`のreuse-guard、`cleanupLiveKit()`(beforeunload / `FaqWidget.destroy()`から呼ばれる真の終了経路)はいずれも既存のまま変更しない

## ⚠️ 単体でマージ・デプロイしないこと
Roomを保持し続けると**LemonSlice/LiveKitのセッション課金が走り続けます**。`collapseAvatarLargeView()`はCSSクラスを外すだけで切断しないため、現状closePanelが唯一の課金停止契機です。この disconnect を外すと、ページを開いている限り課金され続ける状態になります。

→ [PiP 2/2] terminate / reset-idle-timeout でコスト制御(GID 1217083779036278)と**セットでリリース**してください。

## Test plan
- [x] `tests/e2e/widget-fab-avatar.spec.ts`に回帰テストを1件追加。`window.__rajiuceRoom`が`connectLiveKit()`実行時に同期的に設定される特性を使い、`closePanel()`後もnull化されず保持されることを検証(モックのLiveKit URLでも「切断呼び出しの有無」だけは確認できる、page.routeで本番課金APIをモック)
- [x] `npx playwright test --list` でテストが正しく認識されることを確認(ネットワーク依存のためこの環境では実行はしていません)
- [x] `pnpm typecheck` / `pnpm lint` パス

Asana: https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217083772373782

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xq3XPSpwhHBTrNyoJMhvoa