### PR TITLE
fix: adoptVoiceForConfigの孤児リソースログ追加とdead code除去

### DIFF
--- a/src/api/admin/avatar/fishVoiceModel.test.ts
+++ b/src/api/admin/avatar/fishVoiceModel.test.ts
@@ -1,6 +1,7 @@
 // src/api/admin/avatar/fishVoiceModel.test.ts
 
 import { createFishVoiceModel, FishVoiceModelError, adoptVoiceForConfig } from "./fishVoiceModel";
+import { logger } from "../../../lib/logger";
 
 const mockFetch = jest.fn();
 global.fetch = mockFetch as unknown as typeof fetch;
@@ -226,7 +227,7 @@ describe("adoptVoiceForConfig", () => {
     title: "マイボイス",
     audio: Buffer.from("dummy"),
     mimeType: "audio/wav",
-    logEventPrefix: "voice_clone",
+    logEventPrefix: "voice_clone" as const,
     logContext: "[test] voice-clone",
   };
 
@@ -252,6 +253,44 @@ describe("adoptVoiceForConfig", () => {
       expect.stringContaining("UPDATE avatar_configs"),
       "COMMIT",
     ]);
+    expect(release).toHaveBeenCalledTimes(1);
+  });
+
+  // GID: レビュー指摘 — Fish側の生成成功後にUPDATEが失敗すると、課金済みの永続モデルが
+  // どこにも記録されず孤児化する。UPDATE試行前にvoiceIdをログすることを固定する。
+  it("Fish呼び出し成功後、UPDATE実行前にvoiceIdをログする(UPDATE失敗時の孤児追跡用)", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 201, json: async () => ({ _id: "fish-voice-2" }) });
+    const infoSpy = jest.spyOn(logger, "info").mockImplementation(() => {});
+    const { db } = makeTxDb(async (sql) => {
+      if (sql.startsWith("SELECT id FROM avatar_configs")) return { rows: [{ id: "config-1" }] };
+      if (sql.startsWith("UPDATE avatar_configs")) return { rows: [], rowCount: 1 };
+      return { rows: [] };
+    });
+
+    await adoptVoiceForConfig({ ...baseParams, db });
+
+    expect(infoSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ event: "voice_clone_voice_created", voiceId: "fish-voice-2", configId: "config-1" }),
+      expect.any(String),
+    );
+    infoSpy.mockRestore();
+  });
+
+  // UPDATEが(0件更新ではなく)例外で失敗するケース。対象行は直前のSELECT...FOR UPDATEで
+  // 既にロック済みのため0件更新は起こり得ない。例外時は呼び出し元の500ハンドリングに委ね、
+  // Fish側に残った孤児モデルの追跡は直前のvoiceIdログに依存する。
+  it("UPDATEが例外を投げた場合、Fish側は既に成功しているが呼び出し元に例外を伝播しコネクションは解放する", async () => {
+    mockFetch.mockResolvedValueOnce({ ok: true, status: 201, json: async () => ({ _id: "fish-voice-3" }) });
+    const { db, release } = makeTxDb(async (sql) => {
+      if (sql.startsWith("SELECT id FROM avatar_configs")) return { rows: [{ id: "config-1" }] };
+      if (sql.startsWith("UPDATE avatar_configs")) throw new Error("connection terminated unexpectedly");
+      if (sql === "ROLLBACK") return { rows: [] };
+      return { rows: [] };
+    });
+
+    await expect(adoptVoiceForConfig({ ...baseParams, db })).rejects.toThrow(
+      "connection terminated unexpectedly",
+    );
     expect(release).toHaveBeenCalledTimes(1);
   });
 

--- a/src/api/admin/avatar/fishVoiceModel.ts
+++ b/src/api/admin/avatar/fishVoiceModel.ts
@@ -80,10 +80,14 @@ export interface AdoptVoiceForConfigParams {
   audio: Buffer;
   mimeType: string;
   filename?: string;
-  /** ログイベント名の接頭辞（"voice_clone" | "adopt_designed_voice"）。呼び出し元ごとに区別する */
-  logEventPrefix: string;
+  /** ログイベント名の接頭辞。呼び出し元ごとに区別する */
+  logEventPrefix: AdoptVoiceLogEventPrefix;
   logContext: string;
 }
