### PR TITLE
ASR原価を実測秒数化し、multer上限をFish Audio公式の20MBに是正

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -262,7 +262,7 @@ Data Flow の変更点: Widget が `tts_request` に `productCard` を同乗さ�
 
 Web Speech API の代替として Fish Audio の音声認識 API を導入。Firefox 非対応・ネットワーク依存の問題を解消。
 
-- エンドポイント: `POST /api/voice/asr`（multipart `audio`、最大 25MB）
+- エンドポイント: `POST /api/voice/asr`（multipart `audio`、最大 20MB — Fish Audio公式ASR上限に合わせる）
 - 実装: `src/api/avatar/fishAsrRoutes.ts`
 - `language: "ja"`, `ignore_timestamps: true` 固定
 - Widget の音声入力フローを Web Speech API から本エンドポイントへ完全置換

--- a/docs/FISH_AUDIO_VOICE_CLONING.md
+++ b/docs/FISH_AUDIO_VOICE_CLONING.md
@@ -122,7 +122,7 @@ Web Speech API の代替として Fish Audio の音声認識 API を使用。ブ
 **リクエスト**: `multipart/form-data`
 | フィールド | 説明 |
 |---|---|
-| `audio` | 音声ファイル（audio/* MIME、最大 25MB） |
+| `audio` | 音声ファイル（audio/* MIME、最大 20MB — Fish Audio公式ASR上限に合わせる） |
 
 **レスポンス**:
 ```json

--- a/src/api/avatar/fishAsrRoutes.test.ts
+++ b/src/api/avatar/fishAsrRoutes.test.ts
@@ -35,6 +35,35 @@ function mockFishAsrOk(text = 'こんにちは') {
   });
 }
 
+// GID 1217083837550916: 44.1kHz/16bit/モノラルの最小WAVバッファ（parseWavDurationSeconds が
+// 実測できる形式）。dataBytes=44100 は byteRate=88200 に対して 0.5 秒に相当する。
+function buildWavBuffer(dataBytes = 44100): Buffer {
+  const sampleRate = 44100;
+  const numChannels = 1;
+  const bitsPerSample = 16;
+  const byteRate = sampleRate * numChannels * (bitsPerSample / 8);
+  const blockAlign = numChannels * (bitsPerSample / 8);
+  const fmtChunkSize = 16;
+  const riffChunkSize = 4 + (8 + fmtChunkSize) + (8 + dataBytes);
+
+  const buf = Buffer.alloc(12 + 8 + fmtChunkSize + 8 + dataBytes);
+  let o = 0;
+  buf.write('RIFF', o); o += 4;
+  buf.writeUInt32LE(riffChunkSize, o); o += 4;
+  buf.write('WAVE', o); o += 4;
+  buf.write('fmt ', o); o += 4;
+  buf.writeUInt32LE(fmtChunkSize, o); o += 4;
+  buf.writeUInt16LE(1, o); o += 2;
+  buf.writeUInt16LE(numChannels, o); o += 2;
+  buf.writeUInt32LE(sampleRate, o); o += 4;
+  buf.writeUInt32LE(byteRate, o); o += 4;
+  buf.writeUInt16LE(blockAlign, o); o += 2;
+  buf.writeUInt16LE(bitsPerSample, o); o += 2;
+  buf.write('data', o); o += 4;
+  buf.writeUInt32LE(dataBytes, o); o += 4;
+  return buf;
+}
+
 describe('POST /api/voice/asr', () => {
   let savedEnv: NodeJS.ProcessEnv;
 
@@ -109,6 +138,49 @@ describe('POST /api/voice/asr', () => {
       .attach('audio', Buffer.from('fake-audio-bytes'), { filename: 'test.webm', contentType: 'audio/webm' });
 
     expect(res.status).toBe(503);
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
+
+  it('GID 1217083837550916: WAVで実測できる場合はasrAudioSecondsを計上し、asrRequestCountは渡さない（二重計上防止）', async () => {
+    mockFishAsrOk('テスト音声のテキスト');
+
+    const res = await request(makeApp('tenant-a'))
+      .post('/api/voice/asr')
+      .attach('audio', buildWavBuffer(44100), { filename: 'test.wav', contentType: 'audio/wav' });
+
+    expect(res.status).toBe(200);
+    expect(mockTrackUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ asrAudioSeconds: 0.5 }),
+    );
+    const call = mockTrackUsage.mock.calls[0][0];
+    expect('asrRequestCount' in call).toBe(false);
+  });
+
+  it('GID 1217083837550916: 実測できない音声（非WAV等）はasrRequestCount:1にフォールバックする', async () => {
+    mockFishAsrOk();
+
+    const res = await request(makeApp('tenant-a'))
+      .post('/api/voice/asr')
+      .attach('audio', Buffer.from('not-a-wav-file'), { filename: 'test.webm', contentType: 'audio/webm' });
+
+    expect(res.status).toBe(200);
+    expect(mockTrackUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ asrRequestCount: 1 }),
+    );
+    const call = mockTrackUsage.mock.calls[0][0];
+    expect('asrAudioSeconds' in call).toBe(false);
+  });
+
+  it('GID 1217083837550916: 20MB超過の録音は400で親切な日本語メッセージを返し、trackUsageを呼ばない', async () => {
+    const oversized = Buffer.alloc(20 * 1024 * 1024 + 1);
+
+    const res = await request(makeApp('tenant-a'))
+      .post('/api/voice/asr')
+      .attach('audio', oversized, { filename: 'test.webm', contentType: 'audio/webm' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('20MB');
+    expect(mockFetch).not.toHaveBeenCalled();
     expect(mockTrackUsage).not.toHaveBeenCalled();
   });
 });

--- a/src/api/avatar/fishAsrRoutes.ts
+++ b/src/api/avatar/fishAsrRoutes.ts
@@ -1,20 +1,21 @@
 // POST /api/voice/asr
-//   body: multipart/form-data, field "audio" (audio blob, max 25MB)
+//   body: multipart/form-data, field "audio" (audio blob, max 20MB — Fish Audio公式ASR上限に合わせる)
 //   認証: apiStack
 //   Fish Audio Transcribe-1 ASR → { text: string }
 
 import crypto from 'node:crypto';
 import multer from 'multer';
-import type { Express, Request, Response, RequestHandler } from 'express';
+import type { Express, NextFunction, Request, Response, RequestHandler } from 'express';
 import type { AuthedRequest } from '../../agent/http/authMiddleware';
 import { logger } from '../../lib/logger';
 import { trackUsage } from '../../lib/billing/usageTracker';
+import { parseWavDurationSeconds } from '../../lib/audio/wavDuration';
 
 const FISH_ASR_API = 'https://api.fish.audio/v1/asr';
 
 const audioUpload = multer({
   storage: multer.memoryStorage(),
-  limits: { fileSize: 25 * 1024 * 1024 },
+  limits: { fileSize: 20 * 1024 * 1024 },
   fileFilter: (_req, file, cb) => {
     if (/^audio\//i.test(file.mimetype)) {
       cb(null, true);
@@ -24,6 +25,20 @@ const audioUpload = multer({
   },
 });
 
+// GID 1217083837550916: multer のファイルサイズ超過はデフォルトのExpressエラー処理に落ちると
+// 技術的な文言になるため、ここで親切な日本語メッセージに変換する。
+// Express は err.length===3 の通常ミドルウェアと err.length===4 のエラーハンドラを
+// 同一ルートのスタック内でも区別するため、single()の直後に置けば失敗時のみ呼ばれる。
+function handleAsrUploadError(err: unknown, _req: Request, res: Response, next: NextFunction): void {
+  if (err instanceof multer.MulterError && err.code === 'LIMIT_FILE_SIZE') {
+    res.status(400).json({
+      error: '録音が長すぎます。20MB以内に収まるよう、もう一度短く録音してお試しください。',
+    });
+    return;
+  }
+  next(err);
+}
+
 export function registerFishAsrRoutes(app: Express, apiStack: RequestHandler[]): void {
   logger.info('[fishAsr] POST /api/voice/asr registered');
 
@@ -31,6 +46,7 @@ export function registerFishAsrRoutes(app: Express, apiStack: RequestHandler[]):
     '/api/voice/asr',
     ...apiStack,
     audioUpload.single('audio'),
+    handleAsrUploadError,
     async (req: Request, res: Response) => {
       const tenantId = (req as AuthedRequest).tenantId;
       if (!tenantId) {
@@ -45,6 +61,11 @@ export function registerFishAsrRoutes(app: Express, apiStack: RequestHandler[]):
       if (!fishApiKey) {
         return res.status(503).json({ error: 'ASR not configured' });
       }
+
+      // GID 1217083837550916: widgetは_blobToWav()でWAV化してから送るため、
+      // ここで実測秒数を算出できれば公式単価($0.36/audio hour)で正確に計上できる。
+      // WAV以外/解析不能な場合のみ従来のリクエスト単位の概算値にフォールバックする。
+      const durationSeconds = parseWavDurationSeconds(req.file.buffer);
 
       try {
         const fd = new FormData();
@@ -83,7 +104,9 @@ export function registerFishAsrRoutes(app: Express, apiStack: RequestHandler[]):
           inputTokens: 0,
           outputTokens: 0,
           featureUsed: 'voice',
-          asrRequestCount: 1,
+          ...(durationSeconds !== null
+            ? { asrAudioSeconds: durationSeconds }
+            : { asrRequestCount: 1 }),
         });
 
         return res.json({ text });

--- a/src/lib/audio/wavDuration.test.ts
+++ b/src/lib/audio/wavDuration.test.ts
@@ -1,0 +1,65 @@
+// src/lib/audio/wavDuration.test.ts
+
+import { parseWavDurationSeconds } from './wavDuration';
+
+function buildWavBuffer({
+  sampleRate = 44100,
+  numChannels = 1,
+  bitsPerSample = 16,
+  dataBytes = 88200,
+}: Partial<{
+  sampleRate: number;
+  numChannels: number;
+  bitsPerSample: number;
+  dataBytes: number;
+}> = {}): Buffer {
+  const byteRate = sampleRate * numChannels * (bitsPerSample / 8);
+  const blockAlign = numChannels * (bitsPerSample / 8);
+  const fmtChunkSize = 16;
+  const dataChunkSize = dataBytes;
+  const riffChunkSize = 4 + (8 + fmtChunkSize) + (8 + dataChunkSize);
+
+  const buf = Buffer.alloc(12 + 8 + fmtChunkSize + 8 + dataChunkSize);
+  let o = 0;
+  buf.write('RIFF', o); o += 4;
+  buf.writeUInt32LE(riffChunkSize, o); o += 4;
+  buf.write('WAVE', o); o += 4;
+  buf.write('fmt ', o); o += 4;
+  buf.writeUInt32LE(fmtChunkSize, o); o += 4;
+  buf.writeUInt16LE(1, o); o += 2; // PCM
+  buf.writeUInt16LE(numChannels, o); o += 2;
+  buf.writeUInt32LE(sampleRate, o); o += 4;
+  buf.writeUInt32LE(byteRate, o); o += 4;
+  buf.writeUInt16LE(blockAlign, o); o += 2;
+  buf.writeUInt16LE(bitsPerSample, o); o += 2;
+  buf.write('data', o); o += 4;
+  buf.writeUInt32LE(dataChunkSize, o); o += 4;
+  return buf;
+}
+
+describe('parseWavDurationSeconds', () => {
+  it('正常WAV: 44.1kHz/16bit/モノラルで88200バイト(=1秒分)のdataは1.0秒を返す', () => {
+    const buf = buildWavBuffer({ dataBytes: 88200 });
+    expect(parseWavDurationSeconds(buf)).toBeCloseTo(1.0);
+  });
+
+  it('正常WAV: 半分のバイト数(44100)は0.5秒を返す', () => {
+    const buf = buildWavBuffer({ dataBytes: 44100 });
+    expect(parseWavDurationSeconds(buf)).toBeCloseTo(0.5);
+  });
+
+  it('ヘッダ欠損: fmtチャンクが途中で切れている場合は null を返す', () => {
+    const full = buildWavBuffer({ dataBytes: 1000 });
+    const truncated = full.subarray(0, 20); // "fmt " チャンクの途中で切る
+    expect(parseWavDurationSeconds(truncated)).toBeNull();
+  });
+
+  it('非WAVバイト列: RIFF/WAVEマーカーがない場合は null を返す', () => {
+    const notWav = Buffer.from('this is not a wav file at all, just random text bytes');
+    expect(parseWavDurationSeconds(notWav)).toBeNull();
+  });
+
+  it('0バイト: 空バッファは null を返す', () => {
+    expect(parseWavDurationSeconds(Buffer.alloc(0))).toBeNull();
+  });
+});

--- a/src/lib/audio/wavDuration.ts
+++ b/src/lib/audio/wavDuration.ts
@@ -1,0 +1,41 @@
+// GID 1217083837550916: Fish Audio ASRの原価をリクエスト単位の概算値ではなく
+// 実際の録音秒数で計上するため、アップロードされたWAVバイト列から再生時間を算出する。
+
+const RIFF_HEADER_SIZE = 12; // "RIFF" + size(4) + "WAVE"
+const CHUNK_HEADER_SIZE = 8; // chunkId(4) + chunkSize(4)
+
+/**
+ * WAVファイルのヘッダを解析して再生時間(秒)を返す。
+ * 壊れたヘッダ・非WAVバイト列・fmt/dataチャンク欠損時は例外を投げず null を返す。
+ */
+export function parseWavDurationSeconds(buf: Buffer): number | null {
+  if (buf.length < RIFF_HEADER_SIZE) return null;
+  if (buf.toString('ascii', 0, 4) !== 'RIFF') return null;
+  if (buf.toString('ascii', 8, 12) !== 'WAVE') return null;
+
+  let offset = RIFF_HEADER_SIZE;
+  let byteRate: number | null = null;
+  let dataSize: number | null = null;
+
+  while (offset + CHUNK_HEADER_SIZE <= buf.length) {
+    const chunkId = buf.toString('ascii', offset, offset + 4);
+    const chunkSize = buf.readUInt32LE(offset + 4);
+    const chunkDataStart = offset + CHUNK_HEADER_SIZE;
+
+    if (chunkId === 'fmt ') {
+      if (chunkDataStart + 16 > buf.length) return null;
+      byteRate = buf.readUInt32LE(chunkDataStart + 8);
+    } else if (chunkId === 'data') {
+      // 宣言サイズが実データを超える壊れたヘッダは、実際に残っているバイト数に丸める
+      dataSize = Math.min(chunkSize, buf.length - chunkDataStart);
+    }
+
+    if (byteRate !== null && dataSize !== null) break;
+
+    // チャンクは偶数バイト境界にパディングされる
+    offset = chunkDataStart + chunkSize + (chunkSize % 2);
+  }
+
+  if (!byteRate || byteRate <= 0 || dataSize === null || dataSize < 0) return null;
+  return dataSize / byteRate;
+}

