### PR TITLE
docs(ops): バックアップcronの時刻をJST基準で明記する

### DIFF
--- a/SCRIPTS/backup-postgres.sh
+++ b/SCRIPTS/backup-postgres.sh
@@ -250,8 +250,15 @@ exit 0
 #        bash /opt/rajiuce/SCRIPTS/backup-postgres.sh
 #        bash /opt/rajiuce/SCRIPTS/backup-postgres.sh --list
 #
-#   3) crontab -e で以下を追加（毎日 02:00）:
-#        0 2 * * * bash /opt/rajiuce/SCRIPTS/backup-postgres.sh >> /var/log/r2c-pg-backup.log 2>&1
+#   3) crontab -e で以下を追加。
+#      **cron はサーバのタイムゾーンで動く。VPS は UTC。**
+#      JST 深夜 02:00 に取りたいなら 17:00 UTC を指定する。
+#      「0 2」と書くと 11:00 JST = 日本の業務時間帯に走る（最初これで入れて後から直した）:
+#        0 17 * * * bash /opt/rajiuce/SCRIPTS/backup-postgres.sh >> /var/log/r2c-pg-backup.log 2>&1
+#
+#      既存の cron 行（avatar-agent 監視）を消さないよう、追記形式で入れること:
+#        crontab -l 2>/dev/null | grep -q backup-postgres || \
+#          (crontab -l 2>/dev/null; echo "0 17 * * * bash /opt/rajiuce/SCRIPTS/backup-postgres.sh >> /var/log/r2c-pg-backup.log 2>&1") | crontab -
 #
 #   4) **翌日に実ファイルとサイズを確認する。** cron を書いた＝動作確認ではない:
 #        bash /opt/rajiuce/SCRIPTS/backup-postgres.sh --list

--- a/docs/DATA_RETENTION_POLICY.md
+++ b/docs/DATA_RETENTION_POLICY.md
@@ -128,7 +128,7 @@ function getOrCreateVisitorId() {
 
 | 対象 | 方法 | 頻度 | 保持期間 |
 |---|---|---|---|
-| PostgreSQL | `SCRIPTS/backup-postgres.sh`（VPS cron 毎日 02:00） | 日次 | 7日 |
+| PostgreSQL | `SCRIPTS/backup-postgres.sh`（VPS cron `0 17 * * *` = **02:00 JST**） | 日次 | 7日 |
 | Elasticsearch | — | 未実装 | — |
 | ファイルストレージ | Supabase Storage 内蔵 | — | — |
 
@@ -137,7 +137,7 @@ function getOrCreateVisitorId() {
 | 項目 | 結果 |
 |---|---|
 | 手動取得 | `/backup/pg_20260818.sql.gz` 3.0MB |
-| cron 登録 | `0 2 * * * bash /opt/rajiuce/SCRIPTS/backup-postgres.sh >> /var/log/r2c-pg-backup.log 2>&1` |
+| cron 登録 | `0 17 * * * bash /opt/rajiuce/SCRIPTS/backup-postgres.sh >> /var/log/r2c-pg-backup.log 2>&1` |
 | **リストア検証** | **OK — 41テーブル（本番41件と一致）** |
 | 空き容量 | 22GB（7日分に対して十分） |
 
@@ -157,11 +157,19 @@ function getOrCreateVisitorId() {
 ### 4.2 cron の中身と設置手順
 
 ```bash
-# PostgreSQL 日次バックアップ（未設置。設置するならこの形）
-0 2 * * * pg_dump $DATABASE_URL | gzip > /backup/pg_$(date +%Y%m%d).sql.gz
+# 実際の設定（SCRIPTS/backup-postgres.sh が保持期間の削除まで行う）
+0 17 * * * bash /opt/rajiuce/SCRIPTS/backup-postgres.sh >> /var/log/r2c-pg-backup.log 2>&1
+```
 
-# 7日以上古いバックアップを削除
-0 3 * * * find /backup -name "pg_*.sql.gz" -mtime +7 -delete
+**`0 17` は誤記ではない。cron はサーバのタイムゾーンで動き、VPS は UTC。**
+17:00 UTC = **02:00 JST**。ここを `0 2` と書くと **11:00 JST = 日本の業務時間帯**に走る
+（最初これで設置し、後から直した）。時刻を変えるときは必ず JST との対応を書き添えること。
+
+参考: 素の cron でやるならこの形になるが、**そのまま貼ると壊れる**（理由は下記）。
+
+```bash
+0 17 * * * pg_dump $DATABASE_URL | gzip > /backup/pg_$(date +%Y%m%d).sql.gz
+0 18 * * * find /backup -name "pg_*.sql.gz" -mtime +7 -delete
 ```
 
 **この cron をそのまま貼ると動かない。** cron は `/opt/rajiuce/.env` を読まないため


### PR DESCRIPTION
バックアップ cron の時刻がタイムゾーンでずれていたので、実態と手順を直します。

## 何が問題だったか

設置時に `0 2 * * *` と書きました。「毎日 02:00」のつもりでしたが、**cron はサーバのタイムゾーンで動き、VPS は UTC** です。

| | |
|---|---|
| 設定 | `0 2 * * *` |
| 実際の発火 | **11:00 JST** — 日本の業務時間帯 |
| 意図 | 02:00 JST（深夜・オフピーク） |

現在は DB が 3MB で `pg_dump` が2秒で終わるため実害は出ていませんが、データが増えるほどピーク時間帯の負荷になります。**本番の cron は `0 17 * * *`（= 02:00 JST）に修正済み**です。

## 変更内容

- スクリプト末尾の設置手順を `0 17` に修正し、**UTC/JST の対応を明記**
- 既存の cron 行（avatar-agent 監視）を消さないよう**追記形式**で入れることを手順に残した

  `crontab -l | ... | crontab -` は全体を置き換えるため、消えても静かに壊れます。しかもこの監視自体が「**9日間 TTS が壊れていたのに誰も気づかなかった**」ことを受けて入ったものです。

- docs の §4.1 表と稼働確認欄を実際の設定に更新
- §4.2 に「**`0 17` は誤記ではない**」ことと理由を残した。経緯を書かないと、次に読む人が親切心で `0 2` に戻します

## 教訓

時刻の設定は、数字だけ書くと必ずタイムゾーンで事故ります。JST との対応を書き添えることを手順側で強制しました。

## Tier

`SCRIPTS/` + `docs/`。Tier B。
