### PR TITLE
refactor(avatar-agent): 自前FishAudioTTSを公式プラグインに置換し、課金を speak() へ移設する

### DIFF
--- a/avatar-agent/agent.py
+++ b/avatar-agent/agent.py
@@ -28,9 +28,9 @@ import time
 import aiohttp
 from livekit import agents, rtc
 from livekit.agents import Agent, AgentSession
-from livekit.agents import tts as agents_tts
-from livekit.agents.types import DEFAULT_API_CONNECT_OPTIONS, APIConnectOptions
+from livekit.agents.types import NOT_GIVEN
 from livekit.agents.voice import SpeechHandle
+from livekit.plugins import fishaudio
 from livekit.plugins import lemonslice
 from livekit.plugins import openai as openai_plugin
 from emotion_tags import sales_flow_emotion_prefix
@@ -297,130 +297,6 @@ async def _report_avatar_usage(tenant_id: str, session_ms: int) -> None:
         logger.warning(f"[usage] avatar usage report failed (non-critical): {e}")
 
 
-class FishAudioTTS(agents_tts.TTS):
-    def __init__(
-        self,
-        api_key: str,
-        reference_id: str | None = None,
-        tenant_id: str | None = None,
-        emotion_tags: list[str] | None = None,
-    ):
-        super().__init__(
-            capabilities=agents_tts.TTSCapabilities(streaming=False),
-            sample_rate=44100,
-            num_channels=1,
-        )
-        self._api_key = api_key
-        self._reference_id = reference_id
-        self._tenant_id = tenant_id
-        self._emotion_tags = emotion_tags or []
-        logger.info(f"[TTS] FishAudioTTS initialized: ref={self._reference_id} tenant={self._tenant_id} emotion_tags={self._emotion_tags}")
-
-    def synthesize(
-        self,
-        text: str,
-        *,
-        conn_options: APIConnectOptions = DEFAULT_API_CONNECT_OPTIONS,
-    ) -> "FishAudioChunkedStream":
-        # S2-Pro 感情タグ注入: [empathetic][calm] 形式でテキスト先頭に付与（最大3個）
-        prefix = "".join(f"[{t}]" for t in self._emotion_tags[:3]) if self._emotion_tags else ""
-        return FishAudioChunkedStream(
-            tts=self,
-            input_text=prefix + text,
-            conn_options=conn_options,
-            api_key=self._api_key,
-            reference_id=self._reference_id,
-            tenant_id=self._tenant_id,
-        )
-
-
-class FishAudioChunkedStream(agents_tts.ChunkedStream):
-    def __init__(
-        self,
-        *,
-        tts: FishAudioTTS,
-        input_text: str,
-        conn_options: APIConnectOptions,
-        api_key: str,
-        reference_id: str | None,
-        tenant_id: str | None = None,
-    ):
-        super().__init__(tts=tts, input_text=input_text, conn_options=conn_options)
-        self._api_key = api_key
-        self._reference_id = reference_id
-        self._tenant_id = tenant_id
-
-    async def _run(self, output_emitter: agents_tts.AudioEmitter) -> None:
-        # initialize() は _run() の先頭で必ず呼ぶ。
-        # 呼ばずに return/例外で抜けると _main_task の end_input() が
-        # "AudioEmitter isn't started" RuntimeError を投げるため。
-        # mime_type="audio/mpeg" → AudioEmitter が PyAV 経由で MP3 → PCM デコードする。
-        output_emitter.initialize(
-            request_id=f"fish-audio-{id(self)}",
-            sample_rate=self._tts.sample_rate,
-            num_channels=self._tts.num_channels,
-            mime_type="audio/mpeg",
-            stream=False,
-        )
-        try:
-            tts_model = os.environ.get("FISH_AUDIO_TTS_MODEL", "s2.1-pro-free")
-            request_body = {
-                "text": self._input_text,
-                "model": tts_model,
-                "format": "mp3",   # Fish Audio デフォルト形式。WAV より確実。
-                "normalize": True,
-                "latency": "balanced",
-            }
-            if self._reference_id:
-                request_body["reference_id"] = self._reference_id
-
-            logger.info(f"[TTS] requesting Fish Audio: text={self._input_text[:60]!r} ref={self._reference_id}")
-            started_at = time.monotonic()
-            total_bytes = 0
-            async with aiohttp.ClientSession() as http_session:
-                async with http_session.post(
-                    "https://api.fish.audio/v1/tts",
-                    headers={
-                        "Authorization": f"Bearer {self._api_key}",
-                        "Content-Type": "application/json",
-                    },
-                    json=request_body,
-                    timeout=aiohttp.ClientTimeout(total=30),
-                ) as resp:
-                    logger.info(f"[TTS] Fish Audio response: status={resp.status} content-type={resp.content_type}")
-                    if resp.status != 200:
-                        error_text = await resp.text()
-                        logger.error(f"[TTS] Fish Audio error {resp.status}: {error_text[:300]}")
-                        return
-
-                    # Phase B-1: chunk 受信ごとに push して TTFA を短縮
-                    # （公式 openai プラグイン ChunkedStream と同パターン。
-                    #   capabilities.streaming は False のまま — True にすると
-                    #   フレームワークが未実装の stream() を直接呼び NotImplementedError になる）
-                    first_chunk_at: float | None = None
-                    async for chunk in resp.content.iter_chunked(4096):
-                        if not chunk:
-                            continue
-                        if first_chunk_at is None:
-                            first_chunk_at = time.monotonic()
-                            logger.info(f"[TTS] TTFA: {(first_chunk_at - started_at) * 1000:.1f}ms")
-                        output_emitter.push(chunk)
-                        total_bytes += len(chunk)
-
-            if total_bytes < 1000:
-                # 旧実装は一括受信後に skip できたが、streaming では既に push 済みのため警告のみ
-                logger.warning(f"[TTS] Fish Audio returned suspiciously small audio ({total_bytes} bytes)")
-            output_emitter.flush()
-            logger.info(f"[TTS] streamed {total_bytes} bytes to emitter OK")
-
-            # 使用量レポート（fire-and-forget）
-            if self._tenant_id:
-                tts_bytes = len(self._input_text.encode("utf-8"))
-                asyncio.ensure_future(_report_tts_usage(self._tenant_id, tts_bytes, tts_model))
-        except Exception as e:
-            logger.error(f"[TTS] Exception in _run: {type(e).__name__}: {e}")
-
-
 def _build_agent_reply_payload(text: str) -> bytes:
     """agent_reply 形式の Data Channel payload を組み立てる（純粋関数）。"""
     return json.dumps({"type": "agent_reply", "text": text}).encode()
