### PR TITLE
feat(widget): 設置位置を data 属性で変更できるようにする

### DIFF
--- a/admin-ui/src/pages/admin/tenants/EmbedCodeTab.test.tsx
+++ b/admin-ui/src/pages/admin/tenants/EmbedCodeTab.test.tsx
@@ -82,4 +82,37 @@ describe("EmbedCodeTab", () => {
     expect(pre.textContent).not.toContain("data-accent-color");
     expect(pre.textContent).not.toContain("javascript:");
   });
+
+  // 設置位置（サイト右下の「トップへ戻る」ボタン等との重なり回避）。
+  // 判定は src/api/admin/agent/widgetPlacement.ts と同一仕様を保つこと。
+  it("position / offsetX / offsetY が既定と異なるときだけ data-* 属性を出力する", () => {
+    const tenant = makeTenant({ widget_theme: { position: "bottom-left", offsetX: 16, offsetY: 96 } });
+    render(<EmbedCodeTab tenant={tenant} apiKeys={[]} />);
+    const pre = screen.getByText(/data-api-key/);
+    expect(pre.textContent).toContain('data-position="bottom-left"');
+    expect(pre.textContent).toContain('data-offset-x="16"');
+    expect(pre.textContent).toContain('data-offset-y="96"');
+  });
+
+  it("既定値と同じ設置位置は出力しない（スニペットを短く保つ）", () => {
+    const tenant = makeTenant({ widget_theme: { position: "bottom-right", offsetX: 24, offsetY: 24 } });
+    render(<EmbedCodeTab tenant={tenant} apiKeys={[]} />);
+    const pre = screen.getByText(/data-api-key/);
+    expect(pre.textContent).not.toContain("data-position");
+    expect(pre.textContent).not.toContain("data-offset");
+  });
+
+  it("offset 0 は既定と異なるので出力する（falsy 取り違えの回帰）", () => {
+    render(<EmbedCodeTab tenant={makeTenant({ widget_theme: { offsetX: 0 } })} apiKeys={[]} />);
+    expect(screen.getByText(/data-api-key/).textContent).toContain('data-offset-x="0"');
+  });
+
+  it("不正な設置位置は黙って捨てる（直接DB編集などによる不正値の防御）", () => {
+    const tenant = makeTenant({ widget_theme: { position: '" onload="alert(1)', offsetY: 9999 } });
+    render(<EmbedCodeTab tenant={tenant} apiKeys={[]} />);
+    const pre = screen.getByText(/data-api-key/);
+    expect(pre.textContent).not.toContain("data-position");
+    expect(pre.textContent).not.toContain("data-offset");
+    expect(pre.textContent).not.toContain("onload");
+  });
 });

--- a/admin-ui/src/pages/admin/tenants/EmbedCodeTab.tsx
+++ b/admin-ui/src/pages/admin/tenants/EmbedCodeTab.tsx
@@ -3,6 +3,31 @@ import { useLang } from "../../../i18n/LangContext";
 import type { TenantDetail, ApiKey } from "./types";
 import { CARD_STYLE } from "./types";
 
