### PR TITLE
feat: PiP常駐のコスト制御に terminate / reset-idle-timeout を使う

### DIFF
--- a/avatar-agent/agent.py
+++ b/avatar-agent/agent.py
@@ -611,6 +611,11 @@ async def entrypoint(ctx: agents.JobContext) -> None:
             elif msg_type == "widget_connected":
                 logger.info("[data_channel] widget_connected received")
                 # 挨拶は AgentSession が自動的に行うため、手動呼び出し不要
+            elif msg_type == "pip_heartbeat":
+                # PiP常駐: パネルを閉じている間、widget側が定期的に送るハートビート。
+                # LemonSlice側の idle_timeout(300秒)より短い周期で reset-idle-timeout を
+                # 送ることで、PiP表示中にアバターが途中で固まるのを防ぐ(fire-and-forget)。
+                asyncio.create_task(control_lemonslice("reset-idle-timeout"))
         except Exception as e:
             logger.warning(f"[data_channel] parse error: {e}")
 

--- a/public/widget.js
+++ b/public/widget.js
@@ -1064,6 +1064,18 @@
   var avatarInactivityTimer = null;
   var AVATAR_INACTIVITY_MS = 33000; // 大表示非アクティブタイムアウト（33秒）
 
+  // PiP常駐（パネルを閉じてもRoomを保持する）中のコスト制御。
+  // - ハートビート: パネルが閉じている間、LemonSlice側の idle_timeout(300秒、agent.py側で設定)
+  //   より短い周期で reset-idle-timeout を送り、PiP表示中に途中でアバターが固まるのを防ぐ。
+  // - アイドル切断: それでも一定時間パネルが開かれなければ、Roomごと切断してLemonSlice課金を
+  //   確実に止める（terminateはRoomを維持したままアバターだけ止めるため、再開時に新しい
+  //   AvatarSessionを作り直す手段がなく、映像が戻らないまま固まる。それよりRoomごと切断し、
+  //   既存のconnectLiveKit()の再接続経路にそのまま乗せる方が安全）。
+  var pipHeartbeatTimer = null;
+  var pipIdleDisconnectTimer = null;
+  var PIP_HEARTBEAT_MS = 60000;          // 1分ごとに reset-idle-timeout
+  var PIP_IDLE_DISCONNECT_MS = 300000;   // 5分間パネルが閉じたままなら切断
+
   var conversationId = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
     var r = Math.random() * 16 | 0;
     var v = c === 'x' ? r : (r & 0x3 | 0x8);
