### PR TITLE
refactor(admin-ui): プラン制限/読み込み失敗の表示を共通化し、i18n・タップ領域・配色の逸脱を是正

### DIFF
--- a/admin-ui/src/components/common/LoadErrorBanner.tsx
+++ b/admin-ui/src/components/common/LoadErrorBanner.tsx
@@ -1,0 +1,59 @@
+// admin-ui/src/components/common/LoadErrorBanner.tsx
+// 読み込み失敗(5xx・ネットワーク断など)の共通バナー。再試行導線を必ず伴う。
+//
+// 「エラー文言に次の行動を書く / 再試行を促すなら再試行ボタンを同時に置く」
+// (CLAUDE.md 命名・エラーハンドリング)を1箇所で満たすための部品。
+// 配色は --destructive 系トークンを使う。ダーク前提のハードコード色
+// (rgba(127,29,29,*) + #fca5a5)はライトテーマで判読不能になる。
+import { useLang } from "../../i18n/LangContext";
+
+export function LoadErrorBanner({
+  message,
+  onRetry,
+}: {
+  /** 省略時は共通文言 common.load_failed。画面固有の説明が要る場合のみ渡す */
+  message?: string;
+  onRetry: () => void;
+}) {
+  const { t } = useLang();
+
+  return (
+    <div
+      role="alert"
+      style={{
+        marginBottom: 20,
+        padding: "14px 18px",
+        borderRadius: 12,
+        background: "var(--destructive-surface)",
+        border: "1px solid var(--destructive-border)",
+        color: "var(--destructive)",
+        fontSize: 15,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        gap: 12,
+        flexWrap: "wrap",
+      }}
+    >
+      <span>{message ?? t("common.load_failed")}</span>
+      <button
+        onClick={onRetry}
+        style={{
+          padding: "10px 20px",
+          // Mobile First: タップ領域は44px以上(Core Principles)
+          minHeight: 44,
+          borderRadius: 10,
+          border: "1px solid var(--destructive-border)",
+          background: "transparent",
+          color: "var(--destructive)",
+          fontSize: 14,
+          fontWeight: 600,
+          cursor: "pointer",
+          whiteSpace: "nowrap",
+        }}
+      >
+        {t("common.retry")}
+      </button>
+    </div>
+  );
+}

--- a/admin-ui/src/components/common/PlanLimitNotice.tsx
+++ b/admin-ui/src/components/common/PlanLimitNotice.tsx
@@ -1,0 +1,27 @@
+// admin-ui/src/components/common/PlanLimitNotice.tsx
+// プラン制限(403 plan_upgrade_required)の案内。
+//
+// これは「エラー」ではなく正常系の分岐なので、赤帯・❌・「失敗」の語彙を使わない
+// (CLAUDE.md 絶対にやってはいけないこと 21)。サーバが返した message を
+// そのまま見せ、無い場合だけ共通のフォールバック文言に落とす。
+import { useLang } from "../../i18n/LangContext";
+
+export function PlanLimitNotice({ message }: { message: string | null }) {
+  const { t } = useLang();
+
+  return (
+    <div
+      style={{
+        marginBottom: 20,
+        padding: "14px 18px",
+        borderRadius: 12,
+        background: "var(--card)",
+        border: "1px solid var(--border)",
+        color: "var(--foreground)",
+        fontSize: 15,
+      }}
+    >
+      ✨ {message ?? t("common.plan_limit_generic")}
+    </div>
+  );
+}