@@ -521,11 +397,23 @@ async def entrypoint(ctx: agents.JobContext) -> None:
 
     logger.info(f"[entrypoint] effective config: voice_id={effective_reference_id!r}, agent_id={effective_agent_id!r}, image_url={'set' if effective_image_url else 'none'}, custom_prompt={'yes' if avatar_config and avatar_config.get('personality_prompt') else 'no'}, emotion_tags={len(effective_emotion_tags)} {effective_emotion_tags}, category_personas={len(category_persona_map)}")
 
-    fish_tts = FishAudioTTS(
+    # FISH_AUDIO_TTS_MODEL: env で切替可能（有料モデルへの移行用）。
+    # 実際に使用したモデル名は _report_tts_usage() へ申告し、原価計算をモデル別単価に
+    # 連動させる(s2.1-pro-free は無料期間中 $0、他は $15/M byte)。
+    _tts_model = os.environ.get("FISH_AUDIO_TTS_MODEL", "s2.1-pro-free")
+    fish_tts = fishaudio.TTS(
         api_key=os.environ["FISH_AUDIO_API_KEY"],
-        reference_id=effective_reference_id,
-        tenant_id=tenant_id,
-        emotion_tags=effective_emotion_tags,
+        model=_tts_model,
+        output_format="mp3",
+        sample_rate=44100,
+        voice_id=effective_reference_id if effective_reference_id else NOT_GIVEN,
+        normalize=True,
+        latency_mode="balanced",
+    )
+    # emotion_tags（テナントDB設定）は公式プラグインにコンストラクタ引数が無いため、
+    # speak() が TTS 送信直前にテキスト先頭へ付与する（Widget のチャット吹き出しには漏らさない）。
+    _emotion_tags_prefix = (
+        "".join(f"[{t}]" for t in effective_emotion_tags[:3]) if effective_emotion_tags else ""
     )
 
     session = AgentSession(
@@ -577,20 +465,27 @@ async def entrypoint(ctx: agents.JobContext) -> None:
         emotion_prefix: bool,
         allow_interruptions: bool | None = None,
     ) -> SpeechHandle:
-        """発話の唯一の入口。emotion prefix 適用と Data Channel publish を一元化する。
+        """発話の唯一の入口。emotion prefix 適用・課金計上・Data Channel publish を一元化する。
 
         session.say() を直接呼ばないこと — publish/prefix の付け忘れが過去に
         歓迎メッセージのチャット履歴欠落バグ（agent_reply 未送出）を起こした。
+        emotion_tags（テナントDB設定）は _emotion_tags_prefix で TTS 音声にのみ適用し、
+        Widget のチャット吹き出しには漏らさない（旧 FishAudioTTS.synthesize() の挙動を踏襲）。
         """
-        final_text = (
+        publish_text = (
             sales_flow_emotion_prefix(_sales_state["current"]) + text
             if emotion_prefix
             else text
         )
+        tts_text = _emotion_tags_prefix + publish_text
         say_kwargs = {} if allow_interruptions is None else {"allow_interruptions": allow_interruptions}
-        handle = session.say(final_text, **say_kwargs)
+        handle = session.say(tts_text, **say_kwargs)
+        if tenant_id:
+            asyncio.ensure_future(
+                _report_tts_usage(tenant_id, len(tts_text.encode("utf-8")), _tts_model)
+            )
         if publish:
-            asyncio.create_task(_publish_agent_reply(final_text))
+            asyncio.create_task(_publish_agent_reply(publish_text))
         return handle
 
     async def handle_tts_request(reply_text: str) -> None:
@@ -695,10 +590,10 @@ async def entrypoint(ctx: agents.JobContext) -> None:
                             control_lemonslice("update-idle-prompt", idle_prompt=persona["idle_prompt"])
                         )
                     if persona.get("voice_id"):
-                        # 次回 TTS 合成から声を切り替える。FishAudioTTS.synthesize() は
-                        # 呼び出しのたびに self._reference_id を読むため、インスタンス属性を
-                        # 直接更新するだけで反映される（TTSインスタンスの再生成は不要）。
-                        fish_tts._reference_id = persona["voice_id"]
+                        # 次回 TTS 合成から声を切り替える。公式 fishaudio.TTS は
+                        # update_options() でインスタンスの声設定を更新できる
+                        # （TTSインスタンスの再生成は不要）。
+                        fish_tts.update_options(voice_id=persona["voice_id"])
                 else:
                     logger.debug(f"[data_channel] category_change with unmapped category, skipping: {category!r}")
             elif msg_type == "widget_connected":

--- a/avatar-agent/requirements.txt
+++ b/avatar-agent/requirements.txt
@@ -1,7 +1,7 @@
 # Direct dependencies — pinned via `pip freeze` on VPS 2026-04-21
 # To update: pip install -U <package> && pip freeze > /tmp/freeze.txt, then update this file
 # DO NOT use >= constraints — they allow silent version drift that breaks livekit-agents compatibility
-livekit-agents[lemonslice,openai]==1.6.7
+livekit-agents[lemonslice,openai,fishaudio]==1.6.7
 fish-audio-sdk==1.3.0
 groq==1.2.0
 httpx==0.28.1


### PR DESCRIPTION
## 概要
- LiveKit公式最新版調査(2026-08-01)に基づく更新PRの最終(実装完了)。#710の後継(#710はrebaseによりコミットハッシュが変わったため、force-push権限が無く新規PRとして作成。#710はclose予定)。
- 事前調査(4/7, GO判定、Asanaコメント参照)の結論どおり、自前FishAudioTTS/FishAudioChunkedStream(約140行)を公式`livekit-plugins-fishaudio`に置換する。

## #710との差分(rebase時に追加対応)
#708(このPRのbase相当content)が先にmergeされた後、**別Lane由来のPR #700**(「Fish TTSモデルをenv化し原価を実モデルに連動させる」)がほぼ同時にmainへmergeされ、`_report_tts_usage()`のシグネチャを`(tenant_id, tts_text_bytes)`→`(tenant_id, tts_text_bytes, tts_model)`の3引数に変更し、`FishAudioChunkedStream._run()`内で`FISH_AUDIO_TTS_MODEL`env変数を読んでモデル名を課金に渡すようにしていた。

このPRは`FishAudioChunkedStream`ごと削除するため素朴にrebaseするとこの変更を握り潰し、**「実際は無料モデルなのに有料単価$15/M byteで課金される」という#700が修正した不具合を再発させる**ところだった。rebase時に検知し、以下を追加対応した:
- `_tts_model = os.environ.get("FISH_AUDIO_TTS_MODEL", "s2.1-pro-free")` をentrypoint冒頭で計算し、`fishaudio.TTS(model=_tts_model, ...)`に渡す
- `speak()`内の`_report_tts_usage()`呼び出しに`_tts_model`を第3引数として追加

バックエンド側(`src/lib/billing/costCalculator.ts`)は`FISH_AUDIO_MODEL_COST_PER_BYTE_USD`マップで`s2.1-pro-free: 0`、他モデルは$15/M byte、**モデル名省略時は有料単価にフォールバック**する設計だったため、この配線を怠ると静かに誤課金が発生する状態だった。

## 変更ファイル
- `avatar-agent/requirements.txt` — `livekit-agents[lemonslice,openai]` → `livekit-agents[lemonslice,openai,fishaudio]`
- `avatar-agent/agent.py`
  - `FishAudioTTS`/`FishAudioChunkedStream`クラス削除(約140行)
  - `fish_tts = fishaudio.TTS(...)` に置換(4/7調査結論の引数+`FISH_AUDIO_TTS_MODEL`env連動)
  - emotion_tagsを`speak()`内の`_emotion_tags_prefix`に移設(TTS音声にのみ適用、Widgetチャット吹き出しには漏らさない)
  - 課金(`_report_tts_usage`)を`speak()`内に移設、`tts_model`を含む3引数呼び出しに更新
  - `category_change`のペルソナ切替(別PR #701由来)が自前クラスの`_reference_id`直接代入に依存していたため、公式APIの`update_options(voice_id=...)`に置換
  - 不要になったimport(`agents_tts`/`APIConnectOptions`/`DEFAULT_API_CONNECT_OPTIONS`)を削除

## やっていないこと
- `fish-audio-sdk==1.3.0`の削除 — 元々未import(自前実装はaiohttp直呼び)の死んだ依存。既存のdead codeでありこのPRのスコープ外

## ローカル確認
- `origin/main`にrebase後、専用venvで`pip install -r requirements.txt`解決、`fishaudio.TTS` import成功
- `fishaudio.TTS(voice_id=<値>)` / `fishaudio.TTS(voice_id=NOT_GIVEN)` / `update_options(voice_id=...)` の3パターンを実際にインスタンス化して動作確認
- `GROQ_API_KEY=dummy FISH_AUDIO_API_KEY=dummy python3 -m pytest -v` — 24 passed(test_speak_funnel.py 8件 / test_emotion_tags.py 11件 / test_lemonslice_control.py 5件)

## Gate結果
- Gate 1 `pnpm verify`: typecheck / lint(0 errors) / admin-ui build成功。jestは3回実行し毎回異なる無関係ファイル(tuning-rules-api.test.ts → knowledgeGapsAuthGuard.test.ts等)が単発失敗、いずれも単体実行では成功。avatar-agent Python変更とは無関係な既存の並列実行時テスト分離フレーキー(3286テスト中1件が3回とも別ファイルで失敗)
- Gate 2 `security-scan.sh`: PASS (CRITICAL/HIGH=0)
- Gate 3 `pnpm build`: 成功

## デプロイ・実機確認(合否ライン)
avatar-agentのPythonはCI非対象。「[LiveKit更新 7/7] 人間作業」タスクの波4で実施必須:
- 初音までの体感レイテンシが悪化していないか
- cold-startのノイズ(1.6.6の修正対象)が出ていないか
- 感情タグ/SalesFlow prefixが従前通り効いているか
- **DBのTTS課金レコードが従前と同じ単位・モデル名で入っているか**(ゼロや誤単価になっていたら即ロールバック)

## Asana
https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217083993723778