### PR TITLE
fix(admin-ui): テナント詳細の500を「見つかりません」と誤表示しない

### DIFF
--- a/admin-ui/src/i18n/en.ts
+++ b/admin-ui/src/i18n/en.ts
@@ -203,6 +203,7 @@ const en: Record<TranslationKey, string> = {
   "tenant_detail.back": "← Back to Tenant List",
   "tenant_detail.loading": "Loading...",
   "tenant_detail.not_found": "Tenant not found 🙏",
+  "tenant_detail.load_failed": "Failed to load. This may be a temporary problem — please try again 🙏",
   "tenant_detail.tab_settings": "⚙️ Settings",
   "tenant_detail.tab_apikeys": "🔑 API Keys",
   "tenant_detail.tab_embed": "📋 Embed Code",

--- a/admin-ui/src/i18n/ja.ts
+++ b/admin-ui/src/i18n/ja.ts
@@ -201,6 +201,7 @@ const ja = {
   "tenant_detail.back": "← テナント一覧に戻る",
   "tenant_detail.loading": "読み込み中...",
   "tenant_detail.not_found": "テナントが見つかりませんでした 🙏",
+  "tenant_detail.load_failed": "読み込みに失敗しました。一時的な問題の可能性があります。もう一度お試しください 🙏",
   "tenant_detail.tab_settings": "⚙️ 設定",
   "tenant_detail.tab_apikeys": "🔑 APIキー",
   "tenant_detail.tab_embed": "📋 埋め込みコード",

--- a/admin-ui/src/pages/admin/tenants/TenantDetailHeader.tsx
+++ b/admin-ui/src/pages/admin/tenants/TenantDetailHeader.tsx
@@ -11,12 +11,16 @@ export function TenantDetailHeader({
   navigate,
   handleEnterPreview,
   t,
+  emptyTitle,
 }: {
   loading: boolean;
   tenant: TenantDetail | null;
   navigate: NavigateFunction;
   handleEnterPreview: () => void;
   t: (key: TranslationKey, vars?: Record<string, string | number>) => string;
+  // tenant===null のときに表示するタイトル。404の「見つかりません」と
+  // 500等の「読み込み失敗」を呼び出し元(loadError)で区別して渡す(禁止事項21)。
+  emptyTitle?: string;
 }) {
   return (
     <header style={{ marginBottom: 32 }}>
@@ -66,7 +70,7 @@ export function TenantDetailHeader({
         </div>
       </div>
       <h1 style={{ fontSize: 26, fontWeight: 700, margin: "0 0 4px", color: "var(--foreground)" }}>
-        {loading ? t("tenant_detail.loading") : (tenant?.name ?? t("tenant_detail.not_found"))}
+        {loading ? t("tenant_detail.loading") : (tenant?.name ?? emptyTitle ?? t("tenant_detail.not_found"))}
       </h1>
       {tenant && tenant.slug && (
         <p style={{ fontSize: 14, color: "var(--muted-foreground)", margin: 0 }}>

--- a/admin-ui/src/pages/admin/tenants/[id].test.tsx
+++ b/admin-ui/src/pages/admin/tenants/[id].test.tsx
@@ -1,0 +1,137 @@
+// 禁止事項21(CLAUDE.md): 500を「テナントが見つかりませんでした」と誤表示しない回帰テスト。
+// このページ独自の authFetch(supabase由来のトークン + 生fetch)と、
+// ApiKeysTab.fetchApiKeys が使う lib/api の authFetch の両方をモックする必要がある。
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { Route, Routes } from "react-router-dom";
+import { LangProvider } from "../../../i18n/LangContext";
+import TenantDetailPage from "./[id]";
+
+const mockGetSession = vi.fn();
+
+vi.mock("../../../lib/supabaseClient", () => ({
+  supabase: {
+    auth: {
+      getSession: (...args: unknown[]) => mockGetSession(...args),
+      refreshSession: () => Promise.resolve({ data: { session: null } }),
+    },
+  },
+}));
+
+vi.mock("../../../auth/useAuth", () => ({
+  useAuth: () => ({ enterPreview: vi.fn(), isSuperAdmin: true }),
+}));
+
+const mockApiKeysAuthFetch = vi.fn();
+vi.mock("../../../lib/api", () => ({
+  authFetch: (...args: unknown[]) => mockApiKeysAuthFetch(...args),
+  API_BASE: "http://localhost:3100",
+}));
+
+const okSession = { data: { session: { access_token: "test-token" } } };
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as Response;
+}
+
+function renderPage(tenantId = "carnation") {
+  return render(
+    <LangProvider>
+      <MemoryRouter initialEntries={[`/admin/tenants/${tenantId}`]}>
+        <Routes>
+          <Route path="/admin/tenants/:id" element={<TenantDetailPage />} />
+        </Routes>
+      </MemoryRouter>
+    </LangProvider>,
+  );
+}
+
+describe("TenantDetailPage — エラー意味論(500 vs 404 vs 401)", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockGetSession.mockReset().mockResolvedValue(okSession);
+    mockApiKeysAuthFetch.mockReset().mockResolvedValue(jsonResponse(200, { keys: [] }));
+  });
+
+  it("200のとき: タブが描画される", async () => {
+    global.fetch = vi.fn().mockResolvedValue(
+      jsonResponse(200, {
+        id: "carnation", name: "carnation", plan: "starter", is_active: true,
+        allowed_origins: [], billing_enabled: false, billing_free_from: null,
+        billing_free_until: null, features: { avatar: false, voice: false, rag: true },
+        lemonslice_agent_id: null, conversion_types: [],
+      }),
+    );
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("⚙️ 設定")).toBeTruthy());
+    expect(screen.queryByText(/テナントが見つかりませんでした/)).toBeNull();
+    expect(screen.queryByText(/読み込みに失敗しました/)).toBeNull();
+  });
+
+  it("404のとき: 「テナントが見つかりませんでした」を表示し、再試行ボタンは出さない", async () => {
+    global.fetch = vi.fn().mockResolvedValue(jsonResponse(404, { error: "not_found" }));
+
+    renderPage();
+
+    // ヘッダーのタイトルと本文の空状態の両方に出るため getAllByText で許容する
+    await waitFor(() => expect(screen.getAllByText(/テナントが見つかりませんでした/).length).toBeGreaterThan(0));
+    expect(screen.queryByText("やり直す")).toBeNull();
+  });
+
+  it("500のとき: 「テナントが見つかりませんでした」を表示せず、読み込み失敗+再試行ボタンを出す", async () => {
+    global.fetch = vi.fn().mockResolvedValue(jsonResponse(500, { error: "取得に失敗しました" }));
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getAllByText(/読み込みに失敗しました/).length).toBeGreaterThan(0));
+    expect(screen.queryByText(/テナントが見つかりませんでした/)).toBeNull();
+    expect(screen.getByText("やり直す")).toBeTruthy();
+  });
+
+  it("500の後に再試行ボタンを押すと再取得し、成功すればタブが描画される", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse(500, { error: "取得に失敗しました" }))
+      .mockResolvedValue(
+        jsonResponse(200, {
+          id: "carnation", name: "carnation", plan: "starter", is_active: true,
+          allowed_origins: [], billing_enabled: false, billing_free_from: null,
+          billing_free_until: null, features: { avatar: false, voice: false, rag: true },
+          lemonslice_agent_id: null, conversion_types: [],
+        }),
+      );
+    global.fetch = fetchMock;
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText("やり直す")).toBeTruthy());
+    screen.getByText("やり直す").click();
+
+    await waitFor(() => expect(screen.getByText("⚙️ 設定")).toBeTruthy());
+  });
+
+  it("401(未ログイン)のとき: 既存どおり /login へ遷移する(挙動を変えない)", async () => {
+    mockGetSession.mockResolvedValue({ data: { session: null } });
+    global.fetch = vi.fn();
+
+    render(
+      <LangProvider>
+        <MemoryRouter initialEntries={["/admin/tenants/carnation"]}>
+          <Routes>
+            <Route path="/admin/tenants/:id" element={<TenantDetailPage />} />
+            <Route path="/login" element={<div>login-page</div>} />
+          </Routes>
+        </MemoryRouter>
+      </LangProvider>,
+    );
+
+    await waitFor(() => expect(screen.getByText("login-page")).toBeTruthy());
+  });
+});