@@ -2038,8 +2050,8 @@
   }
 
   function cleanupLiveKit() {
-    // 明示的な完全終了用（ページ離脱・SPA再注入前のdestroy()など）
-    // 通常の closePanel() では呼ばない — Room は切断せず保持する
+    // 明示的な完全終了用（ページ離脱・SPA再注入前のdestroy()、PiPアイドル切断など）
+    // 通常の closePanel() 直後には呼ばない — Room は切断せず保持する（PiP常駐）
     try {
       if (window.__rajiuceRoom) {
         var _cleanupRoom = window.__rajiuceRoom;
@@ -2064,6 +2076,44 @@
     fabMediaContainer = null;
     removeAvatarPlaceholder(); // data-avatar-mode="animated" 用の静止画/絵文字要素と avatarPlaceholderImg もリセット
     resetFabIcon();
+  }
+
+  /** PiP常駐中のハートビート送信。agent側で reset-idle-timeout を発火させる。 */
+  function sendPipHeartbeat() {
+    var room = window.__rajiuceRoom;
+    if (!room || room.state !== 'connected' || !room.localParticipant) return;
+    try {
+      var encoder = new TextEncoder();
+      var payload = encoder.encode(JSON.stringify({ type: 'pip_heartbeat' }));
+      var promise = room.localParticipant.publishData(payload, { reliable: true });
+      if (promise && typeof promise.catch === 'function') {
+        promise.catch(function (err) { console.warn('[FAQ Widget] pip_heartbeat publishData rejected:', err && (err.message || err)); });
+      }
+    } catch (e) {
+      console.warn('[FAQ Widget] pip_heartbeat send error:', e && (e.message || e));
+    }
+  }
+
+  /** PiP常駐（パネルを閉じてもRoomを保持する）タイマーを開始する。closePanel()から呼ぶ。 */
+  function startPipTimers() {
+    if (!window.__rajiuceRoom) return; // アバター無効時は何もしない
+    if (!pipHeartbeatTimer) {
+      pipHeartbeatTimer = setInterval(sendPipHeartbeat, PIP_HEARTBEAT_MS);
+    }
+    if (!pipIdleDisconnectTimer) {
+      pipIdleDisconnectTimer = setTimeout(function () {
+        pipIdleDisconnectTimer = null;
+        // PIP_IDLE_DISCONNECT_MS 経過してもまだパネルが閉じたままの場合のみ切断する
+        // （タイマー発火とほぼ同時にユーザーが再度パネルを開いた場合は何もしない）。
+        if (!isOpen) { cleanupLiveKit(); }
+      }, PIP_IDLE_DISCONNECT_MS);
+    }
+  }
+
+  /** PiP常駐タイマーを停止する。openPanel()から呼ぶ。 */
+  function stopPipTimers() {
+    if (pipHeartbeatTimer) { clearInterval(pipHeartbeatTimer); pipHeartbeatTimer = null; }
+    if (pipIdleDisconnectTimer) { clearTimeout(pipIdleDisconnectTimer); pipIdleDisconnectTimer = null; }
   }
 
   function renderMessages() {
@@ -2173,6 +2223,7 @@
     _fabRestored = false;
     dismissProactiveBubble();
     isOpen = true;
+    stopPipTimers(); // PiP常駐: 再開したのでハートビート/アイドル切断タイマーを止める
     panel.classList.add('open');
     panel.setAttribute('aria-hidden', 'false');
     fab.setAttribute('aria-label', 'チャットを閉じる');
@@ -2264,8 +2315,10 @@
     emitToHost('widget:closed', {});
     capturePostHog('widget_closed', {});
     // PiP常駐: LiveKit Room はここでは切断しない。パネルを閉じてもFABでアバター
-    // 映像を表示し続け、再度開いた時に接続待ち(1〜3秒)なしで再開できるようにする
-    // （真の終了経路は cleanupLiveKit() — beforeunload / FaqWidget.destroy()）。
+    // 映像を表示し続け、再度開いた時に接続待ち(1〜3秒)なしで再開できるようにする。
+    // ただし保持し続けるとLemonSlice/LiveKitのセッション課金が走り続けるため、
+    // ハートビート/アイドル切断タイマーを起動する(コスト制御。詳細は各関数コメント参照)。
+    startPipTimers();
     // アバターUI要素を同期的にクリーンアップ
     // （Disconnected イベントは非同期のため、ここで先に削除しておく）
     var _cpClose = avatarArea.querySelectorAll('.avatar-close-btn');


### PR DESCRIPTION
## ⚠️ このPRは #706 ([PiP 1/2])の上に積んだスタックPRです
base branch を `feature/1217083772373782-pip-avatar-persist-close-panel`(#706)に設定しています。#706がマージされたら、このPRのbaseは自動的にmainへ付け替わります(または本PRをmainベースで作り直してください)。単体では意味を持たない変更です。

## Summary
[PiP 1/2](#706, closePanelのdisconnect除去)によりパネルを閉じてもLiveKit Roomが維持されるようになったが、それだけでは開いたままのタブでLemonSlice/LiveKitのセッション課金が無期限に走り続ける懸念があった。

- `public/widget.js`: パネルを閉じている間、1分ごとにDataChannel経由で`pip_heartbeat`を送る。5分間パネルが閉じたままなら、既存の`cleanupLiveKit()`(beforeunload / destroy()と同じ完全切断経路)でRoomごと切断し課金を確実に止める
- `avatar-agent/agent.py`: `pip_heartbeat`受信時に`control_lemonslice("reset-idle-timeout")`を発火し、LemonSlice側の`idle_timeout`(300秒)より早くPiP表示中のアバターが固まるのを防ぐ

## terminateイベントを使わなかった理由
LemonSlice Control APIの`terminate`は「LiveKit Roomは維持したままアバターだけ終了する」設計だが、6種のイベントに「アバターを再開する」ものが無く、一度terminateすると同じRoom上でアバター映像を復活させる手段が無い(Python側で`AvatarSession.start()`を再実行するには構造変更が必要で、今回のセッションでは検証できない領域)。中途半端に片方だけ止めた状態を残すより、確立済みの完全切断(`cleanupLiveKit`)を使う方が安全と判断した。再開時は既存の`connectLiveKit()`の新規接続経路にそのまま乗る。

## Test plan
- [x] `pnpm typecheck` / `pnpm lint` パス
- [x] `avatar-agent`: `python -c "import agent"` でimportエラーなし(scratch venv)
- [ ] 5分間のアイドル切断はPlaywrightのクロック仮想化がwidget全体の他タイマー(proactive bubble等)にも影響しうるためE2Eでは検証していない。コードレビューと**デプロイ後の手動確認**で担保する(#706と同様の運用)

Asana: https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217083779036278

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xq3XPSpwhHBTrNyoJMhvoa