### PR TITLE
feat(agent): 未移行機能5件に旧UI案内キーを追加、アバタースタジオへ設定ID付きで遷移

### DIFF
--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -117,12 +117,16 @@ function parsePriorityTier(raw: unknown): 'low' | 'normal' | 'high' | undefined 
 // 同じ会話の中で同じ機能について何度も full を返すと同じ売り込みの繰り返しになるため、
 // 2回目以降は short に切り替える(制限そのものは変わらない)。判定は
 // knowledgeImportStaging.ts の recordPlanLimitMention((tenantId, sessionId, feature)単位)。
-type PlanLimitedFeature = 'avatar' | 'analytics' | 'conversion' | 'sai_task';
+type PlanLimitedFeature = 'avatar' | 'premium_avatar' | 'analytics' | 'conversion' | 'sai_task';
 
 const PLAN_LIMIT_NOTICES: Record<PlanLimitedFeature, { full: string; short: string }> = {
   avatar: {
     full: 'AIアバター機能はGrowthプラン以上でご利用いただけます',
     short: 'AIアバター機能はプラン対象外のままです',
+  },
+  premium_avatar: {
+    full: '高品質なアバター画像の生成はGrowthプラン以上でご利用いただけます',
+    short: '高品質なアバター画像の生成はプラン対象外のままです',
   },
   analytics: {
     full: 'この機能はGrowthプラン以上でご利用いただけます',
@@ -2889,10 +2893,13 @@ export async function executeToolCall(
     case 'get_legacy_ui_link': {
       const feature = String(args['feature'] ?? '');
       const LEGACY_UI_LINKS: Record<string, { label: string; path: string; description: string }> = {
+        // 請求書の再送・金額調整・無料期間設定・一時停止/再開は実装上すべてsuper_adminガードの
+        // 内側にあり、テナントがこの画面へ行っても実行できない。案内文はテナントが実際に
+        // できること(利用量・請求額の確認)だけを書く。
         billing: {
           label: '請求管理',
           path: '/admin/billing',
-          description: '請求書の再送・金額調整・無料期間設定・一時停止/再開はこちらの画面で行えます',
+          description: '今月の利用量と請求額の確認はこちらの画面で行えます',
         },
         avatar_studio: {
           label: 'アバタースタジオ',
@@ -2952,27 +2959,72 @@ export async function executeToolCall(
           path: `/admin/knowledge/${tenantId}?tab=attribution`,
           description: 'ナレッジ(FAQ・書籍)ごとの成約への貢献度はこちらの画面で確認できます',
         },
+        // knowledge_pdf と同じ理由でtenantIdをpathに含める必要がある(下のガードで !tenantId は事前に弾いている)。
+        faq_publish_toggle: {
+          label: 'AIの知識データ',
+          path: `/admin/knowledge/${tenantId}`,
+          description: 'FAQごとにAIが答えるかどうかを切り替えられます',
+        },
+        faq_bulk_ops: {
+          label: 'AIの知識データ',
+          path: `/admin/knowledge/${tenantId}`,
+          description: 'まとめて非公開・まとめて削除はこちらの画面です',
+        },
+        avatar_feature_toggle: {
+          label: 'アバター設定',
+          path: '/admin/avatar',
+          description: 'アバター機能全体のON/OFFはこちらの画面です',
+        },
+        avatar_profile: {
+          label: 'アバタースタジオ',
+          path: '/admin/avatar/studio',
+          description: '名前・性格・話し方の編集はこちらの画面です',
+        },
+        avatar_premium: {
+          label: 'アバター新規作成',
+          path: '/admin/avatar/wizard',
+          description: '高品質な画像の生成はこちらの画面です',
+        },
       };
 
-      // GID: LP料金表(Growth〜: 高度なAnalytics、CV計測)に基づくプラン制限。
-      // AppSidebar.tsx(225行付近)とは異なり、ここでは super_admin もバイパスさせない。
-      // super_admin がこの新UIに入る経路は「クライアントビューで見る」(previewMode)であり、
-      // 目的はテナントに見えている状態の再現なので、Starterテナントのプレビューで
-      // Growth限定機能の案内を出すのは再現として誤り。読み取り専用の案内でしかなく、
+      // GID: LP料金表(Growth〜: 高度なAnalytics、CV計測、AIアバター、プレミアムアバター生成)に
+      // 基づくプラン制限。AppSidebar.tsx(225行付近)とは異なり、ここでは super_admin も
+      // バイパスさせない。super_admin がこの新UIに入る経路は「クライアントビューで見る」
+      // (previewMode)であり、目的はテナントに見えている状態の再現なので、Starterテナントの
+      // プレビューでGrowth限定機能の案内を出すのは再現として誤り。読み取り専用の案内でしかなく、
       // planFeatures.ts の GID 1216961878992581 が扱う「永続的な権能付与 vs 都度原価」の
       // 判断軸（activate_avatar 等）にも当てはまらない。
-      if (feature === 'analytics' || feature === 'conversion') {
+      // avatar_feature_toggle(ON/OFF切替) / avatar_premium(高品質生成) は実際の操作先が
+      // 403 plan_upgrade_required で拒否される(routes.ts / premiumGenerationRoutes.ts)ため、
+      // 案内リンク側でも同じ制限を返す — さもないと使えない画面へ自信満々に案内してしまう。
+      // get_legacy_ui_link の feature 語彙と GatedFeature/PlanLimitedFeature の語彙が
+      // 異なるキーは、ここで対応付ける。
+      const PLAN_GATED_LEGACY_FEATURES: Partial<Record<string, PlanLimitedFeature>> = {
+        analytics: 'analytics',
+        conversion: 'conversion',
+        avatar_feature_toggle: 'avatar',
+        avatar_premium: 'premium_avatar',
+      };
+      const gatedFeature = PLAN_GATED_LEGACY_FEATURES[feature];
+      if (gatedFeature) {
         if (!tenantId) {
           return truncate('テナントが特定できません。super_admin の場合は対象テナントを指定してください');
         }
         const plan = await queryTenantPlan(db, tenantId);
-        if (!planHasFeature(plan, feature)) {
-          return truncate(planLimitNotice(tenantId, sessionId, feature));
+        if (!planHasFeature(plan, gatedFeature)) {
+          return truncate(planLimitNotice(tenantId, sessionId, gatedFeature));
         }
       }
 
-      // knowledge_pdf / knowledge_attribution は path に tenantId を埋め込む都合上、他のキーと違い必須。
-      if ((feature === 'knowledge_pdf' || feature === 'knowledge_attribution') && !tenantId) {
+      // knowledge_pdf / knowledge_attribution / faq_publish_toggle / faq_bulk_ops は
+      // path に tenantId を埋め込む都合上、他のキーと違い必須。
+      if (
+        (feature === 'knowledge_pdf' ||
+          feature === 'knowledge_attribution' ||
+          feature === 'faq_publish_toggle' ||
+          feature === 'faq_bulk_ops') &&
+        !tenantId
+      ) {
         return truncate('テナントが特定できません。super_admin の場合は対象テナントを指定してください');
       }
 
@@ -2995,6 +3047,38 @@ export async function executeToolCall(
           } catch (err) {
             logger.warn('[actionExecutor] get_legacy_ui_link session resolve failed', err);
           }
+        }
+      }
+
+      // avatar_studio / avatar_profile はどちらも同じ studio.tsx (/admin/avatar/studio)へ
+      // 案内するため、同じ解決ロジックを適用する。avatar_config_id が渡っていればそれを使い
+      // (tenant_id条件により、他テナントのIDは越境せず「不存在」側に倒れる)、渡っていなければ
+      // 稼働中(is_active=true)の設定を1件解決して使う。どちらも解決できないときだけ
+      // 従来のID無しURLに戻す。studio.tsx はID無しだと新規作成の空フォームで開くため、
+      // 既存アバターを編集しているつもりの利用者(例: 「音声クローンをした」「名前を変えたい」)が
+      // 意図せず別の新規アバターを作ってしまう事故を防ぐ(session_deletion の既存パターンに倣う)。
+      if ((feature === 'avatar_studio' || feature === 'avatar_profile') && tenantId) {
+        const configId = String(args['avatar_config_id'] ?? '').trim();
+        try {
+          if (configId) {
+            const resolved = await db.query<{ id: string }>(
+              `SELECT id FROM avatar_configs WHERE id = $1 AND tenant_id = $2 LIMIT 1`,
+              [configId, tenantId]
+            );
+            if (resolved.rows.length > 0) {
+              path = `/admin/avatar/studio/${resolved.rows[0].id}`;
+            }
+          } else {
+            const activeRes = await db.query<{ id: string }>(
+              `SELECT id FROM avatar_configs WHERE tenant_id = $1 AND is_active = true LIMIT 1`,
+              [tenantId]
+            );
+            if (activeRes.rows.length > 0) {
+              path = `/admin/avatar/studio/${activeRes.rows[0].id}`;
+            }
+          }
+        } catch (err) {
+          logger.warn('[actionExecutor] get_legacy_ui_link avatar_studio resolve failed', err);
         }
       }
 

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -6069,6 +6069,8 @@ describe('POST /v1/admin/agent/chat', () => {
         'billing', 'avatar_studio', 'escalation_reply', 'session_deletion',
         'chat_test', 'avatar_wizard', 'knowledge_pdf', 'knowledge_attribution',
         'analytics', 'conversion',
+        'faq_publish_toggle', 'faq_bulk_ops', 'avatar_feature_toggle',
+        'avatar_profile', 'avatar_premium',
       ]);
       const untested = LEGACY_UI_FEATURES.filter((f) => !testedFeatures.has(f));
       expect(untested).toEqual([]);
@@ -6162,6 +6164,205 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(result).toContain('URL: /admin/chat-history\n');
       expect(result).not.toContain(OTHER_TENANT_SESSION.id);
     });
+
+    // GID 1217534700419544: 未移行機能(FAQ公開ON/OFF・一括操作・プロフィール編集)に
+    // 旧UI案内キーを追加した回帰テスト。avatar_feature_toggle / avatar_premium はプラン制限が
+    // あるため下の専用ブロックで検証する。
+    it.each([
+      ['faq_publish_toggle', 'AIの知識データ', '/admin/knowledge/tenant-abc'],
+      ['faq_bulk_ops', 'AIの知識データ', '/admin/knowledge/tenant-abc'],
+      ['avatar_profile', 'アバタースタジオ', '/admin/avatar/studio'],
+    ])('feature=%s: 旧UIの案内(画面名・URL)を返す', async (feature, label, path) => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-lu-new', 'get_legacy_ui_link', { feature }))
+        .mockResolvedValueOnce(makeGroqResponse('こちらの画面でご対応ください。'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '確認したい', sessionId: `sess-lu-new-${feature}` });
+
+      expect(res.status).toBe(200);
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain(label);
+      expect(result).toContain(`URL: ${path}\n`);
+
+      expect(recordedMetrics('agent_legacy_handoff')).toEqual([
+        {
+          metricName: 'agent_legacy_handoff',
+          tenantId: 'tenant-abc',
+          labels: { feature, surface: 'unknown' },
+          value: 1,
+        },
+      ]);
+    });
+
+    // avatar_feature_toggle(ON/OFF切替) / avatar_premium(高品質生成) は実際の操作先が
+    // 403 plan_upgrade_required で拒否される(routes.ts / premiumGenerationRoutes.ts)ため、
+    // analytics/conversion と同じくGrowth未満のテナントにはリンクを返さず、プラン制限を返す。
+    it.each([
+      ['avatar_feature_toggle', 'アバター設定', '/admin/avatar'],
+      ['avatar_premium', 'アバター新規作成', '/admin/avatar/wizard'],
+    ])('feature=%s: growthプランなら旧UIの案内(画面名・URL)を返す', async (feature, label, path) => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-lu-gate-1', 'get_legacy_ui_link', { feature }))
+        .mockResolvedValueOnce(makeGroqResponse('こちらの画面でご対応ください。'));
+      mockQuery.mockResolvedValueOnce({ rows: [{ plan: 'growth' }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '確認したい', sessionId: `sess-lu-gate-${feature}` });
+
+      expect(res.status).toBe(200);
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain(label);
+      expect(result).toContain(`URL: ${path}\n`);
+    });
+
+    it.each([
+      ['avatar_feature_toggle'],
+      ['avatar_premium'],
+    ])('feature=%s: starterプランはリンクを返さずプラン制限メッセージを返す', async (feature) => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-lu-gate-2', 'get_legacy_ui_link', { feature }))
+        .mockResolvedValueOnce(makeGroqResponse('プラン制限のためお伝えしました。'));
+      mockQuery.mockResolvedValueOnce({ rows: [{ plan: 'starter' }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '確認したい', sessionId: `sess-lu-gate-starter-${feature}` });
+
+      expect(res.status).toBe(200);
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain('Growthプラン以上');
+      // 押せないリンクカードが出ないよう、成功時の3行フォーマット(画面:/URL:/説明:)に一致しないこと
+      expect(result).not.toMatch(/画面:/);
+      expect(result).not.toMatch(/URL:/);
+    });
+
+    // faq_publish_toggle / faq_bulk_ops は knowledge_pdf と同じ理由(path に tenantId を
+    // 埋め込む必要がある)で専用ガードがある。
+    it.each([
+      ['faq_publish_toggle'],
+      ['faq_bulk_ops'],
+    ])('feature=%s: super_admin がテナント未特定 → 「テナントが特定できません」を返す', async (feature) => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-lu-new-guard', 'get_legacy_ui_link', { feature }))
+        .mockResolvedValueOnce(makeGroqResponse('テナントを指定してください。'));
+
+      const res = await request(makeApp(SUPER_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '確認したい', sessionId: `sess-lu-new-guard-${feature}` });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('テナントが特定できません');
+    });
+
+    // avatar_studio の案内先を設定ID付きのスタジオURLにする回帰テスト(GID 1217534700419544)。
+    // studio.tsx はID無しだと新規作成の空フォームで開くため、既存アバターを編集している
+    // つもりの利用者が意図せず別の新規アバターを作ってしまう事故を防ぐ。
+    describe('feature=avatar_studio: 設定ID付きのスタジオURLへの解決', () => {
+      it('avatar_config_id を指定 → その設定のスタジオURLを返す', async () => {
+        mockFetch
+          .mockResolvedValueOnce(
+            toolCallResponse('call-lu-as-1', 'get_legacy_ui_link', {
+              feature: 'avatar_studio',
+              avatar_config_id: 'cfg-111',
+            }),
+          )
+          .mockResolvedValueOnce(makeGroqResponse('アバタースタジオをご案内しました。'));
+        mockQuery.mockResolvedValueOnce({ rows: [{ id: 'cfg-111' }] });
+
+        const res = await request(makeApp(CLIENT_ADMIN_USER))
+          .post('/v1/admin/agent/chat')
+          .send({ message: '音声クローンをしたい', sessionId: 'sess-lu-as-01' });
+
+        expect(res.status).toBe(200);
+        const result = res.body.actions[0].result as string;
+        expect(result).toContain('URL: /admin/avatar/studio/cfg-111\n');
+        // 解決クエリは必ず tenant_id で絞られている(越境防止)
+        const [sql, params] = mockQuery.mock.calls[0];
+        expect(sql).toContain('tenant_id = $2');
+        expect(params).toEqual(['cfg-111', 'tenant-abc']);
+      });
+
+      it('avatar_config_id 未指定 + 稼働中の設定あり → 稼働中の設定のスタジオURLを返す', async () => {
+        mockFetch
+          .mockResolvedValueOnce(toolCallResponse('call-lu-as-2', 'get_legacy_ui_link', { feature: 'avatar_studio' }))
+          .mockResolvedValueOnce(makeGroqResponse('アバタースタジオをご案内しました。'));
+        mockQuery.mockResolvedValueOnce({ rows: [{ id: 'cfg-active-1' }] });
+
+        const res = await request(makeApp(CLIENT_ADMIN_USER))
+          .post('/v1/admin/agent/chat')
+          .send({ message: 'アバターを設定したい', sessionId: 'sess-lu-as-02' });
+
+        expect(res.status).toBe(200);
+        const result = res.body.actions[0].result as string;
+        expect(result).toContain('URL: /admin/avatar/studio/cfg-active-1\n');
+        const [sql, params] = mockQuery.mock.calls[0];
+        expect(sql).toContain('is_active = true');
+        expect(params).toEqual(['tenant-abc']);
+      });
+
+      it('avatar_config_id 未指定 + 稼働中の設定なし → 従来のID無しURLへフォールバックする', async () => {
+        mockFetch
+          .mockResolvedValueOnce(toolCallResponse('call-lu-as-3', 'get_legacy_ui_link', { feature: 'avatar_studio' }))
+          .mockResolvedValueOnce(makeGroqResponse('アバタースタジオをご案内しました。'));
+        mockQuery.mockResolvedValueOnce({ rows: [] });
+
+        const res = await request(makeApp(CLIENT_ADMIN_USER))
+          .post('/v1/admin/agent/chat')
+          .send({ message: 'アバターを設定したい', sessionId: 'sess-lu-as-03' });
+
+        expect(res.status).toBe(200);
+        const result = res.body.actions[0].result as string;
+        expect(result).toContain('URL: /admin/avatar/studio\n');
+      });
+
+      it('他テナントの avatar_config_id を指定 → 解決せず(越境は不存在側に倒す)従来のID無しURLへフォールバックする', async () => {
+        mockFetch
+          .mockResolvedValueOnce(
+            toolCallResponse('call-lu-as-4', 'get_legacy_ui_link', {
+              feature: 'avatar_studio',
+              avatar_config_id: 'cfg-other-tenant',
+            }),
+          )
+          .mockResolvedValueOnce(makeGroqResponse('アバタースタジオをご案内しました。'));
+        // tenant_id条件に一致しないため空(他テナントのIDでもこのモックはそのまま使い回せる)
+        mockQuery.mockResolvedValueOnce({ rows: [] });
+
+        const res = await request(makeApp(CLIENT_ADMIN_USER))
+          .post('/v1/admin/agent/chat')
+          .send({ message: '設定を見たい', sessionId: 'sess-lu-as-04' });
+
+        expect(res.status).toBe(200);
+        const result = res.body.actions[0].result as string;
+        expect(result).toContain('URL: /admin/avatar/studio\n');
+        expect(result).not.toContain('cfg-other-tenant');
+      });
+
+      // avatar_profile は avatar_studio と同じ studio.tsx(/admin/avatar/studio)を指すため、
+      // 同じID解決を共有する。「名前を変えたい」でID無しURLに送ると新規作成の空フォームで
+      // 開いてしまう(このタスクが直す対象のバグそのもの)ため、同じ経路であることを固定する。
+      it('feature=avatar_profile も avatar_config_id を指定 → その設定のスタジオURLを返す', async () => {
+        mockFetch
+          .mockResolvedValueOnce(
+            toolCallResponse('call-lu-ap-1', 'get_legacy_ui_link', {
+              feature: 'avatar_profile',
+              avatar_config_id: 'cfg-222',
+            }),
+          )
+          .mockResolvedValueOnce(makeGroqResponse('アバタースタジオをご案内しました。'));
+        mockQuery.mockResolvedValueOnce({ rows: [{ id: 'cfg-222' }] });
+
+        const res = await request(makeApp(CLIENT_ADMIN_USER))
+          .post('/v1/admin/agent/chat')
+          .send({ message: '名前を変えたい', sessionId: 'sess-lu-ap-01' });
+
+        expect(res.status).toBe(200);
+        const result = res.body.actions[0].result as string;
+        expect(result).toContain('URL: /admin/avatar/studio/cfg-222\n');
+      });
+    });
   });
 
   // -------------------------------------------------------------------------