--- a/src/lib/billing/costCalculator.test.ts
+++ b/src/lib/billing/costCalculator.test.ts
@@ -17,6 +17,7 @@ import {
   END_USER_FEATURES,
   QWEN_OCR_COST_PER_PAGE_USD,
   FISH_ASR_COST_PER_REQUEST_USD,
+  FISH_ASR_COST_PER_HOUR_USD,
   MAGNIFIC_UPSCALE_COST_USD,
   FLUX_PRO_COST_PER_IMAGE_USD,
   LEMONSLICE_AVATAR_REGISTRATION_COST_USD,
@@ -710,6 +711,56 @@ describe('calculateBillingAmountCents: asrRequestCount（Fish Audio ASR）', () 
       featureUsed: 'voice', asrRequestCount: 1, marginOverride: 1,
     });
     expect(withDefaultMargin).toBeGreaterThan(atCost);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GID 1217083837550916: calculateBillingAmountCents: asrAudioSeconds（Fish Audio ASR秒数課金）
+// ---------------------------------------------------------------------------
+describe('calculateBillingAmountCents: asrAudioSeconds（Fish Audio ASR秒数課金）', () => {
+  it('FISH_ASR_COST_PER_HOUR_USD は公式単価$0.36/audio hour', () => {
+    expect(FISH_ASR_COST_PER_HOUR_USD).toBe(0.36);
+  });
+
+  it('asrAudioSeconds=0 は既存と同結果', () => {
+    const base = calculateBillingAmountCents({ model: 'fish-audio-asr', inputTokens: 0, outputTokens: 0 });
+    const withZero = calculateBillingAmountCents({
+      model: 'fish-audio-asr', inputTokens: 0, outputTokens: 0, asrAudioSeconds: 0,
+    });
+    expect(withZero).toBe(base);
+  });
+
+  it('asrAudioSeconds=3600(1時間): $0.36の1件分が加算される（voiceはMARGIN_MULTIPLIER×5適用）', () => {
+    // serverCost=0.0001, asrCost=ceil(3600)/3600*0.36=0.36 → total=0.3601 USD × margin5 = 1.8005 → Math.ceil(180.05) = 181 cents
+    const result = calculateBillingAmountCents({
+      model: 'fish-audio-asr', inputTokens: 0, outputTokens: 0,
+      featureUsed: 'voice', asrAudioSeconds: 3600,
+    });
+    expect(result).toBe(181);
+  });
+
+  it('秒未満は切り上げられる（0.4秒は1秒として課金される）', () => {
+    const fractional = calculateBillingAmountCents({
+      model: 'fish-audio-asr', inputTokens: 0, outputTokens: 0,
+      featureUsed: 'voice', asrAudioSeconds: 0.4,
+    });
+    const oneSecond = calculateBillingAmountCents({
+      model: 'fish-audio-asr', inputTokens: 0, outputTokens: 0,
+      featureUsed: 'voice', asrAudioSeconds: 1,
+    });
+    expect(fractional).toBe(oneSecond);
+  });
+
+  it('asrAudioSeconds指定時はasrRequestCountが同時にあっても二重計上されない（asrAudioSecondsを優先）', () => {
+    const secondsOnly = calculateBillingAmountCents({
+      model: 'fish-audio-asr', inputTokens: 0, outputTokens: 0,
+      featureUsed: 'voice', asrAudioSeconds: 3600,
+    });
+    const secondsAndRequestCount = calculateBillingAmountCents({
+      model: 'fish-audio-asr', inputTokens: 0, outputTokens: 0,
+      featureUsed: 'voice', asrAudioSeconds: 3600, asrRequestCount: 100,
+    });
+    expect(secondsAndRequestCount).toBe(secondsOnly);
   });
 });
 

