### PR TITLE
test: 直近の修正7件のテストを強化(境界値・イレギュラー操作)

### DIFF
--- a/admin-ui/src/components/admin/KpiCard.test.tsx
+++ b/admin-ui/src/components/admin/KpiCard.test.tsx
@@ -1,0 +1,82 @@
+// admin-ui/src/components/admin/KpiCard.test.tsx
+// システム稼働状況の「未達成」カードが、ライトテーマで背景色と文字色の区別が
+// つかなくなっていた不具合(2026-08-16, PR #754)の回帰テスト。
+// ダーク画面前提の半透明色(rgba(127,29,29,*) + #fca5a5)から、
+// index.css の --destructive / --destructive-surface / --destructive-border
+// トークンへ置換した。ハードコード色への先祖返りをここで検知する。
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import KpiCard from "./KpiCard";
+
+const BASE_PROPS = {
+  name: "会話完了率",
+  value: "67.1",
+  unit: "%",
+  threshold: "70% 以上",
+};
+
+describe("KpiCard", () => {
+  it("met=true のとき「達成」バッジを表示する", () => {
+    render(<KpiCard {...BASE_PROPS} met description="お客様との会話が正常に完了した割合" />);
+    expect(screen.getByText("達成")).toBeTruthy();
+    expect(screen.queryByText("未達成")).toBeNull();
+  });
+
+  it("met=false のとき「未達成」バッジを表示する", () => {
+    render(<KpiCard {...BASE_PROPS} met={false} />);
+    expect(screen.getByText("未達成")).toBeTruthy();
+    expect(screen.queryByText("達成")).toBeNull();
+  });
+
+  // 壊れやすいポイント: 誰かがこのファイルを直すときに、CSS変数を
+  // ハードコードのrgba/hexへ書き戻してしまう(過去に実際に起きた不具合そのもの)。
+  // ライトテーマでの見た目はここでは検証できないが、参照している値が
+  // 「テーマに応じて変わるトークン」であること自体は固定できる。
+  it("met=false のとき、危険状態の配色はハードコード値ではなくテーマ対応トークンを参照する", () => {
+    render(<KpiCard {...BASE_PROPS} met={false} description="AIが答えられなかった質問の割合" />);
+
+    const badge = screen.getByText("未達成");
+    expect(badge.style.color).toBe("var(--destructive)");
+    expect(badge.style.background).toBe("var(--destructive-border)");
+
+    const card = badge.closest("div")?.parentElement as HTMLElement;
+    expect(card.style.background).toBe("var(--destructive-surface)");
+    expect(card.style.borderColor).toBe("var(--destructive-border)");
+
+    const value = screen.getByText("67.1");
+    expect(value.style.color).toBe("var(--destructive)");
+    // ライトテーマで実際に不可視化していた具体的な誤り(淡いピンク直書き)が
+    // 再導入されていないことも合わせて否定しておく
+    expect(value.style.color).not.toBe("#fca5a5");
+
+    const desc = screen.getByText("AIが答えられなかった質問の割合");
+    expect(desc.style.color).toBe("var(--destructive)");
+  });
+
+  it("met=true のときは危険トークンを使わない(達成カードの見た目まで巻き込んで変えない)", () => {
+    render(<KpiCard {...BASE_PROPS} met description="達成時の説明文" />);
+
+    const value = screen.getByText("67.1");
+    expect(value.style.color).not.toContain("destructive");
+  });
+
+  // 境界値: 任意項目(unit / description)が無い場合
+  it("unit・descriptionが無くてもクラッシュせず、該当要素を描画しない", () => {
+    render(<KpiCard name="緊急停止スイッチ" value="停止中" threshold="停止中 が正常" met />);
+
+    expect(screen.getByText("停止中")).toBeTruthy();
+    // unit相当の別要素が余計に生成されていないこと
+    expect(screen.queryByText("%")).toBeNull();
+  });
+
+  // 境界値: value が数値のとき(呼び出し元によっては number を渡す設計)
+  it("valueが数値でも表示できる", () => {
+    render(<KpiCard {...BASE_PROPS} value={0} met={false} />);
+    expect(screen.getByText("0")).toBeTruthy();
+  });
+
+  // 境界値: 空文字のSLA閾値・空の名前でも例外にならない(サーバ側の異常データ入力への耐性)
+  it("threshold や name が空文字でも例外を投げない", () => {
+    expect(() => render(<KpiCard name="" value="—" threshold="" met={false} />)).not.toThrow();
+  });
+});

