### PR TITLE
chore(deploy): deploy-vps.sh にブランチガードを追加

### DIFF
--- a/SCRIPTS/deploy-vps.sh
+++ b/SCRIPTS/deploy-vps.sh
@@ -26,6 +26,28 @@ if [[ ! -f package.json ]] || [[ ! -f ecosystem.config.cjs ]]; then
   exit 1
 fi
 
+# Branch guard: this script deploys the LOCAL working tree (git build → rsync),
+# not origin/main. Deploying from a non-main branch silently puts production
+# ahead of main — anyone who later deploys from main will roll production back
+# without any error (past incident: fix/round-double-precision-analytics-summary
+# was deployed while main still lacked the fix, until the PR was merged).
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || echo "HEAD")
+if [[ "${CURRENT_BRANCH}" != "main" ]] && [[ "${DEPLOY_ALLOW_NON_MAIN:-0}" != "1" ]]; then
+  echo "❌ ERROR: current branch is '${CURRENT_BRANCH}', not 'main'"
+  echo "  This script deploys whatever is checked out locally, not origin/main."
+  echo "  Deploying from a feature branch puts production ahead of main until"
+  echo "  that branch is merged — the next main-based deploy will silently roll it back."
+  echo ""
+  echo "  Fix: git checkout main && git pull --ff-only origin main, then re-run."
+  echo "  Intentional hotfix verification before merge? Re-run with:"
+  echo "    DEPLOY_ALLOW_NON_MAIN=1 bash SCRIPTS/deploy-vps.sh"
+  exit 1
+fi
+if [[ "${CURRENT_BRANCH}" != "main" ]]; then
+  echo "⚠️  WARNING: deploying from non-main branch '${CURRENT_BRANCH}' (DEPLOY_ALLOW_NON_MAIN=1)"
+  echo "  Remember to merge this branch to main promptly to avoid prod/main desync."
+fi
+
 # Pre-deploy: Environment Check (warning-only, does not block deploy)
 echo "=== Pre-deploy: Environment Check ==="
 bash SCRIPTS/env-check.sh 2>&1 || true


### PR DESCRIPTION
## Summary
- deploy-vps.sh はローカル作業ツリーをrsyncする設計上、origin/mainではなくチェックアウト中のブランチをそのままデプロイする
- 非mainブランチから実行すると、本番がmainより進んだ状態になり、後でmainからデプロイした人が気づかずに巻き戻してしまう
- 実際にfix/round-double-precision-analytics-summaryブランチのままデプロイし、PRマージまでこの状態を作ってしまったインシデントの再発防止

## 変更内容
- CWDガードの直後にブランチガードを追加
- `main` 以外のブランチでは既定でエラー停止し、`git checkout main && git pull --ff-only` を案内
- 意図的な事前検証（merge前の本番確認）は `DEPLOY_ALLOW_NON_MAIN=1 bash SCRIPTS/deploy-vps.sh` で明示的に許可可能（許可時も警告を出し続ける）

## Test plan
- [x] `bash -n SCRIPTS/deploy-vps.sh` で構文チェック
- [x] git worktree上でmain / 非main(ガードなし=exit 1) / 非main(override=警告して継続) の3パターンを実行確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01My9XXuKXbnb8ca9xgDnEqj