### PR TITLE
[SEC][P1] Stripe webhook を冪等化し、処理権獲得をアトミックにする

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,6 +65,8 @@ BASIC_AUTH_TENANT_ID=
 SUPABASE_URL=https://YOUR_PROJECT.supabase.co
 SUPABASE_JWT_SECRET=your-jwt-secret
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+# production 必須（未設定だと起動時に exit(1)）。SUPABASE_JWT_SECRET とは必ず別の値にする —
+# この鍵で署名したトークンは widget.js として公開配布されるため、共用すると公開トークンで管理面に到達できる。
 WIDGET_JWT_SECRET=
 # Admin UI (VITE_ prefix — set in admin-ui/.env.local)
 # VITE_SUPABASE_URL=https://YOUR_PROJECT.supabase.co

--- a/docs/DEPLOY_CHECKLIST.md
+++ b/docs/DEPLOY_CHECKLIST.md
@@ -88,7 +88,27 @@ API_KEY_TENANT_ID=partner
 ALLOWED_ORIGINS=http://65.108.159.161,http://65.108.159.161:5173
 PHASE22_MAX_CONFIRM_REPEATS=2
 DEFAULT_TENANT_ID=partner
+
+# 認証用の署名鍵。production では両方とも必須（未設定だと起動時に process.exit(1)）。
+# 2つは必ず別の値にする — WIDGET_JWT_SECRET で署名するトークンは
+# widget.js として公開配布されるため、管理API用の鍵と共用すると
+# 公開トークンで管理面に到達できてしまう。
+SUPABASE_JWT_SECRET=<supabase-project-jwt-secret>
+WIDGET_JWT_SECRET=<別途生成した独立のランダム値>
 ```
+
+> **⚠️ 新規env `WIDGET_JWT_SECRET` は、デプロイより先に本番 `.env` へ投入すること。**
+> production 必須化（`src/config/env.ts` の起動時バリデーション）と同時に入るため、
+> 未設定のままデプロイすると**起動時に `exit(1)` → PM2 が再起動ループ → API 全断**になる。
+> `SCRIPTS/deploy-vps.sh` は `.env*` を rsync 除外するので、**デプロイでは配布されない**。
+> 順序: ① 本番 `.env` に `WIDGET_JWT_SECRET` を追記 → ② `bash SCRIPTS/deploy-vps.sh`。
+>
+> ```bash
+> # 投入（値は環境ごとに生成する）
+> ssh root@65.108.159.161 'cd /opt/rajiuce && grep -q "^WIDGET_JWT_SECRET=" .env || echo "WIDGET_JWT_SECRET=$(openssl rand -hex 32)" >> .env'
+> # 確認（キー名だけを見る。値は出さない）
+> ssh root@65.108.159.161 'cd /opt/rajiuce && grep -c "^WIDGET_JWT_SECRET=." .env'
+> ```
 
 ```bash
 # Admin UI: /opt/rajiuce/admin-ui/.env.production
@@ -123,6 +143,8 @@ VITE_SUPABASE_ANON_KEY=YOUR_ANON_KEY
 | `src/migrations/phase72a_tenant_settings_history.sql` | tenant_settings_history テーブル新設（設定変更履歴の保存先） | ✅ 2026-08-16 |
 | `src/migrations/phase72d_metrics_snapshots.sql` | metrics_snapshots テーブル新設 | ✅ 2026-08-16 |
 | `src/api/conversion/migration_aaas_source.sql` | conversion_attributions の source CHECK に aaas_site_change 追加 + tenants.aaas_client_id 追加（Asana GID 1215614330355126） | ✅ (2026-08-16 実機確認) |
+| `src/lib/billing/migration_stripe_webhook_events.sql` | stripe_webhook_events テーブル新規作成（Stripe webhook の event.id 冪等化。同一イベント再送での二重処理を防ぐ） | ⬜ 未適用 |
+| `src/lib/billing/migration_stripe_webhook_events.sql` | 同ファイル: `completed_at` カラム追加（2状態管理。ハンドラ失敗後の再送で副作用が永久にスキップされる問題の解消）。**テーブル作成分を先に適用済みの環境でも、この列のために再実行が必要** | ⬜ 未適用 |
 
 ### Phase A Day 2 migration 実行手順
 
@@ -238,6 +260,47 @@ ssh root@65.108.159.161 "psql \$DATABASE_URL -c \"\\d sai_tasks\""
 ```bash
 ssh root@65.108.159.161 "psql \$DATABASE_URL -c 'DROP TABLE IF EXISTS sai_tasks;'"
 ```
+
+### stripe_webhook_events migration 実行手順
+
+> **未適用。** Stripe webhook の冪等化に必要。**適用しないまま新コードをデプロイすると Stripe webhook が全件 500 になる。**
+
+`createStripeWebhookHandler` は署名検証の直後に `stripe_webhook_events` を読み書きする
+（`SELECT completed_at FROM stripe_webhook_events ...` / `INSERT ... ON CONFLICT`）。
+テーブルまたは `completed_at` 列が無いと毎回例外になり、`handler_error` で 500 を返す。
+Stripe は 5xx を一定期間リトライするが、migration を当てるまで**一度も成功しない**ため、
+請求状態の更新 (`billing_status`)・支払い失敗の Slack 通知がすべて止まる。
+
+**適用順序: デプロイ → migration。逆にはできない。**
+`migration_stripe_webhook_events.sql` は rsync でVPSへ配布されるため、デプロイ前はVPS上にファイルが存在しない。
+
+中間状態（デプロイ後・migration前）では webhook が 500 を返し続ける。Stripe のリトライ期間内に
+migration を当てれば取りこぼしは自動で追いつくが、**リトライ期間を過ぎたイベントは失われる**
+（その場合は Stripe ダッシュボードから手動で再送する）。
+**できるだけ短く畳むため、デプロイ直後に続けて実行すること。**
+
+```bash
+# 1. デプロイ (唯一の手順)
+bash SCRIPTS/deploy-vps.sh
+
+# 2. バックアップ (必須)
+ssh root@65.108.159.161 'cd /opt/rajiuce && pg_dump "$(grep -m1 ^DATABASE_URL= .env | cut -d= -f2-)" > /opt/backups/pre_stripe_webhook_events_$(date +%Y%m%d_%H%M).sql'
+
+# 3. 適用前の確認 — テーブルと completed_at 列の有無
+#    (テーブルだけ存在して completed_at が無い状態がありうる。両方見ること)
+ssh root@65.108.159.161 'cd /opt/rajiuce && psql "$(grep -m1 ^DATABASE_URL= .env | cut -d= -f2-)" -c "\d stripe_webhook_events"'
+
+# 4. Migration 実行 (CREATE TABLE IF NOT EXISTS + ADD COLUMN IF NOT EXISTS なので二重実行しても無害)
+ssh root@65.108.159.161 'cd /opt/rajiuce && psql "$(grep -m1 ^DATABASE_URL= .env | cut -d= -f2-)" -f /opt/rajiuce/src/lib/billing/migration_stripe_webhook_events.sql'
+
+# 5. 確認 — event_id(PK) / event_type(NOT NULL) / created_at / completed_at が揃っていること
+ssh root@65.108.159.161 'cd /opt/rajiuce && psql "$(grep -m1 ^DATABASE_URL= .env | cut -d= -f2-)" -c "\d stripe_webhook_events"'
+```
+
+**動作確認**: Stripe ダッシュボードの webhook ログで、直近のイベントが 200 を返していること。
+同一イベントを手動再送すると 2回目は `{"received":true,"duplicate":true}` になる。
+
+**ロールバック**: 新規テーブルのみで既存テーブルへの変更が無いため、コードを戻せばテーブルは無害な残骸になる。
 
 ### 本番500の解消 migration 実行手順 (2026-08-16 実測、Asana 1217530758061266)
 