--- a/src/lib/billing/costCalculator.ts
+++ b/src/lib/billing/costCalculator.ts
@@ -118,10 +118,16 @@ export const QWEN_OCR_COST_PER_PAGE_USD = Number(process.env.QWEN_OCR_COST_PER_P
 
 /**
  * Fish Audio ASR (Transcribe-1) 1リクエストあたりの原価見積もり(USD)。
- * ASR自体は音声長で変動しうるが、本APIは音声長を秒単位で計測していないため
- * リクエスト単位の概算値で暫定計上する(要検証)。
+ * 音声長(秒)を計測できない呼び出し元向けのフォールバック単価(要検証)。
+ * 音声長を計測できる場合は FISH_ASR_COST_PER_HOUR_USD（公式の実単価）を使う。
  */
 export const FISH_ASR_COST_PER_REQUEST_USD = Number(process.env.FISH_ASR_COST_PER_REQUEST_USD ?? '0.01') || 0.01;
+
+/**
+ * GID 1217083837550916: Fish Audio ASR (Transcribe-1) の公式単価: $0.36 / audio hour。
+ * 音声長(秒)を計測できる場合はこちらを使う（FISH_ASR_COST_PER_REQUEST_USD より正確）。
+ */
+export const FISH_ASR_COST_PER_HOUR_USD = Number(process.env.FISH_ASR_COST_PER_HOUR_USD ?? '0.36') || 0.36;
 
 /**
  * Freepik Magnific AI アップスケール1回あたりの原価見積もり(USD)。
@@ -179,8 +185,10 @@ export interface UsageRecord {
   saiAgentSteps?: number;
   /** GID 1216944049264977: Qwen OCRで処理したページ数 */
   ocrPages?: number;
-  /** GID 1216944049264977: Fish Audio ASR呼び出し回数（通常1リクエスト=1) */
+  /** GID 1216944049264977: Fish Audio ASR呼び出し回数（通常1リクエスト=1)。asrAudioSeconds未指定時のフォールバックのみに使う */
   asrRequestCount?: number;
+  /** GID 1217083837550916: Fish Audio ASRの実測音声長(秒)。指定時はこちらを優先し asrRequestCount とは二重計上しない */
+  asrAudioSeconds?: number;
   /** GID 1216944049264977: Magnificアップスケール実行回数 */
   magnificUpscaleCount?: number;
   /** GID 1216944049264977: Flux 2 Pro 画像生成枚数 */
@@ -312,7 +320,11 @@ export function calculateBillingAmountCents(usage: UsageRecord): number {
   const saiUSD   = (usage.saiAgentSteps ?? 0) * SAI_AGENT_COST_PER_STEP_USD;
   // GID 1216944049264977: これまでtrackUsage対象外だった外部API課金経路。
   const ocrUSD      = (usage.ocrPages ?? 0) * QWEN_OCR_COST_PER_PAGE_USD;
-  const asrUSD       = (usage.asrRequestCount ?? 0) * FISH_ASR_COST_PER_REQUEST_USD;
+  // GID 1217083837550916: 音声長(秒)が分かればそちらを優先(公式単価$0.36/hour、秒切り上げ)。
+  // 分からない場合のみ従来のリクエスト単位の概算値にフォールバックする。両方を足さない。
+  const asrUSD       = usage.asrAudioSeconds !== undefined
+    ? (Math.ceil(usage.asrAudioSeconds) / 3600) * FISH_ASR_COST_PER_HOUR_USD
+    : (usage.asrRequestCount ?? 0) * FISH_ASR_COST_PER_REQUEST_USD;
   const magnificUSD  = (usage.magnificUpscaleCount ?? 0) * MAGNIFIC_UPSCALE_COST_USD;
   const fluxUSD      = (usage.fluxImageCount ?? 0) * FLUX_PRO_COST_PER_IMAGE_USD;
   const lemonRegUSD  = (usage.lemonsliceRegistrationCount ?? 0) * LEMONSLICE_AVATAR_REGISTRATION_COST_USD;

--- a/src/lib/billing/usageTracker.ts
+++ b/src/lib/billing/usageTracker.ts
@@ -42,8 +42,10 @@ export interface TrackUsageParams {
   saiAgentSteps?: number;
   /** GID 1216944049264977: Qwen OCRで処理したページ数 */
   ocrPages?: number;
-  /** GID 1216944049264977: Fish Audio ASR呼び出し回数（通常1リクエスト=1) */
+  /** GID 1216944049264977: Fish Audio ASR呼び出し回数（通常1リクエスト=1)。asrAudioSeconds未指定時のフォールバックのみに使う */
   asrRequestCount?: number;
+  /** GID 1217083837550916: Fish Audio ASRの実測音声長(秒)。原価計算にのみ使う。DB列は追加しない */
+  asrAudioSeconds?: number;
   /** GID 1216944049264977: Magnificアップスケール実行回数 */
   magnificUpscaleCount?: number;
   /** GID 1216944049264977: Flux 2 Pro 画像生成枚数 */
@@ -87,7 +89,7 @@ async function _insertUsageLog(params: TrackUsageParams): Promise<void> {
     tenantId, requestId, model, inputTokens, outputTokens,
     featureUsed, marginOverride, ttsTextBytes, ttsModel, avatarCredits, avatarSessionMs, imageCount,
     anam_session_seconds, extraLlmUsages, saiAgentSteps,
-    ocrPages, asrRequestCount, magnificUpscaleCount, fluxImageCount, lemonsliceRegistrationCount,
+    ocrPages, asrRequestCount, asrAudioSeconds, magnificUpscaleCount, fluxImageCount, lemonsliceRegistrationCount,
     billable,
   } = params;
 
@@ -115,7 +117,7 @@ async function _insertUsageLog(params: TrackUsageParams): Promise<void> {
       model, inputTokens, outputTokens, marginOverride,
       ttsTextBytes, ttsModel, avatarCredits, avatarSessionMs,
       featureUsed, imageCount, anam_session_seconds, extraLlmUsages, saiAgentSteps,
-      ocrPages, asrRequestCount, magnificUpscaleCount, fluxImageCount, lemonsliceRegistrationCount,
+      ocrPages, asrRequestCount, asrAudioSeconds, magnificUpscaleCount, fluxImageCount, lemonsliceRegistrationCount,
     });
   } catch (err) {
     _logger?.warn({ err, requestId }, '[usageTracker] cost calculation error, defaulting to 0');


### PR DESCRIPTION
## Summary
- Fish Audio ASRの原価計上を固定$0.01/reqから公式単価$0.36/audio hour（秒切り上げ）の実測課金に変更。短尺(5-15秒)で6-20倍の過大計上、長尺(最大60分)で最大36倍の過小計上になっていた問題を是正
- WAVバイト列から再生時間を算出する`src/lib/audio/wavDuration.ts`を新設（純関数、副作用なし）。widgetは録音済み音声を`_blobToWav()`でWAV化してから送るためサーバ側だけで正確に測れる。widget.js側の変更は不要
- 実測できない場合（非WAV等）のみ従来のリクエスト単位フォールバック（`asrRequestCount: 1`）を維持。両方は同時計上しない
- multerのアップロード上限をFish Audio公式ASRの上限20MBに是正（従来25MBはR2Cを通過してFish側で弾かれる非対称があった）。超過時は親切な日本語メッセージ
- DB migrationなし（`asrAudioSeconds`は原価計算専用、`usage_logs`のINSERT列は不変）

## ⚠️ Base branch について
このPRは #700 (`feature/1217083837550852-fish-tts-model-env`, PR-0) の上に積んでいます。
`costCalculator.ts` / `usageTracker.ts` を共有するため直列が必要（Asana記載の前提どおり）。
**#700がmainにマージされてから、このPRのbaseをmainへ変更してマージしてください。**

## Asana
子タスク: https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217083837550916
親: https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217083837119126

## Test plan
- [x] pnpm typecheck: 0 errors
- [x] pnpm lint: 0 new warnings（59件、閾値63)
- [x] pnpm test: 3286 tests pass（既存の無関係な1テストが並列実行環境で断続的にflakyになる既知事象。#700で既にorigin/mainベースラインでも同一頻度で再現することを確認済み）
- [x] Gate 1.5 dead-code-check: 新規dead exportsなし（wavDuration.tsの新規exportは消費されている）
- [x] Gate 2 security-scan: CRITICAL/HIGH 0
- [x] Gate 3 build: 0 errors（admin-ui未変更のため対象外）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdBRSsTu4YNWBDTpgzqz2c