### PR TITLE
feat(agent): get_faq_list を閲覧系の出力予算に載せ、ページ送り・フィルタ・並び替えを追加

### DIFF
--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -133,6 +133,32 @@ function parseFaqCategoryArg(raw: unknown): { ok: true; category: string | null 
   return { ok: true, category: raw };
 }
 
+// get_faq_list の published 引数。旧UI KnowledgeListTab の状態フィルタ3種(all/published/draft)
+// に合わせる。allowlist外・未指定はすべて 'all' に倒す(get_chat_sessions の LLM由来値検証と
+// 同じ安全側フォールバック)。
+function parseFaqPublishedFilter(raw: unknown): 'all' | 'published' | 'draft' {
+  return raw === 'published' || raw === 'draft' ? raw : 'all';
+}
+
+// get_faq_list の sort_by 引数。旧UI KnowledgeListTab の並び順4種(SORT_PARAMS)に合わせる。
+// SQLへ渡す列名・方向は固定マッピングのみを使い、LLM由来の生値をSQLへ直接補間しない
+// (faqCrudRoutes.ts の SORT_COLUMN_MAP と同じ二重保護)。
+const FAQ_SORT_OPTIONS = {
+  newest: { column: 'created_at', direction: 'DESC' },
+  oldest: { column: 'created_at', direction: 'ASC' },
+  updated: { column: 'updated_at', direction: 'DESC' },
+  category: { column: 'category', direction: 'ASC' },
+} as const;
+type FaqSortBy = keyof typeof FAQ_SORT_OPTIONS;
+function parseFaqSortBy(raw: unknown): FaqSortBy {
+  // `in` 演算子はプロトタイプチェーンを辿るため、raw="hasOwnProperty"等の値が
+  // 誤って許可されてしまう(/code-review high 指摘)。Object.hasOwn相当のown-property
+  // チェックに限定する。
+  return typeof raw === 'string' && Object.prototype.hasOwnProperty.call(FAQ_SORT_OPTIONS, raw)
+    ? (raw as FaqSortBy)
+    : 'newest';
+}
+
 // ---------------------------------------------------------------------------
 // プラン制限の案内文
 // ---------------------------------------------------------------------------