--- a/admin-ui/src/pages/admin/chat-history/OutcomeSection.test.tsx
+++ b/admin-ui/src/pages/admin/chat-history/OutcomeSection.test.tsx
@@ -1,0 +1,127 @@
+// admin-ui/src/pages/admin/chat-history/OutcomeSection.test.tsx
+// 未選択の成果ボタンが「灰地に灰文字」でライトテーマ判読不能だった不具合
+// (2026-08-16, PR #754)の回帰テストと、連打・境界値の確認。
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { OutcomeSection } from "./OutcomeSection";
+
+function setup(overrides: Partial<Parameters<typeof OutcomeSection>[0]> = {}) {
+  const setOutcome = vi.fn();
+  const setOutcomeRecordedAt = vi.fn();
+  const setOutcomeRecordedBy = vi.fn();
+  const handleOutcome = vi.fn().mockResolvedValue(undefined);
+
+  const props = {
+    outcome: null,
+    outcomeRecordedAt: null,
+    outcomeRecordedBy: null,
+    setOutcome,
+    setOutcomeRecordedAt,
+    setOutcomeRecordedBy,
+    conversionTypes: ["購入完了", "予約完了", "問い合わせ送信", "離脱"],
+    outcomeSubmitting: false,
+    handleOutcome,
+    ...overrides,
+  };
+
+  render(<OutcomeSection {...props} />);
+  return { setOutcome, setOutcomeRecordedAt, setOutcomeRecordedBy, handleOutcome };
+}
+
+describe("OutcomeSection", () => {
+  it("未選択のボタンはテーマ対応トークンを参照する(ハードコード灰色への先祖返り検知)", () => {
+    setup();
+
+    const btn = screen.getByText("購入完了") as HTMLButtonElement;
+    expect(btn.style.background).toBe("var(--muted)");
+    expect(btn.style.color).toBe("var(--muted-foreground)");
+    // ライトテーマで実際に不可視化していた具体的な誤り(暗いグレー直書き)が
+    // 再導入されていないことも合わせて否定しておく
+    expect(btn.style.background).not.toBe("rgba(31,41,55,0.5)");
+    expect(btn.style.color).not.toBe("#9ca3af");
+  });
+
+  it("選択済みの成果は緑系トークンでハイライトされる", () => {
+    setup({ outcome: "購入完了" });
+
+    const btn = screen.getByText("✓ 購入完了") as HTMLButtonElement;
+    expect(btn.style.color).toBe("#4ade80");
+    // 未選択(この場合は表示されない)と混同していないこと
+    expect(screen.queryByText("購入完了")).toBeNull();
+  });
+
+  it("ボタンを押すとその値でhandleOutcomeが呼ばれる", async () => {
+    const { handleOutcome } = setup();
+
+    fireEvent.click(screen.getByText("予約完了"));
+
+    expect(handleOutcome).toHaveBeenCalledWith("予約完了");
+    expect(handleOutcome).toHaveBeenCalledTimes(1);
+  });
+
+  // イレギュラー操作: 送信中の連打
+  it("outcomeSubmitting=true のときは全ボタンが無効化され、クリックしてもhandleOutcomeが呼ばれない", () => {
+    const { handleOutcome } = setup({ outcomeSubmitting: true });
+
+    const btn = screen.getByText("購入完了") as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+
+    fireEvent.click(btn);
+    fireEvent.click(btn);
+
+    expect(handleOutcome).not.toHaveBeenCalled();
+  });
+
+  it("送信中は選択されていないボタンが半透明になり、選択中のボタンとの区別がつく", () => {
+    setup({ outcomeSubmitting: true, outcome: "購入完了" });
+
+    const selected = screen.getByText("✓ 購入完了") as HTMLButtonElement;
+    const other = screen.getByText("予約完了") as HTMLButtonElement;
+    expect(selected.style.opacity).toBe("1");
+    expect(other.style.opacity).toBe("0.6");
+  });
+
+  // 記録済みバナー
+  it("outcomeとoutcomeRecordedAtの両方が揃って初めて「記録済み」バナーを表示する", () => {
+    setup({ outcome: "購入完了", outcomeRecordedAt: "2026-08-10T10:00:00Z", outcomeRecordedBy: "田中" });
+
+    expect(screen.getByText(/記録済み/)).toBeTruthy();
+    expect(screen.getByText(/by 田中/)).toBeTruthy();
+  });
+
+  it("outcomeRecordedByが無ければ「by」表記を付けない", () => {
+    setup({ outcome: "購入完了", outcomeRecordedAt: "2026-08-10T10:00:00Z", outcomeRecordedBy: null });
+
+    expect(screen.getByText(/記録済み/)).toBeTruthy();
+    expect(screen.queryByText(/by /)).toBeNull();
+  });
+
+  // 境界値: 片方だけ揃っている(サーバ応答の不整合を想定した防御的なケース)
+  it("outcomeはあるがoutcomeRecordedAtが無い場合、記録済みバナーを出さない", () => {
+    setup({ outcome: "購入完了", outcomeRecordedAt: null });
+
+    expect(screen.queryByText(/記録済み/)).toBeNull();
+    // ボタン一覧は通常どおり操作可能
+    expect(screen.getByText("予約完了")).toBeTruthy();
+  });
+
+  it("「変更」を押すと3つの状態セッターがすべてnullでリセットされる", () => {
+    const { setOutcome, setOutcomeRecordedAt, setOutcomeRecordedBy } = setup({
+      outcome: "購入完了",
+      outcomeRecordedAt: "2026-08-10T10:00:00Z",
+      outcomeRecordedBy: "田中",
+    });
+
+    fireEvent.click(screen.getByText("変更"));
+
+    expect(setOutcome).toHaveBeenCalledWith(null);
+    expect(setOutcomeRecordedAt).toHaveBeenCalledWith(null);
+    expect(setOutcomeRecordedBy).toHaveBeenCalledWith(null);
+  });
+
+  // 境界値: conversionTypesが空(テナント設定が壊れている/未設定のケース)
+  it("conversionTypesが空配列でも例外にならず、ボタンを1つも描画しない", () => {
+    expect(() => setup({ conversionTypes: [] })).not.toThrow();
+    expect(screen.getByText("この会話の営業結果を記録")).toBeTruthy();
+  });
+});

