### PR TITLE
test(avatar-agent): speak()/fishaudio統合の合成ロジックを純粋関数に切り出し境界値テストを追加

### DIFF
--- a/avatar-agent/agent.py
+++ b/avatar-agent/agent.py
@@ -329,6 +329,52 @@ def _build_agent_reply_payload(text: str) -> bytes:
     return json.dumps({"type": "agent_reply", "text": text}).encode()
 
 
+def _resolve_voice_id(reference_id: str | None) -> str | object:
+    """fishaudio.TTS の voice_id 引数を解決する（純粋関数）。
+
+    reference_id が None または空文字列の場合は NOT_GIVEN を返し、プラグインの
+    デフォルト音声(DEFAULT_VOICE_ID)を使わせる。空文字列を素通しすると
+    Fish Audio API が無効な voice_id として拒否するため、None と同じ扱いにする。
+    """
+    return reference_id if reference_id else NOT_GIVEN
+
+
+def _build_emotion_tags_prefix(emotion_tags: list[str] | None) -> str:
+    """テナントDB設定の emotion_tags から TTS用の "[tag][tag]" 形式プレフィックスを
+    組み立てる（純粋関数）。最大3個まで採用する（旧 FishAudioTTS.synthesize() の
+    挙動を踏襲）。
+
+    既知の未対応ケース: 空白のみのタグ（例 "  "）は真値のためここでは除外されず
+    "[  ]" のような見た目のプレフィックスになる。entrypoint() 側の
+    `effective_emotion_tags = [str(t) for t in effective_emotion_tags if t]` は
+    空文字列のみを除外し、空白のみの文字列までは除外しない。
+    """
+    if not emotion_tags:
+        return ""
+    return "".join(f"[{t}]" for t in emotion_tags[:3])
+
+
+def _compose_speak_texts(
+    text: str,
+    *,
+    emotion_prefix: bool,
+    sales_state: str | None,
+    emotion_tags_prefix: str,
+) -> tuple[str, str]:
+    """speak() のテキスト合成ロジック（純粋関数）。(tts_text, publish_text) を返す。
+
+    emotion_tags_prefix（テナントDB設定）は tts_text にのみ適用し、publish_text
+    （Widget のチャット吹き出しに送る文字列）には絶対に含めないこと——ここが
+    崩れると `[calm][happy]` のような装飾記法がそのまま顧客向けチャットUIに
+    露出する（速攻で気づかれる顧客可視のリグレッション）。
+    """
+    publish_text = (
+        sales_flow_emotion_prefix(sales_state) + text if emotion_prefix else text
+    )
+    tts_text = emotion_tags_prefix + publish_text
+    return tts_text, publish_text
+
+
 # --- Groq LLM (AgentSession 用 — session.say() のコンテキスト保持に使用) ---
 groq_llm = openai_plugin.LLM(
     model="llama-3.3-70b-versatile",
@@ -433,15 +479,13 @@ async def entrypoint(ctx: agents.JobContext) -> None:
         model=_tts_model,
         output_format="mp3",
         sample_rate=44100,
-        voice_id=effective_reference_id if effective_reference_id else NOT_GIVEN,
+        voice_id=_resolve_voice_id(effective_reference_id),
         normalize=True,
         latency_mode="balanced",
     )
     # emotion_tags（テナントDB設定）は公式プラグインにコンストラクタ引数が無いため、
     # speak() が TTS 送信直前にテキスト先頭へ付与する（Widget のチャット吹き出しには漏らさない）。