--- a/src/lib/billing/migration_stripe_webhook_events.sql
+++ b/src/lib/billing/migration_stripe_webhook_events.sql
@@ -1,0 +1,9 @@
+-- Stripe Webhook イベントの冪等性テーブル
+-- 同一 event.id の再送（Stripe側のretry）で副作用（Slack通知・DB更新）が重複しないようにする。
+-- 実行: psql 'postgresql://postgres:...@localhost:5432/commerce_faq' -f migration_stripe_webhook_events.sql
+
+CREATE TABLE IF NOT EXISTS stripe_webhook_events (
+  event_id   TEXT        PRIMARY KEY,
+  event_type TEXT        NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/src/lib/billing/migration_stripe_webhook_events.sql
+++ b/src/lib/billing/migration_stripe_webhook_events.sql
@@ -16,3 +16,14 @@ ALTER TABLE stripe_webhook_events
   ADD COLUMN IF NOT EXISTS completed_at TIMESTAMPTZ;
 COMMENT ON COLUMN stripe_webhook_events.completed_at IS
   '副作用(DB更新・Slack通知)の完了時刻。NULLは前回失敗/処理中を意味し、再送時に再試行を許可する';
+
+-- claimed_at: 「処理中」と「失敗して未完了」を区別するための処理権マーカー。
+-- completed_at だけでは、同一イベントが並行到達したとき両方が「未完了だから再試行」と
+-- 判断して副作用(Slack通知は非冪等)を二重実行してしまう。処理開始時に claimed_at を
+-- 単一の条件付きUPSERTで奪い合わせ、獲得できたリクエストだけがハンドラを実行する。
+-- 古い claimed_at (STALE_CLAIM_MINUTES 経過) は、処理中プロセスのクラッシュとみなして
+-- 再獲得を許可する。これが無いと1度クラッシュしたイベントが永久に処理されなくなる。
+ALTER TABLE stripe_webhook_events
+  ADD COLUMN IF NOT EXISTS claimed_at TIMESTAMPTZ;
+COMMENT ON COLUMN stripe_webhook_events.claimed_at IS
+  '処理権を獲得した時刻。並行配信時の二重実行防止に使う。一定時間経過した claim は処理中プロセスの異常終了とみなし再獲得を許可する';

--- a/src/lib/billing/migration_stripe_webhook_events.sql
+++ b/src/lib/billing/migration_stripe_webhook_events.sql
@@ -7,3 +7,12 @@ CREATE TABLE IF NOT EXISTS stripe_webhook_events (
   event_type TEXT        NOT NULL,
   created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
+
+-- 2状態管理: INSERT時点(created_at)は「受信した」ことしか意味しない。
+-- completed_at が NULL のまま再送されてきた場合は、前回ハンドラが失敗した
+-- （または処理中にクラッシュした）とみなし、副作用を再試行する。
+-- NULLのまま = 未完了、NOT NULL = ハンドラが最後まで成功した。
+ALTER TABLE stripe_webhook_events
+  ADD COLUMN IF NOT EXISTS completed_at TIMESTAMPTZ;
+COMMENT ON COLUMN stripe_webhook_events.completed_at IS
+  '副作用(DB更新・Slack通知)の完了時刻。NULLは前回失敗/処理中を意味し、再送時に再試行を許可する';

--- a/src/lib/billing/stripeWebhook.test.ts
+++ b/src/lib/billing/stripeWebhook.test.ts
@@ -31,7 +31,9 @@ function makeReqRes(overrides: {
 }
 
 describe('createStripeWebhookHandler', () => {
-  const mockDb     = { query: jest.fn().mockResolvedValue({ rowCount: 0, rows: [] }) };
+  // rowCount: 1 が既定 = stripe_webhook_events への冪等INSERTが「新規」として通る状態。
+  // 重複挙動を検証するテストでは個別に rowCount: 0 をmockする。
+  const mockDb     = { query: jest.fn().mockResolvedValue({ rowCount: 1, rows: [] }) };
   const mockLogger = {
     warn:  jest.fn(),
     error: jest.fn(),
@@ -102,7 +104,7 @@ describe('createStripeWebhookHandler', () => {
       subscription: 'sub_abc123',
       amount_due:   1000,
     };
-    const event = { type: 'invoice.payment_succeeded', data: { object: invoice } };
+    const event = { id: 'evt_001', type: 'invoice.payment_succeeded', data: { object: invoice } };
 
     const stripeMock = require('stripe');
     stripeMock.mockImplementationOnce(() => ({
@@ -133,7 +135,7 @@ describe('createStripeWebhookHandler', () => {
       subscription: 'sub_abc456',
       amount_due:   2000,
     };
-    const event = { type: 'invoice.payment_failed', data: { object: invoice } };
+    const event = { id: 'evt_002', type: 'invoice.payment_failed', data: { object: invoice } };
 
     const stripeMock = require('stripe');
     stripeMock.mockImplementationOnce(() => ({
@@ -159,7 +161,7 @@ describe('createStripeWebhookHandler', () => {
 
   it('customer.subscription.deleted イベントでテナントを非アクティブ化する', async () => {
     const subscription = { id: 'sub_deleted_001' };
-    const event = { type: 'customer.subscription.deleted', data: { object: subscription } };
+    const event = { id: 'evt_003', type: 'customer.subscription.deleted', data: { object: subscription } };
 
     const stripeMock = require('stripe');
     stripeMock.mockImplementationOnce(() => ({
@@ -185,5 +187,88 @@ describe('createStripeWebhookHandler', () => {
       expect.objectContaining({ subscriptionId: 'sub_deleted_001' }),
       expect.any(String)
     );
+  });
+
+  describe('冪等性: event.id の重複', () => {
+    it('stripe_webhook_events への冪等INSERTを event.id / event.type で行う', async () => {
+      const invoice = { id: 'inv_010', subscription: 'sub_idem_001', amount_due: 500 };
+      const event = { id: 'evt_idem_001', type: 'invoice.payment_succeeded', data: { object: invoice } };
+
+      const stripeMock = require('stripe');
+      stripeMock.mockImplementationOnce(() => ({
+        webhooks: { constructEvent: jest.fn().mockReturnValue(event) },
+      }));
+
+      const handler = createStripeWebhookHandler(mockDb as any, mockLogger);
+      const { req, res } = makeReqRes({
+        body:    Buffer.from(JSON.stringify(event)),
+        headers: { 'stripe-signature': 'valid_sig' },
+      });
+
+      await handler(req, res);
+
+      expect(res._status).toBe(200);
+      expect(mockDb.query).toHaveBeenCalledWith(
+        expect.stringContaining('ON CONFLICT (event_id) DO NOTHING'),
+        ['evt_idem_001', 'invoice.payment_succeeded']
+      );
+    });
+
+    it('同一 event.id の再送では副作用（DB更新等）をスキップし received:true, duplicate:true を返す', async () => {
+      const invoice = { id: 'inv_011', subscription: 'sub_idem_002', amount_due: 700 };
+      const event = { id: 'evt_idem_002', type: 'invoice.payment_succeeded', data: { object: invoice } };
+
+      // 冪等INSERTが ON CONFLICT に当たった状態（rowCount: 0）＝ 既に処理済み
+      const dedupDb = { query: jest.fn().mockResolvedValue({ rowCount: 0, rows: [] }) };
+
+      const stripeMock = require('stripe');
+      stripeMock.mockImplementationOnce(() => ({
+        webhooks: { constructEvent: jest.fn().mockReturnValue(event) },
+      }));
+
+      const handler = createStripeWebhookHandler(dedupDb as any, mockLogger);
+      const { req, res } = makeReqRes({
+        body:    Buffer.from(JSON.stringify(event)),
+        headers: { 'stripe-signature': 'valid_sig' },
+      });
+
+      await handler(req, res);
+
+      expect(res._status).toBe(200);
+      expect(res._body).toEqual({ received: true, duplicate: true });
+      // dedup INSERT の1回だけが呼ばれ、payment_succeeded の billing_status 更新クエリは呼ばれない
+      expect(dedupDb.query).toHaveBeenCalledTimes(1);
+      expect(dedupDb.query).not.toHaveBeenCalledWith(
+        expect.stringContaining("billing_status = 'paid'"),
+        expect.anything()
+      );
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        expect.objectContaining({ eventId: 'evt_idem_002', eventType: 'invoice.payment_succeeded' }),
+        expect.any(String)
+      );
+    });
+
+    it('署名不正の場合は冪等チェックより前に拒否される（重複INSERTしない）', async () => {
+      const dedupDb = { query: jest.fn().mockResolvedValue({ rowCount: 1, rows: [] }) };
+      const stripeMock = require('stripe');
+      stripeMock.mockImplementationOnce(() => ({
+        webhooks: {
+          constructEvent: jest.fn().mockImplementation(() => {
+            throw new Error('No signatures found matching the expected signature');
+          }),
+        },
+      }));
+
+      const handler = createStripeWebhookHandler(dedupDb as any, mockLogger);
+      const { req, res } = makeReqRes({
+        body:    Buffer.from('{"type":"test"}'),
+        headers: { 'stripe-signature': 'invalid_sig' },
+      });
+
+      await handler(req, res);
+
+      expect(res._status).toBe(400);
+      expect(dedupDb.query).not.toHaveBeenCalled();
+    });
   });
 });

--- a/src/lib/billing/stripeWebhook.test.ts
+++ b/src/lib/billing/stripeWebhook.test.ts
@@ -270,5 +270,150 @@ describe('createStripeWebhookHandler', () => {
       expect(res._status).toBe(400);
       expect(dedupDb.query).not.toHaveBeenCalled();
     });
+
+    it('同一event.idが連続で2回配信された場合、1回目は処理され2回目のみ重複扱いになる（実際のハンドラ呼び出しをまたぐ検証）', async () => {
+      const invoice = { id: 'inv_012', subscription: 'sub_idem_003', amount_due: 300 };
+      const event = { id: 'evt_idem_003', type: 'invoice.payment_succeeded', data: { object: invoice } };
+
+      // 1回目は新規(rowCount:1)、2回目は同一event.idの重複配信(rowCount:0)を、
+      // 同じdbモックへの連続呼び出しで表現する（真の同時実行ではないが、
+      // 「1回目で状態が変わり2回目の判定に影響する」ことを検証する）。
+      const sequentialDb = {
+        query: jest
+          .fn()
+          .mockResolvedValueOnce({ rowCount: 1, rows: [] }) // dedup insert #1: 新規
+          .mockResolvedValueOnce({ rowCount: 5, rows: [] }) // billing_status update #1
+          .mockResolvedValueOnce({ rowCount: 0, rows: [] }), // dedup insert #2: 重複
+      };
+
+      const stripeMock = require('stripe');
+      stripeMock.mockImplementation(() => ({
+        webhooks: { constructEvent: jest.fn().mockReturnValue(event) },
+      }));
+
+      const handler = createStripeWebhookHandler(sequentialDb as any, mockLogger);
+      const { req: req1, res: res1 } = makeReqRes({
+        body: Buffer.from(JSON.stringify(event)),
+        headers: { 'stripe-signature': 'valid_sig' },
+      });
+      const { req: req2, res: res2 } = makeReqRes({
+        body: Buffer.from(JSON.stringify(event)),
+        headers: { 'stripe-signature': 'valid_sig' },
+      });
+
+      await handler(req1, res1);
+      await handler(req2, res2);
+
+      expect(res1._body).toEqual({ received: true });
+      expect(res2._body).toEqual({ received: true, duplicate: true });
+      expect(sequentialDb.query).toHaveBeenCalledTimes(3); // dedup×2 + billing_status更新×1（2回目はスキップされる）
+    });
+
+    it('【設計上の既知リスク】冪等INSERT成功後にハンドラが失敗すると、再送時は"処理済み"と誤判定され副作用が永久に実行されない', async () => {
+      // _recordWebhookEvent は _handleStripeEvent より前に成功しているため、
+      // ハンドラ側で例外が起きて500を返しStripeに再送を促しても、
+      // 再送時点では既にevent_idがDBに記録済み＝rowCount:0で「重複」と誤判定され、
+      // 実際には一度も成功していない副作用（billing_status更新等）が二度と実行されない。
+      // このテストはバグ修正ではなく、現状の挙動を固定して可視化するためのもの。
+      const invoice = { id: 'inv_013', subscription: 'sub_poison', amount_due: 999 };
+      const event = { id: 'evt_poison_001', type: 'invoice.payment_succeeded', data: { object: invoice } };
+
+      const poisonDb = {
+        query: jest
+          .fn()
+          .mockResolvedValueOnce({ rowCount: 1, rows: [] }) // 1回目 dedup insert: 新規として記録される
+          .mockRejectedValueOnce(new Error('DB connection lost')) // 1回目 billing_status更新: 失敗
+          .mockResolvedValueOnce({ rowCount: 0, rows: [] }), // 2回目(Stripeの自動再送) dedup insert: 既に記録済み扱い
+      };
+
+      const stripeMock = require('stripe');
+      stripeMock.mockImplementation(() => ({
+        webhooks: { constructEvent: jest.fn().mockReturnValue(event) },
+      }));
+
+      const handler = createStripeWebhookHandler(poisonDb as any, mockLogger);
+
+      // 1回目: ハンドラ内で例外 → 500（Stripeは5xxで再送する）
+      const { req: req1, res: res1 } = makeReqRes({
+        body: Buffer.from(JSON.stringify(event)),
+        headers: { 'stripe-signature': 'valid_sig' },
+      });
+      await handler(req1, res1);
+      expect(res1._status).toBe(500);
+
+      // 2回目(再送): 既に「新規」として記録済みのため duplicate 扱いになり、
+      // billing_status 更新は一度も成功しないまま 200 が返る。
+      const { req: req2, res: res2 } = makeReqRes({
+        body: Buffer.from(JSON.stringify(event)),
+        headers: { 'stripe-signature': 'valid_sig' },
+      });
+      await handler(req2, res2);
+      expect(res2._status).toBe(200);
+      expect(res2._body).toEqual({ received: true, duplicate: true });
+
+      // 呼び出しは dedup(1回目) → billing_status更新(1回目・失敗) → dedup(2回目・重複判定) の3回のみ。
+      // 4回目（billing_status更新の再試行）が発生しないこと＝再送では二度とハンドラ本体に
+      // 到達しないことを示す。
+      expect(poisonDb.query).toHaveBeenCalledTimes(3);
+      const billingUpdateCalls = poisonDb.query.mock.calls.filter(([sql]) =>
+        typeof sql === 'string' && sql.includes("billing_status = 'paid'")
+      );
+      expect(billingUpdateCalls).toHaveLength(1); // 試行は1回だけ（それも失敗）。再送では二度と試みられない。
+    });
+
+    it('冪等INSERT自体がDBエラーで失敗した場合、200を返さずエラーとして扱う（誤って"処理済み"にしない）', async () => {
+      const invoice = { id: 'inv_014', subscription: 'sub_dberr', amount_due: 100 };
+      const event = { id: 'evt_dberr_001', type: 'invoice.payment_succeeded', data: { object: invoice } };
+
+      const failingDb = {
+        query: jest.fn().mockRejectedValueOnce(new Error('connection timeout')),
+      };
+
+      const stripeMock = require('stripe');
+      stripeMock.mockImplementationOnce(() => ({
+        webhooks: { constructEvent: jest.fn().mockReturnValue(event) },
+      }));
+
+      const handler = createStripeWebhookHandler(failingDb as any, mockLogger);
+      const { req, res } = makeReqRes({
+        body: Buffer.from(JSON.stringify(event)),
+        headers: { 'stripe-signature': 'valid_sig' },
+      });
+
+      await handler(req, res);
+
+      // 冪等INSERT自体の失敗は「重複」ではなくハンドラエラーとして扱われ、
+      // Stripeに再送を促すため 200 を返してはならない。
+      expect(res._status).toBe(500);
+      expect(res._body).not.toMatchObject({ received: true });
+    });
+
+    it('event.id が undefined の異常なイベントでも同期的に例外を投げず、DBクエリへ処理を委譲する', async () => {
+      // Stripe SDK の constructEvent は通常 event.id を必ず含むオブジェクトを返すが、
+      // モック/改ざん耐性として「idが無い」場合にサーバが同期クラッシュしないことを確認する。
+      // 実際の一意性制約はDBスキーマ側の責務であり、ここではアプリ層が例外を吸収し
+      // 500として扱うことのみを検証する（重複判定を誤ってtrueにしない）。
+      const malformedEvent = { type: 'invoice.payment_succeeded', data: { object: { id: 'inv_x' } } };
+
+      const strictDb = {
+        query: jest.fn().mockRejectedValueOnce(
+          new Error('null value in column "event_id" violates not-null constraint')
+        ),
+      };
+
+      const stripeMock = require('stripe');
+      stripeMock.mockImplementationOnce(() => ({
+        webhooks: { constructEvent: jest.fn().mockReturnValue(malformedEvent) },
+      }));
+
+      const handler = createStripeWebhookHandler(strictDb as any, mockLogger);
+      const { req, res } = makeReqRes({
+        body: Buffer.from(JSON.stringify(malformedEvent)),
+        headers: { 'stripe-signature': 'valid_sig' },
+      });
+
+      await expect(handler(req, res)).resolves.not.toThrow();
+      expect(res._status).toBe(500);
+    });
   });
 });

--- a/src/lib/billing/stripeWebhook.test.ts
+++ b/src/lib/billing/stripeWebhook.test.ts
@@ -189,8 +189,13 @@ describe('createStripeWebhookHandler', () => {
     );
   });
 
-  describe('冪等性: event.id の重複', () => {
-    it('stripe_webhook_events への冪等INSERTを event.id / event.type で行う', async () => {
+  describe('冪等性: event.id の重複と並行配信', () => {
+    // 処理権の獲得は単一の条件付きUPSERTで行う（INSERT成否を見てから別クエリで
+    // 状態をSELECTする方式だと、並行到達した2リクエストが両方「未完了だから再試行」と
+    // 判断してハンドラを二重実行しうる。DB更新はWHERE条件付きで冪等だがSlack通知は非冪等）。
+    const CLAIM_SQL = 'ON CONFLICT (event_id) DO UPDATE';
+
+    it('処理権の獲得を event.id / event.type / stale閾値 を渡す単一クエリで行う', async () => {
       const invoice = { id: 'inv_010', subscription: 'sub_idem_001', amount_due: 500 };
       const event = { id: 'evt_idem_001', type: 'invoice.payment_succeeded', data: { object: invoice } };
 
@@ -209,23 +214,22 @@ describe('createStripeWebhookHandler', () => {
 
       expect(res._status).toBe(200);
       expect(mockDb.query).toHaveBeenCalledWith(
-        expect.stringContaining('ON CONFLICT (event_id) DO NOTHING'),
-        ['evt_idem_001', 'invoice.payment_succeeded']
+        expect.stringContaining(CLAIM_SQL),
+        ['evt_idem_001', 'invoice.payment_succeeded', '15']
+      );
+      // 完了済み/処理中を弾く条件が落ちていないこと（これが無いと二重実行に戻る）
+      expect(mockDb.query).toHaveBeenCalledWith(
+        expect.stringContaining('completed_at IS NULL'),
+        expect.anything()
       );
     });
 
-    it('同一 event.id の再送で、前回completed_at済み（=ハンドラが最後まで成功済み）なら副作用をスキップし received:true, duplicate:true を返す', async () => {
+    it('処理権を獲得できなければ（完了済み or 他リクエストが処理中）副作用をスキップし duplicate:true を返す', async () => {
       const invoice = { id: 'inv_011', subscription: 'sub_idem_002', amount_due: 700 };
       const event = { id: 'evt_idem_002', type: 'invoice.payment_succeeded', data: { object: invoice } };
 
-      // 冪等INSERTが ON CONFLICT に当たり（rowCount: 0）、続くSELECTで
-      // completed_at が設定済み ＝ 前回ハンドラが最後まで成功している状態。
-      const dedupDb = {
-        query: jest
-          .fn()
-          .mockResolvedValueOnce({ rowCount: 0, rows: [] }) // dedup insert: 重複
-          .mockResolvedValueOnce({ rows: [{ completed_at: new Date() }] }), // completed_at 確認: 完了済み
-      };
+      // claim の条件付きUPSERTが0行 = 完了済み、または他リクエストが処理中
+      const dedupDb = { query: jest.fn().mockResolvedValue({ rowCount: 0, rows: [] }) };
 
       const stripeMock = require('stripe');
       stripeMock.mockImplementationOnce(() => ({
@@ -242,57 +246,56 @@ describe('createStripeWebhookHandler', () => {
 
       expect(res._status).toBe(200);
       expect(res._body).toEqual({ received: true, duplicate: true });
-      // dedup INSERT + completed_at確認SELECT の2回のみ。billing_status 更新は呼ばれない
-      expect(dedupDb.query).toHaveBeenCalledTimes(2);
+      // claim の1クエリだけ。ハンドラにも completed_at マークにも進まない
+      expect(dedupDb.query).toHaveBeenCalledTimes(1);
       expect(dedupDb.query).not.toHaveBeenCalledWith(
         expect.stringContaining("billing_status = 'paid'"),
         expect.anything()
       );
-      expect(mockLogger.info).toHaveBeenCalledWith(
-        expect.objectContaining({ eventId: 'evt_idem_002', eventType: 'invoice.payment_succeeded' }),
-        expect.any(String)
-      );
     });
 
-    it('同一 event.id の再送で、前回completed_at未設定（=ハンドラ未完了）なら副作用を再試行する', async () => {
-      const invoice = { id: 'inv_011b', subscription: 'sub_idem_002b', amount_due: 700 };
-      const event = { id: 'evt_idem_002b', type: 'invoice.payment_succeeded', data: { object: invoice } };
+    it('[回帰] 同一event.idが並行到達しても、処理権を獲得した側だけが副作用を実行する（二重通知の防止）', async () => {
+      // 実装が claim(条件付きUPSERT) ではなく「INSERT成否 → 別クエリでSELECT」に
+      // 戻ると、2つ目も completed_at IS NULL を見て処理してしまいSlack通知が二重に飛ぶ。
+      const invoice = { id: 'inv_race', subscription: 'sub_race', amount_due: 1200 };
+      const event = { id: 'evt_race_001', type: 'invoice.payment_failed', data: { object: invoice } };
 
-      const retryDb = {
+      const raceDb = {
         query: jest
           .fn()
-          .mockResolvedValueOnce({ rowCount: 0, rows: [] }) // dedup insert: 重複
-          .mockResolvedValueOnce({ rows: [{ completed_at: null }] }) // completed_at確認: 未完了
-          .mockResolvedValueOnce({ rowCount: 1, rows: [] }) // billing_status更新: 今回は成功
-          .mockResolvedValueOnce({ rowCount: 1, rows: [] }), // completed_atマーク
+          .mockResolvedValueOnce({ rowCount: 1, rows: [{ event_id: 'evt_race_001' }] }) // A: claim獲得
+          .mockResolvedValueOnce({ rowCount: 1, rows: [] })                              // A: completed_atマーク
+          .mockResolvedValueOnce({ rowCount: 0, rows: [] }),                             // B: claim失敗(Aが処理中)
       };
 
       const stripeMock = require('stripe');
-      stripeMock.mockImplementationOnce(() => ({
+      stripeMock.mockImplementation(() => ({
         webhooks: { constructEvent: jest.fn().mockReturnValue(event) },
       }));
 
-      const handler = createStripeWebhookHandler(retryDb as any, mockLogger);
-      const { req, res } = makeReqRes({
-        body:    Buffer.from(JSON.stringify(event)),
+      const handler = createStripeWebhookHandler(raceDb as any, mockLogger);
+      const { req: reqA, res: resA } = makeReqRes({
+        body: Buffer.from(JSON.stringify(event)),
+        headers: { 'stripe-signature': 'valid_sig' },
+      });
+      const { req: reqB, res: resB } = makeReqRes({
+        body: Buffer.from(JSON.stringify(event)),
         headers: { 'stripe-signature': 'valid_sig' },
       });
 
-      await handler(req, res);
+      await handler(reqA, resA);
+      await handler(reqB, resB);
 
-      expect(res._status).toBe(200);
-      expect(res._body).toEqual({ received: true }); // duplicateフラグ無し = 実際に処理された
-      expect(retryDb.query).toHaveBeenCalledWith(
-        expect.stringContaining("billing_status = 'paid'"),
-        ['sub_idem_002b']
+      expect(resA._body).toEqual({ received: true });
+      expect(resB._body).toEqual({ received: true, duplicate: true });
+      // payment_failed のハンドラ（Slack通知経路）に到達したのはA側の1回だけ
+      const failedWarns = (mockLogger.warn as jest.Mock).mock.calls.filter(
+        ([arg]) => arg && typeof arg === 'object' && arg.invoiceId === 'inv_race'
       );
-      expect(retryDb.query).toHaveBeenCalledWith(
-        expect.stringContaining('UPDATE stripe_webhook_events SET completed_at'),
-        ['evt_idem_002b']
-      );
+      expect(failedWarns).toHaveLength(1);
     });
 
-    it('署名不正の場合は冪等チェックより前に拒否される（重複INSERTしない）', async () => {
+    it('署名不正の場合は処理権の獲得より前に拒否される（DBに触れない）', async () => {
       const dedupDb = { query: jest.fn().mockResolvedValue({ rowCount: 1, rows: [] }) };
       const stripeMock = require('stripe');
       stripeMock.mockImplementationOnce(() => ({
@@ -315,20 +318,17 @@ describe('createStripeWebhookHandler', () => {
       expect(dedupDb.query).not.toHaveBeenCalled();
     });
 
-    it('同一event.idが連続で2回配信された場合、1回目は処理され2回目のみ重複扱いになる（実際のハンドラ呼び出しをまたぐ検証）', async () => {
+    it('同一event.idが連続で2回配信された場合、1回目は処理され2回目は重複扱いになる', async () => {
       const invoice = { id: 'inv_012', subscription: 'sub_idem_003', amount_due: 300 };
       const event = { id: 'evt_idem_003', type: 'invoice.payment_succeeded', data: { object: invoice } };
 
-      // 1回目: dedup insert新規 → billing_status更新 → completed_atマーク（成功で完結）
-      // 2回目: dedup insert重複 → completed_at確認 → 完了済みなのでスキップ
       const sequentialDb = {
         query: jest
           .fn()
-          .mockResolvedValueOnce({ rowCount: 1, rows: [] }) // dedup insert #1: 新規
-          .mockResolvedValueOnce({ rowCount: 5, rows: [] }) // billing_status update #1
-          .mockResolvedValueOnce({ rowCount: 1, rows: [] }) // completed_atマーク #1
-          .mockResolvedValueOnce({ rowCount: 0, rows: [] }) // dedup insert #2: 重複
-          .mockResolvedValueOnce({ rows: [{ completed_at: new Date() }] }), // completed_at確認 #2: 完了済み
+          .mockResolvedValueOnce({ rowCount: 1, rows: [{ event_id: 'x' }] }) // #1 claim獲得
+          .mockResolvedValueOnce({ rowCount: 5, rows: [] })                  // #1 billing_status更新
+          .mockResolvedValueOnce({ rowCount: 1, rows: [] })                  // #1 completed_atマーク
+          .mockResolvedValueOnce({ rowCount: 0, rows: [] }),                 // #2 claim失敗(完了済み)
       };
 
       const stripeMock = require('stripe');
@@ -351,25 +351,23 @@ describe('createStripeWebhookHandler', () => {
 
       expect(res1._body).toEqual({ received: true });
       expect(res2._body).toEqual({ received: true, duplicate: true });
-      expect(sequentialDb.query).toHaveBeenCalledTimes(5);
+      expect(sequentialDb.query).toHaveBeenCalledTimes(4);
     });
 
-    it('[修正確認] 冪等INSERT成功後にハンドラが失敗しても、completed_atが未設定のため再送時に副作用が再試行される', async () => {
-      // 1回目: dedup insert新規 → billing_status更新が失敗 → completed_atはマークされない(500)
-      // 2回目(Stripeの自動再送): dedup insert重複 → completed_at確認で未完了と判明 →
-      //   'retry'としてbilling_status更新を再試行し、今度は成功してcompleted_atをマークする。
+    it('[修正確認] ハンドラが失敗しても completed_at が付かないため、stale claim 経過後の再送で副作用が再試行される', async () => {
+      // 1回目: claim獲得 → billing_status更新が失敗 → completed_atはマークされない(500)
+      // 2回目(再送): 前回claimがstale閾値を過ぎているので再獲得でき、再試行して成功する。
       const invoice = { id: 'inv_013', subscription: 'sub_poison', amount_due: 999 };
       const event = { id: 'evt_poison_001', type: 'invoice.payment_succeeded', data: { object: invoice } };
 
       const recoveringDb = {
         query: jest
           .fn()
-          .mockResolvedValueOnce({ rowCount: 1, rows: [] }) // 1回目 dedup insert: 新規
-          .mockRejectedValueOnce(new Error('DB connection lost')) // 1回目 billing_status更新: 失敗
-          .mockResolvedValueOnce({ rowCount: 0, rows: [] }) // 2回目 dedup insert: 重複
-          .mockResolvedValueOnce({ rows: [{ completed_at: null }] }) // 2回目 completed_at確認: 未完了 → retry
-          .mockResolvedValueOnce({ rowCount: 1, rows: [] }) // 2回目 billing_status更新: 今度は成功
-          .mockResolvedValueOnce({ rowCount: 1, rows: [] }), // 2回目 completed_atマーク
+          .mockResolvedValueOnce({ rowCount: 1, rows: [{ event_id: 'x' }] })  // #1 claim獲得
+          .mockRejectedValueOnce(new Error('DB connection lost'))             // #1 billing_status更新: 失敗
+          .mockResolvedValueOnce({ rowCount: 1, rows: [{ event_id: 'x' }] })  // #2 claim再獲得(stale)
+          .mockResolvedValueOnce({ rowCount: 1, rows: [] })                   // #2 billing_status更新: 成功
+          .mockResolvedValueOnce({ rowCount: 1, rows: [] }),                  // #2 completed_atマーク
       };
 
       const stripeMock = require('stripe');
@@ -379,7 +377,6 @@ describe('createStripeWebhookHandler', () => {
 
       const handler = createStripeWebhookHandler(recoveringDb as any, mockLogger);
 
-      // 1回目: ハンドラ内で例外 → 500（Stripeは5xxで再送する）
       const { req: req1, res: res1 } = makeReqRes({
         body: Buffer.from(JSON.stringify(event)),
         headers: { 'stripe-signature': 'valid_sig' },
@@ -387,26 +384,56 @@ describe('createStripeWebhookHandler', () => {
       await handler(req1, res1);
       expect(res1._status).toBe(500);
 
-      // 2回目(再送): completed_at未設定と分かり再試行 → 今回は成功
       const { req: req2, res: res2 } = makeReqRes({
         body: Buffer.from(JSON.stringify(event)),
         headers: { 'stripe-signature': 'valid_sig' },
       });
       await handler(req2, res2);
       expect(res2._status).toBe(200);
-      expect(res2._body).toEqual({ received: true }); // duplicateフラグ無し = 実際に再試行され成功した
+      expect(res2._body).toEqual({ received: true });
 
       const billingUpdateCalls = recoveringDb.query.mock.calls.filter(([sql]) =>
         typeof sql === 'string' && sql.includes("billing_status = 'paid'")
       );
       expect(billingUpdateCalls).toHaveLength(2); // 1回目(失敗)・2回目(成功)の両方試行された
       const markCompletedCalls = recoveringDb.query.mock.calls.filter(([sql]) =>
-        typeof sql === 'string' && sql.includes('UPDATE stripe_webhook_events SET completed_at')
+        typeof sql === 'string' && sql.includes('SET completed_at')
       );
       expect(markCompletedCalls).toHaveLength(1); // 成功した2回目のみマークされる
     });
 
-    it('冪等INSERT自体がDBエラーで失敗した場合、200を返さずエラーとして扱う（誤って"処理済み"にしない）', async () => {
+    it('completed_atマーク自体がDB断で失敗した場合、500を返して再送に委ねる（副作用は実行済みなので再試行で重複しうることを明示的に固定）', async () => {
+      const invoice = { id: 'inv_015', subscription: 'sub_markfail', amount_due: 450 };
+      const event = { id: 'evt_markfail_001', type: 'invoice.payment_succeeded', data: { object: invoice } };
+
+      const markFailDb = {
+        query: jest
+          .fn()
+          .mockResolvedValueOnce({ rowCount: 1, rows: [{ event_id: 'x' }] }) // claim獲得
+          .mockResolvedValueOnce({ rowCount: 1, rows: [] })                  // billing_status更新: 成功
+          .mockRejectedValueOnce(new Error('DB connection lost')),           // completed_atマーク: 失敗
+      };
+
+      const stripeMock = require('stripe');
+      stripeMock.mockImplementationOnce(() => ({
+        webhooks: { constructEvent: jest.fn().mockReturnValue(event) },
+      }));
+
+      const handler = createStripeWebhookHandler(markFailDb as any, mockLogger);
+      const { req, res } = makeReqRes({
+        body: Buffer.from(JSON.stringify(event)),
+        headers: { 'stripe-signature': 'valid_sig' },
+      });
+
+      await handler(req, res);
+
+      // 副作用は成功しているが completed_at が付かないため、Stripeの再送で
+      // stale claim 経過後に再実行される（DB更新は冪等、Slack通知は重複しうる）。
+      expect(res._status).toBe(500);
+      expect(res._body).not.toMatchObject({ received: true });
+    });
+
+    it('処理権の獲得クエリ自体がDBエラーで失敗した場合、200を返さずエラーとして扱う', async () => {
       const invoice = { id: 'inv_014', subscription: 'sub_dberr', amount_due: 100 };
       const event = { id: 'evt_dberr_001', type: 'invoice.payment_succeeded', data: { object: invoice } };
 
@@ -427,17 +454,11 @@ describe('createStripeWebhookHandler', () => {
 
       await handler(req, res);
 
-      // 冪等INSERT自体の失敗は「重複」ではなくハンドラエラーとして扱われ、
-      // Stripeに再送を促すため 200 を返してはならない。
       expect(res._status).toBe(500);
       expect(res._body).not.toMatchObject({ received: true });
     });
 
-    it('event.id が undefined の異常なイベントでも同期的に例外を投げず、DBクエリへ処理を委譲する', async () => {
-      // Stripe SDK の constructEvent は通常 event.id を必ず含むオブジェクトを返すが、
-      // モック/改ざん耐性として「idが無い」場合にサーバが同期クラッシュしないことを確認する。
-      // 実際の一意性制約はDBスキーマ側の責務であり、ここではアプリ層が例外を吸収し
-      // 500として扱うことのみを検証する（重複判定を誤ってtrueにしない）。
+    it('event.id が undefined の異常なイベントでも同期的に例外を投げず、500として扱う', async () => {
       const malformedEvent = { type: 'invoice.payment_succeeded', data: { object: { id: 'inv_x' } } };
 
       const strictDb = {

--- a/src/lib/billing/stripeWebhook.test.ts
+++ b/src/lib/billing/stripeWebhook.test.ts
@@ -214,12 +214,18 @@ describe('createStripeWebhookHandler', () => {
       );
     });
 
-    it('同一 event.id の再送では副作用（DB更新等）をスキップし received:true, duplicate:true を返す', async () => {
+    it('同一 event.id の再送で、前回completed_at済み（=ハンドラが最後まで成功済み）なら副作用をスキップし received:true, duplicate:true を返す', async () => {
       const invoice = { id: 'inv_011', subscription: 'sub_idem_002', amount_due: 700 };
       const event = { id: 'evt_idem_002', type: 'invoice.payment_succeeded', data: { object: invoice } };
 
-      // 冪等INSERTが ON CONFLICT に当たった状態（rowCount: 0）＝ 既に処理済み
-      const dedupDb = { query: jest.fn().mockResolvedValue({ rowCount: 0, rows: [] }) };
+      // 冪等INSERTが ON CONFLICT に当たり（rowCount: 0）、続くSELECTで
+      // completed_at が設定済み ＝ 前回ハンドラが最後まで成功している状態。
+      const dedupDb = {
+        query: jest
+          .fn()
+          .mockResolvedValueOnce({ rowCount: 0, rows: [] }) // dedup insert: 重複
+          .mockResolvedValueOnce({ rows: [{ completed_at: new Date() }] }), // completed_at 確認: 完了済み
+      };
 
       const stripeMock = require('stripe');
       stripeMock.mockImplementationOnce(() => ({
@@ -236,8 +242,8 @@ describe('createStripeWebhookHandler', () => {
 
       expect(res._status).toBe(200);
       expect(res._body).toEqual({ received: true, duplicate: true });
-      // dedup INSERT の1回だけが呼ばれ、payment_succeeded の billing_status 更新クエリは呼ばれない
-      expect(dedupDb.query).toHaveBeenCalledTimes(1);
+      // dedup INSERT + completed_at確認SELECT の2回のみ。billing_status 更新は呼ばれない
+      expect(dedupDb.query).toHaveBeenCalledTimes(2);
       expect(dedupDb.query).not.toHaveBeenCalledWith(
         expect.stringContaining("billing_status = 'paid'"),
         expect.anything()
@@ -245,6 +251,44 @@ describe('createStripeWebhookHandler', () => {
       expect(mockLogger.info).toHaveBeenCalledWith(
         expect.objectContaining({ eventId: 'evt_idem_002', eventType: 'invoice.payment_succeeded' }),
         expect.any(String)
+      );
+    });
+
+    it('同一 event.id の再送で、前回completed_at未設定（=ハンドラ未完了）なら副作用を再試行する', async () => {
+      const invoice = { id: 'inv_011b', subscription: 'sub_idem_002b', amount_due: 700 };
+      const event = { id: 'evt_idem_002b', type: 'invoice.payment_succeeded', data: { object: invoice } };
+
+      const retryDb = {
+        query: jest
+          .fn()
+          .mockResolvedValueOnce({ rowCount: 0, rows: [] }) // dedup insert: 重複
+          .mockResolvedValueOnce({ rows: [{ completed_at: null }] }) // completed_at確認: 未完了
+          .mockResolvedValueOnce({ rowCount: 1, rows: [] }) // billing_status更新: 今回は成功
+          .mockResolvedValueOnce({ rowCount: 1, rows: [] }), // completed_atマーク
+      };
+
+      const stripeMock = require('stripe');
+      stripeMock.mockImplementationOnce(() => ({
+        webhooks: { constructEvent: jest.fn().mockReturnValue(event) },
+      }));
+
+      const handler = createStripeWebhookHandler(retryDb as any, mockLogger);
+      const { req, res } = makeReqRes({
+        body:    Buffer.from(JSON.stringify(event)),
+        headers: { 'stripe-signature': 'valid_sig' },
+      });
+
+      await handler(req, res);
+
+      expect(res._status).toBe(200);
+      expect(res._body).toEqual({ received: true }); // duplicateフラグ無し = 実際に処理された
+      expect(retryDb.query).toHaveBeenCalledWith(
+        expect.stringContaining("billing_status = 'paid'"),
+        ['sub_idem_002b']
+      );
+      expect(retryDb.query).toHaveBeenCalledWith(
+        expect.stringContaining('UPDATE stripe_webhook_events SET completed_at'),
+        ['evt_idem_002b']
       );
     });
 
@@ -275,15 +319,16 @@ describe('createStripeWebhookHandler', () => {
       const invoice = { id: 'inv_012', subscription: 'sub_idem_003', amount_due: 300 };
       const event = { id: 'evt_idem_003', type: 'invoice.payment_succeeded', data: { object: invoice } };
 
-      // 1回目は新規(rowCount:1)、2回目は同一event.idの重複配信(rowCount:0)を、
-      // 同じdbモックへの連続呼び出しで表現する（真の同時実行ではないが、
-      // 「1回目で状態が変わり2回目の判定に影響する」ことを検証する）。
+      // 1回目: dedup insert新規 → billing_status更新 → completed_atマーク（成功で完結）
+      // 2回目: dedup insert重複 → completed_at確認 → 完了済みなのでスキップ
       const sequentialDb = {
         query: jest
           .fn()
           .mockResolvedValueOnce({ rowCount: 1, rows: [] }) // dedup insert #1: 新規
           .mockResolvedValueOnce({ rowCount: 5, rows: [] }) // billing_status update #1
-          .mockResolvedValueOnce({ rowCount: 0, rows: [] }), // dedup insert #2: 重複
+          .mockResolvedValueOnce({ rowCount: 1, rows: [] }) // completed_atマーク #1
+          .mockResolvedValueOnce({ rowCount: 0, rows: [] }) // dedup insert #2: 重複
+          .mockResolvedValueOnce({ rows: [{ completed_at: new Date() }] }), // completed_at確認 #2: 完了済み
       };
 
       const stripeMock = require('stripe');
@@ -306,24 +351,25 @@ describe('createStripeWebhookHandler', () => {
 
       expect(res1._body).toEqual({ received: true });
       expect(res2._body).toEqual({ received: true, duplicate: true });
-      expect(sequentialDb.query).toHaveBeenCalledTimes(3); // dedup×2 + billing_status更新×1（2回目はスキップされる）
+      expect(sequentialDb.query).toHaveBeenCalledTimes(5);
     });
 
-    it('【設計上の既知リスク】冪等INSERT成功後にハンドラが失敗すると、再送時は"処理済み"と誤判定され副作用が永久に実行されない', async () => {
-      // _recordWebhookEvent は _handleStripeEvent より前に成功しているため、
-      // ハンドラ側で例外が起きて500を返しStripeに再送を促しても、
-      // 再送時点では既にevent_idがDBに記録済み＝rowCount:0で「重複」と誤判定され、
-      // 実際には一度も成功していない副作用（billing_status更新等）が二度と実行されない。
-      // このテストはバグ修正ではなく、現状の挙動を固定して可視化するためのもの。
+    it('[修正確認] 冪等INSERT成功後にハンドラが失敗しても、completed_atが未設定のため再送時に副作用が再試行される', async () => {
+      // 1回目: dedup insert新規 → billing_status更新が失敗 → completed_atはマークされない(500)
+      // 2回目(Stripeの自動再送): dedup insert重複 → completed_at確認で未完了と判明 →
+      //   'retry'としてbilling_status更新を再試行し、今度は成功してcompleted_atをマークする。
       const invoice = { id: 'inv_013', subscription: 'sub_poison', amount_due: 999 };
       const event = { id: 'evt_poison_001', type: 'invoice.payment_succeeded', data: { object: invoice } };
 
-      const poisonDb = {
+      const recoveringDb = {
         query: jest
           .fn()
-          .mockResolvedValueOnce({ rowCount: 1, rows: [] }) // 1回目 dedup insert: 新規として記録される
+          .mockResolvedValueOnce({ rowCount: 1, rows: [] }) // 1回目 dedup insert: 新規
           .mockRejectedValueOnce(new Error('DB connection lost')) // 1回目 billing_status更新: 失敗
-          .mockResolvedValueOnce({ rowCount: 0, rows: [] }), // 2回目(Stripeの自動再送) dedup insert: 既に記録済み扱い
+          .mockResolvedValueOnce({ rowCount: 0, rows: [] }) // 2回目 dedup insert: 重複
+          .mockResolvedValueOnce({ rows: [{ completed_at: null }] }) // 2回目 completed_at確認: 未完了 → retry
+          .mockResolvedValueOnce({ rowCount: 1, rows: [] }) // 2回目 billing_status更新: 今度は成功
+          .mockResolvedValueOnce({ rowCount: 1, rows: [] }), // 2回目 completed_atマーク
       };
 
       const stripeMock = require('stripe');
@@ -331,7 +377,7 @@ describe('createStripeWebhookHandler', () => {
         webhooks: { constructEvent: jest.fn().mockReturnValue(event) },
       }));
 
-      const handler = createStripeWebhookHandler(poisonDb as any, mockLogger);
+      const handler = createStripeWebhookHandler(recoveringDb as any, mockLogger);
 
       // 1回目: ハンドラ内で例外 → 500（Stripeは5xxで再送する）
       const { req: req1, res: res1 } = makeReqRes({
@@ -341,24 +387,23 @@ describe('createStripeWebhookHandler', () => {
       await handler(req1, res1);
       expect(res1._status).toBe(500);
 
-      // 2回目(再送): 既に「新規」として記録済みのため duplicate 扱いになり、
-      // billing_status 更新は一度も成功しないまま 200 が返る。
+      // 2回目(再送): completed_at未設定と分かり再試行 → 今回は成功
       const { req: req2, res: res2 } = makeReqRes({
         body: Buffer.from(JSON.stringify(event)),
         headers: { 'stripe-signature': 'valid_sig' },
       });
       await handler(req2, res2);
       expect(res2._status).toBe(200);
-      expect(res2._body).toEqual({ received: true, duplicate: true });
+      expect(res2._body).toEqual({ received: true }); // duplicateフラグ無し = 実際に再試行され成功した
 
-      // 呼び出しは dedup(1回目) → billing_status更新(1回目・失敗) → dedup(2回目・重複判定) の3回のみ。
-      // 4回目（billing_status更新の再試行）が発生しないこと＝再送では二度とハンドラ本体に
-      // 到達しないことを示す。
-      expect(poisonDb.query).toHaveBeenCalledTimes(3);
-      const billingUpdateCalls = poisonDb.query.mock.calls.filter(([sql]) =>
+      const billingUpdateCalls = recoveringDb.query.mock.calls.filter(([sql]) =>
         typeof sql === 'string' && sql.includes("billing_status = 'paid'")
       );
-      expect(billingUpdateCalls).toHaveLength(1); // 試行は1回だけ（それも失敗）。再送では二度と試みられない。
+      expect(billingUpdateCalls).toHaveLength(2); // 1回目(失敗)・2回目(成功)の両方試行された
+      const markCompletedCalls = recoveringDb.query.mock.calls.filter(([sql]) =>
+        typeof sql === 'string' && sql.includes('UPDATE stripe_webhook_events SET completed_at')
+      );
+      expect(markCompletedCalls).toHaveLength(1); // 成功した2回目のみマークされる
     });
 
     it('冪等INSERT自体がDBエラーで失敗した場合、200を返さずエラーとして扱う（誤って"処理済み"にしない）', async () => {

--- a/src/lib/billing/stripeWebhook.ts
+++ b/src/lib/billing/stripeWebhook.ts
@@ -43,15 +43,20 @@ export function createStripeWebhookHandler(db: any, logger: pino.Logger) {
     }
 
     try {
-      const isNewEvent = await _recordWebhookEvent(event, db);
-      if (!isNewEvent) {
-        logger.info({ eventId: event.id, eventType: event.type }, '[webhook] duplicate event, skipped');
+      const status = await _recordOrCheckWebhookEvent(event, db);
+      if (status === 'done') {
+        logger.info({ eventId: event.id, eventType: event.type }, '[webhook] duplicate event, already completed, skipped');
         res.json({ received: true, duplicate: true });
         return;
       }
+      // 'new'（初回）または 'retry'（前回未完了 = ハンドラ失敗/処理中クラッシュ）は
+      // どちらも副作用を実行する。'retry' はハンドラ内の各処理が個別に冪等
+      // （UPDATE ... WHERE 条件一致のみ更新、Slack通知は再送の可能性を許容）である前提。
       await _handleStripeEvent(event, db, logger);
+      await _markWebhookEventCompleted(event, db);
       res.json({ received: true });
     } catch (err) {
+      // completed_at を更新しないため、Stripeの再送時は 'retry' として再試行される。
       logger.error({ err, eventType: event.type }, '[webhook] event handling failed');
       res.status(500).json({ error: 'handler_error' });
     }
@@ -59,18 +64,34 @@ export function createStripeWebhookHandler(db: any, logger: pino.Logger) {
 }
 
 /**
- * event.id を stripe_webhook_events に記録し、初回受信かどうかを返す。
- * ON CONFLICT DO NOTHING で重複INSERTを無視し、rowCount で新規/既知を判定する
- * （usageTracker.ts の request_id 冪等パターンと同じ方式）。
+ * event.id を stripe_webhook_events に記録し、処理方針を返す。
+ * - 'new'   : 初回受信（ON CONFLICT に当たらず新規INSERTできた）
+ * - 'retry' : 過去に受信済みだが completed_at が NULL＝前回ハンドラが失敗/未完了
+ *             （record-before-handleのため、成功保証はINSERTではなくcompleted_atが持つ）
+ * - 'done'  : 過去に受信済みかつ completed_at が設定済み＝ハンドラは最後まで成功した
  */
-async function _recordWebhookEvent(event: any, db: any): Promise<boolean> {
-  const result = await db.query(
+async function _recordOrCheckWebhookEvent(event: any, db: any): Promise<'new' | 'retry' | 'done'> {
+  const insertResult = await db.query(
     `INSERT INTO stripe_webhook_events (event_id, event_type)
      VALUES ($1, $2)
      ON CONFLICT (event_id) DO NOTHING`,
     [event.id, event.type]
   );
-  return result.rowCount > 0;
+  if (insertResult.rowCount > 0) return 'new';
+
+  const statusResult = await db.query(
+    `SELECT completed_at FROM stripe_webhook_events WHERE event_id = $1`,
+    [event.id]
+  );
+  return statusResult.rows[0]?.completed_at ? 'done' : 'retry';
+}
+
+/** ハンドラが最後まで成功した後にのみ呼ぶ。再送時の 'retry' 判定に使う。 */
+async function _markWebhookEventCompleted(event: any, db: any): Promise<void> {
+  await db.query(
+    `UPDATE stripe_webhook_events SET completed_at = NOW() WHERE event_id = $1`,
+    [event.id]
+  );
 }
 
 async function _handleStripeEvent(event: any, db: any, logger: pino.Logger): Promise<void> {

--- a/src/lib/billing/stripeWebhook.ts
+++ b/src/lib/billing/stripeWebhook.ts
@@ -43,6 +43,12 @@ export function createStripeWebhookHandler(db: any, logger: pino.Logger) {
     }
 
     try {
+      const isNewEvent = await _recordWebhookEvent(event, db);
+      if (!isNewEvent) {
+        logger.info({ eventId: event.id, eventType: event.type }, '[webhook] duplicate event, skipped');
+        res.json({ received: true, duplicate: true });
+        return;
+      }
       await _handleStripeEvent(event, db, logger);
       res.json({ received: true });
     } catch (err) {
@@ -50,6 +56,21 @@ export function createStripeWebhookHandler(db: any, logger: pino.Logger) {
       res.status(500).json({ error: 'handler_error' });
     }
   };
+}
+
+/**
+ * event.id を stripe_webhook_events に記録し、初回受信かどうかを返す。
+ * ON CONFLICT DO NOTHING で重複INSERTを無視し、rowCount で新規/既知を判定する
+ * （usageTracker.ts の request_id 冪等パターンと同じ方式）。
+ */
+async function _recordWebhookEvent(event: any, db: any): Promise<boolean> {
+  const result = await db.query(
+    `INSERT INTO stripe_webhook_events (event_id, event_type)
+     VALUES ($1, $2)
+     ON CONFLICT (event_id) DO NOTHING`,
+    [event.id, event.type]
+  );
+  return result.rowCount > 0;
 }
 
 async function _handleStripeEvent(event: any, db: any, logger: pino.Logger): Promise<void> {

--- a/src/lib/billing/stripeWebhook.ts
+++ b/src/lib/billing/stripeWebhook.ts
@@ -43,47 +43,55 @@ export function createStripeWebhookHandler(db: any, logger: pino.Logger) {
     }
 
     try {
-      const status = await _recordOrCheckWebhookEvent(event, db);
-      if (status === 'done') {
-        logger.info({ eventId: event.id, eventType: event.type }, '[webhook] duplicate event, already completed, skipped');
+      const claimed = await _claimWebhookEvent(event, db);
+      if (!claimed) {
+        // 完了済み、または他リクエストが処理中。どちらも副作用を実行してはならない。
+        logger.info({ eventId: event.id, eventType: event.type }, '[webhook] event not claimed (completed or in progress), skipped');
         res.json({ received: true, duplicate: true });
         return;
       }
-      // 'new'（初回）または 'retry'（前回未完了 = ハンドラ失敗/処理中クラッシュ）は
-      // どちらも副作用を実行する。'retry' はハンドラ内の各処理が個別に冪等
-      // （UPDATE ... WHERE 条件一致のみ更新、Slack通知は再送の可能性を許容）である前提。
       await _handleStripeEvent(event, db, logger);
       await _markWebhookEventCompleted(event, db);
       res.json({ received: true });
     } catch (err) {
-      // completed_at を更新しないため、Stripeの再送時は 'retry' として再試行される。
+      // completed_at を更新しないため、claim が STALE_CLAIM_MINUTES 経過した後の
+      // Stripe再送で再試行される。
       logger.error({ err, eventType: event.type }, '[webhook] event handling failed');
       res.status(500).json({ error: 'handler_error' });
     }
   };
 }
 
-/**
- * event.id を stripe_webhook_events に記録し、処理方針を返す。
- * - 'new'   : 初回受信（ON CONFLICT に当たらず新規INSERTできた）
- * - 'retry' : 過去に受信済みだが completed_at が NULL＝前回ハンドラが失敗/未完了
- *             （record-before-handleのため、成功保証はINSERTではなくcompleted_atが持つ）
- * - 'done'  : 過去に受信済みかつ completed_at が設定済み＝ハンドラは最後まで成功した
- */
-async function _recordOrCheckWebhookEvent(event: any, db: any): Promise<'new' | 'retry' | 'done'> {
-  const insertResult = await db.query(
-    `INSERT INTO stripe_webhook_events (event_id, event_type)
-     VALUES ($1, $2)
-     ON CONFLICT (event_id) DO NOTHING`,
-    [event.id, event.type]
-  );
-  if (insertResult.rowCount > 0) return 'new';
+/** claim をこの時間放置したら、処理中プロセスの異常終了とみなして再獲得を許可する。 */
+const STALE_CLAIM_MINUTES = 15;
 
-  const statusResult = await db.query(
-    `SELECT completed_at FROM stripe_webhook_events WHERE event_id = $1`,
-    [event.id]
+/**
+ * このリクエストが event の処理権を獲得できたかを返す。
+ *
+ * 単一の条件付きUPSERTで判定するのが要点。INSERT成功/失敗を見てから別クエリで
+ * 状態をSELECTする方式だと、同一イベントが並行到達したときに両方が「未完了だから
+ * 再試行」と判断してハンドラを二重実行しうる（DB更新は WHERE 条件付きで冪等だが、
+ * Slack通知は非冪等なので実害が出る）。
+ *
+ * 獲得できる = 次のいずれか
+ *   - 初回受信（衝突せずINSERTできた）
+ *   - 過去に受信済みだが未完了で、かつ前回の claim が STALE_CLAIM_MINUTES 以上前
+ *     （＝処理中プロセスが落ちたとみなせる）
+ * 獲得できない = 完了済み、または他リクエストが現在処理中。
+ */
+async function _claimWebhookEvent(event: any, db: any): Promise<boolean> {
+  const result = await db.query(
+    `INSERT INTO stripe_webhook_events (event_id, event_type, claimed_at)
+     VALUES ($1, $2, NOW())
+     ON CONFLICT (event_id) DO UPDATE
+       SET claimed_at = NOW()
+     WHERE stripe_webhook_events.completed_at IS NULL
+       AND (stripe_webhook_events.claimed_at IS NULL
+            OR stripe_webhook_events.claimed_at < NOW() - ($3 || ' minutes')::INTERVAL)
+     RETURNING event_id`,
+    [event.id, event.type, String(STALE_CLAIM_MINUTES)]
   );
-  return statusResult.rows[0]?.completed_at ? 'done' : 'retry';
+  return (result.rowCount ?? 0) > 0;
 }
 
 /** ハンドラが最後まで成功した後にのみ呼ぶ。再送時の 'retry' 判定に使う。 */


### PR DESCRIPTION
## 問題
同一 `event.id` の再送（Stripeのリトライ）で副作用（billing_status更新・Slack通知）が重複実行されていた。

## 修正の経緯（レビューで方式を変更）
**第1版**: `stripe_webhook_events` に `event.id` を `ON CONFLICT DO NOTHING` でINSERTし、`completed_at` の2状態で「ハンドラ失敗後の再送は再試行する」ようにした。

**レビューで判明した問題**: この2状態版は「INSERT成否を見る → 別クエリで `completed_at` をSELECT」の2段階のため、**同一イベントが並行到達すると両方が『未完了だから再試行』と判定してハンドラを二重実行する窓を新設**していた（修正前の単純なrecord-before-handleでは2通目が確実にスキップされていたので、第1版が持ち込んだ回帰）。DB更新は `WHERE billing_status='reported'` で冪等だが**Slack通知は非冪等**。

**第2版（本PR最終形）**: 処理権の獲得を**単一の条件付きUPSERT**でアトミック化。
```sql
INSERT ... VALUES (..., NOW())
ON CONFLICT (event_id) DO UPDATE SET claimed_at = NOW()
WHERE completed_at IS NULL
  AND (claimed_at IS NULL OR claimed_at < NOW() - INTERVAL '15 minutes')
RETURNING event_id
```
獲得できたリクエストだけがハンドラを実行。`claimed_at` の導入で「処理中」と「失敗して未完了」を区別でき、クラッシュしたイベントもstale閾値経過後に再獲得できる。**クエリ数はむしろ2→1に減少**。

## テスト
並行到達でハンドラが1回しか走らないことの回帰テスト、`completed_at` マーク自体の失敗経路（レビューで指摘されたギャップ）を追加。**ミューテーション検証済み**（claim結果を無視→3件失敗 / `completed_at` 条件削除→1件失敗 / 復元で15/15 pass）。

## ⚠️ migration適用が必須（未適用でデプロイするとwebhookが全件500）
`stripe_webhook_events` はテーブル作成自体も含めて `docs/DEPLOY_CHECKLIST.md` の台帳に未登録だった（grep 0件）。台帳2行と実行手順・ロールバック手順を本PRで追記。**適用は人手**（CLAUDE.md: migration自動実行は禁止）。
あわせて #802 の `WIDGET_JWT_SECRET` 投入順序（.env投入→デプロイ）もDEPLOY_CHECKLISTに明記した。

---
**由来**: 2026-08-22 ローンチ前セキュリティ監査で検出したP0/P1の修正。実装→テスト強化→マージ前レビュー指摘対応まで完了。
**検証**: 全16ブランチ統合で typecheck 0エラー / フルスイート 3974/4000 pass。残る失敗 `avatar/routes.test.ts` (20件) は無変更のmainでも同一に失敗する既存問題と実測確認済み。新規リグレッションなし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)