### PR TITLE
fix(widget): アバター接続失敗時に2カラムレイアウトを残さず、訪問者に案内する

### DIFF
--- a/public/widget.js
+++ b/public/widget.js
@@ -2008,19 +2008,42 @@
           } catch (_e) {}
         })
         .catch(function (e) {
-          avatarArea.style.display = 'none';
           console.warn('[FAQ Widget] LiveKit connect failed:', e && e.message);
-          // 接続自体が確立できなかった（LiveKit Cloud のレート制限/上限超過=429 を含む）。
-          // room-token は enabled:true なので、この層の失敗はテストチャットでしか可視化されない。
-          emitAvatarStatus({ enabled: false, provider: 'lemonslice', reason: 'livekit_connect_failed' });
+          // 接続自体が確立できなかった（LiveKit Cloud のレート制限/上限超過=429、
+          // LemonSlice の同時接続上限、ネットワーク断などを含む）。
+          failAvatarStartGracefully('livekit_connect_failed');
         });
 
       window.__rajiuceRoom = room;
     } catch (e) {
-      avatarArea.style.display = 'none';
       console.warn('[FAQ Widget] LiveKit init failed:', e && e.message);
-      emitAvatarStatus({ enabled: false, provider: 'lemonslice', reason: 'livekit_connect_failed' });
+      failAvatarStartGracefully('livekit_connect_failed');
     }
