### PR TITLE
fix(avatar-agent): avatar.start()にタイムアウトを追加し、無言ハングを解消する

### DIFF
--- a/avatar-agent/agent.py
+++ b/avatar-agent/agent.py
@@ -671,8 +671,18 @@ async def entrypoint(ctx: agents.JobContext) -> None:
             }
         avatar = lemonslice.AvatarSession(**avatar_kwargs)
         # I-4: avatar.start() の戻り値が LemonSlice session_id（plugin avatar.py:132）
+        # avatar.start() 自体にはタイムアウト保護が無い（LemonSlice側の _post() は
+        # 最大3リトライ×60秒でハングしうる）。ここで明示的にタイムアウトさせないと、
+        # 挨拶も session.start() も一切実行されないまま無言で停止し続ける
+        # （wait_for_join の10秒タイムアウトはこの手前で止まるため効かない）。
         global _lemonslice_session_id
-        _lemonslice_session_id = await avatar.start(session, room=ctx.room)
+        try:
+            _lemonslice_session_id = await asyncio.wait_for(
+                avatar.start(session, room=ctx.room), timeout=30.0
+            )
+        except asyncio.TimeoutError:
+            logger.warning("[avatar] avatar.start() timed out after 30s (text-only fallback)")
+            raise
         # 課金: アバター起動成功時刻を記録（_close_avatar でセッション時間を算出）
         _avatar_started_at = time.monotonic()
         logger.info("=== LEMONSLICE AVATAR STARTED ===")

--- a/avatar-agent/test_avatar_start_timeout.py
+++ b/avatar-agent/test_avatar_start_timeout.py
@@ -1,0 +1,118 @@
+"""
+avatar.start() のタイムアウト保護を検証するテスト。
+
+entrypoint() は多数の副作用(LiveKit room接続・内部API呼び出し)を持つ大きな
+関数のため、test_speak_funnel.py と同じ手法（ソースをASTで検査して契約を
+固定する）を用いる。
+
+背景: avatar.start()（LemonSlice側セッション作成）にはタイムアウト保護が
+無く、ハングすると session.start() も挨拶も一切実行されないまま無言で
+停止し続ける不具合があった（LiveKit Cloud dashboard の Sessions で
+参加者2人のまま19分以上残留するセッションとして実機確認済み）。
+"""
+
+import ast
+import os
+from pathlib import Path
+
+os.environ.setdefault("GROQ_API_KEY", "test-dummy-key")
+os.environ.setdefault("FISH_AUDIO_API_KEY", "test-dummy-key")
+
+AGENT_PY = Path(__file__).parent / "agent.py"
+
+
+def _find_calls(tree: ast.AST, dotted_name: str) -> list[ast.Call]:
+    """dotted_name（例: "avatar.start", "asyncio.wait_for"）にマッチする
+    Call ノードを全て返す。
+    """
+    calls = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        parts = []
+        while isinstance(func, ast.Attribute):
+            parts.append(func.attr)
+            func = func.value
+        if isinstance(func, ast.Name):
+            parts.append(func.id)
+            parts.reverse()
+            if ".".join(parts) == dotted_name:
+                calls.append(node)
+    return calls
+
+
+class TestAvatarStartWrappedInTimeout:
+    def test_avatar_start_is_first_arg_of_wait_for(self):
+        tree = ast.parse(AGENT_PY.read_text(encoding="utf-8"))
+        wait_for_calls = _find_calls(tree, "asyncio.wait_for")
+        wrapped = [
+            c
+            for c in wait_for_calls
+            if c.args
+            and isinstance(c.args[0], ast.Call)
+            and isinstance(c.args[0].func, ast.Attribute)
+            and c.args[0].func.attr == "start"
+        ]
+        assert wrapped, (
+            "avatar.start(...) が asyncio.wait_for(...) の第1引数として"
+            "ラップされていません。ハングしても無言で停止し続ける不具合が"
+            "再発します。"
+        )
+
+    def test_timeout_kwarg_is_reasonable(self):
+        tree = ast.parse(AGENT_PY.read_text(encoding="utf-8"))
+        wait_for_calls = _find_calls(tree, "asyncio.wait_for")
+        [call] = [
+            c
+            for c in wait_for_calls
+            if c.args
+            and isinstance(c.args[0], ast.Call)
+            and isinstance(c.args[0].func, ast.Attribute)
+            and c.args[0].func.attr == "start"
+        ]
+        timeout_kw = next(kw for kw in call.keywords if kw.arg == "timeout")
+        assert isinstance(timeout_kw.value, ast.Constant)
+        timeout_value = timeout_kw.value.value
+        # LemonSlice側の理論上限(最大3リトライ×60秒)より十分短く、
+        # 通常の接続時間(数秒)より十分長い範囲。
+        assert 10 <= timeout_value <= 120, (
+            f"timeout={timeout_value} が妥当な範囲(10〜120秒)外です。"
+        )
+
+    def test_timeout_error_is_reraised_not_swallowed(self):
+        """TimeoutError を握りつぶさず外側の except Exception (text-only
+        fallback) へ伝播させていることを確認する。
+        """
+        src = AGENT_PY.read_text(encoding="utf-8")
+        tree = ast.parse(src)
+        handler = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ExceptHandler) and node.type is not None:
+                type_str = ast.unparse(node.type)
+                if type_str == "asyncio.TimeoutError":
+                    handler = node
+                    break
+        assert handler is not None, "except asyncio.TimeoutError: が見つかりません"
+        has_raise = any(isinstance(n, ast.Raise) for n in ast.walk(handler))
+        assert has_raise, (
+            "except asyncio.TimeoutError: 内に raise が無く、例外が"
+            "握りつぶされています。外側の text-only fallback に届きません。"
+        )
+
+
+if __name__ == "__main__":
+    runner = TestAvatarStartWrappedInTimeout()
+    passed = 0
+    failed = 0
+    for t in [m for m in dir(runner) if m.startswith("test_")]:
+        try:
+            getattr(runner, t)()
+            print(f"  PASS  {t}")
+            passed += 1
+        except AssertionError as e:
+            print(f"  FAIL  {t}: {e}")
+            failed += 1
+    print(f"\n{passed} passed, {failed} failed")
+    if failed:
+        raise SystemExit(1)


