### PR TITLE
voice-clone/adopt-designed-voiceの二重送信防止＋原価計算の負値ガード

### DIFF
--- a/src/api/admin/avatar/fishVoiceModel.test.ts
+++ b/src/api/admin/avatar/fishVoiceModel.test.ts
@@ -1,6 +1,6 @@
 // src/api/admin/avatar/fishVoiceModel.test.ts
 
-import { createFishVoiceModel, FishVoiceModelError } from "./fishVoiceModel";
+import { createFishVoiceModel, FishVoiceModelError, adoptVoiceForConfig } from "./fishVoiceModel";
 
 const mockFetch = jest.fn();
 global.fetch = mockFetch as unknown as typeof fetch;
@@ -203,5 +203,133 @@ describe("createFishVoiceModel", () => {
         mimeType: "audio/wav",
       }),
     ).rejects.toThrow("ECONNRESET");
+  });
+});
+
+// GID: voice-clone/adopt-designed-voiceの二重送信(二重課金)防止のための
+// トランザクション処理。ルートレベルの統合テスト(routes.test.ts)ではHTTP経由で
+// 到達しにくい「コネクション解放の保証」「ROLLBACK自体が失敗する二重障害」を
+// ここで直接検証する。
+describe("adoptVoiceForConfig", () => {
+  function makeTxDb(clientQueryImpl: (sql: string, values?: unknown[]) => Promise<any>) {
+    const clientQuery = jest.fn(clientQueryImpl);
+    const release = jest.fn();
+    const connect = jest.fn().mockResolvedValue({ query: clientQuery, release });
+    return { db: { connect }, clientQuery, release };
+  }
+
+  const baseParams = {
+    configId: "config-1",
+    tenantId: "tenant-a",
+    isSuperAdmin: false,
+    fishApiKey: "test-key",
+    title: "マイボイス",
+    audio: Buffer.from("dummy"),
+    mimeType: "audio/wav",
+    logEventPrefix: "voice_clone",
+    logContext: "[test] voice-clone",
+  };
+
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+
+  it("正常系: SELECT FOR UPDATE → Fish呼び出し → UPDATE → COMMITの順に実行し、コネクションを解放する", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 201, json: async () => ({ _id: "fish-voice-1" }) });
+    const { db, clientQuery, release } = makeTxDb(async (sql) => {
+      if (sql.startsWith("SELECT id FROM avatar_configs")) return { rows: [{ id: "config-1" }] };
+      if (sql.startsWith("UPDATE avatar_configs")) return { rows: [], rowCount: 1 };
+      return { rows: [] };
+    });
+
+    const result = await adoptVoiceForConfig({ ...baseParams, db });
+
+    expect(result).toEqual({ ok: true, voiceId: "fish-voice-1" });
+    expect(clientQuery.mock.calls.map((c) => c[0])).toEqual([
+      "BEGIN",
+      "SET LOCAL lock_timeout = '3s'",
+      expect.stringContaining("FOR UPDATE"),
+      expect.stringContaining("UPDATE avatar_configs"),
+      "COMMIT",
+    ]);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("Fish呼び出し失敗時もコネクションを解放する(接続リーク防止)", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: false, status: 500, text: async () => "error" });
+    const { db, release } = makeTxDb(async (sql) => {
+      if (sql.startsWith("SELECT id FROM avatar_configs")) return { rows: [{ id: "config-1" }] };
+      return { rows: [] };
+    });
+
+    const result = await adoptVoiceForConfig({ ...baseParams, db });
+
+    expect(result.ok).toBe(false);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("設定が見つからない場合、404を返しFishを一切呼ばない", async () => {
+    const { db } = makeTxDb(async (sql) => {
+      if (sql.startsWith("SELECT id FROM avatar_configs")) return { rows: [] };
+      return { rows: [] };
+    });
+
+    const result = await adoptVoiceForConfig({ ...baseParams, db });
+
+    expect(result).toEqual({ ok: false, status: 404, error: "設定が見つからないかアクセス権限がありません" });
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("ロックタイムアウトは409を返し、logEventPrefixごとに正しい汎用メッセージにフォールバックする(adopt-designed-voice側)", async () => {
+    const { db } = makeTxDb(async (sql) => {
+      if (sql.startsWith("SELECT id FROM avatar_configs")) throw new Error("canceling statement due to lock timeout");
+      return { rows: [] };
+    });
+
+    const result = await adoptVoiceForConfig({
+      ...baseParams,
+      db,
+      logEventPrefix: "adopt_designed_voice",
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      status: 409,
+      error: "この設定は現在別の操作を処理中です。少し待ってからもう一度お試しください",
+    });
+  });
+
+  // 二重障害: ロック取得に失敗した直後、ROLLBACK自体もコネクション断等で失敗するケース。
+  // .catch(() => {}) で握りつぶさないと、本来のエラー(lock timeout起因の409判定)より
+  // ROLLBACK失敗のエラーが優先されてしまい、呼び出し元が500として扱ってしまう。
+  it("二重障害: ROLLBACK自体が失敗しても、元のロックタイムアウト起因の409判定を優先する", async () => {
+    const { db, release } = makeTxDb(async (sql) => {
+      if (sql.startsWith("SELECT id FROM avatar_configs")) throw new Error("canceling statement due to lock timeout");
+      if (sql === "ROLLBACK") throw new Error("connection terminated unexpectedly");
+      return { rows: [] };
+    });
+
+    const result = await adoptVoiceForConfig({ ...baseParams, db });
+
+    expect(result).toEqual({
+      ok: false,
+      status: 409,
+      error: "この設定は現在別の操作を処理中です。少し待ってからもう一度お試しください",
+    });
+    // ROLLBACK失敗時もコネクションは必ず解放される(finally節)
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  it("ロックタイムアウトでも予期しないDBエラー(接続断等)でもない場合は、呼び出し元に例外を投げる(既存の500ハンドリングに委ねる)", async () => {
+    const { db, release } = makeTxDb(async (sql) => {
+      if (sql.startsWith("SELECT id FROM avatar_configs")) throw new Error("relation \"avatar_configs\" does not exist");
+      if (sql === "ROLLBACK") return { rows: [] };
+      return { rows: [] };
+    });
+
+    await expect(adoptVoiceForConfig({ ...baseParams, db })).rejects.toThrow(
+      'relation "avatar_configs" does not exist',
+    );
+    expect(release).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/api/admin/avatar/fishVoiceModel.ts
+++ b/src/api/admin/avatar/fishVoiceModel.ts
@@ -4,6 +4,8 @@
 // voice-clone（実音声アップロード）と adopt-designed-voice（Voice Design候補の採用）の
 // 両方から呼ばれる — Fish /model への書き込み経路を1箇所に集約し、重複実装を防ぐ。
 
+import { logger } from "../../../lib/logger";
+
 export interface CreateFishVoiceModelParams {
   apiKey: string;
   title: string;
@@ -65,4 +67,108 @@ export async function createFishVoiceModel(
   }
 
   return voiceId;
+}
+
+export interface AdoptVoiceForConfigParams {
+  /** db.connect() を持つプール（routes.ts の activate エンドポイントと同じ注入パターン） */
+  db: { connect(): Promise<{ query: (sql: string, values?: unknown[]) => Promise<any>; release(): void }> };
+  configId: string;
+  tenantId: string;
+  isSuperAdmin: boolean;
+  fishApiKey: string;
+  title: string;
+  audio: Buffer;
+  mimeType: string;
+  filename?: string;
+  /** ログイベント名の接頭辞（"voice_clone" | "adopt_designed_voice"）。呼び出し元ごとに区別する */
+  logEventPrefix: string;
+  logContext: string;
+}
+
+export type AdoptVoiceForConfigResult =
+  | { ok: true; voiceId: string }
+  | { ok: false; status: 404 | 409 | 502; error: string };
+
+/**
+ * GID: voice-clone/adopt-designed-voiceの重複実装を避けるための共通トランザクション処理。
+ *
+ * 【解決している問題】connectAvatarConfigの所有権チェックとFish /model呼び出し・voice_id保存が
+ * 単純なquery()の連続だったため、同じconfigへ2回連続でリクエストされる(二重クリック・複数タブ・
+ * リプレイ)と、Fish側に音声モデルが2つ作成され課金が二重発生し、voice_idは後勝ちで上書きされる
+ * レースコンディションがあった。
+ *
+ * SELECT ... FOR UPDATE で対象行をロックし、Fish呼び出し+UPDATEを同一トランザクション内で
+ * 直列化する（chat-history/deleteSessionRepository.tsと同じ確立済みパターン）。
+ * ロック待ちが3秒を超えた場合（＝同時に別の登録が進行中）は409を返し、二重にFishへ課金しない。
+ *
+ * 外部APIコール(Fish Audio)をロック保持中に行う点は一般的には避けるべきだが、本エンドポイントは
+ * 低頻度の管理操作でありFishのレスポンスも数秒以内のため許容する。
+ */
+export async function adoptVoiceForConfig(
+  params: AdoptVoiceForConfigParams,
+): Promise<AdoptVoiceForConfigResult> {
+  const genericError =
+    params.logEventPrefix === "voice_clone" ? "音声クローンの作成に失敗しました" : "音声の登録に失敗しました";
+
+  const client = await params.db.connect();
+  try {
+    await client.query("BEGIN");
+    await client.query("SET LOCAL lock_timeout = '3s'");
+
+    let checkQuery = "SELECT id FROM avatar_configs WHERE id = $1";
+    const checkValues: unknown[] = [params.configId];
+    if (!params.isSuperAdmin) {
+      checkQuery += " AND tenant_id = $2";
+      checkValues.push(params.tenantId);
+    }
+    checkQuery += " FOR UPDATE";
+    const existing = await client.query(checkQuery, checkValues);
+    if (existing.rows.length === 0) {
+      await client.query("ROLLBACK");
+      return { ok: false, status: 404, error: "設定が見つからないかアクセス権限がありません" };
+    }
+
+    let voiceId: string;
+    try {
+      voiceId = await createFishVoiceModel({
+        apiKey: params.fishApiKey,
+        title: params.title,
+        audio: params.audio,
+        mimeType: params.mimeType,
+        filename: params.filename,
+      });
+    } catch (err) {
+      await client.query("ROLLBACK");
+      logger.warn({
+        event: `${params.logEventPrefix}_fish_error`,
+        status: err instanceof FishVoiceModelError ? err.status : undefined,
+        detail: err instanceof Error ? err.message.slice(0, 300) : String(err),
+      }, params.logContext);
+      return { ok: false, status: 502, error: genericError };
+    }
+
+    const updateValues: unknown[] = [voiceId, params.configId];
+    let updateQuery = "UPDATE avatar_configs SET voice_id = $1, updated_at = NOW() WHERE id = $2";
+    if (!params.isSuperAdmin) {
+      updateValues.push(params.tenantId);
+      updateQuery += " AND tenant_id = $3";
+    }
+    const result = await client.query(updateQuery, updateValues);
+    if ((result.rowCount ?? result.rows?.length ?? 0) === 0) {
+      await client.query("ROLLBACK");
+      return { ok: false, status: 404, error: "設定が見つからないかアクセス権限がありません" };
+    }
+
+    await client.query("COMMIT");
+    return { ok: true, voiceId };
+  } catch (err) {
+    await client.query("ROLLBACK").catch(() => {});
+    // ロックタイムアウト = 同時に別の登録が進行中。二重にFishへ課金しないよう409で確定させる。
+    if (err instanceof Error && /lock timeout|canceling statement/i.test(err.message)) {
+      return { ok: false, status: 409, error: "この設定は現在別の操作を処理中です。少し待ってからもう一度お試しください" };
+    }
+    throw err;
+  } finally {
+    client.release();
+  }
 }

--- a/src/api/admin/avatar/routes.test.ts
+++ b/src/api/admin/avatar/routes.test.ts
@@ -319,6 +319,32 @@ describe("POST /v1/admin/avatar/configs — emotion_tags validation", () => {
 // POST /v1/admin/avatar/configs/:id/voice-clone — FishAudio Phase B-2
 // --------------------------------------------------------------------------
 
+// GID: voice-clone / adopt-designed-voice はいずれも adoptVoiceForConfig() 経由で
+// db.connect() によるトランザクション(BEGIN → SET LOCAL lock_timeout → SELECT...FOR UPDATE
+// → [Fish呼び出し] → UPDATE → COMMIT)を使う(activateエンドポイントと同じ確立済みパターン)。
+// このヘルパーはそのクエリ列を組み立てる。
+function makeTxDb(clientQueryImpl: (sql: string, values?: unknown[]) => Promise<any>) {
+  const clientQuery = jest.fn(clientQueryImpl);
+  const release = jest.fn();
+  const connect = jest.fn().mockResolvedValue({ query: clientQuery, release });
+  return { db: { connect }, clientQuery, release };
+}
+
+// SELECT...FOR UPDATE → 成功 → UPDATE成功、という一番よくある成功シーケンスを
+// 組み立てる。個々のテストは必要な箇所だけ上書きする。
+function successTxQueries(opts: { checkRow: { id: string }; updateRowCount?: number }) {
+  let call = 0;
+  return async (sql: string) => {
+    call += 1;
+    if (sql === "BEGIN" || sql === "SET LOCAL lock_timeout = '3s'" || sql === "COMMIT") return { rows: [] };
+    if (sql.startsWith("SELECT id FROM avatar_configs")) return { rows: [opts.checkRow] };
+    if (sql.startsWith("UPDATE avatar_configs SET voice_id")) {
+      return { rows: [], rowCount: opts.updateRowCount ?? 1 };
+    }
+    throw new Error(`unexpected query in test (call ${call}): ${sql}`);
+  };
+}
+
 describe("POST /v1/admin/avatar/configs/:id/voice-clone", () => {
   const AUDIO_BUFFER = Buffer.from("dummy-audio-bytes");
   let fetchSpy: jest.SpyInstance;
@@ -352,12 +378,9 @@ describe("POST /v1/admin/avatar/configs/:id/voice-clone", () => {
   });
 
   it("正常系: client_admin + 自テナント config → Fish Audio 呼び出し + voice_id UPDATE + 200", async () => {
-    const dbQuery = jest
-      .fn()
-      .mockResolvedValueOnce({ rows: [{ id: "config-1" }] })   // 所有チェック SELECT
-      .mockResolvedValueOnce({ rows: [{ id: "config-1" }] });  // UPDATE RETURNING id
-
-    const db = { query: dbQuery };
+    const { db, clientQuery, release } = makeTxDb(
+      successTxQueries({ checkRow: { id: "config-1" } }),
+    );
 
     const res = await request(makeApp(db, "client_admin", "tenant-a"))
       .post("/v1/admin/avatar/configs/config-1/voice-clone")
@@ -385,21 +408,25 @@ describe("POST /v1/admin/avatar/configs/:id/voice-clone", () => {
     expect(fd.get("title")).toBe("マイボイス");
     expect(fd.get("voices")).toBeTruthy();
 
-    // 所有チェック + UPDATE の両方が tenant スコープ付き
-    const [checkSql, checkParams] = dbQuery.mock.calls[0] as [string, unknown[]];
-    expect(checkSql).toContain("tenant_id = $2");
-    expect(checkParams).toEqual(["config-1", "tenant-a"]);
-
-    const [updateSql, updateParams] = dbQuery.mock.calls[1] as [string, unknown[]];
-    expect(updateSql).toContain("UPDATE avatar_configs SET voice_id = $1");
-    expect(updateSql).toContain("updated_at = NOW()");
-    expect(updateSql).toContain("tenant_id = $3");
-    expect(updateParams).toEqual(["fish-voice-123", "config-1", "tenant-a"]);
+    // トランザクション: BEGIN → lock_timeout → SELECT FOR UPDATE(tenantスコープ付) →
+    // UPDATE(tenantスコープ付) → COMMIT
+    const calls = clientQuery.mock.calls as Array<[string, unknown[]?]>;
+    expect(calls[0]![0]).toBe("BEGIN");
+    expect(calls[1]![0]).toBe("SET LOCAL lock_timeout = '3s'");
+    expect(calls[2]![0]).toContain("FOR UPDATE");
+    expect(calls[2]![0]).toContain("tenant_id = $2");
+    expect(calls[2]![1]).toEqual(["config-1", "tenant-a"]);
+    expect(calls[3]![0]).toContain("UPDATE avatar_configs SET voice_id = $1");
+    expect(calls[3]![0]).toContain("updated_at = NOW()");
+    expect(calls[3]![0]).toContain("tenant_id = $3");
+    expect(calls[3]![1]).toEqual(["fish-voice-123", "config-1", "tenant-a"]);
+    expect(calls[4]![0]).toBe("COMMIT");
+    // ロックしたコネクションを必ず解放している(コネクションプール枯渇の防止)
+    expect(release).toHaveBeenCalledTimes(1);
   });
 
   it("認証エラー: role なし → 403、DB・fetch に到達しない", async () => {
-    const dbQuery = jest.fn();
-    const db = { query: dbQuery };
+    const { db, clientQuery } = makeTxDb(async () => ({ rows: [] }));
 
     const res = await request(makeAppNoRole(db))
       .post("/v1/admin/avatar/configs/config-1/voice-clone")
@@ -411,26 +438,24 @@ describe("POST /v1/admin/avatar/configs/:id/voice-clone", () => {
 
     expect(res.status).toBe(403);
     expect(res.body.code).toBe("AUTHZ_ROLE_DENIED");
-    expect(dbQuery).not.toHaveBeenCalled();
+    expect(clientQuery).not.toHaveBeenCalled();
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it("バリデーション: audio ファイルなし → 400、DB・fetch に到達しない", async () => {
-    const dbQuery = jest.fn();
-    const db = { query: dbQuery };
+    const { db, clientQuery } = makeTxDb(async () => ({ rows: [] }));
 
     const res = await request(makeApp(db, "client_admin", "tenant-a"))
       .post("/v1/admin/avatar/configs/config-1/voice-clone")
       .field("name", "マイボイス");
 
     expect(res.status).toBe(400);
-    expect(dbQuery).not.toHaveBeenCalled();
+    expect(clientQuery).not.toHaveBeenCalled();
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it("バリデーション: name が 101 字 → 400", async () => {
-    const dbQuery = jest.fn();
-    const db = { query: dbQuery };
+    const { db, clientQuery } = makeTxDb(async () => ({ rows: [] }));
 
     const res = await request(makeApp(db, "client_admin", "tenant-a"))
       .post("/v1/admin/avatar/configs/config-1/voice-clone")
@@ -442,13 +467,12 @@ describe("POST /v1/admin/avatar/configs/:id/voice-clone", () => {
 
     expect(res.status).toBe(400);
     expect(res.body.error).toBe("invalid_request");
-    expect(dbQuery).not.toHaveBeenCalled();
+    expect(clientQuery).not.toHaveBeenCalled();
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
   it("バリデーション: 許可外 MIME タイプ → 400、fetch に到達しない", async () => {
-    const dbQuery = jest.fn();
-    const db = { query: dbQuery };
+    const { db } = makeTxDb(async () => ({ rows: [] }));
 
     const res = await request(makeApp(db, "client_admin", "tenant-a"))
       .post("/v1/admin/avatar/configs/config-1/voice-clone")
@@ -463,11 +487,7 @@ describe("POST /v1/admin/avatar/configs/:id/voice-clone", () => {
   });
 
   it("回帰: audio/x-m4a (.m4a macOS Chrome) → Fish Audio 呼び出し + 200", async () => {
-    const dbQuery = jest
-      .fn()
-      .mockResolvedValueOnce({ rows: [{ id: "config-1" }] })
-      .mockResolvedValueOnce({ rows: [{ id: "config-1" }] });
-    const db = { query: dbQuery };
+    const { db } = makeTxDb(successTxQueries({ checkRow: { id: "config-1" } }));
 
     const res = await request(makeApp(db, "client_admin", "tenant-a"))
       .post("/v1/admin/avatar/configs/config-1/voice-clone")
@@ -481,12 +501,12 @@ describe("POST /v1/admin/avatar/configs/:id/voice-clone", () => {
     expect(fetchSpy).toHaveBeenCalledTimes(1);
   });
 
-  it("テナント越境: 他テナント configId → 404、Fish Audio に到達しない", async () => {
-    const dbQuery = jest
-      .fn()
-      .mockResolvedValueOnce({ rows: [] }); // 所有チェック SELECT → 0 件
-
-    const db = { query: dbQuery };
+  it("テナント越境: 他テナント configId → 404、Fish Audio に到達しない・ROLLBACKする", async () => {
+    const { db, clientQuery } = makeTxDb(async (sql) => {
+      if (sql === "BEGIN" || sql === "SET LOCAL lock_timeout = '3s'" || sql === "ROLLBACK") return { rows: [] };
+      if (sql.startsWith("SELECT id FROM avatar_configs")) return { rows: [] }; // 所有チェック 0件
+      throw new Error(`unexpected query: ${sql}`);
+    });
 
     const res = await request(makeApp(db, "client_admin", "tenant-a"))
       .post("/v1/admin/avatar/configs/other-tenant-config/voice-clone")
@@ -498,17 +518,13 @@ describe("POST /v1/admin/avatar/configs/:id/voice-clone", () => {
 
     expect(res.status).toBe(404);
     expect(fetchSpy).not.toHaveBeenCalled();
-    // UPDATE は呼ばれない（SELECT のみ）
-    expect(dbQuery).toHaveBeenCalledTimes(1);
+    // UPDATE は呼ばれず、ROLLBACKで確定する（BEGIN, lock_timeout, SELECT, ROLLBACK の4回）
+    expect(clientQuery).toHaveBeenCalledTimes(4);
+    expect(clientQuery.mock.calls[3]![0]).toBe("ROLLBACK");
   });
 
   it("super_admin は他テナント config も操作可（tenant スコープなし — PATCH と同規則）", async () => {
-    const dbQuery = jest
-      .fn()
-      .mockResolvedValueOnce({ rows: [{ id: "config-x" }] })
-      .mockResolvedValueOnce({ rows: [{ id: "config-x" }] });
-
-    const db = { query: dbQuery };
+    const { db, clientQuery } = makeTxDb(successTxQueries({ checkRow: { id: "config-x" } }));
 
     const res = await request(makeApp(db, "super_admin", ""))
       .post("/v1/admin/avatar/configs/config-x/voice-clone")
@@ -519,16 +535,14 @@ describe("POST /v1/admin/avatar/configs/:id/voice-clone", () => {
       });
 
     expect(res.status).toBe(200);
-    const [checkSql] = dbQuery.mock.calls[0] as [string, unknown[]];
-    expect(checkSql).not.toContain("tenant_id");
-    const [updateSql] = dbQuery.mock.calls[1] as [string, unknown[]];
-    expect(updateSql).not.toContain("tenant_id");
+    const calls = clientQuery.mock.calls as Array<[string, unknown[]?]>;
+    expect(calls[2]![0]).not.toContain("tenant_id"); // SELECT
+    expect(calls[3]![0]).not.toContain("tenant_id"); // UPDATE
   });
 
   it("plan制限(GID: LP料金表 Enterprise〜): client_adminがvoice_clone不可プランだと403、DB所有チェックにも到達しない", async () => {
     mockTenantHasFeature.mockResolvedValueOnce(false);
-    const dbQuery = jest.fn();
-    const db = { query: dbQuery };
+    const { db, clientQuery } = makeTxDb(async () => ({ rows: [] }));
 
     const res = await request(makeApp(db, "client_admin", "tenant-a"))
       .post("/v1/admin/avatar/configs/config-1/voice-clone")
@@ -540,18 +554,14 @@ describe("POST /v1/admin/avatar/configs/:id/voice-clone", () => {
 
     expect(res.status).toBe(403);
     expect(res.body.error).toBe("plan_upgrade_required");
-    expect(dbQuery).not.toHaveBeenCalled();
+    expect(clientQuery).not.toHaveBeenCalled();
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(mockTenantHasFeature).toHaveBeenCalledWith("tenant-a", "voice_clone");
   });
 
   it("super_adminはplan制限をバイパスする(tenantHasFeatureは呼ばれない)", async () => {
     mockTenantHasFeature.mockResolvedValueOnce(false);
-    const dbQuery = jest
-      .fn()
-      .mockResolvedValueOnce({ rows: [{ id: "config-x" }] })
-      .mockResolvedValueOnce({ rows: [{ id: "config-x" }] });
-    const db = { query: dbQuery };
+    const { db } = makeTxDb(successTxQueries({ checkRow: { id: "config-x" } }));
 
     const res = await request(makeApp(db, "super_admin", ""))
       .post("/v1/admin/avatar/configs/config-x/voice-clone")
@@ -565,7 +575,7 @@ describe("POST /v1/admin/avatar/configs/:id/voice-clone", () => {
     expect(mockTenantHasFeature).not.toHaveBeenCalled();
   });
 
-  it("Fish Audio エラー: ok=false → 502、DB UPDATE に到達しない・外部エラー本文を返さない", async () => {
+  it("Fish Audio エラー: ok=false → 502、DB UPDATE に到達しない・外部エラー本文を返さない・ROLLBACKする", async () => {
     fetchSpy.mockResolvedValue({
       ok: false,
       status: 500,
@@ -573,11 +583,11 @@ describe("POST /v1/admin/avatar/configs/:id/voice-clone", () => {
       json: async () => ({}),
     } as any);
 
-    const dbQuery = jest
-      .fn()
-      .mockResolvedValueOnce({ rows: [{ id: "config-1" }] }); // 所有チェックは通る
-
-    const db = { query: dbQuery };
+    const { db, clientQuery } = makeTxDb(async (sql) => {
+      if (sql === "BEGIN" || sql === "SET LOCAL lock_timeout = '3s'" || sql === "ROLLBACK") return { rows: [] };
+      if (sql.startsWith("SELECT id FROM avatar_configs")) return { rows: [{ id: "config-1" }] };
+      throw new Error(`unexpected query: ${sql}`);
+    });
 
     const res = await request(makeApp(db, "client_admin", "tenant-a"))
       .post("/v1/admin/avatar/configs/config-1/voice-clone")
@@ -589,14 +599,14 @@ describe("POST /v1/admin/avatar/configs/:id/voice-clone", () => {
 
     expect(res.status).toBe(502);
     expect(JSON.stringify(res.body)).not.toContain("internal fish error detail");
-    // UPDATE は実行されない（SELECT のみ）
-    expect(dbQuery).toHaveBeenCalledTimes(1);
+    // UPDATE は実行されず、ROLLBACKで確定する
+    expect(clientQuery).toHaveBeenCalledTimes(4);
+    expect(clientQuery.mock.calls[3]![0]).toBe("ROLLBACK");
   });
 
   it("FISH_AUDIO_API_KEY 未設定 → 503、DB・fetch に到達しない", async () => {
     delete process.env.FISH_AUDIO_API_KEY;
-    const dbQuery = jest.fn();
-    const db = { query: dbQuery };
+    const { db, clientQuery } = makeTxDb(async () => ({ rows: [] }));
 
     const res = await request(makeApp(db, "client_admin", "tenant-a"))
       .post("/v1/admin/avatar/configs/config-1/voice-clone")
@@ -607,17 +617,48 @@ describe("POST /v1/admin/avatar/configs/:id/voice-clone", () => {
       });
 
     expect(res.status).toBe(503);
-    expect(dbQuery).not.toHaveBeenCalled();
+    expect(clientQuery).not.toHaveBeenCalled();
     expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  // GID: 二重クリック・複数タブでの同時リクエストを想定した回帰テスト。
+  // SELECT...FOR UPDATE のロック待ちが解決できない場合(=同時に別リクエストが
+  // 同じconfigを処理中)、Fishへ二重課金せず409で確定することを固定する。
+  it("イレギュラー: 同時に別リクエストが同じconfigをロック中(lock timeout)は409で確定し、Fishを呼ばない", async () => {
+    const { db, clientQuery } = makeTxDb(async (sql) => {
+      if (sql === "BEGIN" || sql === "SET LOCAL lock_timeout = '3s'") return { rows: [] };
+      if (sql.startsWith("SELECT id FROM avatar_configs")) {
+        // pg が lock_timeout 超過時に投げるエラーを再現
+        const err = new Error('canceling statement due to lock timeout');
+        throw err;
+      }
+      if (sql === "ROLLBACK") return { rows: [] };
+      throw new Error(`unexpected query: ${sql}`);
+    });
+
+    const res = await request(makeApp(db, "client_admin", "tenant-a"))
+      .post("/v1/admin/avatar/configs/config-1/voice-clone")
+      .field("name", "マイボイス")
+      .attach("audio", AUDIO_BUFFER, {
+        filename: "voice.mp3",
+        contentType: "audio/mpeg",
+      });
+
+    expect(res.status).toBe(409);
+    expect(res.body.error).toContain("別の操作");
+    // ロック待ちで失敗しているため、Fish Audioへは一切到達しない(二重課金防止の核心)
+    expect(fetchSpy).not.toHaveBeenCalled();
+    const calls = clientQuery.mock.calls as Array<[string, unknown[]?]>;
+    expect(calls[calls.length - 1]![0]).toBe("ROLLBACK");
   });
 });
 
 // --------------------------------------------------------------------------
 // GID 1217084040137242: POST /v1/admin/avatar/configs/:id/adopt-designed-voice
 // design-voice が返した候補音声(WAV)を永続音声モデルとして採用する。
-// voice-clone と同じ Fish /model 作成 + tenant スコープ規則を共有するため、
-// 権限境界(client_admin/super_admin)のテストを中心に、実装差分（multipart化・
-// train_mode）を検証する。
+// voice-clone と同じ Fish /model 作成 + tenant スコープ規則 + トランザクション
+// (adoptVoiceForConfig 経由)を共有するため、権限境界(client_admin/super_admin)の
+// テストを中心に、実装差分（multipart化・train_mode）を検証する。
 // --------------------------------------------------------------------------
 describe("POST /v1/admin/avatar/configs/:id/adopt-designed-voice", () => {
   const CANDIDATE_AUDIO = Buffer.from("fake-wav-candidate-bytes");
@@ -640,11 +681,7 @@ describe("POST /v1/admin/avatar/configs/:id/adopt-designed-voice", () => {
   });
 
   it("正常系: client_admin + 自テナント config → Fish Audio呼び出し(train_mode=fast) + voice_id UPDATE + 200", async () => {
-    const dbQuery = jest
-      .fn()
-      .mockResolvedValueOnce({ rows: [{ id: "config-1" }] })
-      .mockResolvedValueOnce({ rows: [{ id: "config-1" }] });
-    const db = { query: dbQuery };
+    const { db, clientQuery } = makeTxDb(successTxQueries({ checkRow: { id: "config-1" } }));
 
     const res = await request(makeApp(db, "client_admin", "tenant-a"))
       .post("/v1/admin/avatar/configs/config-1/adopt-designed-voice")
@@ -660,15 +697,19 @@ describe("POST /v1/admin/avatar/configs/:id/adopt-designed-voice", () => {
     expect(fd.get("train_mode")).toBe("fast");
     expect(fd.get("title")).toBe("設計した声");
 
-    const [updateSql, updateParams] = dbQuery.mock.calls[1] as [string, unknown[]];
-    expect(updateSql).toContain("UPDATE avatar_configs SET voice_id = $1");
-    expect(updateSql).toContain("tenant_id = $3");
-    expect(updateParams).toEqual(["fish-voice-designed-123", "config-1", "tenant-a"]);
+    const calls = clientQuery.mock.calls as Array<[string, unknown[]?]>;
+    expect(calls[3]![0]).toContain("UPDATE avatar_configs SET voice_id = $1");
+    expect(calls[3]![0]).toContain("tenant_id = $3");
+    expect(calls[3]![1]).toEqual(["fish-voice-designed-123", "config-1", "tenant-a"]);
+    expect(calls[4]![0]).toBe("COMMIT");
   });
 
   it("テナント越境: 他テナント configId → 404、Fish Audioに到達しない", async () => {
-    const dbQuery = jest.fn().mockResolvedValueOnce({ rows: [] });
-    const db = { query: dbQuery };
+    const { db } = makeTxDb(async (sql) => {
+      if (sql === "BEGIN" || sql === "SET LOCAL lock_timeout = '3s'" || sql === "ROLLBACK") return { rows: [] };
+      if (sql.startsWith("SELECT id FROM avatar_configs")) return { rows: [] };
+      throw new Error(`unexpected query: ${sql}`);
+    });
 
     const res = await request(makeApp(db, "client_admin", "tenant-a"))
       .post("/v1/admin/avatar/configs/other-tenant-config/adopt-designed-voice")
@@ -680,11 +721,7 @@ describe("POST /v1/admin/avatar/configs/:id/adopt-designed-voice", () => {
   });
 
   it("super_admin は他テナント config も操作可（tenant スコープなし — voice-clone と同規則）", async () => {
-    const dbQuery = jest
-      .fn()
-      .mockResolvedValueOnce({ rows: [{ id: "config-x" }] })
-      .mockResolvedValueOnce({ rows: [{ id: "config-x" }] });
-    const db = { query: dbQuery };
+    const { db, clientQuery } = makeTxDb(successTxQueries({ checkRow: { id: "config-x" } }));
 
     const res = await request(makeApp(db, "super_admin", ""))
       .post("/v1/admin/avatar/configs/config-x/adopt-designed-voice")
@@ -692,16 +729,11 @@ describe("POST /v1/admin/avatar/configs/:id/adopt-designed-voice", () => {
       .attach("audio", CANDIDATE_AUDIO, { filename: "candidate.wav", contentType: "audio/wav" });
 
     expect(res.status).toBe(200);
-    const [checkSql] = dbQuery.mock.calls[0] as [string, unknown[]];
-    expect(checkSql).not.toContain("tenant_id");
+    expect(clientQuery.mock.calls[2]![0]).not.toContain("tenant_id");
   });
 
   it("previewMode相当: super_adminが空テナントで他テナントconfigを操作しても越境しない(super_adminスコープ確認)", async () => {
-    const dbQuery = jest
-      .fn()
-      .mockResolvedValueOnce({ rows: [{ id: "config-y" }] })
-      .mockResolvedValueOnce({ rows: [{ id: "config-y" }] });
-    const db = { query: dbQuery };
+    const { db } = makeTxDb(successTxQueries({ checkRow: { id: "config-y" } }));
 
     const res = await request(makeApp(db, "super_admin", "carnation-demo"))
       .post("/v1/admin/avatar/configs/config-y/adopt-designed-voice")
@@ -713,8 +745,7 @@ describe("POST /v1/admin/avatar/configs/:id/adopt-designed-voice", () => {
 
   it("plan制限: client_adminがvoice_clone不可プランだと403、DB所有チェックにも到達しない", async () => {
     mockTenantHasFeature.mockResolvedValueOnce(false);
-    const dbQuery = jest.fn();
-    const db = { query: dbQuery };
+    const { db, clientQuery } = makeTxDb(async () => ({ rows: [] }));
 
     const res = await request(makeApp(db, "client_admin", "tenant-a"))
       .post("/v1/admin/avatar/configs/config-1/adopt-designed-voice")
@@ -722,7 +753,7 @@ describe("POST /v1/admin/avatar/configs/:id/adopt-designed-voice", () => {
       .attach("audio", CANDIDATE_AUDIO, { filename: "candidate.wav", contentType: "audio/wav" });
 
     expect(res.status).toBe(403);
-    expect(dbQuery).not.toHaveBeenCalled();
+    expect(clientQuery).not.toHaveBeenCalled();
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 
@@ -732,8 +763,11 @@ describe("POST /v1/admin/avatar/configs/:id/adopt-designed-voice", () => {
       status: 500,
       text: async () => "internal fish error detail",
     } as any);
-    const dbQuery = jest.fn().mockResolvedValueOnce({ rows: [{ id: "config-1" }] });
-    const db = { query: dbQuery };
+    const { db, clientQuery } = makeTxDb(async (sql) => {
+      if (sql === "BEGIN" || sql === "SET LOCAL lock_timeout = '3s'" || sql === "ROLLBACK") return { rows: [] };
+      if (sql.startsWith("SELECT id FROM avatar_configs")) return { rows: [{ id: "config-1" }] };
+      throw new Error(`unexpected query: ${sql}`);
+    });
 
     const res = await request(makeApp(db, "client_admin", "tenant-a"))
       .post("/v1/admin/avatar/configs/config-1/adopt-designed-voice")
@@ -742,18 +776,39 @@ describe("POST /v1/admin/avatar/configs/:id/adopt-designed-voice", () => {
 
     expect(res.status).toBe(502);
     expect(JSON.stringify(res.body)).not.toContain("internal fish error detail");
-    expect(dbQuery).toHaveBeenCalledTimes(1);
+    expect(clientQuery.mock.calls[clientQuery.mock.calls.length - 1]![0]).toBe("ROLLBACK");
   });
 
   it("音声ファイル未添付は400、Fish Audioに到達しない", async () => {
-    const dbQuery = jest.fn();
-    const db = { query: dbQuery };
+    const { db, clientQuery } = makeTxDb(async () => ({ rows: [] }));
 
     const res = await request(makeApp(db, "client_admin", "tenant-a"))
       .post("/v1/admin/avatar/configs/config-1/adopt-designed-voice")
       .field("name", "設計した声");
 
     expect(res.status).toBe(400);
+    expect(clientQuery).not.toHaveBeenCalled();
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  // GID: adopt-designed-voiceはdesign-voiceの候補採用という性質上、同一候補に対して
+  // 連打・複数タブでの同時採用が起きやすい。voice-cloneと同じ二重課金防止を確認する。
+  it("イレギュラー: 同時に別リクエストが同じconfigをロック中(lock timeout)は409で確定し、Fishを呼ばない", async () => {
+    const { db } = makeTxDb(async (sql) => {
+      if (sql === "BEGIN" || sql === "SET LOCAL lock_timeout = '3s'") return { rows: [] };
+      if (sql.startsWith("SELECT id FROM avatar_configs")) {
+        throw new Error('canceling statement due to lock timeout');
+      }
+      if (sql === "ROLLBACK") return { rows: [] };
+      throw new Error(`unexpected query: ${sql}`);
+    });
+
+    const res = await request(makeApp(db, "client_admin", "tenant-a"))
+      .post("/v1/admin/avatar/configs/config-1/adopt-designed-voice")
+      .field("name", "設計した声")
+      .attach("audio", CANDIDATE_AUDIO, { filename: "candidate.wav", contentType: "audio/wav" });
+
+    expect(res.status).toBe(409);
     expect(fetchSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/api/admin/avatar/routes.ts
+++ b/src/api/admin/avatar/routes.ts
@@ -11,7 +11,7 @@ import { logger } from '../../../lib/logger';
 import { trackUsage } from '../../../lib/billing/usageTracker';
 import { tenantHasFeature } from '../../../lib/billing/planFeatures';
 import { resolveEffectiveTenantId } from '../../middleware/roleAuth';
-import { createFishVoiceModel, FishVoiceModelError } from './fishVoiceModel';
+import { adoptVoiceForConfig } from './fishVoiceModel';
 
 // ---------------------------------------------------------------------------
 // Supabase Storage: base64 data URL → 公開 HTTP URL
@@ -797,56 +797,25 @@ export function registerAvatarConfigRoutes(app: Express, db: any): void {
       }
 
       try {
-        // 対象 config の存在 + テナント所有を先に確認
-        // （他テナント config への外部 API 呼び出しを防ぐ。tenant スコープは PATCH と同規則:
-        //   super_admin は全テナント可、client_admin は自テナントのみ）
-        let checkQuery = "SELECT id FROM avatar_configs WHERE id = $1";
-        const checkValues: unknown[] = [id];
-        if (!isSuperAdmin) {
-          checkQuery += " AND tenant_id = $2";
-          checkValues.push(tenantId);
-        }
-        const existing = await db.query(checkQuery, checkValues);
-        if (existing.rows.length === 0) {
-          return res
-            .status(404)
-            .json({ error: "設定が見つからないかアクセス権限がありません" });
-        }
+        // GID: 二重クリック・複数タブでの同時リクエストによるFish二重課金/voice_id
+        // 後勝ち上書きを防ぐため、所有権チェック(FOR UPDATE)〜Fish呼び出し〜保存を
+        // 単一トランザクションに直列化する（fishVoiceModel.ts の共通ヘルパー経由）。
+        const outcome = await adoptVoiceForConfig({
+          db,
+          configId: id!,
+          tenantId,
+          isSuperAdmin,
+          fishApiKey,
+          title: name,
+          audio: file.buffer,
+          mimeType: file.mimetype,
+          filename: file.originalname,
+          logEventPrefix: "voice_clone",
+          logContext: "[POST /v1/admin/avatar/configs/:id/voice-clone] Fish Audio API error",
+        });
 
-        // Fish Audio POST /model — 永続クローン作成（共通ヘルパー経由。GID 1217084040137242）
-        let voiceId: string;
-        try {
-          voiceId = await createFishVoiceModel({
-            apiKey: fishApiKey,
-            title: name,
-            audio: file.buffer,
-            mimeType: file.mimetype,
-            filename: file.originalname,
-          });
-        } catch (err) {
-          logger.warn({
-            event: "voice_clone_fish_error",
-            status: err instanceof FishVoiceModelError ? err.status : undefined,
-            detail: err instanceof Error ? err.message.slice(0, 300) : String(err),
-          }, "[POST /v1/admin/avatar/configs/:id/voice-clone] Fish Audio API error");
-          return res.status(502).json({ error: "音声クローンの作成に失敗しました" });
-        }
-
-        // voice_id 保存（UPDATE にも同じ tenant スコープを適用 — 防御的二重化）
-        const updateValues: unknown[] = [voiceId, id];
-        let updateQuery =
-          "UPDATE avatar_configs SET voice_id = $1, updated_at = NOW() WHERE id = $2";
-        if (!isSuperAdmin) {
-          updateValues.push(tenantId);
-          updateQuery += " AND tenant_id = $3";
-        }
-        updateQuery += " RETURNING id";
-
-        const result = await db.query(updateQuery, updateValues);
-        if (result.rows.length === 0) {
-          return res
-            .status(404)
-            .json({ error: "設定が見つからないかアクセス権限がありません" });
+        if (!outcome.ok) {
+          return res.status(outcome.status).json({ error: outcome.error });
         }
 
         // GID 1216944003337122: marginOverride: 1 は「倍率×1=原価のみ」の意図で正しい
@@ -863,7 +832,7 @@ export function registerAvatarConfigRoutes(app: Express, db: any): void {
           marginOverride: 1,
         });
 
-        return res.json({ voiceId });
+        return res.json({ voiceId: outcome.voiceId });
       } catch (err) {
         logger.warn("[POST /v1/admin/avatar/configs/:id/voice-clone]", err);
         return res.status(500).json({ error: "音声クローンの作成に失敗しました" });
@@ -919,52 +888,23 @@ export function registerAvatarConfigRoutes(app: Express, db: any): void {
       }
 
       try {
-        // 対象 config の存在 + テナント所有を先に確認（voice-clone と同規則）
-        let checkQuery = "SELECT id FROM avatar_configs WHERE id = $1";
-        const checkValues: unknown[] = [id];
-        if (!isSuperAdmin) {
-          checkQuery += " AND tenant_id = $2";
-          checkValues.push(tenantId);
-        }
-        const existing = await db.query(checkQuery, checkValues);
-        if (existing.rows.length === 0) {
-          return res
-            .status(404)
-            .json({ error: "設定が見つからないかアクセス権限がありません" });
-        }
+        // GID: voice-clone と同じ二重送信対策（FOR UPDATE + 単一トランザクション）を共有する。
+        const outcome = await adoptVoiceForConfig({
+          db,
+          configId: id!,
+          tenantId,
+          isSuperAdmin,
+          fishApiKey,
+          title: name,
+          audio: file.buffer,
+          mimeType: file.mimetype,
+          filename: file.originalname,
+          logEventPrefix: "adopt_designed_voice",
+          logContext: "[POST /v1/admin/avatar/configs/:id/adopt-designed-voice] Fish Audio API error",
+        });
 
-        let voiceId: string;
-        try {
-          voiceId = await createFishVoiceModel({
-            apiKey: fishApiKey,
-            title: name,
-            audio: file.buffer,
-            mimeType: file.mimetype,
-            filename: file.originalname,
-          });
-        } catch (err) {
-          logger.warn({
-            event: "adopt_designed_voice_fish_error",
-            status: err instanceof FishVoiceModelError ? err.status : undefined,
-            detail: err instanceof Error ? err.message.slice(0, 300) : String(err),
-          }, "[POST /v1/admin/avatar/configs/:id/adopt-designed-voice] Fish Audio API error");
-          return res.status(502).json({ error: "音声の登録に失敗しました" });
-        }
-
-        const updateValues: unknown[] = [voiceId, id];
-        let updateQuery =
-          "UPDATE avatar_configs SET voice_id = $1, updated_at = NOW() WHERE id = $2";
-        if (!isSuperAdmin) {
-          updateValues.push(tenantId);
-          updateQuery += " AND tenant_id = $3";
-        }
-        updateQuery += " RETURNING id";
-
-        const result = await db.query(updateQuery, updateValues);
-        if (result.rows.length === 0) {
-          return res
-            .status(404)
-            .json({ error: "設定が見つからないかアクセス権限がありません" });
+        if (!outcome.ok) {
+          return res.status(outcome.status).json({ error: outcome.error });
         }
 
         trackUsage({
@@ -977,7 +917,7 @@ export function registerAvatarConfigRoutes(app: Express, db: any): void {
           marginOverride: 1,
         });
 
-        return res.json({ voiceId });
+        return res.json({ voiceId: outcome.voiceId });
       } catch (err) {
         logger.warn("[POST /v1/admin/avatar/configs/:id/adopt-designed-voice]", err);
         return res.status(500).json({ error: "音声の登録に失敗しました" });

--- a/src/lib/billing/costCalculator.test.ts
+++ b/src/lib/billing/costCalculator.test.ts
@@ -326,6 +326,54 @@ describe('calculateBillingAmountCents', () => {
     expect(Number.isInteger(result)).toBe(true);
     expect(result).toBeGreaterThan(0);
   });
+
+  // GID: totalUSDに加算される全フィールドは、負値を渡すと「請求額を減らす」
+  // 攻撃・不具合の経路になりうる(例: ttsTextBytes=-1000000で他の正当な費用を
+  // 相殺できてしまう)。inputTokens/outputTokensだけでなく全フィールドを一律で
+  // ガードすることを固定する。
+  describe('負の値は全フィールドで例外を投げる(請求額を減らす攻撃・不具合の防止)', () => {
+    const base = { model: 'llama-3.1-8b-instant', inputTokens: 0, outputTokens: 0 } as const;
+
+    it.each([
+      ['ttsTextBytes', -1],
+      ['avatarCredits', -1],
+      ['imageCount', -1],
+      ['saiAgentSteps', -1],
+      ['ocrPages', -1],
+      ['asrRequestCount', -1],
+      ['asrAudioSeconds', -1],
+      ['magnificUpscaleCount', -1],
+      ['fluxImageCount', -1],
+      ['lemonsliceRegistrationCount', -1],
+      ['voiceDesignRequestCount', -1],
+    ] as const)('%s が負の場合に例外を投げる', (field, value) => {
+      expect(() =>
+        calculateBillingAmountCents({ ...base, [field]: value })
+      ).toThrow(`Invalid ${field}: ${value}`);
+    });
+
+    it('複数フィールドが同時に負でも(最初に検出した1件で)例外を投げる', () => {
+      expect(() =>
+        calculateBillingAmountCents({ ...base, ttsTextBytes: -100, avatarCredits: -5 })
+      ).toThrow();
+    });
+
+    it('巨大な負値(Number.MIN_SAFE_INTEGER)でも例外を投げる(オーバーフローで正の値に化けない)', () => {
+      expect(() =>
+        calculateBillingAmountCents({ ...base, asrAudioSeconds: Number.MIN_SAFE_INTEGER })
+      ).toThrow();
+    });
+
+    it('0はどのフィールドでも例外を投げない(負値ガードの境界は0を含む)', () => {
+      const result = calculateBillingAmountCents({
+        ...base,
+        ttsTextBytes: 0, avatarCredits: 0, imageCount: 0, saiAgentSteps: 0, ocrPages: 0,
+        asrRequestCount: 0, asrAudioSeconds: 0, magnificUpscaleCount: 0, fluxImageCount: 0,
+        lemonsliceRegistrationCount: 0, voiceDesignRequestCount: 0,
+      });
+      expect(result).toBeGreaterThanOrEqual(0);
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/billing/costCalculator.ts
+++ b/src/lib/billing/costCalculator.ts
@@ -308,11 +308,28 @@ export function calculateAvatarCostCents(credits: number): number {
  *
  * @throws inputTokens / outputTokens が負の場合
  */
+// GID: totalUSDの計算式に加算されるフィールド群（マイナス値は「請求額を減らす」
+// 攻撃・不具合の経路になりうる）。現状の全呼び出し元(fishTtsRoutes/fishAsrRoutes/
+// generationRoutes/usageRoutes)は非負値しか渡さないため実害は無いが、将来別の
+// 呼び出し元が検証漏れの値をそのまま渡した場合に静かに請求額が減るのを防ぐため、
+// calculateBillingAmountCentsの入口で一括ガードする。
+const NEGATIVE_GUARD_FIELDS: ReadonlyArray<keyof UsageRecord> = [
+  'ttsTextBytes', 'avatarCredits', 'imageCount', 'saiAgentSteps', 'ocrPages',
+  'asrRequestCount', 'asrAudioSeconds', 'magnificUpscaleCount', 'fluxImageCount',
+  'lemonsliceRegistrationCount', 'voiceDesignRequestCount',
+];
+
 export function calculateBillingAmountCents(usage: UsageRecord): number {
   if (usage.inputTokens < 0 || usage.outputTokens < 0) {
     throw new Error(
       `Invalid token counts: input=${usage.inputTokens}, output=${usage.outputTokens}`
     );
+  }
+  for (const field of NEGATIVE_GUARD_FIELDS) {
+    const value = usage[field];
+    if (typeof value === 'number' && value < 0) {
+      throw new Error(`Invalid ${field}: ${value}`);
+    }
   }
 
   const isEndUser = usage.featureUsed === undefined || END_USER_FEATURES.has(usage.featureUsed);

--- a/src/lib/billing/usageTracker.test.ts
+++ b/src/lib/billing/usageTracker.test.ts
@@ -317,6 +317,43 @@ describe('usageTracker', () => {
     });
   });
 
+  // GID: calculateBillingAmountCentsが例外を投げるケース(負値ガード等)が実際に
+  // trackUsage経由で発生した場合、INSERT自体はクラッシュせずcostTotalCents=0で
+  // 継続することを固定する。この経路はこれまでテストされていなかった。
+  describe('原価計算エラー時（負値ガード等でcalculateBillingAmountCentsが例外を投げた場合）', () => {
+    it('asrAudioSecondsが負の場合、warnログを出しcost_total_cents=0でINSERTは継続する（クラッシュしない）', async () => {
+      const mockQuery = jest.fn().mockResolvedValue({ rowCount: 1 });
+      const mockLogger = { warn: jest.fn(), error: jest.fn(), debug: jest.fn(), info: jest.fn() } as any;
+      initUsageTracker({ query: mockQuery } as any, mockLogger);
+
+      trackUsage({
+        tenantId: 'test-tenant',
+        requestId: 'req-negative-asr-seconds',
+        model: 'fish-audio-asr',
+        inputTokens: 0,
+        outputTokens: 0,
+        featureUsed: 'voice',
+        asrAudioSeconds: -100,
+      });
+
+      await flushSetImmediate();
+      await flushSetImmediate();
+
+      expect(mockLogger.warn).toHaveBeenCalledWith(
+        expect.objectContaining({ requestId: 'req-negative-asr-seconds' }),
+        expect.stringContaining('cost calculation error'),
+      );
+      const insertCall = mockQuery.mock.calls.find(
+        ([, p]: [string, any[]]) => p?.[1] === 'req-negative-asr-seconds'
+      );
+      expect(insertCall).toBeDefined();
+      const [, params] = insertCall!;
+      // cost_llm_cents / cost_total_cents 列は両方0にフォールバックする
+      expect(params[6]).toBe(0);
+      expect(params[7]).toBe(0);
+    });
+  });
+
   describe('DB エラー時', () => {
     it('INSERT 失敗時にエラーをログするが例外を投げない', async () => {
       const mockQuery = jest.fn().mockRejectedValue(new Error('DB connection lost'));


### PR DESCRIPTION
## Summary
前回レビュー（PR #720）で「テストでカバーできていないリスク」として指摘した2件に対処する。

### 1. 二重送信によるFish Audio二重課金の防止
`voice-clone`/`adopt-designed-voice`はクライアント側のdisabledボタンのみで、サーバー側に二重送信対策が無かった。二重クリック・複数タブ・リプレイで同じconfigに2回リクエストされると、Fish側に音声モデルが2つ作成され課金が二重発生し、`voice_id`は後勝ちで上書きされるレースコンディションがあった。

両エンドポイントで重複していた「SELECT所有権チェック→Fish呼び出し→UPDATE」を`fishVoiceModel.ts`の`adoptVoiceForConfig()`へ集約し、`chat-history/deleteSessionRepository.ts`と同じ確立済みパターン（`BEGIN` → `SET LOCAL lock_timeout='3s'` → `SELECT...FOR UPDATE` → `UPDATE` → `COMMIT`）で直列化した。ロック待ちが3秒を超えた場合（＝同時に別の登録が進行中）は409で確定し、Fishへの二重課金を防ぐ。

副次効果として、`voice-clone`/`adopt-designed-voice`の重複実装（同じ関心事の2ファイル複製）も解消された。

### 2. 原価計算の負値ガード
`calculateBillingAmountCents`は`inputTokens`/`outputTokens`のみ負値を弾いており、`ttsTextBytes`・`avatarCredits`・`asrAudioSeconds`・`voiceDesignRequestCount`等、`totalUSD`に加算される他の全フィールド（11個）は無防備だった。現状の呼び出し元は全て非負値しか渡さないため実害は無いが、将来の呼び出し元追加時に「請求額を減らす不具合・攻撃」の経路になりうる。該当フィールドを一括ガードした。

あわせて、`usageTracker.ts`の「原価計算エラー時は0にフォールバックする」既存の安全網（`calculateBillingAmountCents`が例外を投げてもINSERT自体はクラッシュしない）が、これまで一切テストされていなかったため、新規に固定した。

## Asana
親: https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217083837119126

## Test plan
- [x] pnpm typecheck: 0 errors
- [x] pnpm lint: 0 new warnings
- [x] pnpm jest（変更ファイルのみ）: 9 suites / 372 tests all pass
- [x] pnpm jest（フルスイート）: 3415 tests中、無関係な複数ファイルが並列実行時のポート競合で断続的にflaky（既知の環境要因、変更ファイルのみの再実行で解消確認済み）
- [x] Gate 1.5 dead-code-check: 新規exportは全て消費されている
- [x] Gate 2 security-scan: CRITICAL/HIGH 0、SQLインジェクションチェックPASS（パラメータ化クエリ維持）
- [x] Gate 3 build: 0 errors
- [x] 新規: ロックタイムアウト時に409で確定しFishを一切呼ばないことを両エンドポイントで確認
- [x] 新規: `adoptVoiceForConfig`単体で、Fish呼び出し失敗時・ROLLBACK自体が失敗する二重障害時もコネクションが必ず解放されることを確認（接続リーク防止）
- [x] 新規: 全11フィールドの負値が例外を投げ、`usageTracker`側でコスト0にフォールバックしてクラッシュしないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdBRSsTu4YNWBDTpgzqz2c