### PR TITLE
fix(admin-ui): 埋め込みコードに"undefined"が混入するバグを修正

### DIFF
--- a/admin-ui/src/pages/admin/tenants/EmbedCodeTab.test.tsx
+++ b/admin-ui/src/pages/admin/tenants/EmbedCodeTab.test.tsx
@@ -1,0 +1,64 @@
+// 回帰ガード: 埋め込みコードのスニペットに widget.js が読まない/実データが無い属性
+// (data-title / data-color) を出力し、テナントに "undefined" 文字列をそのまま
+// コピペさせてしまっていた不具合(バックエンドが widgetTitle/widgetColor を
+// 一度も返していない・widget.js は data-accent-color しか読まない)の再発防止。
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import EmbedCodeTab from "./EmbedCodeTab";
+import type { TenantDetail, ApiKey } from "./types";
+
+function makeTenant(overrides: Partial<TenantDetail> = {}): TenantDetail {
+  return {
+    id: "tenant-a",
+    name: "Tenant A",
+    slug: "tenant-a",
+    plan: "starter",
+    status: "active",
+    createdAt: "2026-01-01T00:00:00Z",
+    widgetTitle: "",
+    widgetColor: "#000",
+    allowed_origins: ["https://example.com"],
+    billing_enabled: false,
+    billing_free_from: null,
+    billing_free_until: null,
+    features: { avatar: true, voice: false, rag: true },
+    lemonslice_agent_id: null,
+    conversion_types: [],
+    ...overrides,
+  };
+}
+
+describe("EmbedCodeTab", () => {
+  it("生成されるスニペットに undefined 文字列が含まれない（バックエンドが widgetTitle/widgetColor を返さない実際の状況を再現）", () => {
+    // 型は string 必須だが、本番のバックエンドはこの2フィールドを一度も返していない。
+    // JSON レスポンスに無いフィールドは実行時に undefined になるため、
+    // TS の型ではなく実行時の値で再現する（`as unknown as TenantDetail` で型検査を迂回）。
+    const tenant = makeTenant({ widgetTitle: undefined, widgetColor: undefined } as unknown as Partial<TenantDetail>);
+    render(<EmbedCodeTab tenant={tenant} apiKeys={[]} />);
+    const pre = screen.getByText(/data-api-key/);
+    expect(pre.textContent).not.toContain("undefined");
+  });
+
+  it("widget.js が読まない data-title / data-color を出力しない", () => {
+    render(<EmbedCodeTab tenant={makeTenant()} apiKeys={[]} />);
+    const pre = screen.getByText(/data-api-key/);
+    expect(pre.textContent).not.toContain("data-title");
+    expect(pre.textContent).not.toContain("data-color");
+  });
+
+  it("widget.js が実際に読む data-api-key / data-tenant は出力する", () => {
+    const apiKeys: ApiKey[] = [
+      { id: "k1", maskedKey: "r2c_live_****abcd", status: "active", createdAt: "2026-01-01T00:00:00Z", lastUsedAt: null },
+    ];
+    render(<EmbedCodeTab tenant={makeTenant({ slug: "acme" })} apiKeys={apiKeys} />);
+    const pre = screen.getByText(/data-api-key/);
+    expect(pre.textContent).toContain('data-api-key="r2c_live_****abcd"');
+    expect(pre.textContent).toContain('data-tenant="acme"');
+  });
+
+  it("有効なAPIキーが無い場合はプレースホルダーを表示する", () => {
+    render(<EmbedCodeTab tenant={makeTenant()} apiKeys={[]} />);
+    const pre = screen.getByText(/data-api-key/);
+    expect(pre.textContent).toContain('data-api-key="YOUR_API_KEY"');
+  });
+});

