### PR TITLE
feat: テナントブランドカラーを埋め込みコードに自動反映する

### DIFF
--- a/admin-ui/src/pages/admin/tenants/EmbedCodeTab.test.tsx
+++ b/admin-ui/src/pages/admin/tenants/EmbedCodeTab.test.tsx
@@ -61,4 +61,25 @@ describe("EmbedCodeTab", () => {
     const pre = screen.getByText(/data-api-key/);
     expect(pre.textContent).toContain('data-api-key="YOUR_API_KEY"');
   });
+
+  it("widget_theme.primaryColor が設定済みなら data-accent-color を出力する", () => {
+    const tenant = makeTenant({ widget_theme: { primaryColor: "#3B82F6" } });
+    render(<EmbedCodeTab tenant={tenant} apiKeys={[]} />);
+    const pre = screen.getByText(/data-api-key/);
+    expect(pre.textContent).toContain('data-accent-color="#3B82F6"');
+  });
+
+  it("widget_theme が未設定なら data-accent-color を出力しない", () => {
+    render(<EmbedCodeTab tenant={makeTenant({ widget_theme: null })} apiKeys={[]} />);
+    const pre = screen.getByText(/data-api-key/);
+    expect(pre.textContent).not.toContain("data-accent-color");
+  });
+
+  it("primaryColor が #RRGGBB 形式でない場合は出力しない（直接DB編集などによる不正値の防御）", () => {
+    const tenant = makeTenant({ widget_theme: { primaryColor: "javascript:alert(1)" } });
+    render(<EmbedCodeTab tenant={tenant} apiKeys={[]} />);
+    const pre = screen.getByText(/data-api-key/);
+    expect(pre.textContent).not.toContain("data-accent-color");
+    expect(pre.textContent).not.toContain("javascript:");
+  });
 });

