### PR TITLE
fix(admin-ui): copilot-preview初回起動失敗時に再試行導線を追加

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -4436,3 +4436,111 @@ describe("CopilotPreviewPage — 解決確認プロンプト", () => {
     expect(posted).toEqual([]);
   });
 });
+
+// Asana (8/8): 起動時ブリーフィング(BOOTSTRAP_PROMPT, silent送信)が5xxで失敗すると、
+// 復帰手段が画面リロードしかなくなっていた不具合の回帰テスト。silentな自動送信の
+// 失敗時だけ「もう一度試す」チップを出し、押すと同じ文面を既存のrunAction経由の
+// __real:ディスパッチで再送する(新しいチップ種別・新しい送信経路は作らない)。
+describe("CopilotPreviewPage — 起動時ブリーフィング失敗時の再試行", () => {
+  beforeEach(() => {
+    vi.mocked(authFetch).mockReset();
+  });
+
+  // オンボーディング未完了だと業種ヒアリングの挨拶に分岐し、bootstrap(週次ブリーフィング)
+  // 自体が発火しないため、onboarding_completed_at を立てて通常の週次ブリーフィング
+  // パスに固定する(旧UI案内リンクカードのテストと同じ固定方法)。
+  function mockAgentChat(onCall: (n: number) => Promise<Response>) {
+    let agentCalls = 0;
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (isBadgeUrl(url)) return mockEmptyBadges();
+      if (String(url).includes("/v1/admin/my-tenant")) {
+        return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
+      }
+      if (isUnreadFeedbackUrl(url)) return mockNoFeedbackReplies();
+      agentCalls += 1;
+      return onCall(agentCalls);
+    });
+  }
+
+  it("起動時ブリーフィングが500で失敗すると「もう一度試す」チップが表示される", async () => {
+    mockAgentChat(() =>
+      Promise.resolve({
+        ok: false,
+        status: 500,
+        json: () => Promise.resolve({ error: "AIエージェントの応答生成に失敗しました" }),
+      } as Response),
+    );
+
+    renderPage();
+
+    expect(await screen.findByText("エラー: AIエージェントの応答生成に失敗しました")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "もう一度試す" })).toBeTruthy();
+    // 送信中フラグが残らない(無限スピナーにならない)
+    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
+  });
+
+  it("「もう一度試す」を押すと再送信され、成功すれば通常の週次まとめに置き換わる", async () => {
+    mockAgentChat((n) =>
+      n === 1
+        ? Promise.resolve({
+            ok: false,
+            status: 500,
+            json: () => Promise.resolve({ error: "AIエージェントの応答生成に失敗しました" }),
+          } as Response)
+        : mockOk({ reply: "今週も順調です。", actions: [] }),
+    );
+
+    renderPage();
+    await screen.findByRole("button", { name: "もう一度試す" });
+
+    fireEvent.click(screen.getByRole("button", { name: "もう一度試す" }));
+
+    expect(await screen.findByText("今週も順調です。")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "もう一度試す" })).toBeNull();
+  });
+
+  it("「もう一度試す」を連打しても2回目の送信は発火しない(1回目のクリックでチップが消える)", async () => {
+    mockAgentChat((n) =>
+      n === 1
+        ? Promise.resolve({
+            ok: false,
+            status: 500,
+            json: () => Promise.resolve({ error: "AIエージェントの応答生成に失敗しました" }),
+          } as Response)
+        : mockOk({ reply: "今週も順調です。", actions: [] }),
+    );
+
+    renderPage();
+    const retryBtn = await screen.findByRole("button", { name: "もう一度試す" });
+
+    fireEvent.click(retryBtn);
+    fireEvent.click(retryBtn); // 連打(チップは即座に chipsUsed=true になり再クリック不可)
+
+    await screen.findByText("今週も順調です。");
+    const agentCalls = vi
+      .mocked(authFetch)
+      .mock.calls.filter((c) => String(c[0]).includes("/v1/admin/agent/chat"));
+    expect(agentCalls.length).toBe(2); // 1回目の失敗 + 再試行1回のみ
+  });
+
+  it("通常の会話中の送信失敗(silentでない)には「もう一度試す」チップを出さない(自由入力欄で再送できるため)", async () => {
+    mockAgentChat((n) =>
+      n === 1
+        ? mockOk({ reply: "今週も順調です。", actions: [] })
+        : Promise.resolve({
+            ok: false,
+            status: 500,
+            json: () => Promise.resolve({ error: "AIエージェントの応答生成に失敗しました" }),
+          } as Response),
+    );
+
+    renderPage();
+    await waitForBootstrapSendStarted();
+
+    fireEvent.change(screen.getByPlaceholderText(/指示ルール/), { target: { value: "送料を教えて" } });
+    fireEvent.click(screen.getByLabelText("送信"));
+
+    await screen.findByText("エラー: AIエージェントの応答生成に失敗しました");
+    expect(screen.queryByRole("button", { name: "もう一度試す" })).toBeNull();
+  });
+});

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -690,7 +690,14 @@ export default function CopilotPreviewPage() {
     const result = await sendAgentChat(text, { history: realHistory });
     if (requestEpochRef.current !== myEpoch) return; // より新しい呼び出しに追い越された
     if (!result.ok) {
-      push(say(result.message));
+      // silent(起動時ブリーフィング等、ユーザーが打った体でない自動送信)の失敗は、
+      // 唯一の復帰手段が画面リロードになってしまう。同じ文面をチップから
+      // 再送できるようにする(runAction経由の既存の__real:ディスパッチをそのまま使う
+      // — 新しいチップ種別・新しい送信経路は作らない)。
+      const retryChips: Chip[] | undefined = opts?.silent
+        ? [{ label: "もう一度試す", action: `__real:${text}`, tone: "ghost" }]
+        : undefined;
+      push(say(result.message, retryChips));
       setSending(false);
       return;
     }


### PR DESCRIPTION
## Summary
- Asana (8/8) gid 1217530758060403: `/copilot-preview` の起動時ブリーフィング(BOOTSTRAP_PROMPT, silent送信)が5xxで失敗すると、「エラー: AIエージェントの応答生成に失敗しました」で止まり、復帰手段が画面リロードしかなかった。
- silentな自動送信の失敗時だけ「もう一度試す」チップを表示し、既存の`runAction`経由`__real:`ディスパッチ(全チップ共通の唯一の実送信経路)で同じ文面を再送する。新しいチップ種別・新しい送信経路は作らない。
- `sending`は既存の失敗パスで既にfalseへ戻るため無限スピナーは残らない。連打防止も既存の`chipsUsed`によるチップ非表示 + `sendReal`自身の`sending`ガードで他の全チップと同様に効く(新規の連打対策コードは追加していない)。

## 変更ファイル(2件、新規ファイルなし)
- `admin-ui/src/pages/copilot-preview/index.tsx` — `sendReal`の失敗分岐に`opts?.silent`限定の再試行チップを追加
- `admin-ui/src/pages/copilot-preview/index.test.tsx` — 既存ファイルに4件追記(500失敗でチップ表示/再試行で成功に置換/連打で二重送信しない/通常送信の失敗にはチップを出さない)

## Test plan
- [x] `npx vitest run` — 174 passed (新規4件含む)
- [x] `pnpm lint` (oxlint, exit 0, 59 warnings ≤ 63 threshold, 変更ファイルに新規警告なし)
- [x] `pnpm typecheck` (root, admin-ui対象外のため無関係)
- [x] `tsc -b`(admin-ui) — 変更ファイルに新規型エラーなし(既存のAppSidebar型エラーは対象外、CI非検査)
- [x] `bash SCRIPTS/security-scan.sh` — PASS (CRITICAL/HIGH: 0)
- [x] `bash SCRIPTS/dead-code-check.sh` — 変更ファイルに新規dead exportなし
- [x] `cd admin-ui && vite build` — 成功

## Tier / Merge
`admin-ui/src/` に触るため Tier S。high-risk 対象で auto-merge 非対象。hkobayashi の手動マージが必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01My9XXuKXbnb8ca9xgDnEqj