--- a/admin-ui/src/pages/admin/tenants/EmbedCodeTab.tsx
+++ b/admin-ui/src/pages/admin/tenants/EmbedCodeTab.tsx
@@ -12,11 +12,14 @@ export default function EmbedCodeTab({ tenant, apiKeys }: { tenant: TenantDetail
   const activeKey = apiKeys.find((k) => k.status === "active");
   const displayKey = activeKey ? activeKey.maskedKey : "YOUR_API_KEY";
 
+  // widget.js が実際に読む属性のみ出力する。data-title / data-color は
+  // widget.js 側に対応する読み取りが存在せず(タイトルは固定文言、色は
+  // data-accent-color)、tenant.widgetTitle / widgetColor もバックエンドから
+  // 一度も返されたことがないため、常に "undefined" 文字列がテナントの
+  // コピペ用スニペットに混入していた。
   const embedCode = `<script src="https://cdn.r2c.biz/widget.js"
   data-api-key="${displayKey}"
-  data-tenant="${tenant.slug}"
-  data-title="${tenant.widgetTitle}"
-  data-color="${tenant.widgetColor}">
+  data-tenant="${tenant.slug}">
 </script>`;
 
   const purchaseTag = `<script>\n  window.r2c && r2c.trackConversion('purchase', /* 購入金額(円) */ 0);\n</script>`;


### PR DESCRIPTION
## 症状

旧UI（`/admin/tenants/:id`）の「埋め込みコード」タブを開くと、テナントにコピペさせるスニペットに以下が**常に**含まれていた。

```
data-title="undefined"
data-color="undefined"
```

## 原因

`tenant.widgetTitle` / `tenant.widgetColor` は `TenantDetail` 型に存在するが、**バックエンド（`src/api/admin/tenants/*.ts`）がこの2フィールドを一度も返していない**。PR #311（admin-ui リファクタで `EmbedCodeTab.tsx` を分離した際）に型だけ追加され、配線されないまま残っていた。

さらに `widget.js` 側もこの2属性を読まない。

| 属性 | widget.js の実態 |
|---|---|
| `data-title` | 対応する読み取りが存在しない。ヘッダー文言は `"サポートチャット"` 固定（`widget.js:887`） |
| `data-color` | widget.js が実際に読むのは `data-accent-color`（`widget.js:41`）。**属性名自体が誤り** |

チャット・ファーストの `get_embed_code`（`actionExecutor.ts`）は `data-api-key` のみの最小スニペットを返すため、この不具合を踏んでいない。**影響は旧UIの `EmbedCodeTab.tsx` のみ。**

## 修正

widget.js が実際に読む `data-api-key` / `data-tenant` のみを出力するようスニペットを縮小した。

`widgetTitle`/`widgetColor` の型定義自体（`types.ts`）は削除していない（dead code の削除は別タスクの方針のため）。テスト用モック（`AvatarTab.test.tsx` / `DeepResearchTab.test.tsx`）にのみ残存する。

**ブランドカラーを実際にテナントごとに設定・反映する機能**（`data-accent-color` を使った本来の「テナントブランドカラー自動反映」）は別スコープ。設定UI・DBカラム・埋め込みコード生成2箇所への配線が必要な別タスクとして扱う。

## テスト

`EmbedCodeTab.test.tsx` を新規作成（既存テストなし）。修正を外すと2件が実際に `"undefined"` 文字列を検出して落ち、戻すと4件とも通ることを実行して確認済み。

- 生成されるスニペットに `undefined` 文字列が含まれない（バックエンドが `widgetTitle`/`widgetColor` を返さない実際の状況を、実行時の `undefined` 値で再現。TS の型は `string` 必須だが、JSON レスポンスに無いフィールドは実行時 `undefined` になるため `as unknown` 経由でモックする）
- widget.js が読まない `data-title` / `data-color` を出力しない
- widget.js が実際に読む `data-api-key` / `data-tenant` は出力する
- 有効なAPIキーが無い場合はプレースホルダーを表示する

## Gate 結果

| Gate | 結果 |
|---|---|
| typecheck (root) | PASS |
| typecheck (admin-ui `tsc -b`) | 本PRと無関係な pre-existing エラーが main にも存在（`AuthContextValue` 関連、`chat-test`/`conversion`/`options` の `index.test.tsx`。既知の非ブロッカー） |
| lint | PASS（warning 59件 < 上限80） |
| dead-code-check | PASS |
| security-scan | PASS（CRITICAL/HIGH 0） |
| admin-ui vitest | 新規4件 PASS。既存失敗1件（`useAuth.test.tsx`）は main でも同一に再現、本PRと無関係と確認済み |
| build（backend / admin-ui） | PASS |

## Asana

未起票（今回の調査で発見した不具合。Asanaに記載なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bu7egx6YnkxKkHaqxAeDGV
