### PR TITLE
fix(admin-ui): 新UI↔旧UI往復動線を修復

### DIFF
--- a/admin-ui/src/components/AppSidebar.test.tsx
+++ b/admin-ui/src/components/AppSidebar.test.tsx
@@ -1,13 +1,22 @@
 // GID: LP料金表(Growth〜: 会話分析/成約・効果分析)に基づくnav非表示の回帰テスト
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { AppSidebar, MobileHeader } from "./AppSidebar";
+import { AppSidebar, MobileHeader, MobileBottomBar } from "./AppSidebar";
 import { useAuth } from "../auth/useAuth";
 
 vi.mock("../auth/useAuth", () => ({
   useAuth: vi.fn(),
 }));
+
+const mockNavigate = vi.fn();
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-router-dom")>("react-router-dom");
+  return {
+    ...actual,
+    useNavigate: () => mockNavigate,
+  };
+});
 
 vi.mock("../contexts/ThemeContext", () => ({
   useTheme: () => ({ theme: "dark", setTheme: vi.fn() }),
@@ -173,13 +182,13 @@ describe("AppSidebar — ご利用状況・お支払いの可視性", () => {
 // target="_blank" が効かない環境やチャット・ファースト既定OFFのユーザーが
 // 旧UIで行き止まりにならないことを担保する。
 describe("AppSidebar — AIチャット(新UI)への復帰導線", () => {
-  it("client_admin → /copilot-preview へのリンクが表示される", () => {
+  it("client_admin → /copilot-preview?from=legacy へのリンクが表示される", () => {
     vi.mocked(useAuth).mockReturnValue(baseAuth({ tenantPlan: "growth" }));
     renderSidebar();
 
     const link = screen.getByText("AIチャットに戻る").closest("a");
     expect(link).toBeTruthy();
-    expect(link?.getAttribute("href")).toBe("/copilot-preview");
+    expect(link?.getAttribute("href")).toBe("/copilot-preview?from=legacy");
     // 既存navの回帰確認
     expect(screen.getByText("会話履歴")).toBeTruthy();
   });
@@ -197,7 +206,7 @@ describe("AppSidebar — AIチャット(新UI)への復帰導線", () => {
     renderSidebar();
 
     expect(screen.getByText("AIチャットに戻る").closest("a")?.getAttribute("href")).toBe(
-      "/copilot-preview",
+      "/copilot-preview?from=legacy",
     );
     expect(screen.getByText("会話履歴")).toBeTruthy();
   });
@@ -217,6 +226,123 @@ describe("AppSidebar — AIチャット(新UI)への復帰導線", () => {
     // 既存navは従来どおり表示されたまま
     expect(screen.getByText("会話履歴")).toBeTruthy();
     expect(screen.getByText("テナント管理")).toBeTruthy();
+  });
+
+  // GID 1217535151513730: rel="opener"付きの内部リンクで開かれた新規タブなら
+  // window.opener が渡っている。SPA遷移せずタブごと閉じて元のタブ(会話が残っている側)へ戻す。
+  it("window.openerがある場合 → クリックでタブを閉じ、SPA遷移しない", () => {
+    vi.mocked(useAuth).mockReturnValue(baseAuth({ tenantPlan: "growth" }));
+    const originalOpener = window.opener;
+    Object.defineProperty(window, "opener", { value: {}, configurable: true });
+    const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {});
+    try {
+      renderSidebar();
+      const link = screen.getByText("AIチャットに戻る").closest("a") as HTMLAnchorElement;
+      fireEvent.click(link);
+
+      expect(closeSpy).toHaveBeenCalledTimes(1);
+    } finally {
+      Object.defineProperty(window, "opener", { value: originalOpener, configurable: true });
+      closeSpy.mockRestore();
+    }
+  });
+
+  it("window.openerが無い場合 → タブを閉じずリンクのまま(通常のSPA遷移に任せる)", () => {
+    vi.mocked(useAuth).mockReturnValue(baseAuth({ tenantPlan: "growth" }));
+    const originalOpener = window.opener;
+    Object.defineProperty(window, "opener", { value: null, configurable: true });
+    const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {});
+    try {
+      renderSidebar();
+      const link = screen.getByText("AIチャットに戻る").closest("a") as HTMLAnchorElement;
+      fireEvent.click(link);
+
+      expect(closeSpy).not.toHaveBeenCalled();
+    } finally {
+      Object.defineProperty(window, "opener", { value: originalOpener, configurable: true });
+      closeSpy.mockRestore();
+    }
+  });
+
+  // GID: ブラウザはタブ内で複数ページ遷移した後などclose()を無視することがある
+  // (script非開設扱いになるため)。閉じられなかった場合に「詰み」にならず、
+  // 通常のSPA遷移へフォールバックすることの回帰テスト。
+  it("window.opener はあるがタブが閉じられない場合 → 少し待って通常のSPA遷移にフォールバックする", async () => {
+    vi.mocked(useAuth).mockReturnValue(baseAuth({ tenantPlan: "growth" }));
+    mockNavigate.mockReset();
+    const originalOpener = window.opener;
+    Object.defineProperty(window, "opener", { value: {}, configurable: true });
+    // close()が呼ばれても実際には閉じない(=window.closedがfalseのまま)状況を再現する
+    const closeSpy = vi.spyOn(window, "close").mockImplementation(() => {});
+    try {
+      renderSidebar();
+      const link = screen.getByText("AIチャットに戻る").closest("a") as HTMLAnchorElement;
+      fireEvent.click(link);
+
+      expect(closeSpy).toHaveBeenCalledTimes(1);
+      await waitFor(() => expect(mockNavigate).toHaveBeenCalledWith("/copilot-preview?from=legacy"));
+    } finally {
+      Object.defineProperty(window, "opener", { value: originalOpener, configurable: true });
+      closeSpy.mockRestore();
+    }
+  });
+});
+
+// GID 1217535151513730: モバイル下部バー(5枠)。analyticsはgrowth以上のプラン制限があり
+// starterテナントには意味の無い枠のため、client_adminには代わりにAIチャットへの導線を出す。
+// previewModeでない素のsuper_adminには従来どおりanalyticsを出す。
+describe("AppSidebar — MobileBottomBar(client_adminは分析→AIチャットに置換)", () => {
+  function renderBottomBar() {
+    return render(
+      <MemoryRouter>
+        <MobileBottomBar />
+      </MemoryRouter>,
+    );
+  }
+
+  it("client_admin → 「分析」の代わりに「AIチャット」(/copilot-preview)が出る", () => {
+    vi.mocked(useAuth).mockReturnValue(baseAuth({ tenantPlan: "growth" }));
+    renderBottomBar();
+
+    expect(screen.queryByText("分析")).toBeNull();
+    const link = screen.getByText("AIチャット").closest("a");
+    expect(link?.getAttribute("href")).toBe("/copilot-preview");
+    // 残り4枠は従来どおり
+    expect(screen.getByText("ホーム")).toBeTruthy();
+    expect(screen.getByText("会話")).toBeTruthy();
+    expect(screen.getByText("知識データ")).toBeTruthy();
+    expect(screen.getByText("設定")).toBeTruthy();
+  });
+
+  it("プレビューなしの素のsuper_admin → 従来どおり「分析」が出る", () => {
+    vi.mocked(useAuth).mockReturnValue(
+      baseAuth({
+        isSuperAdmin: true,
+        isClientAdmin: false,
+        previewMode: false,
+        user: { id: "2", email: "admin@example.com", role: "super_admin", tenantId: null, tenantName: null },
+      }),
+    );
+    renderBottomBar();
+
+    expect(screen.getByText("分析")).toBeTruthy();
+    expect(screen.queryByText("AIチャット")).toBeNull();
+  });
+
+  it("super_adminのプレビュー中(isClientAdmin=true) → 「AIチャット」が出る", () => {
+    vi.mocked(useAuth).mockReturnValue(
+      baseAuth({
+        isSuperAdmin: false,
+        isClientAdmin: true,
+        previewMode: true,
+        previewTenantId: "preview-tenant",
+        tenantPlan: "growth",
+      }),
+    );
+    renderBottomBar();
+
+    expect(screen.getByText("AIチャット")).toBeTruthy();
+    expect(screen.queryByText("分析")).toBeNull();
   });
 });
 

--- a/admin-ui/src/components/AppSidebar.tsx
+++ b/admin-ui/src/components/AppSidebar.tsx
@@ -48,6 +48,10 @@ interface NavSection {
   superAdminOnly?: boolean;
 }
 
+// 旧UIから新UI(チャット)へ戻るリンクの遷移先。SidebarContentのNavLink `to` と、
+// window.close()が無視された場合のフォールバック navigate() の両方で使う(値を1箇所にする)。
+const COPILOT_PREVIEW_FROM_LEGACY_PATH = "/copilot-preview?from=legacy";
+
 const MAIN_SECTIONS: NavSection[] = [
   {
     items: [
@@ -293,7 +297,7 @@ function SidebarContent({ onClose }: SidebarContentProps) {
             素のsuper_adminにとってはチャットが機能しないため意図的に非表示にする。 */}
         {isClientAdmin && (
           <NavLink
-            to="/copilot-preview?from=legacy"
+            to={COPILOT_PREVIEW_FROM_LEGACY_PATH}
             onClick={(e) => {
               // rel="opener"付きの内部リンクで開かれた新規タブならopenerが渡っている。
               // SPA遷移せずタブごと閉じることで、元の会話が残っているタブへそのまま戻す。
@@ -306,7 +310,7 @@ function SidebarContent({ onClose }: SidebarContentProps) {
                 // 通常のSPA遷移にフォールバックする。close()が成功していればこのタブ自体が
                 // 消えるため到達しない。
                 window.setTimeout(() => {
-                  if (!window.closed) navigate("/copilot-preview?from=legacy");
+                  if (!window.closed) navigate(COPILOT_PREVIEW_FROM_LEGACY_PATH);
                 }, 150);
               }
             }}
@@ -546,10 +550,13 @@ const BOTTOM_NAV: { path: string; icon: React.ElementType; label: string; end?: 
   { path: "/admin/tuning", icon: SlidersHorizontal, label: "設定" },
 ];
 
-// client_adminのモバイル下部バーは「分析」の代わりにAIチャットへの導線を出す。analyticsは
-// growth以上のプラン制限があり、starterテナントには意味の無い枠のため(isClientAdminは
-// previewMode中のsuper_adminも真になるため、previewModeでない素のsuper_adminには
-// 従来どおりanalyticsを出す)。
+// client_adminのモバイル下部バーは、plan(starter/growth)を問わず一律「分析」の代わりに
+// AIチャットへの導線を出す(デスクトップ側 MAIN_SECTIONS の analytics 項目のような
+// requiresPlan によるプラン別出し分けはここでは行わない — チャット導線を優先する設計判断)。
+// analytics自体はgrowth以上のプラン制限がありstarterテナントには意味の無い枠だったことが
+// この置き換えの動機だが、growthテナントでも下部バーからは無くなる(ハンバーガーメニュー
+// 経由のanalyticsアクセスは従来どおり残る)。isClientAdminはpreviewMode中のsuper_adminも
+// 真になるため、previewModeでない素のsuper_adminには従来どおりanalyticsを出す。
 const BOTTOM_NAV_CLIENT_ADMIN: typeof BOTTOM_NAV = BOTTOM_NAV.map((item) =>
   item.path === "/admin/analytics" ? { path: "/copilot-preview", icon: Sparkles, label: "AIチャット" } : item,
 );

--- a/admin-ui/src/components/AppSidebar.tsx
+++ b/admin-ui/src/components/AppSidebar.tsx
@@ -293,7 +293,23 @@ function SidebarContent({ onClose }: SidebarContentProps) {
             素のsuper_adminにとってはチャットが機能しないため意図的に非表示にする。 */}
         {isClientAdmin && (
           <NavLink
-            to="/copilot-preview"
+            to="/copilot-preview?from=legacy"
+            onClick={(e) => {
+              // rel="opener"付きの内部リンクで開かれた新規タブならopenerが渡っている。
+              // SPA遷移せずタブごと閉じることで、元の会話が残っているタブへそのまま戻す。
+              // openerが無い(通常のブラウザ内遷移)場合は従来どおりNavLinkで遷移する。
+              if (window.opener) {
+                e.preventDefault();
+                window.close();
+                // ブラウザはタブ内で複数ページ遷移した後などclose()を無視することがある
+                // (script非開設扱いになるため)。閉じられなかった場合は「詰み」を避け、
+                // 通常のSPA遷移にフォールバックする。close()が成功していればこのタブ自体が
+                // 消えるため到達しない。
+                window.setTimeout(() => {
+                  if (!window.closed) navigate("/copilot-preview?from=legacy");
+                }, 150);
+              }
+            }}
             style={{
               display: "flex",
               alignItems: "center",
@@ -530,8 +546,18 @@ const BOTTOM_NAV: { path: string; icon: React.ElementType; label: string; end?: 
   { path: "/admin/tuning", icon: SlidersHorizontal, label: "設定" },
 ];
 
+// client_adminのモバイル下部バーは「分析」の代わりにAIチャットへの導線を出す。analyticsは
+// growth以上のプラン制限があり、starterテナントには意味の無い枠のため(isClientAdminは
+// previewMode中のsuper_adminも真になるため、previewModeでない素のsuper_adminには
+// 従来どおりanalyticsを出す)。
+const BOTTOM_NAV_CLIENT_ADMIN: typeof BOTTOM_NAV = BOTTOM_NAV.map((item) =>
+  item.path === "/admin/analytics" ? { path: "/copilot-preview", icon: Sparkles, label: "AIチャット" } : item,
+);
+
 export function MobileBottomBar() {
   const location = useLocation();
+  const { isClientAdmin } = useAuth();
+  const navItems = isClientAdmin ? BOTTOM_NAV_CLIENT_ADMIN : BOTTOM_NAV;
 
   return (
     <nav
@@ -549,7 +575,7 @@ export function MobileBottomBar() {
       }}
       className="mobile-bottom-bar"
     >
-      {BOTTOM_NAV.map(({ path, icon: Icon, label, end }) => {
+      {navItems.map(({ path, icon: Icon, label, end }) => {
         const isActive = end ? location.pathname === path : location.pathname.startsWith(path);
         return (
           <NavLink

--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -432,7 +432,7 @@ describe("CopilotPreviewPage — 旧UI案内リンクカード", () => {
     });
   });
 
-  it("リンクは別タブで開き、会話が残る旨の補足が添えられる", async () => {
+  it("リンクは別タブで開き、会話に戻れる旨の補足が添えられる(内部リンクはrel=opener)", async () => {
     renderPage();
     await waitForBootstrapSendStarted();
 
@@ -442,8 +442,113 @@ describe("CopilotPreviewPage — 旧UI案内リンクカード", () => {
     const link = await screen.findByRole("link", { name: /請求管理を開く/ });
     expect(link.getAttribute("href")).toBe("/admin/billing");
     expect(link.getAttribute("target")).toBe("_blank");
+    // /admin/billing は同一オリジンの内部パス(スラッシュ始まり)。主要ブラウザは target="_blank"
+    // を rel 省略時も暗黙にnoopener扱いするため、rel="opener"を明示しないとwindow.openerが
+    // 新規タブへ渡らず、旧UI側のwindow.close()による復路が繋がらない。
+    expect(link.getAttribute("rel")).toBe("opener");
+    expect(screen.getByText("別タブで開きます。終わったらこのタブを閉じると、さきほどの会話に戻れます。")).toBeTruthy();
+  });
+
+  it("「終わったら教えて」チップを押すと、旧画面での作業完了を伝える本文でagentに送信する", async () => {
+    renderPage();
+    await waitForBootstrapSendStarted();
+
+    fireEvent.change(screen.getByPlaceholderText(/指示ルール/), { target: { value: "請求書を再送したい" } });
+    fireEvent.click(screen.getByLabelText("送信"));
+
+    await screen.findByRole("link", { name: /請求管理を開く/ });
+    const doneChip = await screen.findByRole("button", { name: "終わったら教えて" });
+    fireEvent.click(doneChip);
+
+    await waitFor(() => {
+      const chatCall = vi
+        .mocked(authFetch)
+        .mock.calls.find(
+          ([url, init]) =>
+            String(url).includes("/v1/admin/agent/chat") &&
+            String((init as RequestInit | undefined)?.body).includes("旧画面での作業が終わりました。反映を確認してください"),
+        );
+      expect(chatCall).toBeTruthy();
+    });
+  });
+});
+
+// GID: rel の除去は「同一オリジンの内部パス」に限定する安全網。外部URL(http/https始まり)は
+// window.opener が渡ると閲覧者を騙るtabnabbingの経路になり得るため、従来どおり維持する。
+// get_legacy_ui_link は現状すべて内部パスしか返さないが、契約としてこの分岐を固定する。
+describe("CopilotPreviewPage — 旧UI案内リンクカード(外部URL)", () => {
+  it("card.url が http/https で始まる場合は rel=\"noopener noreferrer\" を維持する", async () => {
+    const description = "外部の請求代行サービスの画面です";
+    let agentCalls = 0;
+    vi.mocked(authFetch).mockReset();
+    mockNavigate.mockReset();
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (isBadgeUrl(url)) return mockEmptyBadges();
+      if (String(url).includes("/v1/admin/my-tenant")) {
+        return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
+      }
+      if (isUnreadFeedbackUrl(url)) return mockNoFeedbackReplies();
+      agentCalls += 1;
+      if (agentCalls === 1) return mockOk({ reply: "今週のまとめです。", actions: [] });
+      return mockOk({
+        reply: "外部の請求代行画面をご案内しました。",
+        actions: [
+          {
+            tool: "get_legacy_ui_link",
+            result: `この操作は請求代行画面から行えます。\n画面: 請求代行\nURL: https://billing.example.com/portal\n説明: ${description}`,
+            card: { kind: "legacy_link", label: "請求代行", url: "https://billing.example.com/portal", description },
+          },
+        ],
+      });
+    });
+
+    renderPage();
+    await waitForBootstrapSendStarted();
+    fireEvent.change(screen.getByPlaceholderText(/指示ルール/), { target: { value: "請求代行を見たい" } });
+    fireEvent.click(screen.getByLabelText("送信"));
+
+    const link = await screen.findByRole("link", { name: /請求代行を開く/ });
+    expect(link.getAttribute("href")).toBe("https://billing.example.com/portal");
     expect(link.getAttribute("rel")).toBe("noopener noreferrer");
-    expect(screen.getByText("別タブで開きます。この会話はそのまま残ります。")).toBeTruthy();
+  });
+
+  // GID: card.url.startsWith("/") だけの判定だと "//evil.example.com/phish" のような
+  // プロトコル相対URL(=別オリジンへの絶対URL)も内部パス扱いしてしまい、rel="opener"を
+  // 付けてtabnabbingの経路を開いてしまう。get_legacy_ui_link は現状この形式を返さないが、
+  // 「同一オリジンの内部パスにのみrel="opener"を付ける」という契約をこの分岐で固定する。
+  it("card.url が \"//\" で始まる場合(プロトコル相対URL)はrel=\"noopener noreferrer\"を維持する", async () => {
+    const description = "偽装された外部サイトへの誘導URL";
+    let agentCalls = 0;
+    vi.mocked(authFetch).mockReset();
+    mockNavigate.mockReset();
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (isBadgeUrl(url)) return mockEmptyBadges();
+      if (String(url).includes("/v1/admin/my-tenant")) {
+        return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
+      }
+      if (isUnreadFeedbackUrl(url)) return mockNoFeedbackReplies();
+      agentCalls += 1;
+      if (agentCalls === 1) return mockOk({ reply: "今週のまとめです。", actions: [] });
+      return mockOk({
+        reply: "案内しました。",
+        actions: [
+          {
+            tool: "get_legacy_ui_link",
+            result: `この操作は案内画面から行えます。\n画面: 案内\nURL: //evil.example.com/phish\n説明: ${description}`,
+            card: { kind: "legacy_link", label: "案内", url: "//evil.example.com/phish", description },
+          },
+        ],
+      });
+    });
+
+    renderPage();
+    await waitForBootstrapSendStarted();
+    fireEvent.change(screen.getByPlaceholderText(/指示ルール/), { target: { value: "案内を見たい" } });
+    fireEvent.click(screen.getByLabelText("送信"));
+
+    const link = await screen.findByRole("link", { name: /案内を開く/ });
+    expect(link.getAttribute("href")).toBe("//evil.example.com/phish");
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
   });
 });
 
@@ -496,7 +601,8 @@ describe("CopilotPreviewPage — 構造化カード(card)からの描画", () =>
     const link = await screen.findByRole("link", { name: /アバタースタジオを開く/ });
     expect(link.getAttribute("href")).toBe("/admin/avatar/studio");
     expect(link.getAttribute("target")).toBe("_blank");
-    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+    // 内部パス(スラッシュ始まり)なのでrel="opener"でwindow.openerを維持する
+    expect(link.getAttribute("rel")).toBe("opener");
     // 説明文も card の構造化フィールドから来ている
     expect(screen.getByText(description)).toBeTruthy();
   });
@@ -4542,5 +4648,53 @@ describe("CopilotPreviewPage — 起動時ブリーフィング失敗時の再�
 
     await screen.findByText("エラー: AIエージェントの応答生成に失敗しました");
     expect(screen.queryByRole("button", { name: "もう一度試す" })).toBeNull();
+  });
+});
+
+// GID 1217535151513730: 旧UIの「AIチャットに戻る」から ?from=legacy 付きで戻ってきたが
+// sessionStorage の会話を復元できなかった場合、ログイン直後と同じBOOTSTRAP_PROMPT(LLM 1
+// ターン + get_weekly_briefing の課金)を焚くと「ログインし直した画面」に見えてしまう。
+// 定型文だけを返し、余計な課金を避ける回帰テスト。
+describe("CopilotPreviewPage — 旧UIからの復路(from=legacy)", () => {
+  afterEach(() => {
+    window.history.pushState({}, "", "/copilot-preview");
+  });
+
+  it("会話を復元できなくても BOOTSTRAP_PROMPT を送らず定型文だけを出す", async () => {
+    window.history.pushState({}, "", "/copilot-preview?from=legacy");
+    vi.mocked(authFetch).mockReset();
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (isBadgeUrl(url)) return mockEmptyBadges();
+      if (String(url).includes("/v1/admin/my-tenant")) {
+        return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
+      }
+      if (isUnreadFeedbackUrl(url)) return mockNoFeedbackReplies();
+      return mockOk({ reply: "今週も順調です。", actions: [] });
+    });
+
+    renderPage();
+
+    expect(await screen.findByText("旧画面から戻られましたね。続きから話せます。")).toBeTruthy();
+    const agentCalls = vi
+      .mocked(authFetch)
+      .mock.calls.filter((c) => String(c[0]).includes("/v1/admin/agent/chat"));
+    expect(agentCalls.length).toBe(0);
+  });
+
+  it("from=legacy が無ければ従来どおり週次ブリーフィングを自動取得する", async () => {
+    vi.mocked(authFetch).mockReset();
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (isBadgeUrl(url)) return mockEmptyBadges();
+      if (String(url).includes("/v1/admin/my-tenant")) {
+        return mockOk({ onboarding_completed_at: "2026-01-01T00:00:00Z" });
+      }
+      if (isUnreadFeedbackUrl(url)) return mockNoFeedbackReplies();
+      return mockOk({ reply: "今週も順調です。", actions: [] });
+    });
+
+    renderPage();
+
+    expect(await screen.findByText("今週も順調です。")).toBeTruthy();
+    expect(screen.queryByText("旧画面から戻られましたね。続きから話せます。")).toBeNull();
   });
 });

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -2442,14 +2442,23 @@ function CardView({
         />
       );
     case "link": {
-      // 内部リンク(スラッシュ始まり=同一オリジンのSPA内パスで、"//"始まりのプロトコル相対URL
-      // は除く)だけ rel="opener" を付けて opener を明示的に維持する。主要ブラウザは
-      // target="_blank" を rel 省略時も暗黙に noopener 扱いする(2021年前後のブラウザ既定変更)
-      // ため、rel を外すだけでは window.opener が渡らない。opener を維持することで、旧UI側の
-      // 戻りリンク(AppSidebar)が window.close()で元のタブへ戻せる(=会話が復元できる)。
-      // 外部URL(http/https始まり)は一般のリンクなので、従来どおり rel="noopener noreferrer"
-      // を維持しopenerを渡さない。
-      const isInternalLink = card.url.startsWith("/") && !card.url.startsWith("//");
+      // 同一オリジンの内部パスだけ rel="opener" を付けて opener を明示的に維持する。主要
+      // ブラウザは target="_blank" を rel 省略時も暗黙に noopener 扱いする(2021年前後の
+      // ブラウザ既定変更)ため、rel を外すだけでは window.opener が渡らない。opener を維持
+      // することで、旧UI側の戻りリンク(AppSidebar)が window.close()で元のタブへ戻せる
+      // (=会話が復元できる)。外部URL(他オリジン)は一般のリンクなので、従来どおり
+      // rel="noopener noreferrer" を維持しopenerを渡さない。
+      // 判定は文字列の前方一致(例: startsWith("/"))ではなくURLパースでオリジンを比較する
+      // ("/\\evil.com" のようなバックスラッシュはWHATWG URLパーサでスラッシュに正規化され
+      // 別オリジンへの絶対URLになるため、前方一致だと内部パス扱いしてしまう=reverse
+      // tabnabbingの経路になる)。
+      const isInternalLink = (() => {
+        try {
+          return new URL(card.url, window.location.origin).origin === window.location.origin;
+        } catch {
+          return false;
+        }
+      })();
       return (
         <CardShell hd={<><span>🔗</span>{card.label}へご案内します</>}>
           <Field k="この操作について" v={card.description} />

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -931,7 +931,7 @@ export default function CopilotPreviewPage() {
   // スレッドへ紛れ込む(P2-1)。
   const runOnboardingAwareBriefing = async (
     myEpoch: number,
-    opts: { hasRestoredConversation: boolean; loadingText: string; force?: boolean },
+    opts: { hasRestoredConversation: boolean; loadingText: string; force?: boolean; fromLegacy?: boolean },
   ) => {
     let stage: OnboardingStageFlags | null = null;
     // Asana 1217040568430944(P7): super_adminのクライアントビュー(previewMode)からも
@@ -987,6 +987,14 @@ export default function CopilotPreviewPage() {
       return;
     }
 
+    // 旧UIから戻ってきたが会話を復元できなかった場合は、ログイン直後と同じ
+    // BOOTSTRAP_PROMPT(LLM 1ターン + get_weekly_briefing)を焚かない。復元失敗は
+    // 「初回ログイン」ではなく単なる不通なので、定型文だけ返して余計な課金を避ける。
+    if (opts.fromLegacy) {
+      push({ id: nextId(), role: "ai", text: "旧画面から戻られましたね。続きから話せます。" });
+      return;
+    }
+
     push({ id: nextId(), role: "ai", text: opts.loadingText });
     await sendReal(BOOTSTRAP_PROMPT, { silent: true, force: opts.force });
   };
@@ -1031,6 +1039,7 @@ export default function CopilotPreviewPage() {
     void runOnboardingAwareBriefing(myEpoch, {
       hasRestoredConversation,
       loadingText: "ログイン、お疲れさまです。今週の実データを確認しています…",
+      fromLegacy: new URLSearchParams(window.location.search).get("from") === "legacy",
     });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [needsTenantSelection, authLoading]);
@@ -2432,7 +2441,15 @@ function CardView({
           onAdoptDesigned={onAdoptDesignedVoice}
         />
       );
-    case "link":
+    case "link": {
+      // 内部リンク(スラッシュ始まり=同一オリジンのSPA内パスで、"//"始まりのプロトコル相対URL
+      // は除く)だけ rel="opener" を付けて opener を明示的に維持する。主要ブラウザは
+      // target="_blank" を rel 省略時も暗黙に noopener 扱いする(2021年前後のブラウザ既定変更)
+      // ため、rel を外すだけでは window.opener が渡らない。opener を維持することで、旧UI側の
+      // 戻りリンク(AppSidebar)が window.close()で元のタブへ戻せる(=会話が復元できる)。
+      // 外部URL(http/https始まり)は一般のリンクなので、従来どおり rel="noopener noreferrer"
+      // を維持しopenerを渡さない。
+      const isInternalLink = card.url.startsWith("/") && !card.url.startsWith("//");
       return (
         <CardShell hd={<><span>🔗</span>{card.label}へご案内します</>}>
           <Field k="この操作について" v={card.description} />
@@ -2440,16 +2457,25 @@ function CardView({
           <a
             href={card.url}
             target="_blank"
-            rel="noopener noreferrer"
+            rel={isInternalLink ? "opener" : "noopener noreferrer"}
             style={{ display: "inline-flex", alignSelf: "flex-start", alignItems: "center", gap: 6, padding: "9px 16px", borderRadius: 10, background: AGENT, color: "#fff", fontSize: 14, fontWeight: 700, textDecoration: "none" }}
           >
             {card.label}を開く ↗
           </a>
           <div style={{ fontSize: 12.5, color: "var(--muted-foreground)" }}>
-            別タブで開きます。この会話はそのまま残ります。
+            別タブで開きます。終わったらこのタブを閉じると、さきほどの会話に戻れます。
           </div>
+          {onSendReal && (
+            <button
+              onClick={() => onSendReal("__real:旧画面での作業が終わりました。反映を確認してください")}
+              style={{ alignSelf: "flex-start", fontSize: 14.5, fontWeight: 700, padding: "10px 18px", borderRadius: 12, cursor: "pointer", border: "1px solid var(--border)", background: "transparent", color: "var(--muted-foreground)", minHeight: 44 }}
+            >
+              終わったら教えて
+            </button>
+          )}
         </CardShell>
       );
+    }
     case "chatSessionList":
       return (
         <CardShell hd={<><span>💬</span>会話セッション一覧（全{card.total}件中{card.sessions.length}件）</>}>


### PR DESCRIPTION
## Summary
- 旧UI案内リンク(legacy_link)の内部パスに rel="opener" を明示し、target=_blank の既定noopener挙動を上書き。旧UI側の戻りリンクが window.opener 経由でタブを閉じて元の会話に戻れるようにする。
- AppSidebarの戻りリンクは opener があればタブを閉じ、閉じられない場合(タブ内で複数ページ遷移した後など)はSPA遷移にフォールバックする。
- from=legacy で戻ってきた際、会話を復元できなくても起動時ブリーフィング(LLM1ターン+get_weekly_briefing)を焚かず、定型文のみ返す。
- モバイル下部バー(5枠)は client_admin(previewMode中のsuper_admin含む)なら「分析」の代わりに「AIチャット」への導線を出す。素のsuper_adminは従来どおり。
- 出典: Asana 1217535151513730。Wave 0 の結論により4項目すべて実施(rel除去は縮退せず実施)。

## Test plan
- [x] admin-ui vitest: `pnpm test:ui` (copilot-preview/index.test.tsx, AppSidebar.test.tsx) 追加テスト含め全パス
- [x] root: `pnpm typecheck` / `pnpm lint`
- [x] root: `npx jest --maxWorkers=1`(環境のポート競合を避けた単一worker実行)で全パス確認
- [x] `bash SCRIPTS/dead-code-check.sh`
- [x] `bash SCRIPTS/security-scan.sh` (CRITICAL/HIGH 0)
- [x] `pnpm build` / `admin-ui: pnpm build`
- [x] Codex review (1回目で rel="opener" 未実装のP1指摘を受け修正済み。2回目はCodex側の利用上限で未完了)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HWoUTTu8SKpDk6asbGWDF1