### PR TITLE
feat(ops): バックアップのリストア検証モードを追加する

### DIFF
--- a/SCRIPTS/backup-postgres.sh
+++ b/SCRIPTS/backup-postgres.sh
@@ -28,6 +28,9 @@
 #   bash SCRIPTS/backup-postgres.sh              # 通常実行
 #   bash SCRIPTS/backup-postgres.sh --dry-run    # 接続と空き容量だけ確認し、dumpしない
 #   bash SCRIPTS/backup-postgres.sh --list       # 保管中のバックアップを一覧表示
+#   bash SCRIPTS/backup-postgres.sh --restore-test [ファイル]
+#                                                # 検証用DBへ実際に戻して健全性を確かめる
+#                                                # (省略時は最新のバックアップ)
 #
 # 関連: docs/DATA_RETENTION_POLICY.md / Asana 1217570014112316
 
@@ -42,16 +45,22 @@ MIN_FREE_MB="${MIN_FREE_MB:-2048}"
 # 「接続はできたが中身がほぼ空」を成功と数えないための歯。
 MIN_DUMP_BYTES="${MIN_DUMP_BYTES:-10240}"
 PG_DUMP="${PG_DUMP:-pg_dump}"
+PSQL="${PSQL:-psql}"
+# 検証用DBの名前は固定する。呼び出し側に決めさせない。
+# 変数にすると、いつか本番のDB名が渡されて DROP される事故が起きる。
+RESTORE_TEST_DB="r2c_restore_test"
 # テストから差し替えられるようにしておく。既定は本物の通知スクリプト。
 # 差し替え口が無いと、失敗経路のテストが実際に Slack へ投稿してしまう。
 NOTIFY="${NOTIFY:-${SCRIPT_DIR}/notify-slack.sh}"
 
 MODE=normal
+RESTORE_FILE=""
 case "${1:-}" in
-  --dry-run) MODE=dry ;;
-  --list)    MODE=list ;;
-  "")        ;;
-  *) echo "使い方: $0 [--dry-run|--list]" >&2; exit 64 ;;
+  --dry-run)     MODE=dry ;;
+  --list)        MODE=list ;;
+  --restore-test) MODE=restore; RESTORE_FILE="${2:-}" ;;
+  "")            ;;
+  *) echo "使い方: $0 [--dry-run|--list|--restore-test [ファイル]]" >&2; exit 64 ;;
 esac
 
 log() { echo "[$(date +%Y-%m-%dT%H:%M:%S%z)] $*"; }
@@ -111,6 +120,61 @@ if [ "$MODE" = "dry" ]; then
             fail "DBへ接続できませんでした（接続文字列は表示しません。${ENV_FILE} の DATABASE_URL を確認してください）"
         fi
     fi
