### PR TITLE
fix(admin-ui): tsc -b の既存エラー24件を解消しCIのGate 3に配線する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         run: pnpm test
 
   admin-ui-build:
-    name: Gate 3 — admin-ui test + build
+    name: Gate 3 — admin-ui typecheck + test + build
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: verify
@@ -62,6 +62,11 @@ jobs:
 
       - name: Install admin-ui
         run: cd admin-ui && pnpm install --frozen-lockfile
+
+      # admin-ui の tsc -b は長らく CI 非実行だった(既存エラー24件のため配線できなかった)。
+      # テストより先に置く: 型が壊れているならテストを走らせる前に落としたい。
+      - name: Typecheck admin-ui (tsc -b)
+        run: cd admin-ui && pnpm typecheck
 
       # admin-ui の vitest は長らく CI 非実行で、Gate 1(pnpm verify)をローカルで
       # 回した人しか結果を見ていなかった。そのため useAuth.test.tsx のフレークが

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,13 +255,11 @@ R2C は、テナント（店舗・EC事業者）のサイトに1行で埋め込�
 - Gate 1 が走らせるのは root の `typecheck` / `lint`(oxlint) / `test`(jest)。
   oxlint は `admin-ui/src` も対象（`oxlint src admin-ui/src`）なので、lint は両側を見ている。
 - jest の testMatch は `{src,tests}/**/*.test.ts` で、**`.tsx` は対象外**。
-- **admin-ui の vitest は Gate 3 で走る**（`Gate 3 — admin-ui test + build`。2026-08-18 に追加）。
+- **admin-ui の vitest / `tsc -b` は Gate 3 で走る**（`Gate 3 — admin-ui typecheck + test + build`。
+  vitest は2026-08-18、typecheck は既存エラー24件解消後の同日に追加）。
   それ以前は CI 非実行で、`useAuth.test.tsx` のフレークが #662 以降ずっと赤いまま
   誰にも気づかれていなかった。同じ穴を作らないため、admin-ui にテストランナーを
   増やす場合は必ず CI に配線すること。
-- **admin-ui の `tsc -b`（型チェック）は依然として CI 非実行。** テストファイル中心に
-  24件の既存エラーがあり、まとめて直さないと有効化できない（別タスク）。
-  したがって admin-ui の型エラーは merge を止めない。
 - Cloudflare Pages は main merge = 即本番。上記の穴に入る変更は検出機会が無いまま本番に出る。
 
 **最低限意識すること**

--- a/admin-ui/src/auth/useAuth.test.tsx
+++ b/admin-ui/src/auth/useAuth.test.tsx
@@ -10,7 +10,7 @@ import {
 } from "../lib/chatSessionStore";
 
 const mockGetSession = vi.fn();
