### PR TITLE
fix(api): エスカレーション詳細の「本文0件」を404にせず200で返す

### DIFF
--- a/admin-ui/src/pages/admin/escalations/[sessionId].test.tsx
+++ b/admin-ui/src/pages/admin/escalations/[sessionId].test.tsx
@@ -1,0 +1,143 @@
+// admin-ui/src/pages/admin/escalations/[sessionId].test.tsx
+// エスカレーション詳細: 「本文0件」を赤帯エラーとして出さないこと、
+// 「セッション不在(404)」「サーバ障害(500)」は従来どおりエラー表示することを固定する。
+// (CLAUDE.md 20: 「存在しない」と「空」を同じ値で表現しない — 対応中の会話253件が
+//  全件404だった不具合の回帰テスト)
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import EscalationDetailPage from "./[sessionId]";
+import { authFetch } from "../../../lib/api";
+
+vi.mock("../../../lib/api", () => ({
+  API_BASE: "http://localhost:3100",
+  authFetch: vi.fn(),
+}));
+
+// LangProvider は localStorage.getItem に依存し、このテスト環境の Node組み込み
+// localStorage（--localstorage-file 未指定時は undefined）で例外になるため、
+// 実辞書(ja.ts)をそのまま使う t() を返す薄いモックに置き換える
+// (KnowledgeListTab.test.tsx / PdfUploadTab.test.tsx と同じ既存パターン)。
+vi.mock("../../../i18n/LangContext", async () => {
+  const jaModule = await import("../../../i18n/ja");
+  const ja = jaModule.default as Record<string, string>;
+  const stableT = (key: string, vars?: Record<string, string | number>) => {
+    let text = ja[key] ?? key;
+    if (vars) {
+      for (const [k, v] of Object.entries(vars)) {
+        text = text.replace(new RegExp(`\\{${k}\\}`, "g"), String(v));
+      }
+    }
+    return text;
+  };
+  const stableValue = { lang: "ja" as const, setLang: () => {}, t: stableT };
+  return {
+    useLang: () => stableValue,
+  };
+});
+
+function renderPage(sessionId = "sess-uuid-1") {
+  return render(
+    <MemoryRouter initialEntries={[`/admin/escalations/${sessionId}`]}>
+      <Routes>
+        <Route path="/admin/escalations/:sessionId" element={<EscalationDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as Response;
+}
+
+beforeEach(() => {
+  vi.mocked(authFetch).mockReset();
+});
+
+describe("EscalationDetailPage", () => {
+  it("本文が3件あれば会話が表示される", async () => {
+    vi.mocked(authFetch).mockResolvedValue(
+      jsonResponse(200, {
+        messages: [
+          { id: "m1", role: "user", content: "こんにちは", metadata: {}, created_at: "2026-08-10T00:00:00Z" },
+          { id: "m2", role: "assistant", content: "いらっしゃいませ", metadata: {}, created_at: "2026-08-10T00:00:01Z" },
+          { id: "m3", role: "operator", content: "担当します", metadata: {}, created_at: "2026-08-10T00:00:02Z" },
+        ],
+        total: 3,
+      }),
+    );
+
+    renderPage();
+
+    expect(await screen.findByText("こんにちは")).toBeTruthy();
+    expect(screen.queryByText(/失敗しました/)).toBeNull();
+    expect(screen.queryByText(/まだお客様の発言がありません/)).toBeNull();
+  });
+
+  it("本文0件(200)のとき赤帯エラーを出さず、空状態メッセージを表示する", async () => {
+    vi.mocked(authFetch).mockResolvedValue(jsonResponse(200, { messages: [], total: 0 }));
+
+    renderPage();
+
+    expect(await screen.findByText(/まだお客様の発言がありません/)).toBeTruthy();
+    expect(screen.queryByText(/失敗しました/)).toBeNull();
+  });
+
+  it("本文0件でも返信欄と対応完了ボタンは有効なまま", async () => {
+    vi.mocked(authFetch).mockResolvedValue(jsonResponse(200, { messages: [], total: 0 }));
+
+    renderPage();
+
+    await screen.findByText(/まだお客様の発言がありません/);
+    const textarea = screen.getByPlaceholderText(/お客様への返信を入力してください/) as HTMLTextAreaElement;
+    const resolveButton = screen.getByRole("button", { name: /対応完了にする/ }) as HTMLButtonElement;
+    expect(textarea.disabled).toBe(false);
+    expect(resolveButton.disabled).toBe(false);
+  });
+
+  it("セッション不在(404)のときはエラー表示される(空状態にしない)", async () => {
+    vi.mocked(authFetch).mockResolvedValue(jsonResponse(404, { error: "セッションが見つかりません" }));
+
+    renderPage("nonexistent");
+
+    expect(await screen.findByText(/失敗しました/)).toBeTruthy();
+    expect(screen.queryByText(/まだお客様の発言がありません/)).toBeNull();
+  });
+
+  it("サーバ障害(500)のときもエラー表示される", async () => {
+    vi.mocked(authFetch).mockResolvedValue(jsonResponse(500, { error: "取得に失敗しました" }));
+
+    renderPage();
+
+    expect(await screen.findByText(/失敗しました/)).toBeTruthy();
+  });
+
+  it("返信送信 → 再取得で operator メッセージが表示され、空状態表示が消える", async () => {
+    vi.mocked(authFetch)
+      .mockResolvedValueOnce(jsonResponse(200, { messages: [], total: 0 })) // 初回ロード: 空
+      .mockResolvedValueOnce(jsonResponse(201, { ok: true })) // 返信POST
+      .mockResolvedValue(
+        jsonResponse(200, {
+          messages: [
+            { id: "m1", role: "operator", content: "担当します", metadata: {}, created_at: "2026-08-10T00:00:00Z" },
+          ],
+          total: 1,
+        }),
+      ); // 再取得
+
+    renderPage();
+
+    await screen.findByText(/まだお客様の発言がありません/);
+
+    const textarea = screen.getByPlaceholderText(/お客様への返信を入力してください/);
+    fireEvent.change(textarea, { target: { value: "担当します" } });
+    fireEvent.click(screen.getByRole("button", { name: "送信" }));
+
+    expect(await screen.findByText("担当します")).toBeTruthy();
+    expect(screen.queryByText(/まだお客様の発言がありません/)).toBeNull();
+  });
+});

--- a/admin-ui/src/pages/admin/escalations/[sessionId].tsx
+++ b/admin-ui/src/pages/admin/escalations/[sessionId].tsx
@@ -36,7 +36,7 @@ export default function EscalationDetailPage() {
       setMessages(data.messages ?? []);
       setError(null);
     } catch {
-      setError("会話の取得に失敗しました");
+      setError("会話の取得に失敗しました。しばらく経ってから再度お試しください。");
     } finally {
       setLoading(false);
     }
@@ -168,6 +168,11 @@ export default function EscalationDetailPage() {
           <div style={{ padding: 40, textAlign: "center", color: "var(--muted-foreground)" }}>
             <span style={{ display: "block", fontSize: 32, marginBottom: 8 }}>⏳</span>
             {t("chat_history.loading")}
+          </div>
+        ) : !error && messages.length === 0 ? (
+          <div style={{ padding: 40, textAlign: "center", color: "var(--muted-foreground)" }}>
+            <span style={{ display: "block", fontSize: 32, marginBottom: 8 }}>💬</span>
+            まだお客様の発言がありません
           </div>
         ) : (
           <>

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -2414,8 +2414,10 @@ export async function executeToolCall(
           return truncate(resolved.message);
         }
 
+        // resolveSessionByShortId が存在確認済みのため null は実質到達しないが、
+        // getMessages の戻り型が null|[] になった(CLAUDE.md 20)のでガードする。
         const messages = await getMessages({ sessionDbId: resolved.session.id, tenantId });
-        if (messages.length === 0) {
+        if (messages === null || messages.length === 0) {
           return truncate(`セッション[${resolved.session.session_id.slice(0, 8)}]にメッセージはありません`);
         }
 

--- a/src/api/admin/chat-history/chatHistoryRepository.messages.test.ts
+++ b/src/api/admin/chat-history/chatHistoryRepository.messages.test.ts
@@ -1,0 +1,83 @@
+// src/api/admin/chat-history/chatHistoryRepository.messages.test.ts
+// getMessages() の「セッション不在(null)」と「本文0件([])」の区別を固定する。
+// 区別が無かったため、対応中の会話253件すべてが 404 になり返信できない状態になっていた
+// (CLAUDE.md 20: 「存在しない」と「空」を同じ値で表現しない)。
+
+const mockQuery = jest.fn();
+jest.mock("../../../lib/db", () => ({
+  getPool: () => ({ query: (...args: unknown[]) => mockQuery(...args) }),
+}));
+
+import { getMessages } from "./chatHistoryRepository";
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+describe("getMessages", () => {
+  it("セッションが存在し本文が3件あれば created_at ASC で3件返す", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: "session-db-id" }] }) // 所有権確認
+      .mockResolvedValueOnce({
+        rows: [
+          { id: "m1", role: "user", content: "こんにちは", metadata: {}, created_at: "2026-08-10T00:00:00Z" },
+          { id: "m2", role: "assistant", content: "いらっしゃいませ", metadata: {}, created_at: "2026-08-10T00:00:01Z" },
+          { id: "m3", role: "operator", content: "担当します", metadata: {}, created_at: "2026-08-10T00:00:02Z" },
+        ],
+      });
+
+    const result = await getMessages({ sessionDbId: "session-db-id", tenantId: "carnation" });
+
+    expect(result).not.toBeNull();
+    expect(result).toHaveLength(3);
+    expect(result?.[0].id).toBe("m1");
+  });
+
+  it("セッションは存在するが本文0件のとき、null ではなく空配列を返す", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: "session-db-id" }] }) // 所有権確認: 存在する
+      .mockResolvedValueOnce({ rows: [] }); // 本文: 0件
+
+    const result = await getMessages({ sessionDbId: "session-db-id", tenantId: "carnation" });
+
+    expect(result).toEqual([]);
+    expect(result).not.toBeNull();
+  });
+
+  it("セッションが存在しない場合は null を返す(空配列ではない)", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] }); // 所有権確認: 該当なし
+
+    const result = await getMessages({ sessionDbId: "not-exist", tenantId: "carnation" });
+
+    expect(result).toBeNull();
+    // 本文取得クエリまで進んでいないこと(存在しないのに2本目のSQLを叩かない)
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("他テナントのセッションIDを指定した場合も null を返す(200/[]にしない = 越境で実在を漏らさない)", async () => {
+    // tenant_id 条件付きの所有権確認クエリが「一致なし」を返すケース
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const result = await getMessages({ sessionDbId: "other-tenant-session", tenantId: "carnation" });
+
+    expect(result).toBeNull();
+  });
+
+  it("tenantId 未指定(super_admin)でもセッション不在なら null を返す", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    const result = await getMessages({ sessionDbId: "not-exist" });
+
+    expect(result).toBeNull();
+  });
+
+  it("tenantId 未指定(super_admin)で本文0件のセッションは空配列を返す", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: "session-db-id" }] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const result = await getMessages({ sessionDbId: "session-db-id" });
+
+    expect(result).toEqual([]);
+  });
+});