--- a/admin-ui/src/pages/admin/escalations/[sessionId].test.tsx
+++ b/admin-ui/src/pages/admin/escalations/[sessionId].test.tsx
@@ -3,8 +3,8 @@
 // 「セッション不在(404)」「サーバ障害(500)」は従来どおりエラー表示することを固定する。
 // (CLAUDE.md 20: 「存在しない」と「空」を同じ値で表現しない — 対応中の会話253件が
 //  全件404だった不具合の回帰テスト)
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter, Routes, Route } from "react-router-dom";
 import EscalationDetailPage from "./[sessionId]";
 import { authFetch } from "../../../lib/api";
@@ -186,5 +186,129 @@ describe("EscalationDetailPage", () => {
     fireEvent.keyDown(textarea, { key: "Enter", shiftKey: true });
 
     expect(vi.mocked(authFetch)).toHaveBeenCalledTimes(1);
+  });
+
+  // ── イレギュラー操作: 連打・多重送信 ──────────────────────────────────
+  it("「対応完了にする」を連打しても対応完了リクエストは1回しか送られない", async () => {
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (String(url).endsWith("/resolve-escalation")) {
+        return Promise.resolve(jsonResponse(200, { ok: true }));
+      }
+      return Promise.resolve(jsonResponse(200, { messages: [], total: 0 }));
+    });
+
+    renderPage();
+    await screen.findByText(/まだお客様の発言がありません/);
+
+    const resolveButton = screen.getByRole("button", { name: /対応完了にする/ });
+    fireEvent.click(resolveButton);
+    fireEvent.click(resolveButton); // 連打
+    fireEvent.click(resolveButton);
+
+    await waitFor(() => {
+      const resolveCalls = vi
+        .mocked(authFetch)
+        .mock.calls.filter(([url]) => String(url).endsWith("/resolve-escalation"));
+      expect(resolveCalls.length).toBe(1);
+    });
+  });
+
+  it("送信ボタンを連打しても、送信中は2件目の返信が送られない", async () => {
+    let replyCalls = 0;
+    let resolveReplyPromise: (() => void) | null = null;
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (String(url).endsWith("/reply")) {
+        replyCalls += 1;
+        // 1件目の返信POSTを人為的に「送信中」のまま止め、連打の窓を作る
+        return new Promise((resolve) => {
+          resolveReplyPromise = () => resolve(jsonResponse(201, { ok: true }));
+        });
+      }
+      return Promise.resolve(jsonResponse(200, { messages: [], total: 0 }));
+    });
+
+    renderPage();
+    await screen.findByText(/まだお客様の発言がありません/);
+
+    const textarea = screen.getByPlaceholderText(/お客様への返信を入力してください/);
+    fireEvent.change(textarea, { target: { value: "少々お待ちください" } });
+    const sendButton = screen.getByRole("button", { name: "送信" });
+    fireEvent.click(sendButton);
+    // 送信中はボタンが無効化され、連打しても2件目のPOSTが飛ばない
+    fireEvent.click(sendButton);
+    fireEvent.click(sendButton);
+
+    await waitFor(() => expect(replyCalls).toBe(1));
+    resolveReplyPromise?.();
+  });
+
+  // ── イレギュラー操作: 空白のみの入力 ────────────────────────────────
+  it("空白のみの返信は送信ボタンが無効のままで、送信されない", async () => {
+    vi.mocked(authFetch).mockResolvedValue(jsonResponse(200, { messages: [], total: 0 }));
+
+    renderPage();
+    await screen.findByText(/まだお客様の発言がありません/);
+
+    const textarea = screen.getByPlaceholderText(/お客様への返信を入力してください/) as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "   " } });
+
+    const sendButton = screen.getByRole("button", { name: "送信" }) as HTMLButtonElement;
+    expect(sendButton.disabled).toBe(true);
+
+    fireEvent.click(sendButton);
+    // 初回ロードの1回のみ(送信POSTは飛んでいない)
+    expect(vi.mocked(authFetch)).toHaveBeenCalledTimes(1);
+  });
+
+  // ── イレギュラー操作: 画面離脱後にポーリングが続かない ──────────────
+  describe("ポーリングのライフサイクル", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("画面を離れる(アンマウント)と、以降の5秒ポーリングは発火しない", async () => {
+      vi.useFakeTimers();
+      vi.mocked(authFetch).mockResolvedValue(jsonResponse(200, { messages: [], total: 0 }));
+
+      const { unmount } = renderPage();
+      await vi.waitFor(() => expect(vi.mocked(authFetch)).toHaveBeenCalledTimes(1));
+
+      unmount();
+
+      await vi.advanceTimersByTimeAsync(20_000); // 5秒間隔を4回分進める
+      expect(vi.mocked(authFetch)).toHaveBeenCalledTimes(1); // 増えていない
+    });
+
+    it("画面を開いたままだと、5秒ごとに新着メッセージを自動取得して表示する(ユーザー操作なし)", async () => {
+      vi.useFakeTimers();
+      vi.mocked(authFetch)
+        .mockResolvedValueOnce(jsonResponse(200, { messages: [], total: 0 })) // 初回
+        .mockResolvedValueOnce(
+          jsonResponse(200, {
+            messages: [
+              { id: "m1", role: "user", content: "追加で質問です", metadata: {}, created_at: "2026-08-10T00:00:00Z" },
+            ],
+            total: 1,
+          }),
+        ); // 1回目のポーリングで新着
+
+      renderPage();
+      await vi.waitFor(() => expect(vi.mocked(authFetch)).toHaveBeenCalledTimes(1));
+
+      await vi.advanceTimersByTimeAsync(5_000);
+
+      await vi.waitFor(() => expect(vi.mocked(authFetch)).toHaveBeenCalledTimes(2));
+      expect(screen.getByText("追加で質問です")).toBeTruthy();
+    });
+  });
+
+  // ── ネットワーク例外(非ok応答ではなく fetch 自体が reject するケース) ──
+  it("fetch自体が例外を投げても(オフライン等)、生の例外メッセージを出さず同じ案内文になる", async () => {
+    vi.mocked(authFetch).mockRejectedValue(new TypeError("Failed to fetch"));
+
+    renderPage();
+
+    const errorBanner = await screen.findByText(/失敗しました/);
+    expect(errorBanner.textContent).not.toMatch(/TypeError|Failed to fetch/);
   });
 });

