### PR TITLE
fix(admin-ui): プラン制限403を読み込み失敗/0件と誤表示しない

### DIFF
--- a/admin-ui/src/lib/planFeatures.test.ts
+++ b/admin-ui/src/lib/planFeatures.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { planHasFeature } from "./planFeatures";
+import { planHasFeature, isPlanUpgradeRequired } from "./planFeatures";
 
 describe("planHasFeature", () => {
   it.each([
@@ -32,5 +32,27 @@ describe("planHasFeature", () => {
   it("plan=null(未取得)は常にfalse(fail-safe)", () => {
     expect(planHasFeature(null, "avatar")).toBe(false);
     expect(planHasFeature(null, "conversion")).toBe(false);
+  });
+});
+
+describe("isPlanUpgradeRequired", () => {
+  it("error: plan_upgrade_required の本文で true", () => {
+    expect(isPlanUpgradeRequired({ error: "plan_upgrade_required", message: "..." })).toBe(true);
+  });
+
+  it("他のerror文字列では false", () => {
+    expect(isPlanUpgradeRequired({ error: "not_found" })).toBe(false);
+    expect(isPlanUpgradeRequired({ error: "forbidden" })).toBe(false);
+  });
+
+  it("null / undefined / 非オブジェクトでは false(例外を投げない)", () => {
+    expect(isPlanUpgradeRequired(null)).toBe(false);
+    expect(isPlanUpgradeRequired(undefined)).toBe(false);
+    expect(isPlanUpgradeRequired("plan_upgrade_required")).toBe(false);
+    expect(isPlanUpgradeRequired(42)).toBe(false);
+  });
+
+  it("空オブジェクトでは false", () => {
+    expect(isPlanUpgradeRequired({})).toBe(false);
   });
 });

--- a/admin-ui/src/lib/planFeatures.ts
+++ b/admin-ui/src/lib/planFeatures.ts
@@ -50,3 +50,16 @@ export function planHasFeature(plan: TenantPlan | null, feature: GatedFeature): 
   if (plan === null) return false;
   return PLAN_RANK[plan] >= PLAN_RANK[FEATURE_MIN_PLAN[feature]];
 }
+
+/**
+ * API応答が「プラン制限による403」かどうかを判定する。
+ * 403 plan_upgrade_required は正常系の分岐であり、エラーではない
+ * （読み込み失敗の赤帯や「0件」表示と混同しない。CLAUDE.md 絶対にやってはいけないこと 21）。
+ */
+export function isPlanUpgradeRequired(body: unknown): boolean {
+  return (
+    typeof body === "object" &&
+    body !== null &&
+    (body as { error?: unknown }).error === "plan_upgrade_required"
+  );
+}

--- a/admin-ui/src/pages/admin/analytics/index.test.tsx
+++ b/admin-ui/src/pages/admin/analytics/index.test.tsx
@@ -1,0 +1,135 @@
+// プラン制限(403)を「読み込み失敗」と誤表示しない回帰テスト
+// (2026-08-16 本番実機検証: starterプランのcarnationで /analytics/summary 等が
+//  403 plan_upgrade_required を返すのに画面は赤帯「データの読み込みに失敗しました」を表示していた)
+//
+// analyticsディレクトリにはこれまでテストが1本も無く、403/500の分岐が無言で戻っていた。
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, waitFor, screen } from '@testing-library/react';
+import { MemoryRouter } from 'react-router-dom';
+import AnalyticsDashboardPage from './index';
+import { useAuth } from '../../../auth/useAuth';
+import { authFetch } from '../../../lib/api';
+
+vi.mock('../../../auth/useAuth', () => ({
+  useAuth: vi.fn(),
+}));
+
+vi.mock('../../../lib/api', () => ({
+  API_BASE: 'http://localhost:3100',
+  authFetch: vi.fn(),
+}));
+
+// happy-dom は canvas 2d context を提供しないため、Chart.js を経由する
+// react-chartjs-2 のコンポーネントはテスト用スタブに差し替える(本番コードは触らない)。
+vi.mock('react-chartjs-2', () => ({
+  Line: () => null,
+  Bar: () => null,
+  Doughnut: () => null,
+  Radar: () => null,
+  Pie: () => null,
+}));
+
+const CLIENT_ADMIN = {
+  user: { id: '1', email: 'admin@carnation.example.com', role: 'client_admin', tenantId: 'carnation', tenantName: 'carnation' },
+  isSuperAdmin: false,
+  isClientAdmin: true,
+  isLoading: false,
+  logout: vi.fn(),
+  previewMode: false,
+  previewTenantId: null,
+  previewTenantName: null,
+  enterPreview: vi.fn(),
+  exitPreview: vi.fn(),
+};
+
+const mockStatus = (status: number, body: unknown): Promise<Response> =>
+  Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as Response);
+
+function renderPage() {
+  return render(
+    <MemoryRouter>
+      <AnalyticsDashboardPage />
+    </MemoryRouter>,
+  );
+}
+
+describe('AnalyticsDashboardPage — プラン制限(403)の表示', () => {
+  beforeEach(() => {
+    vi.mocked(useAuth).mockReturnValue(CLIENT_ADMIN as ReturnType<typeof useAuth>);
+    vi.mocked(authFetch).mockReset();
+  });
+
+  it('4本とも403 plan_upgrade_requiredのとき、赤帯を出さずプラン制限メッセージを表示する', async () => {
+    const PLAN_MSG = '高度なAnalyticsはGrowthプラン以上でご利用いただけます';
+    vi.mocked(authFetch).mockImplementation(() =>
+      mockStatus(403, { error: 'plan_upgrade_required', message: PLAN_MSG }),
+    );
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(new RegExp(PLAN_MSG))).toBeTruthy();
+    });
+    // このページ固有のエラー赤帯(「時間をおいて再試行してください」)が出ていないこと。
+    // FlowFunnelSectionは自前で「フロー遷移データの読み込みに失敗しました」を出すため
+    // (どのstatusでも常に出る・plan-limit非対応)、部分一致だと誤ってヒットする。
+    // 完全一致で本ページのエラー文言だけを見る。
+    expect(
+      screen.queryByText('データの読み込みに失敗しました。時間をおいて再試行してください。'),
+    ).toBeNull();
+    // 本ページのエラー赤帯にだけ付く再試行ボタンも出ていないこと
+    expect(screen.queryByRole('button', { name: '再試行' })).toBeNull();
+  });
+
+  it('500など通常のエラーでは「読み込みに失敗しました」+再試行を表示し、プラン制限メッセージは出さない', async () => {
+    vi.mocked(authFetch).mockImplementation(() => mockStatus(500, { error: 'internal_error' }));
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(
+        screen.getByText('データの読み込みに失敗しました。時間をおいて再試行してください。'),
+      ).toBeTruthy();
+    });
+    expect(screen.getByRole('button', { name: '再試行' })).toBeTruthy();
+    expect(screen.queryByText(/プランでご利用いただけます|プランのアップグレード/)).toBeNull();
+  });
+
+  it('一部のエンドポイントだけ403でも、200で取得できたデータは表示される(並列取得の分離)', async () => {
+    vi.mocked(authFetch).mockImplementation((url) => {
+      const u = String(url);
+      if (u.includes('/v1/admin/analytics/summary')) {
+        return mockStatus(200, {
+          period: '30d',
+          tenant_id: 'carnation',
+          total_sessions: 123,
+          avg_judge_score: null,
+          total_knowledge_gaps: 0,
+          avg_messages_per_session: 0,
+          avatar_session_count: 0,
+          avatar_rate: 0,
+          prev_total_sessions: 0,
+          sessions_change_pct: 0,
+          sentiment_distribution: { positive: 0, negative: 0, neutral: 0, total: 0 },
+          cv_count_30d: 0,
+          cv_total_value_30d: 0,
+          cv_types_breakdown: { purchase: 0, inquiry: 0, reservation: 0, signup: 0, other: 0 },
+          cv_fired_status: 'not_fired',
+          cv_days_since_first_session: null,
+        });
+      }
+      // trends/evaluations/conversions と、FlowFunnelSectionが独自に叩く flow-transitions は403
+      return mockStatus(403, { error: 'plan_upgrade_required', message: 'Growthプラン以上でご利用いただけます' });
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('123')).toBeTruthy();
+    });
+  });
+});