### PR DESCRIPTION
## 概要
LiveKit更新プロジェクト（親タスク 1217083772290380）の7/7実機検証中に発見した既存不具合の修正。今回のLiveKit SDK更新（PR 702/703/708/712/704）とは無関係の、以前から存在する不具合。

## 症状（実機確認済み）
`avatar-agent/agent.py`の`entrypoint()`内、`avatar.start(session, room=ctx.room)`（LemonSlice側セッション作成）にタイムアウト保護が無く、ここでハングすると`session.start()`も挨拶（`speak()`）も一切実行されないまま、ウィジェットは「アバターに接続中...」から無言で進まなくなる。

LiveKit Cloud dashboardで再現を確認:
- 正常セッション: 3参加者（widget + agent + LemonSliceアバター）で1分弱にCLOSED
- 問題のセッション: 2参加者（LemonSliceアバター不在）のまま19分以上ACTIVE残留
- 過去7日間の「Agent dispatch errors」グラフに間欠的な発生あり（7/28・7/31）→ 今回の更新以前から存在

## 原因
`wait_for_join(timeout=10.0)`はavatar.start()が返った**後段**の話で、avatar.start()自体には保護が無い。LemonSlice側の内部実装（`livekit-plugins-lemonslice`の`_post()`）は最大3リトライ×60秒タイムアウトの設計で、理論上4分以上ハングしうる。

## 変更内容
`avatar.start(session, room=ctx.room)` を `asyncio.wait_for(timeout=30.0)` で明示的に囲む。タイムアウト値はLemonSlice側の理論上限（最大4分）より十分短く、通常の接続時間（数秒）より十分長い30秒。`asyncio.TimeoutError`は既存の外側`except Exception`（text-only fallback）に自然に伝播するため、フォールバック経路自体は無変更。

`wait_for_join()`自体は公式プラグイン内部で既に`asyncio.wait_for(asyncio.shield(...), timeout=timeout)`を使っており安全（インストール済みパッケージのソースで確認済み、二重ラップ不要）。

## 新規テスト: `test_avatar_start_timeout.py`（3ケース）
`test_speak_funnel.py`と同じASTベースのソース検査手法。
- `avatar.start(...)`が`asyncio.wait_for(...)`の第1引数としてラップされていること
- timeout値が妥当な範囲（10〜120秒）にあること
- `except asyncio.TimeoutError:`内で例外を握りつぶさずre-raiseしていること

## ローカル確認
`GROQ_API_KEY=dummy FISH_AUDIO_API_KEY=dummy python3 -m pytest -v` — 45 passed（新規3ケース含む、既存42ケース無変更）

## Gate結果
- Gate 1 `pnpm verify`: typecheck / lint(0 errors) / admin-ui build成功。jestはローカルマシンの他プロジェクト（無関係）による深刻なメモリ逼迫（空き約60MB）で複数回実行するたび毎回別ファイルが単発失敗したが、単体実行では常に成功。差分はavatar-agentのPythonファイルのみでJS/TSインフラには一切触れておらず、GitHub Actions CI（隔離環境）はこの影響を受けない
- Gate 2 `security-scan.sh`: PASS (CRITICAL/HIGH=0)
- Gate 3 `pnpm build`: 成功

## デプロイ・実機確認
avatar-agentのPythonはCI非対象。デプロイ後、carnation-demoで会話テストしLiveKit Cloud Sessionsタブで3参加者・正常CLOSEDを確認する。

## Asana
https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217084745126879