### PR TITLE
fix(agent): category="" を未指定として扱い FAQ の追加・更新が失敗するのを防ぐ

### DIFF
--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -110,6 +110,15 @@ function parsePriorityTier(raw: unknown): 'low' | 'normal' | 'high' | undefined 
   return raw === 'low' || raw === 'normal' || raw === 'high' ? raw : undefined;
 }
 
+// add_faq / update_faq が共有するcategory引数の解析。空文字列は「未指定」として扱う
+// (LLMのfunction callingで省略時に''が渡ってくることがあるため、nullと区別せず
+// 「不明なカテゴリです」で弾いてしまうと正当なquestion/answerの更新まで失敗する)。
+function parseFaqCategoryArg(raw: unknown): { ok: true; category: string | null } | { ok: false; error: string } {
+  if (typeof raw !== 'string' || raw.trim() === '') return { ok: true, category: null };
+  if (!FAQ_CATEGORY_IDS.includes(raw)) return { ok: false, error: `不明なカテゴリです: ${raw}` };
+  return { ok: true, category: raw };
+}
+
 // ---------------------------------------------------------------------------
 // プラン制限の案内文
 // ---------------------------------------------------------------------------
@@ -558,14 +567,15 @@ export async function executeToolCall(
     case 'add_faq': {
       const question = String(args['question'] ?? '').slice(0, 500);
       const answer = String(args['answer'] ?? '').slice(0, 2000);
-      const category = typeof args['category'] === 'string' ? args['category'] : null;
 
       if (!question || !answer) {
         return truncate('question と answer は必須です');
       }
-      if (category !== null && !FAQ_CATEGORY_IDS.includes(category)) {
-        return truncate(`不明なカテゴリです: ${category}`);
+      const categoryResult = parseFaqCategoryArg(args['category']);
+      if (!categoryResult.ok) {
+        return truncate(categoryResult.error);
       }
+      const category = categoryResult.category;
 
       try {
         const result = await db.query(
@@ -595,14 +605,15 @@ export async function executeToolCall(
       const id = Number(args['id']);
       const question = String(args['question'] ?? '').slice(0, 500);
       const answer = String(args['answer'] ?? '').slice(0, 2000);
-      const category = typeof args['category'] === 'string' ? args['category'] : null;
 
       if (!Number.isFinite(id) || !question || !answer) {
         return truncate('id・question・answer は必須です');
       }
-      if (category !== null && !FAQ_CATEGORY_IDS.includes(category)) {
-        return truncate(`不明なカテゴリです: ${category}`);
+      const categoryResult = parseFaqCategoryArg(args['category']);
+      if (!categoryResult.ok) {
+        return truncate(categoryResult.error);
       }
+      const category = categoryResult.category;
 
       try {
         // テナント確認

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -3201,6 +3201,52 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(res.body.actions[0].result).toContain('不明なカテゴリです');
     });
 
+    // 空文字列は「未指定」として扱う(LLMのfunction callingで省略時に''が渡ることがあるため、
+    // nullと区別せず拒否すると正当な追加まで失敗する)。
+    it('add_faq: category="" は未指定として扱い、categoryにnullでINSERTされる', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-af-4', 'add_faq', { question: 'q', answer: 'a', category: '' }))
+        .mockResolvedValueOnce(makeGroqResponse('追加しました。'));
+
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ id: 2, question: 'q', answer: 'a', is_published: true }],
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'FAQを追加して', sessionId: 'sess-af-5' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).toHaveBeenCalledWith(
+        expect.stringContaining('INSERT INTO faq_docs'),
+        ['tenant-abc', 'q', 'a', null],
+      );
+      expect(res.body.actions[0].result).toContain('ID: 2');
+    });
+
+    it('update_faq: category="" は未指定として扱い、COALESCEでnullを渡して既存カテゴリを保持する', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-uf-7', 'update_faq', { id: 42, question: 'q', answer: 'a', category: '' }))
+        .mockResolvedValueOnce(makeGroqResponse('更新しました。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ id: 42, tenant_id: 'tenant-abc' }] })
+        .mockResolvedValueOnce({ rows: [{ id: 42, question: 'q', answer: 'a', is_published: true }] })
+        .mockResolvedValueOnce({ rows: [] }); // 古いembedding削除(fire-and-forget)
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '本文だけ直して', sessionId: 'sess-uf-07' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining('COALESCE($3, category)'),
+        ['q', 'a', null, 42, 'tenant-abc'],
+      );
+      expect(res.body.actions[0].result).toContain('ID: 42');
+    });
+
     it('update_faq: categoryだけを変更できる', async () => {
       mockFetch
         .mockResolvedValueOnce(

--- a/src/lib/knowledge/faqCategories.ts
+++ b/src/lib/knowledge/faqCategories.ts
@@ -1,13 +1,19 @@
 // src/lib/knowledge/faqCategories.ts
 //
-// FAQカテゴリ語彙の単一情報源。以前は下記3箇所で語彙が個別に維持され、実際に3重化していた:
+// FAQカテゴリ語彙の単一情報源。以前は下記の箇所で語彙が個別に維持され、実際に3重化していた:
 //   - src/lib/knowledge/faqImport.ts のAIへのカテゴリ判定プロンプト(9種)
 //   - src/api/admin/agent/toolDefinitions.ts の add_faq の category enum(旧: 4種のみ)
 //   - admin-ui側の表示ラベル(admin-ui/src/i18n/ja.ts の category.*、
-//     admin-ui/src/components/knowledge/TextInputTab.tsx・UrlScrapeTab.tsx の CATEGORIES)
+//     admin-ui/src/components/knowledge/TextInputTab.tsx・UrlScrapeTab.tsx の CATEGORIES、
+//     admin-ui/src/components/knowledge/shared.ts の CATEGORY_LABELS)
 // このファイルが src/lib/knowledge/ と src/api/admin/agent/ 側の正であり、
 // faqImport.ts / toolDefinitions.ts はここを参照する。admin-ui は別パッケージのため
-// import できず、上記3ファイルへの手動複製が残る(既知の非対称。増やさない)。
+// import できず、上記ファイルへの手動複製が残る(既知の非対称。増やさない)。
+//
+// 既知の残課題: src/api/admin/knowledge/routes.ts にも同じ語彙のローカル定数
+// `CATEGORIES`/`Category` が残っている(現状どこからも参照されない未配線の複製)。
+// 同一パッケージ内でこのファイルを直接importできる場所のため、将来何かに配線すると
+// このファイルと再び乖離する。削除は本PRの範囲外(既存dead codeの削除は別タスク)。
 
 export interface FaqCategory {
   id: string;


### PR DESCRIPTION
## 背景

PR #770 (D1) で `add_faq` / `update_faq` に `category` 引数を追加した際、検証を
`typeof args[category] === "string"` で行っていたため、**LLM の function calling が省略時に空文字列を渡すと弾かれる**状態になっていました。

```
不明なカテゴリです:
```

`category` と無関係な `question` / `answer` の更新まで失敗するため、FAQ 書き込みの中核経路2本に影響します。

## 変更

- 空文字列を「未指定」として扱う `parseFaqCategoryArg` を `add_faq` / `update_faq` で共有
- 両ツールに `category=""` の回帰テストを追加（`update_faq` 側は COALESCE で既存カテゴリが保持されることまで確認）
- `faqCategories.ts` 冒頭コメントを実測に更新。あわせて `src/api/admin/knowledge/routes.ts` に未配線の同名定数が残っていることを既知の残課題として明記（削除は既存 dead code の扱いとして別タスク）

## 経緯

この修正は PR #770 の担当が実施済みで、**コミットされないまま作業ツリーに残っていた**ものです。内容を検証したうえでそのまま取り込みました。D2 が同じファイルを触るため、先に main へ入れて競合を避けます。

## Gate

- Gate 1: **CI に委譲**。`agentRoutes.test.ts` は supertest がローカルソケットを開くため、実行環境の制約で手元では走らせられませんでした（無関係な 37 スイートが同じ `EADDRNOTAVAIL` で落ちるため環境要因）。`faqCategories.test.ts` は手元で 6 件パス
- Gate 2: security-scan **PASS**（CRITICAL/HIGH 0、WARN 1）
- Gate 2.5: 未実行。レビュー時に `/codex:review --base main` を回してください

Tier S のため draft のままにしています。