### PR TITLE
[SEC][P0] JWT検証にalgorithms固定を追加し、管理面用トークン判定を切り出す

### DIFF
--- a/src/auth/jwtClaims.test.ts
+++ b/src/auth/jwtClaims.test.ts
@@ -1,0 +1,43 @@
+import { isAdminUsableToken } from "./jwtClaims";
+import type { SupabaseJwtPayload } from "./verifySupabaseJwt";
+
+function payload(overrides: Partial<SupabaseJwtPayload> & Record<string, unknown> = {}): SupabaseJwtPayload {
+  return { sub: "user-1", ...overrides } as SupabaseJwtPayload;
+}
+
+describe("isAdminUsableToken", () => {
+  it("rejects widget session tokens (purpose claim present)", () => {
+    expect(
+      isAdminUsableToken(payload({ purpose: "widget-session", tenant_id: "t1" }))
+    ).toBe(false);
+  });
+
+  it("rejects chat-test tokens (purpose claim present)", () => {
+    expect(
+      isAdminUsableToken(payload({ purpose: "chat-test", tenant_id: "t1" }))
+    ).toBe(false);
+  });
+
+  it("rejects top-level anon role", () => {
+    expect(isAdminUsableToken(payload({ role: "anon" }))).toBe(false);
+  });
+
+  it("rejects app_metadata anon role", () => {
+    expect(isAdminUsableToken(payload({ app_metadata: { role: "anon" } }))).toBe(false);
+  });
+
+  it("accepts app_metadata client_admin role", () => {
+    expect(
+      isAdminUsableToken(payload({ app_metadata: { role: "client_admin", tenant_id: "t1" } }))
+    ).toBe(true);
+  });
+
+  it("accepts app_metadata super_admin role", () => {
+    expect(isAdminUsableToken(payload({ app_metadata: { role: "super_admin" } }))).toBe(true);
+  });
+
+  it("rejects unknown/missing role", () => {
+    expect(isAdminUsableToken(payload())).toBe(false);
+    expect(isAdminUsableToken(payload({ app_metadata: { role: "unknown" } }))).toBe(false);
+  });
+});

--- a/src/auth/jwtClaims.test.ts
+++ b/src/auth/jwtClaims.test.ts
@@ -1,3 +1,4 @@
+import jwt from "jsonwebtoken";
 import { isAdminUsableToken } from "./jwtClaims";
 import type { SupabaseJwtPayload } from "./verifySupabaseJwt";
 
