### PR TITLE
fix(avatar-agent): 設定を解決できないとき無関係な第三者の顔を出さない

### DIFF
--- a/avatar-agent/agent.py
+++ b/avatar-agent/agent.py
@@ -152,8 +152,19 @@ def resolve_category_persona(category: object, category_persona_map: object) -> 
 
 
 # --- Groq LLM 直接呼び出し ---
-async def fetch_avatar_config(tenant_id: str, api_url: str, avatar_config_id: str | None = None) -> dict | None:
-    """テナント別アバター設定を内部APIから取得。失敗時はNoneを返す。
+async def fetch_avatar_config(
+    tenant_id: str, api_url: str, avatar_config_id: str | None = None
+) -> tuple[dict | None, bool]:
+    """テナント別アバター設定を内部APIから取得し、(config, fetch_ok) を返す。
+
+    fetch_ok=False は「取得に失敗した = 誰のアバターか分からない」。
+    (None, True) は「取得できたが、そのテナントに有効なアバターが無い」。
+
+    この2つを必ず区別すること。区別せずに一律 None を返していたため、
+    /api/internal/avatar-config が 500 を返していた期間、呼び出し側が
+    「アバター未設定」と誤解し、環境変数の汎用エージェント（テナントと
+    無関係な第三者の顔）を無言で配信し続けた（2026-08-08）。
+
     avatar_config_id 指定時は特定アバターを取得（テスト用途）。
     """
     params: dict[str, str] = {"tenantId": tenant_id}
@@ -169,12 +180,48 @@ async def fetch_avatar_config(tenant_id: str, api_url: str, avatar_config_id: st
             ) as resp:
                 if resp.status != 200:
                     logger.warning(f"[avatar-config] API returned {resp.status}")
-                    return None
+                    return None, False
                 data = await resp.json()
-                return data.get("config")
+                return data.get("config"), True
     except Exception as e:
-        logger.warning(f"[avatar-config] fetch failed (using defaults): {e}")
+        logger.warning(f"[avatar-config] fetch failed: {e}")
+        return None, False
+
+
+def resolve_avatar_identity(
+    avatar_config: dict | None, config_fetch_ok: bool, env_agent_id: str | None
+) -> dict | None:
+    """LemonSlice に渡すアバターの同定情報を決める純関数。
+
+    返り値:
+      {"image_url": str} — テナントのアバター写真からトーキングヘッドを生成する
+      {"agent_id": str}  — LemonSlice に登録済みのペルソナを使う
+      None               — 誰のアバターか確定できない。アバターを起動しない
+
+    None を返すのは「顔が分からないなら誰の顔も出さない」ため。
+    以前はここで環境変数のハードコード既定値へ落ちており、設定取得に失敗した
+    テナントの訪問者に、そのテナントとは何の関係もない人物が表示されていた。
+    テキストチャットへの degrade は呼び出し側で既に実装済みなので、
+    起動しないことによる機能不全は起きない。
+    """
+    # 取得に失敗した = 誰のアバターか不明。この状態で誰かの顔を出してはいけない。
+    if not config_fetch_ok:
         return None
+
+    if avatar_config:
+        image_url = avatar_config.get("image_url")
+        if image_url:
+            return {"image_url": image_url}
+        agent_id = avatar_config.get("lemonslice_agent_id")
+        if agent_id:
+            return {"agent_id": agent_id}
+
+    # テナントに有効なアバターが無い場合のみ、運用者が明示的に設定した
+    # 環境変数の既定エージェントを使う。ハードコードの既定値は持たない
+    # （未設定なら None = アバター無しで、テキストチャットとして成立する）。
+    if env_agent_id:
+        return {"agent_id": env_agent_id}
+    return None
 
 
 async def call_groq_llm(
@@ -428,8 +475,11 @@ async def entrypoint(ctx: agents.JobContext) -> None:
     # アバター設定を動的取得
     api_url = os.environ.get("RAJIUCE_API_URL", "http://localhost:3100")
     avatar_config = None
+    # tenant_id が取れない = どのテナントの部屋か分からない。取得失敗と同じ扱いにする
+    # （この状態で既定アバターを出すと、素性の分からない部屋に誰かの顔を出すことになる）。
+    config_fetch_ok = False
     if tenant_id:
-        avatar_config = await fetch_avatar_config(tenant_id, api_url, avatar_config_id)
+        avatar_config, config_fetch_ok = await fetch_avatar_config(tenant_id, api_url, avatar_config_id)
 
     # 設定を適用（fallback: 環境変数のデフォルト）
     effective_system_prompt = (
@@ -440,14 +490,11 @@ async def entrypoint(ctx: agents.JobContext) -> None:
         avatar_config.get("voice_id") if avatar_config and avatar_config.get("voice_id")
         else os.environ.get("FISH_AUDIO_REFERENCE_ID")
     )
-    effective_agent_id = (
-        avatar_config.get("lemonslice_agent_id") if avatar_config and avatar_config.get("lemonslice_agent_id")
-        else os.environ.get("LEMONSLICE_AGENT_ID", "agent_aee377cb0fec68ea")
+    avatar_identity = resolve_avatar_identity(
+        avatar_config, config_fetch_ok, os.environ.get("LEMONSLICE_AGENT_ID")
     )
-    effective_image_url = (
-        avatar_config.get("image_url") if avatar_config and avatar_config.get("image_url")
-        else None
-    )
+    effective_agent_id = (avatar_identity or {}).get("agent_id")
+    effective_image_url = (avatar_identity or {}).get("image_url")
     # emotion_tags: DB には JSON 文字列で格納される場合と list で届く場合の両対応
     effective_emotion_tags = avatar_config.get("emotion_tags") if avatar_config else None
     if isinstance(effective_emotion_tags, str):
@@ -468,7 +515,16 @@ async def entrypoint(ctx: agents.JobContext) -> None:
         logger.warning(f"[entrypoint] category_persona_map is not a dict, ignoring: {type(category_persona_map)}")
         category_persona_map = {}
 
-    logger.info(f"[entrypoint] effective config: voice_id={effective_reference_id!r}, agent_id={effective_agent_id!r}, image_url={'set' if effective_image_url else 'none'}, custom_prompt={'yes' if avatar_config and avatar_config.get('personality_prompt') else 'no'}, emotion_tags={len(effective_emotion_tags)} {effective_emotion_tags}, category_personas={len(category_persona_map)}")
+    logger.info(f"[entrypoint] effective config: config_fetch_ok={config_fetch_ok}, voice_id={effective_reference_id!r}, agent_id={effective_agent_id!r}, image_url={'set' if effective_image_url else 'none'}, custom_prompt={'yes' if avatar_config and avatar_config.get('personality_prompt') else 'no'}, emotion_tags={len(effective_emotion_tags)} {effective_emotion_tags}, category_personas={len(category_persona_map)}")
+    if avatar_identity is None:
+        # 沈黙させない: アバターが出ない理由をログの1行目で分かるようにする。
+        # 以前はここで無言で第三者にフォールバックしており、9日間気づかれなかった。
+        logger.error(
+            f"[entrypoint] アバターを起動しません: 設定を解決できませんでした "
+            f"(config_fetch_ok={config_fetch_ok}, avatar_config={'あり' if avatar_config else 'なし'})。"
+            "内部APIの応答と、テナントに有効なアバターがあるかを確認してください: "
+            "docs/AVATAR_CONFIG_500_RECOVERY.md"
+        )
 
     # FISH_AUDIO_TTS_MODEL: env で切替可能（有料モデルへの移行用）。
     # 実際に使用したモデル名は _report_tts_usage() へ申告し、原価計算をモデル別単価に
@@ -689,6 +745,16 @@ async def entrypoint(ctx: agents.JobContext) -> None:
         f"agent_idle_prompt_src={'db' if avatar_config and avatar_config.get('agent_idle_prompt') else 'env'}"
     )
     try:
+        # 誰のアバターか確定できないならアバターを起動しない。
+        # ここで raise すると下の except が拾い、音声出力を戻したうえで
+        # テキストチャットとして継続する（既存の degrade 経路をそのまま使う）。
+        if avatar_identity is None:
+            raise RuntimeError(
+                "アバター設定を解決できないため起動しません"
+                f"(config_fetch_ok={config_fetch_ok}, tenant_id={tenant_id!r})。"
+                "無関係なアバターを表示しないための意図的な停止です。"
+                "テキストチャットは通常どおり利用できます。"
+            )
         # agent_id と agent_image_url は排他的（両方渡すとエラー）
         if effective_image_url:
             logger.info(f"[lemonslice] using agent_image_url: {effective_image_url[:80]!r}")

--- a/avatar-agent/test_avatar_identity.py
+++ b/avatar-agent/test_avatar_identity.py
@@ -1,0 +1,103 @@
+"""
+resolve_avatar_identity() のユニットテスト。
+
+背景: 2026-08-08、/api/internal/avatar-config が 500 を返していた期間、
+avatar-agent は「取得に失敗した」を「アバター未設定」と同一視して、
+環境変数のハードコード既定値 (agent_aee377cb0fec68ea) へ無言でフォールバックしていた。
+結果、どのテナントの訪問者にも R2C 公式18体のいずれでもない第三者の顔が表示され、
+管理画面は「アバターを起動しました(名前)」と成功表示を出していた。
+
+このテストが守る不変条件は1つ:
+  「誰のアバターか確定できないなら、誰の顔も出さない」
+テキストチャットへの degrade は呼び出し側に実装済みなので、
+起動しないこと自体は機能不全にならない。
+"""
+
+from agent import resolve_avatar_identity
+
+
+class TestFetchFailureNeverShowsSomeoneElse:
+    """取得に失敗したら、env に既定値があっても絶対に誰かの顔を出さない。"""
+
+    def test_fetch_failed_returns_none_even_with_env_default(self):
+        assert resolve_avatar_identity(None, False, "agent_env_default") is None
+
+    def test_fetch_failed_returns_none_even_if_stale_config_passed(self):
+        # 取得失敗時に呼び出し側が古い config を渡してしまっても出さない
+        stale = {"image_url": "https://example.com/haruka.png"}
+        assert resolve_avatar_identity(stale, False, "agent_env_default") is None
+
+    def test_fetch_failed_with_no_env_returns_none(self):
+        assert resolve_avatar_identity(None, False, None) is None
+
+
+class TestResolvedConfigWins:
+    def test_image_url_is_preferred_over_agent_id(self):
+        # image_url と agent_id は LemonSlice 側で排他。写真があるならそちらが正
+        config = {
+            "image_url": "https://example.com/haruka.png",
+            "lemonslice_agent_id": "agent_haruka",
+        }
+        assert resolve_avatar_identity(config, True, "agent_env_default") == {
+            "image_url": "https://example.com/haruka.png"
+        }
+
+    def test_agent_id_used_when_no_image_url(self):
+        config = {"image_url": None, "lemonslice_agent_id": "agent_haruka"}
+        assert resolve_avatar_identity(config, True, "agent_env_default") == {
+            "agent_id": "agent_haruka"
+        }
+
+    def test_tenant_config_wins_over_env_default(self):
+        config = {"lemonslice_agent_id": "agent_tenant"}
+        assert resolve_avatar_identity(config, True, "agent_env_default") == {
+            "agent_id": "agent_tenant"
+        }
+
+
+class TestNoActiveAvatarForTenant:
+    """取得は成功したが、そのテナントに有効なアバターが無い場合。"""
+
+    def test_env_default_used_when_operator_set_it(self):
+        # 運用者が明示的に設定した既定値のみ使う
+        assert resolve_avatar_identity(None, True, "agent_env_default") == {
+            "agent_id": "agent_env_default"
+        }
+
+    def test_no_config_and_no_env_returns_none(self):
+        # ハードコードの既定値を持たない = アバター無しで成立させる
+        assert resolve_avatar_identity(None, True, None) is None
+
+    def test_empty_env_string_is_not_used(self):
+        # LEMONSLICE_AGENT_ID= (空) を「設定済み」と誤認しない
+        assert resolve_avatar_identity(None, True, "") is None
+
+
+class TestBrokenConfigShapes:
+    """avatar_configs は JSONB 由来で欠損しうる。壊れた形でも他人を出さない。"""
+
+    def test_config_with_only_empty_strings_falls_back_to_env(self):
+        config = {"image_url": "", "lemonslice_agent_id": ""}
+        assert resolve_avatar_identity(config, True, "agent_env_default") == {
+            "agent_id": "agent_env_default"
+        }
+
+    def test_config_with_only_empty_strings_and_no_env_returns_none(self):
+        config = {"image_url": "", "lemonslice_agent_id": ""}
+        assert resolve_avatar_identity(config, True, None) is None
+
+    def test_empty_dict_config_falls_back_to_env(self):
+        assert resolve_avatar_identity({}, True, "agent_env_default") == {
+            "agent_id": "agent_env_default"
+        }
+
+
+class TestNoHardcodedStranger:
+    """回帰ガード: 実際に事故を起こした agent_id が返り値に混ざらないこと。"""
+
+    LEAKED = "agent_aee377cb0fec68ea"
+
+    def test_hardcoded_stranger_never_appears_without_explicit_env(self):
+        for config, ok in [(None, False), (None, True), ({}, True)]:
+            result = resolve_avatar_identity(config, ok, None)
+            assert result is None or self.LEAKED not in str(result)


### PR DESCRIPTION
## なぜ

2026-08-08 の障害の**本質的な再発防止**。migration 適用（直接原因）とは別に、この構造が残っている限り別の理由で設定取得が失敗すれば同じ症状が再発する。

これまで `fetch_avatar_config()` は「**取得に失敗した**」と「そのテナントに**アバターが無い**」の両方で一律 `None` を返しており、呼び出し側は後者と解釈して環境変数のハードコード既定値へ無言でフォールバックしていた。

```python
else os.environ.get("LEMONSLICE_AGENT_ID", "agent_aee377cb0fec68ea")
```

この `agent_aee377cb0fec68ea` は **R2C 公式18体（Haruka / Rei / Sophia / … / SERAPH）のいずれでもない第三者**で、しかも `.env.example` の既定値と同一。そのため**設定を解決できない限り、どのテナントでも必ず同じ他人の顔が配信される**構造だった。

管理画面は「✅ アバターを起動しました（Haruka）」と成功表示を出すため、画面からは正常に見えていた。

## 変更

**1. 取得失敗と「アバター無し」を区別する**

`fetch_avatar_config()` が `(config, fetch_ok)` を返すようにした。`(None, True)` は「取得できたが有効なアバターが無い」、`fetch_ok=False` は「誰のアバターか分からない」。

**2. `resolve_avatar_identity()` を純関数として追加**

「**誰のアバターか確定できないなら、誰の顔も出さない**」を1箇所で表現する。

- 取得失敗時は env 既定値があっても `None`
- `tenant_id` が取れない場合も取得失敗と同じ扱い（素性の分からない部屋に誰かの顔を出さない）
- `image_url` は `agent_id` より優先（LemonSlice 側で排他）

**3. ハードコード既定値を削除**

運用者が明示的に `LEMONSLICE_AGENT_ID` を設定した場合のみ既定エージェントを使う。未設定ならアバターを起動せず、テキストチャットとして成立させる。**degrade 経路は既存実装をそのまま使う**ため機能不全にはならない（`except` が音声出力を戻し、`session.start()` は try の外で必ず走る）。

**4. 沈黙させない**

起動しない場合は `logger.error` で理由と確認先を出す。無言で第三者に落ちていたために9日間気づかれなかったので、ここは黙らせない。

## テスト

`avatar-agent/test_avatar_identity.py` を追加（13件）。

**修正前の実装に差し替えると7件が失敗することを確認済み**（ハードコード第三者が混ざらないことの回帰ガードを含む）。テストが実際にこのバグを捕まえることを検証した。

```
修正後: 13 passed
修正前を再現: 7 failed, 6 passed
  ✗ test_fetch_failed_returns_none_even_with_env_default
  ✗ test_fetch_failed_returns_none_even_if_stale_config_passed
  ✗ test_hardcoded_stranger_never_appears_without_explicit_env  ほか
```

`livekit` がローカルに無く `agent.py` を import できないため（既存テストも同じ制約）、関数を機械抽出したハーネスで実行して検証した。手写しによる取り違えを避けるため抽出は正規表現で行っている。

- `python3 -m py_compile avatar-agent/agent.py` → OK
- `bash SCRIPTS/security-scan.sh` → PASS (CRITICAL/HIGH: 0)
- `agent_aee377cb0fec68ea` の `agent.py` 内出現: **0件**

## 要手動対応（この PR に含められなかった）

`avatar-agent/.env.example` の `LEMONSLICE_AGENT_ID` に `agent_aee377cb0fec68ea` が**既定値として残っている**。権限設定により Claude Code からは編集できなかった。

```
LEMONSLICE_AGENT_ID=agent_aee377cb0fec68ea   ← 空にするか、コメントアウトする
```

具体的な agent_id を既定値として配ると、新しい環境でも同じ事故が再現する。

## デプロイ

`avatar-agent` の再起動が必要（`agent.py` の変更）。本番のアバター挙動を変えるため、マージ後の動作確認をお願いしたい。確認ポイントは「正常なテナントでこれまでどおりアバターが出ること」。

🤖 Generated with [Claude Code](https://claude.com/claude-code)