### PR TITLE
feat(agent): FAQカテゴリ語彙を単一情報源化し、add_faq/update_faqを9種対応に

### DIFF
--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -8,6 +8,7 @@ import {
   insertEmbeddingAsync,
   upsertToEsAsync,
 } from '../knowledge/faqCrudRoutes';
+import { FAQ_CATEGORY_IDS } from '../../../lib/knowledge/faqCategories';
 import { callGroq8bSuggestFromText, callGroq8bSuggest } from '../tuning/routes';
 import { listRules, createRule, updateRule, deleteRule, type ApprovedResponse, type RuleEvidence } from '../tuning/tuningRulesRepository';
 import { splitTriggerKeywords } from '../tuning/triggerMatching';
@@ -562,6 +563,9 @@ export async function executeToolCall(
       if (!question || !answer) {
         return truncate('question と answer は必須です');
       }
+      if (category !== null && !FAQ_CATEGORY_IDS.includes(category)) {
+        return truncate(`不明なカテゴリです: ${category}`);
+      }
 
       try {
         const result = await db.query(
@@ -591,9 +595,13 @@ export async function executeToolCall(
       const id = Number(args['id']);
       const question = String(args['question'] ?? '').slice(0, 500);
       const answer = String(args['answer'] ?? '').slice(0, 2000);
+      const category = typeof args['category'] === 'string' ? args['category'] : null;
 
       if (!Number.isFinite(id) || !question || !answer) {
         return truncate('id・question・answer は必須です');
+      }
+      if (category !== null && !FAQ_CATEGORY_IDS.includes(category)) {
+        return truncate(`不明なカテゴリです: ${category}`);
       }
 
       try {
@@ -610,11 +618,12 @@ export async function executeToolCall(
           return truncate('この FAQ へのアクセス権限がありません');
         }
 
+        // category は未指定(null)なら COALESCE で既存値を保持する(指定時のみ更新)。
         const updateResult = await db.query(
-          `UPDATE faq_docs SET question = $1, answer = $2, updated_at = NOW()
-           WHERE id = $3 AND tenant_id = $4
+          `UPDATE faq_docs SET question = $1, answer = $2, category = COALESCE($3, category), updated_at = NOW()
+           WHERE id = $4 AND tenant_id = $5
            RETURNING id, question, answer, is_published`,
-          [question, answer, id, tenantId]
+          [question, answer, category, id, tenantId]
         );
         const updated = updateResult.rows[0] as {
           id: number; question: string; answer: string; is_published: boolean;

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -223,6 +223,7 @@ function recordedSettingsChanges(): Array<Record<string, any>> {
 
 import { registerAdminAgentRoutes } from './agentRoutes';
 import { ADMIN_AGENT_TOOLS, LEGACY_UI_FEATURES } from './toolDefinitions';
+import { FAQ_CATEGORY_IDS } from '../../../lib/knowledge/faqCategories';
 // オンボ 是正A-3: publish_faq_drafts が is_excluded_from_search を正しく引き継ぐことを
 // 検証するため、モック化された upsertToEsAsync への参照を取得する(上のjest.mockで
 // faqCrudRoutes モジュール全体が既にモック済み)。
@@ -3142,6 +3143,145 @@ describe('POST /v1/admin/agent/chat', () => {
         ['tenant-abc', '送料はいくらですか？', '550円です。', 'store_info'],
       );
       expect(res.body.actions[0].result).toContain('ID: 99');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GID 1217534700360088: FAQカテゴリ語彙の単一情報源化(faqCategories.ts)に伴い、
+  // add_faq/update_faq が9種すべてに対応したことの回帰テスト。
+  // -------------------------------------------------------------------------
+  describe('add_faq / update_faq', () => {
+    function toolCallResponse(id: string, name: string, args: Record<string, unknown> = {}) {
+      return {
+        ok: true,
+        json: async () => ({
+          choices: [{
+            message: {
+              content: null,
+              tool_calls: [{ id, type: 'function', function: { name, arguments: JSON.stringify(args) } }],
+            },
+          }],
+        }),
+        text: async () => '',
+      };
+    }
+
+    it.each(FAQ_CATEGORY_IDS as string[])('add_faq: category=%s を受け付ける', async (category) => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-af-1', 'add_faq', { question: 'q', answer: 'a', category }))
+        .mockResolvedValueOnce(makeGroqResponse('追加しました。'));
+
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ id: 1, question: 'q', answer: 'a', is_published: true }],
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'FAQを追加して', sessionId: `sess-af-${category}` });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO faq_docs'),
+        ['tenant-abc', 'q', 'a', category],
+      );
+      expect(res.body.actions[0].result).toContain('ID: 1');
+    });
+
+    it('add_faq: 未知のカテゴリはDBに書き込まず拒否する', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-af-2', 'add_faq', { question: 'q', answer: 'a', category: 'unknown_cat' }))
+        .mockResolvedValueOnce(makeGroqResponse('確認できませんでした。'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'FAQを追加して', sessionId: 'sess-af-3' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('不明なカテゴリです');
+    });
+
+    it('update_faq: categoryだけを変更できる', async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          toolCallResponse('call-uf-1', 'update_faq', { id: 42, question: 'q', answer: 'a', category: 'pricing' }),
+        )
+        .mockResolvedValueOnce(makeGroqResponse('更新しました。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ id: 42, tenant_id: 'tenant-abc' }] }) // テナント確認
+        .mockResolvedValueOnce({ rows: [{ id: 42, question: 'q', answer: 'a', is_published: true }] }) // UPDATE
+        .mockResolvedValueOnce({ rows: [] }); // 古いembedding削除(fire-and-forget)
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'カテゴリを変更して', sessionId: 'sess-uf-01' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining('COALESCE($3, category)'),
+        ['q', 'a', 'pricing', 42, 'tenant-abc'],
+      );
+      expect(res.body.actions[0].result).toContain('ID: 42');
+    });
+
+    it('update_faq: category未指定時はCOALESCEでnullを渡し、既存カテゴリを保持する', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-uf-2', 'update_faq', { id: 42, question: 'q2', answer: 'a2' }))
+        .mockResolvedValueOnce(makeGroqResponse('更新しました。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ id: 42, tenant_id: 'tenant-abc' }] })
+        .mockResolvedValueOnce({ rows: [{ id: 42, question: 'q2', answer: 'a2', is_published: true }] })
+        .mockResolvedValueOnce({ rows: [] }); // 古いembedding削除(fire-and-forget)
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '本文だけ直して', sessionId: 'sess-uf-02' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining('COALESCE($3, category)'),
+        ['q2', 'a2', null, 42, 'tenant-abc'],
+      );
+      expect(res.body.actions[0].result).toContain('ID: 42');
+    });
+
+    it('update_faq: 未知のカテゴリはDBに触れず拒否する', async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          toolCallResponse('call-uf-3', 'update_faq', { id: 42, question: 'q', answer: 'a', category: 'unknown_cat' }),
+        )
+        .mockResolvedValueOnce(makeGroqResponse('確認できませんでした。'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'カテゴリを変更して', sessionId: 'sess-uf-04' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('不明なカテゴリです');
+    });
+
+    it('update_faq: 他テナントのFAQは更新できない', async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          toolCallResponse('call-uf-5', 'update_faq', { id: 42, question: 'q', answer: 'a', category: 'pricing' }),
+        )
+        .mockResolvedValueOnce(makeGroqResponse('確認できませんでした。'));
+
+      mockQuery.mockResolvedValueOnce({ rows: [{ id: 42, tenant_id: 'tenant-zzz' }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'カテゴリを変更して', sessionId: 'sess-uf-06' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('アクセス権限がありません');
+      // 所有権確認のSELECTのみ呼ばれ、UPDATEには到達しない
+      expect(mockQuery).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/api/admin/agent/toolDefinitions.ts
+++ b/src/api/admin/agent/toolDefinitions.ts
@@ -1,6 +1,8 @@
 // src/api/admin/agent/toolDefinitions.ts
 // Phase B-Admin: AIエージェント用ツール定義（Groq function calling 形式）
 
+import { FAQ_CATEGORY_IDS } from '../../../lib/knowledge/faqCategories';
+
 export interface GroqTool {
   type: 'function';
   function: {
@@ -128,8 +130,8 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
           },
           category: {
             type: 'string',
-            description: 'カテゴリ（inventory / campaign / coupon / store_info のいずれか、任意）',
-            enum: ['inventory', 'campaign', 'coupon', 'store_info'],
+            description: `カテゴリ（${FAQ_CATEGORY_IDS.join(' / ')} のいずれか、任意）`,
+            enum: FAQ_CATEGORY_IDS,
           },
         },
         required: ['question', 'answer'],
@@ -155,6 +157,11 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
           answer: {
             type: 'string',
             description: '新しい回答文（2000字以内）',
+          },
+          category: {
+            type: 'string',
+            description: `カテゴリ（${FAQ_CATEGORY_IDS.join(' / ')} のいずれか、任意。未指定なら既存のカテゴリを維持する）`,
+            enum: FAQ_CATEGORY_IDS,
           },
         },
         required: ['id', 'question', 'answer'],

--- a/src/lib/knowledge/faqCategories.test.ts
+++ b/src/lib/knowledge/faqCategories.test.ts
@@ -1,0 +1,42 @@
+// src/lib/knowledge/faqCategories.test.ts
+
+import { FAQ_CATEGORIES, FAQ_CATEGORY_IDS, buildFaqCategoryPromptSection } from "./faqCategories";
+
+describe("faqCategories", () => {
+  it("FAQ_CATEGORIES は9件ある", () => {
+    expect(FAQ_CATEGORIES).toHaveLength(9);
+  });
+
+  it("id が重複しない", () => {
+    const ids = FAQ_CATEGORIES.map((c) => c.id);
+    expect(new Set(ids).size).toBe(ids.length);
+  });
+
+  it("各要素の id・label・criteria がすべて空でない", () => {
+    for (const c of FAQ_CATEGORIES) {
+      expect(c.id.trim()).not.toBe("");
+      expect(c.label.trim()).not.toBe("");
+      expect(c.criteria.trim()).not.toBe("");
+    }
+  });
+
+  it("FAQ_CATEGORY_IDS は FAQ_CATEGORIES の id と同じ内容・順序", () => {
+    expect(FAQ_CATEGORY_IDS).toEqual(FAQ_CATEGORIES.map((c) => c.id));
+  });
+
+  it("buildFaqCategoryPromptSection の出力に全idが含まれる", () => {
+    const section = buildFaqCategoryPromptSection();
+    for (const id of FAQ_CATEGORY_IDS) {
+      expect(section).toContain(`"${id}"`);
+    }
+  });
+
+  it("buildFaqCategoryPromptSection は `* {判定基準} → \"{id}\"` を改行で連結した形式", () => {
+    const section = buildFaqCategoryPromptSection();
+    const lines = section.split("\n");
+    expect(lines).toHaveLength(FAQ_CATEGORIES.length);
+    FAQ_CATEGORIES.forEach((c, i) => {
+      expect(lines[i]).toBe(`* ${c.criteria} → "${c.id}"`);
+    });
+  });
+});

--- a/src/lib/knowledge/faqCategories.ts
+++ b/src/lib/knowledge/faqCategories.ts
@@ -1,0 +1,41 @@
+// src/lib/knowledge/faqCategories.ts
+//
+// FAQカテゴリ語彙の単一情報源。以前は下記3箇所で語彙が個別に維持され、実際に3重化していた:
+//   - src/lib/knowledge/faqImport.ts のAIへのカテゴリ判定プロンプト(9種)
+//   - src/api/admin/agent/toolDefinitions.ts の add_faq の category enum(旧: 4種のみ)
+//   - admin-ui側の表示ラベル(admin-ui/src/i18n/ja.ts の category.*、
+//     admin-ui/src/components/knowledge/TextInputTab.tsx・UrlScrapeTab.tsx の CATEGORIES)
+// このファイルが src/lib/knowledge/ と src/api/admin/agent/ 側の正であり、
+// faqImport.ts / toolDefinitions.ts はここを参照する。admin-ui は別パッケージのため
+// import できず、上記3ファイルへの手動複製が残る(既知の非対称。増やさない)。
+
+export interface FaqCategory {
+  id: string;
+  /** admin-ui の選択肢・表示用の短い日本語ラベル */
+  label: string;
+  /** AIへのカテゴリ自動判定プロンプトに使う判定基準文 */
+  criteria: string;
+}
+
+export const FAQ_CATEGORIES: readonly FaqCategory[] = [
+  { id: "product_info", label: "商品・サービス情報", criteria: "商品・サービスの詳細情報" },
+  { id: "pricing", label: "料金・価格", criteria: "料金・価格・支払い方法" },
+  { id: "store_info", label: "店舗情報・アクセス", criteria: "店舗・アクセス・営業時間" },
+  { id: "campaign", label: "キャンペーン・セール", criteria: "キャンペーン・セール・割引" },
+  { id: "inventory", label: "在庫・車両情報", criteria: "在庫・車両情報" },
+  { id: "coupon", label: "クーポン・割引", criteria: "クーポン・割引コード" },
+  { id: "booking", label: "予約・申し込み", criteria: "予約・申し込み方法" },
+  { id: "warranty", label: "保証・アフターサービス", criteria: "保証・アフターサービス" },
+  { id: "general", label: "よくある質問・一般", criteria: "よくある質問・一般" },
+];
+
+/** id だけを取り出した読み取り専用配列。toolDefinitions.ts の enum・検証に使う。 */
+export const FAQ_CATEGORY_IDS: readonly string[] = FAQ_CATEGORIES.map((c) => c.id);
+
+/**
+ * faqImport.ts のプロンプトに差し込む「カテゴリの判定基準」箇条書きを組み立てる。
+ * 出力は `* {判定基準文} → "{id}"` を改行で連結した文字列(末尾に改行は付けない)。
+ */
+export function buildFaqCategoryPromptSection(): string {
+  return FAQ_CATEGORIES.map((c) => `* ${c.criteria} → "${c.id}"`).join("\n");
+}

--- a/src/lib/knowledge/faqImport.ts
+++ b/src/lib/knowledge/faqImport.ts
@@ -25,6 +25,7 @@ import { groqClient } from '../../agent/llm/groqClient';
 import { embedText } from '../../agent/llm/openaiEmbeddingClient';
 import { encryptText } from '../crypto/textEncrypt';
 import { logger } from '../logger';
+import { buildFaqCategoryPromptSection } from './faqCategories';
 
 export interface FaqEntry {
   question: string;
@@ -74,15 +75,7 @@ export async function textToFaqs(
 * キャンペーン・割引
 ${existingSection}
 カテゴリの判定基準:
-* 商品・サービスの詳細情報 → "product_info"
-* 料金・価格・支払い方法 → "pricing"
-* 店舗・アクセス・営業時間 → "store_info"
-* キャンペーン・セール・割引 → "campaign"
-* 在庫・車両情報 → "inventory"
-* クーポン・割引コード → "coupon"
-* 予約・申し込み方法 → "booking"
-* 保証・アフターサービス → "warranty"
-* よくある質問・一般 → "general"
+${buildFaqCategoryPromptSection()}
 * 上記に当てはまらない場合 → 適切なカテゴリ名を英語スネークケースで生成
 
 テキスト:


### PR DESCRIPTION
## Summary
- Asana [D1] FAQカテゴリ語彙を単一情報源化し、add_faq と update_faq を9種対応にする (GID 1217534700360088)
- 新設 `src/lib/knowledge/faqCategories.ts`: id・日本語ラベル・判定基準文を持つ `FAQ_CATEGORIES`、id専用の `FAQ_CATEGORY_IDS`、faqImport.ts のAIプロンプトへ差し込む文字列を組み立てる `buildFaqCategoryPromptSection()`
- `faqImport.ts` のプロンプト内カテゴリ列挙をこの組み立て関数の呼び出しに置き換え(出力文字列は現状と等価、挙動変更なし)
- `toolDefinitions.ts`: `add_faq` の category enum を4種→9種に拡張、`update_faq` にも category(任意・同enum)を追加
- `actionExecutor.ts`: 両ツールのカテゴリ検証を `FAQ_CATEGORY_IDS` ベースに統一。`update_faq` の既存 UPDATE 文に `category = COALESCE($n, category)` を追加(指定時のみ更新、未指定時は既存値を保持)。検索索引の同期は既存の `upsertToEsAsync` をそのまま呼び、FAQ書き込み経路を増やしていない

## Test plan
- [x] `pnpm typecheck` (root) — pass
- [x] `pnpm lint` (root, oxlint) — pass, 59 warnings(閾値63以内、新規警告なし)
- [x] `pnpm test` (jest) — 3533/3533 pass(クリーン実行時)
- [x] `bash SCRIPTS/dead-code-check.sh` — pass
- [x] `bash SCRIPTS/security-scan.sh` — PASS、CRITICAL/HIGH 0件(新規SQLはパラメータ化済みでSQLi検査もPASS)
- [x] `pnpm build` (root) / admin-ui `pnpm build` — pass
- [ ] Codex review — 2回試行したが使用量上限で失敗(詳細は報告に記載)。PR作成後に `/code-review high` を実行予定
- [ ] hkobayashi の手動マージ(Tier S: src/** を変更するため auto-merge対象外、draftのまま維持)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDCq3hgpSccqkadqEj65ep