--- a/admin-ui/src/pages/admin/tenants/EmbedCodeTab.tsx
+++ b/admin-ui/src/pages/admin/tenants/EmbedCodeTab.tsx
@@ -17,9 +17,17 @@ export default function EmbedCodeTab({ tenant, apiKeys }: { tenant: TenantDetail
   // data-accent-color)、tenant.widgetTitle / widgetColor もバックエンドから
   // 一度も返されたことがないため、常に "undefined" 文字列がテナントの
   // コピペ用スニペットに混入していた。
+  //
+  // ブランドカラーは set_widget_theme(チャットツール)が widget_theme.primaryColor に
+  // 保存する。書き込み時に #RRGGBB 形式を検証済みだが、直接DBを触られた場合の
+  // 防御として出力直前にも再検証する。
+  const primaryColor = tenant.widget_theme?.primaryColor;
+  const accentColorLine = typeof primaryColor === "string" && /^#[0-9a-fA-F]{6}$/.test(primaryColor)
+    ? `\n  data-accent-color="${primaryColor}"`
+    : "";
   const embedCode = `<script src="https://cdn.r2c.biz/widget.js"
   data-api-key="${displayKey}"
-  data-tenant="${tenant.slug}">
+  data-tenant="${tenant.slug}"${accentColorLine}>
 </script>`;
 
   const purchaseTag = `<script>\n  window.r2c && r2c.trackConversion('purchase', /* 購入金額(円) */ 0);\n</script>`;

--- a/admin-ui/src/pages/admin/tenants/types.ts
+++ b/admin-ui/src/pages/admin/tenants/types.ts
@@ -46,6 +46,9 @@ export interface TenantDetail {
   ga4_last_sync_at?: string | null;
   ga4_error_message?: string | null;
   tenant_contact_email?: string | null;
+  // set_widget_theme(チャットツール)が書き込む自由形式JSONB。widget.js が実際に
+  // 反映するのは primaryColor のみ(埋め込みコードの data-accent-color 属性)。
+  widget_theme?: { primaryColor?: string; [key: string]: unknown } | null;
 }
 
 export interface ApiKey {

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -1224,17 +1224,30 @@ export async function executeToolCall(
     case 'get_embed_code': {
       try {
         // 平文 API キーは保存されていないため key_prefix のみ返す
-        const result = await db.query(
-          'SELECT key_prefix FROM tenant_api_keys WHERE tenant_id = $1 ORDER BY created_at DESC LIMIT 1',
-          [tenantId]
-        );
-        const keyPrefix: string = result.rows.length > 0
-          ? String((result.rows[0] as { key_prefix: string }).key_prefix)
+        const [keyResult, themeResult] = await Promise.all([
+          db.query(
+            'SELECT key_prefix FROM tenant_api_keys WHERE tenant_id = $1 ORDER BY created_at DESC LIMIT 1',
+            [tenantId]
+          ),
+          db.query('SELECT widget_theme FROM tenants WHERE id = $1', [tenantId]),
+        ]);
+        const keyPrefix: string = keyResult.rows.length > 0
+          ? String((keyResult.rows[0] as { key_prefix: string }).key_prefix)
           : '（キー未発行）';
+
+        // set_widget_theme で保存された primaryColor のみ、widget.js が実際に読む
+        // data-accent-color 属性として反映する(他のテーマキーは現状ウィジェット側に
+        // 読み取りが無いため出力しない)。値は set_widget_theme 側で #RRGGBB 形式に
+        // 検証済みだが、直接DBを触られた場合の防御として再検証する。
+        const widgetTheme = (themeResult.rows[0] as { widget_theme: Record<string, unknown> | null } | undefined)?.widget_theme;
+        const primaryColor = widgetTheme?.['primaryColor'];
+        const accentColorAttr = typeof primaryColor === 'string' && /^#[0-9a-fA-F]{6}$/.test(primaryColor)
+          ? `\n  data-accent-color="${primaryColor}"`
+          : '';
 
         return truncate(
           `ウィジェット埋め込みコードのひな形:\n\n` +
-          `<script src="https://api.r2c.biz/widget.js" data-api-key="YOUR_API_KEY"></script>\n\n` +
+          `<script src="https://api.r2c.biz/widget.js" data-api-key="YOUR_API_KEY"${accentColorAttr}></script>\n\n` +
           `現在のAPIキー先頭: ${keyPrefix}...\n` +
           `※ 実際のAPIキーは発行時のみ表示されます。再確認が必要な場合は新しいキーを発行してください`
         );
@@ -1249,6 +1262,13 @@ export async function executeToolCall(
       const theme = args['theme'];
       if (typeof theme !== 'object' || theme === null || Array.isArray(theme)) {
         return truncate('theme はオブジェクト形式で指定してください（例: {"primaryColor": "#3B82F6"}）');
+      }
+      // primaryColor は埋め込みコードの data-accent-color 属性としてそのまま出力され、
+      // widget.js 側で CSS カスタムプロパティに直接埋め込まれる(public/widget.js:151)。
+      // 不正な値を許すと埋め込みコード自体が壊れた属性を持つため、ここで厳格に弾く。
+      const primaryColor = (theme as Record<string, unknown>)['primaryColor'];
+      if (primaryColor !== undefined && !/^#[0-9a-fA-F]{6}$/.test(String(primaryColor))) {
+        return truncate('primaryColor は #RRGGBB 形式の16進数カラーコードで指定してください（例: #3B82F6）');
       }
 
       try {

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -6279,6 +6279,76 @@ describe('POST /v1/admin/agent/chat', () => {
   });
 
   // -------------------------------------------------------------------------
+  // get_embed_code — set_widget_theme で保存した primaryColor が
+  // data-accent-color 属性として実際に反映されることの回帰テスト
+  // -------------------------------------------------------------------------
+  describe('get_embed_code', () => {
+    function toolCallResponse(id: string, name: string, args: Record<string, unknown> = {}) {
+      return {
+        ok: true,
+        json: async () => ({
+          choices: [{
+            message: {
+              content: null,
+              tool_calls: [{ id, type: 'function', function: { name, arguments: JSON.stringify(args) } }],
+            },
+          }],
+        }),
+        text: async () => '',
+      };
+    }
+
+    it('widget_theme.primaryColor が設定済みなら data-accent-color 属性を含める', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-ec-1', 'get_embed_code'))
+        .mockResolvedValueOnce(makeGroqResponse('埋め込みコードです。'));
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ key_prefix: 'r2c_live_abc' }] }) // tenant_api_keys
+        .mockResolvedValueOnce({ rows: [{ widget_theme: { primaryColor: '#3B82F6' } }] }); // tenants.widget_theme
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '埋め込みコードを教えて', sessionId: 'sess-embed-01' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('data-accent-color="#3B82F6"');
+    });
+
+    it('widget_theme が未設定なら data-accent-color 属性を含めない', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-ec-2', 'get_embed_code'))
+        .mockResolvedValueOnce(makeGroqResponse('埋め込みコードです。'));
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ key_prefix: 'r2c_live_abc' }] })
+        .mockResolvedValueOnce({ rows: [{ widget_theme: null }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '埋め込みコードを教えて', sessionId: 'sess-embed-02' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).not.toContain('data-accent-color');
+    });
+
+    it('primaryColor が #RRGGBB 形式でない場合は防御的に出力しない（直接DB編集などによる不正値）', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-ec-3', 'get_embed_code'))
+        .mockResolvedValueOnce(makeGroqResponse('埋め込みコードです。'));
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ key_prefix: 'r2c_live_abc' }] })
+        .mockResolvedValueOnce({ rows: [{ widget_theme: { primaryColor: 'javascript:alert(1)' } }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '埋め込みコードを教えて', sessionId: 'sess-embed-03' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).not.toContain('data-accent-color');
+      expect(res.body.actions[0].result).not.toContain('javascript:');
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // get_analytics_summary / get_conversion_summary
   // -------------------------------------------------------------------------
   describe('get_analytics_summary / get_conversion_summary', () => {
@@ -8511,6 +8581,22 @@ describe('POST /v1/admin/agent/chat', () => {
           newValue: { primaryColor: '#3B82F6' },
         },
       ]);
+    });
+
+    it('set_widget_theme の primaryColor が #RRGGBB 形式でない場合は書き込まれず記録しない', async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          toolCallResponse('call-au-3b', 'set_widget_theme', { theme: { primaryColor: 'javascript:alert(1)' } }),
+        )
+        .mockResolvedValueOnce(makeGroqResponse('形式が正しくありませんでした。'));
+
+      const res = await request(makeApp(AUDIT_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'テーマ色を javascript:alert(1) にして', sessionId: 'sess-audit-03b' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('#RRGGBB');
+      expect(mockRecordAgentSettingsChange).not.toHaveBeenCalled();
     });
 
     it('activate_avatar 成功時に active_avatar_config_id の変更を記録する', async () => {

--- a/src/api/admin/agent/toolDefinitions.ts
+++ b/src/api/admin/agent/toolDefinitions.ts
@@ -402,7 +402,7 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
     type: 'function',
     function: {
       name: 'get_embed_code',
-      description: 'ウィジェット埋め込みコードのひな形を取得する（APIキーは発行時のみ表示のため、key_prefix のみ表示）',
+      description: 'ウィジェット埋め込みコードのひな形を取得する（APIキーは発行時のみ表示のため、key_prefix のみ表示。set_widget_theme で primaryColor を設定済みなら data-accent-color 属性も含める）',
       parameters: {
         type: 'object',
         properties: {},
@@ -414,13 +414,13 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
     type: 'function',
     function: {
       name: 'set_widget_theme',
-      description: 'ウィジェットのテーマ設定（色・フォント等）を JSONB で更新する',
+      description: 'ウィジェットのブランドカラーを設定する。primaryColor（#RRGGBB形式の16進数）のみが実際にウィジェットへ反映され、埋め込みコードの data-accent-color 属性として出力される。他のキーは保存はされるが現時点でウィジェットの表示には反映されない',
       parameters: {
         type: 'object',
         properties: {
           theme: {
             type: 'object',
-            description: 'テーマ設定オブジェクト（例: {"primaryColor": "#3B82F6", "fontFamily": "sans-serif"}）',
+            description: 'テーマ設定オブジェクト（例: {"primaryColor": "#3B82F6"}）。primaryColor は #RRGGBB 形式の16進数カラーコードで指定する',
           },
         },
         required: ['theme'],

--- a/src/api/admin/tenants/routes.test.ts
+++ b/src/api/admin/tenants/routes.test.ts
@@ -343,6 +343,46 @@ describe("GET /v1/admin/my-tenant — has_r2c2", () => {
 });
 
 // --------------------------------------------------------------------------
+// widget_theme — get_embed_code(チャットツール)の data-accent-color 反映元。
+// GET 応答から欠落すると、super_admin 側の EmbedCodeTab.tsx が反映を検知できない。
+// --------------------------------------------------------------------------
+
+describe("GET /v1/admin/my-tenant / GET /v1/admin/tenants/:id — widget_theme", () => {
+  it("GET /v1/admin/my-tenant は widget_theme を応答に含める", async () => {
+    const dbQuery = jest
+      .fn()
+      .mockResolvedValueOnce({
+        rows: [{ id: "tenant-a", name: "テストテナント", features: null, lemonslice_agent_id: null, conversion_types: [], widget_theme: { primaryColor: "#3B82F6" } }],
+        rowCount: 1,
+      })
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "client_admin"))
+      .get("/v1/admin/my-tenant")
+      .set("Authorization", "Bearer dummy");
+
+    expect(res.status).toBe(200);
+    expect(res.body.widget_theme).toEqual({ primaryColor: "#3B82F6" });
+  });
+
+  it("GET /v1/admin/tenants/:id (super_admin) は widget_theme を応答に含める", async () => {
+    const dbQuery = jest.fn().mockResolvedValueOnce({
+      rows: [{ id: "tenant-a", name: "テストテナント", features: null, lemonslice_agent_id: null, conversion_types: [], widget_theme: { primaryColor: "#3B82F6" } }],
+      rowCount: 1,
+    });
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "super_admin"))
+      .get("/v1/admin/tenants/tenant-a")
+      .set("Authorization", "Bearer dummy");
+
+    expect(res.status).toBe(200);
+    expect(res.body.widget_theme).toEqual({ primaryColor: "#3B82F6" });
+  });
+});
+
+// --------------------------------------------------------------------------
 // ⑦ PATCH /v1/admin/my-tenant — avatar/voice の plan ゲート(LP料金表: Growth〜)
 // --------------------------------------------------------------------------
 

--- a/src/api/admin/tenants/routes.ts
+++ b/src/api/admin/tenants/routes.ts
@@ -207,7 +207,7 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
     }
     try {
       const result = await db.query(
-        `SELECT id, name, plan, features, lemonslice_agent_id, conversion_types, faq_question_hint, faq_answer_hint, onboarding_industry, onboarding_completed_at, onboarding_widget_seen_at, created_at FROM tenants WHERE id = $1`,
+        `SELECT id, name, plan, features, lemonslice_agent_id, conversion_types, faq_question_hint, faq_answer_hint, onboarding_industry, onboarding_completed_at, onboarding_widget_seen_at, widget_theme, created_at FROM tenants WHERE id = $1`,
         [tenantId]
       );
       if (result.rowCount === 0) {
@@ -400,7 +400,7 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
     const { id } = req.params;
     try {
       const result = await db.query(
-        `SELECT id, name, plan, is_active, allowed_origins, system_prompt, billing_enabled, billing_free_from, billing_free_until, features, lemonslice_agent_id, conversion_types, faq_question_hint, faq_answer_hint, onboarding_industry, onboarding_widget_seen_at, created_at, updated_at FROM tenants WHERE id = $1`,
+        `SELECT id, name, plan, is_active, allowed_origins, system_prompt, billing_enabled, billing_free_from, billing_free_until, features, lemonslice_agent_id, conversion_types, faq_question_hint, faq_answer_hint, onboarding_industry, onboarding_widget_seen_at, widget_theme, created_at, updated_at FROM tenants WHERE id = $1`,
         [id]
       );
       if (result.rowCount === 0) {


### PR DESCRIPTION
## 背景

`set_widget_theme`（チャットツール）は既に `tenants.widget_theme` JSONB へ `primaryColor` 等を書き込めた（Phase B-Admin, PR #383）。だが**書き込み先を実際に読む経路がどこにも無く**、`get_tenant_settings` がJSON文字列として画面に見せるだけの「書いても何も変わらない」状態だった。

widget.js は `data-accent-color` 属性を完全にサポート済み（デフォルト `#2563eb`）なため、欠けていたのは書き込みでも読み取りUIでもなく、**埋め込みコード生成への配線のみ**。DB migrationも新規ツールも不要。

## 変更

### バリデーション追加（既存の未検証を是正）
- `set_widget_theme`（actionExecutor.ts）: `primaryColor` が指定された場合のみ `#RRGGBB` 形式を検証。widget.js 側で CSS カスタムプロパティに直接文字列結合されるため（`widget.js:151`）、不正な値を許すと埋め込みコード自体が壊れる。他のテーマキーは従来どおり自由形式のまま
- `toolDefinitions.ts`: ツール説明を実態に合わせて修正。旧説明は `fontFamily` も設定できるかのように例示していたが、widget.js に対応する読み取りが無く反映されない（font-familyはShadow DOM内で固定）。誤解を招く例を削除し、`primaryColor` のみ効果がある旨を明記

### 反映先2箇所への配線（新規）
- `get_embed_code`（actionExecutor.ts, チャット・ファースト）: `widget_theme` を追加SELECTし、`primaryColor` があれば `data-accent-color` 属性をスニペットに含める。出力直前にも `#RRGGBB` 形式を再検証（直接DB編集の防御）
- `EmbedCodeTab.tsx`（旧UI, super_admin向け）: 同様に `tenant.widget_theme` から `data-accent-color` を条件付きで出力（PR #728 で修正した「undefined混入」バグの続き）

### 読み取りAPIの拡張
- `GET /v1/admin/my-tenant`, `GET /v1/admin/tenants/:id` の SELECT に `widget_theme` を追加（いずれも従来SELECTしておらず、上記2つの反映先が値を取得する前提条件）
- admin-ui `TenantDetail` 型に `widget_theme` を追加

## テスト

修正を外すと2件（`get_embed_code` 反映・`set_widget_theme` 検証）が実際に落ち、戻すと通ることを実行して確認済み。

- `agentRoutes.test.ts`: `get_embed_code` describe を新設（設定時/未設定時/不正値の3ケース）。`set_widget_theme` の不正値が書き込まれず監査ログにも記録されないケースを追加
- `routes.test.ts`: `GET /my-tenant`, `GET /tenants/:id` が `widget_theme` を応答に含めることを確認
- `EmbedCodeTab.test.tsx`: 設定時/未設定時/不正値時の3ケースを追加

## Gate 結果

| Gate | 結果 |
|---|---|
| typecheck | PASS |
| lint | PASS（warning 59件 < 上限80） |
| dead-code-check | PASS |
| security-scan | PASS（CRITICAL/HIGH 0） |
| confirmPolicy網羅性テスト | PASS（20件。`set_widget_theme`/`get_embed_code` とも既存分類のまま変更なし） |
| backend test | 412件 PASS |
| admin-ui vitest（EmbedCodeTab） | 7件 PASS |
| build（backend/admin-ui） | PASS |

## デプロイ

DB migrationは**既に本番適用済み**（同一migrationの兄弟カラム `ga4_measurement_id`/`posthog_host` が `get_tenant_settings` 経由で実働していることで確認）。新規migrationファイルなし、コードデプロイのみで完結する。

## Asana

未起票（棚卸し中に発見した「書き込み専用の死んだ経路」の是正）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Bu7egx6YnkxKkHaqxAeDGV
