### PR TITLE
[SEC][P1] roleAuth配線と存在確認オラクルの解消（tuning/evaluations/chat-history）

### DIFF
--- a/src/agent/judge/judgeEvaluator.test.ts
+++ b/src/agent/judge/judgeEvaluator.test.ts
@@ -42,7 +42,7 @@ jest.mock('../openclaw/rewardBridge', () => ({
 import { callGeminiJudge } from '../../lib/gemini/client';
 import { getPool } from '../../lib/db';
 import { readFile } from 'fs/promises';
-import { evaluateSession } from './judgeEvaluator';
+import { evaluateSession, SessionNotFoundError, SessionTenantMismatchError } from './judgeEvaluator';
 import { sendRewardSignal } from '../openclaw/rewardBridge';
 import {
   getOrInitFlowSessionMeta,
@@ -465,13 +465,26 @@ describe('evaluateSession', () => {
     );
   });
 
-  it('13. [既存動作の確認] セッション自体が存在しない場合は expectedTenantId の有無に関わらず null を返す（throwしない）', async () => {
+  it('13. [存在確認オラクル防止] セッション自体が存在しない場合は expectedTenantId の有無に関わらず SessionNotFoundError をthrowする（nullを返さない）', async () => {
     const mockPool = makeMockPool();
     mockGetPool.mockReturnValue(mockPool as any);
     mockPool.query.mockResolvedValueOnce({ rows: [] }); // chat_sessions: 0行
 
-    const result = await evaluateSession('session-does-not-exist', 'tenant-a');
-    expect(result).toBeNull();
+    await expect(evaluateSession('session-does-not-exist', 'tenant-a')).rejects.toThrow(SessionNotFoundError);
     expect(mockCallGroq).not.toHaveBeenCalled();
+  });
+
+  it('14. [存在確認オラクル防止] 「不在」(SessionNotFoundError)と「他テナントのもの」(SessionTenantMismatchError)が別のエラークラスとして区別できる（呼び出し元routes.tsが同一404に統合するための前提）', async () => {
+    const mockPool1 = makeMockPool();
+    mockGetPool.mockReturnValue(mockPool1 as any);
+    mockPool1.query.mockResolvedValueOnce({ rows: [] });
+    await expect(evaluateSession('missing-session', 'tenant-a')).rejects.toBeInstanceOf(SessionNotFoundError);
+
+    const mockPool2 = makeMockPool();
+    mockGetPool.mockReturnValue(mockPool2 as any);
+    mockPool2.query.mockResolvedValueOnce({
+      rows: [{ id: 'internal-1', tenant_id: 'tenant-b', prompt_variant_id: null }],
+    });
+    await expect(evaluateSession('other-tenant-session', 'tenant-a')).rejects.toBeInstanceOf(SessionTenantMismatchError);
   });
 });

--- a/src/agent/judge/judgeEvaluator.test.ts
+++ b/src/agent/judge/judgeEvaluator.test.ts
@@ -384,4 +384,94 @@ describe('evaluateSession', () => {
       outcome: 'unknown', // flow メタ未存在（プロセス再起動後・手動評価）は中立
     });
   });
+
+  // ---------------------------------------------------------------------------
+  // expectedTenantId によるテナント越境防止（D1a, evaluations/trigger 経由）
+  // ユニットレベルでは今まで未検証だった実ロジック本体（routes.ts側はモックのみでテスト済み）。
+  // ---------------------------------------------------------------------------
+
+  it('9. [正常系] expectedTenantId がセッションのtenant_idと一致 → 通常通り評価される', async () => {
+    const mockPool = makeMockPool();
+    mockGetPool.mockReturnValue(mockPool as any);
+
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [{ id: 'internal-uuid-match', tenant_id: 'tenant-a', prompt_variant_id: null }] })
+      .mockResolvedValueOnce({
+        rows: [
+          { role: 'user', content: 'hi', created_at: new Date() },
+          { role: 'assistant', content: 'hello', created_at: new Date() },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+    mockCallGroq.mockResolvedValueOnce(makeGroqResponse({ overall_score: 80 }));
+
+    const result = await evaluateSession('session-match', 'tenant-a');
+    expect(result).not.toBeNull();
+    expect(result!.overall_score).toBe(80);
+  });
+
+  it('10. [境界値] expectedTenantId がセッションの実tenant_idと不一致 → SessionTenantMismatchErrorをthrow、messagesクエリは実行されない', async () => {
+    const mockPool = makeMockPool();
+    mockGetPool.mockReturnValue(mockPool as any);
+
+    mockPool.query.mockResolvedValueOnce({
+      rows: [{ id: 'internal-uuid-victim', tenant_id: 'tenant-victim', prompt_variant_id: null }],
+    });
+
+    await expect(evaluateSession('session-victim', 'tenant-attacker')).rejects.toThrow(
+      'session session-victim does not belong to the expected tenant',
+    );
+
+    // messages/tuning_rules/INSERT へは到達しない（chat_sessions取得の1回のみ）
+    expect(mockPool.query).toHaveBeenCalledTimes(1);
+    expect(mockCallGroq).not.toHaveBeenCalled();
+  });
+
+  it('11. [正常系] expectedTenantId=undefined（super_admin相当）→ tenant一致チェックをスキップし全テナントを評価できる', async () => {
+    const mockPool = makeMockPool();
+    mockGetPool.mockReturnValue(mockPool as any);
+
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [{ id: 'internal-uuid-any', tenant_id: 'tenant-any-other', prompt_variant_id: null }] })
+      .mockResolvedValueOnce({
+        rows: [
+          { role: 'user', content: 'hi', created_at: new Date() },
+          { role: 'assistant', content: 'hello', created_at: new Date() },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+    mockCallGroq.mockResolvedValueOnce(makeGroqResponse({ overall_score: 80 }));
+
+    const result = await evaluateSession('session-any', undefined);
+    expect(result).not.toBeNull();
+  });
+
+  it('12. [イレギュラー] expectedTenantId が空文字列 → 実テナントIDと一致しない限り不一致扱いになる（空文字を「未指定」として扱わない）', async () => {
+    // routes.ts側は isSuperAdmin ? undefined : jwtTenantId を渡す設計であり、
+    // roleAuthMiddleware が空tenantを事前に403で弾くため理論上到達しない経路だが、
+    // 万一呼び出し規約が破られた場合に「空文字列だから素通り」という劣化防御に
+    // ならないことを固定する（'' !== 'tenant-a' で確実に不一致判定される）。
+    const mockPool = makeMockPool();
+    mockGetPool.mockReturnValue(mockPool as any);
+
+    mockPool.query.mockResolvedValueOnce({
+      rows: [{ id: 'internal-uuid-x', tenant_id: 'tenant-a', prompt_variant_id: null }],
+    });
+
+    await expect(evaluateSession('session-x', '')).rejects.toThrow(
+      'session session-x does not belong to the expected tenant',
+    );
+  });
+
+  it('13. [既存動作の確認] セッション自体が存在しない場合は expectedTenantId の有無に関わらず null を返す（throwしない）', async () => {
+    const mockPool = makeMockPool();
+    mockGetPool.mockReturnValue(mockPool as any);
+    mockPool.query.mockResolvedValueOnce({ rows: [] }); // chat_sessions: 0行
+
+    const result = await evaluateSession('session-does-not-exist', 'tenant-a');
+    expect(result).toBeNull();
+    expect(mockCallGroq).not.toHaveBeenCalled();
+  });
 });

--- a/src/agent/judge/judgeEvaluator.ts
+++ b/src/agent/judge/judgeEvaluator.ts
@@ -21,6 +21,14 @@ import {
 
 const logger = pino();
 
+/** evaluateSession に expectedTenantId を渡した際、セッションの実tenant_idと一致しない場合に投げる。 */
+export class SessionTenantMismatchError extends Error {
+  constructor(sessionId: string) {
+    super(`session ${sessionId} does not belong to the expected tenant`);
+    this.name = 'SessionTenantMismatchError';
+  }
+}
+
 const JUDGE_MODEL = process.env['GEMINI_MODEL'] ?? 'gemini-2.5-flash';
 
 const FALLBACK_PROMPT_TEMPLATE = `あなたは営業チャットAIの品質評価Judgeです。
@@ -130,7 +138,7 @@ async function loadPromptTemplate(): Promise<string> {
   }
 }
 
-export async function evaluateSession(sessionId: string): Promise<JudgeEvaluationResult | null> {
+export async function evaluateSession(sessionId: string, expectedTenantId?: string): Promise<JudgeEvaluationResult | null> {
   try {
     const pool = getPool();
 
@@ -146,6 +154,14 @@ export async function evaluateSession(sessionId: string): Promise<JudgeEvaluatio
     const internalId: string = sessionResult.rows[0]!.id;
     const tenantId: string = sessionResult.rows[0]!.tenant_id;
     const variantId: string | null = sessionResult.rows[0]!.prompt_variant_id ?? null;
+
+    // 越境防止: 非super_adminの呼び出し元は自テナントのセッションのみ評価可能。
+    // 存在有無を漏らさないため「見つからない」場合と同じ扱いにはせず、呼び出し元(routes.ts)が
+    // 明示的に404へ変換できるよう専用エラーを投げる。
+    if (expectedTenantId !== undefined && tenantId !== expectedTenantId) {
+      logger.warn({ sessionId }, 'judgeEvaluator: tenant mismatch, refusing evaluation');
+      throw new SessionTenantMismatchError(sessionId);
+    }
 
     // 2. Fetch all messages using internal UUID (chat_messages.session_id → chat_sessions.id)
     const msgResult = await pool.query<ChatMessageRow>(
@@ -368,6 +384,7 @@ export async function evaluateSession(sessionId: string): Promise<JudgeEvaluatio
 
     return result;
   } catch (err) {
+    if (err instanceof SessionTenantMismatchError) throw err;
     logger.error({ err, sessionId }, 'judgeEvaluator: unexpected error in evaluateSession');
     return null;
   }

--- a/src/agent/judge/judgeEvaluator.ts
+++ b/src/agent/judge/judgeEvaluator.ts
@@ -29,6 +29,18 @@ export class SessionTenantMismatchError extends Error {
   }
 }
 
+/**
+ * セッション自体が存在しない場合に投げる。
+ * 呼び出し元(routes.ts)は SessionTenantMismatchError と同一の404に変換し、
+ * 「存在しない」と「他テナントのもの」を区別可能な応答にしない（存在確認オラクル防止）。
+ */
+export class SessionNotFoundError extends Error {
+  constructor(sessionId: string) {
+    super(`session ${sessionId} not found`);
+    this.name = 'SessionNotFoundError';
+  }
+}
+
 const JUDGE_MODEL = process.env['GEMINI_MODEL'] ?? 'gemini-2.5-flash';
 
 const FALLBACK_PROMPT_TEMPLATE = `あなたは営業チャットAIの品質評価Judgeです。
@@ -149,7 +161,9 @@ export async function evaluateSession(sessionId: string, expectedTenantId?: stri
     );
     if (sessionResult.rows.length === 0) {
       logger.warn({ sessionId }, 'judgeEvaluator: session not found');
-      return null;
+      // 「不在」と「他テナントのもの」を呼び出し元が同一の404にできるよう、
+      // null(=処理失敗として500)ではなく専用エラーを投げる（存在確認オラクル防止）。
+      throw new SessionNotFoundError(sessionId);
     }
     const internalId: string = sessionResult.rows[0]!.id;
     const tenantId: string = sessionResult.rows[0]!.tenant_id;
@@ -384,7 +398,7 @@ export async function evaluateSession(sessionId: string, expectedTenantId?: stri
 
     return result;
   } catch (err) {
-    if (err instanceof SessionTenantMismatchError) throw err;
+    if (err instanceof SessionTenantMismatchError || err instanceof SessionNotFoundError) throw err;
     logger.error({ err, sessionId }, 'judgeEvaluator: unexpected error in evaluateSession');
     return null;
   }

--- a/src/api/admin/chat-history/routes.ts
+++ b/src/api/admin/chat-history/routes.ts
@@ -8,7 +8,7 @@ import { getPool } from "../../../lib/db";
 import { getSessions, getMessages, getActiveEscalations, resolveEscalation, saveMessage, normalizeSessionListParams, getConversionTypes, recordOutcome } from "./chatHistoryRepository";
 import { deleteSession } from "./deleteSessionRepository";
 import { logger } from '../../../lib/logger';
-import { isAllowedAdminRole } from "../../middleware/roleAuth";
+import { isAllowedAdminRole, roleAuthMiddleware } from "../../middleware/roleAuth";
 import { z } from "zod";
 
 /**
@@ -31,7 +31,7 @@ function resolveTenantFilter(
 
 export function registerChatHistoryRoutes(app: Express): void {
   // 認証ミドルウェアを適用
-  app.use("/v1/admin/chat-history", supabaseAuthMiddleware);
+  app.use("/v1/admin/chat-history", supabaseAuthMiddleware, roleAuthMiddleware);
 
   // -----------------------------------------------------------------------
   // GET /v1/admin/chat-history/sessions

--- a/src/api/admin/evaluations/evaluationsAuthGuard.test.ts
+++ b/src/api/admin/evaluations/evaluationsAuthGuard.test.ts
@@ -85,5 +85,19 @@ describe('evaluations — ALLOWED_ROLES whitelist', () => {
       const res = await (request(app) as any)[method](path).send({ session_id: 's', action: 'approve', outcome: 'replied' });
       expect(res.status).not.toBe(403);
     });
+    // [回帰] roleAuthMiddleware配線(D1a)のfail-closed: tenant_id空/欠落は全ルートで403。
+    // 壊れやすいポイント: /v1/admin/evaluations と /v1/admin/tuning の app.use に
+    // roleAuthMiddleware が外れると、この403だけが静かに消える（他の403テストは
+    // isAllowedEvaluationRole 等ルート内の別チェックでも403になり得るため気づけない）。
+    it(`${method.toUpperCase()} ${path} — client_admin + tenant_id空文字 → 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'client_admin', tenant_id: '' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path).send({ session_id: 's', action: 'approve', outcome: 'replied' });
+      expect(res.status).toBe(403);
+    });
+    it(`${method.toUpperCase()} ${path} — client_admin + tenant_idクレーム欠落 → 403`, async () => {
+      const app = makeApp({ app_metadata: { role: 'client_admin' }, email: 't@t.com' });
+      const res = await (request(app) as any)[method](path).send({ session_id: 's', action: 'approve', outcome: 'replied' });
+      expect(res.status).toBe(403);
+    });
   });
 });

--- a/src/api/admin/evaluations/evaluationsRepository.stats.test.ts
+++ b/src/api/admin/evaluations/evaluationsRepository.stats.test.ts
@@ -1,4 +1,7 @@
 // src/api/admin/evaluations/evaluationsRepository.stats.test.ts
+// evaluationsRepository の「発行されるSQLそのもの」を固定する回帰テスト。
+// 現在のカバー範囲: getDetailedStats（JSONB/unnest 回帰）、checkAlreadyEvaluated（tenant絞り込み）。
+//
 // getDetailedStats() が JSONB カラムに unnest() を使って常時500になっていた不具合の回帰テスト。
 //
 // used_principles / effective_principles は JSONB(migration_conversation_evaluations.sql)。
@@ -11,7 +14,7 @@ jest.mock("../../../lib/db", () => ({
   getPool: () => ({ query: (...args: unknown[]) => mockQuery(...args) }),
 }));
 
-import { getDetailedStats } from "./evaluationsRepository";
+import { checkAlreadyEvaluated, getDetailedStats } from "./evaluationsRepository";
 
 /** 呼ばれた全SQLを1本の文字列に連結する（何本目かに依存せず検査するため） */
 function allSql(): string {
@@ -70,5 +73,77 @@ describe("getDetailedStats", () => {
   it("DBが例外を投げた場合はそのまま伝播する（呼び出し元が500へ変換する既存挙動を維持）", async () => {
     mockQuery.mockRejectedValueOnce(new Error("connection terminated"));
     await expect(getDetailedStats("carnation", 7)).rejects.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// checkAlreadyEvaluated — 存在確認オラクル防止の中核。
+//
+// POST /v1/admin/evaluations/trigger は所有権検証(evaluateSession)より前に
+// この関数を呼ぶ。tenant_id で絞らないと「他テナントの評価済みセッション」に
+// 409 already_evaluated が返り、session_id の総当たりで他テナントの有効な
+// セッションIDを列挙できてしまう（CLAUDE.md 禁止事項20/21）。
+//
+// ルート層のテストはモック済みのこの関数に第2引数が渡るかしか見ていないため、
+// 「渡された tenantId を SQL で実際に使うか」はここでしか固定できない。
+// AND 句の削除・三項条件の反転・パラメータ順の取り違えを検出する。
+// ---------------------------------------------------------------------------
+
+describe("checkAlreadyEvaluated", () => {
+  const SESSION_ID = "sess-001";
+  const TENANT_ID = "carnation";
+
+  it("expectedTenantId 指定時は tenant_id で絞り、パラメータを [sessionId, tenantId] の順で渡す", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ count: "0" }] });
+
+    await checkAlreadyEvaluated(SESSION_ID, TENANT_ID);
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringMatching(/session_id\s*=\s*\$1\s+AND\s+tenant_id\s*=\s*\$2/),
+      [SESSION_ID, TENANT_ID],
+    );
+  });
+
+  it("expectedTenantId 未指定(super_admin)時は tenant_id 述語を含めない", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ count: "0" }] });
+
+    await checkAlreadyEvaluated(SESSION_ID);
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockQuery.mock.calls[0] as [string, unknown[]];
+    expect(sql).not.toMatch(/tenant_id/);
+    expect(params).toEqual([SESSION_ID]);
+  });
+
+  it("空文字の tenantId でも「未指定」に倒さず tenant_id で絞る（falsy 判定に退行させない）", async () => {
+    // `expectedTenantId !== undefined` を `if (expectedTenantId)` のような
+    // falsy 判定に変えると、空 tenantId の client_admin が全テナント横断で
+    // 409 を引ける状態に戻る。
+    mockQuery.mockResolvedValueOnce({ rows: [{ count: "0" }] });
+
+    await checkAlreadyEvaluated(SESSION_ID, "");
+
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringMatching(/tenant_id\s*=\s*\$2/),
+      [SESSION_ID, ""],
+    );
+  });
+
+  it("count が '0' なら false、1件以上なら true を返す", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ count: "0" }] });
+    await expect(checkAlreadyEvaluated(SESSION_ID, TENANT_ID)).resolves.toBe(false);
+
+    mockQuery.mockResolvedValueOnce({ rows: [{ count: "1" }] });
+    await expect(checkAlreadyEvaluated(SESSION_ID, TENANT_ID)).resolves.toBe(true);
+
+    mockQuery.mockResolvedValueOnce({ rows: [{ count: "3" }] });
+    await expect(checkAlreadyEvaluated(SESSION_ID, TENANT_ID)).resolves.toBe(true);
+  });
+
+  it("rows が空でも例外を投げず false を返す（未評価扱いに倒す）", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    await expect(checkAlreadyEvaluated(SESSION_ID, TENANT_ID)).resolves.toBe(false);
   });
 });

