### PR TITLE
[SEC][P0] 対話履歴のインメモリストアをテナントスコープでキー付けする

### DIFF
--- a/src/agent/dialog/contextStore.test.ts
+++ b/src/agent/dialog/contextStore.test.ts
@@ -74,30 +74,34 @@ describe("contextStore", () => {
     expect(trimmed[19].content).toBe("tenant-full の21件目");
   });
 
-  describe("キー連結（`${tenantId}::${sessionId}`）のセパレータ衝突", () => {
-    it("【既知の制約】sessionId/tenantIdに区切り文字`::`を含む値を組み合わせると、異なるテナント/セッションの組が同一内部キーに衝突しうる", () => {
-      // tenantId="A", sessionId="B::C" と tenantId="A::B", sessionId="C" は
-      // どちらも内部キー "A::B::C" になり、同じ履歴を共有してしまう。
-      // sessionId はクライアント（req.body.sessionId）が任意の文字列を送れるため、
-      // 攻撃者が他テナントのIDを知っていれば意図的にこの衝突を起こせる可能性がある。
+  describe("キー連結（`${tenantId}::${sessionId}`）のセパレータ衝突防止", () => {
+    it("【修正確認】tenantIdに区切り文字`::`が含まれる場合は例外を投げ、衝突を未然に防ぐ", () => {
+      // tenantId は作成時バリデーション(/^[a-z0-9_-]+$/)によりコロンを含まない
+      // 前提だが、将来その前提が崩れて "A::B" のような tenantId が渡された場合、
+      // sessionId="C" との組み合わせが tenantId="A", sessionId="B::C" と
+      // 同一内部キーに衝突しうる。サイレントな履歴混在よりも早期失敗を優先する。
+      expect(() => appendToSessionHistory("A::B", "C", [
+        { role: "user", content: "should not be stored" },
+      ])).toThrow(/tenantId must not contain/);
+      expect(() => getSessionHistory("A::B", "C")).toThrow(/tenantId must not contain/);
+    });
+
+    it("sessionIdに区切り文字`::`が含まれてもtenantIdがコロンを含まなければ衝突しない（最初の`::`が境界として一意に定まるため）", () => {
+      // tenantId="A", sessionId="B::C" は内部キー "A::B::C" になるが、
+      // tenantId は常にコロン不含のため、他のどの正当な(tenantId, sessionId)の
+      // 組み合わせもこのキーとは衝突しない。
       appendToSessionHistory("A", "B::C", [
         { role: "user", content: "tenant=A, session=B::C の発話" },
       ]);
-      appendToSessionHistory("A::B", "C", [
-        { role: "user", content: "tenant=A::B, session=C の発話" },
+      appendToSessionHistory("A", "other-session", [
+        { role: "user", content: "tenant=A, session=other-session の発話" },
       ]);
 
-      // 現状の実装では両者が同一キーに収束し、appendToSessionHistory はマージ（追記）
-      // であるため、上書きではなく「両テナントのメッセージが同一配列に混在する」
-      // というさらに深刻な形で現れる。このテストは「安全である」ことの証明ではなく、
-      // 現状の挙動を固定して可視化するためのもの。tenantId/sessionId に
-      // エスケープ不能な区切り文字を許す設計は残存リスクとして別途対応を検討すべき。
-      const viaA = getSessionHistory("A", "B::C");
-      const viaAB = getSessionHistory("A::B", "C");
-      expect(viaA).toEqual(viaAB); // 衝突している＝本来は異なるべき2つの取得結果が一致してしまう
-      expect(viaA).toEqual([
+      expect(getSessionHistory("A", "B::C")).toEqual([
         { role: "user", content: "tenant=A, session=B::C の発話" },
-        { role: "user", content: "tenant=A::B, session=C の発話" }, // 別テナントの発話が同一履歴に混入
+      ]);
+      expect(getSessionHistory("A", "other-session")).toEqual([
+        { role: "user", content: "tenant=A, session=other-session の発話" },
       ]);
     });
   });

--- a/src/agent/dialog/contextStore.test.ts
+++ b/src/agent/dialog/contextStore.test.ts
@@ -31,4 +31,74 @@ describe("contextStore", () => {
   it("存在しないsession/tenantの組み合わせは空配列を返す", () => {
     expect(getSessionHistory("tenant-unknown", "session-unknown")).toEqual([]);
   });
+
+  it("tenantIdが空文字列でも他テナントの履歴と混ざらない", () => {
+    appendToSessionHistory("", "session-empty-tenant", [
+      { role: "user", content: "空tenantIdの発話" },
+    ]);
+    appendToSessionHistory("tenant-e", "session-empty-tenant", [
+      { role: "user", content: "tenant-e の発話" },
+    ]);
+
+    expect(getSessionHistory("", "session-empty-tenant")).toEqual([
+      { role: "user", content: "空tenantIdの発話" },
+    ]);
+    expect(getSessionHistory("tenant-e", "session-empty-tenant")).toEqual([
+      { role: "user", content: "tenant-e の発話" },
+    ]);
+  });
+
+  it("上限到達（MAX_HISTORY_LENGTH=20件）はテナント単位で独立している", () => {
+    const twentyMessages = Array.from({ length: 20 }, (_, i) => ({
+      role: "user" as const,
+      content: `tenant-full の発話${i}`,
+    }));
+    appendToSessionHistory("tenant-full", "session-limit", twentyMessages);
+    // tenant-full は上限ちょうど20件
+    expect(getSessionHistory("tenant-full", "session-limit")).toHaveLength(20);
+
+    // 別テナントが同じsessionIdへ1件だけ追記しても、tenant-full 側の20件は変化しない
+    appendToSessionHistory("tenant-other", "session-limit", [
+      { role: "user", content: "tenant-other の発話" },
+    ]);
+    expect(getSessionHistory("tenant-full", "session-limit")).toHaveLength(20);
+    expect(getSessionHistory("tenant-other", "session-limit")).toHaveLength(1);
+
+    // tenant-full がさらに追記すると古い方から切り詰められる（先頭が押し出される）
+    appendToSessionHistory("tenant-full", "session-limit", [
+      { role: "user", content: "tenant-full の21件目" },
+    ]);
+    const trimmed = getSessionHistory("tenant-full", "session-limit");
+    expect(trimmed).toHaveLength(20);
+    expect(trimmed[0].content).toBe("tenant-full の発話1"); // 発話0 が押し出された
+    expect(trimmed[19].content).toBe("tenant-full の21件目");
+  });
+
+  describe("キー連結（`${tenantId}::${sessionId}`）のセパレータ衝突", () => {
+    it("【既知の制約】sessionId/tenantIdに区切り文字`::`を含む値を組み合わせると、異なるテナント/セッションの組が同一内部キーに衝突しうる", () => {
+      // tenantId="A", sessionId="B::C" と tenantId="A::B", sessionId="C" は
+      // どちらも内部キー "A::B::C" になり、同じ履歴を共有してしまう。
+      // sessionId はクライアント（req.body.sessionId）が任意の文字列を送れるため、
+      // 攻撃者が他テナントのIDを知っていれば意図的にこの衝突を起こせる可能性がある。
+      appendToSessionHistory("A", "B::C", [
+        { role: "user", content: "tenant=A, session=B::C の発話" },
+      ]);
+      appendToSessionHistory("A::B", "C", [
+        { role: "user", content: "tenant=A::B, session=C の発話" },
+      ]);
+
+      // 現状の実装では両者が同一キーに収束し、appendToSessionHistory はマージ（追記）
+      // であるため、上書きではなく「両テナントのメッセージが同一配列に混在する」
+      // というさらに深刻な形で現れる。このテストは「安全である」ことの証明ではなく、
+      // 現状の挙動を固定して可視化するためのもの。tenantId/sessionId に
+      // エスケープ不能な区切り文字を許す設計は残存リスクとして別途対応を検討すべき。
+      const viaA = getSessionHistory("A", "B::C");
+      const viaAB = getSessionHistory("A::B", "C");
+      expect(viaA).toEqual(viaAB); // 衝突している＝本来は異なるべき2つの取得結果が一致してしまう
+      expect(viaA).toEqual([
+        { role: "user", content: "tenant=A, session=B::C の発話" },
+        { role: "user", content: "tenant=A::B, session=C の発話" }, // 別テナントの発話が同一履歴に混入
+      ]);
+    });
+  });
 });

--- a/src/agent/dialog/contextStore.test.ts
+++ b/src/agent/dialog/contextStore.test.ts
@@ -1,0 +1,34 @@
+import { appendToSessionHistory, getSessionHistory } from "./contextStore";
+
+describe("contextStore", () => {
+  it("同一sessionIdでも別tenantの履歴は取得できない", () => {
+    appendToSessionHistory("tenant-a", "session-1", [
+      { role: "user", content: "tenant-a の発話" },
+    ]);
+
+    expect(getSessionHistory("tenant-a", "session-1")).toEqual([
+      { role: "user", content: "tenant-a の発話" },
+    ]);
+    expect(getSessionHistory("tenant-b", "session-1")).toEqual([]);
+  });
+
+  it("同一sessionIdでも別tenantへの追記が互いの履歴を汚染しない", () => {
+    appendToSessionHistory("tenant-c", "session-2", [
+      { role: "user", content: "tenant-c の発話" },
+    ]);
+    appendToSessionHistory("tenant-d", "session-2", [
+      { role: "user", content: "tenant-d の発話" },
+    ]);
+
+    expect(getSessionHistory("tenant-c", "session-2")).toEqual([
+      { role: "user", content: "tenant-c の発話" },
+    ]);
+    expect(getSessionHistory("tenant-d", "session-2")).toEqual([
+      { role: "user", content: "tenant-d の発話" },
+    ]);
+  });
+
+  it("存在しないsession/tenantの組み合わせは空配列を返す", () => {
+    expect(getSessionHistory("tenant-unknown", "session-unknown")).toEqual([]);
+  });
+});

--- a/src/agent/dialog/contextStore.ts
+++ b/src/agent/dialog/contextStore.ts
@@ -15,6 +15,16 @@ const sessions = new Map<string, DialogMessage[]>()
 const MAX_HISTORY_LENGTH = 20
 
 function toInternalKey(tenantId: TenantId, sessionId: SessionId): string {
+  // tenantId は作成時バリデーション(/^[a-z0-9_-]+$/、tenants/routes.ts)により
+  // コロンを含まない前提で、文字列中の最初の "::" が常に tenantId/sessionId の
+  // 境界になる（sessionId は z.string().max(128) のみで文字種制限がなく "::" を
+  // 含みうるが、それ自体は境界の一意性を壊さない）。
+  // この前提が将来のバリデーション変更等で崩れると、異なる tenantId/sessionId の
+  // 組み合わせが同一キーに衝突し履歴が混在しうるため、サイレントな衝突より
+  // 明示的な失敗を優先する防御的アサーション。
+  if (tenantId.includes('::')) {
+    throw new Error(`contextStore: tenantId must not contain "::" (got: ${tenantId})`)
+  }
   return `${tenantId}::${sessionId}`
 }
 

--- a/src/agent/dialog/contextStore.ts
+++ b/src/agent/dialog/contextStore.ts
@@ -3,32 +3,41 @@
 import type { DialogMessage } from './types'
 
 type SessionId = string
+type TenantId = string
 
 // MVP: インメモリのセッションストア。
 // 将来 Redis 等に差し替えられるように、I/F はできるだけ単純に保つ。
-const sessions = new Map<SessionId, DialogMessage[]>()
+// キーは `${tenantId}::${sessionId}` — テナントを跨いだ sessionId 衝突で
+// 履歴が相互参照されないようにする（salesContextStore.ts と同じ方式）。
+const sessions = new Map<string, DialogMessage[]>()
 
 // 1 セッションあたり保持する最大メッセージ数（安全のため軽く絞っておく）
 const MAX_HISTORY_LENGTH = 20
 
-export function getSessionHistory(sessionId: SessionId): DialogMessage[] {
-  return sessions.get(sessionId) ?? []
+function toInternalKey(tenantId: TenantId, sessionId: SessionId): string {
+  return `${tenantId}::${sessionId}`
+}
+
+export function getSessionHistory(tenantId: TenantId, sessionId: SessionId): DialogMessage[] {
+  return sessions.get(toInternalKey(tenantId, sessionId)) ?? []
 }
 
 
 export function appendToSessionHistory(
+  tenantId: TenantId,
   sessionId: SessionId,
   messages: DialogMessage[],
 ): DialogMessage[] {
-  const prev = sessions.get(sessionId) ?? []
+  const key = toInternalKey(tenantId, sessionId)
+  const prev = sessions.get(key) ?? []
   const merged = [...prev, ...messages]
 
   if (merged.length > MAX_HISTORY_LENGTH) {
     const trimmed = merged.slice(merged.length - MAX_HISTORY_LENGTH)
-    sessions.set(sessionId, trimmed)
+    sessions.set(key, trimmed)
     return trimmed
   }
 
-  sessions.set(sessionId, merged)
+  sessions.set(key, merged)
   return merged
 }

--- a/src/agent/dialog/dialogAgent.test.ts
+++ b/src/agent/dialog/dialogAgent.test.ts
@@ -47,6 +47,7 @@ import { planMultiStepQuery } from "../flow/multiStepPlanner";
 import { runSalesFlowWithLogging } from "../orchestrator/sales/runSalesFlowWithLogging";
 import { detectSalesIntents } from "../orchestrator/sales/salesIntentDetector";
 import { pool } from "../../lib/db";
+import { getSessionHistory, appendToSessionHistory } from "./contextStore";
 
 const mockOrchestrator = runDialogOrchestrator as jest.MockedFunction<typeof runDialogOrchestrator>;
 const mockPlanner = planMultiStepQuery as jest.MockedFunction<typeof planMultiStepQuery>;
@@ -212,5 +213,71 @@ describe("runDialogTurn — LemonSliceペルソナスワップ ragCategory", () 
     });
 
     expect(result.meta?.ragCategory).toBeUndefined();
+  });
+});
+
+describe("runDialogTurn — tenantId の contextStore への伝播", () => {
+  const mockGetHistory = getSessionHistory as jest.MockedFunction<typeof getSessionHistory>;
+  const mockAppendHistory = appendToSessionHistory as jest.MockedFunction<typeof appendToSessionHistory>;
+
+  beforeEach(() => {
+    mockSalesFlow.mockResolvedValue({
+      nextStage: undefined,
+      prompt: undefined,
+      meta: {} as any,
+    });
+  });
+
+  it("tenantId を指定した場合、getSessionHistory/appendToSessionHistory に同じ tenantId が渡る", async () => {
+    await runDialogTurn({
+      sessionId: "tenant-propagation-session",
+      tenantId: "tenant-x",
+      message: "こんにちは",
+    });
+
+    expect(mockGetHistory).toHaveBeenCalledWith("tenant-x", "tenant-propagation-session");
+    expect(mockAppendHistory).toHaveBeenCalledWith(
+      "tenant-x",
+      "tenant-propagation-session",
+      expect.any(Array)
+    );
+  });
+
+  it("tenantId 未指定（undefined）の場合、DEFAULT_TENANT_ID にフォールバックする（この既定挙動により tenantId 省略時は全リクエストが同一テナントの履歴を共有する残存リスクがある）", async () => {
+    await runDialogTurn({
+      sessionId: "tenant-propagation-session-default",
+      message: "こんにちは",
+    } as any);
+
+    const defaultTenantId = process.env.DEFAULT_TENANT_ID ?? "english-demo";
+    expect(mockGetHistory).toHaveBeenCalledWith(defaultTenantId, "tenant-propagation-session-default");
+  });
+
+  it("tenantId が空文字列の場合、空文字列がそのまま tenantId として使われる（DEFAULT_TENANT_ID にフォールバックしない ── `??` は空文字列を「値あり」とみなすため）", async () => {
+    await runDialogTurn({
+      sessionId: "tenant-propagation-session-empty",
+      tenantId: "",
+      message: "こんにちは",
+    });
+
+    // "" ?? DEFAULT は "" を返す（null/undefined のみフォールバックする ?? の仕様どおり）。
+    // 呼び出し元がテナント未解決を空文字列で表現すると、DEFAULT_TENANT_ID 保護を素通りする点に注意。
+    expect(mockGetHistory).toHaveBeenCalledWith("", "tenant-propagation-session-empty");
+  });
+
+  it("同じ sessionId でも tenantId が異なれば別々に history を要求する", async () => {
+    await runDialogTurn({
+      sessionId: "shared-session-id",
+      tenantId: "tenant-y",
+      message: "tenant-y から",
+    });
+    await runDialogTurn({
+      sessionId: "shared-session-id",
+      tenantId: "tenant-z",
+      message: "tenant-z から",
+    });
+
+    expect(mockGetHistory).toHaveBeenNthCalledWith(1, "tenant-y", "shared-session-id");
+    expect(mockGetHistory).toHaveBeenNthCalledWith(2, "tenant-z", "shared-session-id");
   });
 });

--- a/src/agent/dialog/dialogAgent.ts
+++ b/src/agent/dialog/dialogAgent.ts
@@ -53,7 +53,7 @@ export async function runDialogTurn(
   const effectiveSessionId = ensureSessionId(sessionId);
 
   // 既存セッション履歴を取得
-  const history = getSessionHistory(effectiveSessionId);
+  const history = getSessionHistory(effectiveTenantId, effectiveSessionId);
 
   // 1) Multi-Step Planner
   const useMultiStepPlanner = options?.useMultiStepPlanner ?? true;
@@ -176,7 +176,7 @@ export async function runDialogTurn(
     updates.push({ role: "assistant", content: orchestrated.answer });
   }
 
-  appendToSessionHistory(effectiveSessionId, updates);
+  appendToSessionHistory(effectiveTenantId, effectiveSessionId, updates);
 
   // 4) DialogTurnResult を構築
   const result: DialogTurnResult = {


### PR DESCRIPTION
## 問題
`contextStore` が `sessionId` のみをキーにしており、**同一sessionIdを使う別テナントの会話履歴が相互参照できた**。`sessionId` はクライアント任意文字列（`z.string().max(128)`）。

## 修正
キーを `${tenantId}::${sessionId}` に変更（既に同方式だった `salesContextStore.ts` に揃えた）。`DialogTurnInput` に `tenantId?` が既存だったため型追加は不要で、`dialogAgent` の `effectiveTenantId` を渡すだけの最小変更。
レビュー指摘対応として、tenantIdにセパレータが混入した場合はサイレントな履歴混在ではなく例外で早期失敗させる防御的アサーションを追加。

## テスト
同一sessionId・別tenantで履歴が混ざらないこと（3方向）、`MAX_HISTORY_LENGTH` 上限がテナント単位で独立していること。

## 既知の積み残し
`salesContextStore.ts` に同じキー生成があるが検証未追加＝片肺修正（CLAUDE.md禁止事項6）。純関数への切り出しを後続タスクに分離済み。

---
**由来**: 2026-08-22 ローンチ前セキュリティ監査（認証/テナント分離/アバター/公開面/インフラ/導線の6面）で検出したP0/P1の修正。実装→テスト強化→マージ前レビュー指摘対応まで完了。
**検証**: 全16ブランチ統合で typecheck 0エラー / フルスイート 3974/4000 pass。残る失敗 `avatar/routes.test.ts` (20件) は無変更のmainでも同一に失敗する既存問題（global.fetchスパイのNode環境依存）と実測確認済み。新規リグレッションなし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)