### PR TITLE
fix(avatar/persona): PR #716のGitHub head参照遅延で取りこぼされた3件のバグ修正を再送

### DIFF
--- a/avatar-agent/agent.py
+++ b/avatar-agent/agent.py
@@ -134,11 +134,21 @@ def resolve_category_persona(category: object, category_persona_map: object) -> 
     - 該当カテゴリが未設定、またはマップされた値が辞書でない(DBに不正な形で
       保存された等) → None
     戻り値が None の呼び出し元は、何もしない(ペルソナ切替をスキップする)こと。
+
+    マッチングは大文字小文字・前後空白を無視する(strip/lower正規化)。category は
+    queryPlanner.ts が会話ごとに自由生成する値、category_persona_map のキーは
+    save_category_persona で店主が入力した値で、双方が独立して生成されるため、
+    語彙自体が完全に一致する保証はない(既知の制約)が、表記ゆれだけはここで救う。
     """
     if not isinstance(category, str) or not isinstance(category_persona_map, dict):
         return None
-    persona = category_persona_map.get(category)
-    return persona if isinstance(persona, dict) else None
+    category_norm = category.strip().lower()
+    if not category_norm:
+        return None
+    for key, value in category_persona_map.items():
+        if isinstance(key, str) and key.strip().lower() == category_norm:
+            return value if isinstance(value, dict) else None
+    return None
 
 
 # --- Groq LLM 直接呼び出し ---

--- a/avatar-agent/test_category_persona.py
+++ b/avatar-agent/test_category_persona.py
@@ -43,10 +43,37 @@ class TestResolveCategoryPersonaBoundary:
         assert resolve_category_persona("fashion", {}) is None
 
     def test_empty_string_category_returns_none(self):
-        persona_map = {"": {"voice_id": "v1"}}
-        # 空文字は isinstance チェックを通過しうるが、意味のあるカテゴリとしては扱われない
-        # ことを明示する（widget 側が category を送らず msg.get が "" を返すケースを模す）。
-        assert resolve_category_persona("", persona_map) == {"voice_id": "v1"}
+        # 空文字・空白のみは正規化後に空になるため、意味のあるカテゴリとして扱わない
+        # （widget 側が category を送らず msg.get が "" を返すケースを模す）。
+        persona_map = {"": {"voice_id": "v1"}, "   ": {"voice_id": "v2"}}
+        assert resolve_category_persona("", persona_map) is None
+        assert resolve_category_persona("   ", persona_map) is None
+
+
+class TestResolveCategoryPersonaNormalization:
+    """category は queryPlanner.ts が会話ごとに自由生成する値、
+    category_persona_map のキーは店主が save_category_persona で入力した値で、
+    双方が独立に生成されるため表記ゆれが起きうる。大文字小文字・前後空白の
+    ゆれだけは正規化で吸収されることを確認する（語彙自体のズレまでは救えない、
+    既知の制約）。
+    """
+
+    def test_case_insensitive_match(self):
+        persona_map = {"fashion": {"voice_id": "v1"}}
+        assert resolve_category_persona("Fashion", persona_map) == {"voice_id": "v1"}
+        assert resolve_category_persona("FASHION", persona_map) == {"voice_id": "v1"}
+
+    def test_whitespace_is_trimmed_on_both_sides(self):
+        persona_map = {" fashion ": {"voice_id": "v1"}}
+        assert resolve_category_persona("fashion", persona_map) == {"voice_id": "v1"}
+        assert resolve_category_persona("  Fashion  ", persona_map) == {"voice_id": "v1"}
+
+    def test_vocabulary_mismatch_still_returns_none(self):
+        # 正規化で救えるのは表記ゆれのみ。語彙自体が違えば従来通りマッチしない
+        # （既知の制約であり、この関数の責務外）。
+        persona_map = {"returns": {"voice_id": "v1"}}
+        assert resolve_category_persona("return", persona_map) is None
+        assert resolve_category_persona("返品", persona_map) is None
 
 
 class TestResolveCategoryPersonaIrregularInputs:

--- a/public/widget.js
+++ b/public/widget.js
@@ -1931,6 +1931,11 @@
           voiceModeIndicator.style.display = 'none';
         }
         window.__rajiuceRoom = null;
+        // LemonSliceペルソナスワップ: Room切断で新規agentプロセス側の状態は必ず失われる
+        // （新しいRoomは新しいagentジョブとして起動され、category_persona_mapは再適用が必要）。
+        // ここでリセットしないと、再接続後も「同じカテゴリのまま」と誤認して
+        // category_change を送らず、ペルソナが既定値のまま戻らなくなる。
+        lastRagCategory = null;
         // Room が切断されたら次のパネル開閉で再fetch可能にする
         avatarConfigFetched = false;
         // avatar thumbnail URL を disconnected 後のFAB復元用に保持してから avatarConfig を解放
@@ -2106,7 +2111,12 @@
         pipIdleDisconnectTimer = null;
         // PIP_IDLE_DISCONNECT_MS 経過してもまだパネルが閉じたままの場合のみ切断する
         // （タイマー発火とほぼ同時にユーザーが再度パネルを開いた場合は何もしない）。
-        if (!isOpen) { cleanupLiveKit(); }
+        if (!isOpen) {
+          cleanupLiveKit();
+          // 切断後は sendPipHeartbeat() が空振りするだけの pipHeartbeatTimer を
+          // 止め忘れると、ページ滞在中ずっと60秒毎に動き続けるリークになる。
+          stopPipTimers();
+        }
       }, PIP_IDLE_DISCONNECT_MS);
     }
   }

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -1176,7 +1176,11 @@ export async function executeToolCall(
 
     // -----------------------------------------------------------------------
     case 'save_category_persona': {
-      const category = String(args['category'] ?? '').trim();
+      // category は queryPlanner.ts が会話ごとに自由生成する filters.category と
+      // 完全一致でしか照合されない（agent.py の resolve_category_persona）。
+      // 大文字小文字・前後空白のゆれだけは救えるよう正規化して保存する
+      // （語彙そのものがズレるケースまでは救えない。既知の制約）。
+      const category = String(args['category'] ?? '').trim().toLowerCase();
       if (!category) {
         return truncate('category は必須です');
       }

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -7745,6 +7745,27 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(params).toEqual(['tenant-abc', 'fashion', JSON.stringify({ agent_prompt: 'stylish and confident' })]);
     });
 
+    it('save_category_persona: カテゴリ名は大文字小文字・前後空白を無視して正規化保存される', async () => {
+      // category は queryPlanner.ts が会話ごとに自由生成する filters.category と
+      // agent.py 側で完全一致照合される。表記ゆれ(大文字小文字・空白)だけは
+      // 保存時に正規化して吸収する（2026-08-01のレビューで発見した既知の制約への対処）。
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-scv-norm', 'save_category_persona', {
+          category: '  Fashion  ', agent_prompt: 'stylish', confirmed: true,
+        }))
+        .mockResolvedValueOnce(makeGroqResponse('保存しました。'));
+
+      mockQuery.mockResolvedValueOnce({ rows: [{ name: 'Haruka' }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '保存して', sessionId: 'sess-scv-norm' });
+
+      expect(res.status).toBe(200);
+      const [, params] = mockQuery.mock.calls[0]!;
+      expect((params as unknown[])[1]).toBe('fashion');
+    });
+
     it('save_category_persona: 空白のみの値は保存対象から除外される(トリム後に空ならそのフィールドは送らない)', async () => {
       mockFetch
         .mockResolvedValueOnce(toolCallResponse('call-scv-ws', 'save_category_persona', {


### PR DESCRIPTION
## 背景（重要）
PR #716 に2つ目のコミット(バグ修正3件)をpushした直後、GitHubのPR head参照(`head.sha`)がAPIレベルで数分間古いコミットのまま反映されなかった。この間にマージが実行されたため、**マージコミット `c8a4e4a5` は1つ目のコミット(テスト強化)のみを含み、2つ目のコミット(バグ修正3件)はmainに反映されなかった**。

`git ls-remote` では branch 自体は正しく最新コミットを指していたが、`gh api repos/.../pulls/716` の `head.sha` は3分以上古いままだった（GitHub側の反映遅延、こちら側のpush失敗ではない）。

本PRは、mainから新しいブランチを切って該当コミット(`38af36bc`)を cherry-pick したもの。差分は元のコミットと完全に同一。

## 含まれる修正（レビューで発見した3件の実バグ）
1. **`lastRagCategory`がRoom再接続時にリセットされない**: PiPアイドル切断(5分)後に再接続すると、新しいagent.pyジョブはカテゴリ状態を持たないが、widget側は「変化なし」と誤認しcategory_changeを再送しない → ペルソナが既定値のまま戻らなくなる。`RoomEvent.Disconnected`ハンドラでリセットするよう修正。
2. **PiPアイドル切断後もハートビートsetIntervalが漏れ続ける**: `pipIdleDisconnectTimer`のコールバックで`stopPipTimers()`を呼んでいなかった。
3. **category名の大文字小文字・前後空白ゆれによる完全一致ミスマッチ**: `queryPlanner.ts`のfilters.category(LLM自由生成)と`save_category_persona`のcategory(店主自由入力)が独立生成のため表記ゆれが起きうる。保存時・照合時の双方で正規化(trim+lowercase)。語彙自体のズレ(例: "returns" vs "返品")は既知の制約としてコメントに明記(未対応)。

## Test plan
- [x] `python -m pytest test_emotion_tags.py test_lemonslice_control.py test_category_persona.py` (34 passed)
- [x] `node --check public/widget.js`
- [x] `pnpm typecheck` (0 errors)
- [x] `pnpm jest src/api/admin/agent/agentRoutes.test.ts src/api/chat/route.ragCategory.test.ts` (394 passed)
- [x] cherry-pick はコンフリクトなし（#717 Voice Design UI PRと変更ファイルの重複なし）

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01Xq3XPSpwhHBTrNyoJMhvoa