### PR TITLE
fix(api): chat_sessionsに存在しないcreated_at列の参照をやめ、アナリティクスタブの常時500を解消

### DIFF
--- a/src/api/admin/tenants/analyticsSummaryRoutes.test.ts
+++ b/src/api/admin/tenants/analyticsSummaryRoutes.test.ts
@@ -1,0 +1,110 @@
+// src/api/admin/tenants/analyticsSummaryRoutes.test.ts
+// テナント詳細「📉 アナリティクス」タブが常時500だった不具合の回帰テスト。
+//
+// chat_sessions の時刻列は started_at(chat-history/migration.sql)であり created_at は
+// 存在しない。にもかかわらず created_at で絞っていたため、PostgreSQL が
+// `column "created_at" does not exist` を返し、
+// GET /v1/admin/tenants/:id/analytics-summary が常に500になっていた。
+//
+// 列名の誤りは型で防げない(SQLは文字列)ため、実際にDBへ渡るSQLそのものを検査する。
+
+import express from "express";
+import type { Express } from "express";
+import request from "supertest";
+import type { Pool } from "pg";
+import { registerAnalyticsSummaryRoutes } from "./analyticsSummaryRoutes";
+
+jest.mock("../../../lib/billing/posthogUsageTracker", () => ({
+  getMonthlyLLMUsageFromPostHog: jest.fn().mockResolvedValue(null),
+}));
+
+function makeDevJwt(payload: object): string {
+  const header = Buffer.from(JSON.stringify({ alg: "HS256", typ: "JWT" })).toString("base64url");
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  return `${header}.${body}.devtest`;
+}
+
+const SUPER_ADMIN_TOKEN = makeDevJwt({ app_metadata: { role: "super_admin" } });
+
+const mockQuery = jest.fn();
+const db = { query: (...args: unknown[]) => mockQuery(...args) } as unknown as Pool;
+
+/** 実行された全SQLを連結して返す（何本目かに依存せず検査する） */
+function allSql(): string {
+  return mockQuery.mock.calls.map((c) => String(c[0])).join("\n---\n");
+}
+/** chat_sessions を参照しているSQLだけを抜き出す */
+function chatSessionSql(): string[] {
+  return mockQuery.mock.calls.map((c) => String(c[0])).filter((s) => /FROM\s+chat_sessions/.test(s));
+}
+
+let app: Express;
+
+beforeAll(() => {
+  process.env.NODE_ENV = "development";
+});
+
+beforeEach(() => {
+  mockQuery.mockReset();
+  mockQuery.mockResolvedValue({ rows: [] });
+  app = express();
+  app.use(express.json());
+  registerAnalyticsSummaryRoutes(app, db);
+});
+
+describe("GET /v1/admin/tenants/:id/analytics-summary", () => {
+  it("200を返す（実在しない列を参照して500にならない）", async () => {
+    const res = await request(app)
+      .get("/v1/admin/tenants/carnation/analytics-summary?period=last_30d")
+      .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`);
+
+    expect(res.status).toBe(200);
+  });
+
+  it("chat_sessions は started_at で絞る（created_at は存在しない列）", async () => {
+    await request(app)
+      .get("/v1/admin/tenants/carnation/analytics-summary?period=last_30d")
+      .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`);
+
+    const sqls = chatSessionSql();
+    expect(sqls.length).toBeGreaterThan(0);
+    for (const sql of sqls) {
+      expect(sql).toMatch(/started_at\s*>=/);
+      // chat_sessions 側の絞り込みに created_at を使っていないこと。
+      // (conversion_attributions の created_at は実在するので、chat_sessions のSQLだけを見る)
+      expect(sql).not.toMatch(/AND\s+created_at\s*>=/);
+    }
+  });
+
+  it("全クエリが tenant_id で絞られる（テナント越境しない）", async () => {
+    await request(app)
+      .get("/v1/admin/tenants/carnation/analytics-summary?period=last_30d")
+      .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`);
+
+    expect(mockQuery.mock.calls.length).toBeGreaterThan(0);
+    for (const call of mockQuery.mock.calls) {
+      expect(String(call[0])).toMatch(/tenant_id\s*=\s*\$1/);
+      expect(call[1]).toContain("carnation");
+    }
+  });
+
+  it("DBが列不存在エラーを返しても500で止まり、生のSQLエラーを漏らさない", async () => {
+    mockQuery.mockRejectedValue(new Error('column "created_at" does not exist'));
+
+    const res = await request(app)
+      .get("/v1/admin/tenants/carnation/analytics-summary?period=last_30d")
+      .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`);
+
+    expect(res.status).toBe(500);
+    expect(JSON.stringify(res.body)).not.toContain("does not exist");
+  });
+
+  it("未知のperiodでも既定(30日)にフォールバックし、例外にならない", async () => {
+    const res = await request(app)
+      .get("/v1/admin/tenants/carnation/analytics-summary?period=not_a_period")
+      .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`);
+
+    expect(res.status).toBe(200);
+    expect(allSql()).toMatch(/FROM\s+chat_sessions/);
+  });
+});

--- a/src/api/admin/tenants/analyticsSummaryRoutes.ts
+++ b/src/api/admin/tenants/analyticsSummaryRoutes.ts
@@ -78,7 +78,10 @@ export function registerAnalyticsSummaryRoutes(app: Express, db: Pool): void {
                ROUND(COUNT(*) / GREATEST($2::float, 1), 2)::text AS avg_per_day
              FROM chat_sessions
              WHERE tenant_id = $1
-               AND created_at >= NOW() - ($3::text)::interval`,
+               -- chat_sessions に created_at は存在しない。セッション開始時刻は started_at
+               -- (chat-history/migration.sql)。created_at を参照していたため
+               -- GET /v1/admin/tenants/:id/analytics-summary が常時500だった。
+               AND started_at >= NOW() - ($3::text)::interval`,
             [tenantId, days, interval],
           ),
           db.query<{ source: string; cnt: string }>(

--- a/src/api/admin/variants/variantsRepository.ts
+++ b/src/api/admin/variants/variantsRepository.ts
@@ -86,7 +86,8 @@ export async function getVariantStats(
      FROM chat_sessions cs
      LEFT JOIN conversation_evaluations e ON e.session_id = cs.session_id
      WHERE cs.tenant_id = $1
-       AND cs.created_at >= NOW() - INTERVAL '${days} days'
+       -- chat_sessions の時刻列は started_at(created_at は存在しない)
+       AND cs.started_at >= NOW() - INTERVAL '${days} days'
        AND cs.prompt_variant_id IS NOT NULL
      GROUP BY cs.prompt_variant_id`,
     [tenantId],


### PR DESCRIPTION
## 現象

テナント詳細「📉 アナリティクス」タブが**常に500**を返していました。

```
GET /v1/admin/tenants/carnation/analytics-summary?period=last_30d
→ 500 {"error":"analytics fetch failed"}
```

## 原因

`chat_sessions` の時刻列は **`started_at`**（`chat-history/migration.sql:7`）で、**`created_at` は存在しません**。にもかかわらず `created_at` で絞っていたため、PostgreSQL が `column "created_at" does not exist` を返していました。

## 修正した2箇所

| ファイル | 内容 |
|---|---|
| `tenants/analyticsSummaryRoutes.ts` | 会話数の集計 — **アナリティクスタブ500の直接原因** |
| `variants/variantsRepository.ts` | variant別平均スコア集計 — 同じ誤りが `cs.created_at` として存在。呼び出し経路が別で未検証でしたが、実行されれば同様に失敗します |

同ファイル内の `conversion_attributions.created_at` は**実在する列**なので触っていません。`analytics/summaryQueries.ts` は元から `started_at` を使っており正しいです。

## ⚠️ 経緯 — 誤った仮説を1つ潰しています

当初、`conversion_attributions` の `source` / `rank` 列の不足を疑い、**`migration_phase_a.sql` の適用を提案しました。これは外れです。**

実際に本番へ適用したところ、全て `already exists` かつ `UPDATE 0` で、**phase_a は既に適用済み**でした（`DEPLOY_CHECKLIST` の「要適用」表記が実態と乖離していました）。それでも500が続いたため、コードを読み直して列名の誤りに行き着いています。

migration 自体は冪等で無害でしたが、**原因ではありませんでした**。

## 検証（実測）

PostgreSQL 17 の使い捨てDBに本番同等の `chat_sessions` を作って確認しました。

| 検証 | 結果 |
|---|---|
| `created_at` 版 | ✅ `ERROR: column "created_at" does not exist` を**再現** |
| `started_at` 版 | ✅ 正しく件数が返る |

## テスト

`analyticsSummaryRoutes.test.ts` を新規追加しました。**このルートにはテストがありませんでした。**

列名の誤りは SQL が文字列であるため型で防げません。実際にDBへ渡るSQLを検査し、以下を固定します。

- `chat_sessions` を参照するクエリが `started_at` で絞ること
- 全クエリが `tenant_id` で絞られること（テナント越境防止）
- 列不存在エラー時に**生のSQLエラーを漏らさない**こと
- 未知の `period` でも既定にフォールバックすること

**ミューテーション確認済み**: `created_at` に戻すと該当テストが落ちることを確認してから復元しています。

## Gate

- [x] backend typecheck 0 errors
- [x] 対象スイート 51件 全pass
- [x] `pnpm lint` 0新規警告（58/63）
- [x] `dead-code-check` 新規のdead exportなし
- [x] `security-scan` PASS（CRITICAL/HIGH 0）
- [ ] Gate 2.5（Codex review）未実行

## デプロイ

`src/` の変更のため、反映には**VPSデプロイが必要**です。

これがマージ・デプロイされると、**テナント詳細の17タブすべてが正常になります**（現在16/17）。

## Tier / merge

`src/**` のため Tier S。hkobayashi の手動 merge が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01My9XXuKXbnb8ca9xgDnEqj