@@ -39,5 +40,137 @@ describe("isAdminUsableToken", () => {
   it("rejects unknown/missing role", () => {
     expect(isAdminUsableToken(payload())).toBe(false);
     expect(isAdminUsableToken(payload({ app_metadata: { role: "unknown" } }))).toBe(false);
+  });
+
+  it("rejects when app_metadata itself is absent (not just role)", () => {
+    const p = payload();
+    delete (p as Record<string, unknown>).app_metadata;
+    expect(isAdminUsableToken(p)).toBe(false);
+  });
+
+  // 型を偽装したペイロード (JWTは任意のJSONを積めるため、role が想定外の型で来ることは
+  // 実運用でも起こりうる — 例外を投げず安全に false を返すことを固定する)
+  it("does not throw and rejects when app_metadata.role is an array", () => {
+    expect(() =>
+      isAdminUsableToken(payload({ app_metadata: { role: ["super_admin"] as unknown as string } }))
+    ).not.toThrow();
+    expect(
+      isAdminUsableToken(payload({ app_metadata: { role: ["super_admin"] as unknown as string } }))
+    ).toBe(false);
+  });
+
+  it("does not throw and rejects when app_metadata.role is a number", () => {
+    expect(
+      isAdminUsableToken(payload({ app_metadata: { role: 1 as unknown as string } }))
+    ).toBe(false);
+  });
+
+  it("does not throw and rejects when app_metadata itself is an unexpected type (string)", () => {
+    expect(() =>
+      isAdminUsableToken(payload({ app_metadata: "not-an-object" as unknown as SupabaseJwtPayload["app_metadata"] }))
+    ).not.toThrow();
+  });
+
+  // tenant_id は isAdminUsableToken では判定しない（role のみを見る）が、
+  // トップレベルとapp_metadataでtenant_idが矛盾するペイロードでもrole判定だけは
+  // 揺らがないことを固定する。実際のtenant_id解決（どちらを採用するか）は
+  // 呼び出し元(authMiddleware.ts / roleAuth.ts)の責務であり、ここでは検証しない。
+  it("role judgement is unaffected by a top-level/app_metadata tenant_id mismatch", () => {
+    expect(
+      isAdminUsableToken(
+        payload({ tenant_id: "tenant-a", app_metadata: { role: "client_admin", tenant_id: "tenant-b" } })
+      )
+    ).toBe(true);
+  });
+});
+
+describe("verifySupabaseJwt", () => {
+  const SECRET = "test-secret-for-verify-supabase-jwt";
+  let verifySupabaseJwt: typeof import("./verifySupabaseJwt").verifySupabaseJwt;
+
+  beforeAll(() => {
+    // verifySupabaseJwt.ts はモジュールトップレベルで一度だけ process.env.SUPABASE_JWT_SECRET を
+    // 読む実装のため、import前に環境変数を設定してから jest.isolateModules で新規ロードする。
+    process.env.SUPABASE_JWT_SECRET = SECRET;
+    jest.isolateModules(() => {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      verifySupabaseJwt = require("./verifySupabaseJwt").verifySupabaseJwt;
+    });
+  });
+
+  function sign(payload: object, opts?: jwt.SignOptions, secret: string = SECRET) {
+    return jwt.sign(payload, secret, { algorithm: "HS256", ...opts });
+  }
+
+  it("accepts a correctly-signed HS256 token with the configured secret", () => {
+    const token = sign({ sub: "u1", app_metadata: { role: "client_admin", tenant_id: "t1" } });
+    const result = verifySupabaseJwt(token);
+    expect(result?.sub).toBe("u1");
+    expect(result?.app_metadata?.role).toBe("client_admin");
+  });
+
+  it("rejects alg:none tokens (unsigned-token forgery)", () => {
+    const header = Buffer.from(JSON.stringify({ alg: "none", typ: "JWT" })).toString("base64url");
+    const body = Buffer.from(
+      JSON.stringify({ sub: "attacker", app_metadata: { role: "super_admin" } })
+    ).toString("base64url");
+    const forged = `${header}.${body}.`;
+    expect(verifySupabaseJwt(forged)).toBeNull();
+  });
+
+  it("rejects tokens signed with a different secret (forgery with wrong key)", () => {
+    const forged = sign({ sub: "attacker", app_metadata: { role: "super_admin" } }, undefined, "wrong-secret");
+    expect(verifySupabaseJwt(forged)).toBeNull();
+  });
+
+  it("rejects a token whose payload was tampered with after signing", () => {
+    const token = sign({ sub: "u1", app_metadata: { role: "client_admin" } });
+    const [h, , s] = token.split(".");
+    const tamperedBody = Buffer.from(
+      JSON.stringify({ sub: "u1", app_metadata: { role: "super_admin" } })
+    ).toString("base64url");
+    expect(verifySupabaseJwt(`${h}.${tamperedBody}.${s}`)).toBeNull();
+  });
+
+  it("rejects an expired token", () => {
+    const token = sign({ sub: "u1" }, { expiresIn: -10 });
+    expect(verifySupabaseJwt(token)).toBeNull();
+  });
+
+  it("accepts a token that expires 5s in the future (not-yet-expired boundary)", () => {
+    const token = sign({ sub: "u1" }, { expiresIn: 5 });
+    expect(verifySupabaseJwt(token)).not.toBeNull();
+  });
+
+  it("rejects malformed tokens without throwing (not a JWT at all)", () => {
+    expect(() => verifySupabaseJwt("not-a-jwt")).not.toThrow();
+    expect(verifySupabaseJwt("not-a-jwt")).toBeNull();
+    expect(verifySupabaseJwt("a.b")).toBeNull(); // ドット区切りが2個しかない
+    expect(verifySupabaseJwt("a.b.c.d")).toBeNull(); // ドット区切りが4個
+  });
+
+  it("rejects tokens with an invalid base64/JSON segment without throwing", () => {
+    expect(() => verifySupabaseJwt("not-base64!!.also-not-base64!!.sig")).not.toThrow();
+    expect(verifySupabaseJwt("not-base64!!.also-not-base64!!.sig")).toBeNull();
+  });
+
+  it("returns null (not throw) for empty string, undefined", () => {
+    expect(() => verifySupabaseJwt("")).not.toThrow();
+    expect(verifySupabaseJwt("")).toBeNull();
+    expect(verifySupabaseJwt(undefined)).toBeNull();
+  });
+
+  it("does not accept RS256-header tokens signed with the HMAC secret as a MAC key (alg confusion)", () => {
+    // アルゴリズム混同攻撃の典型形: ヘッダだけRS256に書き換え、HS256用の共有secretで
+    // HMAC署名した偽トークンを作り、サーバがヘッダを信じてRS256公開鍵検証にフォールバック
+    // しないことを確認する。algorithms:['HS256']固定のため、ヘッダのalgと不一致で拒否される。
+    const header = Buffer.from(JSON.stringify({ alg: "RS256", typ: "JWT" })).toString("base64url");
+    const body = Buffer.from(JSON.stringify({ sub: "attacker", app_metadata: { role: "super_admin" } })).toString(
+      "base64url"
+    );
+    const crypto = require("crypto");
+    const sig = crypto.createHmac("sha256", SECRET).update(`${header}.${body}`).digest("base64url");
+    const forged = `${header}.${body}.${sig}`;
+    expect(verifySupabaseJwt(forged)).toBeNull();
   });
 });

