### PR TITLE
fix(admin-ui): ライトテーマで判読不能だった配色を是正

### DIFF
--- a/admin-ui/src/components/admin/KpiCard.tsx
+++ b/admin-ui/src/components/admin/KpiCard.tsx
@@ -20,10 +20,10 @@ export default function KpiCard({
       style={{
         flex: "1 1 260px",
         borderRadius: 14,
-        border: met ? "1px solid #1f2937" : "1px solid rgba(248,113,113,0.4)",
+        border: met ? "1px solid #1f2937" : "1px solid var(--destructive-border)",
         background: met
           ? "linear-gradient(145deg, rgba(15,23,42,0.95), rgba(15,23,42,0.7))"
-          : "linear-gradient(145deg, rgba(127,29,29,0.6), rgba(127,29,29,0.3))",
+          : "var(--destructive-surface)",
         padding: "20px 18px",
         minHeight: 56,
         display: "flex",
@@ -31,7 +31,7 @@ export default function KpiCard({
         gap: 8,
         boxShadow: met
           ? "0 4px 16px rgba(0,0,0,0.2)"
-          : "0 4px 20px rgba(239,68,68,0.2)",
+          : "0 4px 20px rgba(239,68,68,0.15)",
         transition: "all 0.2s ease",
       }}
     >
@@ -47,7 +47,7 @@ export default function KpiCard({
           style={{
             fontSize: 14,
             fontWeight: 600,
-            color: met ? "#9ca3af" : "#fca5a5",
+            color: met ? "#9ca3af" : "var(--destructive)",
             lineHeight: 1.3,
           }}
         >
@@ -59,8 +59,8 @@ export default function KpiCard({
             fontWeight: 700,
             padding: "3px 10px",
             borderRadius: 999,
-            background: met ? "rgba(34,197,94,0.15)" : "rgba(239,68,68,0.2)",
-            color: met ? "#4ade80" : "#f87171",
+            background: met ? "rgba(34,197,94,0.15)" : "var(--destructive-border)",
+            color: met ? "#4ade80" : "var(--destructive)",
             whiteSpace: "nowrap",
             flexShrink: 0,
           }}
@@ -81,7 +81,7 @@ export default function KpiCard({
           style={{
             fontSize: 32,
             fontWeight: 700,
-            color: met ? "#f9fafb" : "#fca5a5",
+            color: met ? "#f9fafb" : "var(--destructive)",
             lineHeight: 1,
           }}
         >
@@ -92,7 +92,7 @@ export default function KpiCard({
             style={{
               fontSize: 14,
               fontWeight: 500,
-              color: met ? "#9ca3af" : "#fca5a5",
+              color: met ? "#9ca3af" : "var(--destructive)",
             }}
           >
             {unit}
@@ -103,7 +103,7 @@ export default function KpiCard({
       <div
         style={{
           fontSize: 12,
-          color: met ? "#6b7280" : "#f87171",
+          color: met ? "#6b7280" : "var(--destructive)",
           marginTop: 2,
         }}
       >
@@ -114,8 +114,8 @@ export default function KpiCard({
         <div
           style={{
             fontSize: 12,
-            color: met ? "#6b7280" : "#fca5a5",
-            opacity: 0.8,
+            color: met ? "#6b7280" : "var(--destructive)",
+            opacity: met ? 0.8 : 0.9,
           }}
         >
           {description}

--- a/admin-ui/src/index.css
+++ b/admin-ui/src/index.css
@@ -45,6 +45,8 @@
   --accent:                 oklch(93% 0.03 240);
   --accent-foreground:      oklch(35% 0.08 240);
   --destructive:            oklch(54% 0.22 27);
+  --destructive-surface:    oklch(54% 0.22 27 / 0.08);
+  --destructive-border:     oklch(54% 0.22 27 / 0.35);
   --ring:                   oklch(52% 0.22 240);
 
   --sidebar:                oklch(97.5% 0.005 240);
@@ -75,6 +77,8 @@
   --accent:                 oklch(62% 0.22 240 / 0.15);
   --accent-foreground:      oklch(75% 0.15 240);
   --destructive:            oklch(60% 0.22 27);
+  --destructive-surface:    oklch(60% 0.22 27 / 0.18);
+  --destructive-border:     oklch(60% 0.22 27 / 0.4);
   --ring:                   oklch(62% 0.22 240);
 
   --card:                   oklch(17% 0.015 240);

--- a/admin-ui/src/pages/admin/chat-history/OutcomeSection.tsx
+++ b/admin-ui/src/pages/admin/chat-history/OutcomeSection.tsx
@@ -79,8 +79,8 @@ export function OutcomeSection({
               background:
                 outcome === value
                   ? "rgba(34,197,94,0.2)"
-                  : "rgba(31,41,55,0.5)",
-              color: outcome === value ? "#4ade80" : "#9ca3af",
+                  : "var(--muted)",
+              color: outcome === value ? "#4ade80" : "var(--muted-foreground)",
               fontSize: 15,
               fontWeight: outcome === value ? 700 : 500,
               cursor: outcomeSubmitting ? "not-allowed" : "pointer",

--- a/admin-ui/src/pages/admin/escalations/[sessionId].tsx
+++ b/admin-ui/src/pages/admin/escalations/[sessionId].tsx
@@ -145,7 +145,7 @@ export default function EscalationDetailPage() {
       </button>
 
       {error && (
-        <div style={{ marginBottom: 16, padding: "14px 18px", borderRadius: 12, background: "rgba(127,29,29,0.4)", border: "1px solid rgba(248,113,113,0.3)", color: "#fca5a5", fontSize: 15 }}>
+        <div style={{ marginBottom: 16, padding: "14px 18px", borderRadius: 12, background: "var(--destructive-surface)", border: "1px solid var(--destructive-border)", color: "var(--destructive)", fontSize: 15 }}>
           {error}
         </div>
       )}
@@ -242,7 +242,7 @@ export default function EscalationDetailPage() {
             borderRadius: 12,
             background: "rgba(15,23,42,0.95)",
             border: "1px solid var(--border)",
-            color: "var(--foreground)",
+            color: "#f9fafb",
             fontSize: 15,
             fontWeight: 600,
             boxShadow: "0 8px 32px rgba(0,0,0,0.5)",


### PR DESCRIPTION
## 背景

本番の実機検証で、ライトテーマ時にダーク画面前提の半透明色が使われている
箇所が「文字色と背景色の区別がつかない」状態になっていることを確認した。

## 変更(3ファイル + トークン追加)

- `components/admin/KpiCard.tsx` — 「未達成」危険カードの背景・文字色を、
  `index.css` に追加した `--destructive-surface` / `--destructive-border` と
  既存(未使用)の `--destructive` トークンに置換。
- `pages/admin/escalations/[sessionId].tsx` — エラー帯を同トークンに置換。
  **トースト通知は今回新規に発見した別の不具合**: 背景が
  `rgba(15,23,42,0.95)`(意図的に常時濃紺)なのに文字色が
  `var(--foreground)` でライトテーマだとほぼ黒になり実質見えなくなっていた。
  背景が固定色のため文字色も固定の明るい色(`#f9fafb`)に統一。
- `pages/admin/chat-history/OutcomeSection.tsx` — 未選択の成果ボタンを
  `var(--muted)` / `var(--muted-foreground)` に置換(灰地に灰文字を解消)。
- `admin-ui/src/index.css` — `--destructive-surface` / `--destructive-border`
  を light/dark 両方に追加。既存の `--accent` がダークモードで使っている
  oklchのアルファ構文と同じパターンを踏襲。新しい抽象化ではなく既存パターンの適用。

## ⚠️ スコープの是正(元タスクから変更)

元のタスクは `AvatarWizard.tsx` と `KnowledgeListTab.tsx` の「全選択」バーも
対象にしていたが、実装前に確認したところどちらも「常時ダーク固定のカード」
として内部で自己完結しており(文字色もその固定ダーク背景に対して選ばれている)、
ライトページに埋め込まれた際の視覚的な非統合感はあっても、**文字が読めなく
なるコントラスト不良ではなかった**。`AvatarWizard.tsx` は40箇所以上ハード
コード色があり、全面テーマ対応は「配色是正」の範囲を超える別タスク
(デザインレビュー付き)が妥当と判断し対象外とした。

## ⚠️ 注意: このPRのbaseは main ではなく #753

#751(3/8)→#753(4/8)→本PR(7/8)の順で同一ファイル
(`escalations/[sessionId].tsx`)をスタックしている。**#751→#753の順で
先にマージしてから本PR**をマージすること。

## Gate

- [x] Gate 1: admin-ui vitest 32ファイル425件 全pass、root lint 0新規警告(58/63)
- [x] Gate 1.5: dead-code-check(新規の dead export なし)
- [x] Gate 3: admin-ui build 成功
- [ ] Gate 2.5(Codex review)未実行 — レビューをお願いします
- [ ] 可能であればライト/ダーク双方の目視確認をお願いします(自動テスト対象外)

## Tier / merge

`admin-ui/src/**` のみ。Tier S、hkobayashi の手動 merge が必要。
auto-merge は要求していません。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01My9XXuKXbnb8ca9xgDnEqj
