### PR TITLE
[SEC][P1] embeddings / Gemini の trackUsage 計上漏れを解消する

### DIFF
--- a/src/agent/llm/openaiEmbeddingClient.test.ts
+++ b/src/agent/llm/openaiEmbeddingClient.test.ts
@@ -1,0 +1,165 @@
+// src/agent/llm/openaiEmbeddingClient.test.ts
+//
+// E3(trackUsage計上)の壊れやすいポイントを検証する:
+//   - NODE_ENV==='test' の早期return分岐は fetch/trackUsage を一切通らない
+//     (このテストファイル自体が jest 実行中は常に NODE_ENV==='test' のため、
+//      本番相当の分岐を検証するには describe 内で明示的に上書きし、必ず afterEach で
+//      復元する。復元漏れは他ファイルのテストへ波及する — 過去に実際そのクラスの
+//      回帰でテストスイート全体が壊れた実績があるため、try/finally 相当で確実に戻す)
+//   - trackUsage は fire-and-forget (setImmediate) で呼び出し元の返り値をブロック/破壊しない
+//   - tenantId 省略時は billable:false + tenantId:'unknown' で計上される
+//   - 外部API失敗時は trackUsage が呼ばれない(コストは計上されない)
+//   - 同一呼び出しでtrackUsageが二重に呼ばれない
+
+const mockTrackUsage = jest.fn();
+jest.mock("../../lib/billing/usageTracker", () => ({
+  trackUsage: (...args: unknown[]) => mockTrackUsage(...args),
+}));
+
+import { embedText, embedTextOpenAI, embedTextWithUsage } from "./openaiEmbeddingClient";
+
+const ORIGINAL_NODE_ENV = process.env.NODE_ENV;
+const ORIGINAL_API_KEY = process.env.OPENAI_API_KEY;
+
+function mockFetchOk(totalTokens = 42) {
+  (global as any).fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      data: [{ embedding: [0.1, 0.2, 0.3] }],
+      usage: { total_tokens: totalTokens },
+    }),
+  });
+}
+
+function mockFetchFail(status = 500, body = "internal error") {
+  (global as any).fetch = jest.fn().mockResolvedValue({
+    ok: false,
+    status,
+    text: async () => body,
+  });
+}
+
+describe("openaiEmbeddingClient — NODE_ENV==='test' 早期return（既存の前提挙動）", () => {
+  it("fetchもtrackUsageも呼ばずにダミーembeddingを返す", async () => {
+    expect(process.env.NODE_ENV).toBe("test");
+    (global as any).fetch = jest.fn();
+    const result = await embedTextWithUsage("hello");
+    expect(result.embedding).toHaveLength(1536);
+    expect(result.totalTokens).toBe(0);
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
+});
+
+describe("openaiEmbeddingClient — 本番相当分岐（NODE_ENV一時的に上書き）", () => {
+  beforeEach(() => {
+    // テスト用に一時的に書き換える
+    process.env.NODE_ENV = "production";
+    process.env.OPENAI_API_KEY = "test-key";
+    mockTrackUsage.mockClear();
+  });
+
+  afterEach(() => {
+    // 復元漏れは他ファイルのテストに波及するため必ず戻す
+    process.env.NODE_ENV = ORIGINAL_NODE_ENV;
+    process.env.OPENAI_API_KEY = ORIGINAL_API_KEY;
+    delete (global as any).fetch;
+  });
+
+  it("正常系: 成功時にtrackUsageが正しいパラメータで1回だけ呼ばれる", async () => {
+    mockFetchOk(42);
+    const result = await embedTextWithUsage("hello world", { tenantId: "tenant-a", requestId: "req-1" });
+
+    expect(result.totalTokens).toBe(42);
+    expect(mockTrackUsage).toHaveBeenCalledTimes(1);
+    expect(mockTrackUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: "tenant-a",
+        requestId: "req-1",
+        inputTokens: 42,
+        outputTokens: 0,
+        featureUsed: "admin_guide",
+        billable: undefined, // tenantId指定時はfeatureUsedの自動判定に委ねる
+      }),
+    );
+  });
+
+  it("境界値: tenantId未指定時はbillable:falseかつtenantId:'unknown'で計上される", async () => {
+    mockFetchOk(10);
+    await embedTextWithUsage("no tenant context");
+
+    expect(mockTrackUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ tenantId: "unknown", billable: false }),
+    );
+  });
+
+  it("異常系: 外部APIが失敗した場合はtrackUsageを呼ばずthrowする（コスト未計上のまま失敗が伝播する）", async () => {
+    mockFetchFail(500, "rate limited");
+    await expect(embedTextWithUsage("boom")).rejects.toThrow(/OpenAI embeddings failed: 500/);
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
+
+  it("異常系: OPENAI_API_KEY未設定はfetchすら呼ばずthrowする", async () => {
+    delete process.env.OPENAI_API_KEY;
+    (global as any).fetch = jest.fn();
+    await expect(embedTextWithUsage("no key")).rejects.toThrow(/OPENAI_API_KEY is not set/);
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
+
+  it("異常系: レスポンスにembeddingが無い不正な形状でもtrackUsageは呼ばず安全にthrowする", async () => {
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [{}], usage: { total_tokens: 5 } }),
+    });
+    await expect(embedTextWithUsage("malformed")).rejects.toThrow(/embedding not found/);
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
+
+  it("境界値: usage.total_tokensが欠落したレスポンスでも例外を投げず0として計上する", async () => {
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ data: [{ embedding: [0.1] }] }), // usage省略
+    });
+    const result = await embedTextWithUsage("no usage field", { tenantId: "tenant-a" });
+    expect(result.totalTokens).toBe(0);
+    expect(mockTrackUsage).toHaveBeenCalledWith(expect.objectContaining({ inputTokens: 0 }));
+  });
+
+  it("イレギュラー: 同一text・同一tenantIdで連続呼び出ししてもrequestIdが毎回異なり、trackUsageは呼び出し回数分だけ呼ばれる（二重計上防止はDBのON CONFLICTに委ねられており、ここでは呼び出し側が重複排除しないことを固定する）", async () => {
+    mockFetchOk(1);
+    await embedTextWithUsage("same text", { tenantId: "tenant-a" });
+    await embedTextWithUsage("same text", { tenantId: "tenant-a" });
+
+    expect(mockTrackUsage).toHaveBeenCalledTimes(2);
+    const [firstCall, secondCall] = mockTrackUsage.mock.calls;
+    // requestId省略時は呼び出し毎に新規生成される → リトライラッパーがrequestIdを
+    // 明示的に引き継がない限り、再試行のたびに別行として二重計上されるリスクが残る。
+    expect(firstCall[0].requestId).not.toBe(secondCall[0].requestId);
+  });
+
+  it("【既知の残存リスク】呼び出し箇所はtrackUsage()をtry/catchで囲んでいないため、trackUsageが同期的に例外を投げるとembedTextWithUsage自体が失敗する。" +
+    "実運用のtrackUsage(usageTracker.ts)はsetImmediate+内部try/catchで同期例外を投げない設計だが、それは" +
+    "呼び出し元のガードではなく実装依存の暗黙契約でしかない。本テストはこの構造的な脆さを固定して可視化する（対処はスコープ外）",
+  async () => {
+    mockFetchOk(7);
+    mockTrackUsage.mockImplementationOnce(() => {
+      throw new Error("db pool exploded");
+    });
+    // 現状: trackUsageの例外はそのままembedTextWithUsageの失敗として伝播する
+    // （＝正常に取得できたembeddingごと呼び出し元に返せず失う）
+    await expect(embedTextWithUsage("resilient", { tenantId: "tenant-a" })).rejects.toThrow("db pool exploded");
+  });
+
+  it("embedText/embedTextOpenAI（互換ラッパー）もtrackUsageを同様に発火させる", async () => {
+    mockFetchOk(3);
+    const embedding = await embedText("via embedText");
+    expect(embedding).toEqual([0.1, 0.2, 0.3]);
+    expect(mockTrackUsage).toHaveBeenCalledTimes(1);
+
+    mockTrackUsage.mockClear();
+    mockFetchOk(4);
+    await embedTextOpenAI("via embedTextOpenAI");
+    expect(mockTrackUsage).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/agent/llm/openaiEmbeddingClient.test.ts
+++ b/src/agent/llm/openaiEmbeddingClient.test.ts
@@ -138,17 +138,14 @@ describe("openaiEmbeddingClient — 本番相当分岐（NODE_ENV一時的に上
     expect(firstCall[0].requestId).not.toBe(secondCall[0].requestId);
   });
 
-  it("【既知の残存リスク】呼び出し箇所はtrackUsage()をtry/catchで囲んでいないため、trackUsageが同期的に例外を投げるとembedTextWithUsage自体が失敗する。" +
-    "実運用のtrackUsage(usageTracker.ts)はsetImmediate+内部try/catchで同期例外を投げない設計だが、それは" +
-    "呼び出し元のガードではなく実装依存の暗黙契約でしかない。本テストはこの構造的な脆さを固定して可視化する（対処はスコープ外）",
-  async () => {
+  it("[修正確認] trackUsageが同期的に例外を投げても呼び出し元でtry/catchされ、正常取得できたembedding結果は失われずそのまま返る", async () => {
     mockFetchOk(7);
     mockTrackUsage.mockImplementationOnce(() => {
       throw new Error("db pool exploded");
     });
-    // 現状: trackUsageの例外はそのままembedTextWithUsageの失敗として伝播する
-    // （＝正常に取得できたembeddingごと呼び出し元に返せず失う）
-    await expect(embedTextWithUsage("resilient", { tenantId: "tenant-a" })).rejects.toThrow("db pool exploded");
+    const result = await embedTextWithUsage("resilient", { tenantId: "tenant-a" });
+    expect(result.embedding).toEqual([0.1, 0.2, 0.3]);
+    expect(result.totalTokens).toBe(7);
   });
 
   it("embedText/embedTextOpenAI（互換ラッパー）もtrackUsageを同様に発火させる", async () => {

--- a/src/agent/llm/openaiEmbeddingClient.ts
+++ b/src/agent/llm/openaiEmbeddingClient.ts
@@ -2,6 +2,7 @@
 // OpenAI Embeddings を REST API 経由で呼ぶラッパー（SDK 不使用）
 
 import { trackUsage } from "../../lib/billing/usageTracker";
+import { logger } from "../../lib/logger";
 
 export interface EmbedTextResult {
   embedding: number[];
@@ -68,15 +69,22 @@ export async function embedTextWithUsage(
 
   // 呼び出し元がtenantIdを渡していない場合は帰属先不明として billable=false で
   // 原価のみ記録する（誤って"unknown"テナントへ請求しないため）。
-  trackUsage({
-    tenantId: usageContext?.tenantId ?? "unknown",
-    requestId: usageContext?.requestId ?? `embed-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-    model,
-    inputTokens: totalTokens,
-    outputTokens: 0,
-    featureUsed: "admin_guide",
-    billable: usageContext?.tenantId ? undefined : false,
-  });
+  // trackUsageは現状setImmediateでスケジュールするだけの同期voidだが、将来の実装変更で
+  // 同期例外を投げるようになっても、正常取得できたembedding結果を道連れにしないよう
+  // 明示的に隔離する（CLAUDE.md: 副作用の記録の失敗が応答を変えてはならない）。
+  try {
+    trackUsage({
+      tenantId: usageContext?.tenantId ?? "unknown",
+      requestId: usageContext?.requestId ?? `embed-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      model,
+      inputTokens: totalTokens,
+      outputTokens: 0,
+      featureUsed: "admin_guide",
+      billable: usageContext?.tenantId ? undefined : false,
+    });
+  } catch (err) {
+    logger.warn({ err }, "embedTextWithUsage: trackUsage failed (non-blocking)");
+  }
 
   return {
     embedding: embedding.map((v) => (typeof v === "number" ? v : Number(v) || 0)),

--- a/src/agent/llm/openaiEmbeddingClient.ts
+++ b/src/agent/llm/openaiEmbeddingClient.ts
@@ -1,13 +1,29 @@
 // src/agent/llm/openaiEmbeddingClient.ts
 // OpenAI Embeddings を REST API 経由で呼ぶラッパー（SDK 不使用）
 
+import { trackUsage } from "../../lib/billing/usageTracker";
+
 export interface EmbedTextResult {
   embedding: number[];
   /** OpenAI total_tokens（課金合算用）。テストモードでは 0。 */
   totalTokens: number;
 }
 
-export async function embedTextWithUsage(text: string): Promise<EmbedTextResult> {
+/**
+ * 呼び出し元がテナントコンテキストを持つ場合に渡す（省略可）。
+ * 省略時も trackUsage は必ず計上する（tenantId="unknown" / billable=false）—
+ * 呼び出し元を横断して埋め込みコストが一切計上されていなかったため、
+ * 帰属先が未確定でも「原価が見える」状態を優先する。
+ */
+export interface EmbedUsageContext {
+  tenantId?: string;
+  requestId?: string;
+}
+
+export async function embedTextWithUsage(
+  text: string,
+  usageContext?: EmbedUsageContext,
+): Promise<EmbedTextResult> {
   if (process.env.NODE_ENV === "test") {
     return {
       embedding: Array.from({ length: 1536 }, () => Math.random()),
@@ -48,20 +64,34 @@ export async function embedTextWithUsage(text: string): Promise<EmbedTextResult>
     throw new Error("OpenAI embedding not found in response");
   }
 
+  const totalTokens = json?.usage?.total_tokens ?? 0;
+
+  // 呼び出し元がtenantIdを渡していない場合は帰属先不明として billable=false で
+  // 原価のみ記録する（誤って"unknown"テナントへ請求しないため）。
+  trackUsage({
+    tenantId: usageContext?.tenantId ?? "unknown",
+    requestId: usageContext?.requestId ?? `embed-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    model,
+    inputTokens: totalTokens,
+    outputTokens: 0,
+    featureUsed: "admin_guide",
+    billable: usageContext?.tenantId ? undefined : false,
+  });
+
   return {
     embedding: embedding.map((v) => (typeof v === "number" ? v : Number(v) || 0)),
-    totalTokens: json?.usage?.total_tokens ?? 0,
+    totalTokens,
   };
 }
 
-export async function embedText(text: string): Promise<number[]> {
-  const { embedding } = await embedTextWithUsage(text);
+export async function embedText(text: string, usageContext?: EmbedUsageContext): Promise<number[]> {
+  const { embedding } = await embedTextWithUsage(text, usageContext);
   return embedding;
 }
 
 // Backward compatibility: older code expects embedTextOpenAI()
-export async function embedTextOpenAI(text: string): Promise<number[]> {
-  return embedText(text);
+export async function embedTextOpenAI(text: string, usageContext?: EmbedUsageContext): Promise<number[]> {
+  return embedText(text, usageContext);
 }
 // src/agent/llm/modelRouter.ts
 // Phase8: lightweight routing model for planner / answer models (20B / 120B)

--- a/src/lib/gemini/client.test.ts
+++ b/src/lib/gemini/client.test.ts
@@ -1,0 +1,126 @@
+// src/lib/gemini/client.test.ts
+//
+// E3(trackUsage計上)の壊れやすいポイントを検証する:
+//   - 呼び出し元省略時は billable:false・featureUsed:'admin_tuning'（R2C運用コストのみ計上、
+//     Stripe請求数量に含めない）
+//   - usageMetadataが欠落した異常なレスポンスでも例外を投げず0トークンとして安全に計上する
+//   - 外部APIが失敗した場合、trackUsageは呼ばれない（＝失敗コールのコストは現状可視化されない
+//     残存リスク。GEMINI_API_KEY課金は発生しうるため、この非対称は既知の限界として明記する）
+//   - trackUsageの呼び出しはレスポンステキストの取得をブロックしない
+
+const mockTrackUsage = jest.fn();
+jest.mock("../billing/usageTracker", () => ({
+  trackUsage: (...args: unknown[]) => mockTrackUsage(...args),
+}));
+
+import { callGeminiJudge } from "./client";
+
+const ORIGINAL_API_KEY = process.env.GEMINI_API_KEY;
+
+function mockFetchOk(text: string, promptTokenCount = 100, candidatesTokenCount = 50) {
+  (global as any).fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      candidates: [{ content: { parts: [{ text }] } }],
+      usageMetadata: { promptTokenCount, candidatesTokenCount },
+    }),
+  });
+}
+
+beforeEach(() => {
+  process.env.GEMINI_API_KEY = "test-key";
+  mockTrackUsage.mockClear();
+});
+
+afterEach(() => {
+  process.env.GEMINI_API_KEY = ORIGINAL_API_KEY;
+  delete (global as any).fetch;
+});
+
+describe("callGeminiJudge — 正常系", () => {
+  it("成功時にレスポンステキストを返し、trackUsageを実トークン数で1回呼ぶ", async () => {
+    mockFetchOk("判定結果です", 120, 60);
+    const text = await callGeminiJudge("この応答を評価して");
+
+    expect(text).toBe("判定結果です");
+    expect(mockTrackUsage).toHaveBeenCalledTimes(1);
+    expect(mockTrackUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        inputTokens: 120,
+        outputTokens: 60,
+        featureUsed: "admin_tuning",
+        billable: false,
+      }),
+    );
+  });
+
+  it("tenantId/billableを明示指定した場合はそれが優先される（テナント課金対象にできる余地を確認）", async () => {
+    mockFetchOk("ok");
+    await callGeminiJudge("prompt", { tenantId: "tenant-a", billable: true, requestId: "req-x" });
+
+    expect(mockTrackUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ tenantId: "tenant-a", billable: true, requestId: "req-x" }),
+    );
+  });
+});
+
+describe("callGeminiJudge — 境界値・異常系", () => {
+  it("usageMetadataが欠落したレスポンスでも例外を投げず0トークンで計上する", async () => {
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ candidates: [{ content: { parts: [{ text: "ok" }] } }] }), // usageMetadata省略
+    });
+    const text = await callGeminiJudge("prompt");
+    expect(text).toBe("ok");
+    expect(mockTrackUsage).toHaveBeenCalledWith(
+      expect.objectContaining({ inputTokens: 0, outputTokens: 0 }),
+    );
+  });
+
+  it("candidatesが空配列の異常なレスポンスでも例外を投げず空文字を返す（LLM出力欠落を無言で握りつぶさないよう、呼び出し元での空文字ハンドリングが前提になる点に注意）", async () => {
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ candidates: [] }),
+    });
+    const text = await callGeminiJudge("prompt");
+    expect(text).toBe("");
+    // 空応答でもコスト自体は発生しているためtrackUsageは呼ばれる
+    expect(mockTrackUsage).toHaveBeenCalledTimes(1);
+  });
+
+  it("GEMINI_API_KEY未設定はfetchを呼ばずthrowし、trackUsageも呼ばれない", async () => {
+    delete process.env.GEMINI_API_KEY;
+    (global as any).fetch = jest.fn();
+    await expect(callGeminiJudge("prompt")).rejects.toThrow(/GEMINI_API_KEY not set/);
+    expect(global.fetch).not.toHaveBeenCalled();
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
+
+  it("既知の残存リスク: 外部APIが5xx/4xxで失敗した場合、trackUsageは呼ばれずコストが可視化されない（本テストは現状のこの非対称な挙動を固定するもので、是正はスコープ外）", async () => {
+    (global as any).fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 429,
+      text: async () => "rate limited",
+    });
+    await expect(callGeminiJudge("prompt")).rejects.toThrow(/Gemini API error: 429/);
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
+
+  it("fetch自体がネットワークエラーで例外を投げた場合もtrackUsageは呼ばれず、例外がそのまま伝播する", async () => {
+    (global as any).fetch = jest.fn().mockRejectedValue(new Error("ECONNRESET"));
+    await expect(callGeminiJudge("prompt")).rejects.toThrow("ECONNRESET");
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
+
+  it("【既知の残存リスク】呼び出し箇所はtrackUsage()をtry/catchで囲んでいないため、同期的に例外を投げると" +
+    "callGeminiJudge自体が失敗し、せっかく取得できたJudge結果（大事なLLM出力）ごと失われる。" +
+    "実運用のtrackUsageは設計上ここで例外を投げないが、それは呼び出し元のガードではなく実装依存の暗黙契約。" +
+    "本テストはこの構造的な脆さを固定して可視化する（対処はスコープ外）",
+  async () => {
+    mockFetchOk("大事な判定結果");
+    mockTrackUsage.mockImplementationOnce(() => {
+      throw new Error("db pool exploded");
+    });
+    await expect(callGeminiJudge("prompt")).rejects.toThrow("db pool exploded");
+  });
+});

--- a/src/lib/gemini/client.test.ts
+++ b/src/lib/gemini/client.test.ts
@@ -112,15 +112,12 @@ describe("callGeminiJudge — 境界値・異常系", () => {
     expect(mockTrackUsage).not.toHaveBeenCalled();
   });
 
-  it("【既知の残存リスク】呼び出し箇所はtrackUsage()をtry/catchで囲んでいないため、同期的に例外を投げると" +
-    "callGeminiJudge自体が失敗し、せっかく取得できたJudge結果（大事なLLM出力）ごと失われる。" +
-    "実運用のtrackUsageは設計上ここで例外を投げないが、それは呼び出し元のガードではなく実装依存の暗黙契約。" +
-    "本テストはこの構造的な脆さを固定して可視化する（対処はスコープ外）",
+  it("[修正確認] trackUsageが同期的に例外を投げても呼び出し元でtry/catchされ、正常取得できたJudge結果は失われずそのまま返る",
   async () => {
     mockFetchOk("大事な判定結果");
     mockTrackUsage.mockImplementationOnce(() => {
       throw new Error("db pool exploded");
     });
-    await expect(callGeminiJudge("prompt")).rejects.toThrow("db pool exploded");
+    await expect(callGeminiJudge("prompt")).resolves.toBe("大事な判定結果");
   });
 });

--- a/src/lib/gemini/client.ts
+++ b/src/lib/gemini/client.ts
@@ -52,15 +52,22 @@ export async function callGeminiJudge(prompt: string, usageContext?: GeminiUsage
     | { promptTokenCount?: number; candidatesTokenCount?: number }
     | undefined;
 
-  trackUsage({
-    tenantId: usageContext?.tenantId ?? 'unknown',
-    requestId: usageContext?.requestId ?? `gemini-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-    model: GEMINI_MODEL,
-    inputTokens: usageMetadata?.promptTokenCount ?? 0,
-    outputTokens: usageMetadata?.candidatesTokenCount ?? 0,
-    featureUsed: 'admin_tuning',
-    billable: usageContext?.billable ?? false,
-  });
+  // trackUsageは現状setImmediateでスケジュールするだけの同期voidだが、将来の実装変更で
+  // 同期例外を投げるようになっても、正常取得できたJudge結果を道連れにしないよう
+  // 明示的に隔離する（CLAUDE.md: 副作用の記録の失敗が応答を変えてはならない）。
+  try {
+    trackUsage({
+      tenantId: usageContext?.tenantId ?? 'unknown',
+      requestId: usageContext?.requestId ?? `gemini-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+      model: GEMINI_MODEL,
+      inputTokens: usageMetadata?.promptTokenCount ?? 0,
+      outputTokens: usageMetadata?.candidatesTokenCount ?? 0,
+      featureUsed: 'admin_tuning',
+      billable: usageContext?.billable ?? false,
+    });
+  } catch (err) {
+    logger.warn({ err }, 'callGeminiJudge: trackUsage failed (non-blocking)');
+  }
 
   return text;
 }

--- a/src/lib/gemini/client.ts
+++ b/src/lib/gemini/client.ts
@@ -2,13 +2,26 @@
 // Gemini 2.5 Flash REST client (Phase46)
 
 import pino from 'pino';
+import { trackUsage } from '../billing/usageTracker';
 
 const logger = pino();
 
 const GEMINI_MODEL = process.env['GEMINI_MODEL'] ?? 'gemini-2.5-flash';
 const GEMINI_API_BASE = 'https://generativelanguage.googleapis.com/v1beta/models';
 
-export async function callGeminiJudge(prompt: string): Promise<string> {
+/**
+ * 呼び出し元がテナント/リクエストコンテキストを持つ場合に渡す（省略可）。
+ * 現状の呼び出し元（judgeEvaluator / gapRecommender / contentAnalyzer / bookStructurizer）は
+ * いずれもR2C運用側のLLM機能のため、省略時は billable=false・featureUsed="admin_tuning" で
+ * 原価のみ記録する（Stripe請求数量には含めない）。
+ */
+export interface GeminiUsageContext {
+  tenantId?: string;
+  requestId?: string;
+  billable?: boolean;
+}
+
+export async function callGeminiJudge(prompt: string, usageContext?: GeminiUsageContext): Promise<string> {
   const apiKey = process.env['GEMINI_API_KEY'];
   if (!apiKey) throw new Error('GEMINI_API_KEY not set');
 
@@ -34,5 +47,20 @@ export async function callGeminiJudge(prompt: string): Promise<string> {
   const content = candidates?.[0]?.['content'] as Record<string, unknown> | undefined;
   const parts = content?.['parts'] as Array<Record<string, unknown>> | undefined;
   const text = (parts?.[0]?.['text'] as string) ?? '';
+
+  const usageMetadata = data['usageMetadata'] as
+    | { promptTokenCount?: number; candidatesTokenCount?: number }
+    | undefined;
+
+  trackUsage({
+    tenantId: usageContext?.tenantId ?? 'unknown',
+    requestId: usageContext?.requestId ?? `gemini-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    model: GEMINI_MODEL,
+    inputTokens: usageMetadata?.promptTokenCount ?? 0,
+    outputTokens: usageMetadata?.candidatesTokenCount ?? 0,
+    featureUsed: 'admin_tuning',
+    billable: usageContext?.billable ?? false,
+  });
+
   return text;
 }


### PR DESCRIPTION
## 問題
外部API利用はテナント請求の従量課金だが、embeddings（OpenAI）とGemini（Judge/Gap推薦/コンテンツ分析/書籍構造化）の呼び出しが `trackUsage` を一切計上していなかった。CLAUDE.mdの方針上「上限で止めるのではなく計上を必ず入れる」ため、計上漏れ＝当社負担の請求漏れ。

## 修正
呼び出し元（10箇所以上）ではなく**wrapper層で一括計上**（漏れにくいため）:
- `openaiEmbeddingClient.ts`: 全経路が集約される `embedTextWithUsage` で計上
- `gemini/client.ts`: 単一入口 `callGeminiJudge` で計上。従来破棄していた `usageMetadata` から実トークン数を抽出。呼び出し元は全てR2C運用系のため既定 `billable:false`（原価のみ記録）

レビュー指摘対応として、`trackUsage` 呼び出しを try/catch で隔離（CLAUDE.md「副作用の記録はfire-and-forget、記録の失敗がユーザーへの応答を変えてはならない」を呼び出し元の暗黙依存ではなくコードで保証）。

## 変更しなかったファイル（判断の記録）
`fishVoiceModel.ts` は元監査で計上漏れとされていたが、調査の結果**唯一の呼び出し元 `avatar/routes.ts` の voice-clone / adopt-designed-voice で既に計上済み**と判明（ファイル単体grepでは検出できない）。追加すると二重計上になるため実装せず＝元監査の誤検知。

## テスト
新規2ファイル。外部API失敗時の扱い、`usageMetadata` 欠落時に例外で落ちないこと、**trackUsageが例外を投げても呼び出し元の戻り値が正常に返ること**を固定（18件）。

---
**由来**: 2026-08-22 ローンチ前セキュリティ監査で検出したP0/P1の修正。実装→テスト強化→マージ前レビュー指摘対応まで完了。
**検証**: 全16ブランチ統合で typecheck 0エラー / フルスイート 3974/4000 pass。残る失敗 `avatar/routes.test.ts` (20件) は無変更のmainでも同一に失敗する既存問題と実測確認済み。新規リグレッションなし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)