### PR TITLE
feat(ops): 本番Postgresの日次バックアップスクリプトを追加する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,13 @@ jobs:
       - name: Test
         run: pnpm test
 
+      # SCRIPTS/ の shell テストは jest の testMatch({src,tests}/**/*.test.ts)に入らないため
+      # 明示的に走らせる。配線しないと、admin-ui の vitest が #662 以降ずっと赤いまま
+      # 誰にも気づかれなかったのと同じ穴になる(CLAUDE.md「テストの最低ライン」)。
+      # backup-postgres.test.sh は本物のDB・Slackに触れない(PG_DUMP と NOTIFY を差し替える)。
+      - name: Test shell scripts
+        run: bash SCRIPTS/backup-postgres.test.sh
+
   admin-ui-build:
     name: Gate 3 — admin-ui typecheck + test + build
     runs-on: ubuntu-latest

--- a/SCRIPTS/backup-postgres.sh
+++ b/SCRIPTS/backup-postgres.sh
@@ -135,10 +135,19 @@ if ! gzip -t "$TMP" 2>/dev/null; then
     rm -f "$TMP"
     fail "ダンプの gzip 整合性チェックに失敗しました"
 fi
-if ! gzip -dc "$TMP" 2>/dev/null | head -c 4096 | grep -q "PostgreSQL database dump"; then
-    rm -f "$TMP"
-    fail "ダンプの内容が pg_dump の出力に見えません"
-fi
+# head が先に閉じると gzip に SIGPIPE が飛び、pipefail のせいで
+# grep が一致していてもパイプライン全体が非ゼロになる。
+# Linux(本番・CI)で顕在化し、macOS では再現しなかった。ダンプが大きいほど確実に踏むため、
+# そのままだと「取得に成功した直後に失敗と判定してファイルを消す」動きになる。
+# パイプの終了コードに依存させず、取り出した文字列だけで判定する。
+HEAD_TEXT="$(gzip -dc "$TMP" 2>/dev/null | head -c 4096 || true)"
+case "$HEAD_TEXT" in
+    *"PostgreSQL database dump"*) ;;
+    *)
+        rm -f "$TMP"
+        fail "ダンプの内容が pg_dump の出力に見えません"
+        ;;
+esac
 
 mv -f "$TMP" "$FINAL" || fail "バックアップの確定（rename）に失敗しました"
 log "完了: ${FINAL} ($(du -h "$FINAL" | cut -f1))"

