### PR TITLE
fix(scripts): post-deploy-smoke.shがCDN検証で無言終了する不具合を修正

### DIFF
--- a/SCRIPTS/post-deploy-smoke.sh
+++ b/SCRIPTS/post-deploy-smoke.sh
@@ -69,7 +69,12 @@ check "Admin UI" "$ADMIN_URL"
 admin_html=$(curl -s --max-time 10 "$ADMIN_URL" 2>/dev/null || echo "")
 admin_js_path=$(echo "$admin_html" | grep -oE '/assets/[A-Za-z0-9_.-]+\.js' | head -1)
 if [ -n "$admin_js_path" ]; then
-  admin_js_body_head=$(curl -s --max-time 10 "$ADMIN_URL$admin_js_path" 2>/dev/null | head -c 1)
+  # `curl | head -c 1` は head がパイプを閉じた後も curl が本体(数百KB〜)を
+  # 送り続けようとして SIGPIPE を受け、set -e + pipefail 下ではその場で
+  # スクリプト全体が無言で落ちる(以降の全チェックが未実行になる)。
+  # HTTP Range で1バイトだけをサーバに要求すれば、ローカルのパイプ切断も
+  # 大きな本体のダウンロードも発生しない。
+  admin_js_body_head=$(curl -s --max-time 10 -r 0-0 "$ADMIN_URL$admin_js_path" 2>/dev/null || echo "")
   if [ "$admin_js_body_head" = "<" ]; then
     echo "  ❌ Admin UI asset ($admin_js_path) body starts with '<' — CDNキャッシュ破損の疑い(HTMLが返っている)"
     FAIL=$((FAIL + 1))


### PR DESCRIPTION
## 背景

今回のデプロイ(#748〜#754反映)で「Some smoke tests failed (non-blocking)」
と表示されたが、実際には全項目が正常だった。原因調査の結果、デプロイ自体
ではなく `SCRIPTS/post-deploy-smoke.sh` 側の既存バグと判明した(私の今回の
PR群とは無関係、以前から存在)。

## 原因

CDNキャッシュ破損検知(PR #487対応)の実装が

```
curl -s "$url" | head -c 1
```

という形になっており、本体(JSアセット、数百KB)を1バイトだけ読んで
`head` がパイプを閉じるため、まだ書き込み中の `curl` が SIGPIPE を受けて
非ゼロ終了する。`set -euo pipefail` 下ではこの時点でスクリプト全体が
**無言で即終了**し、以降のチェック(デモページ・監視系メトリクス3件・
常駐プロセスの稼働状態確認)が一度も実行されないまま「失敗」扱いになっていた。

再現(修正前):
```
$ bash SCRIPTS/post-deploy-smoke.sh
  ✅ API /health — 200
  ...
  ✅ Admin UI — 200
(ここで無言停止、exit 56)
```

## 修正

HTTP Range(`-r 0-0`)でサーバ側に1バイトだけを要求する形に変更。
ローカルのパイプ切断が発生しないため SIGPIPE が起きない。
本番(Cloudflare Pages)で `206 Partial Content` ・1バイトが返ることを確認済み。

## 検証

修正後、本番に対して実行し **11/11 pass・exit 0** を確認。

```
$ bash SCRIPTS/post-deploy-smoke.sh
  ✅ API /health — 200
  ✅ Health body.status = ok
  ✅ Widget JS — 200
  ✅ Widget JS content-type: javascript
  ✅ Admin UI — 200
  ✅ Admin UI asset (...) — JS本文を確認
  ✅ Demo page — 200
  ✅ Metrics — 200 (localhost on VPS)
  ✅ /metrics public spoof denied — 403
  ✅ /metrics via nginx loopback — 200
  ✅ rajiuce-avatar — online

=== Results: 11 passed, 0 failed ===
```

## スコープ

他に2箇所、同種のパイプパターン(53行目のヘッダ取得、70行目の変数からの
抽出)があるが、いずれも小さいデータ(HTTPヘッダ / メモリ上の変数)を
相手にしており、SIGPIPEが起きる条件(大きな本体を送信中に受信側が早期に
パイプを閉じる)に当たらず実害も出ていないため対象外とした(Surgical Changes)。

新規テストファイルは作成していない。このスクリプト自体が本番への
ライブ検証ツールであり、今回の修正確認も本番に対する実行(11/11 pass)で
行っている。既存の `SCRIPTS/*.test.sh` パターン(全150+スクリプト中1件のみ)
は複雑な判定ロジックを持つスクリプト向けで、この単純なネットワーク
チェックスクリプトには不釣り合いと判断した。

## Gate

- [x] `bash -n` 構文チェック OK
- [x] `bash SCRIPTS/security-scan.sh` PASS(CRITICAL/HIGH 0、既存の無関係な警告1件のみ)
- [x] 本番に対する実行で 11/11 pass 確認
- 対象が `SCRIPTS/*.sh` のみのため typecheck/jest/build は対象外

## Tier / merge

`SCRIPTS/**` のみの変更のため Tier B(低リスク、auto-merge対象)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01My9XXuKXbnb8ca9xgDnEqj