-const mockOnAuthStateChange = vi.fn(() => ({ data: { subscription: { unsubscribe: vi.fn() } } }));
+const mockOnAuthStateChange = vi.fn((..._args: unknown[]) => ({ data: { subscription: { unsubscribe: vi.fn() } } }));
 
 vi.mock("../lib/supabaseClient", () => ({
   supabase: {

--- a/admin-ui/src/components/knowledge/KnowledgeListTab.test.tsx
+++ b/admin-ui/src/components/knowledge/KnowledgeListTab.test.tsx
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import KnowledgeListTab from "./KnowledgeListTab";
 import { useAuth } from "../../auth/useAuth";
+import { createAuthMock } from "../../test/authMock";
 
 vi.mock("../../auth/useAuth", () => ({
   useAuth: vi.fn(),
@@ -51,18 +52,10 @@ vi.mock("./shared", async () => {
 
 import { fetchWithAuth } from "./shared";
 
-const CLIENT_ADMIN = {
+const CLIENT_ADMIN = createAuthMock({
   user: { id: "1", email: "owner@example.com", role: "client_admin", tenantId: "tenant-abc", tenantName: "テスト店舗" },
-  isSuperAdmin: false,
   isClientAdmin: true,
-  isLoading: false,
-  logout: vi.fn(),
-  previewMode: false,
-  previewTenantId: null,
-  previewTenantName: null,
-  enterPreview: vi.fn(),
-  exitPreview: vi.fn(),
-};
+});
 
 const ITEM_A = {
   id: 1,
@@ -102,7 +95,7 @@ function renderTab() {
 
 describe("KnowledgeListTab", () => {
   beforeEach(() => {
-    vi.mocked(useAuth).mockReturnValue(CLIENT_ADMIN as ReturnType<typeof useAuth>);
+    vi.mocked(useAuth).mockReturnValue(CLIENT_ADMIN);
     vi.mocked(fetchWithAuth).mockReset();
   });
 

--- a/admin-ui/src/pages/admin/analytics/index.test.tsx
+++ b/admin-ui/src/pages/admin/analytics/index.test.tsx
@@ -9,6 +9,7 @@ import { MemoryRouter } from 'react-router-dom';
 import AnalyticsDashboardPage from './index';
 import { useAuth } from '../../../auth/useAuth';
 import { authFetch } from '../../../lib/api';
+import { createAuthMock } from '../../../test/authMock';
 
 vi.mock('../../../auth/useAuth', () => ({
   useAuth: vi.fn(),
@@ -40,18 +41,10 @@ vi.mock('react-chartjs-2', () => ({
   Pie: () => null,
 }));
 
-const CLIENT_ADMIN = {
+const CLIENT_ADMIN = createAuthMock({
   user: { id: '1', email: 'admin@carnation.example.com', role: 'client_admin', tenantId: 'carnation', tenantName: 'carnation' },
-  isSuperAdmin: false,
   isClientAdmin: true,
-  isLoading: false,
-  logout: vi.fn(),
-  previewMode: false,
-  previewTenantId: null,
-  previewTenantName: null,
-  enterPreview: vi.fn(),
-  exitPreview: vi.fn(),
-};
+});
 
 const mockStatus = (status: number, body: unknown): Promise<Response> =>
   Promise.resolve({
@@ -70,7 +63,7 @@ function renderPage() {
 
 describe('AnalyticsDashboardPage — プラン制限(403)の表示', () => {
   beforeEach(() => {
-    vi.mocked(useAuth).mockReturnValue(CLIENT_ADMIN as ReturnType<typeof useAuth>);
+    vi.mocked(useAuth).mockReturnValue(CLIENT_ADMIN);
     vi.mocked(authFetch).mockReset();
   });
 

--- a/admin-ui/src/pages/admin/chat-history/index.test.tsx
+++ b/admin-ui/src/pages/admin/chat-history/index.test.tsx
@@ -6,6 +6,7 @@ import { MemoryRouter } from 'react-router-dom';
 import ChatHistoryPage from './index';
 import { useAuth } from '../../../auth/useAuth';
 import { authFetch } from '../../../lib/api';
+import { createAuthMock } from '../../../test/authMock';
 
 vi.mock('../../../auth/useAuth', () => ({
   useAuth: vi.fn(),
@@ -20,31 +21,18 @@ vi.mock('../../../lib/api', () => ({
   authFetch: vi.fn(),
 }));
 
-const SUPER_ADMIN_PREVIEWING = {
+const SUPER_ADMIN_PREVIEWING = createAuthMock({
   user: { id: '1', email: 'admin@example.com', role: 'super_admin', tenantId: null, tenantName: null },
-  isSuperAdmin: false, // プレビュー中は client_admin 相当にフォールバック
-  isClientAdmin: true,
-  isLoading: false,
-  logout: vi.fn(),
+  isClientAdmin: true, // プレビュー中は client_admin 相当にフォールバック
   previewMode: true,
   previewTenantId: 'lp-demo-avator',
   previewTenantName: 'LP Demo',
-  enterPreview: vi.fn(),
-  exitPreview: vi.fn(),
-};
+});
 
-const SUPER_ADMIN_NOT_PREVIEWING = {
+const SUPER_ADMIN_NOT_PREVIEWING = createAuthMock({
   user: { id: '1', email: 'admin@example.com', role: 'super_admin', tenantId: null, tenantName: null },
   isSuperAdmin: true,
-  isClientAdmin: false,
-  isLoading: false,
-  logout: vi.fn(),
-  previewMode: false,
-  previewTenantId: null,
-  previewTenantName: null,
-  enterPreview: vi.fn(),
-  exitPreview: vi.fn(),
-};
+});
 
 const mockOk = (data: unknown): Promise<Response> =>
   Promise.resolve({ ok: true, json: () => Promise.resolve(data) } as Response);
@@ -67,7 +55,7 @@ describe('ChatHistoryPage — super_adminプレビューmodeのテナントス�
   });
 
   it('プレビューmode中はpreviewTenantIdでスコープされたリクエストを送る（修正前は tenant パラメータ無しで全件取得していた）', async () => {
-    vi.mocked(useAuth).mockReturnValue(SUPER_ADMIN_PREVIEWING as ReturnType<typeof useAuth>);
+    vi.mocked(useAuth).mockReturnValue(SUPER_ADMIN_PREVIEWING);
     renderPage();
 
     await waitFor(() => {
@@ -80,7 +68,7 @@ describe('ChatHistoryPage — super_adminプレビューmodeのテナントス�
   });
 
   it('プレビューしていない通常のsuper_adminはtenantパラメータ無しで全テナント取得のまま（回帰確認）', async () => {
-    vi.mocked(useAuth).mockReturnValue(SUPER_ADMIN_NOT_PREVIEWING as ReturnType<typeof useAuth>);
+    vi.mocked(useAuth).mockReturnValue(SUPER_ADMIN_NOT_PREVIEWING);
     renderPage();
 
     await waitFor(() => {

--- a/admin-ui/src/pages/admin/chat-test/index.test.tsx
+++ b/admin-ui/src/pages/admin/chat-test/index.test.tsx
@@ -4,6 +4,7 @@ import { MemoryRouter } from 'react-router-dom';
 import ChatTestPage from './index';
 import { useAuth } from '../../../auth/useAuth';
 import { authFetch } from '../../../lib/api';
+import { createAuthMock } from '../../../test/authMock';
 
 vi.mock('../../../auth/useAuth', () => ({
   useAuth: vi.fn(),
@@ -29,43 +30,27 @@ const AVATARS_TENANT_B = [
   { id: 'av-b-1', name: 'Tenant B Avatar', image_url: null, is_default: false, tenant_id: 'tenant-b' },
 ];
 
-const mockClientAdmin = {
+const mockClientAdmin = createAuthMock({
   user: {
     id: '1',
     email: 'client@example.com',
-    role: 'client_admin' as const,
+    role: 'client_admin',
     tenantId: 'tenant-a',
     tenantName: 'Tenant A',
   },
-  isSuperAdmin: false,
   isClientAdmin: true,
-  isLoading: false,
-  logout: vi.fn(),
-  previewMode: false,
-  previewTenantId: null,
-  previewTenantName: null,
-  enterPreview: vi.fn(),
-  exitPreview: vi.fn(),
-};
+});
 
-const mockSuperAdmin = {
+const mockSuperAdmin = createAuthMock({
   user: {
     id: '2',
     email: 'admin@example.com',
-    role: 'super_admin' as const,
+    role: 'super_admin',
     tenantId: null,
     tenantName: null,
   },
   isSuperAdmin: true,
-  isClientAdmin: false,
-  isLoading: false,
-  logout: vi.fn(),
-  previewMode: false,
-  previewTenantId: null,
-  previewTenantName: null,
-  enterPreview: vi.fn(),
-  exitPreview: vi.fn(),
-};
+});
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 

--- a/admin-ui/src/pages/admin/conversion/index.test.tsx
+++ b/admin-ui/src/pages/admin/conversion/index.test.tsx
@@ -6,6 +6,7 @@ import { MemoryRouter } from 'react-router-dom';
 import ConversionDashboardPage from './index';
 import { useAuth } from '../../../auth/useAuth';
 import { authFetch } from '../../../lib/api';
+import { createAuthMock } from '../../../test/authMock';
 
 vi.mock('../../../auth/useAuth', () => ({
   useAuth: vi.fn(),
@@ -36,18 +37,13 @@ vi.mock('../../../lib/api', () => ({
   authFetch: vi.fn(),
 }));
 
-const SUPER_ADMIN_PREVIEWING = {
+const SUPER_ADMIN_PREVIEWING = createAuthMock({
   user: { id: '1', email: 'admin@example.com', role: 'super_admin', tenantId: null, tenantName: null },
-  isSuperAdmin: false,
   isClientAdmin: true,
-  isLoading: false,
-  logout: vi.fn(),
   previewMode: true,
   previewTenantId: 'lp-demo-avator',
   previewTenantName: 'LP Demo',
-  enterPreview: vi.fn(),
-  exitPreview: vi.fn(),
-};
+});
 
 const mockOk = (data: unknown): Promise<Response> =>
   Promise.resolve({ ok: true, json: () => Promise.resolve(data) } as Response);
@@ -67,7 +63,7 @@ describe('ConversionDashboardPage — super_adminプレビューmodeのテナン
   });
 
   it('プレビューmode中はpreviewTenantIdでtenant_idパラメータをリクエストに含める（修正前は空のuser.tenantIdでフィルタ無しになっていた）', async () => {
-    vi.mocked(useAuth).mockReturnValue(SUPER_ADMIN_PREVIEWING as ReturnType<typeof useAuth>);
+    vi.mocked(useAuth).mockReturnValue(SUPER_ADMIN_PREVIEWING);
     renderPage();
 
     await waitFor(() => {
@@ -98,7 +94,7 @@ const mockStatus = (status: number, body: unknown): Promise<Response> =>
 
 describe('ConversionDashboardPage — プラン制限(403)の表示', () => {
   beforeEach(() => {
-    vi.mocked(useAuth).mockReturnValue(SUPER_ADMIN_PREVIEWING as ReturnType<typeof useAuth>);
+    vi.mocked(useAuth).mockReturnValue(SUPER_ADMIN_PREVIEWING);
     vi.mocked(authFetch).mockReset();
   });
 

--- a/admin-ui/src/pages/admin/escalations/[sessionId].test.tsx
+++ b/admin-ui/src/pages/admin/escalations/[sessionId].test.tsx
@@ -215,7 +215,7 @@ describe("EscalationDetailPage", () => {
 
   it("送信ボタンを連打しても、送信中は2件目の返信が送られない", async () => {
     let replyCalls = 0;
-    let resolveReplyPromise: (() => void) | null = null;
+    let resolveReplyPromise: (() => void) | undefined;
     vi.mocked(authFetch).mockImplementation((url: string) => {
       if (String(url).endsWith("/reply")) {
         replyCalls += 1;

--- a/admin-ui/src/pages/admin/options/index.test.tsx
+++ b/admin-ui/src/pages/admin/options/index.test.tsx
@@ -4,6 +4,7 @@ import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import OptionManagementPage from './index';
 import { useAuth } from '../../../auth/useAuth';
 import { authFetch } from '../../../lib/api';
+import { createAuthMock } from '../../../test/authMock';
 
 vi.mock('../../../auth/useAuth', () => ({
   useAuth: vi.fn(),
@@ -19,18 +20,10 @@ vi.mock('../../../lib/api', () => ({
   authFetch: vi.fn(),
 }));
 
-const SUPER_ADMIN = {
+const SUPER_ADMIN = createAuthMock({
   user: { id: '1', email: 'admin@example.com', role: 'super_admin', tenantId: null, tenantName: null },
   isSuperAdmin: true,
-  isClientAdmin: false,
-  isLoading: false,
-  logout: vi.fn(),
-  previewMode: false,
-  previewTenantId: null,
-  previewTenantName: null,
-  enterPreview: vi.fn(),
-  exitPreview: vi.fn(),
-};
+});
 
 const ORDER = {
   id: 'order-1',
@@ -52,7 +45,7 @@ const mockOk = (data: unknown, status = 200): Promise<Response> =>
 
 describe('OptionManagementPage — Sai(Agent S)セクション', () => {
   beforeEach(() => {
-    vi.mocked(useAuth).mockReturnValue(SUPER_ADMIN as ReturnType<typeof useAuth>);
+    vi.mocked(useAuth).mockReturnValue(SUPER_ADMIN);
     vi.mocked(authFetch).mockReset();
   });
 
@@ -123,7 +116,7 @@ describe('OptionManagementPage — Sai(Agent S)セクション', () => {
 
 describe('OptionManagementPage — Phase6 R2Cエージェント提案ルール承認キュー', () => {
   beforeEach(() => {
-    vi.mocked(useAuth).mockReturnValue(SUPER_ADMIN as ReturnType<typeof useAuth>);
+    vi.mocked(useAuth).mockReturnValue(SUPER_ADMIN);
     vi.mocked(authFetch).mockReset();
   });
 

--- a/admin-ui/src/pages/admin/tenants/[id].test.tsx
+++ b/admin-ui/src/pages/admin/tenants/[id].test.tsx
@@ -80,7 +80,7 @@ describe("TenantDetailPage — エラー意味論(500 vs 404 vs 401)", () => {
   });
 
   it("200のとき: タブが描画される", async () => {
-    global.fetch = vi.fn().mockResolvedValue(
+    globalThis.fetch = vi.fn().mockResolvedValue(
       jsonResponse(200, {
         id: "carnation", name: "carnation", plan: "starter", is_active: true,
         allowed_origins: [], billing_enabled: false, billing_free_from: null,
@@ -97,7 +97,7 @@ describe("TenantDetailPage — エラー意味論(500 vs 404 vs 401)", () => {
   });
 
   it("404のとき: 「テナントが見つかりませんでした」を表示し、再試行ボタンは出さない", async () => {
-    global.fetch = vi.fn().mockResolvedValue(jsonResponse(404, { error: "not_found" }));
+    globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse(404, { error: "not_found" }));
 
     renderPage();
 
@@ -107,7 +107,7 @@ describe("TenantDetailPage — エラー意味論(500 vs 404 vs 401)", () => {
   });
 
   it("500のとき: 「テナントが見つかりませんでした」を表示せず、読み込み失敗+再試行ボタンを出す", async () => {
-    global.fetch = vi.fn().mockResolvedValue(jsonResponse(500, { error: "取得に失敗しました" }));
+    globalThis.fetch = vi.fn().mockResolvedValue(jsonResponse(500, { error: "取得に失敗しました" }));
 
     renderPage();
 
@@ -128,7 +128,7 @@ describe("TenantDetailPage — エラー意味論(500 vs 404 vs 401)", () => {
           lemonslice_agent_id: null, conversion_types: [],
         }),
       );
-    global.fetch = fetchMock;
+    globalThis.fetch = fetchMock;
 
     renderPage();
 
@@ -147,9 +147,9 @@ describe("TenantDetailPage — エラー意味論(500 vs 404 vs 401)", () => {
   // したがって setState の実行順に依存する競合は実際には発生しない。
   // この「loadingがボタンを隠すことによる暗黙のガード」が壊れていないことを固定する。
   it("読み込み中は「やり直す」ボタンが画面から消え、二重にクリックできない", async () => {
-    let resolveFirst: ((r: Response) => void) | null = null;
+    let resolveFirst: ((r: Response) => void) | undefined;
     let callCount = 0;
-    global.fetch = vi.fn().mockImplementation(() => {
+    globalThis.fetch = vi.fn().mockImplementation(() => {
       callCount += 1;
       if (callCount === 1) {
         return Promise.resolve(jsonResponse(500, { error: "取得に失敗しました" }));
@@ -176,12 +176,12 @@ describe("TenantDetailPage — エラー意味論(500 vs 404 vs 401)", () => {
       }),
     );
     await waitFor(() => expect(screen.getByText("⚙️ 設定")).toBeTruthy());
-    expect(global.fetch).toHaveBeenCalledTimes(2); // 初回 + やり直す1回のみ
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2); // 初回 + やり直す1回のみ
   });
 
   it("401(未ログイン)のとき: 既存どおり /login へ遷移する(挙動を変えない)", async () => {
     mockGetSession.mockResolvedValue({ data: { session: null } });
-    global.fetch = vi.fn();
+    globalThis.fetch = vi.fn();
 
     render(
       <MemoryRouter initialEntries={["/admin/tenants/carnation"]}>

--- a/admin-ui/src/test/authMock.ts
+++ b/admin-ui/src/test/authMock.ts
@@ -1,0 +1,30 @@
+import { vi } from "vitest";
+import type { useAuth } from "../auth/useAuth";
+
+// useAuth.tsx の AuthContextValue は非export（useAuthの戻り値としてのみ公開）。
+// 製品コードを型のためだけに変更しないため、ReturnType で同じ形を導出する。
+type AuthContextValue = ReturnType<typeof useAuth>;
+
+/**
+ * AuthContextValue の完全なモックを返す factory。
+ * 各テストは差分（overrides）だけ渡す。フィールド追加のたびに全テストの
+ * モックが個別に壊れる（as によるすり抜け）のを防ぐのが目的。
+ */
+export function createAuthMock(overrides: Partial<AuthContextValue> = {}): AuthContextValue {
+  return {
+    user: null,
+    isLoading: false,
+    isSuperAdmin: false,
+    isClientAdmin: false,
+    logout: vi.fn(),
+    previewMode: false,
+    previewTenantId: null,
+    previewTenantName: null,
+    enterPreview: vi.fn(),
+    exitPreview: vi.fn(),
+    tenantPlan: null,
+    onboardingStage: null,
+    onboardingStageResolved: true,
+    ...overrides,
+  };
+}


### PR DESCRIPTION
## Summary
- Asana 1217567836538102。admin-ui の `tsc -b` が既存エラー24件のため CI 未配線だった状態を解消する。
- 13件（`useAuth` モックが `AuthContextValue`(13フィールド)を満たしていない）は、完全なモックを返す共有 factory `admin-ui/src/test/authMock.ts` に置き換えて解消。各テストは差分だけ overrides で渡す形にした。
- 7件（`Cannot find name 'global'`）は `global.fetch` → `globalThis.fetch` に置換（admin-ui はブラウザ環境のため `@types/node` は追加しない）。
- 残り2件（`resolveFirst?.()` / `resolveReplyPromise?.()` が「型 'never' に呼び出しシグネチャがありません」）は、TS の既知の制御フロー解析の挙動（`let x: T | null = null` を入れ子コールバック内でのみ再代入すると呼び出し箇所で `never` に narrowing される）を回避するため、宣言を `null` から `undefined` へ変更。
- 残り1件（`useAuth.test.tsx` の TS2556）は `mockOnAuthStateChange` にレスト引数を明示して解消（呼び出し側は spread 済みのため型のみの変更）。
- `.github/workflows/ci.yml` の Gate 3（`Test admin-ui (vitest)` の直前）に `pnpm typecheck` ステップを追加し、ジョブ名を `Gate 3 — admin-ui typecheck + test + build` に更新。
- `CLAUDE.md` の「admin-ui の tsc -b は依然として CI 非実行」の記述を実態に更新。

## Test plan
- [x] `cd admin-ui && pnpm typecheck` → 0 errors
- [x] `cd admin-ui && pnpm vitest run` → 36 files / 490 tests pass
- [x] `pnpm build`（ルート） / `cd admin-ui && pnpm build` → 両方成功
- [x] `bash SCRIPTS/dead-code-check.sh` → 警告のみ（本PR差分と無関係な既存4件）
- [x] `bash SCRIPTS/security-scan.sh` → PASS（CRITICAL/HIGH=0）
- [x] `/code-review high` → 1件の指摘（対象外3ファイルの未移行モック、下記参照）。修正は本PRのスコープ外と判断し着手せず
- [ ] `pnpm verify`（ルート）→ 実行毎に無関係な src/ テストが CPU競合でタイムアウトし赤くなる（下記参照。個別実行では毎回成功）
- [ ] `/codex:review --base main --background` → Codex が使用上限のため実行不可（下記参照）

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_015cXVQqQoHbuzSJ5G7sc7fm