### PR TITLE
fix(admin-ui): HermesConsentToggle T4 が CI 負荷時に落ちるフレークを直す

### DIFF
--- a/admin-ui/src/pages/admin/avatar/HermesConsentToggle.test.tsx
+++ b/admin-ui/src/pages/admin/avatar/HermesConsentToggle.test.tsx
@@ -81,10 +81,25 @@ describe("HermesConsentToggle", () => {
     const btn = await screen.findByRole("button");
     fireEvent.click(btn);
 
+    // 初期状態が「未同意」なので、getByText("⏸️ 未同意") はロールバック後だけでなく
+    // クリック処理が完了する前でも通ってしまう。既定の 1000ms では CI の負荷時に
+    // PATCH の解決が間に合わず、「未同意はあるがトーストが無い」状態でタイムアウトする
+    // (実際に CI で落ちた。ローカルでは PATCH に遅延を注入して再現済み)。
+    // まず PATCH が実行されたことを呼び出し回数で確定させ、UI の検証と budget を分ける。
+    // こうすると失敗時に「PATCHが飛んでいない」のか「UIが反応していない」のか切り分けられる。
     await waitFor(() => {
-      expect(screen.getByText("⏸️ 未同意")).toBeTruthy();
-      expect(screen.getByText("❌ 保存に失敗しました。もう一度お試しください。")).toBeTruthy();
+      expect(vi.mocked(authFetch)).toHaveBeenCalledTimes(2);
     });
+
+    // トーストは 3000ms で自動的に消える(コンポーネントの setTimeout)。
+    // ここの timeout はそれより短くしないと、待っている間に消えて別の理由で落ちる。
+    await waitFor(
+      () => {
+        expect(screen.getByText("⏸️ 未同意")).toBeTruthy();
+        expect(screen.getByText("❌ 保存に失敗しました。もう一度お試しください。")).toBeTruthy();
+      },
+      { timeout: 2000 },
+    );
   });
 
   it("T5: ネットワーク例外でもロールバックする", async () => {


### PR DESCRIPTION
PR #793（`SCRIPTS/` と `docs/` のみ）の Gate 3 を塞いでいた admin-ui のフレークを直します。**#793 とは無関係の既存バグ**です。同一コミットの2つの Gate 3 実行のうち**片方だけ**が失敗していました。

## 原因

このコンポーネントは初期状態が「未同意」で、クリックすると楽観的に「同意済み」へ変え、PATCH の失敗でロールバックしてトーストを出します。

テストは `waitFor` の中で次を見ていました。

```js
getByText("⏸️ 未同意")                    // ← ロールバック後だけでなく、初期状態でも通る
getByText("❌ 保存に失敗しました。...")
```

**1つ目は初期状態でも成立します。** そのためクリック処理が完了していなくても通ってしまい、既定の 1000ms では CI の負荷時に PATCH の解決が間に合わず、「未同意はあるがトーストが無い」状態でタイムアウトしていました。

ローカルで PATCH に **1.2秒の遅延を注入して再現**させ、原因を確定させています。

## 修正

1. **まず PATCH が実行されたことを `authFetch` の呼び出し回数で確定**させる

   UI の検証と budget を分けることで、失敗時に「PATCH が飛んでいない」のか「UI が反応していない」のかを切り分けられます。今回、CI と手元の再現で**落ちる要素が違った**（CI は「トーストが無い」、手元は「未同意が無い」）のは、この切り分けができていなかったためです。

2. **UI の検証に明示的な `timeout: 2000` を与える**

   ただしトーストはコンポーネント側の `setTimeout` で **3000ms 後に自動的に消えます**。それより短くしないと、待っている間に消えて別の理由で落ちます。この上限をコメントに残しました。

**検証は弱めていません。** ロールバックとトーストの両方を従来どおり確認しています。

## 確認

- **1.2秒の遅延を注入した状態**（修正前は確実に落ちる条件）で 8件 pass
- 遅延なしで admin-ui 全体 490件を **3回連続** pass

## 補足

admin-ui のフレークはこれで3件目です（#782 `useAuth` / #785 `useAdminAgent` / 本PR）。前2件は「実際に検証したい値ではなく別の指標を待っていた」型でしたが、**本件は型が違います** — 待機対象は正しく、**アサーションが初期状態でも成立してしまう**ことが問題でした。

いずれも `#782` で vitest を CI に載せるまで誰も見ていなかったもので、CI に載せた効果が出ています。

## Tier

`admin-ui/src` を触るため Tier S。手動マージが必要です。
