### PR TITLE
fix(agent): set_faq_published のpublishedを文字列でも受理する

### DIFF
--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -86,6 +86,20 @@ function isConfirmed(raw: unknown): boolean {
   return typeof raw === 'string' && raw.trim().toLowerCase() === 'true';
 }
 
+// set_faq_published の published 引数を解析する。isConfirmed と同じ理由(Groqがbooleanを
+// 文字列化して送ってくることがある)で、真偽値そのものに加え "true"/"false" 文字列も受理する。
+// confirmed と違い true/false 両方を区別する必要があるため、どちらでもなければ
+// undefined(未指定/不正値)を返す。
+function parseBooleanArg(raw: unknown): boolean | undefined {
+  if (typeof raw === 'boolean') return raw;
+  if (typeof raw === 'string') {
+    const normalized = raw.trim().toLowerCase();
+    if (normalized === 'true') return true;
+    if (normalized === 'false') return false;
+  }
+  return undefined;
+}
+
 // suggest_tuning_rule がトリガー未決定時に案内していたプレースホルダ文字列。
 // save_tuning_rule にそのまま渡ってきた場合、文字列としてtrigger_patternに
 // 保存させない(D4: 保存は成功するが質問文に一致せず永久に発火しない)。
@@ -702,7 +716,7 @@ export async function executeToolCall(
     // 誤った回答をすぐ止めたいときに delete_faq(不可逆)しか選べない欠落を埋める。
     case 'set_faq_published': {
       const id = Number(args['id']);
-      const published = args['published'];
+      const published = parseBooleanArg(args['published']);
       const confirmed = isConfirmed(args['confirmed']);
 
       if (!confirmed) {
@@ -711,7 +725,7 @@ export async function executeToolCall(
         );
       }
 
-      if (!Number.isFinite(id) || typeof published !== 'boolean') {
+      if (!Number.isFinite(id) || published === undefined) {
         return truncate('id・published は必須です');
       }
 

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -3380,6 +3380,35 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(result).not.toContain('確認が必要');
     });
 
+    // Groq がbooleanを文字列化して送ってくることがある(isConfirmedと同じ既知の挙動)。
+    // 厳密な typeof チェックだと、確認済み(confirmed="true")の正当な要求が
+    // published="false" というだけで「id・publishedは必須です」に弾かれてしまう。
+    it('Groqがpublished/confirmedを文字列("false"/"true")で送っても正しく処理される', async () => {
+      mockFetch
+        .mockResolvedValueOnce(
+          toolCallResponse('call-sfp-7', 'set_faq_published', { id: 42, published: 'false', confirmed: 'true' }),
+        )
+        .mockResolvedValueOnce(makeGroqResponse('非公開にしました。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ id: 42, tenant_id: 'tenant-abc' }] })
+        .mockResolvedValueOnce({
+          rows: [{ id: 42, question: 'q', answer: 'a', is_published: false, is_excluded_from_search: false }],
+        });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'この回答を止めて', sessionId: 'sess-sfp-07' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining('UPDATE faq_docs SET is_published = $1'),
+        [false, 42, 'tenant-abc'],
+      );
+      expect(res.body.actions[0].result).toContain('非公開にしました');
+    });
+
     it('非公開のFAQを公開にできる', async () => {
       mockFetch
         .mockResolvedValueOnce(


### PR DESCRIPTION
## 背景

PR #772 (D2) の `/code-review high` 指摘: `set_faq_published` の `published` 引数を
`typeof published !== 'boolean'` という厳密チェックで検証していたため、Groq が
tool-call の引数でbooleanを文字列化して送ってくる場合(`confirmed` に対して
`isConfirmed()` が既に対応している既知の挙動と同じ)、確認済み(`confirmed="true"`)の
正当な要求が `published="false"` というだけで「id・publishedは必須です」に
弾かれていた。

## 変更

- `isConfirmed` と同じ理由で `true`/`false` の文字列表現も受理する
  `parseBooleanArg` を追加し、`set_faq_published` の検証をこれに置き換える
- Groq が `published`/`confirmed` を文字列で送ってきた場合の回帰テストを1件追加

## 経緯

PR #772 (D2) はマージ済みで、この修正は PR #772 のレビュー対応中に作業ツリーへ
コミットしたものの、共有ワークツリーが次のタスク用ブランチへ切り替わったタイミングと
重なりコミット先を誤りました（別タスクのブランチへコミットされていたのを検知し、
そのブランチはコミット前の状態へ戻したうえで、このPR用に別ブランチへ切り出しています）。

## Gate

- Gate 1: `pnpm typecheck` pass。`set_faq_published` 関連テスト 7/7 pass、
  `confirmPolicy.test.ts` 20/20 pass（フル `pnpm test` はサンドボックスの
  ポート枯渇制約により手元では走らせられないため、対象テストのみで確認）
- Gate 2: `dead-code-check.sh` PASS
- Gate 3: `security-scan.sh` PASS（CRITICAL/HIGH 0件）
- Gate 2.5: 未実行。Codexの使用量上限（2026-09-11リセット）のためレビュー時に
  `/codex:review --base main` を回してください

Tier S のため draft のままにしています。