--- a/SCRIPTS/backup-postgres.sh
+++ b/SCRIPTS/backup-postgres.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+# backup-postgres.sh — 本番 PostgreSQL の日次バックアップ
+#
+# なぜ必要か:
+#   2026-08-18 の実測で、本番DBのバックアップが1本も存在しないことが判明した。
+#   さらに docs/DATA_RETENTION_POLICY.md §4.1 は「pg_dump (VPS cron) / 日次 / 7日」と
+#   実装済みであるかのように書いていた（§4.2 では同じ cron を「想定」と書いており矛盾）。
+#   「バックアップがある」という誤記は、無いことより危険。障害時に復旧できると
+#   誤認したまま判断してしまう。
+#
+# 実行場所: VPS（cron。インストール手順は最下部）
+#
+# 設計上の約束:
+#   - .env を source しない。プレースホルダ（FAL_KEY=<...> 等）がリダイレクトと解釈され、
+#     前後の行がコマンドとして実行されてシークレットが露出する（2026-08-08 に実際に起きた）。
+#     必要な変数だけ sed で1行取り出す（monitor-avatar-agent.sh と同じ作法）。
+#   - DATABASE_URL をログ・Slack・エラー文言に一切出さない。
+#   - **失敗したら成果物を残さない。** ドキュメント記載の
+#       pg_dump $DATABASE_URL | gzip > /backup/pg_YYYYMMDD.sql.gz
+#     をそのまま cron に貼ると、cron は .env を読まないので $DATABASE_URL が空になり、
+#     pg_dump は既定のUNIXソケット接続にフォールバックして失敗する。
+#     ところが **リダイレクトが先に走るので空または壊れた .gz が必ず作られる**。
+#     結果、ファイルは毎日増えるのに中身が無い、という最悪の壊れ方になる。
+#     ここでは一時ファイルに書き、健全性を確認してから最終名へ rename する。
+#   - 失敗は必ず非ゼロ終了 + Slack 通知。黙って成功に見せない。
+#
+# 使い方:
+#   bash SCRIPTS/backup-postgres.sh              # 通常実行
+#   bash SCRIPTS/backup-postgres.sh --dry-run    # 接続と空き容量だけ確認し、dumpしない
+#   bash SCRIPTS/backup-postgres.sh --list       # 保管中のバックアップを一覧表示
+#
+# 関連: docs/DATA_RETENTION_POLICY.md / Asana 1217570014112316
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ENV_FILE="${ENV_FILE:-/opt/rajiuce/.env}"
+BACKUP_DIR="${BACKUP_DIR:-/backup}"
+RETENTION_DAYS="${RETENTION_DAYS:-7}"
+MIN_FREE_MB="${MIN_FREE_MB:-2048}"
+# 健全なダンプの下限。これを下回ったら失敗として扱う。
+# 「接続はできたが中身がほぼ空」を成功と数えないための歯。
+MIN_DUMP_BYTES="${MIN_DUMP_BYTES:-10240}"
+PG_DUMP="${PG_DUMP:-pg_dump}"
+# テストから差し替えられるようにしておく。既定は本物の通知スクリプト。
+# 差し替え口が無いと、失敗経路のテストが実際に Slack へ投稿してしまう。
+NOTIFY="${NOTIFY:-${SCRIPT_DIR}/notify-slack.sh}"
+
+MODE=normal
+case "${1:-}" in
+  --dry-run) MODE=dry ;;
+  --list)    MODE=list ;;
+  "")        ;;
+  *) echo "使い方: $0 [--dry-run|--list]" >&2; exit 64 ;;
+esac
+
+log() { echo "[$(date +%Y-%m-%dT%H:%M:%S%z)] $*"; }
+
+# .env から1行だけ取り出す（source しない）。monitor-avatar-agent.sh と同じ実装。
+load_env_var() {
+    [ -f "$ENV_FILE" ] || return 0
+    sed -n "s/^$1=//p" "$ENV_FILE" 2>/dev/null | head -1 | sed 's/^"//; s/"$//'
+}
+
+# 失敗を必ず可視化する。Slack が使えない場合でも標準エラーと終了コードには残す。
+# 第2引数以降に DATABASE_URL を含む文字列を渡さないこと。
+fail() {
+    local msg="$1"
+    log "ERROR: $msg" >&2
+    for _v in SLACK_BOT_TOKEN SLACK_WEBHOOK_URL_R2C SLACK_WEBHOOK_URL; do
+        if [ -z "$(eval "echo \${$_v:-}")" ]; then
+            _val="$(load_env_var "$_v")"
+            [ -n "$_val" ] && export "$_v=$_val"
+        fi
+    done
+    if [ -x "$NOTIFY" ]; then
+        bash "$NOTIFY" "🔴 本番DBバックアップ失敗: ${msg}" --color error >/dev/null 2>&1 || true
+    fi
+    exit 1
+}
+
+if [ "$MODE" = "list" ]; then
+    log "保管中のバックアップ (${BACKUP_DIR}):"
+    ls -lh "${BACKUP_DIR}"/pg_*.sql.gz 2>/dev/null || log "  (1件も無い)"
+    exit 0
+fi
+
+DB_URL="$(load_env_var DATABASE_URL)"
+# 空のまま進むと pg_dump が既定のソケット接続にフォールバックし、
+# `FATAL: role "root" does not exist` になる。これは「DBが壊れた」ではなく
+# 「値を渡せていない」なので、ここで明示的に止めて誤診を防ぐ。
+[ -n "$DB_URL" ] || fail "DATABASE_URL を ${ENV_FILE} から取得できませんでした（cron は .env を自動では読みません）"
+
+mkdir -p "$BACKUP_DIR" 2>/dev/null || fail "バックアップ先 ${BACKUP_DIR} を作成できませんでした"
+[ -w "$BACKUP_DIR" ] || fail "バックアップ先 ${BACKUP_DIR} に書き込めません"
+
+FREE_MB="$(df -Pm "$BACKUP_DIR" | awk 'NR==2 {print $4}')"
+if [ -n "$FREE_MB" ] && [ "$FREE_MB" -lt "$MIN_FREE_MB" ]; then
+    fail "空き容量が不足しています（${FREE_MB}MB < ${MIN_FREE_MB}MB）"
+fi
+
+if [ "$MODE" = "dry" ]; then
+    # 接続確認のみ。dump はしない。エラー本文に接続文字列が混ざらないよう捨てる。
+    if "$PG_DUMP" --schema-only --table=__no_such_table__ "$DB_URL" >/dev/null 2>&1; then
+        log "dry-run: 接続OK / 空き ${FREE_MB}MB / 出力先 ${BACKUP_DIR}"
+    else
+        # 存在しないテーブル指定は正常系でも非ゼロになりうるため、接続可否は別途判定する
+        if "$PG_DUMP" --schema-only "$DB_URL" >/dev/null 2>&1; then
+            log "dry-run: 接続OK / 空き ${FREE_MB}MB / 出力先 ${BACKUP_DIR}"
+        else
+            fail "DBへ接続できませんでした（接続文字列は表示しません。${ENV_FILE} の DATABASE_URL を確認してください）"
+        fi
+    fi
+    exit 0
+fi
+
+STAMP="$(date +%Y%m%d)"
+FINAL="${BACKUP_DIR}/pg_${STAMP}.sql.gz"
+TMP="${FINAL}.tmp"
+
+rm -f "$TMP"
+# pipefail により pg_dump 側の失敗も検出できる。
+if ! "$PG_DUMP" "$DB_URL" 2>/dev/null | gzip -c > "$TMP"; then
+    rm -f "$TMP"
+    fail "pg_dump に失敗しました（成果物は残していません）"
+fi
+
+# 「作られたが中身が無い」を成功と数えない。3段階で確かめる。
+SIZE="$(wc -c < "$TMP" 2>/dev/null || echo 0)"
+if [ "$SIZE" -lt "$MIN_DUMP_BYTES" ]; then
+    rm -f "$TMP"
+    fail "ダンプが小さすぎます（${SIZE}バイト < ${MIN_DUMP_BYTES}バイト）"
+fi
+if ! gzip -t "$TMP" 2>/dev/null; then
+    rm -f "$TMP"
+    fail "ダンプの gzip 整合性チェックに失敗しました"
+fi
+if ! gzip -dc "$TMP" 2>/dev/null | head -c 4096 | grep -q "PostgreSQL database dump"; then
+    rm -f "$TMP"
+    fail "ダンプの内容が pg_dump の出力に見えません"
+fi
+
+mv -f "$TMP" "$FINAL" || fail "バックアップの確定（rename）に失敗しました"
+log "完了: ${FINAL} ($(du -h "$FINAL" | cut -f1))"
+
+# 直前のバックアップから急に小さくなっていないかを見る。
+# テーブル削除・部分的な権限喪失は、成功扱いのまま中身だけ痩せるため気づけない。
+PREV="$(ls -1t "${BACKUP_DIR}"/pg_*.sql.gz 2>/dev/null | sed -n '2p')"
+if [ -n "$PREV" ]; then
+    PREV_SIZE="$(wc -c < "$PREV")"
+    if [ "$PREV_SIZE" -gt 0 ] && [ "$((SIZE * 2))" -lt "$PREV_SIZE" ]; then
+        log "警告: 前回($(basename "$PREV"), ${PREV_SIZE}バイト)の半分未満です" >&2
+        for _v in SLACK_BOT_TOKEN SLACK_WEBHOOK_URL_R2C SLACK_WEBHOOK_URL; do
+            if [ -z "$(eval "echo \${$_v:-}")" ]; then
+                _val="$(load_env_var "$_v")"; [ -n "$_val" ] && export "$_v=$_val"
+            fi
+        done
+        [ -x "$NOTIFY" ] && bash "$NOTIFY" \
+            "⚠️ 本番DBバックアップのサイズが前回の半分未満です（${SIZE} < ${PREV_SIZE} バイト）。内容を確認してください" \
+            --color warning >/dev/null 2>&1 || true
+    fi
+fi
+
+# 保持期間を過ぎたものを削除する。削除は最後に行う。
+# 先に消すと、今回の取得に失敗したとき手元に何も残らない。
+DELETED="$(find "$BACKUP_DIR" -maxdepth 1 -name 'pg_*.sql.gz' -mtime "+${RETENTION_DAYS}" -print -delete 2>/dev/null | wc -l | tr -d ' ')"
+[ "$DELETED" != "0" ] && log "保持期間(${RETENTION_DAYS}日)超過を ${DELETED} 件削除しました"
+
+exit 0
+
+# --- VPS へのインストール手順（hkobayashi 手動） ---
+#
+#   1) 投入前に dry-run で接続と空き容量を確認する:
+#        bash /opt/rajiuce/SCRIPTS/backup-postgres.sh --dry-run
+#
+#   2) 手動で1回実行し、実ファイルが出ることを確認する:
+#        bash /opt/rajiuce/SCRIPTS/backup-postgres.sh
+#        bash /opt/rajiuce/SCRIPTS/backup-postgres.sh --list
+#
+#   3) crontab -e で以下を追加（毎日 02:00）:
+#        0 2 * * * bash /opt/rajiuce/SCRIPTS/backup-postgres.sh >> /var/log/r2c-pg-backup.log 2>&1
+#
+#   4) **翌日に実ファイルとサイズを確認する。** cron を書いた＝動作確認ではない:
+#        bash /opt/rajiuce/SCRIPTS/backup-postgres.sh --list
+#
+#   5) **リストアを1度だけ実地で試す。** 取れているが戻せない、が最悪のケース。
+#      本番へ流し込まないこと。検証用DBを作って戻す:
+#        createdb -T template0 restore_test
+#        gzip -dc /backup/pg_YYYYMMDD.sql.gz | psql restore_test
+#        psql restore_test -c '\dt' | head
+#        dropdb restore_test

--- a/SCRIPTS/backup-postgres.test.sh
+++ b/SCRIPTS/backup-postgres.test.sh
@@ -1,0 +1,114 @@
+#!/usr/bin/env bash
+# backup-postgres.test.sh — backup-postgres.sh の失敗経路を固定する
+#
+# なぜ必要か:
+#   このスクリプトが防ぎたいのは「失敗したのに成果物が残り、成功に見える」こと。
+#   ドキュメント記載の `pg_dump $URL | gzip > out.gz` はリダイレクトが先に走るため、
+#   pg_dump が失敗しても空の .gz が必ず作られる。毎日ファイルは増えるのに中身が無い、
+#   という壊れ方は、必要になるまで誰も気づけない。
+#   正常系が通ることより、失敗時に何も残さないことの方が重要なのでそちらを厚く見る。
+#
+# 実行: bash SCRIPTS/backup-postgres.test.sh
+# 本物のDB・Slackには一切触らない（PG_DUMP と NOTIFY を差し替える）。
+
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="${SCRIPT_DIR}/backup-postgres.sh"
+PASS=0; FAIL=0
+
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+# Slack を叩かないダミー。呼ばれた回数を記録する。
+NOTIFY_STUB="${WORK}/notify.sh"
+cat > "$NOTIFY_STUB" <<'EOS'
+#!/usr/bin/env bash
+echo "$*" >> "${NOTIFY_LOG}"
+EOS
+chmod +x "$NOTIFY_STUB"
+
+mk_env() { printf 'DATABASE_URL=%s\n' "$1" > "${WORK}/env"; }
+mk_pgdump() {  # $1: 終了コード, $2: 出力内容
+    printf '%s' "$2" > "${WORK}/dump_body"
+    cat > "${WORK}/pg_dump" <<EOS
+#!/usr/bin/env bash
+cat "${WORK}/dump_body"
+exit $1
+EOS
+    chmod +x "${WORK}/pg_dump"
+}
+run() {
+    NOTIFY_LOG="${WORK}/notify.log" \
+    ENV_FILE="${WORK}/env" BACKUP_DIR="${WORK}/out" \
+    PG_DUMP="${WORK}/pg_dump" NOTIFY="$NOTIFY_STUB" MIN_FREE_MB=0 \
+    bash "$TARGET" "$@" >"${WORK}/stdout" 2>"${WORK}/stderr"
+}
+check() {  # $1: 説明, $2: 実際, $3: 期待
+    if [ "$2" = "$3" ]; then PASS=$((PASS+1)); echo "  ✓ $1"
+    else FAIL=$((FAIL+1)); echo "  ✗ $1 — 期待:[$3] 実際:[$2]"; fi
+}
+reset_out() { rm -rf "${WORK}/out" "${WORK}/notify.log"; mkdir -p "${WORK}/out"; touch "${WORK}/notify.log"; }
+count_gz() { ls -1 "${WORK}/out"/pg_*.sql.gz 2>/dev/null | wc -l | tr -d ' '; }
+count_tmp() { ls -1 "${WORK}/out"/*.tmp 2>/dev/null | wc -l | tr -d ' '; }
+
+# 健全なダンプの中身。先頭に pg_dump のヘッダを置き、本体は圧縮しにくいデータにする。
+# MIN_DUMP_BYTES の判定は **圧縮後** のサイズに対して行われるため、
+# 同じ文字の繰り返しでは gzip 後に数十バイトまで縮んで下限を割る（実際に踏んだ）。
+GOOD_DUMP="-- PostgreSQL database dump
+$(head -c 60000 /dev/urandom | base64)"
+
+echo "== 1. DATABASE_URL が空（cron が .env を読まない状況の再現） =="
+reset_out; mk_env ""; mk_pgdump 0 "$GOOD_DUMP"
+run; rc=$?
+check "非ゼロで終了する" "$rc" "1"
+check "成果物を作らない" "$(count_gz)" "0"
+check "一時ファイルを残さない" "$(count_tmp)" "0"
+check "Slack へ通知する" "$([ -s "${WORK}/notify.log" ] && echo yes || echo no)" "yes"
+check "接続文字列を出力に含めない" "$(grep -c 'postgres://' "${WORK}/stderr" "${WORK}/notify.log" 2>/dev/null | awk -F: '{s+=$2} END{print s+0}')" "0"
+
+echo "== 2. pg_dump が失敗する =="
+reset_out; mk_env "postgres://u:p@127.0.0.1:5432/db"; mk_pgdump 1 ""
+run; rc=$?
+check "非ゼロで終了する" "$rc" "1"
+check "空の .gz を残さない（ドキュメント版はここで残る）" "$(count_gz)" "0"
+check "一時ファイルを残さない" "$(count_tmp)" "0"
+
+echo "== 3. 接続はできたが中身がほぼ空 =="
+reset_out; mk_env "postgres://u:p@127.0.0.1:5432/db"; mk_pgdump 0 "-- PostgreSQL database dump"
+run; rc=$?
+check "非ゼロで終了する" "$rc" "1"
+check "成果物を作らない" "$(count_gz)" "0"
+
+echo "== 4. pg_dump の出力に見えない内容 =="
+reset_out; mk_env "postgres://u:p@127.0.0.1:5432/db"
+mk_pgdump 0 "$(head -c 60000 /dev/urandom | base64)"
+run; rc=$?
+check "非ゼロで終了する" "$rc" "1"
+check "成果物を作らない" "$(count_gz)" "0"
+
+echo "== 5. 正常系 =="
+reset_out; mk_env "postgres://u:p@127.0.0.1:5432/db"; mk_pgdump 0 "$GOOD_DUMP"
+run; rc=$?
+check "ゼロで終了する" "$rc" "0"
+check "成果物が1件できる" "$(count_gz)" "1"
+check "一時ファイルを残さない" "$(count_tmp)" "0"
+check "Slack へ通知しない" "$([ -s "${WORK}/notify.log" ] && echo yes || echo no)" "no"
+check "gzip として健全" "$(gzip -t "${WORK}/out"/pg_*.sql.gz 2>/dev/null && echo ok || echo ng)" "ok"
+
+echo "== 6. 保持期間 =="
+reset_out; mk_env "postgres://u:p@127.0.0.1:5432/db"; mk_pgdump 0 "$GOOD_DUMP"
+touch -t 200001010000 "${WORK}/out/pg_19991231.sql.gz"
+touch "${WORK}/out/pg_20990101.sql.gz"
+run >/dev/null 2>&1
+check "古いものは削除される" "$([ -f "${WORK}/out/pg_19991231.sql.gz" ] && echo yes || echo no)" "no"
+check "新しいものは残る" "$([ -f "${WORK}/out/pg_20990101.sql.gz" ] && echo yes || echo no)" "yes"
+
+echo "== 7. --list は成果物を作らない =="
+reset_out; mk_env ""; mk_pgdump 0 "$GOOD_DUMP"
+run --list; rc=$?
+check "ゼロで終了する" "$rc" "0"
+check "成果物を作らない" "$(count_gz)" "0"
+
+echo ""
+echo "PASS=${PASS} FAIL=${FAIL}"
+[ "$FAIL" -eq 0 ] || exit 1

--- a/SCRIPTS/backup-postgres.test.sh
+++ b/SCRIPTS/backup-postgres.test.sh
@@ -45,7 +45,12 @@ run() {
 }
 check() {  # $1: 説明, $2: 実際, $3: 期待
     if [ "$2" = "$3" ]; then PASS=$((PASS+1)); echo "  ✓ $1"
-    else FAIL=$((FAIL+1)); echo "  ✗ $1 — 期待:[$3] 実際:[$2]"; fi
+    else
+        FAIL=$((FAIL+1)); echo "  ✗ $1 — 期待:[$3] 実際:[$2]"
+        # 失敗理由を推測させない。どのガードが発火したかを必ず出す。
+        # (CI で落ちたときローカルで再現せず、原因の特定に時間を溶かしたため)
+        [ -s "${WORK}/stderr" ] && sed 's/^/      stderr> /' "${WORK}/stderr"
+    fi
 }
 reset_out() { rm -rf "${WORK}/out" "${WORK}/notify.log"; mkdir -p "${WORK}/out"; touch "${WORK}/notify.log"; }
 count_gz() { ls -1 "${WORK}/out"/pg_*.sql.gz 2>/dev/null | wc -l | tr -d ' '; }


### PR DESCRIPTION
本番DBのバックアップが1本も存在しない件（Asana `1217570014112316`）。設置はVPS作業なので人間が行いますが、**cron に貼るスクリプトをリポジトリ側に用意します**。デプロイ時にVPSへ配布されるので、VPS上で手書きする必要がなくなります。

## ドキュメント記載の形をそのまま使うと壊れる

`docs/DATA_RETENTION_POLICY.md` にあった形:

```bash
0 2 * * * pg_dump $DATABASE_URL | gzip > /backup/pg_$(date +%Y%m%d).sql.gz
```

cron は `/opt/rajiuce/.env` を読まないので `$DATABASE_URL` が空になり、`pg_dump` は既定のUNIXソケット接続にフォールバックして失敗します。

**問題はその先です。リダイレクトが先に走るので、空の `.gz` が必ず作られます。**

実測しました:

```
$ false | gzip -c > pg_doc.sql.gz
20 bytes  pg_doc.sql.gz   gzip -t = ok
```

**20バイトのファイルができ、しかも `gzip -t` は ok を返します。** 整合性チェックだけでは捕まりません。ファイルは毎日増えるのに中身が無い、という壊れ方になり、必要になるまで誰も気づけません。

## 対策

一時ファイルへ書き、**3つ確認してから**最終名へ rename します。

| # | 確認 | 何を防ぐか |
|---|---|---|
| 1 | `pg_dump` の終了コード（`pipefail`） | 接続失敗 |
| 2 | 圧縮後サイズが下限以上 | 接続はできたが中身が空 |
| 3 | 中身が `pg_dump` の出力に見えるか | **`gzip -t` だけでは20バイトの空を通す** |

そのほか:

- 失敗時は**成果物を残さず**、非ゼロ終了 + Slack 通知
- `DATABASE_URL` は `.env` から `sed` で1行だけ取り出す。**`source` しない**（プレースホルダの山括弧がリダイレクトと解釈され、前後の行がコマンドとして実行されてシークレットが露出する。2026-08-08 に実際に起きた経路）。この作法は `monitor-avatar-agent.sh` の `load_env_var` と同じ
- `DATABASE_URL` をログ・Slack・エラー文言に一切出さない
- **前回より半分未満に痩せたら警告**する。テーブル削除・権限喪失は成功扱いのまま中身だけ減るため、サイズを見ないと気づけない
- 保持期間超過の削除は**最後**に行う。先に消すと今回の取得に失敗したとき手元に何も残らない

## テスト

`SCRIPTS/backup-postgres.test.sh` を追加し、**Gate 1 に配線**しました。正常系より失敗経路を厚く見ています（失敗時に成果物を残さないことがこのスクリプトの存在理由のため）。本物のDB・Slackには触れません（`PG_DUMP` と `NOTIFY` を差し替え）。

```
1. DATABASE_URL が空 → 非ゼロ / 成果物なし / 通知あり / 接続文字列を出力しない
2. pg_dump 失敗      → 非ゼロ / 空の .gz を残さない
3. 中身がほぼ空      → 非ゼロ / 成果物なし
4. pg_dump の出力に見えない → 非ゼロ / 成果物なし
5. 正常系            → ゼロ / 成果物1件 / 通知なし / gzip健全
6. 保持期間          → 古いものだけ削除
7. --list            → 成果物を作らない

PASS=21 FAIL=0
```

shell テストは jest の `testMatch({src,tests}/**/*.test.ts)` に入らないため CI に明示配線しました。配線しないと、admin-ui の vitest が #662 以降ずっと赤いまま気づかれなかったのと同じ穴になります。

なお `SCRIPTS/pr-risk-scorer.test.sh` も未配線ですが、**本PRでは触っていません**（別件・別PR）。

## マージ後にお願いする作業

デプロイでVPSへ配布した後、スクリプト末尾の手順に従ってください。

1. `--dry-run` で接続と空き容量を確認
2. 手動で1回実行し、実ファイルが出ることを確認
3. cron に登録（毎日 02:00）
4. **翌日に実ファイルとサイズを確認**（cron を書いた＝動作確認ではない）
5. **リストアを1度だけ実地で試す**（検証用DBへ。本番へ流し込まない）。取れているが戻せない、が最悪のケース

## Tier

`SCRIPTS/` + `.github/workflows/`。`src/**` / `admin-ui/src/**` は触っていないため Tier B。
