### PR TITLE
fix(avatar): アバター参照画像生成プロンプトに口元の指定を追加する(リップシンク品質)

### DIFF
--- a/admin-ui/src/lib/buildAvatarPrompt.test.ts
+++ b/admin-ui/src/lib/buildAvatarPrompt.test.ts
@@ -180,4 +180,22 @@ describe('buildAvatarPrompt', () => {
       expect(prompt).toContain('8k resolution');
     });
   });
+
+  // GID 1215698617426707: LemonSlice公式ガイドライン(avatar-image-tips)は
+  // 「口を閉じた参照画像」がリップシンク品質を落とすと明示しており、口をわずかに
+  // 開けた画像を推奨している。viseme制御が実装不可と判明したため、この代替手段
+  // (参照画像の口元)へスコープを差し替えた際に追加した回帰テスト。
+  describe('mouth suffix（リップシンク品質・GID 1215698617426707）', () => {
+    it('全タイプで口を開けた状態の指定が含まれる', () => {
+      for (const type of ['human', 'anime', '3d', 'animal', 'robot'] as const) {
+        const { prompt } = buildAvatarPrompt({
+          type,
+          composition: 'bust',
+          expression: 'smile',
+          background: 'simple',
+        });
+        expect(prompt).toContain('mouth slightly open');
+      }
+    });
+  });
 });

--- a/admin-ui/src/lib/buildAvatarPrompt.ts
+++ b/admin-ui/src/lib/buildAvatarPrompt.ts
@@ -102,6 +102,15 @@ const BACKGROUND_MAP: Record<Background, string> = {
   custom:  'clean studio background',
 };
 
+// LemonSlice公式ガイドライン(https://lemonslice.com/docs/prompting-guide/avatar-image-tips)準拠:
+// 「口を閉じた参照画像」はリップシンクの質を落とす。人物は「話している最中(口が開いている)」、
+// 非人間キャラクターは「口をわずかに開けた」画像を使うことが明示的に推奨されている。
+// Asana GID 1215698617426707(Fish Audioワードタイムスタンプでのリップシンク改善)は
+// LemonSlice Control APIにviseme制御が存在しないため実装不可と判明し、公式が案内する
+// この代替手段(参照画像の口元)にスコープを差し替えた(docs/FISH_AUDIO_WORD_TIMESTAMPS_LIPSYNC.md)。
+const MOUTH_SUFFIX =
+  'mouth slightly open as if speaking mid-sentence (required for accurate lip-sync animation on the avatar platform)';
+
 const QUALITY_SUFFIX =
   'high quality, professional lighting, sharp focus, 8k resolution, award-winning photography, centered composition, looking at camera';
 
@@ -158,6 +167,9 @@ export function buildAvatarPrompt(input: AvatarPromptInput): {
 
   // Expression
   parts.push(EXPRESSION_MAP[input.expression]);
+
+  // Mouth (リップシンク品質のためのLemonSlice推奨事項。全タイプ共通)
+  parts.push(MOUTH_SUFFIX);
 
   // Background
   const bgStr = input.background === 'custom' && input.customBgColor


### PR DESCRIPTION
## Summary
- LemonSlice公式ガイドライン(https://lemonslice.com/docs/prompting-guide/avatar-image-tips)は「口を閉じた参照画像」がリップシンク品質を落とすと明示し、人物は「話している最中(口が開いている)」、非人間キャラクターは「口をわずかに開けた」画像を使うことを推奨している
- `buildAvatarPrompt.ts`が組み立てる生成プロンプトには口元の指定が一切なく、生成される参照画像は口を閉じたものになりがちだった
- Asana GID 1215698617426707「Fish Audioワードタイムスタンプ→リップシンク精度向上」は、LemonSlice Control APIにviseme/phoneme制御イベントが存在しないため実装不可と判明し(PR #709 / `docs/FISH_AUDIO_WORD_TIMESTAMPS_LIPSYNC.md`参照)、公式が案内するこの代替手段(参照画像の口元)へスコープを差し替えた
- `buildAvatarPrompt.ts`は旧UI(`AvatarWizard.tsx`)と新UI(`copilot-preview/index.tsx`)の両方が使う単一の共有実装のため、1箇所の変更で両面に反映される

## 声変更について(スコープのもう一方)
`voice_id`は`avatar_configs`および(PR #701で追加された)`category_persona_map`で既に設定可能な既存フィールドのため、新規コードは不要。リップシンク品質に違和感がある場合は既存の声設定を変更して試すことを運用側の選択肢として残す。

## Test plan
- [x] `buildAvatarPrompt.test.ts`に回帰テストを1件追加(全5タイプで口を開けた指定を含むことを確認)、既存12件と合わせて全13件pass
- [x] `AvatarWizard`/`copilot-preview`の既存テストに厳密なプロンプト文字列の完全一致アサーションが無いことを確認済み(回帰なし、copilot-preview全159件pass)
- [x] admin-ui `pnpm typecheck`は本PRの変更ファイルに起因するエラーなし(mainに既存の別Laneのlivekit-server-sdk型エラー・admin-ui pre-existing AuthContextValue型エラーはCI非対象・本PR無関係)

Asana: https://app.asana.com/1/817733952351708/project/1213607637045514/task/1215698617426707

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xq3XPSpwhHBTrNyoJMhvoa