### PR TITLE
fix(agent): アバター一覧の「既定」表示と reset ツールの前提を一致させる

### DIFF
--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -1081,33 +1081,56 @@ export async function executeToolCall(
     case 'get_avatar_list': {
       try {
         const res = await db.query(
-          `SELECT id, name, is_active, tenant_id
+          `SELECT id, name, is_active, is_default, tenant_id
              FROM avatar_configs
             WHERE tenant_id = $1 OR tenant_id = 'r2c_default'
             ORDER BY (tenant_id = $1) DESC, is_default ASC, created_at DESC`,
           [tenantId],
         );
-        const rows = res.rows as { id: string; name: string; is_active: boolean; tenant_id: string }[];
+        const rows = res.rows as { id: string; name: string; is_active: boolean; is_default: boolean; tenant_id: string }[];
         if (rows.length === 0) {
           return truncate('アバター設定はまだありません');
         }
 
-        // 戻り値は500字で切られる。切られると一覧の末尾が黙って欠けるため、
-        // 収まる分だけ出して残件数を明示する（欠落を沈黙させない）。
-        const LIST_CHAR_BUDGET = 420;
-        const lines: string[] = [];
-        let used = 0;
-        for (const row of rows) {
+        // reset_avatar_to_default が成功するのは「自テナント かつ is_default=true」の行だけ
+        // （下の case のガード参照）。一覧の印はその条件と完全に一致させる。r2c_default
+        // 所属行は reset の対象外（越境）なので、「既定」を含まない別語彙にして、
+        // 一覧とツールで「既定の見本」の意味が食い違わないようにする。
+        const lines = rows.map((row) => {
           const own = row.tenant_id === tenantId;
-          const mark = own ? (row.is_active ? '（稼働中）' : '') : '（既定の見本）';
-          const line = `- ${row.name}${mark} ID: ${row.id}`;
-          if (used + line.length > LIST_CHAR_BUDGET) break;
-          lines.push(line);
-          used += line.length + 1;
+          if (!own) return `- ${row.name}（R2C提供の見本） ID: ${row.id}`;
+          const parts: string[] = [];
+          if (row.is_active) parts.push('稼働中');
+          if (row.is_default) parts.push('既定に戻せます');
+          const mark = parts.length > 0 ? `（${parts.join('・')}）` : '';
+          return `- ${row.name}${mark} ID: ${row.id}`;
+        });
+
+        // このツールには get_faq_list と違い limit/offset/search が無く、絞り込めない
+        // （toolDefinitions.ts の parameters 参照）。truncateRead の汎用注記
+        // 「絞り込み条件やページを変えて」はこのツールには実行不能な案内になるため使わない。
+        // 行の途中では切らず、実際に表示した件数を必ず残す
+        // （src/api/admin/CLAUDE.md: 打ち切るなら「全N件中M件」を必ず残し、黙って切らない）。
+        // 予算は truncateRead と同じ READ_RESULT_MAX_CHARS を使い、新しい予算は作らない。
+        // header は打ち切り判定と実際の返却値の両方から呼び、文言を1箇所に保つ。
+        const header = (shownCount: number): string =>
+          shownCount < rows.length
+            ? `アバター設定は全${rows.length}件中${shownCount}件を表示しています` +
+              '（このツールに絞り込み条件が無いため、残りはこの一覧には出せません）:\n'
+            : `アバター設定は${rows.length}件あります:\n`;
+
+        let used = header(0).length;
+        let shown = 0;
+        for (const line of lines) {
+          const next = used + line.length + 1;
+          if (next > READ_RESULT_MAX_CHARS) break;
+          used = next;
+          shown++;
         }
-        const remaining = rows.length - lines.length;
-        const footer = remaining > 0 ? `\nほか${remaining}件` : '';
-        return truncate(`アバター設定は${rows.length}件あります:\n${lines.join('\n')}${footer}`);
+        const shownLines = shown === rows.length ? lines : lines.slice(0, shown);
+        // truncateRead は上のループで既に予算内に収めているため通常は no-op だが、
+        // 行単位の見積もりがズレた場合の保険として最後に一度だけ掛ける。
+        return truncateRead(`${header(shown)}${shownLines.join('\n')}`);
       } catch (err) {
         logger.warn('[actionExecutor] get_avatar_list failed', err);
         return truncate('アバター一覧の取得に失敗しました');
@@ -1301,18 +1324,17 @@ export async function executeToolCall(
     // 既定値の取得元はルートと同じ「同一行の default_voice_id / default_personality_prompt /
     // default_name の3列」のみ（phase44_default_avatars.sql）。復元する列を増やさない。
     //
-    // 既知の未解決点（2026-08-18、コードレビューで判明・hkobayashi 要判断）:
-    // 下のSELECTは他ツール（activate_avatar 等）と同じく tenant_id = 呼び出し元テナント
-    // で絞っている。しかし migration_r2c_default.sql（Phase66）以降、is_default=true の
-    // 行は 'r2c_default' テナントに集約されており、実テナントが自分の tenant_id で
-    // is_default=true の行を所有することは想定されていない（tenants/routes.ts:353-380
-    // のテナント作成時シードが今も is_default=true をテナント自身の tenant_id で作って
-    // いるように見えるが、Phase66 の意図と矛盾しており未検証・本タスクのスコープ外）。
-    // 結果、現状のスコープ（自テナント限定）だと本ツールは実質的に「対象が見つからない」
-    // を返し続ける可能性が高い。対案は tenant_id = 'r2c_default' に絞ること
-    // （suggest_avatar_preset/adopt_avatar_preset と同じ形）だが、それは「どのテナントの
-    // チャットからでも全テナント共有の既定見本18体を書き換えられる」という、本タスクの
-    // 本文が明示的に許可していない越境操作を新設することになるため、独断で変更しない。
+    // 実機照合(2026-08-18): 下のSELECTは他ツール（activate_avatar 等）と同じく
+    // tenant_id = 呼び出し元テナント で絞っている。tenants/routes.ts:352-380 の
+    // テナント作成時シードは今も is_default=true を自テナントの tenant_id で18体作る
+    // ため、これは「対象が見つからない」を返し続けるツールではない — 自テナントの
+    // シード済み見本に対しては成功する（get_avatar_list の「（既定に戻せます）」印と
+    // 揃えたのはこの行）。'r2c_default' テナント所属行（Phase66 で追加された、
+    // 全テナント共有の別プール）はここでは対象外のまま（越境）。対案は
+    // tenant_id = 'r2c_default' も許容すること（suggest_avatar_preset/adopt_avatar_preset
+    // と同じ形）だが、それは「どのテナントのチャットからでも全テナント共有の見本を
+    // 書き換えられる」という、本タスクの本文が明示的に許可していない越境操作を
+    // 新設することになるため、独断で変更しない。
     case 'reset_avatar_to_default': {
       const id = String(args['id'] ?? '');
       if (!id) {
@@ -1336,7 +1358,7 @@ export async function executeToolCall(
         // （routes.ts:725-727 の 404 相当。ただしチャットではエラーにせず次の行動が
         // 分かる日本語1行で返す）。
         if (!row.is_default) {
-          return truncate('このアバターは既定の見本ではないため、既定に戻す操作はできません');
+          return truncate('既定に戻せるのは、一覧で「既定に戻せます」と表示された設定だけです。get_avatar_list でご確認ください');
         }
 
         const result = await db.query(

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -7211,6 +7211,27 @@ describe('POST /v1/admin/agent/chat', () => {
   });
 
   // -------------------------------------------------------------------------
+  // GID 1217567940165423(P1) 問題2: PR #768 で追加した feature キーのうち
+  // faq_publish_toggle / avatar_feature_toggle / avatar_profile の3つは、
+  // その後 set_faq_published(#772) / set_avatar_feature(#777) / update_avatar_profile(#778)
+  // が実装されたのに get_legacy_ui_link の description が旧UI誘導のままだった
+  // （実装済み機能をわざわざ旧UIへ送り、agent_legacy_handoff を水増しして
+  // LEGACY_UI_SUNSET.md の閉鎖判定を妨げる）。機械検査で再発を防ぐ
+  // （文言の一致ではなく、実装済みツール名が description に含まれることを見る）。
+  // -------------------------------------------------------------------------
+  describe('get_legacy_ui_link description: 実装済みツールへの言及', () => {
+    it.each([
+      ['set_faq_published'],
+      ['set_avatar_feature'],
+      ['update_avatar_profile'],
+    ])('description に %s への言及がある', (toolName) => {
+      const tool = ADMIN_AGENT_TOOLS.find((t) => t.function.name === 'get_legacy_ui_link');
+      expect(tool).toBeDefined();
+      expect(tool!.function.description).toContain(toolName);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // 構造化カード(card)チャネル
   //
   // ツールが自然文に加えて構造化データを返せる経路。フロントが自然文を正規表現で
@@ -8398,8 +8419,9 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(res.status).toBe(200);
       const result = res.body.actions[0].result as string;
       expect(result).toContain('自社スタッフ');
-      expect(result).toContain('見本アバターA（既定の見本）');
+      expect(result).toContain('見本アバターA（R2C提供の見本）');
       expect(result).not.toContain('見本アバターA（稼働中）');
+      expect(result).not.toContain('見本アバターA（既定に戻せます）');
     });
 
     it('自テナントの稼働中の設定には稼働中の印が付く', async () => {
@@ -8449,15 +8471,19 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(result).not.toContain('試作中（稼働中）');
     });
 
-    it('件数が多くても500字で黙って欠けず、残件数を明示する', async () => {
+    // truncateRead(#776)と同じ4000字予算を使うが、その汎用注記(「絞り込み条件やページを
+    // 変えて」)はこのツールに limit/offset/search が無いため実行不能な案内になる。行の
+    // 途中で切らず、実際に表示した件数を「全N件中M件」で必ず残す(CLAUDE.mdの必須事項)。
+    it('件数が多くても黙って欠けず、全件数と表示件数の両方が分かる', async () => {
       mockFetch
         .mockResolvedValueOnce(toolCallResponse('call-list-3', 'get_avatar_list', {}))
         .mockResolvedValueOnce(makeGroqResponse('一覧をお伝えしました。'));
 
-      const rows = Array.from({ length: 30 }, (_, i) => ({
-        id: `550e8400-e29b-41d4-a716-4466554400${String(i).padStart(2, '0')}`,
+      const rows = Array.from({ length: 120 }, (_, i) => ({
+        id: `550e8400-e29b-41d4-a716-${String(i).padStart(12, '0')}`,
         name: `アバター${i}`,
         is_active: false,
+        is_default: false,
         tenant_id: 'tenant-abc',
       }));
       mockQuery.mockResolvedValueOnce({ rows });
@@ -8468,9 +8494,13 @@ describe('POST /v1/admin/agent/chat', () => {
 
       expect(res.status).toBe(200);
       const result = res.body.actions[0].result as string;
-      expect(result).toContain('アバター設定は30件あります');
-      expect(result).toMatch(/ほか\d+件/);
-      expect(result.length).toBeLessThanOrEqual(500);
+      expect(result).toMatch(/アバター設定は全120件中\d+件を表示しています/);
+      expect(result).toContain('このツールに絞り込み条件が無いため、残りはこの一覧には出せません');
+      expect(result).not.toContain('アバター119');
+      // 行の途中(idの半端な位置)で切れていないこと。最後は必ず完全な1行で終わる
+      expect(result.trimEnd()).toMatch(/ID: 550e8400-e29b-41d4-a716-\d{12}$/);
+      // truncateRead(4000字)の予算に収まっていること(見積もりのズレで超過しないことの固定)
+      expect(result.length).toBeLessThanOrEqual(4000);
     });
 
     it('設定が1件も無い場合はその旨を返す', async () => {
@@ -8519,6 +8549,118 @@ describe('POST /v1/admin/agent/chat', () => {
 
       expect(res.status).toBe(200);
       expect(res.body.actions[0].result).toContain('稼働中のアバターはありません');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // GID 1217567940165423(P1): get_avatar_list の印と reset_avatar_to_default の
+  // 成否は同じ条件（自テナント かつ is_default=true）でなければならない。
+  // 一覧は「r2c_default 所属か」、reset は「is_default=true か」という別の軸で
+  // 判定していたため、一覧の「既定の見本」表示と reset の成否が食い違っていた
+  // （越境行に印が付き必ず失敗する一方、実際に reset が成功する自テナントの
+  // is_default 行には印が無かった）。本テストは表示とツールの前提一致を固定する。
+  // -------------------------------------------------------------------------
+  describe('get_avatar_list の「既定に戻せます」表示と reset_avatar_to_default の成否一致', () => {
+    function toolCallResponse(id: string, name: string, args: Record<string, unknown> = {}) {
+      return {
+        ok: true,
+        json: async () => ({
+          choices: [{
+            message: {
+              content: null,
+              tool_calls: [{ id, type: 'function', function: { name, arguments: JSON.stringify(args) } }],
+            },
+          }],
+        }),
+        text: async () => '',
+      };
+    }
+
+    it('一覧で「既定に戻せます」と表示された自テナント行の ID は reset_avatar_to_default で成功する', async () => {
+      // 1) 一覧を取得し、印が付いた行の ID を確認する
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-consist-list', 'get_avatar_list', {}))
+        .mockResolvedValueOnce(makeGroqResponse('一覧をお伝えしました。'));
+      mockQuery.mockResolvedValueOnce({
+        rows: [
+          { id: 'own-default-1', name: '接客見本', is_active: false, is_default: true, tenant_id: 'tenant-abc' },
+          { id: 'own-custom-1', name: '自作アバター', is_active: false, is_default: false, tenant_id: 'tenant-abc' },
+        ],
+      });
+      const listRes = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'アバターの一覧を見せて', sessionId: 'sess-consist-01' });
+      const listResult = listRes.body.actions[0].result as string;
+      expect(listResult).toContain('接客見本（既定に戻せます） ID: own-default-1');
+      expect(listResult).not.toContain('自作アバター（既定に戻せます）');
+
+      // 2) 印が付いた own-default-1 で reset_avatar_to_default を実行 → 成功する
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-consist-reset', 'reset_avatar_to_default', { id: 'own-default-1', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('既定に戻しました。'));
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ is_default: true }] })
+        .mockResolvedValueOnce({ rows: [{ name: '接客見本' }] });
+      const resetRes = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'own-default-1を既定に戻して', sessionId: 'sess-consist-02' });
+
+      expect(resetRes.status).toBe(200);
+      expect(resetRes.body.actions[0].result).toContain('既定の設定に戻しました');
+    });
+
+    it('印が付かない自テナント行（is_default=false）で reset を実行すると、一覧の表示に対応した案内を返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-consist-reset-fail', 'reset_avatar_to_default', { id: 'own-custom-1', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('戻せませんでした。'));
+      mockQuery.mockResolvedValueOnce({ rows: [{ is_default: false }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'own-custom-1を既定に戻して', sessionId: 'sess-consist-03' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('一覧で「既定に戻せます」と表示された設定だけです');
+    });
+
+    it('r2c_default 所属（越境）行は一覧で「R2C提供の見本」と表示され、reset は不存在側に倒れる', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-consist-list-2', 'get_avatar_list', {}))
+        .mockResolvedValueOnce(makeGroqResponse('一覧をお伝えしました。'));
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ id: 'r2c-sample-1', name: '見本C', is_active: true, is_default: true, tenant_id: 'r2c_default' }],
+      });
+      const listRes = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'アバターの一覧を見せて', sessionId: 'sess-consist-04' });
+      expect(listRes.body.actions[0].result).toContain('見本C（R2C提供の見本） ID: r2c-sample-1');
+
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-consist-reset-2', 'reset_avatar_to_default', { id: 'r2c-sample-1', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('見つかりませんでした。'));
+      mockQuery.mockResolvedValueOnce({ rows: [] });
+
+      const resetRes = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'r2c-sample-1を既定に戻して', sessionId: 'sess-consist-05' });
+
+      expect(resetRes.status).toBe(200);
+      expect(resetRes.body.actions[0].result).toContain('見つかりませんでした');
+    });
+
+    it('自テナントかつ稼働中かつ既定の行は「稼働中」「既定に戻せます」の両方を表示する', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-consist-list-3', 'get_avatar_list', {}))
+        .mockResolvedValueOnce(makeGroqResponse('一覧をお伝えしました。'));
+      mockQuery.mockResolvedValueOnce({
+        rows: [{ id: 'own-active-default-1', name: '見本D', is_active: true, is_default: true, tenant_id: 'tenant-abc' }],
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'アバターの一覧を見せて', sessionId: 'sess-consist-06' });
+
+      expect(res.body.actions[0].result).toContain('見本D（稼働中・既定に戻せます） ID: own-active-default-1');
     });
   });
 
@@ -9631,7 +9773,7 @@ describe('POST /v1/admin/agent/chat', () => {
         .send({ message: 'このアバターを既定に戻して', sessionId: 'sess-rst-02' });
 
       expect(res.status).toBe(200);
-      expect(res.body.actions[0].result).toContain('既定の見本ではないため、既定に戻す操作はできません');
+      expect(res.body.actions[0].result).toContain('一覧で「既定に戻せます」と表示された設定だけです');
       // is_defaultチェックのSELECTのみ呼ばれ、UPDATEには到達しない
       expect(mockQuery).toHaveBeenCalledTimes(1);
     });

--- a/src/api/admin/agent/toolDefinitions.ts
+++ b/src/api/admin/agent/toolDefinitions.ts
@@ -292,8 +292,9 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
     function: {
       name: 'get_avatar_list',
       description:
-        'アバター設定の一覧（ID・名前・稼働中かどうか）を取得する読み取り専用ツール。' +
-        'activate_avatar に渡す ID はこのツールで確認したものだけを使うこと。' +
+        'アバター設定の一覧（ID・名前・稼働中かどうか・既定に戻せるかどうか）を取得する読み取り専用ツール。' +
+        'activate_avatar / reset_avatar_to_default に渡す ID はこのツールで確認したものだけを使うこと。' +
+        'reset_avatar_to_default が使えるのは「（既定に戻せます）」と表示された行だけ。' +
         'テナント自身の設定に加えて、そのまま使える既定の見本も返す。',
       parameters: {
         type: 'object',
@@ -402,7 +403,8 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
       name: 'reset_avatar_to_default',
       description:
         '既定の見本として作られたアバター設定を、名前・性格・声を作成時点の値に戻す。' +
-        '対象は既定の見本（is_default）のみで、テナントが独自に作成・採用したアバターには使えない。' +
+        '対象は get_avatar_list で「（既定に戻せます）」と表示された設定のみで、' +
+        'テナントが独自に作成・採用したアバターには使えない。' +
         '対象の ID は get_avatar_list で確認したものを使うこと（一覧を取るための専用ツールは他にない）。',
       parameters: {
         type: 'object',
@@ -1305,10 +1307,13 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
         'また会話分析・成約/効果分析の「数値サマリー」は get_analytics_summary / get_conversion_summary で' +
         'チャット上に直接返せるため、まずそちらを使うこと。この2機能でこのツールを使うのは、' +
         'グラフの詳細・個別の低評価セッション・ABテスト結果を旧UIで見たい場合に限る。' +
-        'FAQごとにAIが答えるかどうかを切り替えたいと聞かれたら feature="faq_publish_toggle" を使うこと。' +
-        'FAQのまとめて非公開・まとめて削除をしたいと聞かれたら feature="faq_bulk_ops" を使うこと。' +
-        'アバター機能全体のON/OFFを切り替えたいと聞かれたら feature="avatar_feature_toggle" を使うこと。' +
-        'アバターの名前・性格・話し方を編集したいと聞かれたら feature="avatar_profile" を使うこと。' +
+        'FAQごとの公開/非公開切替は set_faq_published で直接実行できるため、まずそちらを使うこと。' +
+        'feature="faq_publish_toggle" は set_faq_published で対応できない場合にのみ使うこと' +
+        '（まとめて非公開・まとめて削除をしたい場合は feature="faq_bulk_ops" を使うこと）。' +
+        'アバター機能全体のON/OFFは set_avatar_feature で直接実行できるため、まずそちらを使うこと。' +
+        'feature="avatar_feature_toggle" は set_avatar_feature で対応できない場合にのみ使うこと。' +
+        'アバターの名前・性格・話し方の編集は update_avatar_profile で直接実行できるため、まずそちらを使うこと。' +
+        'feature="avatar_profile" は update_avatar_profile で対応できない場合にのみ使うこと。' +
         '高品質なアバター画像を生成したいと聞かれたら feature="avatar_premium" を使うこと。',
       parameters: {
         type: 'object',


### PR DESCRIPTION
## Summary
Asana GID 1217567940165423 (Tier S)。3つの問題を1PRで修正。

- **問題1**: `get_avatar_list` は「r2c_default 所属か」、`reset_avatar_to_default` は「is_default=true か」という別の軸で「既定」を判定していた。一覧で「（既定の見本）」と表示された行（越境）は必ず失敗し、実際に reset が成功する自テナントの is_default 行には印が無かった。`get_avatar_list` の SELECT に `is_default` を追加し、`own && is_default` の行だけに「（既定に戻せます）」を付けて両者の前提を揃えた。r2c_default 所属行は別語彙「（R2C提供の見本）」にして意味の衝突を解消。reset の失敗文言も一覧表示に対応づけた。
- **問題2**: `get_legacy_ui_link` の description が `faq_publish_toggle` / `avatar_feature_toggle` / `avatar_profile` を旧UIへ案内し続けていたが、それぞれ `set_faq_published`(#772) / `set_avatar_feature`(#777) / `update_avatar_profile`(#778) が実装済み。既存の analytics / escalation_reply と同じ書式で「まず実装済みツールを使う」よう誘導し直した。feature キー自体は削除していない（撤去は4週の計測窓経過後）。
- **問題3**: `get_avatar_list` の戻り値を `truncate`(500字)から `truncateRead`(4000字、#776で導入済み)に変更。このツールには limit/offset/search が無く絞り込めないため、truncateRead の汎用注記（「絞り込み条件やページを変えて」）ではなく「全N件中M件を表示」を必ず残す形で打ち切りを可視化した（src/api/admin/CLAUDE.md の要求事項）。

## 受け入れテスト（本質）
「一覧で（既定に戻せます）と表示された行の ID が reset_avatar_to_default で成功すること」を新規 describe で固定。r2c_default 所属行が不存在側に倒れることも合わせて固定。

## Test plan
- [x] `pnpm typecheck` — 0 errors
- [x] `pnpm lint` — 0 warnings in touched files (58/63 budget, all pre-existing elsewhere)
- [x] `agentRoutes.test.ts` — 498/498 pass（in-band。並列実行時は sandbox の EADDRNOTAVAIL でフレークするが本PRとは無関係、環境要因）
- [x] `bash SCRIPTS/dead-code-check.sh` — 4件は本PR無関係の既存warning
- [x] `bash SCRIPTS/security-scan.sh` — PASS（WARN 1件は本PR無関係の既存コメント誤検知）
- [x] `/code-review high`（2周: 修正込みで再実行）— correctness bug なし。cleanupの一部を追加修正
- [ ] `/codex:review --base main` — **アカウントの利用上限で実行不可**（下記参照）
- [x] `pnpm build`（root）/ `pnpm build`（admin-ui）— both pass

## ⚠️ hkobayashi の判断が必要
Gate 5 (`/codex:review --base main --background`) が Codex アカウントの利用上限で実行不可でした:
```
Codex error: You've hit your usage limit. Upgrade to Plus to continue using Codex
(https://chatgpt.com/explore/plus), or try again at Sep 11th, 2026 8:00 AM.
```
実際の `/codex:review` スクリプトを直接実行して確認済み（同じエラー）。draft PR のまま、Codex review 復旧後の再実行、または手動レビューでの merge 判断をお願いします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnrvptrLNYAjUaf3Q6VSSF