### PR TITLE
fix(api): JSONBカラムへのunnest()をやめ、AI改善レポートの常時500を解消

### DIFF
--- a/src/api/admin/evaluations/evaluationsRepository.stats.test.ts
+++ b/src/api/admin/evaluations/evaluationsRepository.stats.test.ts
@@ -1,0 +1,74 @@
+// src/api/admin/evaluations/evaluationsRepository.stats.test.ts
+// getDetailedStats() が JSONB カラムに unnest() を使って常時500になっていた不具合の回帰テスト。
+//
+// used_principles / effective_principles は JSONB(migration_conversation_evaluations.sql)。
+// unnest() は配列型専用で、PostgreSQL は `function unnest(jsonb) does not exist` で失敗する。
+// そのため GET /v1/admin/evaluations/stats(テナント詳細「AI改善レポート」タブ)が
+// 常に500を返していた。実行されるSQLそのものを検査して再発を止める。
+
+const mockQuery = jest.fn();
+jest.mock("../../../lib/db", () => ({
+  getPool: () => ({ query: (...args: unknown[]) => mockQuery(...args) }),
+}));
+
+import { getDetailedStats } from "./evaluationsRepository";
+
+/** 呼ばれた全SQLを1本の文字列に連結する（何本目かに依存せず検査するため） */
+function allSql(): string {
+  return mockQuery.mock.calls.map((c) => String(c[0])).join("\n---\n");
+}
+
+beforeEach(() => {
+  mockQuery.mockReset();
+  // getDetailedStats は複数クエリを順に投げる。どれも空結果で構わない。
+  mockQuery.mockResolvedValue({ rows: [] });
+});
+
+describe("getDetailedStats", () => {
+  it("JSONBカラムに unnest() を使わない（使うと本番で必ず500になる）", async () => {
+    await getDetailedStats("carnation", 7);
+
+    const sql = allSql();
+    expect(sql).not.toMatch(/unnest\s*\(\s*used_principles\s*\)/);
+    expect(sql).not.toMatch(/unnest\s*\(\s*effective_principles\s*\)/);
+  });
+
+  it("JSONB用の jsonb_array_elements_text で展開する", async () => {
+    await getDetailedStats("carnation", 7);
+
+    const sql = allSql();
+    expect(sql).toMatch(/jsonb_array_elements_text\s*\(\s*used_principles\s*\)/);
+    expect(sql).toMatch(/jsonb_array_elements_text\s*\(\s*effective_principles\s*\)/);
+  });
+
+  it("tenantId 指定時は全クエリが tenant_id で絞られる（テナント越境しない）", async () => {
+    await getDetailedStats("carnation", 7);
+
+    // principle 集計を含む全クエリに tenant_id 条件が入っていること
+    const principleQueries = mockQuery.mock.calls
+      .map((c) => String(c[0]))
+      .filter((s) => s.includes("jsonb_array_elements_text"));
+    expect(principleQueries.length).toBe(2);
+    for (const q of principleQueries) {
+      expect(q).toMatch(/tenant_id\s*=\s*\$\d/);
+    }
+    for (const c of mockQuery.mock.calls) {
+      expect(c[1]).toContain("carnation");
+    }
+  });
+
+  it("tenantId 未指定(super_adminの横断ビュー)でも例外にならない", async () => {
+    await expect(getDetailedStats(undefined, 30)).resolves.toBeDefined();
+    expect(allSql()).toMatch(/jsonb_array_elements_text/);
+  });
+
+  it("結果が0件でも例外にならず、空の principle_stats を返す", async () => {
+    const stats = await getDetailedStats("carnation", 7);
+    expect(stats.principle_stats).toEqual({});
+  });
+
+  it("DBが例外を投げた場合はそのまま伝播する（呼び出し元が500へ変換する既存挙動を維持）", async () => {
+    mockQuery.mockRejectedValueOnce(new Error("connection terminated"));
+    await expect(getDetailedStats("carnation", 7)).rejects.toThrow();
+  });
+});

