### PR TITLE
fix(api): CORS許可ヘッダにX-R2C-Traffic-Sourceを追加

### DIFF
--- a/src/lib/cors.test.ts
+++ b/src/lib/cors.test.ts
@@ -89,4 +89,26 @@ describe("corsMiddleware", () => {
     mw(req, res, nextFn);
     expect(nextFn).toHaveBeenCalled();
   });
+
+  // E2E(playwright.config.ts の extraHTTPHeaders)が x-r2c-traffic-source を全リクエストに
+  // 付けるが、この許可リストに無いとプリフライトで admin-ui の全 fetch が拒否される
+  // (CLAUDE.md 絶対にやってはいけないこと 22)。
+  it("includes X-R2C-Traffic-Source in Access-Control-Allow-Headers", () => {
+    const mw = createCorsMiddleware({ defaultAllowedOrigins: [] });
+    const req = mockReq({ headers: { origin: "https://anything.example" } });
+    const res = mockRes();
+    mw(req, res, nextFn);
+    expect(res.headers["Access-Control-Allow-Headers"]).toContain("X-R2C-Traffic-Source");
+  });
+
+  it("still includes the pre-existing allowed headers", () => {
+    const mw = createCorsMiddleware({ defaultAllowedOrigins: [] });
+    const req = mockReq({ headers: { origin: "https://anything.example" } });
+    const res = mockRes();
+    mw(req, res, nextFn);
+    const allowHeaders = res.headers["Access-Control-Allow-Headers"];
+    for (const h of ["Content-Type", "Authorization", "X-API-Key", "X-Tenant-ID", "X-Request-ID"]) {
+      expect(allowHeaders).toContain(h);
+    }
+  });
 });

--- a/src/lib/cors.ts
+++ b/src/lib/cors.ts
@@ -22,6 +22,7 @@ const ALLOWED_HEADERS = [
   "X-API-Key",
   "X-Tenant-ID",
   "X-Request-ID",
+  "X-R2C-Traffic-Source",
 ].join(", ");
 const EXPOSED_HEADERS = [
   "X-Request-ID",


### PR DESCRIPTION
## 背景（Asana 2/8, gid 1217531242336419）

本番管理画面(admin.r2c.biz)をPlaywrightで実機確認した際、admin-uiの全fetchがCORSプリフライトで拒否されていることが判明した。

判別コマンド:
```
curl -s -i -X OPTIONS "https://api.r2c.biz/v1/admin/my-tenant" \
  -H "Origin: https://admin.r2c.biz" -H "Access-Control-Request-Method: GET" \
  -H "Access-Control-Request-Headers: authorization,x-r2c-traffic-source"
```
応答の `Access-Control-Allow-Headers` に `x-r2c-traffic-source` が含まれず、
本番指標汚染防止のためE2E(playwright.config.ts の extraHTTPHeaders)が
全リクエストに付けているこのヘッダが、サーバの許可リストに無かった。

ドキュメント読み込み(page.goto)は素通りするため画面自体は表示され、データだけが載らない
——最も気づきにくい形の壊れ方で、既存のadmin-ui E2Eは「動いているのに何も見ていない」
状態で走っていたことになる。

## 変更

- `src/lib/cors.ts`: `ALLOWED_HEADERS` に `X-R2C-Traffic-Source` を追加(既存5ヘッダは変更なし)
- `src/lib/cors.test.ts`: 既存ファイルに回帰テストを2件追加(新ヘッダを含むこと／既存5ヘッダが残っていること)

## Gate結果

- Gate 1 (typecheck/lint/test): 差分に起因する失敗なし。typecheck/lint/`cors.test.ts`単体は全pass。
  jest全体では本worktreeの環境要因(EADDRNOTAVAIL等、ポート競合と思われる)で無関係なsuiteが
  失敗するが、`git stash`でこの変更を外した状態でも同数程度失敗することを確認済み(pre-existing、対象外)。
  admin-ui vitestも1件pre-existingな失敗(`useAuth.test.tsx`、本PRの変更と無関係)があるのみ。
- Gate 1.5 (dead-code-check): 変更に起因する新規dead exportなし
- Gate 2 (security-scan): PASS (CRITICAL/HIGH 0)
- Gate 3 (build): backend/admin-ui共にビルド成功

## 注意

- E2Eの`x-r2c-traffic-source`ヘッダをクライアント側から消す方向では直していない(本番指標汚染防止の
  ために入ったヘッダのため)。サーバの許可リストに追加するのが正しい修正方向(CLAUDE.md 禁止事項22)。
- 本PRは`src/`変更のためTier S。high-riskラベル対象でauto-merge対象外、手動マージが必要。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01My9XXuKXbnb8ca9xgDnEqj