### PR TITLE
docs(deploy): feedback_flagged migration を適用済みに更新し、手順の DATABASE_URL 渡し方を直す

### DIFF
--- a/docs/DEPLOY_CHECKLIST.md
+++ b/docs/DEPLOY_CHECKLIST.md
@@ -111,7 +111,7 @@ VITE_SUPABASE_ANON_KEY=YOUR_ANON_KEY
 | ファイル | 内容 | 適用済み |
 |---|---|---|
 | `src/api/admin/feedback/migration_feedback.sql` | feedback_messages テーブル初期作成 | ✅ |
-| `src/api/admin/feedback/migration_feedback_flagged.sql` | flagged_for_improvement カラム追加 + インデックス | 要適用 |
+| `src/api/admin/feedback/migration_feedback_flagged.sql` | flagged_for_improvement カラム追加 + インデックス | ✅ (2026-08-18 実機確認) |
 | `src/api/admin/tenants/migration_phase_a.sql` | Phase A Day 2: tenants GA4/PostHog拡張 + notification_preferences + ga4_connection_logs + ga4_test_history + conversion_attributions拡張 | ✅ (2026-08-16 実機確認) |
 | `src/api/admin/avatar/migration_category_persona.sql` | LemonSliceペルソナスワップ: avatar_configs に category_persona_map(JSONB)追加 | ✅ (2026-08-16 実機確認) |
 | `src/lib/sai/migration_sai_tasks.sql` | Sai代行タスクの所有権レジストリ(sai_tasks)新設。get_sai_task_status の越境読み取り・課金誤帰属を止める (PR #755) | ✅ 2026-08-16 |
@@ -157,10 +157,37 @@ GOOGLE_APPLICATION_CREDENTIALS_JSON=<base64-encoded-service-account-json>
 INTERNAL_API_HMAC_SECRET=<random-256bit-secret>
 ```
 
+> **適用済み (2026-08-18 実機確認)。** 列 `flagged_for_improvement`(boolean, default false) と
+> 部分インデックス `idx_feedback_flagged` の両方が本番に存在することを確認済み。
+> 以下は再構築時・別環境向けの記録。
+
 ```bash
-# VPS で実行:
-ssh root@65.108.159.161 "psql \$DATABASE_URL -f /opt/rajiuce/src/api/admin/feedback/migration_feedback_flagged.sql"
+# DATABASE_URL の渡し方に注意。
+# `ssh ... "psql \$DATABASE_URL ..."` は動かない — リモートの非対話シェルに
+# DATABASE_URL は無く(/opt/rajiuce/.env にあるだけ)、psql が既定のUNIXソケット接続に
+# フォールバックして `FATAL: role "root" does not exist` になる。接続情報が違うのではなく、
+# 渡せていないだけなので、この失敗を「DBが壊れた」と誤診しないこと。
+#
+# .env を `source` / `. ./.env` しないこと。値にプレースホルダの山括弧が残っていると
+# リダイレクトと解釈され、前後の行がコマンドとして実行されてシークレットが端末に出る
+# (2026-08-08 に OpenAI キーが実際に露出した経路)。DATABASE_URL の行だけ取り出して渡す。
+#
+# 外側をシングルクォートにするとローカルシェルが中身に触れない。
+# grep はローカル側で結果を絞るだけなので、接続文字列は画面にも履歴にも出ない。
+
+# 1) 適用済みかの確認（何か出れば適用済み）
+ssh root@65.108.159.161 'cd /opt/rajiuce && psql "$(grep -m1 ^DATABASE_URL= .env | cut -d= -f2-)" -c "\d feedback_messages"' | grep -E 'flagged_for_improvement|idx_feedback_flagged'
+
+# 2) 未適用なら適用（ADD COLUMN IF NOT EXISTS なので二重実行しても無害）
+ssh root@65.108.159.161 'cd /opt/rajiuce && psql "$(grep -m1 ^DATABASE_URL= .env | cut -d= -f2-)" -f /opt/rajiuce/src/api/admin/feedback/migration_feedback_flagged.sql'
+
+# 3) 適用後は 1) を再実行して列とインデックスの両方を確認する。pm2 再起動は不要（列追加のみ）
 ```
+
+**この列が無いと壊れるのは一覧だけではない。** `feedbackRepository.ts` の3関数すべてが参照しており、
+とくに `sendMessage()` は `INSERT ... RETURNING flagged_for_improvement` なので**送信自体が失敗する**。
+同ファイルに try/catch が0件のため、画面には一般文言しか出ず原因が分からない。
+動作確認では一覧・送信・改善マークの**3つとも**見ること。
 
 ### sai_tasks migration 実行手順 (PR #755)
 


### PR DESCRIPTION
ローンチブロッカーと見なしていた L1 は、**実測の結果ブロッカーではありませんでした**。

## 実測結果

本番に列とインデックスの両方が既に存在していました。

```
flagged_for_improvement | boolean | | | false
"idx_feedback_flagged" btree (flagged_for_improvement, created_at)
  WHERE flagged_for_improvement = true
```

migration ファイルの内容と一致します。**本番の「お客様の声」は壊れていません。**

## なぜ「要適用」のまま残っていたか

PR #766（2026-08-17）は9本を実測して ✅ に反転させましたが、**この行だけ変更していません**。差分からは「測って未適用だった」と「測っていない」が区別できず、未測定のまま「要適用」が残っていました。

**チェックリストは未適用方向にも誤りうる**、というのがここでの教訓です。「要適用」を見たら、適用する前にまず確認する。

## 手順の修正（こちらが本体）

記載されていた `ssh ... "psql \$DATABASE_URL -f ..."` は**動きません**。リモートの非対話シェルに `DATABASE_URL` は無く（`/opt/rajiuce/.env` にあるだけ）、psql が既定の UNIX ソケット接続にフォールバックして

```
FATAL:  role "root" does not exist
```

になります。接続情報が違うのではなく渡せていないだけですが、この文言は「DBが壊れた」と誤診しやすいので、注意書きごと手順を差し替えました。

あわせて **`.env` の `source` 禁止**を明記しました。値にプレースホルダの山括弧が残っているとリダイレクトと解釈され、前後の行がコマンドとして実行されてシークレットが端末に出ます（2026-08-08 に OpenAI キーが実際に露出した経路）。

## 影響範囲の追記

この列が無いと壊れるのは一覧だけではありません。`feedbackRepository.ts` の3関数すべてが参照しており、`sendMessage()` は `INSERT ... RETURNING` に含むため**送信自体が失敗**します。同ファイルは try/catch が0件で画面に一般文言しか出ないため、動作確認では**一覧・送信・改善マークの3つとも**見ること、と明記しました。

## Tier

docs のみ。Tier B。