### PR TITLE
fix(admin-ui): エスカレーション返信のIME誤送信を修正

### DIFF
--- a/admin-ui/src/pages/admin/escalations/[sessionId].test.tsx
+++ b/admin-ui/src/pages/admin/escalations/[sessionId].test.tsx
@@ -140,4 +140,51 @@ describe("EscalationDetailPage", () => {
     expect(await screen.findByText("担当します")).toBeTruthy();
     expect(screen.queryByText(/まだお客様の発言がありません/)).toBeNull();
   });
+
+  // CLAUDE.md 禁止事項2: IME/Enter判定を手書きしない。この重複は過去に
+  // 13日間の実バグを産んでいる。返信先はエンドユーザー(お客様)であり、
+  // 変換途中の文字列が送信されると取り消せない。
+  it("IME変換中のEnterでは送信されない(変換確定のEnterを誤送信しない)", async () => {
+    vi.mocked(authFetch).mockResolvedValue(jsonResponse(200, { messages: [], total: 0 }));
+
+    renderPage();
+    await screen.findByText(/まだお客様の発言がありません/);
+
+    const textarea = screen.getByPlaceholderText(/お客様への返信を入力してください/) as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "へんかんちゅう" } });
+    fireEvent.compositionStart(textarea);
+    fireEvent.keyDown(textarea, { key: "Enter", keyCode: 229 });
+
+    // 送信APIが叩かれていないこと(初回ロードの1回だけ)
+    expect(vi.mocked(authFetch)).toHaveBeenCalledTimes(1);
+  });
+
+  it("IME変換確定後のEnterでは送信される", async () => {
+    vi.mocked(authFetch).mockResolvedValue(jsonResponse(200, { messages: [], total: 0 }));
+
+    renderPage();
+    await screen.findByText(/まだお客様の発言がありません/);
+
+    const textarea = screen.getByPlaceholderText(/お客様への返信を入力してください/) as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "担当します" } });
+    fireEvent.compositionStart(textarea);
+    fireEvent.compositionEnd(textarea);
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    // 初回ロード(1回) + 返信POST(1回)
+    await vi.waitFor(() => expect(vi.mocked(authFetch)).toHaveBeenCalledTimes(2));
+  });
+
+  it("Shift+Enterでは送信されず改行として扱われる(既存挙動を維持)", async () => {
+    vi.mocked(authFetch).mockResolvedValue(jsonResponse(200, { messages: [], total: 0 }));
+
+    renderPage();
+    await screen.findByText(/まだお客様の発言がありません/);
+
+    const textarea = screen.getByPlaceholderText(/お客様への返信を入力してください/) as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "1行目" } });
+    fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
+
+    expect(vi.mocked(authFetch)).toHaveBeenCalledTimes(1);
+  });
 });

--- a/admin-ui/src/pages/admin/escalations/[sessionId].tsx
+++ b/admin-ui/src/pages/admin/escalations/[sessionId].tsx
@@ -6,6 +6,7 @@ import { useNavigate, useParams } from "react-router-dom";
 import { useLang } from "../../../i18n/LangContext";
 import LangSwitcher from "../../../components/LangSwitcher";
 import { authFetch, API_BASE } from "../../../lib/api";
+import { shouldSubmitOnEnter } from "../../../lib/utils";
 import { MessageList } from "../chat-history/MessageList";
 import type { Message } from "../chat-history/types";
 
@@ -23,6 +24,7 @@ export default function EscalationDetailPage() {
   const [sending, setSending] = useState(false);
   const [resolving, setResolving] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
+  const [isComposing, setIsComposing] = useState(false);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
   const locale = lang === "en" ? "en-US" : "ja-JP";
@@ -187,11 +189,13 @@ export default function EscalationDetailPage() {
           value={replyText}
           onChange={(e) => setReplyText(e.target.value)}
           onKeyDown={(e) => {
-            if (e.key === "Enter" && !e.shiftKey) {
+            if (shouldSubmitOnEnter(e, isComposing)) {
               e.preventDefault();
               void handleSend();
             }
           }}
+          onCompositionStart={() => setIsComposing(true)}
+          onCompositionEnd={() => setIsComposing(false)}
           placeholder="お客様への返信を入力してください..."
           rows={2}
           style={{


### PR DESCRIPTION
## 背景

`admin-ui/src/pages/admin/escalations/[sessionId].tsx` の返信欄が
`e.key === "Enter" && !e.shiftKey` を手書きしており、IME合成中かどうか
(`isComposing`)を見ていなかった。日本語変換の確定Enterで、変換途中の
文字列がそのままエンドユーザー(お客様)に送信されてしまう可能性がある。
送信先が顧客であるため取り消せず、実害は大きい。

CLAUDE.md 禁止事項2「IME/Enter判定を手書きしない。この重複は過去に
13日間の実バグを産んでいる」が名指ししている類の箇所。

## 変更

`admin-ui/src/pages/admin/escalations/[sessionId].tsx`
- `lib/utils.ts` の既存 `shouldSubmitOnEnter(e, isComposing)` に置換
  (`AdminAgentPanel.tsx` / `copilot-preview/index.tsx` と同じ形)。
- `isComposing` state と `onCompositionStart`/`onCompositionEnd` を追加。
- Shift+Enterでの改行は既存どおり維持。

新しい判定関数は作っていない。手書き判定を新規に増やしていない。

## ⚠️ 注意: このPRのbaseは main ではなく #751

本PRは #751 (`fix/escalation-empty-session-404`) の上に積んだスタック
ブランチ。同一ファイルを触るため、**#751 を先にマージしてから本PRをマージ**
すること。#751 マージ後、必要ならこのPRのbaseをmainに retarget してください。

## テスト

`[sessionId].test.tsx` に3件追加(既存6件+3件=9件、全pass):
- IME変換中のEnterで送信されない
- IME変換確定後のEnterで送信される
- Shift+Enterで送信されない(既存挙動維持)

## Gate

- [x] Gate 1: `pnpm verify`(root typecheck/lint/jest + admin-ui vitest 全pass、
      admin-ui vitest 32ファイル425件全pass)
- [x] Gate 1.5: dead-code-check(新規の dead export なし)
- [x] Gate 2: 対象外(admin-ui/src/**のみ、security-scan は #751 で確認済み範囲)
- [x] Gate 3: admin-ui build 成功
- [ ] Gate 2.5(Codex review)未実行 — レビューをお願いします

## Tier / merge

`admin-ui/src/**` のみ。Tier S、hkobayashi の手動 merge が必要。
auto-merge は要求していません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01My9XXuKXbnb8ca9xgDnEqj
