### PR TITLE
fix(docs): DEPLOY_CHECKLIST の重複除去とrunbookに混入した別migrationコマンドの削除

### DIFF
--- a/docs/DEPLOY_CHECKLIST.md
+++ b/docs/DEPLOY_CHECKLIST.md
@@ -253,9 +253,10 @@ PostgreSQL 17 の使い捨てDBに対して、5本を実際に流して以下を
 **既知の副作用(実害なし、ただし見た目が変わる)**
 
 `posthog_host` は `DEFAULT 'https://app.posthog.com'` を持つため、適用後は全テナントで
-この値が入る(リハーサルで実際に全行へ入ることを確認済み。`widget_theme` は `{}`)。チャットの `get_tenant_settings` の表示が「PostHog ホスト: 未設定」から
-このURLに変わる。**PostHog の有効化は別列 `posthog_project_api_key_encrypted` が
-握っており、データ送信が始まることはない。**
+この値が入る(リハーサルで実際に全行へ入ることを確認済み。`widget_theme` は `{}`)。
+チャットの `get_tenant_settings` の表示が「PostHog ホスト: 未設定」からこのURLに変わる。
+**PostHog の有効化は別列 `posthog_project_api_key_encrypted` が握っており、
+データ送信が始まることはない。**
 
 **デプロイとの順序**: どちらが先でもよい。コードは既に本番へ出ており(PR #748〜#759)、
 現在は「列が無いので500」の状態。migration 単独で解消する。
@@ -285,157 +286,14 @@ LEFT JOIN information_schema.columns col
 SELECT 'table.conversation_flow_logs',
        CASE WHEN to_regclass('conversation_flow_logs') IS NULL THEN 'MISSING' ELSE 'ok' END;
 SQL
-
-# 2. バックアップ (必須)
-pg_dump $DATABASE_URL > /opt/backups/pre_phase_a_$(date +%Y%m%d_%H%M).sql
-
-# 3. Migration 実行
-psql $DATABASE_URL < /opt/rajiuce/src/api/admin/tenants/migration_phase_a.sql
-
-# 4. 確認
-psql $DATABASE_URL -c "\d tenants" | grep ga4
-psql $DATABASE_URL -c "\d notification_preferences"
-psql $DATABASE_URL -c "\d ga4_connection_logs"
-psql $DATABASE_URL -c "\d ga4_test_history"
-psql $DATABASE_URL -c "\d conversion_attributions" | grep event_id
-```
-
-### Phase A Day 2 環境変数追加 (.env)
-
-```bash
-# GA4 Data API (サービスアカウントJSON をbase64エンコード)
-GOOGLE_APPLICATION_CREDENTIALS_JSON=<base64-encoded-service-account-json>
-
-# Cloudflare Workers → VPS HMAC認証 (Workers側と同じ値を設定)
-INTERNAL_API_HMAC_SECRET=<random-256bit-secret>
 ```
 
 ```bash
-# VPS で実行:
-ssh root@65.108.159.161 "psql \$DATABASE_URL -f /opt/rajiuce/src/api/admin/feedback/migration_feedback_flagged.sql"
-```
-
-### sai_tasks migration 実行手順 (PR #755)
-
-> **本番適用済み (2026-08-16)。** 以下は再構築時・別環境向けの記録。
-> `CREATE TABLE IF NOT EXISTS` なので再実行しても無害だが、通常は不要。
-> 適用時の確認結果: `task_id`(PK) / `tenant_id`(NOT NULL) / `tenants(id)` へのFK /
-> `idx_sai_tasks_tenant` がいずれも作成済み。
-
-**適用順序: デプロイ → migration。逆にはできない。**
-`migration_sai_tasks.sql` は rsync でVPSへ配布されるため、デプロイ前はVPS上にファイルが存在しない。
-
-この順序で安全な理由 — どの瞬間も現状より悪くならないため:
-
-| タイミング | `get_sai_task_status` の挙動 | 状態 |
-|---|---|---|
-| デプロイ前(現状) | 所有権照合なしで他テナントのタスクを読める | **脆弱** |
-| デプロイ後・migration前 | 照合先が無いため全件拒否 (fail-closed) | 安全・機能停止 |
-| migration後 | 依頼元テナントのタスクのみ読める | 安全・正常 |
-
-中間状態では進捗照会が「確認できませんでした」を返すのみで、依頼(`request_sai_task`)自体は通る。
-できるだけ短く畳むため、デプロイ直後に続けて実行すること。
-
-```bash
-# 1. デプロイ (唯一の手順)
-bash SCRIPTS/deploy-vps.sh
-
-# 2. バックアップ (必須)
-ssh root@65.108.159.161 "pg_dump \$DATABASE_URL > /opt/backups/pre_sai_tasks_\$(date +%Y%m%d_%H%M).sql"
-
-# 3. 適用前の確認 — 既に存在しないこと (存在するなら適用済み。二重実行は不要)
-ssh root@65.108.159.161 "psql \$DATABASE_URL -c \"\\d sai_tasks\""
-
-# 4. Migration 実行
-ssh root@65.108.159.161 "psql \$DATABASE_URL -f /opt/rajiuce/src/lib/sai/migration_sai_tasks.sql"
-
-# 5. 確認 — task_id(PK) / tenant_id(NOT NULL) / tenants(id)へのFK / インデックスが揃っていること
-ssh root@65.108.159.161 "psql \$DATABASE_URL -c \"\\d sai_tasks\""
-```
-
-**動作確認**: 管理画面のチャットで代行を1件依頼し、返ってきたタスクIDで進捗照会する。
-「確認できませんでした」が消え、状態が表示されれば適用成功。
-別テナントのタスクIDを渡すと「見つかりません」になる（「権限がありません」ではない）。
-
-**ロールバック**: 新規テーブルのみで既存テーブルへの変更が無いため、コードを戻せばテーブルは無害な残骸になる。
-テーブル自体を消す必要がある場合のみ以下。**コードが新しいままだと進捗照会が全件拒否に戻る**ので、
-必ずコードのロールバックとセットで行う。
-
-```bash
-ssh root@65.108.159.161 "psql \$DATABASE_URL -c 'DROP TABLE IF EXISTS sai_tasks;'"
-```
-
-### 本番500の解消 migration 実行手順 (2026-08-16 実測、Asana 1217530758061266)
-
-> **未適用。** 本番の実機検証で以下4系統の500が確認されており、いずれも
-> 列/テーブルの未適用が原因。**コードのデプロイでは解消しない。**
-
-```
-GET /v1/admin/my-tenant                     500 {"error":"取得に失敗しました"}
-GET /v1/admin/tenants/:id                   500 (全テナントで再現)
-GET /v1/admin/feedback?unread=true&limit=5  500 {"error":"フィードバック一覧の取得に失敗しました"}
-GET /v1/admin/analytics/flow-transitions    500 {"error":"フロー遷移の集計に失敗しました"}
-```
-
-**原因の切り分け根拠**: 一覧の `GET /v1/admin/tenants` は200で通り、500になる2本
-(`my-tenant` / `tenants/:id`)だけが列を追加で SELECT している。差分列がそのまま原因。
-共通処理の `fetchOnboardingStageStatus` は全クエリが try/catch 済みで500を出せない構造。
-
-| 適用するファイル | 追加されるもの | どの500が直るか |
-|---|---|---|
-| `src/api/admin/tenants/migration_faq_hints.sql` | `tenants.faq_question_hint` / `faq_answer_hint` | my-tenant / tenants/:id |
-| `src/api/admin/tenants/migration_onboarding.sql` | `tenants.onboarding_industry` / `onboarding_completed_at` / `onboarding_widget_seen_at` | 同上 |
-| `src/api/admin/agent/migration_admin_agent_columns.sql` | `tenants.ga4_measurement_id` / `posthog_host` / `widget_theme` | 同上 |
-| `src/api/admin/feedback/migration_admin_feedback_reply.sql` | `admin_feedback` の返信5列 + 部分インデックス | feedback?unread=true |
-| `src/migrations/phase72c_conversation_flow_logs.sql` | `conversation_flow_logs` テーブル + 3インデックス | flow-transitions |
-
-**安全性(適用前に確認済み)**
-
-- 全て `ADD COLUMN IF NOT EXISTS` / `CREATE TABLE IF NOT EXISTS` / `CREATE INDEX IF NOT EXISTS`。
-  **再実行しても無害**。既にどれかが適用済みでも順序を気にせず流せる。
-- `DROP`・既存列の型変更・既存行の UPDATE は**一つも含まれない**。
-- PostgreSQL 11+ では `ADD COLUMN ... DEFAULT` はテーブル書き換えを伴わないため、
-  行数に関わらずロックは一瞬(本番は PG16)。
-- FK は `admin_feedback.parent_feedback_id UUID → admin_feedback(id)` の自己参照1本のみ。
-  `admin_feedback.id` は `UUID PRIMARY KEY` で型は一致している。
-
-**既知の副作用(実害なし、ただし見た目が変わる)**
-
-`posthog_host` は `DEFAULT 'https://app.posthog.com'` を持つため、適用後は全テナントで
-この値が入る(リハーサルで実際に全行へ入ることを確認済み。`widget_theme` は `{}`)。チャットの `get_tenant_settings` の表示が「PostHog ホスト: 未設定」から
-このURLに変わる。**PostHog の有効化は別列 `posthog_project_api_key_encrypted` が
-握っており、データ送信が始まることはない。**
-
-**デプロイとの順序**: どちらが先でもよい。コードは既に本番へ出ており(PR #748〜#759)、
-現在は「列が無いので500」の状態。migration 単独で解消する。
-
-適用対象の `.sql` は既に VPS 上にある(いずれも以前からの tracked file で、
-本日のデプロイで `/opt/rajiuce/` へ配布済み)。**このためデプロイ待ちは不要。**
-確認クエリだけは新規なので、ファイル参照ではなく標準入力で流す。
-
-```bash
-# 1. 適用前の確認 — MISSING が出た項目が原因。結果はAsanaに記録する
-ssh root@65.108.159.161 "psql \$DATABASE_URL -t -A -F' ' <<'SQL'
-SELECT 'tenants.'||c.name,
-       CASE WHEN col.column_name IS NULL THEN 'MISSING' ELSE 'ok' END
-FROM (VALUES ('faq_question_hint'),('faq_answer_hint'),('onboarding_industry'),
-             ('onboarding_completed_at'),('onboarding_widget_seen_at'),
-             ('widget_theme'),('ga4_measurement_id'),('posthog_host')) AS c(name)
-LEFT JOIN information_schema.columns col
-  ON col.table_name='tenants' AND col.column_name=c.name;
-SELECT 'admin_feedback.'||c.name,
-       CASE WHEN col.column_name IS NULL THEN 'MISSING' ELSE 'ok' END
-FROM (VALUES ('reply_body'),('replied_at'),('replied_by_email'),
-             ('reply_read_at'),('parent_feedback_id')) AS c(name)
-LEFT JOIN information_schema.columns col
-  ON col.table_name='admin_feedback' AND col.column_name=c.name;
-SELECT 'table.conversation_flow_logs',
-       CASE WHEN to_regclass('conversation_flow_logs') IS NULL THEN 'MISSING' ELSE 'ok' END;
-SQL"
-
 # 2. バックアップ (必須)
 ssh root@65.108.159.161 "pg_dump \$DATABASE_URL > /opt/backups/pre_500fix_\$(date +%Y%m%d_%H%M).sql"
+```
 
+```bash
 # 3. 適用 (順序は任意。全て冪等)
 ssh root@65.108.159.161 "psql \$DATABASE_URL -v ON_ERROR_STOP=1 \
   -f /opt/rajiuce/src/api/admin/tenants/migration_faq_hints.sql \
@@ -443,12 +301,12 @@ ssh root@65.108.159.161 "psql \$DATABASE_URL -v ON_ERROR_STOP=1 \
   -f /opt/rajiuce/src/api/admin/agent/migration_admin_agent_columns.sql \
   -f /opt/rajiuce/src/api/admin/feedback/migration_admin_feedback_reply.sql \
   -f /opt/rajiuce/src/migrations/phase72c_conversation_flow_logs.sql"
-
-# 4. 適用後の確認 — 手順1と同じクエリを再実行し、MISSING が0件になること
 ```
 
 `ON_ERROR_STOP=1` を付けているため、途中で失敗すればそこで止まる(残りは流れない)。
 **API の再起動は不要** — 列の追加はアプリ側のキャッシュに影響しない。
+
+**4. 適用後の確認**: 手順1と同じクエリを再実行し、`MISSING` が0件になること。
 
 **動作確認 (4系統すべて 200 になること)**
 


### PR DESCRIPTION
**PR #760 で私が入れた runbook が壊れた状態で main に入っていました。その修正です。**

## 実害（修正前の状態）

runbook の手順1の ```bash ブロックが、確認クエリの直後にそのまま以下へ続いていました:

```
pg_dump ... > /opt/backups/pre_phase_a_...
psql $DATABASE_URL < .../migration_phase_a.sql
```

**手順どおりコピペすると、意図しない別の migration（Phase A Day 2）が本番で走ります。**
ドキュメントとして危険な状態でした。

あわせて、以下3セクションが丸ごと2重になっていました。

- Phase A Day 2 環境変数追加
- sai_tasks migration 実行手順
- 本番500の解消 migration 実行手順（自分自身）

## 原因

heredoc を修正する際、置換範囲をこう決めていました:

```python
start = s.index("# 1. 適用前の確認 ...")    # runbook内(後方)
end   = s.index("# 2. バックアップ (必須)")  # Phase A セクション内(前方)
s = s[:start] + new + s[end:]
```

`# 2. バックアップ (必須)` は **Phase A 手順にも同じ文字列があり**、`str.index` は
ファイル先頭から探すため `end < start` になりました。結果 `s[end:]` が Phase A 以降を
丸ごと再連結し、重複とコマンド混入が同時に発生しました。

## 修正

`f1867d9f`（壊れる前）の `DEPLOY_CHECKLIST.md` を出発点に、一覧表の5行と runbook を
**1回だけ**入れ直して再構築しました。差分は `+7 / -149` です。

**検証済み**

| 項目 | 結果 |
|---|---|
| 4つの見出しが各1回のみ | ✅ |
| runbook 内に `migration_phase_a` / `pre_phase_a` 等の混入 | ✅ なし |
| コードフェンス(```)の個数 | ✅ 全体30・runbook内10、いずれも偶数 |
| 手順1〜4が揃っている | ✅ |

## 再発防止

文書への挿入・置換でアンカー文字列を使うときは:

- そのアンカーが**ファイル内で一意か `assert` する**
- **範囲指定のスライスを使わず**、一意なアンカーへの `replace(count=1)` にする

今回の再構築スクリプトでは `count == 1` を assert してから置換しています。

## お詫び

migration の実行を支援する目的の runbook で、そのまま実行すると別の migration が走る
状態のものを出してしまいました。**適用作業に着手される前に本PRのマージをお願いします。**

## Tier / merge

`docs/` のみのため Tier B。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01My9XXuKXbnb8ca9xgDnEqj