--- a/src/auth/jwtClaims.ts
+++ b/src/auth/jwtClaims.ts
@@ -1,0 +1,14 @@
+import type { SupabaseJwtPayload } from "./verifySupabaseJwt";
+
+// admin API (管理面) で使ってよいトークンかを判定する。
+// verifySupabaseJwt は widget セッション/chat-test トークンの検証にも共用されているため、
+// 「署名が正しい」ことと「管理面で使える」ことを分離する必要がある。
+export function isAdminUsableToken(payload: SupabaseJwtPayload): boolean {
+  const topLevelRole = payload.role;
+  const metadataRole = payload.app_metadata?.role;
+
+  if (topLevelRole === "anon" || metadataRole === "anon") return false;
+  if ((payload as Record<string, unknown>).purpose) return false;
+
+  return metadataRole === "super_admin" || metadataRole === "client_admin";
+}

--- a/src/auth/verifySupabaseJwt.ts
+++ b/src/auth/verifySupabaseJwt.ts
@@ -31,7 +31,14 @@ export function verifySupabaseJwt(
     // audience は固定しない — この関数は Supabase 発行トークンだけでなく、
     // widget セッション/chat-test トークン (同じ secret で署名、aud クレーム無し) の検証にも
     // 共用されているため、ここでの検証は署名の正当性確認に限定する。
-    // 用途ごとの許可判定 (purpose/role) は jwtClaims.ts の isAdminUsableToken で行う。
+    // 用途ごとの許可判定 (purpose/role) は本関数では行わない。
+    // ⚠️ jwtClaims.ts の isAdminUsableToken がその判定を担う想定だが、
+    //    **現時点ではどの認証ミドルウェアからも呼ばれていない**（配線は未完了）。
+    //    「この関数を通ったトークン = 管理面で使ってよいトークン」ではないことに注意。
+    //    現状 widget/anon/chat-test トークンを管理面で弾いているのは
+    //    (a) widget は別鍵(WIDGET_JWT_SECRET)署名なのでそもそも検証を通らない
+    //    (b) roleAuthMiddleware が app_metadata.role 不在を 403 にする
+    //    の2層であり、purpose クレームによる遮断は効いていない。
     return jwt.verify(token, jwtSecret, { algorithms: ["HS256"] }) as SupabaseJwtPayload;
   } catch (err) {
     logger.warn("[verifySupabaseJwt] invalid token:", (err as Error).message);

--- a/src/auth/verifySupabaseJwt.ts
+++ b/src/auth/verifySupabaseJwt.ts
@@ -27,7 +27,12 @@ export function verifySupabaseJwt(
   if (!token || !jwtSecret) return null;
 
   try {
-    return jwt.verify(token, jwtSecret) as SupabaseJwtPayload;
+    // アルゴリズム混同攻撃 (alg:none 等) を防ぐため HS256 に固定する。
+    // audience は固定しない — この関数は Supabase 発行トークンだけでなく、
+    // widget セッション/chat-test トークン (同じ secret で署名、aud クレーム無し) の検証にも
+    // 共用されているため、ここでの検証は署名の正当性確認に限定する。
+    // 用途ごとの許可判定 (purpose/role) は jwtClaims.ts の isAdminUsableToken で行う。
+    return jwt.verify(token, jwtSecret, { algorithms: ["HS256"] }) as SupabaseJwtPayload;
   } catch (err) {
     logger.warn("[verifySupabaseJwt] invalid token:", (err as Error).message);
     return null;


### PR DESCRIPTION
## 問題
`jwt.verify` に `algorithms` 指定が無く、alg confusion攻撃の余地があった（jsonwebtoken 9 + string secret のため実害は限定的だが、明示ピンが無い状態）。

## 修正
- `verifySupabaseJwt` に `algorithms:['HS256']` を固定
- `jwtClaims.ts`（新規）に純関数 `isAdminUsableToken` を切り出し。`purpose` クレーム保持トークン（widgetセッション/chat-test）と `role:'anon'` を管理面から排除する判定

`audience` 検証は追加していない。この関数は widget/chat-test トークンの検証にも共用されており `aud` クレームを持たないため（コード内に理由をコメント）。

## テスト
alg:none偽造 / **alg confusion（RS256偽装をHMAC鍵で検証）** / 別鍵再署名 / ペイロード改ざん / 期限切れ境界 / 不正フォーマットで例外を投げず安全にnull（22件）。

## ⚠️ 既知の積み残し（重要）
`isAdminUsableToken` は**本番のどの認証経路からも呼ばれていない**。配線先の `supabaseAuthMiddleware` は #805 (D1c) 側にあり、片方のブランチで実施すると重複ファイルかマージ衝突になるため分離した。
`verifySupabaseJwt.ts` のコメントが「用途判定はjwtClaimsで行う」と**事実に反していた**ため、未配線である旨と現在の実際の防御2層（widget別鍵署名 / roleAuthMiddleware）を明記するよう修正済み。
**本PRと #805 のマージ後に配線する後続タスクをAsanaに起票済み。**

---
**由来**: 2026-08-22 ローンチ前セキュリティ監査で検出したP0/P1の修正。実装→テスト強化→マージ前レビュー指摘対応まで完了。
**検証**: 全16ブランチ統合で typecheck 0エラー / フルスイート 3974/4000 pass。残る失敗 `avatar/routes.test.ts` (20件) は無変更のmainでも同一に失敗する既存問題と実測確認済み。新規リグレッションなし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)