-    _emotion_tags_prefix = (
-        "".join(f"[{t}]" for t in effective_emotion_tags[:3]) if effective_emotion_tags else ""
-    )
+    _emotion_tags_prefix = _build_emotion_tags_prefix(effective_emotion_tags)
 
     session = AgentSession(
         llm=groq_llm,
@@ -499,12 +543,12 @@ async def entrypoint(ctx: agents.JobContext) -> None:
         emotion_tags（テナントDB設定）は _emotion_tags_prefix で TTS 音声にのみ適用し、
         Widget のチャット吹き出しには漏らさない（旧 FishAudioTTS.synthesize() の挙動を踏襲）。
         """
-        publish_text = (
-            sales_flow_emotion_prefix(_sales_state["current"]) + text
-            if emotion_prefix
-            else text
+        tts_text, publish_text = _compose_speak_texts(
+            text,
+            emotion_prefix=emotion_prefix,
+            sales_state=_sales_state["current"],
+            emotion_tags_prefix=_emotion_tags_prefix,
         )
-        tts_text = _emotion_tags_prefix + publish_text
         say_kwargs = {} if allow_interruptions is None else {"allow_interruptions": allow_interruptions}
         handle = session.say(tts_text, **say_kwargs)
         if tenant_id:

--- a/avatar-agent/test_fishaudio_config.py
+++ b/avatar-agent/test_fishaudio_config.py
@@ -1,0 +1,79 @@
+"""
+公式 fishaudio.TTS プラグイン統合まわりの純粋関数のテスト
+(_resolve_voice_id / _build_emotion_tags_prefix)。
+
+いずれも entrypoint() 冒頭で1回だけ計算され fishaudio.TTS の構築・speak() に
+渡される値。DBから来る値(avatar_configs.voice_id / emotion_tags)は
+テナント管理者の入力やAI提案結果に由来し、空文字列・None・想定外の型が
+混ざることを前提にテストする(「通れば良い」ではなく壊れやすい境界を踏む)。
+"""
+
+import os
+
+os.environ.setdefault("GROQ_API_KEY", "test-dummy-key")
+os.environ.setdefault("FISH_AUDIO_API_KEY", "test-dummy-key")
+
+import agent  # noqa: E402
+from livekit.agents.types import NOT_GIVEN
+
+
+class TestResolveVoiceId:
+    def test_none_returns_not_given(self):
+        assert agent._resolve_voice_id(None) is NOT_GIVEN
+
+    def test_empty_string_returns_not_given(self):
+        # avatar_configs.voice_id が空文字列で保存されているケース
+        # (未設定と空文字列保存を区別しないDB設計。空文字列をそのまま
+        # fishaudio.TTS に渡すと Fish Audio API が無効な voice_id として拒否する)。
+        assert agent._resolve_voice_id("") is NOT_GIVEN
+
+    def test_real_value_passes_through_unchanged(self):
+        assert agent._resolve_voice_id("933563129e564b19a115bedd57b7406a") == (
+            "933563129e564b19a115bedd57b7406a"
+        )
+
+    def test_whitespace_only_string_is_truthy_and_passes_through(self):
+        # 既知の未対応ケース: " "(空白のみ)は Python では truthy なので
+        # NOT_GIVEN に落ちずそのまま voice_id として渡ってしまう。
+        # DB側にバリデーションが無い場合、Fish Audio API 側で無効な
+        # voice_id エラーになる可能性がある(このテストは現在の挙動を
+        # 固定するもので、望ましい挙動を主張するものではない)。
+        assert agent._resolve_voice_id("   ") == "   "
+
+
+class TestBuildEmotionTagsPrefix:
+    def test_none_returns_empty_string(self):
+        assert agent._build_emotion_tags_prefix(None) == ""
+
+    def test_empty_list_returns_empty_string(self):
+        assert agent._build_emotion_tags_prefix([]) == ""
+
+    def test_single_tag(self):
+        assert agent._build_emotion_tags_prefix(["calm"]) == "[calm]"
+
+    def test_exactly_three_tags_all_included(self):
+        assert agent._build_emotion_tags_prefix(["a", "b", "c"]) == "[a][b][c]"
+
+    def test_more_than_three_tags_truncated_to_first_three(self):
+        # 旧 FishAudioTTS.synthesize() の挙動踏襲: self._emotion_tags[:3]
+        assert agent._build_emotion_tags_prefix(["a", "b", "c", "d", "e"]) == "[a][b][c]"
+
+    def test_order_is_preserved(self):
+        assert agent._build_emotion_tags_prefix(["joyful", "calm"]) == "[joyful][calm]"
+
+    def test_whitespace_only_tag_is_not_filtered_here(self):
+        # 既知の未対応ケース: entrypoint() 側の
+        # `effective_emotion_tags = [str(t) for t in effective_emotion_tags if t]`
+        # は空文字列のみを除外し、空白のみの文字列("  "など)は truthy のため
+        # 素通しする。ここではその素通しされた入力に対する本関数の実際の
+        # 挙動("[  ]"という見た目の悪いプレフィックスになる)を固定している。
+        assert agent._build_emotion_tags_prefix(["  ", "calm"]) == "[  ][calm]"
+
+    def test_tag_containing_brackets_is_not_escaped(self):
+        # 既知の未対応ケース: タグ自体に "]" を含む場合、プレフィックスの
+        # 構文が壊れる(例: "]state["というタグは "[]state[]"のような
+        # 不正な形になり得る)。テナント管理画面からemotion_tagsを自由入力
+        # できる経路がある場合はこの境界の悪用余地を検討すべきだが、
+        # 現状のUI/APIにそのような自由入力経路があるかは別途確認が必要。
+        result = agent._build_emotion_tags_prefix(["ordinary]tag"])
+        assert result == "[ordinary]tag]"

--- a/avatar-agent/test_speak_funnel.py
+++ b/avatar-agent/test_speak_funnel.py
@@ -70,6 +70,133 @@ class TestBuildAgentReplyPayload:
         payload = agent._build_agent_reply_payload("test")
         assert isinstance(payload, bytes)
 
+    def test_empty_string(self):
+        payload = agent._build_agent_reply_payload("")
+        assert json.loads(payload.decode()) == {"type": "agent_reply", "text": ""}
+
+    def test_text_with_quotes_and_backslashes_round_trips(self):
+        # ユーザー入力/LLM生成テキストに引用符・バックスラッシュが混ざるのは
+        # 珍しくない（例: 「"保証付き"というのは本当ですか？」）。JSONエスケープが
+        # 崩れると Widget 側の JSON.parse がそのメッセージだけ静かに失敗する。
+        text = '価格は"応相談"です。パス: C:\\Users\\test\\file'
+        payload = agent._build_agent_reply_payload(text)
+        assert json.loads(payload.decode())["text"] == text
+
+    def test_text_with_embedded_newlines(self):
+        text = "1行目\n2行目\n3行目"
+        payload = agent._build_agent_reply_payload(text)
+        assert json.loads(payload.decode())["text"] == text
+
+    def test_emoji_and_multibyte_text_round_trips(self):
+        text = "🚗新潟で30年の実績✨よろしくお願いします🙏"
+        payload = agent._build_agent_reply_payload(text)
+        assert json.loads(payload.decode())["text"] == text
+
+    def test_long_text_does_not_raise(self):
+        # LLM応答が想定より長く返るケース(プロンプト逸脱・エラー時の長文等)。
+        # ここでの責務は「壊れずJSONを組み立てられること」であり、長さ制限は
+        # 呼び出し元(本体API側)の責務なのでここでは検証しない。
+        text = "あ" * 5000
+        payload = agent._build_agent_reply_payload(text)
+        assert json.loads(payload.decode())["text"] == text
+
+
+class TestComposeSpeakTexts:
+    """speak() のテキスト合成ロジック(_compose_speak_texts)の振る舞いテスト。
+
+    従来の test_speak_funnel.py の他のテストはソースを文字列/AST照合するのみで、
+    実際の入出力(emotion_tags_prefix・SalesFlow prefix・textの合成順序、
+    publish_textへの漏洩有無)は一切検証していなかった。ここでは実際に関数を
+    呼び出し、合成結果そのものを固定する。
+    """
+
+    def test_no_prefixes_returns_text_unchanged(self):
+        tts_text, publish_text = agent._compose_speak_texts(
+            "こんにちは", emotion_prefix=False, sales_state=None, emotion_tags_prefix=""
+        )
+        assert tts_text == "こんにちは"
+        assert publish_text == "こんにちは"
+        assert tts_text == publish_text
+
+    def test_emotion_tags_prefix_applies_to_tts_text_only(self):
+        # 最重要の回帰ガード: emotion_tags_prefix (テナントDB設定) が
+        # publish_text (Widgetのチャット吹き出し) に絶対に漏れないこと。
+        # ここが崩れると "[calm][happy]" のような装飾記法が顧客向けUIに露出する。
+        tts_text, publish_text = agent._compose_speak_texts(
+            "こんにちは",
+            emotion_prefix=False,
+            sales_state=None,
+            emotion_tags_prefix="[calm][happy]",
+        )
+        assert tts_text == "[calm][happy]こんにちは"
+        assert publish_text == "こんにちは"
+        assert "[calm][happy]" not in publish_text
+
+    def test_sales_flow_prefix_applies_to_both_texts_when_emotion_prefix_true(self):
+        tts_text, publish_text = agent._compose_speak_texts(
+            "今なら特典があります",
+            emotion_prefix=True,
+            sales_state="close",
+            emotion_tags_prefix="",
+        )
+        expected_sales_prefix = "[強調]今なら[/強調][明るく]"
+        assert publish_text == expected_sales_prefix + "今なら特典があります"
+        assert tts_text == publish_text  # emotion_tags_prefix が空なので両者一致
+
+    def test_both_prefixes_combine_with_emotion_tags_first(self):
+        tts_text, publish_text = agent._compose_speak_texts(
+            "本日は特別価格です",
+            emotion_prefix=True,
+            sales_state="close",
+            emotion_tags_prefix="[joyful]",
+        )
+        sales_prefix = "[強調]今なら[/強調][明るく]"
+        # publish_text には emotion_tags_prefix が含まれないこと
+        assert publish_text == sales_prefix + "本日は特別価格です"
+        # tts_text は publish_text の前に emotion_tags_prefix が付くこと(合成順序固定)
+        assert tts_text == "[joyful]" + publish_text
+        assert "[joyful]" not in publish_text
+
+    def test_unknown_sales_state_yields_no_sales_prefix(self):
+        # sales_flow_emotion_prefix は未知のstateに対して空文字列を返す
+        # (test_emotion_tags.py で保証済み)。ここでは speak() の合成側が
+        # その空文字列を正しく素通しすることを確認する。
+        tts_text, publish_text = agent._compose_speak_texts(
+            "テスト", emotion_prefix=True, sales_state="no_such_state", emotion_tags_prefix=""
+        )
+        assert tts_text == "テスト"
+        assert publish_text == "テスト"
+
+    def test_emotion_prefix_false_ignores_sales_state_even_if_set(self):
+        # emotion_prefix=False のとき、sales_state に有効な値が入っていても
+        # SalesFlow prefix は一切適用されないこと(呼び出し元の意図どおり)。
+        tts_text, publish_text = agent._compose_speak_texts(
+            "テスト", emotion_prefix=False, sales_state="close", emotion_tags_prefix=""
+        )
+        assert "強調" not in tts_text
+        assert "強調" not in publish_text
+
+    def test_empty_text_does_not_raise(self):
+        tts_text, publish_text = agent._compose_speak_texts(
+            "", emotion_prefix=True, sales_state="close", emotion_tags_prefix="[calm]"
+        )
+        # prefix はテキストが空でも付与される(prefix + "" = prefix)
+        assert tts_text == "[calm][強調]今なら[/強調][明るく]"
+        assert publish_text == "[強調]今なら[/強調][明るく]"
+
+    def test_billing_byte_count_differs_from_char_count_for_japanese_text(self):
+        # 課金は tts_text の UTF-8 バイト数(speak() 内 len(tts_text.encode("utf-8")))
+        # を計上する。日本語はマルチバイトなので文字数とバイト数が一致しない
+        # ——ここを char count で計算するリグレッションが起きると原価が過小計上される。
+        tts_text, _ = agent._compose_speak_texts(
+            "こんにちは", emotion_prefix=False, sales_state=None, emotion_tags_prefix=""
+        )
+        char_count = len(tts_text)
+        byte_count = len(tts_text.encode("utf-8"))
+        assert char_count == 5
+        assert byte_count == 15  # 「こんにちは」は1文字3バイト×5文字
+        assert byte_count != char_count
+
 
 class TestCallSitesUseSpeakFunnel:
     """DoD: 4箇所（tts_request / handle_chat / filler / 挨拶）全てが speak() 経由。"""
@@ -94,12 +221,38 @@ class TestCallSitesUseSpeakFunnel:
         assert "speak(initial_greeting, publish=True, emotion_prefix=False)" in src
 
 
+class TestVoiceIdCategorySwitchRegression:
+    """category_change によるアバター声切替の回帰ガード。
+
+    背景: 自前 FishAudioTTS 時代は `fish_tts._reference_id = persona["voice_id"]`
+    という private 属性への直接代入で声を切り替えていた。公式 fishaudio.TTS は
+    この属性を読まない(内部は self._opts.voice_id)ため、この古いパターンが
+    復活すると「声が切り替わらない」不具合が無言で再発する
+    (update_agent_prompt のイベント名誤字と同種の、fire-and-forgetで気づけない
+    パターン)。
+    """
+
+    def test_old_private_attribute_assignment_pattern_is_gone(self):
+        src = AGENT_PY.read_text(encoding="utf-8")
+        assert "fish_tts._reference_id" not in src, (
+            "fish_tts._reference_id への直接代入が復活しています。公式"
+            " fishaudio.TTS はこの属性を読まないため、声の切り替えが無言で"
+            "効かなくなります。fish_tts.update_options(voice_id=...) を使うこと。"
+        )
+
+    def test_update_options_is_used_for_voice_switch(self):
+        src = AGENT_PY.read_text(encoding="utf-8")
+        assert "fish_tts.update_options(voice_id=" in src
+
+
 if __name__ == "__main__":
     # pytest なし環境向けフォールバック assert ランナー（test_emotion_tags.py に倣う）
     classes = [
         TestSessionSayOnlyInsideSpeak,
         TestBuildAgentReplyPayload,
+        TestComposeSpeakTexts,
         TestCallSitesUseSpeakFunnel,
+        TestVoiceIdCategorySwitchRegression,
     ]
     passed = 0
     failed = 0


### PR DESCRIPTION
## 概要
LiveKit更新プロジェクトで実装したspeak()ファネル・fishaudioプラグイン統合のテスト強化。従来のtest_speak_funnel.pyはAST/文字列によるソース照合のみで、実際の合成結果(emotion_tags_prefix + SalesFlow prefix + text)は一切検証していなかった。

## 変更内容
3つの純粋関数を切り出し(振る舞い完全不変、diffで確認済み):
- `_resolve_voice_id(reference_id) -> str | NOT_GIVEN`
- `_build_emotion_tags_prefix(emotion_tags) -> str`
- `_compose_speak_texts(text, *, emotion_prefix, sales_state, emotion_tags_prefix) -> (tts_text, publish_text)`

## 最重要の回帰ガード
`TestComposeSpeakTexts.test_emotion_tags_prefix_applies_to_tts_text_only` — emotion_tags_prefix(テナントDB設定)がpublish_text(Widgetのチャット吹き出し)に絶対に漏れないことを実際に関数を呼んで検証。従来はこの不変条件を検証するテストが1件も無かった(publish=Trueとemotion_prefix=Trueが同時に立つ呼び出しが現状無いため気づかれていなかった潜在リスク)。ここが崩れると`[calm][happy]`のような装飾記法が顧客向けチャットUIにそのまま露出する。

課金バイト数が日本語マルチバイトで文字数と一致しないことも固定(過小計上リグレッション防止)。

## テスト内訳(pytest 72 passed、既存41 + 新規27 + 波及4)
- `test_speak_funnel.py`
  - `TestComposeSpeakTexts`(8件、上記の回帰ガード含む)
  - `TestBuildAgentReplyPayload`拡張(+4件): 空文字列・引用符/バックスラッシュ・改行・絵文字・長文
  - `TestVoiceIdCategorySwitchRegression`(2件): 自前FishAudioTTS時代の`fish_tts._reference_id`直接代入パターンが復活していないこと、`update_options()`経由になっていることを固定
- `test_fishaudio_config.py`(新規、9件)
  - `_resolve_voice_id`: None/空文字列→NOT_GIVEN、実値通過、**空白のみ文字列はtruthyのため素通りする既知の未対応挙動も明示的に固定**
  - `_build_emotion_tags_prefix`: 0/1/3件(境界)/4件超(切り捨て)、順序保持、**空白のみタグの未フィルタ・タグ内`]`混入時の構文崩れも既知の未対応挙動として固定**(修正はスコープ外)

## カバーできていないリスク(指摘のみ、このPRでは対応せず)
1. **speak()の並行呼び出し時の状態競合**: `_filler_state`/`_sales_state`はentrypoint()内のクロージャで共有されるdict。同時に複数メッセージが来た場合の競合は、entrypoint()のクロージャ構造を大規模リファクタしない限り単体テスト不可能。
2. **emotion_tagsの入力サニタイズ**: 空白のみタグ・`]`を含むタグはテナント管理画面からの自由入力経路の有無を含めて未確認。現状はDB側にバリデーションが無い前提でテストしているのみで、実際に悪用可能な入力経路が存在するかは別途調査が必要。
3. **avatar-agentのPythonはCI非対象のまま**: `pnpm verify`にpytestは組み込まれていない(GID 1217083837948787で別途起票済み、未着手)。今回追加した72件も含め、実行するのは人間または次回セッションのみ。

## Gate結果
- Gate 1 `pnpm verify`: typecheck/lint(0 errors)/admin-ui build成功。jestは複数回実行で0〜3件の無関係ファイルが毎回別ファイルで単発失敗(ローカルマシンの他プロジェクトによるメモリ逼迫由来、ECONNRESET等)。差分はavatar-agentのPythonファイルのみでJS/TSには一切触れていないため無関係。
- Gate 2 `security-scan.sh`: PASS
- Gate 3 `pnpm build`: 成功

## ローカル確認
`GROQ_API_KEY=dummy FISH_AUDIO_API_KEY=dummy python3 -m pytest -v` — 72 passed