### PR TITLE
fix(sai): get_sai_task_status のテナント所有権チェック欠落を是正

### DIFF
--- a/docs/DEPLOY_CHECKLIST.md
+++ b/docs/DEPLOY_CHECKLIST.md
@@ -114,6 +114,7 @@ VITE_SUPABASE_ANON_KEY=YOUR_ANON_KEY
 | `src/api/admin/feedback/migration_feedback_flagged.sql` | flagged_for_improvement カラム追加 + インデックス | 要適用 |
 | `src/api/admin/tenants/migration_phase_a.sql` | Phase A Day 2: tenants GA4/PostHog拡張 + notification_preferences + ga4_connection_logs + ga4_test_history + conversion_attributions拡張 | 要適用 |
 | `src/api/admin/avatar/migration_category_persona.sql` | LemonSliceペルソナスワップ: avatar_configs に category_persona_map(JSONB)追加 | 要適用 |
+| `src/lib/sai/migration_sai_tasks.sql` | Sai代行タスクの所有権レジストリ(sai_tasks)新設。get_sai_task_status の越境読み取り・課金誤帰属を止める (PR #755) | 要適用 |
 
 ### Phase A Day 2 migration 実行手順
 
@@ -148,6 +149,51 @@ INTERNAL_API_HMAC_SECRET=<random-256bit-secret>
 ```bash
 # VPS で実行:
 ssh root@65.108.159.161 "psql \$DATABASE_URL -f /opt/rajiuce/src/api/admin/feedback/migration_feedback_flagged.sql"
+```
+
+### sai_tasks migration 実行手順 (PR #755)
+
+**適用順序: デプロイ → migration。逆にはできない。**
+`migration_sai_tasks.sql` は rsync でVPSへ配布されるため、デプロイ前はVPS上にファイルが存在しない。
+
+この順序で安全な理由 — どの瞬間も現状より悪くならないため:
+
+| タイミング | `get_sai_task_status` の挙動 | 状態 |
+|---|---|---|
+| デプロイ前(現状) | 所有権照合なしで他テナントのタスクを読める | **脆弱** |
+| デプロイ後・migration前 | 照合先が無いため全件拒否 (fail-closed) | 安全・機能停止 |
+| migration後 | 依頼元テナントのタスクのみ読める | 安全・正常 |
+
+中間状態では進捗照会が「確認できませんでした」を返すのみで、依頼(`request_sai_task`)自体は通る。
+できるだけ短く畳むため、デプロイ直後に続けて実行すること。
+
+```bash
+# 1. デプロイ (唯一の手順)
+bash SCRIPTS/deploy-vps.sh
+
+# 2. バックアップ (必須)
+ssh root@65.108.159.161 "pg_dump \$DATABASE_URL > /opt/backups/pre_sai_tasks_\$(date +%Y%m%d_%H%M).sql"
+
+# 3. 適用前の確認 — 既に存在しないこと (存在するなら適用済み。二重実行は不要)
+ssh root@65.108.159.161 "psql \$DATABASE_URL -c \"\\d sai_tasks\""
+
+# 4. Migration 実行
+ssh root@65.108.159.161 "psql \$DATABASE_URL -f /opt/rajiuce/src/lib/sai/migration_sai_tasks.sql"
+
+# 5. 確認 — task_id(PK) / tenant_id(NOT NULL) / tenants(id)へのFK / インデックスが揃っていること
+ssh root@65.108.159.161 "psql \$DATABASE_URL -c \"\\d sai_tasks\""
+```
+
+**動作確認**: 管理画面のチャットで代行を1件依頼し、返ってきたタスクIDで進捗照会する。
+「確認できませんでした」が消え、状態が表示されれば適用成功。
+別テナントのタスクIDを渡すと「見つかりません」になる（「権限がありません」ではない）。
+
+**ロールバック**: 新規テーブルのみで既存テーブルへの変更が無いため、コードを戻せばテーブルは無害な残骸になる。
+テーブル自体を消す必要がある場合のみ以下。**コードが新しいままだと進捗照会が全件拒否に戻る**ので、
+必ずコードのロールバックとセットで行う。
+
+```bash
+ssh root@65.108.159.161 "psql \$DATABASE_URL -c 'DROP TABLE IF EXISTS sai_tasks;'"
 ```
 
 ## トラブルシューティング

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -37,6 +37,7 @@ import { getEvaluationsBySession } from '../evaluations/evaluationsRepository';
 import { computeKpis } from '../monitoring/routes';
 import { checkSaiMonthlyCostCeiling } from '../options/routes';
 import { submitSaiTask, getSaiTask } from '../../../lib/sai/saiClient';
+import { recordSaiTask, resolveSaiTaskTenant } from '../../../lib/sai/saiTaskRegistry';
 import { trackUsage } from '../../../lib/billing/usageTracker';
 import { queryTenantPlan, planHasFeature } from '../../../lib/billing/planFeatures';
 import { fetchAnalyticsSummary, fetchConversionSummary } from '../analytics/summaryQueries';
@@ -2796,6 +2797,23 @@ export async function executeToolCall(
         }
 
         const { task_id } = await submitSaiTask({ description });
+
+        // 所有権を記録してからでないと、あとで進捗を照会できない（照合先が無いと
+        // fail-closed で拒否される）。記録に失敗しても依頼自体は VPS 側で進行して
+        // いるため、成功を装わず「進捗確認ができない」ことを明示して返す。
+        const recorded = await recordSaiTask(db, {
+          taskId: task_id,
+          tenantId,
+          description,
+          requestedBy: actor.email || null,
+        });
+        if (!recorded) {
+          return truncate(
+            `Saiにタスクを依頼しました（タスクID: ${task_id}）。` +
+            'ただし依頼の記録に失敗したため、このタスクの進捗はチャットから確認できません。' +
+            'お手数ですが運営（R2Cサポート）にタスクIDをお伝えください',
+          );
+        }
         return truncate(`Saiにタスクを依頼しました（タスクID: ${task_id}）。get_sai_task_status で進捗を確認できます`);
       } catch (err: any) {
         if (err?.message === 'SAI_API_KEY not set') {
@@ -2811,6 +2829,30 @@ export async function executeToolCall(
       const taskId = String(args['task_id'] ?? '').trim();
       if (!taskId) {
         return truncate('task_id は必須です');
+      }
+      if (!tenantId) {
+        return truncate('テナントが特定できません。super_admin の場合は対象テナントを指定してください');
+      }
+
+      // 所有権照合。task_id は LLM/ユーザー由来の文字列なので、依頼元テナントと
+      // 一致しない限り Sai VPS へ問い合わせない（越境で status/outcome/last_action が
+      // 読め、さらに他テナント分のステップが自テナントに計上されてしまうため）。
+      // super_admin もバイパスしない — チャット経路は常に実効テナントスコープで動く
+      // （previewMode 中は isSuperAdmin のまま対象テナントを見ているため、
+      //   ここでロールを見ると preview の意味が壊れる）。
+      const owner = await resolveSaiTaskTenant(db, taskId);
+      if (owner.status === 'unavailable') {
+        return truncate(
+          'タスクの進捗を確認できませんでした。時間をおいて再度お試しいただくか、' +
+          '解消しない場合は運営（R2Cサポート）にご連絡ください',
+        );
+      }
+      // 越境は「権限がない」ではなく「不存在」に倒す（IDの実在を漏らさない）。
+      if (owner.status === 'not_found' || owner.tenantId !== tenantId) {
+        return truncate(
+          `タスクID「${taskId}」の依頼が見つかりません。IDをご確認のうえ、` +
+          'もう一度お知らせください',
+        );
       }
 
       try {

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -8318,7 +8318,23 @@ describe('POST /v1/admin/agent/chat', () => {
       });
     });
 
+    // sai_tasks レジストリ(所有権照合)の応答を SQL 内容で判定して返す。
+    // mockResolvedValueOnce のキューだと、他のクエリが先に消費した場合に
+    // 照合結果が undefined になり fail-closed へ倒れてテストが偽陽性になるため、
+    // 呼び出し順に依存しない形にする。
+    function seedSaiTaskOwners(owners: Record<string, string>) {
+      mockQuery.mockImplementation(async (sql: string, params?: unknown[]) => {
+        if (typeof sql === 'string' && sql.includes('FROM sai_tasks')) {
+          const taskId = Array.isArray(params) ? String(params[0]) : '';
+          const ownerTenantId = owners[taskId];
+          return { rows: ownerTenantId ? [{ tenant_id: ownerTenantId }] : [] };
+        }
+        return { rows: [] };
+      });
+    }
+
     it('client_admin: get_sai_task_status で状態と自己申告非信用の注記を返す', async () => {
+      seedSaiTaskOwners({ 'sai-task-99': 'tenant-abc' });
       mockFetch
         .mockResolvedValueOnce(toolCallResponse('get_sai_task_status', { task_id: 'sai-task-99' }))
         .mockResolvedValueOnce(makeGroqResponse('進捗を確認しました。'));
@@ -8340,6 +8356,7 @@ describe('POST /v1/admin/agent/chat', () => {
     });
 
     it('タスク完了時のみ、他のLLM機能と同じtrackUsage(sai_agent)でコストが計上される', async () => {
+      seedSaiTaskOwners({ 'sai-task-100': 'tenant-abc' });
       mockFetch
         .mockResolvedValueOnce(toolCallResponse('get_sai_task_status', { task_id: 'sai-task-100' }))
         .mockResolvedValueOnce(makeGroqResponse('完了しました。'));
@@ -8365,6 +8382,142 @@ describe('POST /v1/admin/agent/chat', () => {
           saiAgentSteps: 5,
         }),
       );
+    });
+
+    // -----------------------------------------------------------------------
+    // get_sai_task_status: テナント所有権
+    // task_id は LLM/ユーザー由来の文字列であり、所有権照合が無いと
+    // 他テナントのタスクの status/outcome/last_action が読め、さらに
+    // usage_logs.request_id がグローバルUNIQUE + ON CONFLICT DO NOTHING のため
+    // 他テナント分のステップが自テナントに計上され、正当な計上が消える。
+    // -----------------------------------------------------------------------
+    describe('get_sai_task_status: テナント所有権', () => {
+      it('他テナントが依頼したtask_idは「見つかりません」を返し、Sai VPSに到達しない', async () => {
+        seedSaiTaskOwners({ 'sai-task-other': 'tenant-zzz' });
+        mockFetch
+          .mockResolvedValueOnce(toolCallResponse('get_sai_task_status', { task_id: 'sai-task-other' }))
+          .mockResolvedValueOnce(makeGroqResponse('見つかりませんでした。'));
+
+        const res = await request(makeApp(CLIENT_ADMIN_USER))
+          .post('/v1/admin/agent/chat')
+          .send({ message: '進捗を教えて', sessionId: 'sess-sai-cross-01' });
+
+        expect(res.status).toBe(200);
+        const result = res.body.actions[0].result as string;
+        expect(result).toContain('見つかりません');
+        // 越境は「権限がない」ではなく「不存在」に倒す(IDの実在を漏らさない)
+        expect(result).not.toContain('権限');
+        expect(mockGetSaiTask).not.toHaveBeenCalled();
+        expect(mockTrackUsage).not.toHaveBeenCalledWith(
+          expect.objectContaining({ featureUsed: 'sai_agent' }),
+        );
+      });
+
+      it('記録の無いtask_idも「見つかりません」を返し、Sai VPSに到達しない', async () => {
+        seedSaiTaskOwners({});
+        mockFetch
+          .mockResolvedValueOnce(toolCallResponse('get_sai_task_status', { task_id: 'sai-task-unknown' }))
+          .mockResolvedValueOnce(makeGroqResponse('見つかりませんでした。'));
+
+        const res = await request(makeApp(CLIENT_ADMIN_USER))
+          .post('/v1/admin/agent/chat')
+          .send({ message: '進捗を教えて', sessionId: 'sess-sai-cross-02' });
+
+        expect(res.status).toBe(200);
+        expect(res.body.actions[0].result).toContain('見つかりません');
+        expect(mockGetSaiTask).not.toHaveBeenCalled();
+      });
+
+      it('sai_tasks 未マイグレーション時は fail-closed で Sai VPS に到達しない(不存在とは別文言)', async () => {
+        mockQuery.mockImplementation(async () => {
+          const err = new Error('relation "sai_tasks" does not exist') as Error & { code: string };
+          err.code = '42P01';
+          throw err;
+        });
+        mockFetch
+          .mockResolvedValueOnce(toolCallResponse('get_sai_task_status', { task_id: 'sai-task-99' }))
+          .mockResolvedValueOnce(makeGroqResponse('確認できませんでした。'));
+
+        const res = await request(makeApp(CLIENT_ADMIN_USER))
+          .post('/v1/admin/agent/chat')
+          .send({ message: '進捗を教えて', sessionId: 'sess-sai-cross-03' });
+
+        expect(res.status).toBe(200);
+        const result = res.body.actions[0].result as string;
+        expect(result).toContain('確認できませんでした');
+        expect(result).not.toContain('見つかりません');
+        expect(mockGetSaiTask).not.toHaveBeenCalled();
+      });
+
+      it('super_admin も previewMode の実効テナントで照合される(ロールでバイパスしない)', async () => {
+        seedSaiTaskOwners({ 'sai-task-other': 'tenant-zzz' });
+        mockFetch
+          .mockResolvedValueOnce(toolCallResponse('get_sai_task_status', { task_id: 'sai-task-other' }))
+          .mockResolvedValueOnce(makeGroqResponse('見つかりませんでした。'));
+
+        const res = await request(makeApp(SUPER_ADMIN_USER))
+          .post('/v1/admin/agent/chat')
+          .send({ message: '進捗を教えて', sessionId: 'sess-sai-cross-04', targetTenantId: 'tenant-abc' });
+
+        expect(res.status).toBe(200);
+        expect(res.body.actions[0].result).toContain('見つかりません');
+        expect(mockGetSaiTask).not.toHaveBeenCalled();
+      });
+    });
+
+    // -----------------------------------------------------------------------
+    // request_sai_task: 所有権の記録
+    // 記録が無いと後から進捗を照会できない(fail-closed で拒否される)ため、
+    // 「依頼できたが記録できなかった」を成功と同じ文言にしない。
+    // -----------------------------------------------------------------------
+    describe('request_sai_task: 所有権の記録', () => {
+      it('依頼元テナントと依頼内容が sai_tasks に記録される', async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [{ plan: 'enterprise' }] });
+        mockFetch
+          .mockResolvedValueOnce(toolCallResponse('request_sai_task', { description: '送料表記を直して', confirmed: true }))
+          .mockResolvedValueOnce(makeGroqResponse('依頼しました。'));
+
+        mockSubmitSaiTask.mockResolvedValueOnce({ task_id: 'sai-task-301', status: 'queued' });
+
+        const res = await request(makeApp(CLIENT_ADMIN_USER))
+          .post('/v1/admin/agent/chat')
+          .send({ message: '送料表記を直して', sessionId: 'sess-sai-reg-01' });
+
+        expect(res.status).toBe(200);
+        const insertCall = mockQuery.mock.calls.find(
+          (c) => typeof c[0] === 'string' && c[0].includes('INSERT INTO sai_tasks'),
+        );
+        expect(insertCall).toBeDefined();
+        expect(insertCall![1]).toEqual(
+          expect.arrayContaining(['sai-task-301', 'tenant-abc', '送料表記を直して']),
+        );
+        expect(res.body.actions[0].result).toContain('sai-task-301');
+      });
+
+      it('記録に失敗した場合は成功を装わず、進捗確認ができない旨とタスクIDを返す', async () => {
+        mockQuery.mockImplementation(async (sql: string) => {
+          if (typeof sql === 'string' && sql.includes('INSERT INTO sai_tasks')) {
+            const err = new Error('relation "sai_tasks" does not exist') as Error & { code: string };
+            err.code = '42P01';
+            throw err;
+          }
+          return { rows: [{ plan: 'enterprise' }] };
+        });
+        mockFetch
+          .mockResolvedValueOnce(toolCallResponse('request_sai_task', { description: '送料表記を直して', confirmed: true }))
+          .mockResolvedValueOnce(makeGroqResponse('依頼しました。'));
+
+        mockSubmitSaiTask.mockResolvedValueOnce({ task_id: 'sai-task-302', status: 'queued' });
+
+        const res = await request(makeApp(CLIENT_ADMIN_USER))
+          .post('/v1/admin/agent/chat')
+          .send({ message: '送料表記を直して', sessionId: 'sess-sai-reg-02' });
+
+        expect(res.status).toBe(200);
+        const result = res.body.actions[0].result as string;
+        expect(result).toContain('sai-task-302');
+        expect(result).toContain('確認できません');
+      });
     });
   });
 

