### PR TITLE
fix(admin-ui): useAdminAgent のテストが CI 負荷時に落ちるフレークを直す

### DIFF
--- a/admin-ui/src/components/AdminAgent/useAdminAgent.test.tsx
+++ b/admin-ui/src/components/AdminAgent/useAdminAgent.test.tsx
@@ -104,12 +104,17 @@ describe("useAdminAgent — 会話の復元(sessionStorage)", () => {
     render(<Probe />);
     fireEvent.click(screen.getByText("send"));
 
-    await waitFor(() =>
-      expect(screen.getByTestId("messages").textContent).toContain("assistant:10時から19時です。"),
-    );
-
-    const stored = restoreChatSession<{ role: string; content: string }>(CHAT_SESSION_SURFACE_PANEL);
-    expect(stored?.messages).toEqual([
+    // DOM の描画を待つだけでは足りない。永続化は useAdminAgent の useEffect([messages,...])
+    // 経由で走るため、DOM に assistant が出た「後」に sessionStorage が書かれる。
+    // その隙間でアサーションが走ると user 1件だけを読んでしまい、CI の負荷が高いときだけ落ちた
+    // (#782 で直した useAuth のフレークと同型: 実際に検証したい値ではなく別の指標を待っていた)。
+    // ここでは検証対象そのもの = sessionStorage の中身が揃うのを待つ。
+    let stored: ReturnType<typeof restoreChatSession<{ role: string; content: string }>>;
+    await waitFor(() => {
+      stored = restoreChatSession<{ role: string; content: string }>(CHAT_SESSION_SURFACE_PANEL);
+      expect(stored?.messages).toHaveLength(2);
+    });
+    expect(stored!.messages).toEqual([
       { role: "user", content: "営業時間を教えて" },
       { role: "assistant", content: "10時から19時です。", actions: [] },
     ]);


### PR DESCRIPTION
PR #784 の Gate 3 を塞いでいた admin-ui のフレークを直します。**#784 とは無関係の既存バグ**です。

## 経緯

`#782` で admin-ui の vitest を CI に載せた結果、**2件目の既存フレークが表面化**しました。1件目（`useAuth.test.tsx`）は #782 で修正済みです。

`#784` は `src/api/admin/agent/` しか変更していないのに Gate 3 が落ち、**同一コミットで CI が1回成功・1回失敗**していました（02:16:25 success / 02:16:41 failure）。負荷依存のフレークであることの決定的な証拠です。

## 原因

```js
await waitFor(() =>
  expect(screen.getByTestId("messages").textContent).toContain("assistant:..."),
);                                    // ← DOM の描画を待っている
const stored = restoreChatSession(CHAT_SESSION_SURFACE_PANEL);
expect(stored?.messages).toEqual([user, assistant]);   // ← sessionStorage を検証している
```

永続化は `useAdminAgent` の `useEffect([messages, sessionId, tenantId])` 経由で走るため、**DOM 描画の「後」に sessionStorage が書かれます**。その隙間でアサーションが走ると `[user]` だけを読み、期待値2件と食い違います。CI ログの受信値が `[user]` のみだったことと一致します。

`#782` で直した `useAuth.test.tsx` と**同型**（実際に検証したい値ではなく別の指標を待っていた）です。

## 修正

待機対象を**検証対象そのもの**（sessionStorage の中身）に変え、2件揃うのを待ってから deep equal で検証します。製品コードは変更しておらず、検証内容も弱めていません。

## 確認

- `cd admin-ui && pnpm typecheck`: 0 errors
- **全体実行を4回連続: 490件全パス**（修正前はローカルでは再現せず、CI の負荷時のみ発生）
- 該当ファイル単体: 8件パス

## 補足

これで admin-ui のフレークは2件とも解消です。CI に載せた直後に2件出たことは、**#782 以前は誰もこれらを見ていなかった**ことを意味します。今後同種が出た場合も「実際に検証したい値を待つ」で直せます。