### PR TITLE
Fish Audio機能群のテスト強化＋実機発見の2件を修正

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -2330,6 +2330,134 @@ describe("CopilotPreviewPage — アバターの声の作成・採用(Voice Desi
     const designCall = vi.mocked(authFetch).mock.calls.find(([url]) => String(url).includes("/design-voice"));
     expect(String(designCall![0])).toBe("http://localhost:3100/v1/admin/avatar/design-voice");
   });
+
+  // design-voiceもGroq相当の実費用が発生する外部API呼び出しのため、match-voiceと
+  // 同じ連打防止(busyDesignVoice state)を検証する。
+  it("「声を作る」を連打しても、生成中はdesign-voiceが1回しか呼ばれない", async () => {
+    let resolveDesign: (() => void) | null = null;
+    const pending = new Promise<Response>((resolve) => {
+      resolveDesign = () =>
+        resolve({
+          ok: true,
+          status: 200,
+          json: () =>
+            Promise.resolve({
+              candidates: [{ id: "cand-1", index: 0, audioBase64: "ZmFrZS13YXY=", sampleRate: 44100, durationMs: 3000, text: null, language: "ja" }],
+            }),
+        } as Response);
+    });
+    mockAdoptedThenDesignEndpoints({ design: () => pending });
+
+    const designButton = await sendAndFindDesignVoiceButton();
+    fireEvent.click(designButton);
+    await waitFor(() => expect((designButton as HTMLButtonElement).disabled).toBe(true));
+    fireEvent.click(designButton);
+
+    expect(vi.mocked(authFetch).mock.calls.filter(([url]) => String(url).includes("/design-voice")).length).toBe(1);
+
+    resolveDesign!();
+    await waitFor(() => expect(screen.getByRole("button", { name: "この声にする" })).toBeTruthy());
+    expect(vi.mocked(authFetch).mock.calls.filter(([url]) => String(url).includes("/design-voice")).length).toBe(1);
+  });
+
+  // match-voiceの複数候補排他制御(#635実装時に無かった観点)と同じ検証をdesignモードにも適用する。
+  it("複数の声の候補から1件を採用すると、残りの候補は選べなくなる(design)", async () => {
+    mockAdoptedThenDesignEndpoints({
+      design: () =>
+        mockOk({
+          candidates: [
+            { id: "cand-1", index: 0, audioBase64: "AAA=", sampleRate: 44100, durationMs: 1000, text: null, language: "ja" },
+            { id: "cand-2", index: 1, audioBase64: "BBB=", sampleRate: 44100, durationMs: 1000, text: null, language: "ja" },
+            { id: "cand-3", index: 2, audioBase64: "CCC=", sampleRate: 44100, durationMs: 1000, text: null, language: "ja" },
+          ],
+        }),
+    });
+
+    const designButton = await sendAndFindDesignVoiceButton();
+    fireEvent.click(designButton);
+    await waitFor(() => expect(screen.getAllByRole("button", { name: "この声にする" }).length).toBe(3));
+
+    fireEvent.click(screen.getAllByRole("button", { name: "この声にする" })[1]!);
+
+    // 実装は「1件でも採用したら全候補を確定表示にする」設計(理由は下記コメント)
+    // のため、決定済みボタンは複数出現する。単数形getByRoleは使えない。
+    await waitFor(() => expect(screen.getAllByRole("button", { name: "決定済み" }).length).toBe(3));
+    // 採用されたのはcand-2であること(fetchWithAuthのFormDataに反映される候補音声を確認)
+    const [, opts] = vi.mocked(fetchWithAuth).mock.calls[0]!;
+    const form = (opts as RequestInit).body as FormData;
+    expect(form.get("name")).toContain("cand-2".slice(0, 8));
+
+    // 残り2件の「この声にする」は無効化されており誤って選び直せない(二重採用防止)。
+    // 採用済みの候補IDが分からない設計(FishのvoiceIdとcandidate.idは別物)のため、
+    // 「1件でも採用したら全候補を確定表示にする」実装になっている。
+    expect(screen.queryAllByRole("button", { name: "この声にする" }).length).toBe(0);
+  });
+
+  // 万一サーバーが壊れたbase64を返した場合、atob()が例外を投げてページ全体が
+  // 白画面になる(Reactのレンダリング外での未捕捉例外)リスクがある。try/catch内に
+  // 収まっており、カードのエラー表示で確定することを固定する。
+  it("サーバーが壊れたbase64を返しても、ページ全体がクラッシュせずエラー表示で確定する", async () => {
+    mockAdoptedThenDesignEndpoints({
+      design: () =>
+        mockOk({
+          candidates: [{ id: "cand-broken", index: 0, audioBase64: "not-valid-base64!!!", sampleRate: 44100, durationMs: 1000, text: null, language: "ja" }],
+        }),
+    });
+
+    const designButton = await sendAndFindDesignVoiceButton();
+    fireEvent.click(designButton);
+
+    const adoptButton = await screen.findByRole("button", { name: "この声にする" });
+    fireEvent.click(adoptButton);
+
+    // atob失敗はcatchされ、汎用エラーメッセージで確定する(白画面にならない)
+    expect(await screen.findByText("この声を反映できませんでした。少し時間をおいてもう一度お試しください。")).toBeTruthy();
+    // ページの他の要素(採用ボタン自体)がまだ描画されている=クラッシュしていないことの確認
+    expect(screen.getByRole("button", { name: "この声にする" })).toBeTruthy();
+  });
+
+  // card.description(採用済みアバターの性格・話し方)がVoice Designのinstruction上限(2000字)
+  // を超えている場合、クライアント側で静かに切り詰めてから送信する。表示上の説明とは
+  // 別に「実際に送られた文字数」が2000字以下であることを固定する。
+  it("性格・話し方の説明が2000字を超えていても、instructionは2000字に切り詰められて送信される", async () => {
+    const longDescription = "とても丁寧な性格です。".repeat(200); // 2000字超
+    vi.mocked(authFetch).mockReset();
+    vi.mocked(fetchWithAuth).mockReset();
+    mockNavigate.mockReset();
+    let agentCalls = 0;
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (isBadgeUrl(url)) return mockEmptyBadges();
+      if (String(url).includes("/v1/admin/my-tenant")) return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
+      if (isUnreadFeedbackUrl(url)) return mockNoFeedbackReplies();
+      if (String(url).includes("/v1/admin/avatar/design-voice")) {
+        return mockOk({ candidates: [{ id: "cand-1", index: 0, audioBase64: "AAA=", sampleRate: 44100, durationMs: 1000, text: null, language: "ja" }] });
+      }
+      if (String(url).includes("/v1/admin/agent/chat")) {
+        agentCalls += 1;
+        if (agentCalls === 1) return mockOk({ reply: "今週も順調です。", actions: [] });
+        return mockOk({
+          reply: "採用しました。",
+          actions: [
+            {
+              tool: "adopt_avatar_preset",
+              result: "採用しました。",
+              card: { kind: "avatar_adopted", configId: "cfg-1", name: "Haruka", imageUrl: null, description: longDescription },
+            },
+          ],
+        });
+      }
+      return mockOk({});
+    });
+
+    const designButton = await sendAndFindDesignVoiceButton();
+    fireEvent.click(designButton);
+
+    await waitFor(() => expect(screen.getByRole("button", { name: "この声にする" })).toBeTruthy());
+    const designCall = vi.mocked(authFetch).mock.calls.find(([url]) => String(url).includes("/design-voice"));
+    const sentInstruction = JSON.parse(String((designCall![1] as RequestInit).body)).instruction as string;
+    expect(sentInstruction.length).toBe(2000);
+    expect(longDescription.length).toBeGreaterThan(2000);
+  });
 });
 
 // 想定ユーザーは100%日本語入力の店主。かな漢字変換の確定Enterで未変換のまま