--- a/src/api/admin/options/routes.ts
+++ b/src/api/admin/options/routes.ts
@@ -8,6 +8,7 @@ import { logger } from '../../../lib/logger';
 import { chargeOneOffJpy } from '../../../lib/billing/stripeSync';
 import { createNotification } from '../../../lib/notifications';
 import { submitSaiTask, getSaiTask } from '../../../lib/sai/saiClient';
+import { recordSaiTask } from '../../../lib/sai/saiTaskRegistry';
 import { trackUsage } from '../../../lib/billing/usageTracker';
 import {
   listSaiRules,
@@ -196,6 +197,17 @@ async function attemptSaiForOrder(
 
   try {
     const { task_id } = await submitSaiTask({ description, orderId: order.id, maxSteps });
+
+    // 所有権レジストリ（チャットの get_sai_task_status が照合する単一情報源）。
+    // option_orders.sai_task_id は試行のたびに上書きされ履歴を持たないため、
+    // 照合先には使えない。失敗しても発注フロー自体は止めない（super_admin の
+    // レビューは GET .../sai-task 経由で従来どおり到達できる）。
+    await recordSaiTask(pool, {
+      taskId: task_id,
+      tenantId: order.tenant_id,
+      description,
+      orderId: order.id,
+    });
 
     await pool
       .query(

--- a/src/api/admin/options/saiBridge.test.ts
+++ b/src/api/admin/options/saiBridge.test.ts
@@ -72,6 +72,10 @@ describe('POST /v1/admin/options/:id/try-sai', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // キュー(mockResolvedValueOnce)を使い切った後の既定値。undefined を返すと
+    // 呼び出し側の `pool.query(...).catch(...)` が TypeError になり、本来通るはずの
+    // 経路が502として観測されてしまうため、空の結果セットを既定にする。
+    mockQuery.mockResolvedValue({ rowCount: 0, rows: [] });
     // デフォルトは明示的に無制限('0')にしておき、上限そのものを検証したいテストだけが
     // 個別に上書き/未設定化する(GID 1216947740906009 で未設定時のデフォルト上限が有効化された
     // ため、上限チェックを意図しない既存テストへ副作用が及ぶのを防ぐ)。
@@ -116,6 +120,39 @@ describe('POST /v1/admin/options/:id/try-sai', () => {
     );
   });
 
+  it('sai_tasks に依頼元テナントを記録する(チャットの進捗照会が所有権を照合できるようにする)', async () => {
+    mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'order-1', tenant_id: 'tenant-x', description: 'FAQ登録代行' }] });
+    mockSubmitSaiTask.mockResolvedValueOnce({ task_id: 'sai-task-1', status: 'queued' });
+
+    await request(superAdminApp()).post('/v1/admin/options/order-1/try-sai').send({});
+
+    const insertCall = mockQuery.mock.calls.find(
+      (c) => typeof c[0] === 'string' && c[0].includes('INSERT INTO sai_tasks'),
+    );
+    expect(insertCall).toBeDefined();
+    // task_id / tenant_id / order_id / description の順に渡す
+    expect(insertCall![1]).toEqual(['sai-task-1', 'tenant-x', 'order-1', 'FAQ登録代行', null]);
+  });
+
+  it('sai_tasks への記録が失敗しても発注フロー自体は止めない(202を返す)', async () => {
+    mockQuery.mockImplementation(async (sql: string) => {
+      if (typeof sql === 'string' && sql.includes('INSERT INTO sai_tasks')) {
+        const err = new Error('relation "sai_tasks" does not exist') as Error & { code: string };
+        err.code = '42P01';
+        throw err;
+      }
+      if (typeof sql === 'string' && sql.includes('FROM option_orders')) {
+        return { rowCount: 1, rows: [{ id: 'order-1', tenant_id: 'tenant-x', description: 'FAQ登録代行' }] };
+      }
+      return { rowCount: 0, rows: [] };
+    });
+    mockSubmitSaiTask.mockResolvedValueOnce({ task_id: 'sai-task-1', status: 'queued' });
+
+    const res = await request(superAdminApp()).post('/v1/admin/options/order-1/try-sai').send({});
+
+    expect(res.status).toBe(202);
+  });
+
   it('Phase6: 承認済みルールが0件なら作業内容はそのまま渡す(現状のデフォルト挙動)', async () => {
     mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'order-1', tenant_id: 'tenant-x', description: 'FAQ登録代行' }] });
     mockSubmitSaiTask.mockResolvedValueOnce({ task_id: 'sai-task-1', status: 'queued' });
@@ -155,8 +192,9 @@ describe('POST /v1/admin/options/:id/try-sai', () => {
     const res = await request(superAdminApp()).post('/v1/admin/options/order-1/try-sai').send({});
 
     expect(res.status).toBe(202);
-    // env未設定でもデフォルト上限のチェックは行われる(発注SELECT+テナント上限SELECT+全体上限SELECT+UPDATE)
-    expect(mockQuery).toHaveBeenCalledTimes(4);
+    // env未設定でもデフォルト上限のチェックは行われる
+    // (発注SELECT+テナント上限SELECT+全体上限SELECT+sai_tasks INSERT+UPDATE)
+    expect(mockQuery).toHaveBeenCalledTimes(5);
   });
 
   it('env未設定でテナント使用量がデフォルト上限($50=5000セント)以上なら429で拒否される', async () => {
@@ -194,8 +232,9 @@ describe('POST /v1/admin/options/:id/try-sai', () => {
     const res = await request(superAdminApp()).post('/v1/admin/options/order-1/try-sai').send({});
 
     expect(res.status).toBe(202);
-    // 明示的に0を渡すと上限チェックSELECTは発火しない(発注SELECT+UPDATEのみ)
-    expect(mockQuery).toHaveBeenCalledTimes(2);
+    // 明示的に0を渡すと上限チェックSELECTは発火しない
+    // (発注SELECT+sai_tasks INSERT+UPDATEのみ)
+    expect(mockQuery).toHaveBeenCalledTimes(3);
   });
 
   it('月次コスト上限に達している場合は429を返しSaiに依頼しない', async () => {

--- a/src/lib/sai/migration_sai_tasks.sql
+++ b/src/lib/sai/migration_sai_tasks.sql
@@ -1,0 +1,31 @@
+-- Sai代行タスクの所有権レジストリ
+--
+-- 目的: task_id から「依頼したテナント」を解決する単一情報源。
+-- これが無かったため get_sai_task_status は所有権を照合できず、
+-- 任意の task_id を Sai VPS へそのまま転送していた（越境読み取り + 課金の誤帰属）。
+--
+-- なぜ option_orders に相乗りしないか:
+--   チャット起点(request_sai_task)の依頼は「発注(option_orders)」ではない。
+--   発注行を作ると super_admin の代行作業キュー・請求フローに実在しない発注が混ざる。
+--   逆に option_orders.sai_task_id は「最後に試行したタスク」を保持する列であり
+--   （試行のたびに上書き・履歴を持たない）、所有権の照合先には使えない。
+--   したがって両経路が共通して書き込む専用レジストリを置く。
+--
+-- 参照制約は option_orders と同じ規約に合わせる（tenants(id) への FK）。
+
+CREATE TABLE IF NOT EXISTS sai_tasks (
+  task_id TEXT PRIMARY KEY,                    -- Sai VPS が採番したタスクID
+  tenant_id TEXT NOT NULL,                     -- 依頼元テナント。所有権照合の唯一の根拠
+  order_id UUID,                               -- option_orders 経由の場合のみ。チャット起点は NULL
+  description TEXT NOT NULL,                   -- 依頼内容（監査証跡。従来どこにも残っていなかった）
+  requested_by TEXT,                           -- 依頼した管理ユーザーのメール。不明時は NULL
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  CONSTRAINT fk_sai_tasks_tenant FOREIGN KEY (tenant_id) REFERENCES tenants(id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_sai_tasks_tenant ON sai_tasks(tenant_id, created_at DESC);
+
+COMMENT ON TABLE sai_tasks IS 'Sai代行タスクの所有権レジストリ。get_sai_task_status の越境防止に使う';
+COMMENT ON COLUMN sai_tasks.tenant_id IS '依頼元テナント。この列との一致が唯一の閲覧許可条件';
+COMMENT ON COLUMN sai_tasks.order_id IS 'option_orders 経由の依頼のみ設定。チャット起点(request_sai_task)は NULL';
+COMMENT ON COLUMN sai_tasks.description IS '依頼内容の監査証跡。チャット起点の依頼は従来どこにも記録が残らなかった';

--- a/src/lib/sai/saiTaskRegistry.test.ts
+++ b/src/lib/sai/saiTaskRegistry.test.ts
@@ -1,0 +1,96 @@
+// src/lib/sai/saiTaskRegistry.test.ts
+// Sai代行タスク所有権レジストリの単体テスト。
+// 「不存在」「照合不能(migration未適用)」「越境」を別々に固定する。
+
+import type { Pool } from 'pg';
+import { recordSaiTask, resolveSaiTaskTenant } from './saiTaskRegistry';
+
+function makePool(impl: (sql: string, params?: unknown[]) => unknown): Pool {
+  return { query: jest.fn(impl as any) } as unknown as Pool;
+}
+
+function pgError(code: string): Error & { code: string } {
+  const err = new Error(`pg error ${code}`) as Error & { code: string };
+  err.code = code;
+  return err;
+}
+
+describe('saiTaskRegistry', () => {
+  describe('recordSaiTask', () => {
+    it('task_id・tenant_id・依頼内容を記録し true を返す', async () => {
+      const pool = makePool(() => ({ rows: [], rowCount: 1 }));
+
+      const ok = await recordSaiTask(pool, {
+        taskId: 'task-1',
+        tenantId: 'tenant-a',
+        description: '送料表記を直して',
+        requestedBy: 'admin@example.com',
+      });
+
+      expect(ok).toBe(true);
+      const [sql, params] = (pool.query as jest.Mock).mock.calls[0];
+      expect(sql).toContain('INSERT INTO sai_tasks');
+      expect(params).toEqual(['task-1', 'tenant-a', null, '送料表記を直して', 'admin@example.com']);
+    });
+
+    it('option_orders 経由は order_id を保持する', async () => {
+      const pool = makePool(() => ({ rows: [], rowCount: 1 }));
+
+      await recordSaiTask(pool, {
+        taskId: 'task-2',
+        tenantId: 'tenant-a',
+        description: 'FAQ登録代行',
+        orderId: 'order-9',
+      });
+
+      const [, params] = (pool.query as jest.Mock).mock.calls[0];
+      expect(params[2]).toBe('order-9');
+      expect(params[4]).toBeNull();
+    });
+
+    it('sai_tasks 未マイグレーション(42P01)でも例外を投げず false を返す', async () => {
+      const pool = makePool(() => { throw pgError('42P01'); });
+
+      await expect(
+        recordSaiTask(pool, { taskId: 't', tenantId: 'tenant-a', description: 'x' }),
+      ).resolves.toBe(false);
+    });
+
+    it('DB障害でも例外を投げず false を返す（依頼はVPS側で進行済みのため）', async () => {
+      const pool = makePool(() => { throw pgError('08006'); });
+
+      await expect(
+        recordSaiTask(pool, { taskId: 't', tenantId: 'tenant-a', description: 'x' }),
+      ).resolves.toBe(false);
+    });
+  });
+
+  describe('resolveSaiTaskTenant', () => {
+    it('記録があれば ok と依頼元テナントを返す', async () => {
+      const pool = makePool(() => ({ rows: [{ tenant_id: 'tenant-a' }], rowCount: 1 }));
+
+      await expect(resolveSaiTaskTenant(pool, 'task-1')).resolves.toEqual({
+        status: 'ok',
+        tenantId: 'tenant-a',
+      });
+    });
+
+    it('記録が無ければ not_found を返す（unavailable と区別する）', async () => {
+      const pool = makePool(() => ({ rows: [], rowCount: 0 }));
+
+      await expect(resolveSaiTaskTenant(pool, 'task-x')).resolves.toEqual({ status: 'not_found' });
+    });
+
+    it('sai_tasks 未マイグレーション(42P01)は unavailable を返す（fail-closed、not_found に丸めない）', async () => {
+      const pool = makePool(() => { throw pgError('42P01'); });
+
+      await expect(resolveSaiTaskTenant(pool, 'task-1')).resolves.toEqual({ status: 'unavailable' });
+    });
+
+    it('DB障害も unavailable を返す（照合できない＝許可しない）', async () => {
+      const pool = makePool(() => { throw pgError('08006'); });
+
+      await expect(resolveSaiTaskTenant(pool, 'task-1')).resolves.toEqual({ status: 'unavailable' });
+    });
+  });
+});

--- a/src/lib/sai/saiTaskRegistry.ts
+++ b/src/lib/sai/saiTaskRegistry.ts
@@ -1,0 +1,89 @@
+// src/lib/sai/saiTaskRegistry.ts
+// Sai代行タスクの所有権レジストリ。詳細は migration_sai_tasks.sql を参照。
+//
+// 背景: get_sai_task_status は LLM/ユーザーが渡した task_id を所有権照合なしで
+// Sai VPS に転送していた。tenantId は同じスコープにあるのに使われておらず、
+// 他テナントのタスクの status/steps/outcome/last_action が読め、さらに
+// usage_logs.request_id がグローバル UNIQUE + ON CONFLICT DO NOTHING のため
+// 「先に叩いたテナントに課金され、正当な計上は黙って消える」状態だった。
+//
+// db は必ず呼び出し元から注入する（getPool() を内部で呼ぶとテストのモックPoolと
+// 食い違う — CLAUDE.md の既知の罠）。
+
+import type { Pool } from 'pg';
+import { logger } from '../logger';
+
+export interface RecordSaiTaskParams {
+  taskId: string;
+  tenantId: string;
+  description: string;
+  orderId?: string | null;
+  requestedBy?: string | null;
+}
+
+/**
+ * task_id の所有権解決結果。
+ *
+ * 「不存在」と「照合できない」を同じ値で表現しない（CLAUDE.md 禁止事項20）。
+ * unavailable は migration 未適用・DB障害であり、呼び出し元は fail-closed で
+ * 拒否しつつ、ユーザーには不存在とは別の文言を出す必要がある。
+ */
+export type SaiTaskOwnerLookup =
+  | { status: 'ok'; tenantId: string }
+  | { status: 'not_found' }
+  | { status: 'unavailable' };
+
+/**
+ * Sai へ投入したタスクの所有権を記録する。
+ *
+ * 投入(submitSaiTask)は既に成功している前提で呼ばれるため、記録の失敗で例外を
+ * 投げない。ただし「記録に失敗したのに処理が進んだと表示しない」ため false を返し、
+ * 呼び出し元はユーザーに進捗確認ができない旨を伝えること。
+ */
+export async function recordSaiTask(db: Pool, params: RecordSaiTaskParams): Promise<boolean> {
+  try {
+    await db.query(
+      `INSERT INTO sai_tasks (task_id, tenant_id, order_id, description, requested_by)
+       VALUES ($1, $2, $3, $4, $5)
+       ON CONFLICT (task_id) DO NOTHING`,
+      [
+        params.taskId,
+        params.tenantId,
+        params.orderId ?? null,
+        params.description,
+        params.requestedBy ?? null,
+      ],
+    );
+    return true;
+  } catch (err: any) {
+    if (err?.code === '42P01') {
+      logger.warn(
+        { taskId: params.taskId },
+        '[saiTaskRegistry] sai_tasks not migrated yet — task ownership will not be verifiable',
+      );
+    } else {
+      logger.warn({ err, taskId: params.taskId }, '[saiTaskRegistry] recordSaiTask failed');
+    }
+    return false;
+  }
+}
+
+/** task_id を依頼元テナントに解決する。照合できない場合は not_found と区別して unavailable を返す。 */
+export async function resolveSaiTaskTenant(db: Pool, taskId: string): Promise<SaiTaskOwnerLookup> {
+  try {
+    const result = await db.query<{ tenant_id: string }>(
+      `SELECT tenant_id FROM sai_tasks WHERE task_id = $1`,
+      [taskId],
+    );
+    const row = result.rows[0];
+    if (!row) return { status: 'not_found' };
+    return { status: 'ok', tenantId: row.tenant_id };
+  } catch (err: any) {
+    if (err?.code === '42P01') {
+      logger.warn('[saiTaskRegistry] sai_tasks not migrated yet — denying task status lookup (fail-closed)');
+    } else {
+      logger.warn({ err }, '[saiTaskRegistry] resolveSaiTaskTenant failed');
+    }
+    return { status: 'unavailable' };
+  }
+}


### PR DESCRIPTION
Asana: https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217532704928358

## 何が起きていたか

`get_sai_task_status` が LLM/ユーザー由来の `task_id` を所有権照合なしで Sai VPS へ転送していた。
`tenantId` は同じスコープに存在するのに使われていない。

```ts
const taskId = String(args['task_id'] ?? '').trim();
if (!taskId) return truncate('task_id は必須です');
const task = await getSaiTask(taskId);   // option_orders との照合ゼロ
```

帰結は2つ。

1. **越境読み取り** — 他テナントのタスクの `status` / `steps` / `outcome` / `last_action` が返る。
   `last_action` は他テナント管理画面上の操作内容を含む。
2. **課金の誤帰属** — `requestId` が `sai-agent-request:taskId` 固定で、`usage_logs.request_id` は
   グローバル UNIQUE + `ON CONFLICT DO NOTHING`。先に他テナントのタスクを叩いたテナントに課金され、
   正当な計上は黙って握り潰される。悪意がなくても成立する。

実際に踏めるかは task_id のエントロピー（VPS 側の採番規則）に依存するため、そこは断定しない。
所有権チェックが1枚も無いこと自体が問題。

## なぜ単純に条件を足せなかったか

チャット起点の `request_sai_task` は `submitSaiTask` を呼んで task_id を返すだけで、
**どこにも永続化していなかった**。発注経路の `attemptSaiForOrder` が `option_orders.sai_task_id` を
UPDATE するのと非対称で、照合先そのものが存在しない。依頼内容の監査証跡も残っていない。

## 変更内容

- `sai_tasks` レジストリを新設。チャット/発注の両経路から書き込む所有権の単一情報源にする。
  `option_orders.sai_task_id` は試行のたびに上書きされ履歴を持たないため照合先には使えない。
- `get_sai_task_status` を所有権照合つきにする。
  - 越境は「権限がない」ではなく **「不存在」** に倒す（ID の実在を漏らさない）
  - super_admin もバイパスしない。previewMode 中はロールが super_admin のままなので、
    ここでロールを見ると preview の意味が壊れる（チャット経路は常に実効テナントスコープ）
  - レジストリが引けない場合（migration 未適用・DB障害）は **fail-closed**。不存在とは別文言
- 記録に失敗した場合は成功を装わず、進捗確認ができない旨とタスクIDを返す。

### やらなかったこと

`requestId` へのテナント付与は入れていない。所有権照合により task_id とテナントが 1 対 1 になるため
不要になる一方、書式変更は在庫タスクの二重課金リスクを生むため。

## 適用順の注意

`src/lib/sai/migration_sai_tasks.sql` は hkobayashi の手動適用が必要（不可逆操作のため自動実行しない）。

**順序は「反映 → migration」の一方向。** SQL はファイル同期で配布されるため、反映前はVPS上に存在せず
逆順にはできない。当初「migration を先に」と書いていたが誤りだったため訂正した。

この順序で安全な理由 — どの瞬間も現状より悪くならない:

| タイミング | `get_sai_task_status` | 状態 |
|---|---|---|
| 反映前(現状) | 所有権照合なしで他テナントのタスクを読める | **脆弱** |
| 反映後・migration前 | 照合先が無いため全件拒否 (fail-closed) | 安全・機能停止 |
| migration後 | 依頼元テナントのタスクのみ読める | 安全・正常 |

中間状態でも依頼(`request_sai_task`)自体は通り、進捗照会だけが止まる。
手順・バックアップ・確認・ロールバックは `docs/DEPLOY_CHECKLIST.md` に追記済み。

## テスト

追加16本、いずれも新規:

- `saiTaskRegistry.test.ts` 8本 — 記録 / order_id 保持 / 42P01 / DB障害、および
  「不存在(`not_found`)」と「照合不能(`unavailable`)」を別々に固定
- `agentRoutes.test.ts` 6本 — 越境 / 記録なし / fail-closed / previewMode の super_admin /
  記録の成功・失敗
- `saiBridge.test.ts` 2本 — 発注経路の記録、記録失敗でも発注フローは止まらない

越境・fail-closed の各ケースで **Sai VPS に到達しないこと**（`mockGetSaiTask` 未呼び出し）を固定している。

## Gate

- Gate 1 `pnpm verify`: typecheck 0 / lint 既存warningのみ / test 3471 passed
  - 1件の 5秒タイムアウト失敗が出るが、**main でも毎回別スイートで再現する既存の並列フレーク**
    （main: chatTestAuthGuard、本ブランチ: avatarGenerationAuthGuard など）。単独実行では全て通る
  - 補足: Node 26 で回すと 466件失敗する。`engines` は node 20.x 指定で、Node 20 では 1件のみ
- Gate 1.5 dead-code: 既存4件(notionSchemas)のみ、本PR由来なし
- Gate 2 security-scan: CRITICAL/HIGH 0、PASS
- Gate 3 build: 成功（admin-ui は未変更のため対象外）

## 未確認・別件

Sai VPS が出店者としてどう認証するか、タスク間でブラウザプロファイルを破棄するかは本リポジトリ外。
**テナント識別子は往路にも復路にも構造化データとして到達していない**ことは確認済み
（Hermes MCP は専用 inbound + 同意チェックを持つ対照例）。本PRはその調査とは独立して、
リポジトリ内で確定した欠陥のみを直している。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012Brpajn8JvzmHbgNnSozuz
