### PR TITLE
fix(agent): update_tuning_rule/update_engagement_ruleの空文字列引数を未指定扱いにする

### DIFF
--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -1841,7 +1841,9 @@ export async function executeToolCall(
       }
 
       const triggerPattern = typeof args['trigger_pattern'] === 'string' ? args['trigger_pattern'].slice(0, 1000) : undefined;
-      const expectedBehavior = typeof args['expected_behavior'] === 'string' ? args['expected_behavior'].slice(0, 4000) : undefined;
+      // parseOptionalTextArg で '' を未指定扱いにする(#780と同型)。trimもするが、
+      // 空白だけの応答方針に正当な用途は無いため未指定と同一視してよい。
+      const expectedBehavior = parseOptionalTextArg(args['expected_behavior'])?.slice(0, 4000);
       const isActive = typeof args['is_active'] === 'boolean' ? args['is_active'] : undefined;
       // AI提案(source='judge')の承認/却下でのみ指定される。is_activeだけではpending(未承認)と
       // rejected(却下済み)を区別できない(どちらもis_active=falseのため)。
@@ -2643,7 +2645,9 @@ export async function executeToolCall(
         typeof triggerConfigRaw === 'object' && triggerConfigRaw !== null && !Array.isArray(triggerConfigRaw)
           ? triggerConfigRaw
           : undefined;
-      const messageTemplate = typeof args['message_template'] === 'string' ? args['message_template'].slice(0, 500) : undefined;
+      // parseOptionalTextArg で '' を未指定扱いにする(#780と同型)。trimもするが、
+      // 空白だけの声がけ文言に正当な用途は無いため未指定と同一視してよい。
+      const messageTemplate = parseOptionalTextArg(args['message_template'])?.slice(0, 500);
       const priorityRaw = args['priority'];
       const priority =
         typeof priorityRaw === 'number' && Number.isFinite(priorityRaw)

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -1754,6 +1754,64 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(res.body.actions[0].result).toContain('変更する内容がありません');
     });
 