--- a/admin-ui/src/pages/admin/tenants/[id].test.tsx
+++ b/admin-ui/src/pages/admin/tenants/[id].test.tsx
@@ -5,7 +5,6 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { Route, Routes } from "react-router-dom";
-import { LangProvider } from "../../../i18n/LangContext";
 import TenantDetailPage from "./[id]";
 
 const mockGetSession = vi.fn();
@@ -29,6 +28,30 @@ vi.mock("../../../lib/api", () => ({
   API_BASE: "http://localhost:3100",
 }));
 
+// LangProvider は localStorage.getItem に依存し、このテスト環境の Node組み込み
+// localStorage（--localstorage-file 未指定時は undefined）で例外になるため、
+// 実辞書(ja.ts)をそのまま使う t() を返す薄いモックに置き換える
+// (KnowledgeListTab.test.tsx / PdfUploadTab.test.tsx / escalations/[sessionId].test.tsx
+//  と同じ既存パターン。このファイルは元々 <LangProvider> を直接使っていたため、
+//  この環境では全ケースが localStorage 例外でマウント時に落ちていた)。
+vi.mock("../../../i18n/LangContext", async () => {
+  const jaModule = await import("../../../i18n/ja");
+  const ja = jaModule.default as Record<string, string>;
+  const stableT = (key: string, vars?: Record<string, string | number>) => {
+    let text = ja[key] ?? key;
+    if (vars) {
+      for (const [k, v] of Object.entries(vars)) {
+        text = text.replace(new RegExp(`\\{${k}\\}`, "g"), String(v));
+      }
+    }
+    return text;
+  };
+  const stableValue = { lang: "ja" as const, setLang: () => {}, t: stableT };
+  return {
+    useLang: () => stableValue,
+  };
+});
+
 const okSession = { data: { session: { access_token: "test-token" } } };
 
 function jsonResponse(status: number, body: unknown): Response {
@@ -41,13 +64,11 @@ function jsonResponse(status: number, body: unknown): Response {
 
 function renderPage(tenantId = "carnation") {
   return render(
-    <LangProvider>
-      <MemoryRouter initialEntries={[`/admin/tenants/${tenantId}`]}>
-        <Routes>
-          <Route path="/admin/tenants/:id" element={<TenantDetailPage />} />
-        </Routes>
-      </MemoryRouter>
-    </LangProvider>,
+    <MemoryRouter initialEntries={[`/admin/tenants/${tenantId}`]}>
+      <Routes>
+        <Route path="/admin/tenants/:id" element={<TenantDetailPage />} />
+      </Routes>
+    </MemoryRouter>,
   );
 }
 
@@ -117,19 +138,58 @@ describe("TenantDetailPage — エラー意味論(500 vs 404 vs 401)", () => {
     await waitFor(() => expect(screen.getByText("⚙️ 設定")).toBeTruthy());
   });
 
+  // イレギュラー操作: 「やり直す」の連打で、in-flightの古いレスポンスが後から
+  // 新しい状態を上書きしないか(handleRetryLoad は reloadKey をインクリメントする
+  // だけで、AbortController等による古いリクエストの無効化は行っていない)。
+  // 検証の結果: loading=true の間は再試行ボタン自体がロード中表示に置き換わり
+  // 画面から消えるため、ユーザー操作としての「連打」はそもそも起こせない
+  // (直前のリクエストが確定するまで次のクリックが物理的にできない)。
+  // したがって setState の実行順に依存する競合は実際には発生しない。
+  // この「loadingがボタンを隠すことによる暗黙のガード」が壊れていないことを固定する。
+  it("読み込み中は「やり直す」ボタンが画面から消え、二重にクリックできない", async () => {
+    let resolveFirst: ((r: Response) => void) | null = null;
+    let callCount = 0;
+    global.fetch = vi.fn().mockImplementation(() => {
+      callCount += 1;
+      if (callCount === 1) {
+        return Promise.resolve(jsonResponse(500, { error: "取得に失敗しました" }));
+      }
+      // 1回目の「やり直す」: 解決を止めて loading 中の画面を観測する
+      return new Promise<Response>((resolve) => { resolveFirst = resolve; });
+    });
+
+    renderPage();
+    await waitFor(() => expect(screen.getByText("やり直す")).toBeTruthy());
+
+    screen.getByText("やり直す").click();
+
+    // loading 中は再試行ボタンが消え、ロード中の表示に置き換わる
+    await waitFor(() => expect(screen.queryByText("やり直す")).toBeNull());
+    expect(screen.getByText(/読み込んでいます/)).toBeTruthy();
+
+    resolveFirst?.(
+      jsonResponse(200, {
+        id: "carnation", name: "carnation", plan: "starter", is_active: true,
+        allowed_origins: [], billing_enabled: false, billing_free_from: null,
+        billing_free_until: null, features: { avatar: false, voice: false, rag: true },
+        lemonslice_agent_id: null, conversion_types: [],
+      }),
+    );
+    await waitFor(() => expect(screen.getByText("⚙️ 設定")).toBeTruthy());
+    expect(global.fetch).toHaveBeenCalledTimes(2); // 初回 + やり直す1回のみ
+  });
+
   it("401(未ログイン)のとき: 既存どおり /login へ遷移する(挙動を変えない)", async () => {
     mockGetSession.mockResolvedValue({ data: { session: null } });
     global.fetch = vi.fn();
 
     render(
-      <LangProvider>
-        <MemoryRouter initialEntries={["/admin/tenants/carnation"]}>
-          <Routes>
-            <Route path="/admin/tenants/:id" element={<TenantDetailPage />} />
-            <Route path="/login" element={<div>login-page</div>} />
-          </Routes>
-        </MemoryRouter>
-      </LangProvider>,
+      <MemoryRouter initialEntries={["/admin/tenants/carnation"]}>
+        <Routes>
+          <Route path="/admin/tenants/:id" element={<TenantDetailPage />} />
+          <Route path="/login" element={<div>login-page</div>} />
+        </Routes>
+      </MemoryRouter>,
     );
 
     await waitFor(() => expect(screen.getByText("login-page")).toBeTruthy());

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -4474,6 +4474,45 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(res.body.actions[0].card).toBeUndefined();
     });
 
+    // CLAUDE.md 20: getMessages() は「セッション不在」= null と「本文0件」= []
+    // を区別する契約に是正した(2026-08-16, PR #751)。resolveSessionByShortId で
+    // 存在確認済みのこの経路では実際には0件配列しか返らないはずだが、両方の値を
+    // 明示的にテストし、どちらでも例外にならず同じ「メッセージはありません」に
+    // 落ちることを固定する(型変更に伴うnullガードの回帰防止)。
+    it('本文が0件(空配列)のセッションは「メッセージはありません」を返し、cardは付けない', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-cm-empty', 'get_chat_session_messages', { session_id: 'a1b2c3d4' }))
+        .mockResolvedValueOnce(makeGroqResponse('まだメッセージがありません。'));
+
+      seedSessions([OWN_SESSION]);
+      mockGetMessages.mockResolvedValueOnce([]);
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'a1b2c3d4の会話を見せて', sessionId: 'sess-cm-empty' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('メッセージはありません');
+      expect(res.body.actions[0].card).toBeUndefined();
+    });
+
+    it('getMessages が null を返しても(存在確認済みの経路で理論上到達しない値でも)例外にならず同じ案内を返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-cm-null', 'get_chat_session_messages', { session_id: 'a1b2c3d4' }))
+        .mockResolvedValueOnce(makeGroqResponse('まだメッセージがありません。'));
+
+      seedSessions([OWN_SESSION]);
+      mockGetMessages.mockResolvedValueOnce(null);
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'a1b2c3d4の会話を見せて', sessionId: 'sess-cm-null' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('メッセージはありません');
+      expect(res.body.actions[0].card).toBeUndefined();
+    });
+
     // 既知のリスク: resolveSessionByShortId は `LIMIT 6` で候補を取得し、6件返ってきた場合
     // 実際の一致件数がそれ以上あっても「result.rows.length」(=6)をそのまま件数として表示する。
     // 同じ短縮IDプレフィックスを持つセッションが7件以上ある(極めて起こりにくいが、テナントの

