### PR TITLE
fix(avatar): avatar.start()失敗時の音声出力永久ハイジャックを解消

### DIFF
--- a/avatar-agent/agent.py
+++ b/avatar-agent/agent.py
@@ -656,7 +656,7 @@ async def entrypoint(ctx: agents.JobContext) -> None:
                         asyncio.create_task(
                             control_lemonslice("update-idle-prompt", idle_prompt=persona["idle_prompt"])
                         )
-                    if persona.get("voice_id"):
+                    if isinstance(persona.get("voice_id"), str) and persona["voice_id"]:
                         # 次回 TTS 合成から声を切り替える。公式 fishaudio.TTS は
                         # update_options() でインスタンスの声設定を更新できる
                         # （TTSインスタンスの再生成は不要）。
@@ -722,10 +722,14 @@ async def entrypoint(ctx: agents.JobContext) -> None:
         global _lemonslice_session_id
         try:
             _lemonslice_session_id = await asyncio.wait_for(
-                avatar.start(session, room=ctx.room), timeout=30.0
+                avatar.start(session, room=ctx.room), timeout=15.0
             )
         except asyncio.TimeoutError:
-            logger.warning("[avatar] avatar.start() timed out after 30s (text-only fallback)")
+            logger.warning("[avatar] avatar.start() timed out after 15s (text-only fallback)")
+            try:
+                await avatar.aclose()
+            except Exception:
+                pass
             raise
         # 課金: アバター起動成功時刻を記録（_close_avatar でセッション時間を算出）
         _avatar_started_at = time.monotonic()
@@ -757,6 +761,15 @@ async def entrypoint(ctx: agents.JobContext) -> None:
         ctx.add_shutdown_callback(_close_avatar)
     except Exception as e:
         logger.warning(f"Lemonslice avatar failed (text-only fallback): {e}")
+        # I-4 root fix: avatar.start() は失敗有無に関わらずネットワーク呼び出し前に
+        # session.output.audio を DataStreamAudioOutput (アバター宛て) へ差し替え済み
+        # （plugin avatar.py: replace_audio_tail）。失敗時にそのまま session.start() へ
+        # 進むと、音声出力が二度と参加しないアバター宛てに固定されたまま残り、
+        # テキストと課金だけが動いて音声が永久に無音になる。
+        # output.audio を None に戻すと、直後の session.start() が
+        # RoomIO の通常デフォルト音声出力を自動生成する（agent_session.py:
+        # `if self.output.audio is not None: [warn] ignoring` の分岐を利用）。
+        session.output.audio = None
 
     await session.start(
         room=ctx.room,

--- a/avatar-agent/test_avatar_start_timeout.py
+++ b/avatar-agent/test_avatar_start_timeout.py
@@ -100,19 +100,90 @@ class TestAvatarStartWrappedInTimeout:
             "握りつぶされています。外側の text-only fallback に届きません。"
         )
 
+    def test_avatar_aclose_attempted_on_timeout(self):
+        """タイムアウト時、re-raise の前に avatar.aclose() をベストエフォートで
+        呼んでいることを確認する（LemonSlice側にセッションが作成済みのまま
+        放置されるゾンビセッションを防ぐ）。
+        """
+        src = AGENT_PY.read_text(encoding="utf-8")
+        tree = ast.parse(src)
+        handler = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ExceptHandler) and node.type is not None:
+                if ast.unparse(node.type) == "asyncio.TimeoutError":
+                    handler = node
+                    break
+        assert handler is not None
+        aclose_calls = _find_calls(handler, "avatar.aclose")
+        assert aclose_calls, (
+            "except asyncio.TimeoutError: 内で avatar.aclose() が"
+            "呼ばれていません。LemonSlice側にゾンビセッションが残ります。"
+        )
+
+
+class TestAudioOutputResetOnAvatarFailure:
+    """I-4 root fix: avatar.start() 失敗時、session.output.audio が
+    DataStreamAudioOutput（アバター宛て）に固定されたまま session.start() へ
+    進むと、音声が永久に無音になる不具合の回帰ガード。
+
+    plugin avatar.py の replace_audio_tail はネットワーク呼び出し前に走るため、
+    失敗の原因（タイムアウト/その他例外）に関わらず output.audio は既に
+    差し替わっている。text-only fallback の except Exception 節で
+    session.output.audio = None にリセットし、直後の session.start() が
+    RoomIO の通常デフォルト音声出力を自動生成できるようにする。
+    """
+
+    def test_output_audio_reset_in_text_only_fallback_handler(self):
+        src = AGENT_PY.read_text(encoding="utf-8")
+        tree = ast.parse(src)
+        handler = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ExceptHandler) and node.type is not None:
+                if ast.unparse(node.type) == "Exception":
+                    segment = ast.get_source_segment(src, node) or ""
+                    if "text-only fallback" in segment:
+                        handler = node
+                        break
+        assert handler is not None, (
+            "Lemonslice avatar failed (text-only fallback) の except節が"
+            "見つかりません。"
+        )
+        reset_found = False
+        for n in ast.walk(handler):
+            if (
+                isinstance(n, ast.Assign)
+                and len(n.targets) == 1
+                and isinstance(n.targets[0], ast.Attribute)
+                and n.targets[0].attr == "audio"
+                and isinstance(n.targets[0].value, ast.Attribute)
+                and n.targets[0].value.attr == "output"
+                and isinstance(n.value, ast.Constant)
+                and n.value.value is None
+            ):
+                reset_found = True
+                break
+        assert reset_found, (
+            "text-only fallback の except節内に "
+            "`session.output.audio = None` のリセットがありません。"
+            "avatar.start() 失敗後、音声出力がアバター宛てに固定されたまま"
+            "残り、音声が永久に無音になります。"
+        )
+
 
 if __name__ == "__main__":