+    exit 0
+fi
+
+if [ "$MODE" = "restore" ]; then
+    # 取れているが戻せない、が最悪のケース。テストで代替できない唯一の検証なので、
+    # 手組みの一行コマンドを本番へ投げるのではなくここに置く。
+    # 定期的に繰り返すべき作業でもある(バックアップは静かに腐る)。
+    [ -n "$RESTORE_FILE" ] || RESTORE_FILE="$(ls -1t "${BACKUP_DIR}"/pg_*.sql.gz 2>/dev/null | head -1)"
+    [ -n "$RESTORE_FILE" ] || fail "検証するバックアップがありません（${BACKUP_DIR} が空です）"
+    [ -f "$RESTORE_FILE" ] || fail "指定されたバックアップが見つかりません: ${RESTORE_FILE}"
+
+    # 接続文字列から検証用DBのURLを導く。クエリ文字列(?sslmode=... 等)は保持する。
+    BASE="${DB_URL%%\?*}"
+    QS="${DB_URL#"$BASE"}"
+    SRC_DB="${BASE##*/}"
+    TEST_URL="${BASE%/*}/${RESTORE_TEST_DB}${QS}"
+
+    # 最重要のガード。導出を1文字でも誤ると本番DBを DROP しかねない。
+    # 「検証用の名前になっていること」と「元のDBと違うこと」の両方を確かめる。
+    [ "${RESTORE_TEST_DB}" != "${SRC_DB}" ] \
+        || fail "検証用DB名が本番DB名と同一です。中止しました"
+    case "$TEST_URL" in
+        *"/${RESTORE_TEST_DB}"|*"/${RESTORE_TEST_DB}?"*) ;;
+        *) fail "検証用DBのURLを正しく導出できませんでした。中止しました" ;;
+    esac
+
+    log "リストア検証: ${RESTORE_FILE} → ${RESTORE_TEST_DB}"
+    "$PSQL" "$DB_URL" -q -c "DROP DATABASE IF EXISTS ${RESTORE_TEST_DB}" >/dev/null 2>&1 \
+        || fail "検証用DBの初期化に失敗しました"
+    "$PSQL" "$DB_URL" -q -c "CREATE DATABASE ${RESTORE_TEST_DB} TEMPLATE template0" >/dev/null 2>&1 \
+        || fail "検証用DBの作成に失敗しました"
+
+    RESTORE_ERR="$(mktemp)"
+    # ON_ERROR_STOP を付けないと、途中のエラーを無視して最後まで走り「成功」に見える。
+    if ! gzip -dc "$RESTORE_FILE" 2>/dev/null | "$PSQL" "$TEST_URL" -q -v ON_ERROR_STOP=1 >/dev/null 2>"$RESTORE_ERR"; then
+        ERR_HEAD="$(head -3 "$RESTORE_ERR" | tr '\n' ' ')"
+        rm -f "$RESTORE_ERR"
+        "$PSQL" "$DB_URL" -q -c "DROP DATABASE IF EXISTS ${RESTORE_TEST_DB}" >/dev/null 2>&1
+        fail "リストアに失敗しました: ${ERR_HEAD}"
+    fi
+    rm -f "$RESTORE_ERR"
+
+    TABLES="$("$PSQL" "$TEST_URL" -tAc "SELECT count(*) FROM information_schema.tables WHERE table_schema='public'" 2>/dev/null | tr -d ' ')"
+    SRC_TABLES="$("$PSQL" "$DB_URL" -tAc "SELECT count(*) FROM information_schema.tables WHERE table_schema='public'" 2>/dev/null | tr -d ' ')"
+
+    "$PSQL" "$DB_URL" -q -c "DROP DATABASE IF EXISTS ${RESTORE_TEST_DB}" >/dev/null 2>&1 \
+        || log "警告: 検証用DB ${RESTORE_TEST_DB} の後片付けに失敗しました。手動で削除してください" >&2
+
+    # 戻せたことと、戻した中身が本番と釣り合っていることは別。両方見る。
+    [ -n "$TABLES" ] && [ "$TABLES" -gt 0 ] 2>/dev/null \
+        || fail "リストアはできましたが、テーブルが1つもありません"
+    if [ -n "$SRC_TABLES" ] && [ "$SRC_TABLES" -gt 0 ] 2>/dev/null && [ "$TABLES" -lt "$SRC_TABLES" ]; then
+        fail "リストア後のテーブル数が本番より少ないです（${TABLES} < ${SRC_TABLES}）"
+    fi
+    log "リストア検証OK: テーブル ${TABLES}件（本番 ${SRC_TABLES}件）。検証用DBは削除済み"
     exit 0
 fi
 
@@ -192,9 +256,10 @@ exit 0
 #   4) **翌日に実ファイルとサイズを確認する。** cron を書いた＝動作確認ではない:
 #        bash /opt/rajiuce/SCRIPTS/backup-postgres.sh --list
 #
-#   5) **リストアを1度だけ実地で試す。** 取れているが戻せない、が最悪のケース。
-#      本番へ流し込まないこと。検証用DBを作って戻す:
-#        createdb -T template0 restore_test
-#        gzip -dc /backup/pg_YYYYMMDD.sql.gz | psql restore_test
-#        psql restore_test -c '\dt' | head
-#        dropdb restore_test
+#   5) リストアを実地で試す。取れているが戻せない、が最悪のケース:
+#        bash /opt/rajiuce/SCRIPTS/backup-postgres.sh --restore-test
+#
+#      検証用DB(r2c_restore_test)を作って最新のバックアップを戻し、
+#      テーブル数を本番と突き合わせてから削除する。本番には書き込まない。
+#      DB名は固定で、本番DB名と同一なら DROP 前に中止する。
+#      **一度きりにしないこと。** バックアップは静かに腐るので定期的に回す。