+  }
+
+  /**
+   * アバターの起動に失敗したときの後始末を1か所に集約する。
+   *
+   * パネルを開いた状態でここに到達する場合、すでに showAvatarPlaceholder() で静止画を出し
+   * setAvatarActive() で UI をアバターモードへ切り替え済み。avatarArea を隠すだけだと
+   * .panel.avatar-active の 2 カラム Grid（左=アバター固定幅・右=チャット）が残るため、
+   * 訪問者には「左半分が空白のまま横に広がった巨大パネル」が見える。
+   * 既存の collapseAvatarLargeView() でテキストレイアウトへ確実に戻す。
+   */
+  function failAvatarStartGracefully(reason) {
+    // 「静止画が出た後に消える」のを訪問者が見たかどうか。案内を出すかの判定に使うため
+    // レイアウトを戻す前に確定させる。
+    var wasVisibleToVisitor = panel.classList.contains('avatar-active');
+    removeAvatarPlaceholder();
+    collapseAvatarLargeView();
+    textarea.setAttribute('placeholder', placeholderText);
+    // アバターが見えていた場合だけ案内する。何も表示していない状態（パネル未オープン等）は
+    // 従来どおり黙ってテキストへフォールバックする — アバターを期待していない訪問者に
+    // 不要な不安を与えないため。
+    if (wasVisibleToVisitor) {
+      showError('アバターの映像を表示できませんでした。文字でのご案内は続けられますので、そのままご質問ください。');
+    }
+    emitAvatarStatus({ enabled: false, provider: 'lemonslice', reason: reason });
   }
 
   function sendTTSRequest(text) {

--- a/tests/e2e/widget-fab-avatar.spec.ts
+++ b/tests/e2e/widget-fab-avatar.spec.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { test, expect } from '@playwright/test';
 import { mockAvatarBackend } from './helpers/mockAvatarBackend';
 import { DEMO_INDEX_URL } from './config';
@@ -188,6 +190,83 @@ test.describe('Widget FAB — Avatar persistence on chat open/close', () => {
 
     const roomAfterClose = await page.evaluate(() => !!(window as any).__rajiuceRoom);
     expect(roomAfterClose).toBe(true); // PiP: 閉じてもRoomは保持される(nullにならない)
+  });
+
+  test('アバター接続に失敗したら、2カラムのアバターレイアウトを残さずテキストへ戻して案内する', async ({ page }) => {
+    // 回帰ガード: 接続失敗時に avatarArea を隠すだけの実装へ戻っていないことを検証する。
+    // .panel.avatar-active は 2 カラム Grid(左=アバター固定幅・右=チャット)なので、
+    // クラスを付けたまま avatarArea だけ隠すと左カラムが幅を確保したまま残り、
+    // 訪問者には「左半分が空白の巨大パネル」が見える。
+    //
+    // mockAvatarBackend は room-token に enabled:true + wss://e2e-mock.invalid を返すため、
+    // room.connect() は必ず失敗する。実 LiveKit / 実 LemonSlice には一切接続しないので
+    // このテストはアバターセッションの課金を発生させない。
+    await mockAvatarBackend(page);
+
+    // デモページは本番配信の widget.js を読み込むため、そのままだとリポジトリの変更を
+    // 検証できない(デプロイ後にしか赤にならない回帰ガードになってしまう)。
+    // public/widget.js の実物を差し込み、main のコードそのものを検証する。
+    const localWidgetJs = readFileSync(resolve(__dirname, '../../public/widget.js'), 'utf8');
+    await page.route('**/widget.js*', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/javascript; charset=utf-8',
+        body: localWidgetJs,
+      })
+    );
+
+    const resp = await page.goto(AVATAR_DEMO_URL);
+    expect(resp?.status()).toBe(200);
+
+    await page.waitForFunction(
+      () => {
+        const host = document.getElementById('faq-chat-widget-host') as HTMLElement | null;
+        return !!host?.shadowRoot?.querySelector('.fab');
+      },
+      { timeout: 8000 }
+    );
+    await page.waitForTimeout(3000);
+
+    const fabInitial = await getFabState(page);
+    if (!fabInitial || !(fabInitial.hasImg || fabInitial.hasVideo)) {
+      test.skip(); // アバター未設定 — connectLiveKit() が走らないため対象外
+      return;
+    }
+
+    // パネルを開く → showAvatarPlaceholder() + setAvatarActive() が走り、
+    // その後 room.connect() が mock URL で失敗する。
+    await page.evaluate(() => {
+      const host = document.getElementById('faq-chat-widget-host') as HTMLElement | null;
+      host?.shadowRoot?.querySelector<HTMLButtonElement>('.fab')?.click();
+    });
+    await page.waitForTimeout(3000);
+
+    const state = await page.evaluate(() => {
+      const host = document.getElementById('faq-chat-widget-host') as HTMLElement | null;
+      const root = host?.shadowRoot;
+      const panel = root?.querySelector('.panel') as HTMLElement | null;
+      const errorBanner = root?.querySelector('.error-banner') as HTMLElement | null;
+      const textarea = root?.querySelector('textarea') as HTMLTextAreaElement | null;
+      return {
+        stillAvatarLayout: !!root?.querySelector('.panel.avatar-active'),
+        panelOpen: !!panel?.classList.contains('open'),
+        errorVisible: !!errorBanner && errorBanner.style.display !== 'none',
+        errorText: errorBanner?.textContent ?? '',
+        canStillType: !!textarea && !textarea.disabled,
+      };
+    });
+
+    // 1. アバター用の2カラムレイアウトが残っていないこと（本命の回帰ガード）
+    expect(state.stillAvatarLayout).toBe(false);
+    // 2. 会話自体は続けられること（テキストへのフォールバックが成立している）
+    expect(state.panelOpen).toBe(true);
+    expect(state.canStillType).toBe(true);
+    // 3. 無言で消えるのではなく案内が出ること。専門用語を画面に出さないこと
+    expect(state.errorVisible).toBe(true);
+    expect(state.errorText).toContain('アバター');
+    for (const jargon of ['LiveKit', 'LemonSlice', '429', 'WebSocket', 'error', 'Error']) {
+      expect(state.errorText).not.toContain(jargon);
+    }
   });
 
   test('FAB shows chat SVG icon for non-avatar tenant (demo page without avatar)', async ({ page }) => {


### PR DESCRIPTION
## 症状

パネルを開いた状態で `room.connect()` が失敗すると、訪問者には**「左半分が黒い空白のまま横に広がった巨大パネル」**が残っていた。

## 原因

接続失敗ハンドラが `avatarArea` を `display:none` にするだけで、panel の `avatar-active` クラスを外していなかった。`.panel.avatar-active` は 2 カラムの CSS Grid（`grid-template-columns:` 左=アバター固定幅 / 右=チャット）なので、**クラスが付いたままだと左カラムが幅を確保し続ける**。

さらにこの経路に到達する時点で `showAvatarPlaceholder()` が静止画を表示し `setAvatarActive()` が UI をアバターモードへ切り替え済みのため、訪問者から見ると「顔が出た直後に消えて、空白が残る」状態だった。

`emitAvatarStatus()` のコメントは「本番埋め込みページにはリスナーが無いため無害（サイレントにテキストへフォールバック）」としているが、**これが成立するのはパネル未オープンで何も表示していない場合のみ**で、開いている場合は UI が見た目上コミット済みだった。

## 修正

後始末を `failAvatarStartGracefully()` に集約し、既存の `collapseAvatarLargeView()` を再利用してテキストレイアウトへ確実に戻す（共有済みの層を手書きでコピーしない）。connect の失敗と初期化の失敗は同じ失敗クラスなので両方から呼ぶ。

**案内は「訪問者に実際にアバターが見えていた場合」だけ出す。** 何も表示していない場合は従来どおり黙ってテキストへ落とし、既存の設計意図を壊さない（アバターを期待していない訪問者に不要な不安を与えないため）。

文言は専門用語を出さず、次に何をすればよいかを書く:

> アバターの映像を表示できませんでした。文字でのご案内は続けられますので、そのままご質問ください。

## テスト

`tests/e2e/widget-fab-avatar.spec.ts` に回帰ガードを追加。**修正を外すと赤、入れると緑**になることを実行して確認済み。

| 検証項目 | 内容 |
|---|---|
| 本命 | `.panel.avatar-active` が残っていないこと |
| フォールバック成立 | パネルは開いたまま・入力を継続できること |
| 案内 | バナーが表示され、`アバター` を含むこと |
| 用語 | `LiveKit` / `LemonSlice` / `429` / `WebSocket` / `Error` が画面に出ないこと |

**課金の副作用なし**: 既存の `mockAvatarBackend` が room-token に `enabled:true` と `wss://e2e-mock.invalid` を返すため connect は必ず失敗する。実 LiveKit / 実 LemonSlice には接続しない。

**テスト設計の変更点**: デモページは本番配信の widget.js を読み込むため、そのままだとリポジトリの変更を検証できず「デプロイ後にしか赤にならない回帰ガード」になってしまう。`public/widget.js` の実物を `page.route` で差し込み、main のコードそのものを検証する形にした。

## Gate 結果

| Gate | 結果 |
|---|---|
| Gate 1 typecheck | PASS (exit 0) |
| Gate 1 lint | PASS (exit 0 / warning 59件 < 上限80) |
| Gate 1 test (jest) | 既存 flaky のため green 未確認（後述） |
| Gate 1 E2E (該当スイート) | PASS (3 passed) |
| Gate 1.5 dead-code-check | PASS |
| Gate 2 security-scan | PASS (CRITICAL/HIGH 0) |
| Gate 3 build (backend / admin-ui) | PASS |

jest は実行ごとに異なるテストで落ちる既存 flaky 状態にある（本セッションで 2件 → 4件 → 5件と変動）。本 PR は `public/widget.js` と E2E spec のみの変更で jest 対象外。別途起票済み（Asana 1217106513143707）。

## 本 PR で実装しなかったこと

サーバ側で同時セッション数を数えて事前にブロックする案は、**同時接続の上限が1テナントあたりかアカウント全体かが未確定**（Asana 1217083779259175、期日 2026-08-10）のため見送った。

本 PR は上限到達に限らず、レート制限・ネットワーク断を含む**全ての接続失敗**で訪問者が置き去りにされないようにする。

## Asana

https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217105076479325

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bu7egx6YnkxKkHaqxAeDGV