+
+/** adoptVoiceForConfig の呼び出し元識別子。genericErrorの分岐にも使うため、タイポ時に
+ *  誤ったエラーメッセージへ無言でフォールバックしないようリテラルユニオン型で固定する。 */
+export type AdoptVoiceLogEventPrefix = "voice_clone" | "adopt_designed_voice";
 
 export type AdoptVoiceForConfigResult =
   | { ok: true; voiceId: string }
@@ -147,17 +151,25 @@ export async function adoptVoiceForConfig(
       return { ok: false, status: 502, error: genericError };
     }
 
+    // Fish側は既にこの時点で課金対象のモデルを作成済み。ここから先のUPDATEが
+    // （0件更新ではなく）例外で失敗した場合、Fishのモデルはどこにも記録されず
+    // 孤児化する。UPDATE試行前にログしておき、失敗時に手動でFish側から追跡・
+    // 削除できるようにする。
+    logger.info({
+      event: `${params.logEventPrefix}_voice_created`,
+      voiceId,
+      configId: params.configId,
+    }, `${params.logContext} (Fish voice model created, persisting voice_id)`);
+
     const updateValues: unknown[] = [voiceId, params.configId];
     let updateQuery = "UPDATE avatar_configs SET voice_id = $1, updated_at = NOW() WHERE id = $2";
     if (!params.isSuperAdmin) {
       updateValues.push(params.tenantId);
       updateQuery += " AND tenant_id = $3";
     }
-    const result = await client.query(updateQuery, updateValues);
-    if ((result.rowCount ?? result.rows?.length ?? 0) === 0) {
-      await client.query("ROLLBACK");
-      return { ok: false, status: 404, error: "設定が見つからないかアクセス権限がありません" };
-    }
+    // 対象行は直前の SELECT ... FOR UPDATE で既にロック済みのため、この UPDATE が
+    // 0件になることはない（ロック保持中に他トランザクションが行を削除/移動できない）。
+    await client.query(updateQuery, updateValues);
 
     await client.query("COMMIT");
     return { ok: true, voiceId };


### PR DESCRIPTION
## Summary
- Fish Audio側でのモデル作成成功後、DB UPDATEが例外で失敗すると課金済みリソースが追跡不能なまま孤児化するリスクがあったため、UPDATE試行前にvoiceIdをログする(logger.info)
- `SELECT ... FOR UPDATE` で対象行をロック済みのため到達不能だった「UPDATE 0行→404」分岐を削除
- `logEventPrefix: string` をリテラルユニオン型 (`AdoptVoiceLogEventPrefix`) にし、将来のタイポによる誤ったエラーメッセージへの無言フォールバックを型で防止

fish.audio統合(PR #700/#711/#714/#715/#717/#720/#721)の厳格レビューで判明した指摘事項への対応。

## Test plan
- [x] `pnpm typecheck` — 0 errors
- [x] `bash SCRIPTS/security-scan.sh` — CRITICAL/HIGH 0
- [x] `bash SCRIPTS/dead-code-check.sh` — 新規dead exportなし(既存4件はnotionSchemas.ts、本PR無関係)
- [x] `pnpm build` (backend) / `pnpm build` (admin-ui) — 両方成功
- [x] `pnpm exec jest src/api/admin/avatar/fishVoiceModel.test.ts src/api/admin/avatar/routes.test.ts` — 58/58 pass（孤児ログのassertテスト・UPDATE例外伝播テストを新規追加）
- [ ] `pnpm verify` フルスイート中、admin-ui vitestの`useAuth.test.tsx`が1件失敗したが、分離実行では12/12 pass。本PRはadmin-uiを一切変更しておらず、既存の他テストファイルとの並行実行起因のflakinessと確認済み(既知のトラブル: 複数Lane同時実行時の環境要因)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EdBRSsTu4YNWBDTpgzqz2c