@@ -523,8 +549,15 @@ export async function executeToolCall(
     // -----------------------------------------------------------------------
     case 'get_faq_list': {
       try {
+        // GID 1217534700543996(D3): get_chat_sessions と同じ引数設計(limit/offset の
+        // 扱い・LLM由来値のallowlist検証)を踏襲する。
         const limit = clampToolLimit(args['limit'], 10, 20);
+        const rawOffset = Number(args['offset'] ?? 0);
+        const offset = Number.isFinite(rawOffset) ? Math.max(0, Math.floor(rawOffset)) : 0;
         const search = typeof args['search'] === 'string' ? args['search'] : undefined;
+        const published = parseFaqPublishedFilter(args['published']);
+        const sortBy = parseFaqSortBy(args['sort_by']);
+        const { column, direction } = FAQ_SORT_OPTIONS[sortBy];
 
         const whereParams: unknown[] = [tenantId];
         let whereClause = 'WHERE tenant_id = $1';
@@ -537,32 +570,45 @@ export async function executeToolCall(
           whereParams.push(`%${escapedSearch}%`);
           whereClause += ` AND (question ILIKE $${whereParams.length} OR answer ILIKE $${whereParams.length})`;
         }
+        if (published === 'published') {
+          whereClause += ' AND is_published = true';
+        } else if (published === 'draft') {
+          whereClause += ' AND is_published = false';
+        }
 
-        const listParams = [...whereParams, limit];
+        const listParams = [...whereParams, limit, offset];
         // 表示件数(上限20)と総数(COUNT)を分けて取得する。以前は result.rows.length を
         // 「N件」として返しており、LIMIT 20 が総数の頭打ちに見えていた(#実測: 21件以上の
-        // テナントで常に「20件」と誤答していた)。
+        // テナントで常に「20件」と誤答していた)。総数は絞り込み(search/published)適用後の値。
         const [countRes, listRes] = await Promise.all([
           db.query(
             `SELECT COUNT(*)::int AS n FROM faq_docs ${whereClause}`,
             whereParams,
           ),
           db.query(
-            `SELECT id, question, answer FROM faq_docs ${whereClause} ORDER BY created_at DESC LIMIT $${listParams.length}`,
+            `SELECT id, question, answer FROM faq_docs ${whereClause} ORDER BY ${column} ${direction} ` +
+            `LIMIT $${listParams.length - 1} OFFSET $${listParams.length}`,
             listParams,
           ),
         ]);
 
-        if (listRes.rows.length === 0) {
-          // search 指定時のヒット0件は「FAQが登録されていない」わけではない(FAQ自体は
-          // 大量にある可能性がある)。検索条件に一致するものが無いだけなので文言を分ける。
-          if (search) {
-            return truncate(`「${search.slice(0, 100)}」に一致する FAQ は見つかりませんでした`);
-          }
-          return truncate('FAQ が登録されていません');
-        }
+        const total = Number(countRes.rows[0]?.n ?? 0);
 
-        const total = Number(countRes.rows[0]?.n ?? listRes.rows.length);
+        if (listRes.rows.length === 0) {
+          if (total === 0) {
+            // search 指定時のヒット0件は「FAQが登録されていない」わけではない(FAQ自体は
+            // 大量にある可能性がある)。検索条件に一致するものが無いだけなので文言を分ける。
+            if (search) {
+              return truncate(`「${search.slice(0, 100)}」に一致する FAQ は見つかりませんでした`);
+            }
+            return truncate('FAQ が登録されていません');
+          }
+          // offset が総件数を超えている(FAQ自体は存在する)。次にどう頼めばよいかを示す。
+          return truncate(
+            `指定した位置には表示できるFAQがありません（全${total}件）。` +
+            `offset を0から${Math.max(total - 1, 0)}の間で指定し直してください`,
+          );
+        }
 
         // anti-slop: answer は .slice(0,200) 必須 / console.log で内容出力禁止
         const lines = (listRes.rows as { id: number; question: string; answer: string }[])
@@ -570,7 +616,11 @@ export async function executeToolCall(
         const header = total > listRes.rows.length
           ? `FAQ 一覧（全${total}件中${listRes.rows.length}件を表示）:`
           : `FAQ 一覧（${total}件）:`;
-        return truncate(`${header}\n` + lines.join('\n'));
+        const hasMore = offset + listRes.rows.length < total;
+        const nextHint = hasMore
+          ? `\n続きを見るには offset=${offset + listRes.rows.length} で再度お尋ねください。`
+          : '';
+        return truncateRead(`${header}\n` + lines.join('\n') + nextHint);
       } catch (err) {
         logger.warn('[actionExecutor] get_faq_list failed', err);
         return truncate('FAQ 一覧の取得に失敗しました');

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -2840,8 +2840,8 @@ describe('POST /v1/admin/agent/chat', () => {
         .send({ message: 'FAQ一覧を見せて', sessionId: `sess-fl-clamp-${input}` });
 
       expect(res.status).toBe(200);
-      // 1件目=COUNT(*)（tenant_idのみ）、2件目=一覧取得（tenant_id + limit）
-      expect(mockQuery.mock.calls[1]?.[1]).toEqual(['tenant-abc', expected]);
+      // 1件目=COUNT(*)（tenant_idのみ）、2件目=一覧取得（tenant_id + limit + offset）
+      expect(mockQuery.mock.calls[1]?.[1]).toEqual(['tenant-abc', expected, 0]);
     });
 
     it('limit="abc"（数値でない）は例外にならず既定件数(10)にフォールバックしてFAQ一覧が正しく返る', async () => {
@@ -2862,7 +2862,7 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(result).not.toContain('取得に失敗しました');
       expect(result).toContain('FAQ 一覧（1件）:');
       // NaN のまま LIMIT の SQL パラメータに渡らず、既定値10にフォールバックしていることを確認する
-      expect(mockQuery.mock.calls[1]?.[1]).toEqual(['tenant-abc', 10]);
+      expect(mockQuery.mock.calls[1]?.[1]).toEqual(['tenant-abc', 10, 0]);
     });
 
     // LLMが小数を返しても、非整数のまま SQL の LIMIT に渡らないことを固定する
@@ -2887,7 +2887,7 @@ describe('POST /v1/admin/agent/chat', () => {
         .send({ message: 'FAQ一覧を見せて', sessionId: `sess-fl-clamp-decimal-${input}` });
 
       expect(res.status).toBe(200);
-      expect(mockQuery.mock.calls[1]?.[1]).toEqual(['tenant-abc', expected]);
+      expect(mockQuery.mock.calls[1]?.[1]).toEqual(['tenant-abc', expected, 0]);
       expect(Number.isInteger(mockQuery.mock.calls[1]?.[1]?.[1])).toBe(true);
     });
 
@@ -2917,7 +2917,7 @@ describe('POST /v1/admin/agent/chat', () => {
 
       expect(res.status).toBe(200);
       // Number.isFinite(Infinity) は false なので defaultValue(10) にフォールバックする
-      expect(mockQuery.mock.calls[1]?.[1]).toEqual(['tenant-abc', 10]);
+      expect(mockQuery.mock.calls[1]?.[1]).toEqual(['tenant-abc', 10, 0]);
     });
 
     it('他テナントで呼び出すと0件になり、かつSQLに自テナントのtenant_idが渡る（テナント越境なし）', async () => {
@@ -2940,7 +2940,7 @@ describe('POST /v1/admin/agent/chat', () => {
       // COUNT(*)クエリにも一覧クエリにも自テナント("tenant-other")のIDが渡っており、
       // 他テナント("tenant-abc")のデータが混ざっていないことを確認する
       expect(mockQuery.mock.calls[0]?.[1]).toEqual(['tenant-other']);
-      expect(mockQuery.mock.calls[1]?.[1]).toEqual(['tenant-other', 10]);
+      expect(mockQuery.mock.calls[1]?.[1]).toEqual(['tenant-other', 10, 0]);
     });
 
     it('search指定時、総数(COUNT)も検索条件で絞り込まれた件数になる', async () => {
@@ -3028,6 +3028,155 @@ describe('POST /v1/admin/agent/chat', () => {
       // params[1] が検索パラメータ(%…%でラップされた値)。中身の % と _ がバックスラッシュで
       // エスケープされていること(先頭と末尾のワイルドカード%はそのまま残る)。
       expect(listCall[1][1]).toBe('%50\\%offセール\\_限定%');
+    });
+
+    // GID 1217534700543996(D3): get_chat_sessions と同じ絞り込み・ページングをFAQ一覧にも追加
+    it('offsetが総件数を超えるとき0件になり、次にどうすればよいかを示す文言を返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-fl-offset-over', 'get_faq_list', { offset: 100 }))
+        .mockResolvedValueOnce(makeGroqResponse('確認できませんでした。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ n: 5 }] }) // FAQ自体は5件存在する
+        .mockResolvedValueOnce({ rows: [] }); // offset=100では表示対象が無い
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'FAQ一覧を見せて', sessionId: 'sess-fl-offset-over' });
+
+      expect(res.status).toBe(200);
+      const result = res.body.actions[0].result as string;
+      // FAQ自体は存在するので「FAQが登録されていません」に誤答してはいけない
+      expect(result).not.toContain('FAQ が登録されていません');
+      expect(result).toContain('全5件');
+      expect(result).toContain('offset');
+      expect(mockQuery.mock.calls[1]?.[1]).toEqual(['tenant-abc', 10, 100]);
+    });
+
+    it.each([
+      ['all', null],
+      ['published', 'is_published = true'],
+      ['draft', 'is_published = false'],
+    ])('published=%s のときCOUNT/一覧のWHERE句が正しく組み立てられる', async (published, expectedFragment) => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-fl-pub', 'get_faq_list', { published }))
+        .mockResolvedValueOnce(makeGroqResponse('FAQ一覧です。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ n: 1 }] })
+        .mockResolvedValueOnce({ rows: [{ id: 1, question: 'q1', answer: 'a1' }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'FAQ一覧を見せて', sessionId: `sess-fl-pub-${published}` });
+
+      expect(res.status).toBe(200);
+      const countCallSql = mockQuery.mock.calls[0]?.[0] as string;
+      const listCallSql = mockQuery.mock.calls[1]?.[0] as string;
+      if (expectedFragment) {
+        expect(countCallSql).toContain(expectedFragment);
+        expect(listCallSql).toContain(expectedFragment);
+      } else {
+        expect(countCallSql).not.toContain('is_published');
+        expect(listCallSql).not.toContain('is_published');
+      }
+    });
+
+    it.each([
+      ['newest', 'created_at', 'DESC'],
+      ['oldest', 'created_at', 'ASC'],
+      ['updated', 'updated_at', 'DESC'],
+      ['category', 'category', 'ASC'],
+    ])('sort_by=%s は ORDER BY %s %s でSQLに渡る（旧UI KnowledgeListTabの並び順と一致）', async (sortBy, column, direction) => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-fl-sort', 'get_faq_list', { sort_by: sortBy }))
+        .mockResolvedValueOnce(makeGroqResponse('FAQ一覧です。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ n: 1 }] })
+        .mockResolvedValueOnce({ rows: [{ id: 1, question: 'q1', answer: 'a1' }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'FAQ一覧を見せて', sessionId: `sess-fl-sort-${sortBy}` });
+
+      expect(res.status).toBe(200);
+      const listCallSql = mockQuery.mock.calls[1]?.[0] as string;
+      expect(listCallSql).toContain(`ORDER BY ${column} ${direction}`);
+    });
+
+    it('sort_by未指定・不正値は newest(created_at DESC) にフォールバックする', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-fl-sort-invalid', 'get_faq_list', { sort_by: 'invalid_value' }))
+        .mockResolvedValueOnce(makeGroqResponse('FAQ一覧です。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ n: 1 }] })
+        .mockResolvedValueOnce({ rows: [{ id: 1, question: 'q1', answer: 'a1' }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'FAQ一覧を見せて', sessionId: 'sess-fl-sort-invalid' });
+
+      expect(res.status).toBe(200);
+      const listCallSql = mockQuery.mock.calls[1]?.[0] as string;
+      expect(listCallSql).toContain('ORDER BY created_at DESC');
+    });
+
+    // /code-review high 指摘: `in` 演算子はプロトタイプチェーンを辿るため、
+    // Object.prototype由来の名前(hasOwnProperty等)がallowlistを誤って通過しうる。
+    it('sort_by="hasOwnProperty"（Object.prototype由来）は許可されずnewestにフォールバックする', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-fl-sort-proto', 'get_faq_list', { sort_by: 'hasOwnProperty' }))
+        .mockResolvedValueOnce(makeGroqResponse('FAQ一覧です。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ n: 1 }] })
+        .mockResolvedValueOnce({ rows: [{ id: 1, question: 'q1', answer: 'a1' }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'FAQ一覧を見せて', sessionId: 'sess-fl-sort-proto' });
+
+      expect(res.status).toBe(200);
+      const result = res.body.actions[0].result as string;
+      expect(result).not.toContain('取得に失敗しました');
+      const listCallSql = mockQuery.mock.calls[1]?.[0] as string;
+      expect(listCallSql).toContain('ORDER BY created_at DESC');
+      expect(listCallSql).not.toContain('undefined');
+    });
+
+    // Wave 0 調査1の観測(500字truncateだと実際には数件しか読めないまま黙って切れる)への
+    // 回帰テスト。get_faq_list は truncateRead(4000字)を使うため、打ち切り時は必ず末尾の
+    // 省略注記が付き、ヘッダーの件数表記(「全N件中M件を表示」)は実データのまま保持される。
+    it('4000字を超える場合、末尾に省略注記が付き、ヘッダーの件数表記は黙って切れない', async () => {
+      const longQuestion = 'あ'.repeat(50);
+      const longAnswer = 'い'.repeat(200);
+      const rows = Array.from({ length: 20 }, (_, i) => ({
+        id: i + 1,
+        question: longQuestion,
+        answer: longAnswer,
+      }));
+
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-fl-long', 'get_faq_list', { limit: 20 }))
+        .mockResolvedValueOnce(makeGroqResponse('FAQ一覧です。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ n: 25 }] })
+        .mockResolvedValueOnce({ rows });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'FAQ一覧を見せて', sessionId: 'sess-fl-long' });
+
+      expect(res.status).toBe(200);
+      const result = res.body.actions[0].result as string;
+      // 黙って切れない: 打ち切りが起きたこと自体が分かる注記が末尾に付く
+      expect(result).toContain('…(文字数上限のため以降省略');
+      // ヘッダーの「全25件中20件を表示」は実データの件数のままで、表示件数と実際の行数が
+      // 食い違わない(500字truncateの旧実装で起きていた「20件表示と嘘をつく」の回帰確認)
+      expect(result).toContain('全25件中20件を表示');
     });
   });
 

--- a/src/api/admin/agent/toolDefinitions.ts
+++ b/src/api/admin/agent/toolDefinitions.ts
@@ -95,17 +95,26 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
     type: 'function',
     function: {
       name: 'get_faq_list',
-      description: 'テナントの FAQ 一覧を取得する（最大20件。登録されている総件数も併記されるため、表示件数が上限に達していても総数は正しく分かる）',
+      description:
+        'テナントの FAQ 一覧を取得する読み取り専用ツール。公開状態・並び順・キーワード検索・ページ送りで絞り込める。' +
+        '（絞り込み適用後の総件数も併記されるため、表示件数が上限に達していても総数は正しく分かる）',
       parameters: {
         type: 'object',
         properties: {
-          limit: {
-            type: 'integer',
-            description: '取得件数（1〜20、デフォルト10）',
-          },
-          search: {
+          limit: { type: 'integer', description: '取得件数の上限（任意、省略時10、最大20）' },
+          offset: { type: 'integer', description: '取得開始位置（任意、省略時0）。前回の続きを見るときに limit ずつ進める' },
+          search: { type: 'string', description: '検索キーワード（任意）' },
+          published: {
             type: 'string',
-            description: '検索キーワード（任意）',
+            enum: ['all', 'published', 'draft'],
+            description: '公開状態での絞り込み（任意、省略時は全件）。published=公開中のみ、draft=下書きのみ',
+          },
+          sort_by: {
+            type: 'string',
+            enum: ['newest', 'oldest', 'updated', 'category'],
+            description:
+              '並び替えの基準（任意、省略時は新しい順）。newest=登録が新しい順、oldest=登録が古い順、' +
+              'updated=更新が新しい順、category=カテゴリ順',
           },
         },
         required: [],


### PR DESCRIPTION
## Summary
- Asana [D3] get_faq_list を閲覧系の出力予算に載せ、ページ送り・公開状態フィルタ・並び替えを追加する (GID 1217534700543996)
- PR #616 が会話一覧に対して行ったこと（閲覧系の出力予算分離 + 絞り込み・ページング）を、`get_chat_sessions` を手本に FAQ一覧にも同じ形で適用
- `get_faq_list` に `offset`(整数)・`published`(all/published/draft)・`sort_by`(newest/oldest/updated/category)を追加。語彙は旧UI KnowledgeListTabの状態フィルタ3種・並び順4種と一致
- 戻り値を `truncate`(500字)から `truncateRead`(4000字、既に get_chat_sessions 等4ツールで使用中)に変更。Wave 0 調査1で判明した「500字では数件しか読めないまま黙って切れ、ヘッダーが嘘をつく」問題を解消
- 総件数は絞り込み適用後の値を返し、続きの取り方(offset)を1行添える
- `/code-review high` の指摘を反映: `sort_by` の allowlist 検証を `in` 演算子から `Object.prototype.hasOwnProperty.call` に変更(プロトタイプチェーン由来の値の誤通過を防止)

## 本文と実機の食い違い
本文には当初「構造化カード化」方針(Wave 0の結論)が書かれていたが、同一本文末尾の「設計の差し替え(2026-08-17 実機照合)」節がこれを明示的に上書き・破棄している。そちらを正として実装した(カード化なし、admin-ui/src は無変更)。

## Test plan
- [x] `pnpm typecheck` (root) — pass
- [x] `pnpm lint` (root, oxlint) — pass, 58 warnings(閾値63以内、新規警告なし)
- [x] `pnpm test`(jest) — agentRoutes.test.ts 452/452 pass（get_faq_list関連37件を含む）、confirmPolicy.test.ts pass
- [x] `bash SCRIPTS/dead-code-check.sh` — pass
- [x] `bash SCRIPTS/security-scan.sh` — PASS、CRITICAL/HIGH 0件
- [x] `/code-review high`（push前・作業ツリー差分に対して実行） — 1件のバグ指摘を反映済み(上記参照)
- [x] `pnpm build` (root) / admin-ui `pnpm build` — pass（admin-ui無変更のため影響なし）
- [ ] Codex review — 使用量上限で失敗(詳細は報告に記載)
- [ ] hkobayashi の手動マージ(Tier S: src/** を変更するため auto-merge対象外、draftのまま維持)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WDCq3hgpSccqkadqEj65ep