@@ -6189,7 +6390,7 @@ describe('POST /v1/admin/agent/chat', () => {
       };
     }
 
-    const BILLING_DESCRIPTION = '請求書の再送・金額調整・無料期間設定・一時停止/再開はこちらの画面で行えます';
+    const BILLING_DESCRIPTION = '今月の利用量と請求額の確認はこちらの画面で行えます';
 
     it('JSON経路: get_legacy_ui_link は自然文(result)に加えて card を返す', async () => {
       mockFetch

--- a/src/api/admin/agent/toolDefinitions.ts
+++ b/src/api/admin/agent/toolDefinitions.ts
@@ -34,6 +34,11 @@ export const LEGACY_UI_FEATURES = [
   'avatar_wizard',
   'knowledge_pdf',
   'knowledge_attribution',
+  'faq_publish_toggle',
+  'faq_bulk_ops',
+  'avatar_feature_toggle',
+  'avatar_profile',
+  'avatar_premium',
 ] as const;
 
 export const ADMIN_AGENT_TOOLS: GroqTool[] = [
@@ -1169,7 +1174,12 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
         'ユーザーが明示した場合にのみ案内すること。' +
         'また会話分析・成約/効果分析の「数値サマリー」は get_analytics_summary / get_conversion_summary で' +
         'チャット上に直接返せるため、まずそちらを使うこと。この2機能でこのツールを使うのは、' +
-        'グラフの詳細・個別の低評価セッション・ABテスト結果を旧UIで見たい場合に限る。',
+        'グラフの詳細・個別の低評価セッション・ABテスト結果を旧UIで見たい場合に限る。' +
+        'FAQごとにAIが答えるかどうかを切り替えたいと聞かれたら feature="faq_publish_toggle" を使うこと。' +
+        'FAQのまとめて非公開・まとめて削除をしたいと聞かれたら feature="faq_bulk_ops" を使うこと。' +
+        'アバター機能全体のON/OFFを切り替えたいと聞かれたら feature="avatar_feature_toggle" を使うこと。' +
+        'アバターの名前・性格・話し方を編集したいと聞かれたら feature="avatar_profile" を使うこと。' +
+        '高品質なアバター画像を生成したいと聞かれたら feature="avatar_premium" を使うこと。',
       parameters: {
         type: 'object',
         properties: {
@@ -1183,6 +1193,12 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
             description:
               '対象の会話の短縮ID（get_chat_sessions や get_escalations が返す8文字のID）。' +
               'session_deletion で使うと、その会話を直接開くリンクになる。',
+          },
+          avatar_config_id: {
+            type: 'string',
+            description:
+              '対象のアバター設定ID。avatar_studio / avatar_profile で使うと、そのアバターを直接開く' +
+              'リンクになる。指定が無ければ稼働中のアバター設定を自動で解決する。',
           },
         },
         required: ['feature'],


### PR DESCRIPTION
## Summary
- Asana [C] 未移行機能の旧UI案内キーを追加し、アバタースタジオへ設定ID付きで遷移させる (GID 1217534700419544)
- `get_legacy_ui_link` の `LEGACY_UI_FEATURES` に5キー追加: `faq_publish_toggle` / `faq_bulk_ops` / `avatar_feature_toggle` / `avatar_profile` / `avatar_premium`
- `avatar_studio` / `avatar_profile` は avatar_config_id 指定 or 稼働中設定を解決してスタジオURLに含める(ID無しだと新規作成の空フォームで開く不具合を回避)
- `avatar_feature_toggle` / `avatar_premium` は実操作先が plan_upgrade_required で拒否されるため、analytics/conversion と同じプラン制限を適用(Codexレビュー指摘を反映)
- billing の案内文を、テナントが実際に行える操作(利用量・請求額の確認)に修正

## Test plan
- [x] `pnpm typecheck` (root) — pass
- [x] `pnpm lint` (root, oxlint) — pass, 59 warnings (閾値63以内、新規警告なし)
- [x] `pnpm test` (jest) — 3513/3513 pass (クリーン実行時)
- [x] `bash SCRIPTS/dead-code-check.sh` — pass
- [x] `bash SCRIPTS/security-scan.sh` — PASS, CRITICAL/HIGH 0件
- [x] `pnpm build` (root) — pass
- [x] Codex review (1回完走、3件の指摘を修正反映。2回目は使用量上限で失敗、詳細はPRコメント/報告に記載)
- [ ] hkobayashi の手動マージ(Tier S: src/** を変更するため auto-merge対象外)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDCq3hgpSccqkadqEj65ep