### PR TITLE
ci: admin-ui の vitest を CI で走らせ、#662 以降赤かったフレークを直す

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: pnpm test
 
   admin-ui-build:
-    name: Gate 3 — admin-ui build
+    name: Gate 3 — admin-ui test + build
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: verify
@@ -62,6 +62,14 @@ jobs:
 
       - name: Install admin-ui
         run: cd admin-ui && pnpm install --frozen-lockfile
+
+      # admin-ui の vitest は長らく CI 非実行で、Gate 1(pnpm verify)をローカルで
+      # 回した人しか結果を見ていなかった。そのため useAuth.test.tsx のフレークが
+      # #662 以降ずっと赤いまま誰にも気づかれなかった(本PRで修正)。
+      # ビルドより先に置く: 壊れているなら成果物を作る前に落としたい。
+      # 依存は上の Install admin-ui で入っているため追加コストは無い。
+      - name: Test admin-ui (vitest)
+        run: cd admin-ui && pnpm test:ui
 
       - name: Build admin-ui
         run: cd admin-ui && pnpm build

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -252,11 +252,17 @@ R2C は、テナント（店舗・EC事業者）のサイトに1行で埋め込�
 
 **CIが守ってくれない範囲（Gate 1 を省略した瞬間に無防備になる）**
 
-- `.github/workflows/ci.yml` が走らせるのは root の `typecheck` / `lint`(oxlint) / `test`(jest) のみ。
-  **admin-ui の vitest と eslint は CI で走らない。**
+- Gate 1 が走らせるのは root の `typecheck` / `lint`(oxlint) / `test`(jest)。
+  oxlint は `admin-ui/src` も対象（`oxlint src admin-ui/src`）なので、lint は両側を見ている。
 - jest の testMatch は `{src,tests}/**/*.test.ts` で、**`.tsx` は対象外**。
-- したがって admin-ui のUI回帰を検出できるのは Gate 1 の `pnpm verify`（内部で `test:ui` を呼ぶ）だけ。
-  Cloudflare Pages は main merge = 即本番なので、ここを飛ばすと検出機会がゼロになる。
+- **admin-ui の vitest は Gate 3 で走る**（`Gate 3 — admin-ui test + build`。2026-08-18 に追加）。
+  それ以前は CI 非実行で、`useAuth.test.tsx` のフレークが #662 以降ずっと赤いまま
+  誰にも気づかれていなかった。同じ穴を作らないため、admin-ui にテストランナーを
+  増やす場合は必ず CI に配線すること。
+- **admin-ui の `tsc -b`（型チェック）は依然として CI 非実行。** テストファイル中心に
+  24件の既存エラーがあり、まとめて直さないと有効化できない（別タスク）。
+  したがって admin-ui の型エラーは merge を止めない。
+- Cloudflare Pages は main merge = 即本番。上記の穴に入る変更は検出機会が無いまま本番に出る。
 
 **最低限意識すること**
 

--- a/admin-ui/src/auth/useAuth.test.tsx
+++ b/admin-ui/src/auth/useAuth.test.tsx
@@ -189,11 +189,18 @@ describe("useAuth — onboardingStage", () => {
       </AuthProvider>,
     );
 
+    // resolved=true を待つだけでは不十分。useAuth の useEffect は
+    // [user, previewMode, previewTenantId] に依存しており、マウント直後の
+    // user=null の回で最後の分岐に落ちて resolved=true / stage=null を先に確定させる。
+    // その後 user が確定して2回目が走り、my-tenant を fetch して stage が入る。
+    // resolved=true だけを待つと1回目の結果を掴んでしまい、負荷が高いときだけ
+    // stage=null で落ちる(全体実行でのみ再現するフレークだった)。
+    // 実際に確認したい値そのものを待つ。
     await waitFor(() => {
-      expect(screen.getByTestId("stage-probe").textContent).toContain("resolved=true");
+      expect(screen.getByTestId("stage-probe").textContent).toContain('"industryAnswered":true');
     });
     const text = screen.getByTestId("stage-probe").textContent ?? "";
-    expect(text).toContain('"industryAnswered":true');
+    expect(text).toContain("resolved=true");
     expect(text).toContain('"knowledgePublished":false');
   });
 


### PR DESCRIPTION
## 背景

「残っているもの」として挙げた **admin-ui が CI で検査されない**件の対応。

調べたところ、実際の穴は **vitest のみ**だった。oxlint は元々 `admin-ui/src` も対象にしており（`oxlint src admin-ui/src`）、admin-ui ローカルの `eslint .` が走らないのは ESLint 不採用という方針どおりで穴ではない。私が以前「vitest と eslint が走らない」と説明したのは不正確だったので訂正する。

## 穴が実害を出していた証拠

CI に足す前に現状を実測したところ、**admin-ui のテストは既に赤かった**。

```
Test Files  1 failed | 35 passed (36)
      Tests  1 failed | 489 passed (490)
```

`useAuth.test.tsx` の1件で、`useAuth.tsx` の最終変更は **#662**、テストは #627。今回の一連の作業（`405437c6..HEAD`）はこのファイルを一切触っていない。**#662 以降ずっと赤いまま、誰も気づいていなかった。** CI に無いとはこういうことだ、という実例そのものだった。

## フレークの原因

`useAuth` の `useEffect` は `[user, previewMode, previewTenantId]` に依存し、**マウント直後の `user=null` の回で最後の分岐に落ちて `resolved=true` / `stage=null` を先に確定させる**。その後 `user` が確定して2回目が走り `my-tenant` を fetch して `stage` が入る。

テストは `resolved=true` だけを待っていたため、1回目の結果を掴んで `stage=null` で落ちることがあった。単体実行では通り、全体実行の負荷が高いときだけ再現するため発見が遅れていた。

**製品側のバグではなく、テストの待ち方の誤り。** 実際に確認したい値（`"industryAnswered":true`）そのものを待つように変更した。

修正後、全体実行を **5回連続**で回して 490件全パスを確認している（修正前は2回に1回程度落ちた）。

## CI への配線

Gate 3（`admin-ui-build`）は既に admin-ui の依存をインストールしているので、そこにステップを追加した。**追加のインストールコストは無い。**

ビルドより**前**に置いた。壊れているなら成果物を作る前に落としたい。

ジョブ名も実態に合わせて `Gate 3 — admin-ui test + build` に変更した。このチェック名に依存する必須設定が無いことは、branch protection（`required_status_checks` 自体が未設定）と `ci-auto-merge.sh` の `DEFAULT_REQUIRED`（Gate 1 / security-scan / gitleaks のみ）で確認済み。

## 対象外にしたもの（別タスク相当）

**admin-ui の `tsc -b` は依然 CI 非実行。** テストファイル中心に既存エラーが24件（9ファイル）あり、まとめて直さないと有効化できない。今回のスコープを超えるため CLAUDE.md に現状として明記するに留めた。

| ファイル | 件数 |
|---|---|
| `pages/admin/tenants/[id].test.tsx` | 8 |
| `pages/admin/chat-test/index.test.tsx` | 6 |
| その他7ファイル | 10 |

内容は `Cannot find name 'global'` 系が中心で、機械的に直せる見込み。

## Gate

- typecheck: 0 errors
- lint: 警告 58（閾値 63・本変更による増加なし）
- admin-ui vitest: 490 passed（5回連続）

Tier S ではないが（`src/**` `admin-ui/src/**` に触れるのはテスト1ファイルのみ）、CI 設定の変更を含むため draft にしている。