--- a/tests/phase38/chat-history-api.test.ts
+++ b/tests/phase38/chat-history-api.test.ts
@@ -153,6 +153,51 @@ describe("Chat History API", () => {
       expect(res.status).toBe(404);
     });
 
+    it("returns 500 (not a crash) and does not leak the raw DB error when getMessages throws", async () => {
+      mockGetMessages.mockRejectedValueOnce(new Error("connection terminated unexpectedly"));
+
+      const res = await request(app)
+        .get("/v1/admin/chat-history/sessions/sess-uuid-1/messages")
+        .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`);
+
+      expect(res.status).toBe(500);
+      expect(JSON.stringify(res.body)).not.toContain("connection terminated");
+    });
+
+    it("client_admin without a tenant_id claim on the JWT gets 403, not a crash or another tenant's data", async () => {
+      const noTenantToken = makeDevJwt({ app_metadata: { role: "client_admin" } });
+
+      const res = await request(app)
+        .get("/v1/admin/chat-history/sessions/sess-uuid-1/messages")
+        .set("Authorization", `Bearer ${noTenantToken}`);
+
+      expect(res.status).toBe(403);
+      expect(mockGetMessages).not.toHaveBeenCalled();
+    });
+
+    it("a role outside the admin allowlist gets 403 and never reaches getMessages", async () => {
+      const viewerToken = makeDevJwt({ app_metadata: { role: "viewer", tenant_id: "demo-tenant" } });
+
+      const res = await request(app)
+        .get("/v1/admin/chat-history/sessions/sess-uuid-1/messages")
+        .set("Authorization", `Bearer ${viewerToken}`);
+
+      expect(res.status).toBe(403);
+      expect(mockGetMessages).not.toHaveBeenCalled();
+    });
+
+    it("client_admin cannot escape their own tenant via a ?tenant= query override (super_admin-only param)", async () => {
+      const clientAdminToken = makeDevJwt({ app_metadata: { role: "client_admin", tenant_id: "demo-tenant" } });
+      mockGetMessages.mockResolvedValueOnce([MESSAGE_FIXTURE] as any);
+
+      await request(app)
+        .get("/v1/admin/chat-history/sessions/sess-uuid-1/messages?tenant=other-tenant")
+        .set("Authorization", `Bearer ${clientAdminToken}`);
+
+      // client_admin の tenantId は常に JWT 由来。クエリの ?tenant= は無視される
+      expect(mockGetMessages).toHaveBeenCalledWith({ sessionDbId: "sess-uuid-1", tenantId: "demo-tenant" });
+    });
+
     it("returns 401 without auth token", async () => {
       const res = await request(app).get(
         "/v1/admin/chat-history/sessions/sess-uuid-1/messages"


### PR DESCRIPTION
## 目的

先行してマージ済みの7PR(#748〜#754、CORS・エスカレーション404・
プラン制限403・テナント詳細エラー意味論・IME誤送信・ライトテーマ・
copilot-preview再試行)について、正常系だけでなく境界値・異常系・
イレギュラー操作を優先してテストを追加・強化した。

「通るだけのテスト」にしないため、追加した主要なテストは実装側を
一時的に元の(誤った)状態へ戻して**実際に失敗することを個別に確認**
してから正規の実装に戻している。

## 追加・変更したファイル

| ファイル | 内容 |
|---|---|
| `src/api/admin/agent/agentRoutes.test.ts` | `get_chat_session_messages` に `getMessages()` が `[]`(本文0件)と `null`(不在)を返す2ケースを追加 |
| `tests/phase38/chat-history-api.test.ts` | messages エンドポイントに DB例外時の生エラー非漏洩・tenant_id無しclient_adminの403・許可外ロールの403・**client_adminが`?tenant=`でテナントを越境できないこと**(テナント分離の直接的な回帰テスト)を追加 |
| `admin-ui/.../escalations/[sessionId].test.tsx` | 連打による多重リクエスト防止(対応完了・送信)、空白のみ入力での未送信、アンマウント後のポーリング停止、開いたままでの5秒自動更新、fetch例外時の文言サニタイズを追加 |
| `admin-ui/.../tenants/[id].test.tsx` | **既存の全ケースが実行環境で例外により機能していなかった不具合を修正**(下記参照)。あわせて「やり直す」連打の二重リクエスト防止を追加 |
| `admin-ui/src/components/admin/KpiCard.test.tsx`(新規) | 「未達成」カードのハードコード色への先祖返り検知 |
| `admin-ui/.../chat-history/OutcomeSection.test.tsx`(新規) | 未選択ボタンの同種の先祖返り検知、送信中の全ボタン無効化、記録済みバナーの表示条件、空配列での非クラッシュ |

## 副次的に見つかった問題(このPRで修正)

`tenants/[id].test.tsx` は `<LangProvider>` を直接使っており、この
実行環境の Node組み込み `localStorage`(`--localstorage-file` 未指定時は
未提供)で**全6ケースがマウント時に例外を投げ、実質的に機能していなかった**。
他の3ファイルで既に確立している「実辞書ベースの `t()` モックに置き換える」
パターンへ統一して復旧した。

## 見つかったが未修正の問題(記録のみ、このPRのスコープ外)

`tenants/[id].tsx` のエラー表示(500/404)が `escalations/[sessionId].tsx`
と同じハードコードのピンク/赤(`rgba(127,29,29,0.2)` + `#fca5a5`)を使って
おり、ライトテーマで同種の判読性低下が起きる可能性がある。#754 の対象には
入っていなかった。別タスクとして起票を推奨。

## Gate

- [x] 追加テスト(backend jest 18件・admin-ui vitest 46件)を単体実行で全pass
- [x] 各テストのミューテーション確認(実装を壊して失敗することを確認→復元)
- [x] `pnpm lint` 0新規警告(59/63)
- [x] `bash SCRIPTS/dead-code-check.sh` 新規のdead exportなし
- [x] `bash SCRIPTS/security-scan.sh` PASS(CRITICAL/HIGH 0)
- [x] backend typecheck 0 errors
- [x] admin-ui vitest 全体 467/468 pass(残る1件は `useAuth.test.tsx` — 本PR着手前から存在する無関係な既存失敗、git履歴で確認済み)
- backend jest 全体実行はサンドボックス環境のポート/接続競合で毎回異なる無関係ファイルが非決定的に失敗する(既知の環境要因)。対象ファイル単体では安定して全pass

## Tier / merge

すべて `*.test.ts(x)` のみの変更のため Tier B(低リスク、auto-merge対象)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01My9XXuKXbnb8ca9xgDnEqj