--- a/src/api/admin/evaluations/evaluationsRepository.ts
+++ b/src/api/admin/evaluations/evaluationsRepository.ts
@@ -572,12 +572,23 @@ export async function getEvaluationById(
 // セッション評価済みチェック - Stream B
 // ---------------------------------------------------------------------------
 
-export async function checkAlreadyEvaluated(sessionId: string): Promise<boolean> {
+/**
+ * expectedTenantId 指定時（非super_admin）は自テナント分のみを対象にする。
+ * 未指定（super_admin）はテナント問わず判定する。
+ * tenant_id で絞らないと、他テナントの評価済みセッションに対して409を返してしまい、
+ * ownership検証（evaluateSession内）より前に session_id の存在確認オラクルになる。
+ */
+export async function checkAlreadyEvaluated(sessionId: string, expectedTenantId?: string): Promise<boolean> {
   const pool = getPool();
-  const result = await pool.query<{ count: string }>(
-    `SELECT COUNT(*) AS count FROM conversation_evaluations WHERE session_id = $1`,
-    [sessionId],
-  );
+  const result = expectedTenantId !== undefined
+    ? await pool.query<{ count: string }>(
+        `SELECT COUNT(*) AS count FROM conversation_evaluations WHERE session_id = $1 AND tenant_id = $2`,
+        [sessionId, expectedTenantId],
+      )
+    : await pool.query<{ count: string }>(
+        `SELECT COUNT(*) AS count FROM conversation_evaluations WHERE session_id = $1`,
+        [sessionId],
+      );
   return parseInt(result.rows[0]?.count ?? "0", 10) > 0;
 }
 

--- a/src/api/admin/evaluations/routes.ts
+++ b/src/api/admin/evaluations/routes.ts
@@ -5,6 +5,7 @@
 import type { Express, Request, Response } from "express";
 import { z } from "zod";
 import { supabaseAuthMiddleware } from "../../../admin/http/supabaseAuthMiddleware";
+import { roleAuthMiddleware } from "../../middleware/roleAuth";
 import {
   listEvaluations,
   getDetailedStats,
@@ -41,7 +42,7 @@ function resolveAuth(req: Request): { su: Record<string, any> | undefined; role:
   return {
     su,
     role,
-    jwtTenantId: su?.app_metadata?.tenant_id ?? su?.tenant_id ?? "",
+    jwtTenantId: su?.app_metadata?.tenant_id ?? "", // トップレベルclaimは信用しない（P1-2: 越境）
     isSuperAdmin: role === "super_admin",
     email: su?.email ?? "",
   };
@@ -90,8 +91,8 @@ const outcomeSchema = z.object({
 // ---------------------------------------------------------------------------
 
 export function registerEvaluationRoutes(app: Express): void {
-  app.use("/v1/admin/evaluations", supabaseAuthMiddleware);
-  app.use("/v1/admin/tuning", supabaseAuthMiddleware);
+  app.use("/v1/admin/evaluations", supabaseAuthMiddleware, roleAuthMiddleware);
+  app.use("/v1/admin/tuning", supabaseAuthMiddleware, roleAuthMiddleware);
 
   // -------------------------------------------------------------------------
   // GET /v1/admin/evaluations
@@ -181,7 +182,7 @@ export function registerEvaluationRoutes(app: Express): void {
   // 指定セッションの評価を手動トリガー（未評価の場合のみ）
   // -------------------------------------------------------------------------
   app.post("/v1/admin/evaluations/trigger", async (req: Request, res: Response) => {
-    const { su, role } = resolveAuth(req);
+    const { su, role, jwtTenantId, isSuperAdmin } = resolveAuth(req);
     if (!isAllowedEvaluationRole(role)) {
       return denyEvaluationRole(req, res, su, role);
     }
@@ -198,12 +199,17 @@ export function registerEvaluationRoutes(app: Express): void {
 
       // Dynamic import to avoid circular deps
       const { evaluateSession } = await import("../../../agent/judge/judgeEvaluator");
-      const result = await evaluateSession(session_id);
+      // 越境防止: session_id はbody由来のためtenant所有を必ず検証する（super_adminは検証省略）
+      const result = await evaluateSession(session_id, isSuperAdmin ? undefined : jwtTenantId);
       if (!result) {
         return res.status(500).json({ error: "evaluation_failed" });
       }
       return res.json({ evaluation: result });
     } catch (err) {
+      const { SessionTenantMismatchError } = await import("../../../agent/judge/judgeEvaluator");
+      if (err instanceof SessionTenantMismatchError) {
+        return res.status(404).json({ error: "セッションが見つかりません" });
+      }
       logger.warn("[POST /v1/admin/evaluations/trigger]", err);
       return res.status(500).json({ error: "評価の実行に失敗しました" });
     }

--- a/src/api/admin/evaluations/routes.ts
+++ b/src/api/admin/evaluations/routes.ts
@@ -192,7 +192,11 @@ export function registerEvaluationRoutes(app: Express): void {
     }
 
     try {
-      const alreadyDone = await checkAlreadyEvaluated(session_id);
+      // 越境防止: checkAlreadyEvaluated もtenant_idで絞る。絞らないと、他テナントの
+      // 評価済みセッションに対して409(=存在する)が返り、ownership検証より前の
+      // 存在確認オラクルになる。
+      const expectedTenantId = isSuperAdmin ? undefined : jwtTenantId;
+      const alreadyDone = await checkAlreadyEvaluated(session_id, expectedTenantId);
       if (alreadyDone) {
         return res.status(409).json({ error: "already_evaluated" });
       }
@@ -200,14 +204,15 @@ export function registerEvaluationRoutes(app: Express): void {
       // Dynamic import to avoid circular deps
       const { evaluateSession } = await import("../../../agent/judge/judgeEvaluator");
       // 越境防止: session_id はbody由来のためtenant所有を必ず検証する（super_adminは検証省略）
-      const result = await evaluateSession(session_id, isSuperAdmin ? undefined : jwtTenantId);
+      const result = await evaluateSession(session_id, expectedTenantId);
       if (!result) {
         return res.status(500).json({ error: "evaluation_failed" });
       }
       return res.json({ evaluation: result });
     } catch (err) {
-      const { SessionTenantMismatchError } = await import("../../../agent/judge/judgeEvaluator");
-      if (err instanceof SessionTenantMismatchError) {
+      const { SessionTenantMismatchError, SessionNotFoundError } = await import("../../../agent/judge/judgeEvaluator");
+      // 「不在」と「他テナントのもの」を同一の404にし、存在確認オラクルにしない。
+      if (err instanceof SessionTenantMismatchError || err instanceof SessionNotFoundError) {
         return res.status(404).json({ error: "セッションが見つかりません" });
       }
       logger.warn("[POST /v1/admin/evaluations/trigger]", err);

--- a/src/api/admin/tuning/routes.ts
+++ b/src/api/admin/tuning/routes.ts
@@ -5,6 +5,7 @@
 import { GROQ_INSTANT_8B } from '../../../config/groqModels';
 import type { Express, Request, Response } from "express";
 import type { AuthedReq } from "../../middleware/roleAuth";
+import { roleAuthMiddleware } from "../../middleware/roleAuth";
 import { z } from "zod";
 import { supabaseAuthMiddleware } from "../../../admin/http/supabaseAuthMiddleware";
 import {
@@ -244,7 +245,7 @@ const updateSchema = z.object({
 // ---------------------------------------------------------------------------
 
 export function registerTuningRoutes(app: Express): void {
-  app.use("/v1/admin/tuning-rules", supabaseAuthMiddleware);
+  app.use("/v1/admin/tuning-rules", supabaseAuthMiddleware, roleAuthMiddleware);
 
   // -----------------------------------------------------------------------
   // POST /v1/admin/tuning/suggest-rule
@@ -254,6 +255,7 @@ export function registerTuningRoutes(app: Express): void {
   app.post(
     "/v1/admin/tuning/suggest-rule",
     supabaseAuthMiddleware,
+    roleAuthMiddleware,
     async (req: Request, res: Response) => {
       const su = (req as AuthedReq).supabaseUser;
       if (!su) {
@@ -294,7 +296,7 @@ export function registerTuningRoutes(app: Express): void {
       }
 
       const anchorText = isFreeTextMode ? (freeText as string).trim() : (userMessage as string).trim();
-      const tenantId: string = su?.app_metadata?.tenant_id ?? su?.tenant_id ?? "";
+      const tenantId: string = su?.app_metadata?.tenant_id ?? ""; // トップレベルclaimは信用しない（P1-2: 越境）
 
       // deep_researchフラグ確認（DB失敗時はfalse）
       const deepResearchEnabled = await isDeepResearchEnabled(tenantId);
@@ -367,7 +369,7 @@ export function registerTuningRoutes(app: Express): void {
   app.get("/v1/admin/tuning-rules", async (req: Request, res: Response) => {
     const su = (req as any).supabaseUser as Record<string, any> | undefined;
     const role = su?.app_metadata?.role;
-    const jwtTenantId: string = su?.app_metadata?.tenant_id ?? su?.tenant_id ?? "";
+    const jwtTenantId: string = su?.app_metadata?.tenant_id ?? ""; // トップレベルclaimは信用しない（P1-2: 越境）
     const isSuperAdmin: boolean = role === "super_admin";
     if (!isAllowedTuningRole(role)) {
       logger.warn({
@@ -407,7 +409,7 @@ export function registerTuningRoutes(app: Express): void {
   app.post("/v1/admin/tuning-rules", async (req: Request, res: Response) => {
     const su = (req as any).supabaseUser as Record<string, any> | undefined;
     const role = su?.app_metadata?.role;
-    const jwtTenantId: string = su?.app_metadata?.tenant_id ?? su?.tenant_id ?? "";
+    const jwtTenantId: string = su?.app_metadata?.tenant_id ?? ""; // トップレベルclaimは信用しない（P1-2: 越境）
     const isSuperAdmin: boolean = role === "super_admin";
     const jwtEmail: string = su?.email ?? "";
     if (!isAllowedTuningRole(role)) {
@@ -466,7 +468,7 @@ export function registerTuningRoutes(app: Express): void {
     async (req: Request, res: Response) => {
       const su = (req as AuthedReq).supabaseUser;
       const role = su?.app_metadata?.role;
-      const jwtTenantId: string = su?.app_metadata?.tenant_id ?? su?.tenant_id ?? "";
+      const jwtTenantId: string = su?.app_metadata?.tenant_id ?? ""; // トップレベルclaimは信用しない（P1-2: 越境）
       const isSuperAdmin: boolean = role === "super_admin";
       if (!isAllowedTuningRole(role)) {
         logger.warn({
@@ -521,7 +523,7 @@ export function registerTuningRoutes(app: Express): void {
     async (req: Request, res: Response) => {
       const su = (req as AuthedReq).supabaseUser;
       const role = su?.app_metadata?.role;
-      const jwtTenantId: string = su?.app_metadata?.tenant_id ?? su?.tenant_id ?? "";
+      const jwtTenantId: string = su?.app_metadata?.tenant_id ?? ""; // トップレベルclaimは信用しない（P1-2: 越境）
       const isSuperAdmin: boolean = role === "super_admin";
       if (!isAllowedTuningRole(role)) {
         logger.warn({

--- a/src/api/admin/tuning/tuningAuthGuard.test.ts
+++ b/src/api/admin/tuning/tuningAuthGuard.test.ts
@@ -246,3 +246,44 @@ describe('tuning routes — logger.warn structured payload on 403 (observability
     expect(res.body).toMatchObject({ code: 'AUTHZ_ROLE_DENIED' });
   });
 });
+
+// ---------------------------------------------------------------------------
+// [回帰] roleAuthMiddleware配線: client_admin + tenant_id 空/欠落 → 全ルートで403
+// 壊れやすいポイント: このミドルウェアは jest.mock されておらず実物が動作する。
+// app.use への配線(fail-closed)が将来外れた場合にここで検知する。
+// ---------------------------------------------------------------------------
+
+describe('tuning routes — roleAuthMiddleware fail-closed: client_admin + empty/missing tenant_id', () => {
+  TUNING_ALL_ROUTES.forEach(({ method, path }) => {
+    it(`${method.toUpperCase()} ${path} — client_admin + tenant_id:'' → 403`, async () => {
+      const app = makeApp({ role: 'client_admin', tenant_id: '' });
+      const res = await (request(app) as any)[method](path);
+      expect(res.status).toBe(403);
+    });
+
+    it(`${method.toUpperCase()} ${path} — client_admin + tenant_idクレーム欠落 → 403`, async () => {
+      const app = makeApp({ role: 'client_admin' }); // tenant_id自体が無い
+      const res = await (request(app) as any)[method](path);
+      expect(res.status).toBe(403);
+    });
+
+    it(`${method.toUpperCase()} ${path} — client_admin + tenant_id:'   '(空白のみ) → 403`, async () => {
+      const app = makeApp({ role: 'client_admin', tenant_id: '   ' });
+      const res = await (request(app) as any)[method](path);
+      expect(res.status).toBe(403);
+    });
+  });
+
+  // P1-2是正の回帰: トップレベル tenant_id（app_metadata外）はもう信用されない。
+  // roleAuthMiddleware は app_metadata.tenant_id のみを見るため、role が
+  // app_metadata に無ければ isAllowedAdminRole 判定自体も通らず 403 になる。
+  it('トップレベルclaimのみに正しい値があっても、app_metadata.role が無ければ403（越境の芽を断つ）', async () => {
+    const app = makeAppWithUser({
+      role: 'client_admin', // トップレベル — 無視されるべき
+      tenant_id: 'tenant-a', // トップレベル — 無視されるべき
+      email: 'legacy-token@test.com',
+    });
+    const res = await request(app).get('/v1/admin/tuning-rules');
+    expect(res.status).toBe(403);
+  });
+});

--- a/tests/integration/wiring-check.test.ts
+++ b/tests/integration/wiring-check.test.ts
@@ -125,7 +125,7 @@ import {
 import { searchTool } from "../../src/agent/tools/searchTool";
 import { synthesizeAnswer } from "../../src/agent/tools/synthesisTool";
 import { getActiveRulesForTenant } from "../../src/api/admin/tuning/tuningRulesRepository";
-import { evaluateSession } from "../../src/agent/judge/judgeEvaluator";
+import { evaluateSession, SessionNotFoundError } from "../../src/agent/judge/judgeEvaluator";
 import { sanitizeInput } from "../../src/middleware/inputSanitizer";
 import { applyPromptFirewall } from "../../src/middleware/promptFirewall";
 import { guardOutput } from "../../src/middleware/outputGuard";
@@ -435,12 +435,10 @@ describe("Flow 3: Judge evaluateSession → Gemini → DB persistence", () => {
     expect(MOCK_POOL.query).toHaveBeenCalledTimes(4);
   });
 
-  it("evaluateSession returns null when session not found in DB", async () => {
+  it("evaluateSession throws SessionNotFoundError when session not found in DB (存在確認オラクル防止のためnullではなくthrow)", async () => {
     MOCK_POOL.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
 
-    const result = await evaluateSession("nonexistent-session");
-
-    expect(result).toBeNull();
+    await expect(evaluateSession("nonexistent-session")).rejects.toThrow(SessionNotFoundError);
     expect(callGeminiJudge).not.toHaveBeenCalled();
   });
 

--- a/tests/phase38/chat-history-escalation.test.ts
+++ b/tests/phase38/chat-history-escalation.test.ts
@@ -147,5 +147,52 @@ describe("Chat History Escalation API", () => {
       expect(res.status).toBe(200);
       expect(mockResolveEscalation).toHaveBeenCalledWith({ sessionDbId: "s1", tenantId: undefined });
     });
+
+    // 壊れやすいポイント: roleAuthMiddleware配線(D1a)が外れると、tenant_id空の
+    // client_adminがリポジトリ層まで到達してしまう。実際のミドルウェア連鎖(mock無し)を
+    // 通す統合テストで固定する — ルーティング単体テストでは検出できない再発パターン。
+    it("[回帰] client_admin + tenant_id空文字 → roleAuthMiddlewareで403、resolveEscalationは呼ばれない", async () => {
+      const emptyTenantToken = makeDevJwt({ app_metadata: { role: "client_admin", tenant_id: "" } });
+      const res = await request(app)
+        .patch("/v1/admin/chat-history/sessions/s1/resolve-escalation")
+        .set("Authorization", `Bearer ${emptyTenantToken}`);
+      expect(res.status).toBe(403);
+      expect(mockResolveEscalation).not.toHaveBeenCalled();
+    });
+
+    it("[回帰] client_admin + tenant_idクレーム欠落 → 403、resolveEscalationは呼ばれない", async () => {
+      const noTenantToken = makeDevJwt({ app_metadata: { role: "client_admin" } });
+      const res = await request(app)
+        .patch("/v1/admin/chat-history/sessions/s1/resolve-escalation")
+        .set("Authorization", `Bearer ${noTenantToken}`);
+      expect(res.status).toBe(403);
+      expect(mockResolveEscalation).not.toHaveBeenCalled();
+    });
+
+    // 存在確認オラクル防止の確認: 「他テナントのセッション」も「存在しないセッション」も
+    // resolveEscalation内部で同一のtenant_id述語付きWHEREにより false を返す設計なので、
+    // レスポンスは区別不能な404で統一されているべき（evaluations/triggerとは対照的 —後述）。
+    it("他テナントのセッションIDを指定 → 存在しない場合と同じ404（存在有無を漏らさない）", async () => {
+      mockResolveEscalation.mockResolvedValueOnce(false); // tenant_id述語で0行 = 他テナント所有と同じ結果
+      const res = await request(app)
+        .patch("/v1/admin/chat-history/sessions/other-tenant-session/resolve-escalation")
+        .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`);
+      expect(res.status).toBe(404);
+      expect(res.body).toEqual({ error: "セッションが見つかりません" });
+    });
+
+    it("トップレベルclaimのtenant_id（app_metadata外）は無視され、client_adminは403になる", async () => {
+      // P1-2是正の回帰: su.tenant_id（トップレベル）はもう読まれないこと。
+      const topLevelOnlyToken = makeDevJwt({
+        role: "client_admin",
+        tenant_id: "tenant-a", // トップレベル — app_metadata配下ではない
+      });
+      const res = await request(app)
+        .patch("/v1/admin/chat-history/sessions/s1/resolve-escalation")
+        .set("Authorization", `Bearer ${topLevelOnlyToken}`);
+      // app_metadata.role が無いため isAllowedAdminRole すら通らず 403
+      expect(res.status).toBe(403);
+      expect(mockResolveEscalation).not.toHaveBeenCalled();
+    });
   });
 });

--- a/tests/phase45/evaluationRoutes.test.ts
+++ b/tests/phase45/evaluationRoutes.test.ts
@@ -25,6 +25,7 @@ jest.mock("../../src/api/admin/evaluations/evaluationsRepository", () => ({
 // Mock judgeEvaluator
 jest.mock("../../src/agent/judge/judgeEvaluator", () => ({
   evaluateSession: jest.fn(),
+  SessionTenantMismatchError: class SessionTenantMismatchError extends Error {},
 }));
 
 import {
@@ -130,7 +131,37 @@ describe("1. POST /v1/admin/evaluations/trigger", () => {
 
     expect(res.status).toBe(200);
     expect(res.body.evaluation.overall_score).toBe(72);
-    expect(evaluateSession).toHaveBeenCalledWith("sess-001");
+    // client_admin: 越境防止のため自テナントIDを第2引数として必ず渡す
+    expect(evaluateSession).toHaveBeenCalledWith("sess-001", "tenant-a");
+  });
+
+  it("passes undefined tenantId for super_admin (no ownership restriction)", async () => {
+    (checkAlreadyEvaluated as jest.Mock).mockResolvedValue(false);
+    (evaluateSession as jest.Mock).mockResolvedValue(JUDGE_RESULT);
+
+    const res = await request(makeApp("super_admin"))
+      .post("/v1/admin/evaluations/trigger")
+      .send({ session_id: "sess-001" });
+
+    expect(res.status).toBe(200);
+    expect(evaluateSession).toHaveBeenCalledWith("sess-001", undefined);
+  });
+
+  it("returns 404 when evaluateSession reports a tenant mismatch (cross-tenant trigger blocked)", async () => {
+    const { SessionTenantMismatchError } = jest.requireMock(
+      "../../src/agent/judge/judgeEvaluator",
+    ) as { SessionTenantMismatchError: new (sessionId: string) => Error };
+    (checkAlreadyEvaluated as jest.Mock).mockResolvedValue(false);
+    (evaluateSession as jest.Mock).mockRejectedValue(
+      new SessionTenantMismatchError("sess-001"),
+    );
+
+    const res = await request(makeApp())
+      .post("/v1/admin/evaluations/trigger")
+      .send({ session_id: "sess-001" });
+
+    expect(res.status).toBe(404);
+    expect(evaluateSession).toHaveBeenCalledWith("sess-001", "tenant-a");
   });
 
   it("returns 409 when session already evaluated", async () => {

--- a/tests/phase45/evaluationRoutes.test.ts
+++ b/tests/phase45/evaluationRoutes.test.ts
@@ -26,6 +26,7 @@ jest.mock("../../src/api/admin/evaluations/evaluationsRepository", () => ({
 jest.mock("../../src/agent/judge/judgeEvaluator", () => ({
   evaluateSession: jest.fn(),
   SessionTenantMismatchError: class SessionTenantMismatchError extends Error {},
+  SessionNotFoundError: class SessionNotFoundError extends Error {},
 }));
 
 import {
@@ -176,7 +177,7 @@ describe("1. POST /v1/admin/evaluations/trigger", () => {
     expect(evaluateSession).not.toHaveBeenCalled();
   });
 
-  it("returns 500 when evaluateSession returns null", async () => {
+  it("returns 500 when evaluateSession returns null (e.g. 空/1通話のみで評価をスキップした場合。'不在'とは区別される — 下記オラクル防止テスト参照)", async () => {
     (checkAlreadyEvaluated as jest.Mock).mockResolvedValue(false);
     (evaluateSession as jest.Mock).mockResolvedValue(null);
 
@@ -208,26 +209,32 @@ describe("1. POST /v1/admin/evaluations/trigger", () => {
     expect(evaluateSession).not.toHaveBeenCalled();
   });
 
-  // 既知のリスク（未修正・報告目的のテスト）: evaluateSession は
-  // 「セッションが存在しない」→ null（routes.ts側で500 evaluation_failed）と
-  // 「セッションは存在するが他テナント」→ SessionTenantMismatchError（404）を
-  // 異なるステータスコードで返す。CLAUDE.mdの禁止事項20
-  // 「テナント越境だけは必ず『不存在』側に倒す（[]を返すとIDの実在が漏れる）」に反しており、
-  // 攻撃者は session_id を総当たりして「存在するが自分のではない(404)」と
-  // 「存在しない(500)」を区別できる＝他テナントの有効な session_id を列挙できる。
-  // このテストは現状の(壊れた)挙動を固定して可視化するものであり、本来は両方とも
-  // 同一の404に統一すべき。修正は本タスクのスコープ外のため実施していない。
-  it("[既知のリスク・要修正] session未検出は500、tenant不一致は404 — 存在確認オラクルになっている", async () => {
-    (checkAlreadyEvaluated as jest.Mock).mockResolvedValue(false);
+  // 存在確認オラクル防止（修正済み）: 「セッションが存在しない」
+  // (SessionNotFoundError) と「セッションは存在するが他テナント」
+  // (SessionTenantMismatchError) を、攻撃者から見て区別不能な同一の404に統一する。
+  // CLAUDE.md禁止事項20「テナント越境だけは必ず『不存在』側に倒す」に対応。
+  // checkAlreadyEvaluated もtenant_idで絞るため、「他テナントの評価済みセッション」に
+  // 対して409(存在する)が漏れないことも併せて検証する（409はここに至るオラクルの
+  // もう一つの経路だったため）。
+  it("[存在確認オラクル防止] session不在・他テナント(未評価/評価済み)がいずれも同一の404になる", async () => {
+    const { SessionTenantMismatchError, SessionNotFoundError } = jest.requireMock(
+      "../../src/agent/judge/judgeEvaluator",
+    ) as {
+      SessionTenantMismatchError: new (sessionId: string) => Error;
+      SessionNotFoundError: new (sessionId: string) => Error;
+    };
 
-    (evaluateSession as jest.Mock).mockResolvedValueOnce(null); // 本当に存在しない
+    // ケース1: 本当に存在しない
+    (checkAlreadyEvaluated as jest.Mock).mockResolvedValueOnce(false);
+    (evaluateSession as jest.Mock).mockRejectedValueOnce(
+      new SessionNotFoundError("sess-does-not-exist"),
+    );
     const notFoundRes = await request(makeApp())
       .post("/v1/admin/evaluations/trigger")
       .send({ session_id: "sess-does-not-exist" });
 
-    const { SessionTenantMismatchError } = jest.requireMock(
-      "../../src/agent/judge/judgeEvaluator",
-    ) as { SessionTenantMismatchError: new (sessionId: string) => Error };
+    // ケース2: 存在するが他テナント・未評価
+    (checkAlreadyEvaluated as jest.Mock).mockResolvedValueOnce(false);
     (evaluateSession as jest.Mock).mockRejectedValueOnce(
       new SessionTenantMismatchError("sess-other-tenant"),
     );
@@ -235,10 +242,28 @@ describe("1. POST /v1/admin/evaluations/trigger", () => {
       .post("/v1/admin/evaluations/trigger")
       .send({ session_id: "sess-other-tenant" });
 
-    // 現状の実際の挙動（オラクルが存在することの証跡）
-    expect(notFoundRes.status).toBe(500);
+    // ケース3: 存在するが他テナント・評価済み — checkAlreadyEvaluated が
+    // tenant_idで絞られていれば「自テナント分は0件」なのでfalseのまま
+    // evaluateSession まで進み、同じ404に落ちる（絞っていなければここで
+    // 409が返り、409自体が独立した存在確認オラクルになる）。
+    (checkAlreadyEvaluated as jest.Mock).mockResolvedValueOnce(false);
+    (evaluateSession as jest.Mock).mockRejectedValueOnce(
+      new SessionTenantMismatchError("sess-other-tenant-evaluated"),
+    );
+    const mismatchEvaluatedRes = await request(makeApp())
+      .post("/v1/admin/evaluations/trigger")
+      .send({ session_id: "sess-other-tenant-evaluated" });
+
+    expect(notFoundRes.status).toBe(404);
     expect(mismatchRes.status).toBe(404);
-    expect(notFoundRes.status).not.toBe(mismatchRes.status); // ← 本来はここが同一であるべき
+    expect(mismatchEvaluatedRes.status).toBe(404);
+    expect(notFoundRes.body).toEqual(mismatchRes.body);
+    expect(mismatchRes.body).toEqual(mismatchEvaluatedRes.body);
+
+    // checkAlreadyEvaluated がクライアント指定の tenantId で呼ばれていること
+    // （routes.ts が絞り込みをtenant_id引数に渡す責務を持つことの回帰確認）
+    expect(checkAlreadyEvaluated).toHaveBeenCalledWith("sess-does-not-exist", "tenant-a");
+    expect(checkAlreadyEvaluated).toHaveBeenCalledWith("sess-other-tenant", "tenant-a");
   });
 });
 

--- a/tests/phase45/evaluationRoutes.test.ts
+++ b/tests/phase45/evaluationRoutes.test.ts
@@ -196,6 +196,50 @@ describe("1. POST /v1/admin/evaluations/trigger", () => {
     expect(res.status).toBe(400);
     expect(res.body.error).toBe("session_id is required");
   });
+
+  // 壊れやすいポイント: roleAuthMiddleware配線(D1a)の実物を通す統合テスト。
+  // makeApp は supabaseAuthMiddleware のみバイパスし roleAuthMiddleware はモックしていない。
+  it("[回帰] client_admin + tenant_id空文字 → roleAuthMiddlewareで403、evaluateSessionは呼ばれない", async () => {
+    const res = await request(makeApp("client_admin", ""))
+      .post("/v1/admin/evaluations/trigger")
+      .send({ session_id: "sess-001" });
+
+    expect(res.status).toBe(403);
+    expect(evaluateSession).not.toHaveBeenCalled();
+  });
+
+  // 既知のリスク（未修正・報告目的のテスト）: evaluateSession は
+  // 「セッションが存在しない」→ null（routes.ts側で500 evaluation_failed）と
+  // 「セッションは存在するが他テナント」→ SessionTenantMismatchError（404）を
+  // 異なるステータスコードで返す。CLAUDE.mdの禁止事項20
+  // 「テナント越境だけは必ず『不存在』側に倒す（[]を返すとIDの実在が漏れる）」に反しており、
+  // 攻撃者は session_id を総当たりして「存在するが自分のではない(404)」と
+  // 「存在しない(500)」を区別できる＝他テナントの有効な session_id を列挙できる。
+  // このテストは現状の(壊れた)挙動を固定して可視化するものであり、本来は両方とも
+  // 同一の404に統一すべき。修正は本タスクのスコープ外のため実施していない。
+  it("[既知のリスク・要修正] session未検出は500、tenant不一致は404 — 存在確認オラクルになっている", async () => {
+    (checkAlreadyEvaluated as jest.Mock).mockResolvedValue(false);
+
+    (evaluateSession as jest.Mock).mockResolvedValueOnce(null); // 本当に存在しない
+    const notFoundRes = await request(makeApp())
+      .post("/v1/admin/evaluations/trigger")
+      .send({ session_id: "sess-does-not-exist" });
+
+    const { SessionTenantMismatchError } = jest.requireMock(
+      "../../src/agent/judge/judgeEvaluator",
+    ) as { SessionTenantMismatchError: new (sessionId: string) => Error };
+    (evaluateSession as jest.Mock).mockRejectedValueOnce(
+      new SessionTenantMismatchError("sess-other-tenant"),
+    );
+    const mismatchRes = await request(makeApp())
+      .post("/v1/admin/evaluations/trigger")
+      .send({ session_id: "sess-other-tenant" });
+
+    // 現状の実際の挙動（オラクルが存在することの証跡）
+    expect(notFoundRes.status).toBe(500);
+    expect(mismatchRes.status).toBe(404);
+    expect(notFoundRes.status).not.toBe(mismatchRes.status); // ← 本来はここが同一であるべき
+  });
 });
 
 // ===========================================================================


### PR DESCRIPTION
## 問題
1. これらのルータは `roleAuthMiddleware` が未配線で、各所が `su?.app_metadata?.tenant_id ?? su?.tenant_id` とトップレベルclaimにフォールバックしていた。**client_adminのtenant_idが空だと述語なしクエリに落ちる**経路があった
2. `evaluations/trigger` の `session_id` はbody由来で所有権未検証だった

## 修正
- 3ルータに `roleAuthMiddleware` を配線（client_adminのtenant空を403でfail-closed）
- トップレベルclaimフォールバックを6箇所から除去
- `judgeEvaluator.evaluateSession` に `expectedTenantId` を追加、不一致は専用エラー

## レビュー後の追加修正: 存在確認オラクルの解消
検証の結果、**3経路が別々のステータスを返し、他テナントの有効なsession_idを列挙できる**状態だった:
| ケース | 修正前 | 修正後 |
|---|---|---|
| 存在しない | 500 | **404** |
| 他テナント・未評価 | 404 | **404** |
| 他テナント・**評価済み** | **409** | **404** |

3つ目は `checkAlreadyEvaluated` が**テナント非スコープかつ所有権チェックより前**に走っていたため。同関数に `expectedTenantId` を追加し、`SessionNotFoundError` を新設して `null` の多義性から「不在」を分離（CLAUDE.md禁止事項20「テナント越境は必ず不存在側に倒す」）。

## テスト
`checkAlreadyEvaluated` のSQL分岐が**完全ノーテスト**（全てjest.fnモック）でミューテーションに生き残る状態だったため、リポジトリ層テストを追加。**実装を3通りに壊して全て検出されることを実測**（述語削除→2件失敗 / 三項反転→3件失敗 / パラメータ順誤り→2件失敗）。

## 既知の積み残し
`evaluateSession` の `null` は今も「空/1通話のみ」「Gemini失敗」「内部エラー」の3義を持ち、空セッション（正常）が500になる。後続タスクに分離済み。

---
**由来**: 2026-08-22 ローンチ前セキュリティ監査で検出したP0/P1の修正。実装→テスト強化→マージ前レビュー指摘対応まで完了。
**検証**: 全16ブランチ統合で typecheck 0エラー / フルスイート 3974/4000 pass。残る失敗 `avatar/routes.test.ts` (20件) は無変更のmainでも同一に失敗する既存問題と実測確認済み。新規リグレッションなし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)