+    // -----------------------------------------------------------------------
+    // 空文字列の扱い。#780(update_avatar_profileのname='')と同型で、Groqの
+    // function callingは省略した任意引数に''を入れて送ってくる実測がある。
+    // expected_behaviorは「壊れても画面に何も出ないため事故が沈黙する」tuning_rulesの
+    // 応答方針そのものなので、実害が最も見えにくい経路。
+    // -----------------------------------------------------------------------
+    it('update_tuning_rule: expected_behavior="" のみ → 「変更する内容がありません」を返し、updateRule が呼ばれない', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-tr-eb-empty', 'update_tuning_rule', { id: 1, expected_behavior: '', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('変更内容を教えてください。'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '振る舞いを空にして', sessionId: 'sess-tr-eb-empty' });
+
+      expect(res.status).toBe(200);
+      expect(mockUpdateRule).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('変更する内容がありません');
+    });
+
+    it('update_tuning_rule: expected_behavior="" と is_active=false を同時指定 → is_active だけ更新され、expected_behavior は undefined のまま updateRule に渡る（空文字列で上書きしない）', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-tr-eb-mixed', 'update_tuning_rule', { id: 1, expected_behavior: '', is_active: false, confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('無効にしました。'));
+
+      mockUpdateRule.mockResolvedValueOnce({
+        id: 1, tenant_id: 'tenant-abc', trigger_pattern: '保証', expected_behavior: '2年と案内する', priority: 5, is_active: false, created_by: null, source_message_id: null, created_at: '', updated_at: '',
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルール1を無効にして', sessionId: 'sess-tr-eb-mixed' });
+
+      expect(res.status).toBe(200);
+      // expected_behavior が undefined で渡ることが本質。''がそのまま渡ると
+      // repository層の COALESCE($2, expected_behavior) が効かず空文字列で上書きされる。
+      expect(mockUpdateRule).toHaveBeenCalledWith(
+        1,
+        expect.objectContaining({ is_active: false, expected_behavior: undefined }),
+        'tenant-abc',
+      );
+      expect(res.body.actions[0].result).toContain('現在無効');
+    });
+
+    it('update_tuning_rule: expected_behavior="   "（空白のみ）も未指定として扱われる', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-tr-eb-ws', 'update_tuning_rule', { id: 1, expected_behavior: '   ', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('変更内容を教えてください。'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '振る舞いを空白にして', sessionId: 'sess-tr-eb-ws' });
+
+      expect(res.status).toBe(200);
+      expect(mockUpdateRule).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('変更する内容がありません');
+    });
+
     it('delete_tuning_rule: confirmed=false → 削除されずブロックされる', async () => {
       mockFetch
         .mockResolvedValueOnce(toolCallResponse('call-tr-6', 'delete_tuning_rule', { id: 1, confirmed: false }))
@@ -4333,6 +4391,46 @@ describe('POST /v1/admin/agent/chat', () => {
         [null, null, null, null, false, 1],
       );
       expect(res.body.actions[0].result).toContain('現在無効');
+    });
+
+    // -----------------------------------------------------------------------
+    // 空文字列の扱い。#780(update_avatar_profileのname='')と同型で、Groqの
+    // function callingは省略した任意引数に''を入れて送ってくる実測がある。
+    // message_templateはエンドユーザーに出る文面なので、空になると顧客に
+    // 空メッセージが表示される。
+    // -----------------------------------------------------------------------
+    it('update_engagement_rule: message_template="" のみ → 「変更する内容がありません」で UPDATE に到達しない', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-er-mt-empty', 'update_engagement_rule', { id: 1, message_template: '', confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('変更内容を教えてください。'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '声がけ文言を空にして', sessionId: 'sess-er-mt-empty' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('変更する内容がありません');
+    });
+
+    it('update_engagement_rule: message_template="" と priority=50 を同時指定 → UPDATE は走るが $3 は "" ではなく null（COALESCE で既存値を残す）', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-er-mt-mixed', 'update_engagement_rule', { id: 1, message_template: '', priority: 50, confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('優先度を変更しました。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ id: 1, tenant_id: 'tenant-abc' }] }) // SELECT ownership
+        .mockResolvedValueOnce({ rows: [{ id: 1, trigger_type: 'idle_time', message_template: '既存の文言', is_active: true }] }); // UPDATE
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルール1の優先度を50にして', sessionId: 'sess-er-mt-mixed' });
+
+      expect(res.status).toBe(200);
+      expect(mockQuery).toHaveBeenLastCalledWith(
+        expect.stringContaining('UPDATE trigger_rules'),
+        [null, null, null, 50, null, 1],
+      );
     });
 
     it('delete_engagement_rule: confirmed=false → 削除されずブロックされる', async () => {


### PR DESCRIPTION
## 背景
Groq の function calling は省略した任意引数に `''` を入れて送ってくることがある実測済みの挙動。
実害の前例3件（#771 category='' / #774 published='"false"' / #780 name=''）のうち、
#780 は `update_avatar_profile` だけを直し、同型の兄弟2箇所が残っていた。

## 変更
`#780` で追加済みの `parseOptionalTextArg`（trimして空なら undefined）を再利用し、各1行を書き換え。
新しい関数・抽象化は追加していない。

- `src/api/admin/agent/actionExecutor.ts:1843` `update_tuning_rule` の `expected_behavior`
  - 修正前: `''` が `typeof === 'string'` を通過 → 「変更する内容がありません」ガードが発火せず、
    `UPDATE ... SET expected_behavior = ''` が走ってテナントの応答方針が空で上書きされる。
    `tuning_rules` は「壊れても画面に何も出ないため事故が沈黙する」層で実害が最も見えにくい。
- `src/api/admin/agent/actionExecutor.ts:2647` `update_engagement_rule` の `message_template`
  - 修正前: `''` が `??` では nullish 扱いされず素通りし、
    `COALESCE($3, message_template)` の `$3` が `''`（NOT NULL）になって上書きされる。
    `message_template` はエンドユーザーに出る文面なので、空になると顧客に空メッセージが表示される。

## 触らなかった箇所（意図的）
- **`trigger_pattern`（`update_tuning_rule` 1842行付近）**: 既に下流の
  `splitTriggerKeywords(triggerPattern).length === 0` ガードが `''` を捕まえ、
  「トリガーが決まっていないようです…」という親切な文言を返している。既に守られている行。
- **`save_tuning_rule` / `save_engagement_rule`**: 実機確認済みで、こちらも既に必須チェック
  （`save_engagement_rule` は `if (!messageTemplate)`）で空文字列を弾いている。

## テスト
`src/api/admin/agent/agentRoutes.test.ts` に4本 + 余力で1本追加（既存の `update_avatar_profile`
空文字列テストと同じ書き方に統一）:

1. `update_tuning_rule` に `expected_behavior: ''` のみ →「変更する内容がありません」を返し、
   `updateRule` が呼ばれないこと
2. `update_tuning_rule` に `expected_behavior: ''` + `is_active: false` →
   `updateRule` に渡る呼び出し引数の `expected_behavior` が `undefined` のまま
   （空文字列で上書きしない。COALESCE が効く形）
3. `update_tuning_rule` に `expected_behavior: '   '`（空白のみ）→ 同じく未指定扱い
4. `update_engagement_rule` に `message_template: ''` のみ →「変更する内容がありません」で
   `db.query` (UPDATE) に到達しないこと
5. `update_engagement_rule` に `message_template: ''` + `priority: 50` →
   UPDATE は走るが `$3`（message_template）が `''` ではなく `null` であること
   （`COALESCE` が既存値を残す）

「何も起きない」（テスト1,4）と「一部だけ起きる」（テスト2,5）を別テストにして区別している。

## Gate
```
pnpm typecheck   # 0 errors
pnpm lint (src / admin-ui/src 個別実行)  # 0 warnings (分割実行はローカル環境のメモリ制約回避のため。CI は結合実行)
npx jest src/api/admin/agent/ --runInBand  # 579 passed, 0 failed
pnpm build       # OK
SCRIPTS/dead-code-check.sh  # warning のみ、既存分（本PRと無関係）
SCRIPTS/security-scan.sh    # PASS (CRITICAL/HIGH: 0)
```
並列実行 (`npx jest src/api/admin/agent/`) 単体だとローカルのポート枯渇（`EADDRNOTAVAIL`）で
無関係なテストが落ちることがあるドキュメント記載の既知の環境事象。`--runInBand` で全579件パス確認済み。
CI（並列でない/別環境）での最終判定を想定。

## Test plan
- [x] `update_tuning_rule` 系4本のうち新規テスト3本を含めて pass
- [x] `update_engagement_rule` 系のうち新規テスト2本を含めて pass
- [x] 既存テストの破壊なし（579件 pass）