--- a/admin-ui/src/pages/admin/analytics/index.tsx
+++ b/admin-ui/src/pages/admin/analytics/index.tsx
@@ -16,6 +16,7 @@ import {
 } from "chart.js";
 import { authFetch, API_BASE } from "../../../lib/api";
 import { useAuth } from "../../../auth/useAuth";
+import { isPlanUpgradeRequired } from "../../../lib/planFeatures";
 import type {
   AnalyticsSummaryResponse,
   AnalyticsTrendsResponse,
@@ -66,6 +67,9 @@ export default function AnalyticsDashboardPage() {
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  // 403 plan_upgrade_required は正常系の分岐であり、error(赤帯)とは別の状態として持つ
+  // (CLAUDE.md 絶対にやってはいけないこと 21: 403を「読み込みに失敗しました」と混同しない)。
+  const [planLimitMessage, setPlanLimitMessage] = useState<string | null>(null);
 
   const tenantId = isSuperAdmin && !previewMode
     ? undefined
@@ -85,6 +89,7 @@ export default function AnalyticsDashboardPage() {
   const loadData = useCallback(async () => {
     setLoading(true);
     setError(null);
+    setPlanLimitMessage(null);
 
     const params = new URLSearchParams({ period });
     if (tenantId) params.set("tenant", tenantId);
@@ -98,14 +103,47 @@ export default function AnalyticsDashboardPage() {
         authFetch(`${API_BASE}/v1/admin/analytics/conversions?${params}`),
       ]);
 
-      if (!summaryRes.ok || !trendsRes.ok || !evalsRes.ok || !convRes.ok) {
-        throw new Error("データの読み込みに失敗しました");
-      }
+      // 各レスポンスを個別に判定する: 403 plan_upgrade_required は正常系の分岐であり
+      // 「読み込みに失敗しました」の赤帯にしない。1本が403でも残り3本の成功結果を
+      // 巻き込んで消さない(以前は !ok を1本でも検出すると全体を throw していた)。
+      let sawPlanLimit = false;
+      let planLimitText: string | null = null;
+      let sawGenericFailure = false;
 
-      setSummary((await summaryRes.json()) as AnalyticsSummaryResponse);
-      setTrends((await trendsRes.json()) as AnalyticsTrendsResponse);
-      setEvaluations((await evalsRes.json()) as AnalyticsEvaluationsResponse);
-      setConversion((await convRes.json()) as ConversionResponse);
+      const applyIfOk = async <T,>(res: Response, setter: (v: T) => void): Promise<void> => {
+        if (res.ok) {
+          setter((await res.json()) as T);
+          return;
+        }
+        let body: unknown = null;
+        try {
+          body = await res.json();
+        } catch {
+          // JSON化できない失敗は generic 扱いへ
+        }
+        if (isPlanUpgradeRequired(body)) {
+          sawPlanLimit = true;
+          planLimitText =
+            planLimitText ??
+            (body as { message?: string }).message ??
+            "この機能は現在のプランではご利用いただけません。プランのアップグレードをご検討ください。";
+        } else {
+          sawGenericFailure = true;
+        }
+      };
+
+      await Promise.all([
+        applyIfOk<AnalyticsSummaryResponse>(summaryRes, setSummary),
+        applyIfOk<AnalyticsTrendsResponse>(trendsRes, setTrends),
+        applyIfOk<AnalyticsEvaluationsResponse>(evalsRes, setEvaluations),
+        applyIfOk<ConversionResponse>(convRes, setConversion),
+      ]);
+
+      if (sawGenericFailure) {
+        setError("データの読み込みに失敗しました。時間をおいて再試行してください。");
+      } else if (sawPlanLimit) {
+        setPlanLimitMessage(planLimitText);
+      }
 
       // Phase68: ナレッジ貢献度（特定テナントが選ばれている場合のみ）
       const effectiveTenantId =
@@ -143,7 +181,7 @@ export default function AnalyticsDashboardPage() {
         setKnowledgeTop3AvgRate(null);
       }
     } catch {
-      setError("データの読み込みに失敗しました");
+      setError("データの読み込みに失敗しました。時間をおいて再試行してください。");
     } finally {
       setLoading(false);
     }
@@ -350,7 +388,7 @@ export default function AnalyticsDashboardPage() {
         setPeriod={setPeriod}
       />
 
-      {/* Error */}
+      {/* Error(読み込み失敗。403プラン制限はここに出さない） */}
       {error && (
         <div
           style={{
@@ -361,9 +399,48 @@ export default function AnalyticsDashboardPage() {
             border: "1px solid rgba(248,113,113,0.3)",
             color: "#fca5a5",
             fontSize: 15,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 12,
+            flexWrap: "wrap",
           }}
         >
-          {error}
+          <span>{error}</span>
+          <button
+            onClick={() => void loadData()}
+            style={{
+              padding: "8px 16px",
+              minHeight: 36,
+              borderRadius: 8,
+              border: "1px solid rgba(248,113,113,0.4)",
+              background: "transparent",
+              color: "#fca5a5",
+              fontSize: 13,
+              fontWeight: 600,
+              cursor: "pointer",
+              whiteSpace: "nowrap",
+            }}
+          >
+            再試行
+          </button>
+        </div>
+      )}
+
+      {/* プラン制限（正常系の分岐。エラーではないので赤帯にしない） */}
+      {!error && planLimitMessage && (
+        <div
+          style={{
+            marginBottom: 20,
+            padding: "14px 18px",
+            borderRadius: 12,
+            background: "var(--card)",
+            border: "1px solid var(--border)",
+            color: "var(--foreground)",
+            fontSize: 15,
+          }}
+        >
+          ✨ {planLimitMessage}
         </div>
       )}
 

--- a/admin-ui/src/pages/admin/conversion/index.test.tsx
+++ b/admin-ui/src/pages/admin/conversion/index.test.tsx
@@ -1,7 +1,7 @@
 // GID 1216277595663810 派生棚卸し: super_adminプレビューmode中に成約・効果分析ページも
 // テナントスコープされず全テナント横断データが表示されていた不具合の回帰テスト
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, waitFor } from '@testing-library/react';
+import { render, waitFor, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import ConversionDashboardPage from './index';
 import { useAuth } from '../../../auth/useAuth';
@@ -66,6 +66,75 @@ describe('ConversionDashboardPage — super_adminプレビューmodeのテナン
       );
       expect(expCall).toBeTruthy();
       expect(String(expCall![0])).toContain('tenant_id=lp-demo-avator');
+    });
+  });
+});
+
+// プラン制限(403)を「読み込み失敗」「0件」と誤表示しない回帰テスト
+// (2026-08-16 本番実機検証: starterプランのcarnationで /conversion/effectiveness が
+//  403 plan_upgrade_required を返すのに画面は「合計成約数 0」を平然と表示していた)
+const mockStatus = (status: number, body: unknown): Promise<Response> =>
+  Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    json: () => Promise.resolve(body),
+  } as Response);
+
+describe('ConversionDashboardPage — プラン制限(403)の表示', () => {
+  beforeEach(() => {
+    vi.mocked(useAuth).mockReturnValue(SUPER_ADMIN_PREVIEWING as ReturnType<typeof useAuth>);
+    vi.mocked(authFetch).mockReset();
+  });
+
+  it('3本とも403 plan_upgrade_requiredのとき「0」を描画せず、プラン制限メッセージを出す(赤帯は出さない)', async () => {
+    const PLAN_MSG = 'CV計測はGrowthプラン以上でご利用いただけます';
+    vi.mocked(authFetch).mockImplementation((url) => {
+      const u = String(url);
+      if (u.includes('/v1/admin/notifications')) return mockStatus(200, { notifications: [] });
+      return mockStatus(403, { error: 'plan_upgrade_required', message: PLAN_MSG });
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(new RegExp(PLAN_MSG))).toBeTruthy();
+    });
+    // 「合計成約数」のKPIカードに「0」という実データ風の値が出ていないこと
+    expect(screen.queryByText('0')).toBeNull();
+    // エラー赤帯(「読み込みに失敗しました」)は出ない — 403は正常系の分岐
+    expect(screen.queryByText(/読み込みに失敗しました/)).toBeNull();
+  });
+
+  it('500など通常のエラーでは「読み込みに失敗しました」+再試行を出し、プラン制限メッセージは出さない', async () => {
+    vi.mocked(authFetch).mockImplementation((url) => {
+      const u = String(url);
+      if (u.includes('/v1/admin/notifications')) return mockStatus(200, { notifications: [] });
+      return mockStatus(500, { error: 'internal_error' });
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText(/読み込みに失敗しました/)).toBeTruthy();
+    });
+    expect(screen.getByRole('button', { name: '再試行' })).toBeTruthy();
+    expect(screen.queryByText(/プランでご利用いただけます|プランのアップグレード/)).toBeNull();
+  });
+
+  it('一部だけ200・一部だけ403でも、200で取得できたデータは表示される(並列取得の分離)', async () => {
+    vi.mocked(authFetch).mockImplementation((url) => {
+      const u = String(url);
+      if (u.includes('/v1/admin/notifications')) return mockStatus(200, { notifications: [] });
+      if (u.includes('/v1/admin/conversion/attributions')) {
+        return mockStatus(200, { summary: { total: 7, by_type: {}, by_principle: {}, avg_temp_score: 42 } });
+      }
+      return mockStatus(403, { error: 'plan_upgrade_required', message: 'Growthプラン以上でご利用いただけます' });
+    });
+
+    renderPage();
+
+    await waitFor(() => {
+      expect(screen.getByText('7')).toBeTruthy();
     });
   });
 });

