### PR TITLE
chore(knowledge): FAQカテゴリ語彙の後片付け(未配線dead code削除 + admin-ui側の写し明記)

### DIFF
--- a/admin-ui/src/components/knowledge/shared.ts
+++ b/admin-ui/src/components/knowledge/shared.ts
@@ -47,6 +47,9 @@ export interface OcrJobStatus {
 }
 
 export type DeleteState = "idle" | "confirming" | "deleting" | "success" | "error";
+// カテゴリ語彙の正はサーバ側の src/lib/knowledge/faqCategories.ts。
+// admin-ui は別パッケージで import できないため、これは写しである。
+// 変更するときは必ずサーバ側と両方直すこと。
 export type Category = "" | "inventory" | "campaign" | "coupon" | "store_info" | "product_info" | "pricing" | "booking" | "warranty" | "general";
 export type Tab = "list" | "text" | "scrape";
 

--- a/admin-ui/src/i18n/ja.ts
+++ b/admin-ui/src/i18n/ja.ts
@@ -166,6 +166,9 @@ const ja = {
   "knowledge.url_max": "一度に処理できるURLは最大5件です",
 
   // Categories
+  // カテゴリ語彙の正はサーバ側の src/lib/knowledge/faqCategories.ts。
+  // admin-ui は別パッケージで import できないため、これは写しである。
+  // 変更するときは必ずサーバ側と両方直すこと。
   "category.inventory": "在庫・車両情報",
   "category.campaign": "キャンペーン・セール",
   "category.coupon": "クーポン・割引",

--- a/src/api/admin/knowledge/routes.ts
+++ b/src/api/admin/knowledge/routes.ts
@@ -23,10 +23,6 @@ import {
 // このパスからの import に依存しているため、ここから再エクスポートする形で後方互換を維持する。
 export { textToFaqs, type FaqEntry } from "../../../lib/knowledge/faqImport";
 
-
-const CATEGORIES = ["inventory", "campaign", "coupon", "store_info", "product_info", "pricing", "booking", "warranty", "general"] as const;
-type Category = (typeof CATEGORIES)[number];
-
 type KnowledgeUser = { id: string; email: string; role: string; tenantId: string | null };
 type KnowledgeReq = Request & {
   supabaseUser?: SupabaseJwtUser;

--- a/src/lib/knowledge/faqCategories.ts
+++ b/src/lib/knowledge/faqCategories.ts
@@ -10,10 +10,8 @@
 // faqImport.ts / toolDefinitions.ts はここを参照する。admin-ui は別パッケージのため
 // import できず、上記ファイルへの手動複製が残る(既知の非対称。増やさない)。
 //
-// 既知の残課題: src/api/admin/knowledge/routes.ts にも同じ語彙のローカル定数
-// `CATEGORIES`/`Category` が残っている(現状どこからも参照されない未配線の複製)。
-// 同一パッケージ内でこのファイルを直接importできる場所のため、将来何かに配線すると
-// このファイルと再び乖離する。削除は本PRの範囲外(既存dead codeの削除は別タスク)。
+// GID 1217542880792819: src/api/admin/knowledge/routes.ts に残っていた同じ語彙の
+// 未配線ローカル定数(`CATEGORIES`/`Category`、どこからも参照されていなかった)は削除済み。
 
 export interface FaqCategory {
   id: string;


### PR DESCRIPTION
## Summary
- Asana [G] FAQカテゴリ語彙の後片付け(未配線 dead code 削除 + admin-ui 側の写し明記) (GID 1217542880792819)
- 作業1: `src/api/admin/knowledge/routes.ts` の未配線ローカル定数 `CATEGORIES`/`Category`（export無し、全域gerpで参照ゼロ確認済み）を削除
- 作業2: admin-ui側の写し2箇所（`components/knowledge/shared.ts` の `Category` 型、`i18n/ja.ts` の `category.*`）に、正はサーバ側の `src/lib/knowledge/faqCategories.ts` であり写しであることを明記するコメントを追加

## 本文と実機の食い違い
本文は `copilot-preview/index.tsx` の `CATEGORIES` 定義への追加コメントを必須と指示していたが、全域grepで確認したところそのCATEGORIESはFAQカテゴリと無関係なサイドバーのナビゲータブ（assistant/weekly/escalations/history/knowledge/rules/avatar）であり対象を誤っていた。本文が同時に列挙していた実在の写し2箇所（shared.ts / i18n/ja.ts）へ趣旨のコメントを配置し、`copilot-preview/index.tsx` には触れていない。詳細は報告に記載。

## Test plan
- [x] `pnpm typecheck` (root + admin-ui) — pass
- [x] `pnpm lint` (root, oxlint) — pass, 58 warnings(閾値63以内)
- [x] `pnpm test`(jest) 対象: confirmPolicy.test.ts / faqCategories.test.ts / faqImport.test.ts / src/api/admin/knowledge/*.test.ts — 99/99 pass
- [x] admin-ui vitest 対象: components/knowledge/ — 23/23 pass
- [x] `bash SCRIPTS/dead-code-check.sh` — pass
- [x] `bash SCRIPTS/security-scan.sh` — PASS、CRITICAL/HIGH 0件
- [x] `/code-review high`（push前・作業ツリー差分に対して実行） — 指摘0件
- [x] `pnpm build` (root) / admin-ui `pnpm build` — pass
- [ ] Codex review — 使用量上限で失敗(詳細は報告に記載)
- [ ] hkobayashi の手動マージ(Tier S: src/** および admin-ui/src/** を変更するため auto-merge対象外、draftのまま維持)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDCq3hgpSccqkadqEj65ep