--- a/admin-ui/src/pages/admin/tenants/[id].tsx
+++ b/admin-ui/src/pages/admin/tenants/[id].tsx
@@ -174,8 +174,12 @@ export default function TenantDetailPage() {
   const [tenant, setTenant] = useState<TenantDetail | null>(null);
   const [apiKeys, setApiKeys] = useState<ApiKey[]>([]);
   const [loading, setLoading] = useState(true);
+  // 500等の「読み込み失敗」と404の「見つかりません」を区別する(禁止事項21)。
+  // どちらも tenant===null で表れるが、文言と再試行導線を変える必要があるため別state。
+  const [loadError, setLoadError] = useState<"not_found" | "failed" | null>(null);
   const [activeTab, setActiveTab] = useState<TabId>("settings");
   const [toast, setToast] = useState<string | null>(null);
+  const [reloadKey, setReloadKey] = useState(0);
 
   const showToast = (message: string) => {
     setToast(message);
@@ -185,6 +189,7 @@ export default function TenantDetailPage() {
   useEffect(() => {
     const load = async () => {
       setLoading(true);
+      setLoadError(null);
       try {
         const [tenantData, keysData] = await Promise.all([
           fetchTenantDetail(tenantId),
@@ -197,13 +202,17 @@ export default function TenantDetailPage() {
           navigate("/login", { replace: true });
           return;
         }
-        // tenant not found — leave null
+        setTenant(null);
+        const status = err instanceof Error ? err.message.match(/^HTTP (\d+)$/)?.[1] : undefined;
+        setLoadError(status === "404" ? "not_found" : "failed");
       } finally {
         setLoading(false);
       }
     };
     load();
-  }, [tenantId, navigate]);
+  }, [tenantId, navigate, reloadKey]);
+
+  const handleRetryLoad = () => setReloadKey((k) => k + 1);
 
   const handleSaveSettings = async (data: {
     name: string;
@@ -291,6 +300,7 @@ export default function TenantDetailPage() {
         navigate={navigate}
         handleEnterPreview={handleEnterPreview}
         t={t}
+        emptyTitle={loadError === "failed" ? t("tenant_detail.load_failed") : t("tenant_detail.not_found")}
       />
 
       {loading ? (
@@ -394,7 +404,26 @@ export default function TenantDetailPage() {
             fontSize: 15,
           }}
         >
-          {t("tenant_detail.not_found")}
+          <div>{loadError === "not_found" ? t("tenant_detail.not_found") : t("tenant_detail.load_failed")}</div>
+          {loadError === "failed" && (
+            <button
+              onClick={handleRetryLoad}
+              style={{
+                marginTop: 16,
+                padding: "10px 20px",
+                minHeight: 44,
+                borderRadius: 10,
+                border: "1px solid var(--border)",
+                background: "var(--card)",
+                color: "var(--foreground)",
+                fontSize: 14,
+                fontWeight: 600,
+                cursor: "pointer",
+              }}
+            >
+              {t("common.retry")}
+            </button>
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## 背景
本番で `GET /v1/admin/tenants/:id` が500になった際、画面は一律「テナントが見つかりませんでした 🙏」と表示していた。404(実際に存在しない)と500(サーバ障害)を区別できず、本番調査のたびに遠回りが発生していた(CLAUDE.md 禁止事項21)。

## 変更内容
- `[id].tsx`: `fetchTenantDetail` が投げる `Error("HTTP <status>")` から404/それ以外を判定し、`loadError` state (`"not_found" | "failed"`) で分岐。`__AUTH_REQUIRED__` の既存分岐(ログイン遷移)は変更なし。再試行ボタンで読み込みをやり直せる。
- `TenantDetailHeader.tsx`: 見出し(h1)も同じ理由で `tenant===null` のとき常に「見つかりません」を出していたため、`emptyTitle` propを追加して同じ区別を適用(このバグは本文と見出しの2箇所で同時に起きていた)。
- `ja.ts` / `en.ts`: `tenant_detail.load_failed` を追加。再試行の文言は既存の `common.retry`(「やり直す」)を再利用し、新規文言を増やしていない。
- `[id].test.tsx`(新規): 200/404/500/再試行成功/401(既存挙動維持)の5ケースを固定。同ディレクトリはタブ単位のテスト(`AvatarTab.test.tsx`等)のみでページ本体のテストが無かった。

## Gate
- Gate 1 (typecheck / lint / test): PASS
- Gate 1.5 (dead-code-check): 変更ファイルに新規死コードなし(既存の未使用exportのみ、無関係)
- Gate 2 (security-scan): PASS (CRITICAL/HIGH 0)
- Gate 3 (build ×2): PASS

## Tier
`admin-ui/src/**` を変更するため Tier S。hkobayashi の手動 merge が必要です。auto-merge は有効化していません。

Asana: 1217528788023873 (5/8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
