### PR TITLE
fix(api): ROUNDにdouble precisionを渡さないようにし、アナリティクスタブの500を解消

### DIFF
--- a/src/api/admin/tenants/analyticsSummaryRoutes.test.ts
+++ b/src/api/admin/tenants/analyticsSummaryRoutes.test.ts
@@ -107,4 +107,23 @@ describe("GET /v1/admin/tenants/:id/analytics-summary", () => {
     expect(res.status).toBe(200);
     expect(allSql()).toMatch(/FROM\s+chat_sessions/);
   });
+
+  // 2引数の ROUND() は numeric 版しか存在しない。COUNT(*)/float の結果
+  // (double precision)をそのまま渡すと `function round(double precision, integer)
+  // does not exist` で落ちる。started_at の修正後に実際に踏んだ二段目の不具合。
+  it("ROUND に渡す前に numeric へキャストする（double precision のままだと落ちる）", async () => {
+    await request(app)
+      .get("/v1/admin/tenants/carnation/analytics-summary?period=last_30d")
+      .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`);
+
+    const sqls = chatSessionSql();
+    expect(sqls.length).toBeGreaterThan(0);
+    for (const sql of sqls) {
+      if (!/ROUND\s*\(/i.test(sql)) continue;
+      // ROUND(...) の第1引数が ::numeric でキャストされていること
+      expect(sql).toMatch(/ROUND\s*\([\s\S]*?::numeric\s*,\s*\d+\s*\)/i);
+      // float を直接 ROUND に渡す形に戻っていないこと
+      expect(sql).not.toMatch(/ROUND\s*\(\s*COUNT\(\*\)\s*\/[^,]*,\s*\d+\s*\)/i);
+    }
+  });
 });

--- a/src/api/admin/tenants/analyticsSummaryRoutes.ts
+++ b/src/api/admin/tenants/analyticsSummaryRoutes.ts
@@ -75,7 +75,10 @@ export function registerAnalyticsSummaryRoutes(app: Express, db: Pool): void {
           db.query<{ total: string; avg_per_day: string }>(
             `SELECT
                COUNT(*)::text AS total,
-               ROUND(COUNT(*) / GREATEST($2::float, 1), 2)::text AS avg_per_day
+               -- COUNT(*)/float は double precision になるが、PostgreSQL の2引数 round() は
+               -- numeric 版しか無く "function round(double precision, integer) does not exist"
+               -- で落ちる。numeric へキャストしてから丸める。
+               ROUND((COUNT(*) / GREATEST($2::float, 1))::numeric, 2)::text AS avg_per_day
              FROM chat_sessions
              WHERE tenant_id = $1
                -- chat_sessions に created_at は存在しない。セッション開始時刻は started_at


### PR DESCRIPTION
## 現象

PR #763 で `chat_sessions.started_at` の誤りを直した結果、**同じクエリの二段目のエラー**が表面化しました。本番ログで確定しています。

```
DatabaseError: function round(double precision, integer) does not exist
code: 42883
at dist/src/api/admin/tenants/analyticsSummaryRoutes.js:66
```

## 原因

`COUNT(*) / GREATEST($2::float, 1)` は **double precision** になりますが、PostgreSQL の2引数 `round()` は **numeric 版しか存在しません**。

```diff
- ROUND(COUNT(*) / GREATEST($2::float, 1), 2)
+ ROUND((COUNT(*) / GREATEST($2::float, 1))::numeric, 2)
```

## なぜ1回で気づけなかったか

PostgreSQL は文のパース時に**最初に見つけたエラーだけ**を返します。`created_at` の列不存在が解決するまで、`round()` の型エラーは表に出ませんでした。**同一クエリ内に独立した不具合が2つあった**ということです。

前回「これで17タブすべて正常になる見込み」とお伝えしましたが、結果的に一段目しか直っていませんでした。

## 検証（実測）

PostgreSQL 17 で確認しました。

| 検証 | 結果 |
|---|---|
| 修正前 | ✅ `function round(double precision, integer) does not exist` を**再現** |
| 修正後 | ✅ `0.07` が返る |
| 0件のとき | ✅ `0.00`（壊れない） |
| `days=0` のとき | ✅ `GREATEST(...,1)` が効き0除算にならない |

## 他に同種が無いか

SQL内の2引数 `ROUND` は `analytics/routes.ts` に3箇所ありますが、**いずれも `::numeric` を先にキャストしており正常**です。JS側の `Math.round` は無関係。本件の1箇所のみが誤りでした。

## テスト

`analyticsSummaryRoutes.test.ts` に1件追加。`ROUND` の第1引数が `::numeric` でキャストされていること、float を直接渡す形に戻っていないことを固定します。**ミューテーション確認済み**。

## 補足（作業中に自分で踏んだミス）

この修正のコメントを**テンプレートリテラル内にバッククォート付き**で書いてしまい、SQL文字列を途中で終端させました。テストが `ReferenceError: does is not defined` で検出し、コミット前に修正しています。テンプレートリテラル内のコメントでバッククォートは使えません。

## Gate

- [x] backend typecheck 0 errors
- [x] 対象スイート 30件 全pass
- [x] `pnpm lint` 0新規警告（58/63）
- [x] `security-scan` PASS（CRITICAL/HIGH 0）
- [ ] Gate 2.5（Codex review）未実行

## デプロイ

`src/` の変更のため **VPSデプロイが必要**です（ローカルMacから `bash SCRIPTS/deploy-vps.sh`）。

## Tier / merge

`src/**` のため Tier S。手動 merge をお願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01My9XXuKXbnb8ca9xgDnEqj