--- a/src/api/admin/evaluations/evaluationsRepository.ts
+++ b/src/api/admin/evaluations/evaluationsRepository.ts
@@ -209,16 +209,21 @@ export async function getDetailedStats(
   const stage_progression_rate = rawStage / 100;
 
   // principle_stats: used_principles の usage_count + effective_principles との照合で effectiveness_rate
+  // used_principles / effective_principles は JSONB(migration_conversation_evaluations.sql)。
+  // unnest() は配列型専用で JSONB を受け取れず `function unnest(jsonb) does not exist` で
+  // 落ちるため、GET /v1/admin/evaluations/stats が常時500になっていた
+  // (テナント詳細「AI改善レポート」タブ)。JSONB 用の jsonb_array_elements_text を使う。
+  // NULL や空配列の行は LATERAL 相当の暗黙結合で自然に除外されるため追加のガードは不要。
   const usageResult = await pool.query<{ principle: string; usage_count: string }>(
     `SELECT p AS principle, COUNT(*) AS usage_count
-     FROM conversation_evaluations, unnest(used_principles) AS p
+     FROM conversation_evaluations, jsonb_array_elements_text(used_principles) AS p
      ${where}
      GROUP BY p`,
     args,
   );
   const effectiveResult = await pool.query<{ principle: string; effective_count: string }>(
     `SELECT p AS principle, COUNT(*) AS effective_count
-     FROM conversation_evaluations, unnest(effective_principles) AS p
+     FROM conversation_evaluations, jsonb_array_elements_text(effective_principles) AS p
      ${where}
      GROUP BY p`,
     args,

--- a/src/api/conversion/autoTuning.ts
+++ b/src/api/conversion/autoTuning.ts
@@ -21,8 +21,12 @@ export async function detectRepeatedJudgeSuggestions(
   if (!pool) return [];
   try {
     const result = await pool.query(
-      `SELECT unnest(suggested_rules) AS rule, COUNT(*) AS cnt
-       FROM conversation_evaluations
+      // suggested_rules は JSONB(migration_evaluations.sql)。unnest() は配列型専用で
+       // JSONB を受け取れず必ず例外になる(evaluationsRepository と同じ不具合)。
+       // ここは catch で [] を返すため無症状だが、この関数を配線した瞬間に
+       // 「常に候補0件」として静かに壊れるため、同時に是正しておく。
+      `SELECT rule, COUNT(*) AS cnt
+       FROM conversation_evaluations, jsonb_array_elements_text(suggested_rules) AS rule
        WHERE tenant_id = $1
          AND created_at >= NOW() - INTERVAL '30 days'
          AND suggested_rules IS NOT NULL


### PR DESCRIPTION
## 現象

テナント詳細「📊 AI改善レポート」タブが**常に500**を返していました。

```
GET /v1/admin/evaluations/stats?tenantId=carnation&days=7
→ 500 {"error":"統計データの取得に失敗しました"}
```

## 原因

`getDetailedStats()` が JSONB カラムに `unnest()` を使っていました。

```sql
FROM conversation_evaluations, unnest(used_principles) AS p
```

`used_principles` / `effective_principles` は **JSONB**（`migration_conversation_evaluations.sql:9-10`）。
`unnest()` は配列型専用で、PostgreSQL は `function unnest(jsonb) does not exist` で必ず失敗します。

## 発見の経緯

本番のテナント詳細ページは `tenants` の列不足で長らく500になっており、**ページ自体が開けなかったため配下のタブが一度も検証されていませんでした**。migration 適用でページが開くようになり、17タブを実際に開いて初めて表面化しました。

## 併せて是正した同一バグ

`src/api/conversion/autoTuning.ts` の `detectRepeatedJudgeSuggestions()` も `suggested_rules`（JSONB）に `unnest()` を使っています。

この関数は**現在どこからも import されておらず**、さらに `catch` で `[]` を返すため無症状ですが、**配線した瞬間に「常に候補0件」として静かに壊れます**。同一の1行バグなので同時に直しました（デッドコードの削除はしていません）。

## 検証（実測）

PostgreSQL 17 の使い捨てDBに同じスキーマ（JSONB列）を作って確認しました。

| 検証 | 結果 |
|---|---|
| 修正前のSQL | ✅ `ERROR: function unnest(jsonb) does not exist` を**再現** |
| 修正後のSQL | ✅ 正しく集計（共感2 / 具体化1 / 提案1 / 要約1） |
| `NULL`・空配列 `[]` が混ざる場合 | ✅ 落ちない |
| `suggested_rules` 側 | ✅ 同様に集計できる |

## テスト

`evaluationsRepository.stats.test.ts` を新規追加しました。

このディレクトリには repository のテストが無く、**既存の `routes.test.ts` は `getDetailedStats` を `jest.mock` で丸ごと差し替えている**ため、SQL自体が一度も検査されていませんでした。実行されるSQL文字列を直接検査し、以下を固定します。

- `unnest(...)` が使われていないこと
- `jsonb_array_elements_text(...)` が使われていること
- principle集計クエリが `tenant_id` で絞られていること（テナント越境防止）
- `tenantId` 未指定（super_admin横断）でも例外にならないこと

**ミューテーション確認済み**: `unnest()` に戻すと3件が失敗することを確認してから復元しています。

## Gate

- [x] backend typecheck 0 errors
- [x] 対象スイート 93件 全pass
- [x] `pnpm lint` 0新規警告（58/63。`autoTuning.ts` の `runAutoTuningCheck` 未使用警告は本PR以前から存在）
- [x] `security-scan` PASS（CRITICAL/HIGH 0）
- [ ] Gate 2.5（Codex review）未実行

## デプロイ

`src/` の変更のため、反映には**VPSデプロイが必要**です。migration では直りません。

## Tier / merge

`src/**` のため Tier S。hkobayashi の手動 merge が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01My9XXuKXbnb8ca9xgDnEqj
