### PR TITLE
chore(avatar-agent): 未使用の fish-audio-sdk を requirements.txt から除去する

### DIFF
--- a/avatar-agent/requirements.txt
+++ b/avatar-agent/requirements.txt
@@ -2,7 +2,6 @@
 # To update: pip install -U <package> && pip freeze > /tmp/freeze.txt, then update this file
 # DO NOT use >= constraints — they allow silent version drift that breaks livekit-agents compatibility
 livekit-agents[lemonslice,openai,fishaudio]==1.6.7
-fish-audio-sdk==1.3.0
 groq==1.2.0
 httpx==0.28.1
 python-dotenv==1.2.2


### PR DESCRIPTION
## 概要

`fish-audio-sdk==1.3.0` は初回コミット `318e7b74` (avatar-agent skeleton) から一度も import されていない死んだ依存だった。1行削除する。

PR #712 のコミットメッセージにも「元々未import(自前実装はaiohttp直呼び)の死んだ依存だったため、このPRのスコープ外として触れていない」と明記されており、既知のまま先送りされていたもの。

## 未使用であることの根拠（3系統）

| 検証 | 結果 |
|---|---|
| import 箇所 | `avatar-agent/` 全体を grep して 0 件。`agent.py:33` の `from livekit.plugins import fishaudio` のみ |
| 公式プラグインの依存か | PyPI の `livekit-plugins-fishaudio` 1.6.7 の requires_dist は `livekit-agents[codecs]` と `msgpack` のみ。**含まれない** |
| 旧自前実装での使用 | PR #712 以前の `FishAudioTTS` も aiohttp 直呼びで未使用 |

## 実機検証（新規 venv）

- `pip install -r requirements.txt` が解決し、インストール一覧に `fish-audio-sdk` が現れないこと（推移的依存でもない）を確認
- `importlib.util.find_spec('fish_audio_sdk')` が `None` を返す状態で `fishaudio.TTS()` のインスタンス化が成功することを確認
- 既存テスト **75件が無変更のまま通過**

## Gate 結果

| Gate | 結果 |
|---|---|
| Gate 1 typecheck | PASS (exit 0) |
| Gate 1 lint | PASS (exit 0 / warning 59件 < 上限80) |
| Gate 1 test | 後述（本PRとは無関係の既存 flaky） |
| Gate 1.5 dead-code-check | PASS (dead exports 4 = warning only / unregistered routes 0) |
| Gate 2 security-scan | PASS (CRITICAL/HIGH 0) |
| Gate 3 build (backend / admin-ui) | PASS |

### Gate 1 test について（正直な報告）

jest が **実行ごとに異なるテストで落ちる flaky 状態**にあり、クリーンな green を確認できていない。ただし本PRの変更は Python の依存1行削除であり、jest には影響し得ない。

- 同一環境で `git stash` して origin/main と同内容にしても同じ失敗が再現することを確認済み（21件が完全に一致）
- 実行ごとに失敗内容が変わる（4件 → 2件、内容も別物）ため、非決定性は本PRと独立

なお、ローカルで大量に失敗して見えた分は環境要因だった:
- **Node 26 で実行すると** `jest.spyOn(global, "fetch")` が "Property `fetch` does not exist" で失敗する。本リポジトリは `engines: node 20.x` / CI も node-version 20 固定
- **サンドボックス下では** supertest の localhost bind が `EADDRNOTAVAIL` で失敗する

Node 20 かつ通常環境で実行すると 3417件中 2〜4件まで減る。この残りが既存 flaky。別途起票する。

## デプロイ

既存 venv からはアンインストールされないため既存環境への即時影響はなく、**新規 venv 構築時に初めて効く**。**avatar-agent の再デプロイが必要**（実行は人間）。

## Asana

https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217104979398629

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bu7egx6YnkxKkHaqxAeDGV
