### PR TITLE
voice-cloneのFish Audio呼び出しにtrain_mode必須フィールドを追加

### DIFF
--- a/src/api/admin/avatar/routes.test.ts
+++ b/src/api/admin/avatar/routes.test.ts
@@ -379,6 +379,9 @@ describe("POST /v1/admin/avatar/configs/:id/voice-clone", () => {
     const fd = init.body as FormData;
     expect(fd.get("visibility")).toBe("private");
     expect(fd.get("type")).toBe("tts");
+    // GID 1217084551565350: train_mode は公式Fish Audio APIの必須フィールド。
+    // 欠落すると422("train_mode: Field required")で常に失敗することを実APIで確認済み。
+    expect(fd.get("train_mode")).toBe("fast");
     expect(fd.get("title")).toBe("マイボイス");
     expect(fd.get("voices")).toBeTruthy();
 

--- a/src/api/admin/avatar/routes.ts
+++ b/src/api/admin/avatar/routes.ts
@@ -813,9 +813,12 @@ export function registerAvatarConfigRoutes(app: Express, db: any): void {
         }
 
         // Fish Audio POST /model — 永続クローン作成
+        // GID 1217084551565350: train_mode は公式APIの必須フィールド。欠落すると422で
+        // 常に失敗する（実APIで確認済み）。fast=作成直後から即座に利用可能。
         const fd = new FormData();
         fd.append("visibility", "private");
         fd.append("type", "tts");
+        fd.append("train_mode", "fast");
         fd.append("title", name);
         fd.append(
           "voices",


### PR DESCRIPTION
## Summary
- `POST /v1/admin/avatar/configs/:id/voice-clone` がFish Audio APIの`POST /model`を呼ぶ際、必須フィールド`train_mode`を送っておらず**常に422で失敗していた**（実APIで確認済み）
- `train_mode: "fast"`を追加。作成直後から`state: "trained"`で即座に利用可能になることも実APIで確認済み
- 挙動を検証していた既存の正常系テストに`train_mode`アサーションを追記（新規テストファイルは作らず、既存の`fd.get(...)`検証パターンに1行追加）

## 発見の経緯
Voice Designスパイク調査（別Asanaタスク）で実APIを叩いた際に判明。詳細: https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217084040142043

## Asana
https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217084551565350

## Test plan
- [x] pnpm typecheck: 0 errors
- [x] pnpm lint: 0 new warnings
- [x] routes.test.ts: 31/31 pass（新規アサーション含む）
- [x] Gate 1.5 dead-code-check / Gate 2 security-scan: PASS
- [x] Gate 3 build: 0 errors
- 補足: フル`pnpm test`で他ファイル（本PRと無関係な領域）が並列実行時のポート競合(EADDRNOTAVAIL、34並行node/jestプロセス確認)で断続的に落ちる既知の環境要因あり。本PRの変更ファイルは単独実行で安定してpass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdBRSsTu4YNWBDTpgzqz2c