--- a/SCRIPTS/backup-postgres.test.sh
+++ b/SCRIPTS/backup-postgres.test.sh
@@ -37,10 +37,46 @@ exit $1
 EOS
     chmod +x "${WORK}/pg_dump"
 }
+# psql スタブ。呼び出しを記録し、モードに応じた結果を返す。
+# 本物のDBには一切触らない。
+# $1: "" | restore_fail | zero_tables | fewer_tables
+mk_psql() {
+    printf '%s' "${1:-}" > "${WORK}/psql_mode"
+    cat > "${WORK}/psql" <<'EOS'
+#!/usr/bin/env bash
+echo "$*" >> "${PSQL_LOG}"
+MODE="$(cat "${PSQL_MODE_FILE}" 2>/dev/null)"
+# リストア本体(標準入力を受ける呼び出し)は -v ON_ERROR_STOP=1 が付く
+case "$*" in
+  *ON_ERROR_STOP*)
+      cat >/dev/null
+      [ "$MODE" = "restore_fail" ] && { echo "ERROR: relation does not exist" >&2; exit 1; }
+      exit 0 ;;
+  *"SELECT count(*)"*)
+      # 検証用DB側か本番側かをURLで判別する
+      case "$*" in
+        *r2c_restore_test*)
+            case "$MODE" in
+              zero_tables)   echo 0 ;;
+              fewer_tables)  echo 3 ;;
+              *)             echo 42 ;;
+            esac ;;
+        *) echo 42 ;;
+      esac
+      exit 0 ;;
+esac
+exit 0
+EOS
+    chmod +x "${WORK}/psql"
+    : > "${WORK}/psql.log"
+}
+psql_calls() { wc -l < "${WORK}/psql.log" 2>/dev/null | tr -d ' '; }
+
 run() {
     NOTIFY_LOG="${WORK}/notify.log" \
+    PSQL_LOG="${WORK}/psql.log" PSQL_MODE_FILE="${WORK}/psql_mode" \
     ENV_FILE="${WORK}/env" BACKUP_DIR="${WORK}/out" \
-    PG_DUMP="${WORK}/pg_dump" NOTIFY="$NOTIFY_STUB" MIN_FREE_MB=0 \
+    PG_DUMP="${WORK}/pg_dump" PSQL="${WORK}/psql" NOTIFY="$NOTIFY_STUB" MIN_FREE_MB=0 \
     bash "$TARGET" "$@" >"${WORK}/stdout" 2>"${WORK}/stderr"
 }
 check() {  # $1: 説明, $2: 実際, $3: 期待
@@ -52,7 +88,7 @@ check() {  # $1: 説明, $2: 実際, $3: 期待
         [ -s "${WORK}/stderr" ] && sed 's/^/      stderr> /' "${WORK}/stderr"
     fi
 }
-reset_out() { rm -rf "${WORK}/out" "${WORK}/notify.log"; mkdir -p "${WORK}/out"; touch "${WORK}/notify.log"; }
+reset_out() { rm -rf "${WORK}/out" "${WORK}/notify.log" "${WORK}/psql.log"; mkdir -p "${WORK}/out"; touch "${WORK}/notify.log" "${WORK}/psql.log"; }
 count_gz() { ls -1 "${WORK}/out"/pg_*.sql.gz 2>/dev/null | wc -l | tr -d ' '; }
 count_tmp() { ls -1 "${WORK}/out"/*.tmp 2>/dev/null | wc -l | tr -d ' '; }
 
@@ -113,6 +149,67 @@ reset_out; mk_env ""; mk_pgdump 0 "$GOOD_DUMP"
 run --list; rc=$?
 check "ゼロで終了する" "$rc" "0"
 check "成果物を作らない" "$(count_gz)" "0"
+
+echo "== 8. --restore-test: 本番DBを DROP しないガード =="
+# 接続文字列のDB名が検証用DB名と同一なら、DROP 前に中止しなければならない。
+# ここが破れると本番が消える。このテストが最重要。
+reset_out; mk_env "postgres://u:p@127.0.0.1:5432/r2c_restore_test"; mk_psql
+printf 'x' | gzip -c > "${WORK}/out/pg_20260101.sql.gz"
+run --restore-test; rc=$?
+check "非ゼロで終了する" "$rc" "1"
+check "psql を1度も呼ばない（DROP に到達しない）" "$(psql_calls)" "0"
+
+echo "== 9. --restore-test: クエリ文字列を保持してDB名だけ差し替える =="
+reset_out; mk_env "postgres://u:p@127.0.0.1:5432/faq?sslmode=require"; mk_psql
+printf 'x' | gzip -c > "${WORK}/out/pg_20260101.sql.gz"
+run --restore-test >/dev/null 2>&1
+check "検証用DBのURLが正しい" \
+  "$(grep -c 'postgres://u:p@127.0.0.1:5432/r2c_restore_test?sslmode=require' "${WORK}/psql.log")" \
+  "$(grep -c 'r2c_restore_test?sslmode=require' "${WORK}/psql.log")"
+# DROP は削除対象のDBに接続したままでは実行できないため、本番DBへ接続して発行する。
+# 接続先が本番であること自体は正常。守るべきは「DROP の対象が常に検証用DBであること」。
+check "DROP の対象が常に検証用DBである" \
+  "$(grep -c 'DROP DATABASE' "${WORK}/psql.log")" \
+  "$(grep -c 'DROP DATABASE IF EXISTS r2c_restore_test' "${WORK}/psql.log")"
+
+echo "== 10. --restore-test: 検証用DBは必ず後片付けされる =="
+reset_out; mk_env "postgres://u:p@127.0.0.1:5432/faq"; mk_psql
+printf 'x' | gzip -c > "${WORK}/out/pg_20260101.sql.gz"
+run --restore-test >/dev/null 2>&1
+check "最後に DROP DATABASE が呼ばれる" \
+  "$(grep -c 'DROP DATABASE IF EXISTS r2c_restore_test' "${WORK}/psql.log")" "2"
+
+echo "== 11. --restore-test: リストアが失敗したら検証用DBを残さず落ちる =="
+reset_out; mk_env "postgres://u:p@127.0.0.1:5432/faq"; mk_psql restore_fail
+printf 'x' | gzip -c > "${WORK}/out/pg_20260101.sql.gz"
+run --restore-test; rc=$?
+check "非ゼロで終了する" "$rc" "1"
+check "検証用DBを片付ける" "$(grep -c 'DROP DATABASE IF EXISTS r2c_restore_test' "${WORK}/psql.log")" "2"
+
+echo "== 12. --restore-test: 戻せてもテーブルが0なら失敗 =="
+reset_out; mk_env "postgres://u:p@127.0.0.1:5432/faq"; mk_psql zero_tables
+printf 'x' | gzip -c > "${WORK}/out/pg_20260101.sql.gz"
+run --restore-test; rc=$?
+check "非ゼロで終了する" "$rc" "1"
+
+echo "== 13. --restore-test: 本番よりテーブルが少なければ失敗 =="
+reset_out; mk_env "postgres://u:p@127.0.0.1:5432/faq"; mk_psql fewer_tables
+printf 'x' | gzip -c > "${WORK}/out/pg_20260101.sql.gz"
+run --restore-test; rc=$?
+check "非ゼロで終了する" "$rc" "1"
+
+echo "== 14. --restore-test: 正常系 =="
+reset_out; mk_env "postgres://u:p@127.0.0.1:5432/faq"; mk_psql
+printf 'x' | gzip -c > "${WORK}/out/pg_20260101.sql.gz"
+run --restore-test; rc=$?
+check "ゼロで終了する" "$rc" "0"
+check "Slack へ通知しない" "$([ -s "${WORK}/notify.log" ] && echo yes || echo no)" "no"
+
+echo "== 15. --restore-test: バックアップが1件も無ければ失敗 =="
+reset_out; mk_env "postgres://u:p@127.0.0.1:5432/faq"; mk_psql
+run --restore-test; rc=$?
+check "非ゼロで終了する" "$rc" "1"
+check "psql を1度も呼ばない" "$(psql_calls)" "0"
 
 echo ""
 echo "PASS=${PASS} FAIL=${FAIL}"

--- a/docs/DATA_RETENTION_POLICY.md
+++ b/docs/DATA_RETENTION_POLICY.md
@@ -163,7 +163,10 @@ function getOrCreateVisitorId() {
    2026-08-08 に OpenAI キーが実際に露出した経路）
 3. 設置の翌日に**実際にファイルが出ていること**と**サイズが妥当なこと**を確認する。
    cron を書いた＝動作確認ではない
-4. **リストアを1度だけ実地で試す。** 取れているが戻せない、が最悪のケース
+4. **リストアを実地で試す**（`bash SCRIPTS/backup-postgres.sh --restore-test`）。
+   取れているが戻せない、が最悪のケース。検証用DB `r2c_restore_test` へ戻して
+   テーブル数を本番と突き合わせ、終わったら削除する。本番には書き込まない。
+   **一度きりにしないこと** — バックアップは静かに腐るので定期的に回す
 
 **Cold Storage（将来）:**
 - Hetzner Object Storage または AWS S3 Glacier


### PR DESCRIPTION
バックアップ設置（#790）は完了し、**本番で 3.0MB の取得を確認済み**です。cron も登録されました。

残っていたのは「**戻せること**」の検証だけです。これは自動テストで代替できません。取れているが戻せない、が最悪のケースなので、ここを埋めます。

## なぜ手順書ではなくスクリプトにしたか

リストア検証は、接続文字列から**DB名を差し替える**操作を含みます。手組みの一行コマンドを本番へ投げると、導出を1文字誤っただけで**本番DBを DROP しかねません**。

加えて、バックアップは静かに腐ります。一度きりではなく定期的に回す作業なので、実行可能な形にしました。

```bash
bash SCRIPTS/backup-postgres.sh --restore-test [ファイル]   # 省略時は最新
```

検証用DB `r2c_restore_test` を作って戻し、テーブル数を本番と突き合わせてから削除します。本番には書き込みません。

## 安全側の作り

| 守ること | 実装 |
|---|---|
| 本番DBを消さない | 検証用DB名は**固定**。呼び出し側に決めさせない（変数にすると、いつか本番DB名が渡される） |
| 同上 | 本番DB名と同一なら **DROP 前に**中止 |
| 同上 | URL導出結果が検証用DB名で終わっていなければ中止 |
| 接続形式の違いに耐える | クエリ文字列（`?sslmode=` 等）は保持し、DB名だけ差し替え |
| 途中の失敗を見逃さない | `ON_ERROR_STOP=1`。付けないと途中のエラーを無視して最後まで走り「成功」に見える |
| 後始末 | 失敗しても検証用DBを必ず削除 |
| 中身を確かめる | 戻せたことと中身が釣り合うことは別。テーブル0件・本番より少ない、をそれぞれ失敗にする |

## テスト

8件追加して計34件。**最重要は「本番DBを DROP しないガード」**で、接続文字列のDB名が検証用DB名と同一のとき **psql を1度も呼ばずに**中止することを固定しています。

```
8.  本番DBを DROP しないガード        → 非ゼロ / psql 呼び出し0回
9.  クエリ文字列を保持してDB名だけ差し替え
10. 検証用DBは必ず後片付けされる
11. リストア失敗 → 検証用DBを残さず落ちる
12. 戻せてもテーブル0件なら失敗
13. 本番よりテーブルが少なければ失敗
14. 正常系
15. バックアップが1件も無ければ失敗（psql 呼び出し0回）

PASS=34 FAIL=0
```

## 補足（自分の誤り）

作成中、テスト9のアサーションが誤っていて1件落ちました。`DROP` は削除対象のDBに接続したままでは実行できないため**本番DBへ接続して**発行します。ログ1行に接続先と削除対象が両方現れるのを、私が混同していました。**スクリプトは正しく**、テスト側を「DROP の対象が常に検証用DBであること」に直しています。

## Tier

`SCRIPTS/` + `docs/`。`src/**` / `admin-ui/src/**` は触っていないため Tier B。