--- a/src/api/admin/avatar/fishVoiceModel.test.ts
+++ b/src/api/admin/avatar/fishVoiceModel.test.ts
@@ -96,4 +96,112 @@ describe("createFishVoiceModel", () => {
     const voicesEntry = fd.get("voices") as File;
     expect(voicesEntry.name).toBe("voice-sample");
   });
+
+  // ── イレギュラー入力: 呼び出し元(routes.ts)がガードせず渡してきた場合 ──────
+  // このヘルパー自体は音声サイズ・空バッファのバリデーションを一切行わない
+  // (multerのfileSize上限のみが唯一の防御線)ことを明示的に固定する。
+  it("0バイトの音声バッファでもクラッシュせずFish Audioへ送信を試みる(サイズ検証はこの層の責務外)", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ _id: "fish-voice-empty" }),
+    });
+
+    const voiceId = await createFishVoiceModel({
+      apiKey: "test-key",
+      title: "空の音声",
+      audio: Buffer.alloc(0),
+      mimeType: "audio/wav",
+    });
+
+    expect(voiceId).toBe("fish-voice-empty");
+    const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    const fd = init.body as FormData;
+    const voicesEntry = fd.get("voices") as File;
+    expect(voicesEntry.size).toBe(0);
+  });
+
+  it("_idが文字列でない場合(数値型)は欠落扱いでFishVoiceModelErrorを投げる", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ _id: 12345 }),
+    });
+
+    await expect(
+      createFishVoiceModel({
+        apiKey: "test-key",
+        title: "マイボイス",
+        audio: Buffer.from("dummy"),
+        mimeType: "audio/wav",
+      }),
+    ).rejects.toThrow(FishVoiceModelError);
+  });
+
+  it("_idが空文字列の場合も欠落扱いでFishVoiceModelErrorを投げる", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => ({ _id: "" }),
+    });
+
+    await expect(
+      createFishVoiceModel({
+        apiKey: "test-key",
+        title: "マイボイス",
+        audio: Buffer.from("dummy"),
+        mimeType: "audio/wav",
+      }),
+    ).rejects.toThrow(FishVoiceModelError);
+  });
+
+  it("HTTP 200(201以外の成功コード)でも_idがあれば成功として扱う(厳密な201チェックはしていない)", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      json: async () => ({ _id: "fish-voice-200" }),
+    });
+
+    const voiceId = await createFishVoiceModel({
+      apiKey: "test-key",
+      title: "マイボイス",
+      audio: Buffer.from("dummy"),
+      mimeType: "audio/wav",
+    });
+
+    expect(voiceId).toBe("fish-voice-200");
+  });
+
+  // ── 呼び出し元が想定すべき「このヘルパーがラップしない」失敗モード ──────
+  it("Fish Audioが200を返すが本文がJSONとしてパースできない場合、素のErrorが伝播する(FishVoiceModelErrorではない)", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 201,
+      json: async () => {
+        throw new SyntaxError("Unexpected token in JSON");
+      },
+    });
+
+    await expect(
+      createFishVoiceModel({
+        apiKey: "test-key",
+        title: "マイボイス",
+        audio: Buffer.from("dummy"),
+        mimeType: "audio/wav",
+      }),
+    ).rejects.not.toBeInstanceOf(FishVoiceModelError);
+  });
+
+  it("fetch自体が例外を投げる(ネットワーク断)場合、素のErrorが伝播する(呼び出し元のtry/catchに委ねる設計)", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("ECONNRESET"));
+
+    await expect(
+      createFishVoiceModel({
+        apiKey: "test-key",
+        title: "マイボイス",
+        audio: Buffer.from("dummy"),
+        mimeType: "audio/wav",
+      }),
+    ).rejects.toThrow("ECONNRESET");
+  });
 });

