### PR TITLE
fix(agent): set_faq_published の published を文字列でも受理する

### DIFF
--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -86,6 +86,20 @@ function isConfirmed(raw: unknown): boolean {
   return typeof raw === 'string' && raw.trim().toLowerCase() === 'true';
 }
 
+// set_faq_published の published 引数を解析する。isConfirmed と同じ理由(Groqがbooleanを
+// 文字列化して送ってくることがある)で、真偽値そのものに加え "true"/"false" 文字列も受理する。
+// confirmed と違い true/false 両方を区別する必要があるため、どちらでもなければ
+// undefined(未指定/不正値)を返す。
+function parseBooleanArg(raw: unknown): boolean | undefined {
+  if (typeof raw === 'boolean') return raw;
+  if (typeof raw === 'string') {
+    const normalized = raw.trim().toLowerCase();
+    if (normalized === 'true') return true;
+    if (normalized === 'false') return false;
+  }
+  return undefined;
+}
+
 // suggest_tuning_rule がトリガー未決定時に案内していたプレースホルダ文字列。
 // save_tuning_rule にそのまま渡ってきた場合、文字列としてtrigger_patternに
 // 保存させない(D4: 保存は成功するが質問文に一致せず永久に発火しない)。
@@ -702,7 +716,7 @@ export async function executeToolCall(
     // 誤った回答をすぐ止めたいときに delete_faq(不可逆)しか選べない欠落を埋める。
     case 'set_faq_published': {
       const id = Number(args['id']);
-      const published = args['published'];
+      const published = parseBooleanArg(args['published']);
       const confirmed = isConfirmed(args['confirmed']);
 
       if (!confirmed) {
@@ -711,7 +725,7 @@ export async function executeToolCall(
         );
       }
 
-      if (!Number.isFinite(id) || typeof published !== 'boolean') {
+      if (!Number.isFinite(id) || published === undefined) {
         return truncate('id・published は必須です');
       }
 

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -3380,6 +3380,35 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(result).not.toContain('確認が必要');
     });
 
+    // Groq がbooleanを文字列化して送ってくることがある(isConfirmedと同じ既知の挙動)。
+    // 厳密な typeof チェックだと、確認済み(confirmed="true")の正当な要求が
+    // published="false" というだけで「id・publishedは必須です」に弾かれてしまう。
+    it('Groqがpublished/confirmedを文字列("false"/"true")で送っても正しく処理される', async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          toolCallResponse('call-sfp-7', 'set_faq_published', { id: 42, published: 'false', confirmed: 'true' }),
+        )
+        .mockResolvedValueOnce(makeGroqResponse('非公開にしました。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ id: 42, tenant_id: 'tenant-abc' }] })
+        .mockResolvedValueOnce({
+          rows: [{ id: 42, question: 'q', answer: 'a', is_published: false, is_excluded_from_search: false }],
+        });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'この回答を止めて', sessionId: 'sess-sfp-07' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining('UPDATE faq_docs SET is_published = $1'),
+        [false, 42, 'tenant-abc'],
+      );
+      expect(res.body.actions[0].result).toContain('非公開にしました');
+    });
+
     it('非公開のFAQを公開にできる', async () => {
       mockFetch
         .mockResolvedValueOnce(


### PR DESCRIPTION
## 背景

PR #772 (D2) で追加した `set_faq_published` は `published` を `typeof published === "boolean"` で検証していましたが、**Groq は真偽値を文字列で送ってくることがあります**。同じファイルの `isConfirmed` が既にその対策をしているとおり、既知の挙動です。

`published: "false"` が渡ると引数エラーで弾かれ、**「誤った回答を今すぐ止めたい」というこのツールの主目的が果たせません**。止められない場面が確率的に発生する形なので、再現しにくく気づきにくい壊れ方です。

## 変更

- `parseBooleanArg` を追加し、真偽値に加えて `"true"` / `"false"` 文字列も受理する。`confirmed` と違い両方を区別する必要があるため、どちらでもなければ `undefined`（未指定/不正値）を返す
- `published` / `confirmed` を文字列で送った場合の回帰テストを追加

## 経緯

この修正は PR #772 の担当が `/code-review` 後に自ら発見・修正したもので、**コミットされないまま作業ツリーに残っていました**。D1 (#770 → #771) と同じ経路です。

なお本コミットは、当方がレーン稼働中に worktree のブランチを切り替えてしまったため、一時的に別タスク([G])のブランチ上に載っていました。内容は無関係なので、正しいブランチへ切り出して本PRとしています。[G] のブランチはこの後クリーンな状態に作り直します。

## Gate

- Gate 1: **CI に委譲**。`agentRoutes.test.ts` は supertest がローカルソケットを開くため実行環境の制約で手元では走らせられません
- Gate 2.5: 未実行。レビュー時に `/codex:review --base main` を回してください

Tier S のため draft のままにしています。