--- a/admin-ui/src/i18n/en.ts
+++ b/admin-ui/src/i18n/en.ts
@@ -11,6 +11,8 @@ const en: Record<TranslationKey, string> = {
   "common.deleting": "Deleting...",
   "common.refresh": "🔄 Refresh",
   "common.retry": "Try Again",
+  "common.load_failed": "Failed to load the data. Please wait a moment and try again.",
+  "common.plan_limit_generic": "This feature is not available on your current plan. Please consider upgrading.",
 
   // Nav
   "nav.dashboard": "Admin Dashboard",

--- a/admin-ui/src/i18n/ja.ts
+++ b/admin-ui/src/i18n/ja.ts
@@ -9,6 +9,12 @@ const ja = {
   "common.deleting": "削除中...",
   "common.refresh": "🔄 更新",
   "common.retry": "やり直す",
+  // 読み込み失敗(5xx・ネットワーク断など)の共通文言。
+  // 403 plan_upgrade_required はエラーではないので、こちらを使わない。
+  "common.load_failed": "データの読み込みに失敗しました。時間をおいて、もう一度お試しください。",
+  // サーバがプラン制限の理由文(message)を返さなかった場合のフォールバック。
+  // 通常はサーバの message をそのまま表示する。
+  "common.plan_limit_generic": "この機能は現在のプランではご利用いただけません。プランのアップグレードをご検討ください。",
 
   // Nav
   "nav.dashboard": "管理ダッシュボード",

--- a/admin-ui/src/lib/planFeatures.test.ts
+++ b/admin-ui/src/lib/planFeatures.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { planHasFeature, isPlanUpgradeRequired } from "./planFeatures";
+import { describe, it, expect, vi } from "vitest";
+import { planHasFeature, isPlanUpgradeRequired, applyFetchResults } from "./planFeatures";
 
 describe("planHasFeature", () => {
   it.each([
@@ -54,5 +54,98 @@ describe("isPlanUpgradeRequired", () => {
 
   it("空オブジェクトでは false", () => {
     expect(isPlanUpgradeRequired({})).toBe(false);
+  });
+});
+
+// applyFetchResults: 会話分析・成約分析が共有する「成功だけ反映し、失敗を
+// プラン制限とそれ以外に仕分ける」処理。以前は両ページに同じ実装が重複していた。
+describe("applyFetchResults", () => {
+  const res = (status: number, body: unknown): Response =>
+    ({
+      ok: status >= 200 && status < 300,
+      status,
+      json: () => Promise.resolve(body),
+    }) as Response;
+
+  const rejectingRes = (status: number): Response =>
+    ({
+      ok: false,
+      status,
+      json: () => Promise.reject(new SyntaxError("Unexpected token <")),
+    }) as unknown as Response;
+
+  it("全て成功なら全ての apply が呼ばれ、失敗フラグは立たない", async () => {
+    const a = vi.fn();
+    const b = vi.fn();
+    const outcome = await applyFetchResults([
+      { res: res(200, { v: 1 }), apply: a },
+      { res: res(200, { v: 2 }), apply: b },
+    ]);
+
+    expect(a).toHaveBeenCalledWith({ v: 1 });
+    expect(b).toHaveBeenCalledWith({ v: 2 });
+    expect(outcome).toEqual({ planLimited: false, planLimitMessage: null, genericFailure: false });
+  });
+
+  it("403 plan_upgrade_required は genericFailure にせず、message を拾う", async () => {
+    const outcome = await applyFetchResults([
+      { res: res(403, { error: "plan_upgrade_required", message: "Growth以上です" }), apply: vi.fn() },
+    ]);
+
+    expect(outcome.planLimited).toBe(true);
+    expect(outcome.planLimitMessage).toBe("Growth以上です");
+    expect(outcome.genericFailure).toBe(false);
+  });
+
+  it("message の無い403でも planLimited は true になる(message有無で判定しない)", async () => {
+    const outcome = await applyFetchResults([
+      { res: res(403, { error: "plan_upgrade_required" }), apply: vi.fn() },
+    ]);
+
+    expect(outcome.planLimited).toBe(true);
+    expect(outcome.planLimitMessage).toBeNull();
+  });
+
+  it("失敗した項目の apply は呼ばれない(古い値を上書きしない)", async () => {
+    const ok = vi.fn();
+    const ng = vi.fn();
+    await applyFetchResults([
+      { res: res(200, { v: 1 }), apply: ok },
+      { res: res(500, { error: "internal_error" }), apply: ng },
+    ]);
+
+    expect(ok).toHaveBeenCalledTimes(1);
+    expect(ng).not.toHaveBeenCalled();
+  });
+
+  it("エラーボディがJSONでない(502のHTML等)場合は genericFailure 扱いにする", async () => {
+    const outcome = await applyFetchResults([{ res: rejectingRes(502), apply: vi.fn() }]);
+
+    expect(outcome.genericFailure).toBe(true);
+    expect(outcome.planLimited).toBe(false);
+  });
+
+  it("403と500が混在したら両方のフラグが立つ(表示側が復旧行動の要る方を優先できる)", async () => {
+    const outcome = await applyFetchResults([
+      { res: res(403, { error: "plan_upgrade_required", message: "Growth以上です" }), apply: vi.fn() },
+      { res: res(500, { error: "internal_error" }), apply: vi.fn() },
+    ]);
+
+    expect(outcome.planLimited).toBe(true);
+    expect(outcome.genericFailure).toBe(true);
+  });
+
+  it("複数本が403でも最初の message を代表として使う", async () => {
+    const outcome = await applyFetchResults([
+      { res: res(403, { error: "plan_upgrade_required", message: "1本目" }), apply: vi.fn() },
+      { res: res(403, { error: "plan_upgrade_required", message: "2本目" }), apply: vi.fn() },
+    ]);
+
+    expect(outcome.planLimitMessage).toBe("1本目");
+  });
+
+  it("空配列でも例外にならない", async () => {
+    const outcome = await applyFetchResults([]);
+    expect(outcome).toEqual({ planLimited: false, planLimitMessage: null, genericFailure: false });
   });
 });

--- a/admin-ui/src/lib/planFeatures.ts
+++ b/admin-ui/src/lib/planFeatures.ts
@@ -63,3 +63,63 @@ export function isPlanUpgradeRequired(body: unknown): boolean {
     (body as { error?: unknown }).error === "plan_upgrade_required"
   );
 }
+
+/** 複数レスポンスを一括判定した結果。planLimited と genericFailure は同時に立ちうる。 */
+export interface FetchOutcome {
+  /**
+   * 403 plan_upgrade_required を1本でも受けたか。
+   * message を持たない403もあるため、message の有無ではなくこのフラグで判定すること
+   * (planLimitMessage が null でも制限は掛かっている場合がある)。
+   */
+  planLimited: boolean;
+  /** サーバが返したプラン制限の理由文。無ければ null(呼び出し側で共通文言に落とす) */
+  planLimitMessage: string | null;
+  /** プラン制限以外の失敗(5xx・非JSON応答など)を1本でも受けたか */
+  genericFailure: boolean;
+}
+
+/**
+ * 「成功したものだけ state に反映し、失敗はプラン制限とそれ以外に仕分ける」処理。
+ *
+ * 複数エンドポイントを Promise.all で並列取得する画面(会話分析・成約分析)が
+ * 同じ処理を各自で持っていたため共通化した。ページごとに403判定を書かない
+ * (CLAUDE.md「実装の置き場所」: プラン制限のフロント判定は planFeatures.ts)。
+ *
+ * - 403 plan_upgrade_required は正常系の分岐であり genericFailure に含めない
+ * - 1本が失敗しても他の成功結果は巻き込まない(applyの呼び出しは独立)
+ * - 失敗した項目の apply は呼ばれないため、呼び出し元が「前回値を残すか null に
+ *   戻すか」を選べる。古い期間のデータが新しい期間ラベルの下に残らないよう、
+ *   呼び出し元は失敗時に null へ倒すこと。
+ */
+export async function applyFetchResults(
+  entries: Array<{ res: Response; apply: (data: unknown) => void }>,
+): Promise<FetchOutcome> {
+  let planLimited = false;
+  let planLimitMessage: string | null = null;
+  let genericFailure = false;
+
+  await Promise.all(
+    entries.map(async ({ res, apply }) => {
+      if (res.ok) {
+        apply(await res.json());
+        return;
+      }
+      let body: unknown = null;
+      try {
+        body = await res.json();
+      } catch {
+        // 非JSON応答(nginx の502 HTML など)は本文を読めない。generic 扱いにする。
+      }
+      if (isPlanUpgradeRequired(body)) {
+        planLimited = true;
+        // 複数本が403でも最初の message を代表として使う(同じ制限が並ぶだけのため)
+        planLimitMessage =
+          planLimitMessage ?? (body as { message?: string }).message ?? null;
+      } else {
+        genericFailure = true;
+      }
+    }),
+  );
+
+  return { planLimited, planLimitMessage, genericFailure };
+}

--- a/admin-ui/src/pages/admin/analytics/index.test.tsx
+++ b/admin-ui/src/pages/admin/analytics/index.test.tsx
@@ -4,7 +4,7 @@
 //
 // analyticsディレクトリにはこれまでテストが1本も無く、403/500の分岐が無言で戻っていた。
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, waitFor, screen } from '@testing-library/react';
+import { render, waitFor, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import AnalyticsDashboardPage from './index';
 import { useAuth } from '../../../auth/useAuth';
@@ -18,6 +18,17 @@ vi.mock('../../../lib/api', () => ({
   API_BASE: 'http://localhost:3100',
   authFetch: vi.fn(),
 }));
+
+// t() は実辞書(ja.ts)を引く。キー名をそのまま返すモックだと「間違ったキーを
+// 参照していても素通りする」ため、画面に実際に出る日本語で検証する
+// (KnowledgeListTab.test.tsx / escalations/[sessionId].test.tsx と同じ既存パターン)。
+vi.mock('../../../i18n/LangContext', async () => {
+  const jaModule = await import('../../../i18n/ja');
+  const ja = jaModule.default as Record<string, string>;
+  const stableT = (key: string) => ja[key] ?? key;
+  const stableValue = { lang: 'ja' as const, setLang: () => {}, t: stableT };
+  return { useLang: () => stableValue };
+});
 
 // happy-dom は canvas 2d context を提供しないため、Chart.js を経由する
 // react-chartjs-2 のコンポーネントはテスト用スタブに差し替える(本番コードは触らない)。
@@ -78,11 +89,9 @@ describe('AnalyticsDashboardPage — プラン制限(403)の表示', () => {
     // FlowFunnelSectionは自前で「フロー遷移データの読み込みに失敗しました」を出すため
     // (どのstatusでも常に出る・plan-limit非対応)、部分一致だと誤ってヒットする。
     // 完全一致で本ページのエラー文言だけを見る。
-    expect(
-      screen.queryByText('データの読み込みに失敗しました。時間をおいて再試行してください。'),
-    ).toBeNull();
-    // 本ページのエラー赤帯にだけ付く再試行ボタンも出ていないこと
-    expect(screen.queryByRole('button', { name: '再試行' })).toBeNull();
+    expect(screen.queryByText('データの読み込みに失敗しました。時間をおいて、もう一度お試しください。')).toBeNull();
+    // 読み込み失敗バナーにだけ付く再試行ボタンも出ていないこと
+    expect(screen.queryByRole('button', { name: 'やり直す' })).toBeNull();
   });
 
   it('500など通常のエラーでは「読み込みに失敗しました」+再試行を表示し、プラン制限メッセージは出さない', async () => {
@@ -91,11 +100,9 @@ describe('AnalyticsDashboardPage — プラン制限(403)の表示', () => {
     renderPage();
 
     await waitFor(() => {
-      expect(
-        screen.getByText('データの読み込みに失敗しました。時間をおいて再試行してください。'),
-      ).toBeTruthy();
+      expect(screen.getByText('データの読み込みに失敗しました。時間をおいて、もう一度お試しください。')).toBeTruthy();
     });
-    expect(screen.getByRole('button', { name: '再試行' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'やり直す' })).toBeTruthy();
     expect(screen.queryByText(/プランでご利用いただけます|プランのアップグレード/)).toBeNull();
   });
 
@@ -131,5 +138,72 @@ describe('AnalyticsDashboardPage — プラン制限(403)の表示', () => {
     await waitFor(() => {
       expect(screen.getByText('123')).toBeTruthy();
     });
+  });
+
+  // ── レビュー指摘(P2-2): 再試行ボタンが「存在する」だけでなく実際に再取得すること ──
+  // ハンドラ未接続でも「ボタンがある」テストは通ってしまうため、click→再fetch→復帰まで見る。
+  it('「やり直す」を押すと再取得し、成功すればエラーが消えてデータが表示される', async () => {
+    let call = 0;
+    vi.mocked(authFetch).mockImplementation((url) => {
+      const u = String(url);
+      // summary 以外はプラン制限(403)のままにして未取得状態に倒す。
+      // 中途半端な形の200を返すとチャート描画側が落ち、再試行の検証にならない。
+      if (!u.includes('/v1/admin/analytics/summary')) {
+        return mockStatus(403, { error: 'plan_upgrade_required', message: 'Growthプラン以上でご利用いただけます' });
+      }
+      call += 1;
+      if (call === 1) return mockStatus(500, { error: 'internal_error' });
+      return mockStatus(200, {
+        period: '30d', tenant_id: 'carnation', total_sessions: 456,
+        avg_judge_score: null, total_knowledge_gaps: 0, avg_messages_per_session: 0,
+        avatar_session_count: 0, avatar_rate: 0, prev_total_sessions: 0, sessions_change_pct: 0,
+        sentiment_distribution: { positive: 0, negative: 0, neutral: 0, total: 0 },
+        cv_count_30d: 0, cv_total_value_30d: 0,
+        cv_types_breakdown: { purchase: 0, inquiry: 0, reservation: 0, signup: 0, other: 0 },
+        cv_fired_status: 'not_fired', cv_days_since_first_session: null,
+      });
+    });
+
+    renderPage();
+    await waitFor(() => expect(screen.getByText('データの読み込みに失敗しました。時間をおいて、もう一度お試しください。')).toBeTruthy());
+
+    fireEvent.click(screen.getByRole('button', { name: 'やり直す' }));
+
+    await waitFor(() => expect(screen.getByText('456')).toBeTruthy());
+    expect(screen.queryByText('データの読み込みに失敗しました。時間をおいて、もう一度お試しください。')).toBeNull();
+  });
+
+  // ── レビュー指摘(P2-3): 非JSONのエラーボディ(nginxの502 HTML等) ──
+  // res.json() が throw する経路。実運用で最も起きやすい失敗形なのに未検証だった。
+  it('エラーボディがJSONでない(502のHTML等)場合もプラン制限と誤判定せず読み込み失敗にする', async () => {
+    vi.mocked(authFetch).mockImplementation(() =>
+      Promise.resolve({
+        ok: false,
+        status: 502,
+        json: () => Promise.reject(new SyntaxError('Unexpected token < in JSON')),
+      } as unknown as Response),
+    );
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('データの読み込みに失敗しました。時間をおいて、もう一度お試しください。')).toBeTruthy());
+    expect(screen.queryByText(/プラン/)).toBeNull();
+  });
+
+  // ── レビュー指摘(P2-4): 403と500が混在したとき ──
+  // 「一部は制限・一部は本当に壊れている」状況。復旧行動が必要な方(読み込み失敗)を優先する。
+  it('403と500が混在するときは読み込み失敗を優先し、プラン制限バナーは出さない', async () => {
+    vi.mocked(authFetch).mockImplementation((url) => {
+      const u = String(url);
+      if (u.includes('/v1/admin/analytics/summary')) {
+        return mockStatus(403, { error: 'plan_upgrade_required', message: 'Growthプラン以上でご利用いただけます' });
+      }
+      return mockStatus(500, { error: 'internal_error' });
+    });
+
+    renderPage();
+
+    await waitFor(() => expect(screen.getByText('データの読み込みに失敗しました。時間をおいて、もう一度お試しください。')).toBeTruthy());
+    expect(screen.queryByText(/Growthプラン以上でご利用いただけます/)).toBeNull();
   });
 });

--- a/admin-ui/src/pages/admin/analytics/index.tsx
+++ b/admin-ui/src/pages/admin/analytics/index.tsx
@@ -16,7 +16,10 @@ import {
 } from "chart.js";
 import { authFetch, API_BASE } from "../../../lib/api";
 import { useAuth } from "../../../auth/useAuth";
-import { isPlanUpgradeRequired } from "../../../lib/planFeatures";
+import { useLang } from "../../../i18n/LangContext";
+import { applyFetchResults } from "../../../lib/planFeatures";
+import { LoadErrorBanner } from "../../../components/common/LoadErrorBanner";
+import { PlanLimitNotice } from "../../../components/common/PlanLimitNotice";
 import type {
   AnalyticsSummaryResponse,
   AnalyticsTrendsResponse,
@@ -52,6 +55,7 @@ ChartJS.register(
 export default function AnalyticsDashboardPage() {
   const navigate = useNavigate();
   const { user, isSuperAdmin, previewMode, previewTenantId } = useAuth();
+  const { t } = useLang();
 
   const [period, setPeriod] = useState<string>("30d");
   const [tenantFilter, setTenantFilter] = useState<string>("");
@@ -69,7 +73,9 @@ export default function AnalyticsDashboardPage() {
   const [error, setError] = useState<string | null>(null);
   // 403 plan_upgrade_required は正常系の分岐であり、error(赤帯)とは別の状態として持つ
   // (CLAUDE.md 絶対にやってはいけないこと 21: 403を「読み込みに失敗しました」と混同しない)。
-  const [planLimitMessage, setPlanLimitMessage] = useState<string | null>(null);
+  // null = 制限なし / オブジェクト = 制限あり(message はサーバが返さなければ null)。
+  // message の有無で判定すると「403だが message 無し」を取りこぼすため状態で持つ。
+  const [planLimit, setPlanLimit] = useState<{ message: string | null } | null>(null);
 
   const tenantId = isSuperAdmin && !previewMode
     ? undefined
@@ -89,7 +95,7 @@ export default function AnalyticsDashboardPage() {
   const loadData = useCallback(async () => {
     setLoading(true);
     setError(null);
-    setPlanLimitMessage(null);
+    setPlanLimit(null);
 
     const params = new URLSearchParams({ period });
     if (tenantId) params.set("tenant", tenantId);
@@ -103,46 +109,33 @@ export default function AnalyticsDashboardPage() {
         authFetch(`${API_BASE}/v1/admin/analytics/conversions?${params}`),
       ]);
 
-      // 各レスポンスを個別に判定する: 403 plan_upgrade_required は正常系の分岐であり
-      // 「読み込みに失敗しました」の赤帯にしない。1本が403でも残り3本の成功結果を
-      // 巻き込んで消さない(以前は !ok を1本でも検出すると全体を throw していた)。
-      let sawPlanLimit = false;
-      let planLimitText: string | null = null;
-      let sawGenericFailure = false;
-
-      const applyIfOk = async <T,>(res: Response, setter: (v: T) => void): Promise<void> => {
-        if (res.ok) {
-          setter((await res.json()) as T);
-          return;
-        }
-        let body: unknown = null;
-        try {
-          body = await res.json();
-        } catch {
-          // JSON化できない失敗は generic 扱いへ
-        }
-        if (isPlanUpgradeRequired(body)) {
-          sawPlanLimit = true;
-          planLimitText =
-            planLimitText ??
-            (body as { message?: string }).message ??
-            "この機能は現在のプランではご利用いただけません。プランのアップグレードをご検討ください。";
-        } else {
-          sawGenericFailure = true;
-        }
-      };
-
-      await Promise.all([
-        applyIfOk<AnalyticsSummaryResponse>(summaryRes, setSummary),
-        applyIfOk<AnalyticsTrendsResponse>(trendsRes, setTrends),
-        applyIfOk<AnalyticsEvaluationsResponse>(evalsRes, setEvaluations),
-        applyIfOk<ConversionResponse>(convRes, setConversion),
+      // 403 plan_upgrade_required は正常系の分岐であり「読み込みに失敗しました」に
+      // しない。1本が失敗しても他の成功結果は巻き込まない。仕分けの実装は
+      // lib/planFeatures.ts に共通化してある(成約分析も同じものを使う)。
+      // 失敗した項目は null に戻す — 期間を切り替えて失敗したときに、前の期間の
+      // 数値が新しい期間ラベルの下に残るのを防ぐ(CLAUDE.md 17)。
+      const outcome = await applyFetchResults([
+        {
+          res: summaryRes,
+          apply: (d) => setSummary(d as AnalyticsSummaryResponse),
+        },
+        { res: trendsRes, apply: (d) => setTrends(d as AnalyticsTrendsResponse) },
+        {
+          res: evalsRes,
+          apply: (d) => setEvaluations(d as AnalyticsEvaluationsResponse),
+        },
+        { res: convRes, apply: (d) => setConversion(d as ConversionResponse) },
       ]);
 
-      if (sawGenericFailure) {
-        setError("データの読み込みに失敗しました。時間をおいて再試行してください。");
-      } else if (sawPlanLimit) {
-        setPlanLimitMessage(planLimitText);
+      if (!summaryRes.ok) setSummary(null);
+      if (!trendsRes.ok) setTrends(null);
+      if (!evalsRes.ok) setEvaluations(null);
+      if (!convRes.ok) setConversion(null);
+
+      if (outcome.genericFailure) {
+        setError(t("common.load_failed"));
+      } else if (outcome.planLimited) {
+        setPlanLimit({ message: outcome.planLimitMessage });
       }
 
       // Phase68: ナレッジ貢献度（特定テナントが選ばれている場合のみ）
@@ -181,11 +174,11 @@ export default function AnalyticsDashboardPage() {
         setKnowledgeTop3AvgRate(null);
       }
     } catch {
-      setError("データの読み込みに失敗しました。時間をおいて再試行してください。");
+      setError(t("common.load_failed"));
     } finally {
       setLoading(false);
     }
-  }, [period, tenantId, isSuperAdmin, tenantFilter]);
+  }, [period, tenantId, isSuperAdmin, tenantFilter, t]);
 
   useEffect(() => {
     void loadData();
@@ -388,61 +381,11 @@ export default function AnalyticsDashboardPage() {
         setPeriod={setPeriod}
       />
 
-      {/* Error(読み込み失敗。403プラン制限はここに出さない） */}
-      {error && (
-        <div
-          style={{
-            marginBottom: 20,
-            padding: "14px 18px",
-            borderRadius: 12,
-            background: "rgba(127,29,29,0.4)",
-            border: "1px solid rgba(248,113,113,0.3)",
-            color: "#fca5a5",
-            fontSize: 15,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            gap: 12,
-            flexWrap: "wrap",
-          }}
-        >
-          <span>{error}</span>
-          <button
-            onClick={() => void loadData()}
-            style={{
-              padding: "8px 16px",
-              minHeight: 36,
-              borderRadius: 8,
-              border: "1px solid rgba(248,113,113,0.4)",
-              background: "transparent",
-              color: "#fca5a5",
-              fontSize: 13,
-              fontWeight: 600,
-              cursor: "pointer",
-              whiteSpace: "nowrap",
-            }}
-          >
-            再試行
-          </button>
-        </div>
-      )}
+      {/* 読み込み失敗(5xx等)。403プラン制限はここに出さない */}
+      {error && <LoadErrorBanner message={error} onRetry={() => void loadData()} />}
 
       {/* プラン制限（正常系の分岐。エラーではないので赤帯にしない） */}
-      {!error && planLimitMessage && (
-        <div
-          style={{
-            marginBottom: 20,
-            padding: "14px 18px",
-            borderRadius: 12,
-            background: "var(--card)",
-            border: "1px solid var(--border)",
-            color: "var(--foreground)",
-            fontSize: 15,
-          }}
-        >
-          ✨ {planLimitMessage}
-        </div>
-      )}
+      {!error && planLimit && <PlanLimitNotice message={planLimit.message} />}
 
       {loading ? (
         <div style={{ padding: 60, textAlign: "center", color: "var(--muted-foreground)" }}>

--- a/admin-ui/src/pages/admin/conversion/index.test.tsx
+++ b/admin-ui/src/pages/admin/conversion/index.test.tsx
@@ -11,9 +11,25 @@ vi.mock('../../../auth/useAuth', () => ({
   useAuth: vi.fn(),
 }));
 
-vi.mock('../../../i18n/LangContext', () => ({
-  useLang: () => ({ t: (k: string) => k, lang: 'ja' }),
-}));
+// t() はキーをそのまま返すのではなく実辞書(ja.ts)を引く。
+// キー名を返すだけのモックだと「間違ったキーを参照していても素通りする」ため、
+// 画面に実際に出る日本語で検証できるようにする
+// (KnowledgeListTab.test.tsx / escalations/[sessionId].test.tsx と同じ既存パターン)。
+vi.mock('../../../i18n/LangContext', async () => {
+  const jaModule = await import('../../../i18n/ja');
+  const ja = jaModule.default as Record<string, string>;
+  const stableT = (key: string, vars?: Record<string, string | number>) => {
+    let text = ja[key] ?? key;
+    if (vars) {
+      for (const [k, v] of Object.entries(vars)) {
+        text = text.replace(new RegExp(`\\{${k}\\}`, 'g'), String(v));
+      }
+    }
+    return text;
+  };
+  const stableValue = { lang: 'ja' as const, setLang: () => {}, t: stableT };
+  return { useLang: () => stableValue };
+});
 
 vi.mock('../../../lib/api', () => ({
   API_BASE: 'http://localhost:3100',
@@ -117,7 +133,7 @@ describe('ConversionDashboardPage — プラン制限(403)の表示', () => {
     await waitFor(() => {
       expect(screen.getByText(/読み込みに失敗しました/)).toBeTruthy();
     });
-    expect(screen.getByRole('button', { name: '再試行' })).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'やり直す' })).toBeTruthy();
     expect(screen.queryByText(/プランでご利用いただけます|プランのアップグレード/)).toBeNull();
   });
 

--- a/admin-ui/src/pages/admin/conversion/index.tsx
+++ b/admin-ui/src/pages/admin/conversion/index.tsx
@@ -7,7 +7,9 @@ import { useNavigate, useSearchParams } from "react-router-dom";
 import { authFetch, API_BASE } from "../../../lib/api";
 import { useAuth } from "../../../auth/useAuth";
 import { useLang } from "../../../i18n/LangContext";
-import { isPlanUpgradeRequired } from "../../../lib/planFeatures";
+import { applyFetchResults } from "../../../lib/planFeatures";
+import { LoadErrorBanner } from "../../../components/common/LoadErrorBanner";
+import { PlanLimitNotice } from "../../../components/common/PlanLimitNotice";
 
 // ------------------------------------------------------------------ //
 // Types
@@ -113,7 +115,8 @@ export default function ConversionDashboardPage() {
   const [error, setError] = useState<string | null>(null);
   // 403 plan_upgrade_required は正常系の分岐であり、error(赤帯)とは別に持つ
   // (CLAUDE.md 絶対にやってはいけないこと 21: 403を「読み込みに失敗しました」/「0件」と混同しない)。
-  const [planLimitMessage, setPlanLimitMessage] = useState<string | null>(null);
+  // null = 制限なし / オブジェクト = 制限あり(message はサーバが返さなければ null)。
+  const [planLimit, setPlanLimit] = useState<{ message: string | null } | null>(null);
   // A/Bテスト件数は experiments=[] だと「0件成功」と「未取得」を区別できないため専用フラグを持つ
   const [expLoadFailed, setExpLoadFailed] = useState(false);
   const [searchParams, setSearchParams] = useSearchParams();
@@ -127,7 +130,7 @@ export default function ConversionDashboardPage() {
   const loadData = useCallback(async () => {
     setLoading(true);
     setError(null);
-    setPlanLimitMessage(null);
+    setPlanLimit(null);
     try {
       const [attrRes, effRes, expRes] = await Promise.all([
         authFetch(`${API_BASE}/v1/admin/conversion/attributions?period=${period}${tenantParam}`),
@@ -136,52 +139,31 @@ export default function ConversionDashboardPage() {
       ]);
 
       // 403 plan_upgrade_required は正常系の分岐(エラーではない)。それ以外の失敗だけを
-      // 「読み込み失敗」として扱う。いずれの失敗でも summary/experiments を [] や 0 のまま
-      // にしておくと「実績0件」と誤読されるため、成功したものだけ状態を更新する。
-      let sawPlanLimit = false;
-      let planLimitText: string | null = null;
-      let sawGenericFailure = false;
-
-      const handle = async (res: Response, onOk: (data: any) => void): Promise<void> => {
-        if (res.ok) {
-          onOk(await res.json());
-          return;
-        }
-        let body: unknown = null;
-        try {
-          body = await res.json();
-        } catch {
-          // JSON化できない失敗は generic 扱いへ
-        }
-        if (isPlanUpgradeRequired(body)) {
-          sawPlanLimit = true;
-          planLimitText =
-            planLimitText ??
-            (body as { message?: string }).message ??
-            "この機能は現在のプランではご利用いただけません。プランのアップグレードをご検討ください。";
-        } else {
-          sawGenericFailure = true;
-        }
-      };
-
-      await Promise.all([
-        handle(attrRes, (data) => setSummary(data.summary)),
-        handle(effRes, (data) => setRankings(data.rankings ?? [])),
-        handle(expRes, (data) => setExperiments(data.experiments ?? [])),
+      // 「読み込み失敗」として扱う。仕分けの実装は lib/planFeatures.ts に共通化してある
+      // (会話分析も同じものを使う)。
+      const outcome = await applyFetchResults([
+        { res: attrRes, apply: (d) => setSummary((d as { summary: ConversionSummary }).summary) },
+        { res: effRes, apply: (d) => setRankings((d as { rankings?: EffectivenessRanking[] }).rankings ?? []) },
+        { res: expRes, apply: (d) => setExperiments((d as { experiments?: ABExperiment[] }).experiments ?? []) },
       ]);
+
+      // 失敗した項目は「実績0件」と誤読されないよう未取得状態へ戻す。期間を切り替えて
+      // 失敗したときに前の期間の数値が新しい期間ラベルの下に残るのも防ぐ(CLAUDE.md 17)。
+      if (!attrRes.ok) setSummary(null);
+      if (!effRes.ok) setRankings([]);
       setExpLoadFailed(!expRes.ok);
 
-      if (sawGenericFailure) {
-        setError("データの読み込みに失敗しました。時間をおいて再試行してください。");
-      } else if (sawPlanLimit) {
-        setPlanLimitMessage(planLimitText);
+      if (outcome.genericFailure) {
+        setError(t("common.load_failed"));
+      } else if (outcome.planLimited) {
+        setPlanLimit({ message: outcome.planLimitMessage });
       }
     } catch {
-      setError("データの読み込みに失敗しました。時間をおいて再試行してください。");
+      setError(t("common.load_failed"));
     } finally {
       setLoading(false);
     }
-  }, [period, isSuperAdmin, effectiveTenantId, tenantParam]);
+  }, [period, isSuperAdmin, effectiveTenantId, tenantParam, t]);
 
   useEffect(() => { void loadData(); }, [loadData]);
 
@@ -243,61 +225,11 @@ export default function ConversionDashboardPage() {
         </div>
       </div>
 
-      {/* Error(読み込み失敗。403プラン制限はここに出さない） */}
-      {error && (
-        <div
-          style={{
-            marginBottom: 20,
-            padding: "14px 18px",
-            borderRadius: 12,
-            background: "rgba(127,29,29,0.4)",
-            border: "1px solid rgba(248,113,113,0.3)",
-            color: "#fca5a5",
-            fontSize: 15,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "space-between",
-            gap: 12,
-            flexWrap: "wrap",
-          }}
-        >
-          <span>{error}</span>
-          <button
-            onClick={() => void loadData()}
-            style={{
-              padding: "8px 16px",
-              minHeight: 36,
-              borderRadius: 8,
-              border: "1px solid rgba(248,113,113,0.4)",
-              background: "transparent",
-              color: "#fca5a5",
-              fontSize: 13,
-              fontWeight: 600,
-              cursor: "pointer",
-              whiteSpace: "nowrap",
-            }}
-          >
-            再試行
-          </button>
-        </div>
-      )}
+      {/* 読み込み失敗(5xx等)。403プラン制限はここに出さない */}
+      {error && <LoadErrorBanner message={error} onRetry={() => void loadData()} />}
 
       {/* プラン制限（正常系の分岐。エラーではないので赤帯にしない） */}
-      {!error && planLimitMessage && (
-        <div
-          style={{
-            marginBottom: 20,
-            padding: "14px 18px",
-            borderRadius: 12,
-            background: "var(--card)",
-            border: "1px solid var(--border)",
-            color: "var(--foreground)",
-            fontSize: 15,
-          }}
-        >
-          ✨ {planLimitMessage}
-        </div>
-      )}
+      {!error && planLimit && <PlanLimitNotice message={planLimit.message} />}
 
       {/* KPI Cards */}
       <div style={GRID4}>


### PR DESCRIPTION
レビュー指摘(P1-1〜P1-4, P2-1〜P2-4)への対応です。

## 背景

PR #752 で会話分析と成約分析に同じ処理が別々に実装され、**共有されたのは
`isPlanUpgradeRequired`(3行)だけ**でした。残る約90行 —— 判定ロジック・
文言・赤帯JSX・プラン制限バナーJSX —— が2ファイルにほぼ逐語で重複していました。

## 是正した逸脱

| # | 逸脱 | 是正 |
|---|---|---|
| 1 | **重複**(禁止事項6 /「同じ文言を4箇所に散らさない」)。同一の失敗文言リテラルが**ちょうど4箇所**に散在 | 判定を `lib/planFeatures.ts` の `applyFetchResults()` に集約、表示を `components/common/` の2部品へ |
| 2 | **i18nを通っていない**。新規の再試行ボタンだけ生の「再試行」をハードコードし、英語UIでも日本語が残っていた。既存6箇所は `t("common.retry")`=「やり直す」で、**同一機能に2ラベルが並存** | 共通部品側で `t("common.retry")` に統一 |
| 3 | **タップ領域44px未満**(Core Principles: Mobile First)。`minHeight:36`。同じバッチで直した `tenants/[id].tsx` は44pxで**バッチ内不統一** | 44px に統一 |
| 4 | **#754 のトークンを使っていない**。新規の赤帯が `rgba(127,29,29,0.4)`+`#fca5a5` = **#754 が「ライトテーマで判読不能」として直した色そのもの**を新しく2箇所に追加していた | `--destructive` 系トークンへ統一 |

## 併せて直した表示の不整合

- **期間切替に失敗すると前の期間の数値が新しい期間ラベルの下に残っていた**(CLAUDE.md 17)。失敗した項目は未取得状態(`null`)へ戻すようにした
- **「403だが `message` が無い」場合にプラン制限バナーが出なかった**。`message` の有無ではなく `planLimited` フラグで判定する設計に変更

## 追加ファイル(2件、いずれも共有が必要で既存に該当が無いもの)

- `components/common/LoadErrorBanner.tsx`
- `components/common/PlanLimitNotice.tsx`

`components/common/` は**汎用UI部品の既定の置き場所**(CLAUDE.md「実装の置き場所」)。

## テスト

**レビューで指摘した3つの抜けを埋めました**

- **再試行ボタンが実際に再取得すること** — 従来は「ボタンが存在する」だけの検証で、
  **ハンドラ未接続でも通る**状態でした
- **非JSONのエラーボディ**(nginxの502 HTML等、`res.json()` が throw する経路)を
  プラン制限と誤判定しないこと — 実運用で最も起きやすい失敗形なのに未検証でした
- **403と500の混在時**は復旧行動の要る「読み込み失敗」を優先すること

**i18nモックの強化**: `analytics`/`conversion` のモックを、キー名をそのまま返すものから
**実辞書(ja.ts)を引く**ものへ変更しました。キー名モックでは「間違ったキーを参照して
いても素通りする」ため、画面に出る実際の日本語で検証します(既存3ファイルと同じパターン)。

`planFeatures.test.ts` に `applyFetchResults` の8ケース(403/500混在・message無し403・
非JSONボディ・空配列など)を追加。

**ミューテーション確認済み**: プラン制限判定を無効化すると、3ファイル計7テストが
失敗することを確認してから復元しています。

## Gate

- [x] admin-ui vitest **479/479 全パス**(rebase前に残っていた `useAuth.test.tsx` の失敗も #758 取り込みで解消)
- [x] `pnpm lint` 0新規警告(58/63)
- [x] backend typecheck 0 errors
- [x] `dead-code-check` 新規のdead exportなし
- [x] `security-scan` PASS(CRITICAL/HIGH 0)
- [x] admin-ui build 成功
- [ ] Gate 2.5(Codex review)未実行 — レビューをお願いします

## 差分の性質

`+418 / -206`。増加分の大半はテスト(+180行)と共通部品のコメントで、
**ページ側は analytics `-135`、conversion `-120` の純減**です。

## Tier / merge

`admin-ui/src/**` のみ。Tier S、hkobayashi の手動 merge が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01My9XXuKXbnb8ca9xgDnEqj