--- a/src/api/admin/chat-history/chatHistoryRepository.ts
+++ b/src/api/admin/chat-history/chatHistoryRepository.ts
@@ -283,11 +283,14 @@ export interface ChatHistoryMessage {
 
 /**
  * セッション内の全メッセージを created_at ASC で返す。
- * tenantId が一致しない場合は空配列を返す（セキュリティ）。
+ * セッションが存在しない（またはtenantIdが一致しない = 越境）場合は null を返す。
+ * セッションは存在するが本文が0件の場合は [] を返す。
+ * 呼び出し元はこの2つを区別すること（CLAUDE.md 20: 「存在しない」と「空」を同じ値で表現しない）。
+ * 越境は必ず null 側に倒す — [] を返すとそのIDのセッションが実在することが漏れる。
  */
 export async function getMessages(
   params: MessageListParams,
-): Promise<ChatHistoryMessage[]> {
+): Promise<ChatHistoryMessage[] | null> {
   const pool = getPool();
 
   // テナント所有権を検証 (tenantId が undefined = super_admin → tenant チェック省略)
@@ -297,14 +300,14 @@ export async function getMessages(
       `SELECT id FROM chat_sessions WHERE id = $1 AND tenant_id = $2`,
       [params.sessionDbId, params.tenantId],
     );
-    if (sessionResult.rows.length === 0) return [];
+    if (sessionResult.rows.length === 0) return null;
     verifiedSessionId = sessionResult.rows[0].id;
   } else {
     const sessionResult = await pool.query<{ id: string }>(
       `SELECT id FROM chat_sessions WHERE id = $1`,
       [params.sessionDbId],
     );
-    if (sessionResult.rows.length === 0) return [];
+    if (sessionResult.rows.length === 0) return null;
     verifiedSessionId = sessionResult.rows[0].id;
   }
 

--- a/src/api/admin/chat-history/routes.ts
+++ b/src/api/admin/chat-history/routes.ts
@@ -122,9 +122,8 @@ export function registerChatHistoryRoutes(app: Express): void {
       try {
         const messages = await getMessages({ sessionDbId, tenantId });
 
-        // messages が空 = セッションが存在しないかテナント不一致
-        if (messages.length === 0) {
-          // 存在確認は getMessages 内で実施済みなので 404 で返す
+        // null = セッションが存在しない（またはテナント不一致）。[] は「存在するが本文0件」で正常。
+        if (messages === null) {
           return res.status(404).json({ error: "セッションが見つかりません" });
         }
 

--- a/tests/phase38/chat-history-api.test.ts
+++ b/tests/phase38/chat-history-api.test.ts
@@ -128,8 +128,23 @@ describe("Chat History API", () => {
       expect(msg).toHaveProperty("created_at");
     });
 
-    it("returns 404 when getMessages returns empty array", async () => {
+    // CLAUDE.md 20: 「存在しない」と「空」を同じ値で表現しない。
+    // getMessages() は不在= null / 存在するが本文0件= [] を返す契約(2026-08-16是正)。
+    // 以前はどちらも [] で表現され、messages.length===0 を一律404にしていたため、
+    // 「本文がまだ無い(対応待ち)セッション」まで全て404になっていた。
+    it("returns 200 with empty array when the session exists but has 0 messages", async () => {
       mockGetMessages.mockResolvedValueOnce([]);
+
+      const res = await request(app)
+        .get("/v1/admin/chat-history/sessions/sess-uuid-1/messages")
+        .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`);
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({ messages: [], total: 0 });
+    });
+
+    it("returns 404 when getMessages returns null (session not found)", async () => {
+      mockGetMessages.mockResolvedValueOnce(null);
 
       const res = await request(app)
         .get("/v1/admin/chat-history/sessions/nonexistent/messages")


### PR DESCRIPTION
## 背景

本番検証で「対応中の会話」253件すべての詳細ページが404になり、画面に
「会話の取得に失敗しました」が出続けていることを確認した(無作為4件で再現4/4)。

実害の補足: 返信フォーム・「対応完了にする」自体は動作していた
(`POST .../reply` は `chat_sessions` の存在しか見ていないため)。つまり
実害は「返信できない」ではなく「故障に見えるので返信されない」+
「5秒ポーリングが404を叩き続ける」だった。

## 原因

`getMessages()`(chatHistoryRepository.ts)が「セッション不在」と
「本文0件」の両方を `[]` で返しており、呼び出し側 (`routes.ts`) が
`messages.length === 0` を一律404にしていた。

## 変更

- `chatHistoryRepository.ts` — `getMessages()` の戻り値を `ChatHistoryMessage[] | null` に。
  不在=`null` / 存在するが0件=`[]`。越境も `null` に倒す(IDの実在を漏らさない)。
  既存の所有権確認クエリの結果をそのまま使い、3本目のクエリは追加していない。
- `routes.ts` — `null`→404 / `[]`→200 `{messages:[], total:0}`。
- `actionExecutor.ts`(`get_chat_session_messages`) — 元々 `resolveSessionByShortId` で
  存在確認済みのため挙動は変わらず、型変更に伴う `null` ガードのみ追加。
- `escalations/[sessionId].tsx` — 本文0件を赤帯エラーにせず空状態表示に変更。
  返信欄・対応完了ボタンは有効なまま。エラー文言に次の行動を追記。
- `chat-history-api.test.ts` — 「`[]` を返したら404」という旧仕様を検証していた
  既存テストを新契約(0件→200 / null→404)に更新。

## 新規ファイル(いずれもテスト。ソース新規ファイルはなし)

- `src/api/admin/chat-history/chatHistoryRepository.messages.test.ts` — 既存テストが
  outcome/trafficSource/deleteSessionの3関心事に分割済みで getMessages を扱うものが無かった。
- `admin-ui/src/pages/admin/escalations/[sessionId].test.tsx` — 同ディレクトリにテストが無かった。

## Gate

- [x] Gate 1: `pnpm verify`(typecheck + jest 全パス。無関係な既存失敗2件は `git stash` で
      本PRの差分と無関係と確認済み — `avatar/routes.test.ts` の `fetchSpy.mockRestore`、
      および並列実行時の `agentRoutes.test.ts` タイムアウトは単体実行で解消)
- [x] Gate 1.5: dead-code-check(新規の dead export なし)
- [x] Gate 2: security-scan PASS(CRITICAL/HIGH 0)
- [x] Gate 3: backend build / admin-ui build 両方成功
- [x] vitest 6/6 pass(escalations detail page)
- [ ] Gate 2.5(Codex review)は未実行 — push前ステップのため、このPRの再確認をお願いします

## デプロイ順序の注意

バックエンド(`src/`)を先にVPS反映してから admin-ui をmergeすること。
逆順だとフロントが新レスポンス形を前提にして一時的に壊れる。

## Tier / merge

`src/**` および `admin-ui/src/**` に触るため Tier S。high-risk 対象、
hkobayashi の手動 merge が必要。auto-merge は要求していません。

同一ファイル(`escalations/[sessionId].tsx`)を後続タスク(IME誤送信修正・
ライトテーマ是正)が触るため、このPRのマージを先に済ませてから
それらのブランチを作成する必要があります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01My9XXuKXbnb8ca9xgDnEqj