--- a/admin-ui/src/pages/admin/conversion/index.tsx
+++ b/admin-ui/src/pages/admin/conversion/index.tsx
@@ -7,6 +7,7 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { authFetch, API_BASE } from "../../../lib/api";
 import { useAuth } from "../../../auth/useAuth";
 import { useLang } from "../../../i18n/LangContext";
+import { isPlanUpgradeRequired } from "../../../lib/planFeatures";
 
 // ------------------------------------------------------------------ //
 // Types
@@ -109,6 +110,12 @@ export default function ConversionDashboardPage() {
   const [experiments, setExperiments] = useState<ABExperiment[]>([]);
   const [suggestions, setSuggestions] = useState<Array<{ description: string; suggestedAction: string; type: string }>>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  // 403 plan_upgrade_required は正常系の分岐であり、error(赤帯)とは別に持つ
+  // (CLAUDE.md 絶対にやってはいけないこと 21: 403を「読み込みに失敗しました」/「0件」と混同しない)。
+  const [planLimitMessage, setPlanLimitMessage] = useState<string | null>(null);
+  // A/Bテスト件数は experiments=[] だと「0件成功」と「未取得」を区別できないため専用フラグを持つ
+  const [expLoadFailed, setExpLoadFailed] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
   const period = (searchParams.get("period") ?? "30d") as "7d" | "30d" | "90d";
   const setPeriod = (p: "7d" | "30d" | "90d") => setSearchParams({ period: p }, { replace: true });
@@ -119,6 +126,8 @@ export default function ConversionDashboardPage() {
 
   const loadData = useCallback(async () => {
     setLoading(true);
+    setError(null);
+    setPlanLimitMessage(null);
     try {
       const [attrRes, effRes, expRes] = await Promise.all([
         authFetch(`${API_BASE}/v1/admin/conversion/attributions?period=${period}${tenantParam}`),
@@ -126,20 +135,49 @@ export default function ConversionDashboardPage() {
         authFetch(`${API_BASE}/v1/admin/ab/experiments?${isSuperAdmin ? '' : `tenant_id=${effectiveTenantId ?? ''}`}`),
       ]);
 
-      if (attrRes.ok) {
-        const data = await attrRes.json();
-        setSummary(data.summary);
-      }
-      if (effRes.ok) {
-        const data = await effRes.json();
-        setRankings(data.rankings ?? []);
-      }
-      if (expRes.ok) {
-        const data = await expRes.json();
-        setExperiments(data.experiments ?? []);
+      // 403 plan_upgrade_required は正常系の分岐(エラーではない)。それ以外の失敗だけを
+      // 「読み込み失敗」として扱う。いずれの失敗でも summary/experiments を [] や 0 のまま
+      // にしておくと「実績0件」と誤読されるため、成功したものだけ状態を更新する。
+      let sawPlanLimit = false;
+      let planLimitText: string | null = null;
+      let sawGenericFailure = false;
+
+      const handle = async (res: Response, onOk: (data: any) => void): Promise<void> => {
+        if (res.ok) {
+          onOk(await res.json());
+          return;
+        }
+        let body: unknown = null;
+        try {
+          body = await res.json();
+        } catch {
+          // JSON化できない失敗は generic 扱いへ
+        }
+        if (isPlanUpgradeRequired(body)) {
+          sawPlanLimit = true;
+          planLimitText =
+            planLimitText ??
+            (body as { message?: string }).message ??
+            "この機能は現在のプランではご利用いただけません。プランのアップグレードをご検討ください。";
+        } else {
+          sawGenericFailure = true;
+        }
+      };
+
+      await Promise.all([
+        handle(attrRes, (data) => setSummary(data.summary)),
+        handle(effRes, (data) => setRankings(data.rankings ?? [])),
+        handle(expRes, (data) => setExperiments(data.experiments ?? [])),
+      ]);
+      setExpLoadFailed(!expRes.ok);
+
+      if (sawGenericFailure) {
+        setError("データの読み込みに失敗しました。時間をおいて再試行してください。");
+      } else if (sawPlanLimit) {
+        setPlanLimitMessage(planLimitText);
       }
     } catch {
-      // ignore
+      setError("データの読み込みに失敗しました。時間をおいて再試行してください。");
     } finally {
       setLoading(false);
     }
@@ -205,12 +243,71 @@ export default function ConversionDashboardPage() {
         </div>
       </div>
 
+      {/* Error(読み込み失敗。403プラン制限はここに出さない） */}
+      {error && (
+        <div
+          style={{
+            marginBottom: 20,
+            padding: "14px 18px",
+            borderRadius: 12,
+            background: "rgba(127,29,29,0.4)",
+            border: "1px solid rgba(248,113,113,0.3)",
+            color: "#fca5a5",
+            fontSize: 15,
+            display: "flex",
+            alignItems: "center",
+            justifyContent: "space-between",
+            gap: 12,
+            flexWrap: "wrap",
+          }}
+        >
+          <span>{error}</span>
+          <button
+            onClick={() => void loadData()}
+            style={{
+              padding: "8px 16px",
+              minHeight: 36,
+              borderRadius: 8,
+              border: "1px solid rgba(248,113,113,0.4)",
+              background: "transparent",
+              color: "#fca5a5",
+              fontSize: 13,
+              fontWeight: 600,
+              cursor: "pointer",
+              whiteSpace: "nowrap",
+            }}
+          >
+            再試行
+          </button>
+        </div>
+      )}
+
+      {/* プラン制限（正常系の分岐。エラーではないので赤帯にしない） */}
+      {!error && planLimitMessage && (
+        <div
+          style={{
+            marginBottom: 20,
+            padding: "14px 18px",
+            borderRadius: 12,
+            background: "var(--card)",
+            border: "1px solid var(--border)",
+            color: "var(--foreground)",
+            fontSize: 15,
+          }}
+        >
+          ✨ {planLimitMessage}
+        </div>
+      )}
+
       {/* KPI Cards */}
       <div style={GRID4}>
-        <KpiCard label={t("conversion.total")} value={summary?.total ?? 0} />
+        <KpiCard label={t("conversion.total")} value={summary ? summary.total : "—"} />
         <KpiCard label={t("conversion.avg_temp")} value={summary ? `${summary.avg_temp_score}/100` : '-'} />
         <KpiCard label={t("conversion.top_principle")} value={topPrinciple} />
-        <KpiCard label="実施中A/Bテスト" value={experiments.filter((e) => e.status === 'running').length} />
+        <KpiCard
+          label="実施中A/Bテスト"
+          value={expLoadFailed ? "—" : experiments.filter((e) => e.status === 'running').length}
+        />
       </div>
 
       {/* Effectiveness Rankings */}


### PR DESCRIPTION
## Asana

(6/8) プラン制限(403)を「読み込み失敗」「成約0件」と表示する不具合

## 背景(本番実機検証 2026-08-16)

`GET /v1/admin/analytics/summary` 等は starter プランのテナントに対し
`403 {"error":"plan_upgrade_required","message":"..."}` を正しく返しているが、
フロント側の表示が2つとも壊れていた。

- 会話分析(`/admin/analytics`): 403も5xxも一律「データの読み込みに失敗しました」の赤帯
- 成約・効果分析(`/admin/conversion`): 403でも通知なく KPI カードに **実データ風の「0」** を描画
  (テナントは CV計測が動いていて実績0だと誤解する)

バックエンドのプランゲート自体は正しく機能しており、変更していません。

## 変更内容

- `admin-ui/src/lib/planFeatures.ts`: `isPlanUpgradeRequired(body)` を追加。
  既存の `planHasFeature` の隣に配置(プラン判定の単一責務ファイル)。
- `admin-ui/src/pages/admin/analytics/index.tsx`: 4本のAPI応答を個別判定。
  403は非エラーのプラン制限バナー(赤帯にしない)へ、それ以外の失敗のみ
  「読み込みに失敗しました」+ 再試行ボタンへ。1本が403でも残り3本の成功結果は
  引き続き表示される(旧実装は `!ok` を1本検出すると全体を throw していた)。
- `admin-ui/src/pages/admin/conversion/index.tsx`: 同様の403判定を追加。
  「合計成約数」「実施中A/Bテスト」は取得失敗時に `0` ではなく `—` を描画。
- テスト: `planFeatures.test.ts` に追記 / `conversion/index.test.tsx` に追記 /
  `analytics/index.test.tsx` を新規作成(このディレクトリにテストが1本も無かった)。

## Gate

- `pnpm verify`: admin-ui vitest **426/426 pass**
- Gate 1.5 (dead-code-check): 新規dead exportなし(既存の notion 関連4件のみ、無関係)
- Gate 2 (security-scan): **0 High/Critical**
- Gate 3 (build): root + admin-ui とも成功

backend jest は本サンドボックス環境固有の `EADDRNOTAVAIL`(エフェメラルポート割当)
で非決定的に失敗するテストがありましたが、diffは `admin-ui/src/` のみで backend は
無変更、失敗したテストファイルを単体で再実行するとすべて pass することを確認済みです
(環境要因、コード変更とは無関係)。

## 注意

Tier S(`admin-ui/src/` 変更)。**hkobayashi の手動マージが必要**です。auto-merge対象外。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01My9XXuKXbnb8ca9xgDnEqj