+/** 既定値と同じ設定・不正値は出力しない（コピペ用スニペットを短く保ち、壊れた属性を出さない） */
+function buildPlacementLines(theme: TenantDetail["widget_theme"]): string {
+  if (!theme) return "";
+  const lines: string[] = [];
+
+  if (theme.position === "bottom-left") {
+    lines.push(`data-position="bottom-left"`);
+  }
+  const offsets: Array<["offsetX" | "offsetY", string]> = [
+    ["offsetX", "data-offset-x"],
+    ["offsetY", "data-offset-y"],
+  ];
+  for (const [key, attr] of offsets) {
+    const raw = theme[key];
+    const n = typeof raw === "number" || (typeof raw === "string" && /^\d+$/.test(raw.trim()))
+      ? Number(raw)
+      : NaN;
+    if (Number.isInteger(n) && n >= 0 && n <= 320 && n !== 24) {
+      lines.push(`${attr}="${n}"`);
+    }
+  }
+
+  return lines.map((l) => `\n  ${l}`).join("");
+}
+
 export default function EmbedCodeTab({ tenant, apiKeys }: { tenant: TenantDetail; apiKeys: ApiKey[] }) {
   const { t } = useLang();
   const [copied, setCopied] = useState(false);
@@ -25,9 +50,14 @@ export default function EmbedCodeTab({ tenant, apiKeys }: { tenant: TenantDetail
   const accentColorLine = typeof primaryColor === "string" && /^#[0-9a-fA-F]{6}$/.test(primaryColor)
     ? `\n  data-accent-color="${primaryColor}"`
     : "";
+  // 設置位置。FAB は z-index に int 最大値を使うため、サイト側の「トップへ戻る」ボタン等が
+  // 右下にあると相手がクリック不能になる。その逃げ道として position / offsetX / offsetY を出力する。
+  // ⚠️ 同じ判定が src/api/admin/agent/widgetPlacement.ts にもある(別ビルドで import 共有不可)。
+  // 片方だけ直さない。丸め範囲は public/widget.js の parseOffset() と一致させること。
+  const placementLines = buildPlacementLines(tenant.widget_theme);
   const embedCode = `<script src="https://cdn.r2c.biz/widget.js"
   data-api-key="${displayKey}"
-  data-tenant="${tenant.slug}"${accentColorLine}>
+  data-tenant="${tenant.slug}"${accentColorLine}${placementLines}>
 </script>`;
 
   const purchaseTag = `<script>\n  window.r2c && r2c.trackConversion('purchase', /* 購入金額(円) */ 0);\n</script>`;

--- a/admin-ui/src/pages/admin/tenants/types.ts
+++ b/admin-ui/src/pages/admin/tenants/types.ts
@@ -47,8 +47,15 @@ export interface TenantDetail {
   ga4_error_message?: string | null;
   tenant_contact_email?: string | null;
   // set_widget_theme(チャットツール)が書き込む自由形式JSONB。widget.js が実際に
-  // 反映するのは primaryColor のみ(埋め込みコードの data-accent-color 属性)。
-  widget_theme?: { primaryColor?: string; [key: string]: unknown } | null;
+  // 反映するのは primaryColor(data-accent-color)と設置位置の position / offsetX /
+  // offsetY(data-position / data-offset-x / data-offset-y)のみ。
+  widget_theme?: {
+    primaryColor?: string;
+    position?: string;
+    offsetX?: number | string;
+    offsetY?: number | string;
+    [key: string]: unknown;
+  } | null;
 }
 
 export interface ApiKey {

--- a/public/widget.js
+++ b/public/widget.js
@@ -4,6 +4,11 @@
  * 使い方:
  *   <script src="/widget.js" data-tenant="YOUR_TENANT_ID" async></script>
  *
+ * 設置位置（任意 — サイト側の「トップへ戻る」ボタン等と重なる場合に使う）:
+ *   data-position="bottom-left"   寄せる角を左下に変える（既定: bottom-right）
+ *   data-offset-x="24"            画面端からの横余白 px（既定 24、0〜320 に丸め）
+ *   data-offset-y="96"            画面端からの縦余白 px（既定 24、0〜320 に丸め）
+ *
  * セキュリティ:
  *   - innerHTML 禁止 → textContent / createElement のみ使用
  *   - tenantId は data-tenant 属性から取得（body から禁止）
@@ -46,6 +51,20 @@
   var placeholderText = currentScript ? (currentScript.getAttribute('data-placeholder') || 'メッセージを入力…') : 'メッセージを入力…';
   var proactiveMessage = currentScript ? (currentScript.getAttribute('data-proactive-message') || '') : '';
   var proactiveDelay = currentScript ? parseInt(currentScript.getAttribute('data-proactive-delay') || '5000', 10) : 5000;
+  // 設置位置（既定は右下）。テナントサイト側の「トップへ戻る」ボタン等と重なると、
+  // FAB の z-index が最大値のため相手側がクリック不能になる。その回避手段として、
+  // 寄せる角（data-position）と余白（data-offset-x / data-offset-y）を公開する。
+  var positionRaw = currentScript ? (currentScript.getAttribute('data-position') || '') : '';
+  var horizontalSide = positionRaw.trim().toLowerCase() === 'bottom-left' ? 'left' : 'right';
+  // 画面外へ押し出さないよう 0〜320px に収める。数値でない指定は既定の 24px に戻す。
+  function parseOffset(raw) {
+    var n = parseInt(raw || '', 10);
+    if (isNaN(n)) return 24;
+    return Math.max(0, Math.min(320, n));
+  }
+  var offsetX = parseOffset(currentScript ? currentScript.getAttribute('data-offset-x') : '');
+  var offsetY = parseOffset(currentScript ? currentScript.getAttribute('data-offset-y') : '');
+
   var scriptedResponsesRaw = currentScript ? currentScript.getAttribute('data-scripted-responses') : '';
   var scriptedResponses = null;
   if (scriptedResponsesRaw) {
@@ -151,14 +170,15 @@
 
   var styleEl = document.createElement('style');
   styleEl.textContent = [
-    ':host { all: initial; font-family: system-ui, -apple-system, sans-serif; --accent: ' + accentColor + '; }',
+    ':host { all: initial; font-family: system-ui, -apple-system, sans-serif; --accent: ' + accentColor + ';',
+    '  --offset-x: ' + offsetX + 'px; --offset-y: ' + offsetY + 'px; }',
     '*,*::before,*::after { box-sizing: border-box; }',
 
     /* FABボタン */
     '.fab {',
     '  position: fixed;',
-    '  bottom: 24px;',
-    '  right: 24px;',
+    '  bottom: var(--offset-y);',
+    '  ' + horizontalSide + ': var(--offset-x);',
     '  z-index: 2147483647;',
     '  min-width: 120px;',
     '  min-height: 120px;',
@@ -262,11 +282,13 @@
     /* プロアクティブバブル */
     '.proactive-bubble {',
     '  position: fixed;',
-    '  bottom: 152px;',
-    '  right: 24px;',
+    /* FAB(120px) の上端 + 8px の間隔 */
+    '  bottom: calc(var(--offset-y) + 128px);',
+    '  ' + horizontalSide + ': var(--offset-x);',
     '  z-index: 2147483646;',
     '  background: #fff;',
-    '  border-radius: 16px 16px 4px 16px;',
+    /* 尻尾は FAB のある側の下角に向ける */
+    '  border-radius: ' + (horizontalSide === 'left' ? '16px 16px 16px 4px' : '16px 16px 4px 16px') + ';',
     '  padding: 12px 16px;',
     '  box-shadow: 0 4px 20px rgba(0,0,0,0.12);',
     '  font-size: 14px;',
@@ -280,7 +302,7 @@
     '.proactive-bubble-dismiss {',
     '  position: absolute;',
     '  top: -8px;',
-    '  right: -8px;',
+    '  ' + horizontalSide + ': -8px;',
     '  width: 20px;',
     '  height: 20px;',
     '  border-radius: 50%;',
@@ -302,11 +324,14 @@
     /* チャットパネル */
     '.panel {',
     '  position: fixed;',
-    '  bottom: 132px;',
-    '  right: 24px;',
+    /* FAB(120px) の上端 -12px（従来の bottom:132px 相当） */
+    '  bottom: calc(var(--offset-y) + 108px);',
+    '  ' + horizontalSide + ': var(--offset-x);',
     '  z-index: 2147483646;',
     '  width: min(390px, calc(100vw - 32px));',
-    '  height: min(672px, calc(100vh - 120px));',
+    /* 高さは下端(offset-y + 108px)を起点に算出する。定数にすると data-offset-y を
+       大きくした分だけパネルが画面上端からはみ出す（+16px は上端の余白） */
+    '  height: min(672px, calc(100vh - var(--offset-y) - 124px));',
     '  background: #fff;',
     '  border-radius: 16px;',
     '  box-shadow: 0 20px 60px rgba(0,0,0,0.18), 0 4px 16px rgba(0,0,0,0.08);',
@@ -315,7 +340,7 @@
     '  overflow: hidden;',
     '  opacity: 0;',
     '  transform: scale(0.9) translateY(16px);',
-    '  transform-origin: bottom right;',
+    '  transform-origin: bottom ' + horizontalSide + ';',
     '  transition: ' + (prefersReducedMotion ? 'none' : 'opacity 0.2s, transform 0.2s') + ';',
     '  pointer-events: none;',
     '}',
@@ -756,7 +781,8 @@
     '    flex-direction: column;',
     '    width: 100vw !important;',
     '    max-width: 100vw !important;',
-    '    right: 0 !important; bottom: 0 !important;',
+    /* 全画面表示。data-position="bottom-left" 時は base の left も打ち消す必要がある */
+    '    left: 0 !important; right: 0 !important; bottom: 0 !important;',
     '    height: 100dvh;',
     '    border-radius: 0;',
     '  }',

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -41,6 +41,7 @@ import { trackUsage } from '../../../lib/billing/usageTracker';
 import { queryTenantPlan, planHasFeature } from '../../../lib/billing/planFeatures';
 import { fetchAnalyticsSummary, fetchConversionSummary } from '../analytics/summaryQueries';
 import { isOnboardingIndustry, ONBOARDING_INDUSTRY_LABELS, INDUSTRY_FAQ_TEMPLATES } from './industryFaqTemplates';
+import { buildPlacementAttributes, validateWidgetPlacement } from './widgetPlacement';
 
 // チャットでの一括インポートで一度に生成・コミットできるFAQ数の上限。
 // POST /v1/admin/knowledge/text/commit・/scrape/commit の zod スキーマ(max 20)と揃える。
@@ -1244,10 +1245,12 @@ export async function executeToolCall(
         const accentColorAttr = typeof primaryColor === 'string' && /^#[0-9a-fA-F]{6}$/.test(primaryColor)
           ? `\n  data-accent-color="${primaryColor}"`
           : '';
+        // 設置位置(position / offsetX / offsetY)。既定のままなら何も出力しない
+        const placementAttrs = buildPlacementAttributes(widgetTheme);
 
         return truncate(
           `ウィジェット埋め込みコードのひな形:\n\n` +
-          `<script src="https://api.r2c.biz/widget.js" data-api-key="YOUR_API_KEY"${accentColorAttr}></script>\n\n` +
+          `<script src="https://api.r2c.biz/widget.js" data-api-key="YOUR_API_KEY"${accentColorAttr}${placementAttrs}></script>\n\n` +
           `現在のAPIキー先頭: ${keyPrefix}...\n` +
           `※ 実際のAPIキーは発行時のみ表示されます。再確認が必要な場合は新しいキーを発行してください`
         );
@@ -1269,6 +1272,12 @@ export async function executeToolCall(
       const primaryColor = (theme as Record<string, unknown>)['primaryColor'];
       if (primaryColor !== undefined && !/^#[0-9a-fA-F]{6}$/.test(String(primaryColor))) {
         return truncate('primaryColor は #RRGGBB 形式の16進数カラーコードで指定してください（例: #3B82F6）');
+      }
+      // position / offsetX / offsetY も同様に埋め込みコードの属性として出力されるため、
+      // 壊れた属性を作らないよう書き込み前に弾く
+      const placementError = validateWidgetPlacement(theme as Record<string, unknown>);
+      if (placementError) {
+        return truncate(placementError);
       }
 
       try {

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -6346,6 +6346,42 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(res.body.actions[0].result).not.toContain('data-accent-color');
       expect(res.body.actions[0].result).not.toContain('javascript:');
     });
+
+    // 設置位置 — サイト右下の「トップへ戻る」ボタン等と FAB が重なると相手が
+    // クリック不能になるため、その逃げ道が埋め込みコードまで届くことを固定する
+    it('widget_theme の position / offset が既定と異なるなら data-position / data-offset-* を含める', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-ec-4', 'get_embed_code'))
+        .mockResolvedValueOnce(makeGroqResponse('埋め込みコードです。'));
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ key_prefix: 'r2c_live_abc' }] })
+        .mockResolvedValueOnce({ rows: [{ widget_theme: { position: 'bottom-left', offsetY: 96 } }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '埋め込みコードを教えて', sessionId: 'sess-embed-04' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('data-position="bottom-left"');
+      expect(res.body.actions[0].result).toContain('data-offset-y="96"');
+    });
+
+    it('設置位置が既定のままなら data-position / data-offset-* を含めない', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-ec-5', 'get_embed_code'))
+        .mockResolvedValueOnce(makeGroqResponse('埋め込みコードです。'));
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ key_prefix: 'r2c_live_abc' }] })
+        .mockResolvedValueOnce({ rows: [{ widget_theme: { position: 'bottom-right', offsetX: 24, offsetY: 24 } }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '埋め込みコードを教えて', sessionId: 'sess-embed-05' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).not.toContain('data-position');
+      expect(res.body.actions[0].result).not.toContain('data-offset');
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -8596,6 +8632,22 @@ describe('POST /v1/admin/agent/chat', () => {
 
       expect(res.status).toBe(200);
       expect(res.body.actions[0].result).toContain('#RRGGBB');
+      expect(mockRecordAgentSettingsChange).not.toHaveBeenCalled();
+    });
+
+    it('set_widget_theme の設置位置が不正な場合は書き込まれず記録しない（壊れた属性を埋め込みコードに出さない）', async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          toolCallResponse('call-au-3c', 'set_widget_theme', { theme: { position: 'top-right' } }),
+        )
+        .mockResolvedValueOnce(makeGroqResponse('形式が正しくありませんでした。'));
+
+      const res = await request(makeApp(AUDIT_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ウィジェットを右上に置いて', sessionId: 'sess-audit-03c' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('bottom-left');
       expect(mockRecordAgentSettingsChange).not.toHaveBeenCalled();
     });
 

--- a/src/api/admin/agent/toolDefinitions.ts
+++ b/src/api/admin/agent/toolDefinitions.ts
@@ -402,7 +402,7 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
     type: 'function',
     function: {
       name: 'get_embed_code',
-      description: 'ウィジェット埋め込みコードのひな形を取得する（APIキーは発行時のみ表示のため、key_prefix のみ表示。set_widget_theme で primaryColor を設定済みなら data-accent-color 属性も含める）',
+      description: 'ウィジェット埋め込みコードのひな形を取得する（APIキーは発行時のみ表示のため、key_prefix のみ表示。set_widget_theme で primaryColor を設定済みなら data-accent-color 属性、position / offsetX / offsetY を設定済みなら data-position / data-offset-x / data-offset-y 属性も含める）',
       parameters: {
         type: 'object',
         properties: {},
@@ -414,13 +414,13 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
     type: 'function',
     function: {
       name: 'set_widget_theme',
-      description: 'ウィジェットのブランドカラーを設定する。primaryColor（#RRGGBB形式の16進数）のみが実際にウィジェットへ反映され、埋め込みコードの data-accent-color 属性として出力される。他のキーは保存はされるが現時点でウィジェットの表示には反映されない',
+      description: 'ウィジェットのブランドカラーと設置位置を設定する。実際にウィジェットへ反映されるのは primaryColor（#RRGGBB形式の16進数）と、設置位置の position / offsetX / offsetY の4キーのみで、いずれも埋め込みコードの data-* 属性として出力される。他のキーは保存はされるが現時点でウィジェットの表示には反映されない。設置位置はサイト右下の「トップへ戻る」ボタン等と重なる場合に変更する',
       parameters: {
         type: 'object',
         properties: {
           theme: {
             type: 'object',
-            description: 'テーマ設定オブジェクト（例: {"primaryColor": "#3B82F6"}）。primaryColor は #RRGGBB 形式の16進数カラーコードで指定する',
+            description: 'テーマ設定オブジェクト（例: {"primaryColor": "#3B82F6", "offsetY": 96}）。primaryColor は #RRGGBB 形式の16進数カラーコード。position は "bottom-right"（既定）か "bottom-left" で寄せる角を指定する。offsetX / offsetY は画面端からの余白 px で 0〜320 の整数（既定 24）',
           },
         },
         required: ['theme'],

--- a/src/api/admin/agent/widgetPlacement.test.ts
+++ b/src/api/admin/agent/widgetPlacement.test.ts
@@ -1,0 +1,97 @@
+import {
+  isValidWidgetPosition,
+  parseWidgetOffset,
+  validateWidgetPlacement,
+  buildPlacementAttributes,
+} from './widgetPlacement';
+
+describe('widgetPlacement', () => {
+  describe('parseWidgetOffset', () => {
+    it('数値・数字文字列の両方を受ける（LLM由来の引数は型が揺れる）', () => {
+      expect(parseWidgetOffset(96)).toBe(96);
+      expect(parseWidgetOffset('96')).toBe(96);
+      expect(parseWidgetOffset(' 96 ')).toBe(96);
+    });
+
+    it('境界値 0 と 320 は通す', () => {
+      expect(parseWidgetOffset(0)).toBe(0);
+      expect(parseWidgetOffset(320)).toBe(320);
+    });
+
+    it('範囲外・非整数・非数値・真偽値は null', () => {
+      expect(parseWidgetOffset(-1)).toBeNull();
+      expect(parseWidgetOffset(321)).toBeNull();
+      expect(parseWidgetOffset(24.5)).toBeNull();
+      expect(parseWidgetOffset('96px')).toBeNull();
+      expect(parseWidgetOffset('')).toBeNull();
+      expect(parseWidgetOffset(NaN)).toBeNull();
+      expect(parseWidgetOffset(true)).toBeNull();
+      expect(parseWidgetOffset(null)).toBeNull();
+      expect(parseWidgetOffset(undefined)).toBeNull();
+      expect(parseWidgetOffset({})).toBeNull();
+    });
+  });
+
+  describe('isValidWidgetPosition', () => {
+    it('許可されている2値のみ', () => {
+      expect(isValidWidgetPosition('bottom-right')).toBe(true);
+      expect(isValidWidgetPosition('bottom-left')).toBe(true);
+      expect(isValidWidgetPosition('top-left')).toBe(false);
+      expect(isValidWidgetPosition('BOTTOM-LEFT')).toBe(false);
+      expect(isValidWidgetPosition(undefined)).toBe(false);
+    });
+  });
+
+  describe('validateWidgetPlacement', () => {
+    it('未指定・正常値は null（エラーなし）', () => {
+      expect(validateWidgetPlacement({})).toBeNull();
+      expect(validateWidgetPlacement({ primaryColor: '#3B82F6' })).toBeNull();
+      expect(validateWidgetPlacement({ position: 'bottom-left', offsetX: 0, offsetY: 96 })).toBeNull();
+    });
+
+    it('不正な position は日本語メッセージを返す', () => {
+      const msg = validateWidgetPlacement({ position: 'top-right' });
+      expect(msg).toContain('position');
+      expect(msg).toContain('bottom-left');
+    });
+
+    it('不正な offset はどちらのキーでも弾く', () => {
+      expect(validateWidgetPlacement({ offsetX: 999 })).toContain('offsetX');
+      expect(validateWidgetPlacement({ offsetY: 'abc' })).toContain('offsetY');
+    });
+  });
+
+  describe('buildPlacementAttributes', () => {
+    it('未設定・null は空文字（既定の埋め込みコードを汚さない）', () => {
+      expect(buildPlacementAttributes(null)).toBe('');
+      expect(buildPlacementAttributes(undefined)).toBe('');
+      expect(buildPlacementAttributes({})).toBe('');
+    });
+
+    it('既定値と同じ設定は出力しない', () => {
+      expect(buildPlacementAttributes({ position: 'bottom-right', offsetX: 24, offsetY: 24 })).toBe('');
+    });
+
+    it('既定と異なる設定のみ属性化する', () => {
+      expect(buildPlacementAttributes({ position: 'bottom-left' })).toBe('\n  data-position="bottom-left"');
+      expect(buildPlacementAttributes({ offsetY: 96 })).toBe('\n  data-offset-y="96"');
+      expect(buildPlacementAttributes({ position: 'bottom-left', offsetX: 16, offsetY: 96 })).toBe(
+        '\n  data-position="bottom-left"\n  data-offset-x="16"\n  data-offset-y="96"'
+      );
+    });
+
+    it('offset 0 は既定と異なるので出力する（falsy 取り違えの回帰）', () => {
+      expect(buildPlacementAttributes({ offsetX: 0 })).toBe('\n  data-offset-x="0"');
+    });
+
+    it('DBを直接触られた場合の不正値は黙って捨てる（壊れた属性を出さない）', () => {
+      expect(buildPlacementAttributes({ position: 'top-left', offsetY: 9999 })).toBe('');
+      expect(buildPlacementAttributes({ position: '" onload="alert(1)' })).toBe('');
+      expect(buildPlacementAttributes({ offsetX: '12"><script>' })).toBe('');
+    });
+
+    it('primaryColor など無関係のキーは無視する', () => {
+      expect(buildPlacementAttributes({ primaryColor: '#3B82F6', tone: 'polite' })).toBe('');
+    });
+  });
+});

--- a/src/api/admin/agent/widgetPlacement.ts
+++ b/src/api/admin/agent/widgetPlacement.ts
@@ -1,0 +1,83 @@
+// src/api/admin/agent/widgetPlacement.ts
+//
+// ウィジェットの設置位置（widget_theme.position / offsetX / offsetY）の検証と、
+// 埋め込みコード属性への変換。
+//
+// なぜ設定可能にしているか: FAB は z-index に int 最大値を使うため、テナントサイト側の
+// 「トップへ戻る」ボタン・カート・LINE相談などが右下にあると、見えなくなるだけでなく
+// クリック不能になる（=こちらが相手のサイトを壊す）。寄せる角と余白を逃げ道として公開する。
+//
+// ⚠️ 同じ関心事が admin-ui/src/pages/admin/tenants/EmbedCodeTab.tsx にもある。
+// admin-ui は別ビルドで src/ から import できないため複製になっている。片方だけ直さない。
+// 丸め範囲は public/widget.js の parseOffset() と一致させること。
+
+export const WIDGET_POSITIONS = ['bottom-right', 'bottom-left'] as const;
+export type WidgetPosition = (typeof WIDGET_POSITIONS)[number];
+
+export const WIDGET_OFFSET_MIN = 0;
+export const WIDGET_OFFSET_MAX = 320;
+
+/** 既定値。埋め込みコードには出力しない（widget.js 側の既定と同じため） */
+const DEFAULT_POSITION: WidgetPosition = 'bottom-right';
+const DEFAULT_OFFSET = 24;
+
+export function isValidWidgetPosition(value: unknown): value is WidgetPosition {
+  return typeof value === 'string' && (WIDGET_POSITIONS as readonly string[]).includes(value);
+}
+
+/**
+ * 余白を px の整数として解釈する。範囲外・非数値は null（=不正）。
+ * LLM 由来の引数は数値と数字文字列が混在するため両方受ける。
+ */
+export function parseWidgetOffset(value: unknown): number | null {
+  if (typeof value !== 'number' && typeof value !== 'string') return null;
+  if (typeof value === 'string' && !/^\d+$/.test(value.trim())) return null;
+  const n = Number(value);
+  if (!Number.isInteger(n) || n < WIDGET_OFFSET_MIN || n > WIDGET_OFFSET_MAX) return null;
+  return n;
+}
+
+/**
+ * set_widget_theme の入力検証。問題があればユーザー向け日本語メッセージ、無ければ null。
+ * 不正値を保存させると埋め込みコードが壊れた属性を持つため、書き込み前に弾く。
+ */
+export function validateWidgetPlacement(theme: Record<string, unknown>): string | null {
+  const position = theme['position'];
+  if (position !== undefined && !isValidWidgetPosition(position)) {
+    return `position は ${WIDGET_POSITIONS.join(' か ')} で指定してください（例: "bottom-left"）`;
+  }
+  for (const key of ['offsetX', 'offsetY']) {
+    const raw = theme[key];
+    if (raw !== undefined && parseWidgetOffset(raw) === null) {
+      return `${key} は ${WIDGET_OFFSET_MIN}〜${WIDGET_OFFSET_MAX} の整数（px）で指定してください（例: 96）`;
+    }
+  }
+  return null;
+}
+
+/**
+ * widget_theme から埋め込みコードに追記する属性行を組み立てる。
+ * 既定値と同じ設定・不正値は出力しない（テナントがコピペするスニペットを短く保つため、
+ * また直接DBを触られた場合に壊れた属性を出さないため）。
+ */
+export function buildPlacementAttributes(theme: Record<string, unknown> | null | undefined): string {
+  if (!theme) return '';
+  const attrs: string[] = [];
+
+  const position = theme['position'];
+  if (isValidWidgetPosition(position) && position !== DEFAULT_POSITION) {
+    attrs.push(`data-position="${position}"`);
+  }
+  const pairs: Array<[string, string]> = [
+    ['offsetX', 'data-offset-x'],
+    ['offsetY', 'data-offset-y'],
+  ];
+  for (const [key, attr] of pairs) {
+    const offset = parseWidgetOffset(theme[key]);
+    if (offset !== null && offset !== DEFAULT_OFFSET) {
+      attrs.push(`${attr}="${offset}"`);
+    }
+  }
+
+  return attrs.map((a) => `\n  ${a}`).join('');
+}

--- a/tests/widget/widgetSourceInvariants.test.ts
+++ b/tests/widget/widgetSourceInvariants.test.ts
@@ -82,6 +82,47 @@ describe('public/widget.js ソース不変条件', () => {
   });
 });
 
+// 設置位置（data-position / data-offset-x / data-offset-y）
+//
+// FAB は z-index に int 最大値を使うため、テナントサイト側の「トップへ戻る」ボタン等が
+// 右下にあると、見えなくなるだけでなくクリック不能になる（=こちらが相手のサイトを壊す）。
+// その唯一の逃げ道がこの属性なので、読み取り・丸め・CSSへの反映が消えていないことを固定する。
+describe('public/widget.js 設置位置の不変条件', () => {
+  it('data-position / data-offset-x / data-offset-y を読み取っている', () => {
+    expect(WIDGET_SRC).toMatch(/getAttribute\(\s*['"]data-position['"]\s*\)/);
+    expect(WIDGET_SRC).toMatch(/getAttribute\(\s*['"]data-offset-x['"]\s*\)/);
+    expect(WIDGET_SRC).toMatch(/getAttribute\(\s*['"]data-offset-y['"]\s*\)/);
+  });
+
+  it('余白を 0〜320px に丸めている（画面外へ押し出してウィジェットを不可視にしない）', () => {
+    expect(WIDGET_SRC).toMatch(/Math\.max\(\s*0\s*,\s*Math\.min\(\s*320\s*,\s*n\s*\)\s*\)/);
+  });
+
+  it('不正な data-position は既定の right にフォールバックする', () => {
+    expect(WIDGET_SRC).toMatch(/===\s*'bottom-left'\s*\?\s*'left'\s*:\s*'right'/);
+  });
+
+  it('角と余白がハードコードに戻っていない（FAB・パネル・バブルの3要素すべて）', () => {
+    // 3要素は position:fixed で画面の角に貼り付く唯一の要素。ここが定数に戻ると設定が効かなくなる。
+    expect(WIDGET_SRC).not.toMatch(/'\s*(bottom|right):\s*24px;'/);
+    expect(WIDGET_SRC).not.toMatch(/'\s*bottom:\s*(132|152)px;'/);
+    expect(WIDGET_SRC).toContain('--offset-x');
+    expect(WIDGET_SRC).toContain('--offset-y');
+    // バブル・パネルは FAB(120px) を基準にした相対配置を保つ
+    expect(WIDGET_SRC).toContain('calc(var(--offset-y) + 128px)');
+    expect(WIDGET_SRC).toContain('calc(var(--offset-y) + 108px)');
+  });
+
+  it('パネル高さが offset-y に追随する（定数に戻すと offset を上げた分だけ画面上端からはみ出す）', () => {
+    expect(WIDGET_SRC).toContain('calc(100vh - var(--offset-y) - 124px)');
+    expect(WIDGET_SRC).not.toContain('calc(100vh - 120px)');
+  });
+
+  it('モバイル全画面表示が left / right の両方を打ち消している（bottom-left 時に画面外へはみ出さない）', () => {
+    expect(WIDGET_SRC).toMatch(/left:\s*0\s*!important;\s*right:\s*0\s*!important;/);
+  });
+});
+
 describe('public/widget.min.js が壊れたビルド成果物になっていない', () => {
   // 当初は「特定の文字列(data-scripted-responses 等)が難読化後も残っているか」で
   // ビルド忘れを検知しようとしたが、javascript-obfuscator の文字列配列抽出は実行の


### PR DESCRIPTION
## 問題

テナントサイトの右下には「トップへ戻る」ボタン・カート・LINE相談などが置かれていることが多い。
FAB は 120x120px を `bottom:24px / right:24px` に固定し、`z-index` に int 最大値 (2147483647) を
使うため、相手側のボタンが**見えなくなるだけでなくクリック不能になる**。
位置を変える手段が一切なく、逃げ道が無かった。

## 実測（Playwright, 900x700、サイト側ボタンを bottom:32/right:32 の 48px 角と想定）

| 設定 | FAB rect | 相手ボタン | 重なり |
|---|---|---|---|
| 既定 (bottom-right) | (756,556,120,120) | (820,620) | **true** |
| `data-position="bottom-left"` | (24,556,120,120) | (820,620) | false |
| `data-offset-y="160"` | (756,420,120,120) | (820,620) | false |
| 390px + bottom-left | (24,556,120,120) | (310,620) | false |

パネルを開いた状態でも viewport 内に収まることを 900x800 / 390x750 / offset-y=200 で確認済み。

## 変更内容

追加した属性（いずれも任意、未指定なら従来と完全に同じ表示）:

- `data-position="bottom-left"` — 寄せる角を変える（既定 `bottom-right`）
- `data-offset-x` / `data-offset-y` — 画面端からの余白 px（既定 24、0〜320 に丸め）

FAB・チャットパネル・プロアクティブバブルの 3 要素を CSS 変数 `--offset-x` / `--offset-y` に寄せ、
左右は変数で切り替える。バブルの尻尾の向き、パネルの `transform-origin`、モバイル全画面時の
left/right 打ち消しも左右に追随させた。

**パネル高さも合わせて修正した。** 従来 `calc(100vh - 120px)` の定数で、下端 (`bottom:132px`) と
12px 食い違っており、既定でも上端を 4px はみ出していた。offset-y を上げると差が拡大して画面外へ
出るため、offset-y 起点の式に変えている。

埋め込みコード生成は既知の重複箇所（`EmbedCodeTab.tsx` と `get_embed_code`）なので両方に反映し、
値の検証は `widgetPlacement.ts` の純関数に集約した。既定値と同じ設定・不正値は出力しない
（コピペ用スニペットを短く保ち、直接DBを触られても壊れた属性を出さないため）。
`set_widget_theme` は書き込み前に同じ検証で弾く。

新しいツールは追加していないため `confirmPolicy` / `REAL_TOOL_LABEL` は変更なし。

## テスト

- `widgetPlacement.test.ts` 13件（境界値 0/320、非整数、真偽値、属性注入を狙った不正値、offset 0 の falsy 取り違え回帰）
- `widgetSourceInvariants.test.ts` +6件（属性読み取り・丸め・ハードコード復帰・パネル高さ・モバイル打ち消し）
- `agentRoutes.test.ts` +3件（`get_embed_code` の出力有無、`set_widget_theme` の不正値ブロック）
- `EmbedCodeTab.test.tsx` +4件（同上のフロント側）

Gate 1 typecheck 0 / lint 0 / 新規テスト全パス、Gate 1.5 dead export 増加なし、Gate 2 High/Critical 0、Gate 3 build 成功。

## スコープ外（別 PR）

既存テナントには HTML の書き換えが必要。サーバ配信の設定（`/api/widget/features`）に載せて
既設置分にも配る対応は別途。

## 注意

`public/widget.min.js` は本 PR では再生成していない（現状どこからも参照されていないため）。

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HDt61FhbaVn3oXR6QGnyap