--- a/src/api/admin/avatar/generationRoutes.test.ts
+++ b/src/api/admin/avatar/generationRoutes.test.ts
@@ -186,4 +186,193 @@ describe("POST /v1/admin/avatar/design-voice", () => {
     expect(res.status).toBe(500);
     expect(mockTrackUsage).not.toHaveBeenCalled();
   });
+
+  // ── 境界値: instruction ───────────────────────────────────────────────
+  it("バリデーション境界: instructionがちょうど2000字は通る(2001字だけが400)", async () => {
+    mockVoiceDesignOk();
+    const res = await request(makeApp())
+      .post("/v1/admin/avatar/design-voice")
+      .send({ instruction: "あ".repeat(2000) });
+
+    expect(res.status).toBe(200);
+  });
+
+  it("バリデーション境界: reference_textがちょうど150字は通る(151字だけが400)", async () => {
+    mockVoiceDesignOk();
+    const res = await request(makeApp())
+      .post("/v1/admin/avatar/design-voice")
+      .send({ instruction: "落ち着いた声", reference_text: "あ".repeat(150) });
+
+    expect(res.status).toBe(200);
+  });
+
+  // ── 境界値: n(候補数) ─────────────────────────────────────────────────
+  it("バリデーション境界: n=0は400(1未満)、Fish APIに到達しない", async () => {
+    const res = await request(makeApp())
+      .post("/v1/admin/avatar/design-voice")
+      .send({ instruction: "落ち着いた声", n: 0 });
+
+    expect(res.status).toBe(400);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("バリデーション境界: n=5は400(4を超える)、Fish APIに到達しない", async () => {
+    const res = await request(makeApp())
+      .post("/v1/admin/avatar/design-voice")
+      .send({ instruction: "落ち着いた声", n: 5 });
+
+    expect(res.status).toBe(400);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("バリデーション境界: n=1.5(非整数)は400", async () => {
+    const res = await request(makeApp())
+      .post("/v1/admin/avatar/design-voice")
+      .send({ instruction: "落ち着いた声", n: 1.5 });
+
+    expect(res.status).toBe(400);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("バリデーション境界: n=1〜4はいずれも通る", async () => {
+    for (const n of [1, 2, 3, 4]) {
+      mockVoiceDesignOk();
+      const res = await request(makeApp())
+        .post("/v1/admin/avatar/design-voice")
+        .send({ instruction: "落ち着いた声", n });
+      expect(res.status).toBe(200);
+    }
+  });
+
+  // ── 境界値: speed ────────────────────────────────────────────────────
+  // 公式仕様は "0 < speed <= 3"。0自体は不可(除外境界)であることを固定する。
+  it("バリデーション境界: speed=0は400(公式仕様は0を含まない排他的下限)", async () => {
+    const res = await request(makeApp())
+      .post("/v1/admin/avatar/design-voice")
+      .send({ instruction: "落ち着いた声", speed: 0 });
+
+    expect(res.status).toBe(400);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("バリデーション境界: speed=-1は400", async () => {
+    const res = await request(makeApp())
+      .post("/v1/admin/avatar/design-voice")
+      .send({ instruction: "落ち着いた声", speed: -1 });
+
+    expect(res.status).toBe(400);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("バリデーション境界: speed=3ちょうどは通る(3.01だけが400)", async () => {
+    mockVoiceDesignOk();
+    const res = await request(makeApp())
+      .post("/v1/admin/avatar/design-voice")
+      .send({ instruction: "落ち着いた声", speed: 3 });
+
+    expect(res.status).toBe(200);
+  });
+
+  it("バリデーション境界: speed=3.01は400", async () => {
+    const res = await request(makeApp())
+      .post("/v1/admin/avatar/design-voice")
+      .send({ instruction: "落ち着いた声", speed: 3.01 });
+
+    expect(res.status).toBe(400);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("バリデーション境界: speedの極小正数(0.0001)は通る(下限は排他的だが正であればよい)", async () => {
+    mockVoiceDesignOk();
+    const res = await request(makeApp())
+      .post("/v1/admin/avatar/design-voice")
+      .send({ instruction: "落ち着いた声", speed: 0.0001 });
+
+    expect(res.status).toBe(200);
+  });
+
+  // ── 禁止ワード（二重防御。generate-imageと同じ判定を再利用） ─────────────
+  it("禁止ワード: instructionにNSFW表現が含まれると400、Fish APIに到達しない", async () => {
+    const res = await request(makeApp())
+      .post("/v1/admin/avatar/design-voice")
+      .send({ instruction: "セクシーな声で話してください" });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain("不適切");
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
+
+  it("禁止ワード: 大文字小文字を無視して判定される(NSFWの英語表記)", async () => {
+    const res = await request(makeApp())
+      .post("/v1/admin/avatar/design-voice")
+      .send({ instruction: "Sound like a NSFW voice" });
+
+    expect(res.status).toBe(400);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  // ── イレギュラーなリクエスト形状 ─────────────────────────────────────
+  it("イレギュラー: instructionが数値型(文字列でない)は400", async () => {
+    const res = await request(makeApp())
+      .post("/v1/admin/avatar/design-voice")
+      .send({ instruction: 12345 });
+
+    expect(res.status).toBe(400);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("イレギュラー: nが文字列(\"2\")は400(型強制しない)", async () => {
+    const res = await request(makeApp())
+      .post("/v1/admin/avatar/design-voice")
+      .send({ instruction: "落ち着いた声", n: "2" });
+
+    expect(res.status).toBe(400);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("イレギュラー: bodyがnull(JSON \"null\"送信)は400", async () => {
+    const res = await request(makeApp())
+      .post("/v1/admin/avatar/design-voice")
+      .set("Content-Type", "application/json")
+      .send("null");
+
+    expect(res.status).toBe(400);
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  // ── Fish Audioが200だが不正な形のJSONを返した場合 ─────────────────────
+  it("Fish Audioが200だがcandidatesフィールド自体が無い場合は空配列として返す(クラッシュしない)", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({}),
+    });
+
+    const res = await request(makeApp())
+      .post("/v1/admin/avatar/design-voice")
+      .send({ instruction: "落ち着いた声" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.candidates).toEqual([]);
+    // 空配列でも「成功」扱いなのでtrackUsageは呼ばれる(design-voice自体は成功しているため。
+    // 0件フォールバックの判断はフロント側の責務 — match-voiceのような「空なら失敗扱い」に
+    // していない点に注意。フロント側テストで別途カバー)
+    expect(mockTrackUsage).toHaveBeenCalledTimes(1);
+  });
+
+  it("Fish Audioが200だが本文がJSONとしてパースできない場合は500で確定する(無限待ちにしない)", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => {
+        throw new Error("Unexpected token in JSON");
+      },
+    });
+
+    const res = await request(makeApp())
+      .post("/v1/admin/avatar/design-voice")
+      .send({ instruction: "落ち着いた声" });
+
+    expect(res.status).toBe(500);
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
 });

--- a/src/api/admin/avatar/generationRoutes.ts
+++ b/src/api/admin/avatar/generationRoutes.ts
@@ -64,7 +64,8 @@ const designVoiceSchema = z.object({
   instruction: z.string().min(1).max(2000),
   reference_text: z.string().max(150).optional(),
   n: z.number().int().min(1).max(4).optional(),
-  speed: z.number().min(0).max(3).optional(),
+  // 公式仕様: 0 < speed <= 3 (0自体は不可)
+  speed: z.number().gt(0).max(3).optional(),
 });
 
 const generatePromptSchema = z.object({
@@ -397,6 +398,12 @@ JSONのみ返してください。`,
       }
 
       const { instruction, reference_text, n, speed } = parsed.data;
+
+      // Phase5-D: 禁止ワードチェック（二重防御。generate-imageと同じ判定を再利用）
+      if (containsBannedWord(instruction)) {
+        return res.status(400).json({ error: "この指示にはビジネスに不適切な表現が含まれています" });
+      }
+
       const tenantId: string = resolveEffectiveTenantId(req);
       if (!tenantId) {
         return res.status(400).json({ error: "テナント情報が取得できません" });

--- a/src/api/avatar/fishAsrRoutes.test.ts
+++ b/src/api/avatar/fishAsrRoutes.test.ts
@@ -183,4 +183,109 @@ describe('POST /api/voice/asr', () => {
     expect(mockFetch).not.toHaveBeenCalled();
     expect(mockTrackUsage).not.toHaveBeenCalled();
   });
+
+  // ── 境界値 ───────────────────────────────────────────────────────────
+  // 実機で確認した挙動: multer/busboyのfileSize上限は「以下」ではなく「未満」で
+  // 判定される(ちょうど20MBも拒否される)。エラー文言は「20MB未満」に是正済み。
+  // ここでは実際の閾値が20MB-1バイトであることを両境界で固定する。
+  it('境界値: 20MBちょうどの録音は400で拒否される(multer/busboyのfileSize上限は"未満"判定)', async () => {
+    const exactly20MB = Buffer.alloc(20 * 1024 * 1024);
+
+    const res = await request(makeApp('tenant-a'))
+      .post('/api/voice/asr')
+      .attach('audio', exactly20MB, { filename: 'test.webm', contentType: 'audio/webm' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toContain('20MB');
+  });
+
+  it('境界値: 20MB-1バイトの録音は拒否されない(実際に許容される最大サイズ)', async () => {
+    mockFishAsrOk();
+    const justUnder20MB = Buffer.alloc(20 * 1024 * 1024 - 1);
+
+    const res = await request(makeApp('tenant-a'))
+      .post('/api/voice/asr')
+      .attach('audio', justUnder20MB, { filename: 'test.webm', contentType: 'audio/webm' });
+
+    expect(res.status).toBe(200);
+  });
+
+  it('境界値: 0バイトの音声ファイルはクラッシュせず送信を試み、asrRequestCount:1にフォールバックする', async () => {
+    mockFishAsrOk();
+
+    const res = await request(makeApp('tenant-a'))
+      .post('/api/voice/asr')
+      .attach('audio', Buffer.alloc(0), { filename: 'empty.webm', contentType: 'audio/webm' });
+
+    expect(res.status).toBe(200);
+    expect(mockTrackUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ asrRequestCount: 1 }),
+    );
+  });
+
+  // ── イレギュラーなアップロード操作（実機で確認した実害バグの回帰ガード） ──
+  // 修正前はどちらもExpressのデフォルトエラー処理に落ち、HTMLの500エラー
+  // (内部スタックトレース・サーバーのファイルパスを含む)が返っていた。
+  it('イレギュラー: 音声以外のMIMEタイプ(.txt等)は400のJSONで返り、スタックトレースを含むHTMLにならない', async () => {
+    const res = await request(makeApp('tenant-a'))
+      .post('/api/voice/asr')
+      .attach('audio', Buffer.from('not audio content'), { filename: 'test.txt', contentType: 'text/plain' });
+
+    expect(res.status).toBe(400);
+    expect(res.headers['content-type']).toContain('application/json');
+    expect(res.body.error).toBeTruthy();
+    expect(res.text).not.toContain('<html');
+    expect(res.text).not.toContain('at fileFilter');
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
+
+  it('イレギュラー: 同一フィールド名(audio)に複数ファイルを添付しても400のJSONで返る(HTMLの500にならない)', async () => {
+    const res = await request(makeApp('tenant-a'))
+      .post('/api/voice/asr')
+      .attach('audio', Buffer.from('a1'), { filename: 'a.webm', contentType: 'audio/webm' })
+      .attach('audio', Buffer.from('a2'), { filename: 'b.webm', contentType: 'audio/webm' });
+
+    expect(res.status).toBe(400);
+    expect(res.headers['content-type']).toContain('application/json');
+    expect(res.text).not.toContain('<html');
+    expect(mockFetch).not.toHaveBeenCalled();
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
+
+  it('実世界パターン: LISTチャンク付きのWAV(録音アプリのメタデータ混在)でも秒数を正しく計上する', async () => {
+    mockFishAsrOk();
+
+    function chunk(id: string, data: Buffer): Buffer {
+      const header = Buffer.alloc(8);
+      header.write(id, 0);
+      header.writeUInt32LE(data.length, 4);
+      const padding = data.length % 2 === 1 ? Buffer.alloc(1) : Buffer.alloc(0);
+      return Buffer.concat([header, data, padding]);
+    }
+    const fmtData = Buffer.alloc(16);
+    fmtData.writeUInt16LE(1, 0); fmtData.writeUInt16LE(1, 2);
+    fmtData.writeUInt32LE(44100, 4); fmtData.writeUInt32LE(88200, 8);
+    fmtData.writeUInt16LE(2, 12); fmtData.writeUInt16LE(16, 14);
+
+    const body = Buffer.concat([
+      chunk('fmt ', fmtData),
+      chunk('LIST', Buffer.from('INFOIART\x05\x00\x00\x00Me\x00\x00\x00')), // 奇数長パディング検証も兼ねる
+      chunk('data', Buffer.alloc(44100)), // 0.5秒
+    ]);
+    const header = Buffer.alloc(12);
+    header.write('RIFF', 0);
+    header.writeUInt32LE(4 + body.length, 4);
+    header.write('WAVE', 8);
+    const wavWithList = Buffer.concat([header, body]);
+
+    const res = await request(makeApp('tenant-a'))
+      .post('/api/voice/asr')
+      .attach('audio', wavWithList, { filename: 'recorded.wav', contentType: 'audio/wav' });
+
+    expect(res.status).toBe(200);
+    expect(mockTrackUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ asrAudioSeconds: 0.5 }),
+    );
+  });
 });

--- a/src/api/avatar/fishAsrRoutes.ts
+++ b/src/api/avatar/fishAsrRoutes.ts
@@ -20,23 +20,35 @@ const audioUpload = multer({
     if (/^audio\//i.test(file.mimetype)) {
       cb(null, true);
     } else {
-      cb(new Error('audio file required'));
+      cb(new Error('UNSUPPORTED_AUDIO_TYPE'));
     }
   },
 });
 
-// GID 1217083837550916: multer のファイルサイズ超過はデフォルトのExpressエラー処理に落ちると
-// 技術的な文言になるため、ここで親切な日本語メッセージに変換する。
+// GID 1217083837550916 / 実機発見: multer のアップロード失敗(サイズ超過・非audio MIME・
+// 同一フィールドへの複数ファイル添付など)はどれもデフォルトのExpressエラー処理に落ちると、
+// HTMLの500エラー(内部スタックトレース・サーバーのファイルパスを含む)が返っていた
+// （本番でも同様）。この位置に到達するエラーは multer(single('audio')の処理)由来のみ
+// のため、種別を問わずクライアント起因のアップロード失敗として安全な日本語400へ変換する。
 // Express は err.length===3 の通常ミドルウェアと err.length===4 のエラーハンドラを
 // 同一ルートのスタック内でも区別するため、single()の直後に置けば失敗時のみ呼ばれる。
-function handleAsrUploadError(err: unknown, _req: Request, res: Response, next: NextFunction): void {
+function handleAsrUploadError(err: unknown, _req: Request, res: Response, _next: NextFunction): void {
   if (err instanceof multer.MulterError && err.code === 'LIMIT_FILE_SIZE') {
     res.status(400).json({
-      error: '録音が長すぎます。20MB以内に収まるよう、もう一度短く録音してお試しください。',
+      error: '録音が長すぎます。20MB未満になるよう、もう一度短く録音してお試しください。',
     });
     return;
   }
-  next(err);
+  if (err instanceof Error && err.message === 'UNSUPPORTED_AUDIO_TYPE') {
+    res.status(400).json({
+      error: '音声ファイルの形式に対応していません。もう一度録音するか、別の音声ファイルでお試しください。',
+    });
+    return;
+  }
+  logger.warn({ err }, '[fishAsr] upload rejected by multer (unclassified)');
+  res.status(400).json({
+    error: '録音を受け取れませんでした。もう一度録音してお試しください。',
+  });
 }
 
 export function registerFishAsrRoutes(app: Express, apiStack: RequestHandler[]): void {

--- a/src/api/internal/usageRoutes.test.ts
+++ b/src/api/internal/usageRoutes.test.ts
@@ -142,4 +142,106 @@ describe("POST /api/internal/usage", () => {
     expect(typeof call.requestId).toBe("string");
     expect(call.requestId.length).toBeGreaterThan(0);
   });
+
+  // ── イレギュラーな入力形状（内部APIだが境界値として型を信用しない） ──────
+  it("イレギュラー: ttsModelが配列(JSON \"?tenant=a&tenant=b\"型の汚染)は文字列扱いされず undefined になる", async () => {
+    await request(makeApp())
+      .post("/api/internal/usage")
+      .set("X-Internal-Request", "1")
+      .send({ tenantId: "tenant-abc", ttsTextBytes: 100, ttsModel: ["s2.1-pro-free", "s2.1-pro"] });
+
+    expect(mockTrackUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ ttsModel: undefined }),
+    );
+  });
+
+  it("イレギュラー: ttsModelがオブジェクトは文字列扱いされず undefined になる", async () => {
+    await request(makeApp())
+      .post("/api/internal/usage")
+      .set("X-Internal-Request", "1")
+      .send({ tenantId: "tenant-abc", ttsTextBytes: 100, ttsModel: { toString: () => "s2.1-pro-free" } });
+
+    expect(mockTrackUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ ttsModel: undefined }),
+    );
+  });
+
+  it("イレギュラー: tenantIdが配列は400(型強制せず拒否する)", async () => {
+    const res = await request(makeApp())
+      .post("/api/internal/usage")
+      .set("X-Internal-Request", "1")
+      .send({ tenantId: ["tenant-a", "tenant-b"] });
+
+    expect(res.status).toBe(400);
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
+
+  it("イレギュラー: tenantIdが数値は400", async () => {
+    const res = await request(makeApp())
+      .post("/api/internal/usage")
+      .set("X-Internal-Request", "1")
+      .send({ tenantId: 12345 });
+
+    expect(res.status).toBe(400);
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
+
+  it("イレギュラー: 負のttsTextBytesは請求額を減らす攻撃になり得るため0扱い(undefined)に落とされる", async () => {
+    await request(makeApp())
+      .post("/api/internal/usage")
+      .set("X-Internal-Request", "1")
+      .send({ tenantId: "tenant-abc", ttsTextBytes: -1000000 });
+
+    expect(mockTrackUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ ttsTextBytes: undefined }),
+    );
+  });
+
+  it("イレギュラー: 負のinputTokens/outputTokensは0にフォールバックする(負のコストで相殺する攻撃を防ぐ)", async () => {
+    await request(makeApp())
+      .post("/api/internal/usage")
+      .set("X-Internal-Request", "1")
+      .send({ tenantId: "tenant-abc", inputTokens: -500, outputTokens: -500 });
+
+    expect(mockTrackUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ inputTokens: 0, outputTokens: 0 }),
+    );
+  });
+
+  it("イレギュラー: 負のavatarCredits/avatarSessionMsはundefinedにフォールバックする", async () => {
+    await request(makeApp())
+      .post("/api/internal/usage")
+      .set("X-Internal-Request", "1")
+      .send({ tenantId: "tenant-abc", avatarCredits: -10, avatarSessionMs: -5000 });
+
+    expect(mockTrackUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ avatarCredits: undefined, avatarSessionMs: undefined }),
+    );
+  });
+
+  it("イレギュラー: NaN/InfinityのinputTokensは0にフォールバックする", async () => {
+    await request(makeApp())
+      .post("/api/internal/usage")
+      .set("X-Internal-Request", "1")
+      .send({ tenantId: "tenant-abc", inputTokens: Number.POSITIVE_INFINITY });
+
+    // JSON経由ではInfinityはnullになるが、Number.MAX_VALUE等の巨大値経路も含め
+    // 数値として素通りしないことをここで固定する(型ガードのみで上限は無いため
+    // 巨大値そのものはtrackUsageに渡ってよい —素通りする値そのものの妥当性は
+    // costCalculator側の責務であり、ここでは「型が壊れていない」ことだけ検証する)
+    const call = mockTrackUsage.mock.calls[0][0];
+    expect(typeof call.inputTokens).toBe("number");
+    expect(Number.isNaN(call.inputTokens)).toBe(false);
+  });
+
+  it("イレギュラー: bodyが空文字列(Content-Typeだけ設定されパースエラー)でも500にならず400/403いずれかで確定する", async () => {
+    const res = await request(makeApp())
+      .post("/api/internal/usage")
+      .set("X-Internal-Request", "1")
+      .set("Content-Type", "application/json")
+      .send("");
+
+    expect([400, 403]).toContain(res.status);
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
 });

--- a/src/lib/audio/wavDuration.test.ts
+++ b/src/lib/audio/wavDuration.test.ts
@@ -37,6 +37,39 @@ function buildWavBuffer({
   return buf;
 }
 
+// 任意のチャンク列からWAVバッファを組み立てる低レベルヘルパー。
+// 実録音アプリ/ブラウザが付与するLIST/INFO等の余剰チャンクや、
+// fmt/dataの出現順序が非標準なケースを再現するために使う。
+function chunk(id: string, data: Buffer): Buffer {
+  const header = Buffer.alloc(8);
+  header.write(id, 0);
+  header.writeUInt32LE(data.length, 4);
+  const padding = data.length % 2 === 1 ? Buffer.alloc(1) : Buffer.alloc(0);
+  return Buffer.concat([header, data, padding]);
+}
+
+function fmtChunkData({ sampleRate = 44100, numChannels = 1, bitsPerSample = 16 } = {}): Buffer {
+  const byteRate = sampleRate * numChannels * (bitsPerSample / 8);
+  const blockAlign = numChannels * (bitsPerSample / 8);
+  const d = Buffer.alloc(16);
+  d.writeUInt16LE(1, 0);
+  d.writeUInt16LE(numChannels, 2);
+  d.writeUInt32LE(sampleRate, 4);
+  d.writeUInt32LE(byteRate, 8);
+  d.writeUInt16LE(blockAlign, 12);
+  d.writeUInt16LE(bitsPerSample, 14);
+  return d;
+}
+
+function buildWavFromChunks(chunks: Buffer[]): Buffer {
+  const body = Buffer.concat(chunks);
+  const header = Buffer.alloc(12);
+  header.write('RIFF', 0);
+  header.writeUInt32LE(4 + body.length, 4);
+  header.write('WAVE', 8);
+  return Buffer.concat([header, body]);
+}
+
 describe('parseWavDurationSeconds', () => {
   it('正常WAV: 44.1kHz/16bit/モノラルで88200バイト(=1秒分)のdataは1.0秒を返す', () => {
     const buf = buildWavBuffer({ dataBytes: 88200 });
@@ -61,5 +94,85 @@ describe('parseWavDurationSeconds', () => {
 
   it('0バイト: 空バッファは null を返す', () => {
     expect(parseWavDurationSeconds(Buffer.alloc(0))).toBeNull();
+  });
+
+  // ── 実世界のWAVで頻出する非標準パターン ─────────────────────────────
+  it('実世界パターン: fmtとdataの間にLISTチャンク(メタデータ)が挟まっても正しく解析できる', () => {
+    // 録音アプリ/DAWがタイトル・作者等のメタデータをLISTチャンクとして
+    // fmtとdataの間に挟むことがある。88200バイトのPCMデータ=1.0秒。
+    const buf = buildWavFromChunks([
+      chunk('fmt ', fmtChunkData()),
+      chunk('LIST', Buffer.from('INFOIART\x05\x00\x00\x00Me\x00\x00\x00')), // 奇数長データで自動パディング検証も兼ねる
+      chunk('data', Buffer.alloc(88200)),
+    ]);
+    expect(parseWavDurationSeconds(buf)).toBeCloseTo(1.0);
+  });
+
+  it('実世界パターン: LISTチャンクがRIFFヘッダ直後・fmtより前に来ても正しく解析できる', () => {
+    const buf = buildWavFromChunks([
+      chunk('LIST', Buffer.from('INFOIART\x04\x00\x00\x00Test')),
+      chunk('fmt ', fmtChunkData()),
+      chunk('data', Buffer.alloc(44100)), // 0.5秒
+    ]);
+    expect(parseWavDurationSeconds(buf)).toBeCloseTo(0.5);
+  });
+
+  it('奇数長チャンクのパディングを正しくスキップする(パディングバイトを読み飛ばさないとチャンクIDがズレて誤判定/nullになる)', () => {
+    // 奇数長(999バイト)のLISTチャンクの後に1バイトのパディングが入る。
+    // パディング計算を誤ると次の"data"の4バイトIDがズレて読めなくなる。
+    const oddSizedList = Buffer.alloc(999, 0x41);
+    const buf = buildWavFromChunks([
+      chunk('fmt ', fmtChunkData()),
+      chunk('LIST', oddSizedList),
+      chunk('data', Buffer.alloc(22050)), // 0.25秒
+    ]);
+    expect(parseWavDurationSeconds(buf)).toBeCloseTo(0.25);
+  });
+
+  it('順序異常: dataチャンクがfmtより前に出現しても最終的に両方揃えば解析できる', () => {
+    const buf = buildWavFromChunks([
+      chunk('data', Buffer.alloc(44100)),
+      chunk('fmt ', fmtChunkData()),
+    ]);
+    expect(parseWavDurationSeconds(buf)).toBeCloseTo(0.5);
+  });
+
+  it('破損ヘッダ: fmtチャンクのbyteRateが0の場合はnullを返す(ゼロ除算を起こさない)', () => {
+    const corruptFmt = Buffer.alloc(16); // 全フィールド0、byteRateも0
+    const buf = buildWavFromChunks([
+      chunk('fmt ', corruptFmt),
+      chunk('data', Buffer.alloc(1000)),
+    ]);
+    expect(parseWavDurationSeconds(buf)).toBeNull();
+  });
+
+  it('壊れたヘッダ: dataチャンクの宣言サイズが実際のバッファ長を超える場合、実データ量に丸めて計算する(クラッシュや負の値にしない)', () => {
+    // ブラウザのMediaRecorderが録音途中でタブが閉じられた等でストリームが
+    // 打ち切られると、ヘッダの宣言サイズと実データが食い違うことがある。
+    const buf = buildWavFromChunks([
+      chunk('fmt ', fmtChunkData()),
+    ]);
+    // dataチャンクヘッダだけ手書きし、宣言サイズ(1,000,000バイト)に対し
+    // 実際のバッファには44100バイトしか続かない状態を作る。
+    const dataHeader = Buffer.alloc(8);
+    dataHeader.write('data', 0);
+    dataHeader.writeUInt32LE(1_000_000, 4);
+    const truncatedBuf = Buffer.concat([buf, dataHeader, Buffer.alloc(44100)]);
+
+    const result = parseWavDurationSeconds(truncatedBuf);
+    expect(result).not.toBeNull();
+    expect(result).toBeCloseTo(0.5); // 実際に存在する44100バイト分として計算される
+  });
+
+  it('fmtチャンクのサイズが16バイト未満(拡張フィールドの手前で切れている)場合はnullを返す', () => {
+    const shortFmtHeader = Buffer.alloc(8);
+    shortFmtHeader.write('fmt ', 0);
+    shortFmtHeader.writeUInt32LE(16, 4); // 16バイトあると宣言しているが実際は10バイトしかない
+    const buf = Buffer.concat([
+      Buffer.from('RIFF\x00\x00\x00\x00WAVE'),
+      shortFmtHeader,
+      Buffer.alloc(10),
+    ]);
+    expect(parseWavDurationSeconds(buf)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
先行実装(PR-0/PR-1/train_mode修正/PR-2 backend/frontend)のテストを、境界値・異常系・実際にユーザーが起こしうるイレギュラー操作を突く形に強化。テスト追加の過程で実害のあるバグを2件、production影響のあるバグを2件発見・修正した。

## 修正した実害バグ
1. **design-voiceにNSFW等のコンテンツガードが無かった** — `generate-image`にある`containsBannedWord`二重防御が新設した`design-voice`には抜けていた。同じチェックを追加。
2. **speedバリデーションの排他境界ミス** — 公式仕様は`0 < speed <= 3`だがzodスキーマは`min(0)`で0を許容していた。`gt(0)`に修正。
3. **アップロード失敗時にHTMLの500エラー(スタックトレース・サーバーファイルパス漏洩)** — 非audioファイル添付・同一フィールドへの複数ファイル添付が`handleAsrUploadError`で捕捉されず、Expressのデフォルトエラー処理に落ちていた。親切な日本語400 JSONに統一。
4. **multerのfileSize上限は「以下」ではなく「未満」判定** — ちょうど20MBのファイルも拒否される実機挙動を確認。エラー文言を是正。

## テスト追加の主な観点
- **design-voice**: n(1-4)/speed(0<x<=3)の境界値、禁止ワード、非string型payload、Fish応答のJSON解析失敗
- **fishVoiceModel**: 0バイト音声、`_id`型不正(数値/空文字)、201以外の成功コード、fetchやJSON解析自体が例外を投げるケース
- **fishAsrRoutes**: 20MB境界(20MB/20MB-1)、0バイト音声、LIST/INFOチャンク混在WAV(実際の録音アプリが付与するメタデータ)、multerエラーのHTML漏洩回帰ガード
- **wavDuration**: LISTチャンクの前後混在、奇数長チャンクのパディングスキップ、data→fmt順序異常、byteRate=0の破損ヘッダ、宣言サイズが実データを超える場合のトランケート計算
- **usageRoutes**: `ttsModel`の配列/オブジェクト型攻撃、負のトークン数による請求相殺攻撃、`tenantId`の型汚染
- **copilot-preview**: 「声を作る」連打防止(busyDesignVoice)、複数候補の排他制御、壊れたbase64でのページクラッシュ耐性、2000字超instructionのクライアント側切り詰め

## カバーできていないリスク(指摘のみ、対応は別判断)
- `adopt-designed-voice`にサーバー側の二重送信防止が無い(クライアント側のdisabledのみ)。同じ設計を持つ既存`voice-clone`と同一パターンのため、直すなら両方まとめて別タスク。
- costCalculatorの`asrAudioSeconds`/`voiceDesignRequestCount`は負数を渡されても防御していない(現状の全呼び出し元は非負値しか渡さないため実害なし。将来の呼び出し元追加時に要注意)。

## Test plan
- [x] pnpm typecheck (backend): 0 errors
- [x] pnpm lint (backend): 0 new warnings
- [x] pnpm jest (変更ファイルのみ): 11 suites / 381 tests all pass
- [x] pnpm jest (フルスイート): 3392 tests中、無関係な2ファイルが並列実行時のポート競合で断続的にflaky(既知の環境要因、再実行で解消確認済み)
- [x] Gate 1.5 dead-code-check / Gate 2 security-scan: PASS
- [x] Gate 3 build (backend + admin-ui): 成功
- [x] admin-ui vitest: 170/170 pass
- [x] admin-ui typecheck/lint: copilot-preview関連の新規エラー0件

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdBRSsTu4YNWBDTpgzqz2c