-    runner = TestAvatarStartWrappedInTimeout()
+    classes = [TestAvatarStartWrappedInTimeout, TestAudioOutputResetOnAvatarFailure]
     passed = 0
     failed = 0
-    for t in [m for m in dir(runner) if m.startswith("test_")]:
-        try:
-            getattr(runner, t)()
-            print(f"  PASS  {t}")
-            passed += 1
-        except AssertionError as e:
-            print(f"  FAIL  {t}: {e}")
-            failed += 1
+    for cls in classes:
+        runner = cls()
+        for t in [m for m in dir(runner) if m.startswith("test_")]:
+            try:
+                getattr(runner, t)()
+                print(f"  PASS  {cls.__name__}.{t}")
+                passed += 1
+            except AssertionError as e:
+                print(f"  FAIL  {cls.__name__}.{t}: {e}")
+                failed += 1
     print(f"\n{passed} passed, {failed} failed")
     if failed:
         raise SystemExit(1)

--- a/avatar-agent/test_speak_funnel.py
+++ b/avatar-agent/test_speak_funnel.py
@@ -244,6 +244,33 @@ class TestVoiceIdCategorySwitchRegression:
         src = AGENT_PY.read_text(encoding="utf-8")
         assert "fish_tts.update_options(voice_id=" in src
 
+    def test_voice_id_is_type_checked_before_switch(self):
+        """category_persona_map はテナントDB設定由来で、voice_id が数値や
+        リスト等の非文字列で紛れ込んでいても resolve_category_persona() は
+        弾かない（dict の値であることしか見ない）。truthy チェックだけで
+        fish_tts.update_options(voice_id=...) に渡すと、fishaudio API に
+        非文字列が渡り例外化する。isinstance(..., str) を先に見ていること。
+        """
+        src = AGENT_PY.read_text(encoding="utf-8")
+        tree = ast.parse(src)
+        found = False
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Name) and node.func.id == "isinstance":
+                if (
+                    len(node.args) == 2
+                    and isinstance(node.args[0], ast.Call)
+                    and isinstance(node.args[0].func, ast.Attribute)
+                    and node.args[0].func.attr == "get"
+                    and isinstance(node.args[1], ast.Name)
+                    and node.args[1].id == "str"
+                ):
+                    found = True
+                    break
+        assert found, (
+            "persona.get(\"voice_id\") を isinstance(..., str) で"
+            "型チェックしていません。voice_id 型チェック除去の回帰です。"
+        )
+
 
 if __name__ == "__main__":
     # pytest なし環境向けフォールバック assert ランナー（test_emotion_tags.py に倣う）


### PR DESCRIPTION
## Summary

厳格レビュー（本セッション実施）で発見した avatar-agent の5件の問題を修正。

- **P0（根本原因）**: `avatar.start()` がタイムアウト/例外で失敗すると、LemonSlice plugin が
  ネットワーク呼び出し前に `session.output.audio` を `DataStreamAudioOutput`（二度と参加しない
  アバター宛て）へ差し替え済みのまま text-only fallback へ進んでいた。結果、テキスト応答と課金は
  動くが音声だけが永久に無音になる。`except Exception` の text-only fallback 節で
  `session.output.audio = None` にリセットし、直後の `session.start()` で RoomIO が通常の
  デフォルト音声出力を自動生成するようにした。
  - livekit-agents ソース確認済み: `AgentSession.start()` は `output.audio is None` の場合のみ
    RoomIO のデフォルト音声出力を生成する。
  - `DataStreamAudioOutput` は `next_in_chain=None` の leaf node で、`on_detached()`
    （継承元 `if self.source: ...`）は安全な no-op であることを確認済み。
- **P1**: `category_change` の声切替で `persona.get("voice_id")` の truthy チェックのみだったのを
  `isinstance(..., str)` 型チェック追加。テナントDB設定由来の非文字列混入で fishaudio API が
  例外化するのを防止。
- **P2**: `avatar.start()` タイムアウトを 30s→15s に短縮（UX改善、LemonSlice側理論上限より
  十分短く保ちつつユーザー待機時間を削減）。
- **P3**: タイムアウト時に `avatar.aclose()` をベストエフォートで呼び、LemonSlice側の
  ゾンビセッションを防止。

## Background

先行PR #722（avatar.start() タイムアウト保護 + speak()ファネル + fishaudio移行のテスト強化）の
後に実施した厳格レビューで、タイムアウト保護自体は機能する一方、その後の text-only fallback で
音声出力が壊れたまま残る副作用が未対応だったことが判明。本PRはその根本修正。

## Test plan

- [x] `python avatar-agent/test_avatar_start_timeout.py` — 5 passed（新規2件含む）
- [x] `python avatar-agent/test_speak_funnel.py` — 24 passed（新規1件含む）
- [x] `bash SCRIPTS/security-scan.sh` — PASS (CRITICAL/HIGH: 0)
- [ ] 実機検証（VPSデプロイ後、LiveKit Cloud dashboard で avatar.start() タイムアウトを人為的に
      発生させ、テキスト応答に加えて音声フォールバックが機能することを確認）

Python-only の変更のため `pnpm verify`（TS向け）は対象外。CI は avatar-agent の Python テストを
実行しないため、上記の standalone test runner 実行結果が唯一の自動検証。

Tier: S（`avatar-agent/**` はテナント向け音声出力の中核ロジックのため high-risk）。
hkobayashi の手動 merge が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VY7SvyvFkyotiLxjb9ZSvV