### PR TITLE
[SEC][P1] APIキーの失効・期限切れを即時反映し、発行時のOrigin制限を保持する

### DIFF
--- a/src/api/admin/tenants/routes.test.ts
+++ b/src/api/admin/tenants/routes.test.ts
@@ -4,6 +4,7 @@
 import express from "express";
 import request from "supertest";
 import { registerTenantAdminRoutes } from "./routes";
+import { registerTenant, setTenantApiKeyExpiry, revokeTenantApiKeyIfCurrent } from "../../../lib/tenant-context";
 
 // --------------------------------------------------------------------------
 // モック
@@ -16,6 +17,8 @@ jest.mock("../../../auth/supabaseClient", () => ({
 jest.mock("../../../lib/tenant-context", () => ({
   registerTenant: jest.fn(),
   updateTenantEnabled: jest.fn(),
+  setTenantApiKeyExpiry: jest.fn(),
+  revokeTenantApiKeyIfCurrent: jest.fn(),
 }));
 
 jest.mock("../../../agent/openclaw/workspaceCache", () => ({
@@ -465,5 +468,113 @@ describe("PATCH /v1/admin/my-tenant — avatar/voice plan ゲート", () => {
       .send({ features: { avatar: true, voice: false, rag: true } });
 
     expect(res.status).toBe(403);
+  });
+});
+
+// --------------------------------------------------------------------------
+// ⑤ POST /v1/admin/tenants/:id/keys — 発行時に allowedOrigins/features を保持
+// --------------------------------------------------------------------------
+
+describe("POST /v1/admin/tenants/:id/keys — in-memory登録がDBの現行設定を上書きしない", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("DB上の allowed_origins / features を registerTenant にそのまま引き継ぐ（固定値で上書きしない）", async () => {
+    const dbQuery = jest
+      .fn()
+      // テナント存在チェック（features/allowed_originsも取得）
+      .mockResolvedValueOnce({
+        rows: [{
+          id: "tenant-a",
+          name: "テストテナント",
+          plan: "growth",
+          is_active: true,
+          features: { avatar: true, voice: true, rag: true },
+          allowed_origins: ["https://shop.example.com"],
+        }],
+        rowCount: 1,
+      })
+      // INSERT INTO tenant_api_keys ... RETURNING
+      .mockResolvedValueOnce({
+        rows: [{ id: "key-1", tenant_id: "tenant-a", key_prefix: "rjc_abcd1234", is_active: true, created_at: new Date().toISOString(), expires_at: null }],
+        rowCount: 1,
+      });
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "super_admin"))
+      .post("/v1/admin/tenants/tenant-a/keys")
+      .set("Authorization", "Bearer dummy")
+      .send({});
+
+    expect(res.status).toBe(201);
+    expect(registerTenant).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tenantId: "tenant-a",
+        features: { avatar: true, voice: true, rag: true },
+        security: expect.objectContaining({ allowedOrigins: ["https://shop.example.com"] }),
+      })
+    );
+    expect(setTenantApiKeyExpiry).toHaveBeenCalledWith("tenant-a", null);
+  });
+
+  it("expires_at 指定時に setTenantApiKeyExpiry へ渡す", async () => {
+    const expiresAtIso = new Date(Date.now() + 86_400_000).toISOString();
+    const dbQuery = jest
+      .fn()
+      .mockResolvedValueOnce({
+        rows: [{ id: "tenant-a", name: "テストテナント", plan: "starter", is_active: true, features: {}, allowed_origins: [] }],
+        rowCount: 1,
+      })
+      .mockResolvedValueOnce({
+        rows: [{ id: "key-2", tenant_id: "tenant-a", key_prefix: "rjc_xyz98765", is_active: true, created_at: new Date().toISOString(), expires_at: expiresAtIso }],
+        rowCount: 1,
+      });
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "super_admin"))
+      .post("/v1/admin/tenants/tenant-a/keys")
+      .set("Authorization", "Bearer dummy")
+      .send({ expires_at: expiresAtIso });
+
+    expect(res.status).toBe(201);
+    expect(setTenantApiKeyExpiry).toHaveBeenCalledWith("tenant-a", expect.any(Date));
+  });
+});
+
+// --------------------------------------------------------------------------
+// ⑥ DELETE /v1/admin/tenants/:id/keys/:keyId — 失効を即時にin-memoryへ反映
+// --------------------------------------------------------------------------
+
+describe("DELETE /v1/admin/tenants/:id/keys/:keyId — PM2再起動を待たずに失効", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("失効したキーのハッシュで revokeTenantApiKeyIfCurrent を呼ぶ", async () => {
+    const dbQuery = jest.fn().mockResolvedValueOnce({
+      rows: [{ id: "key-1", tenant_id: "tenant-a", is_active: false, key_hash: "the-revoked-key-hash" }],
+      rowCount: 1,
+    });
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "super_admin"))
+      .delete("/v1/admin/tenants/tenant-a/keys/key-1")
+      .set("Authorization", "Bearer dummy");
+
+    expect(res.status).toBe(200);
+    expect(revokeTenantApiKeyIfCurrent).toHaveBeenCalledWith("tenant-a", "the-revoked-key-hash");
+  });
+
+  it("存在しないキーIDは404で、revokeTenantApiKeyIfCurrentは呼ばれない", async () => {
+    const dbQuery = jest.fn().mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "super_admin"))
+      .delete("/v1/admin/tenants/tenant-a/keys/nonexistent")
+      .set("Authorization", "Bearer dummy");
+
+    expect(res.status).toBe(404);
+    expect(revokeTenantApiKeyIfCurrent).not.toHaveBeenCalled();
   });
 });

--- a/src/api/admin/tenants/routes.ts
+++ b/src/api/admin/tenants/routes.ts
@@ -560,6 +560,10 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
       if (expiresAt && isNaN(expiresAt.getTime())) {
         return res.status(400).json({ error: "invalid_expires_at", message: "expires_atの日時形式が不正です。" });
       }
+      // 過去日時を許可すると、発行直後から使えない「死んだキー」が201で作れてしまう。
+      if (expiresAt && expiresAt.getTime() <= Date.now()) {
+        return res.status(400).json({ error: "expires_at_in_past", message: "expires_atは未来の日時である必要があります。" });
+      }
 
       const plainKey = generateApiKey();
       const keyHash = hashApiKey(plainKey);

--- a/src/api/admin/tenants/routes.ts
+++ b/src/api/admin/tenants/routes.ts
@@ -6,7 +6,7 @@ import { isAllowedAdminRole } from "../../middleware/roleAuth";
 import { Pool } from "pg";
 import { z } from "zod";
 import jwt from "jsonwebtoken";
-import { registerTenant, updateTenantEnabled } from "../../../lib/tenant-context";
+import { registerTenant, updateTenantEnabled, setTenantApiKeyExpiry, revokeTenantApiKeyIfCurrent } from "../../../lib/tenant-context";
 import { invalidateWorkspaceCache } from "../../../agent/openclaw/workspaceCache";
 import { generateApiKey, hashApiKey, maskApiKeyPrefix } from "./apiKeyUtils";
 import { supabaseAdmin } from "../../../auth/supabaseClient";
@@ -542,8 +542,11 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
   app.post("/v1/admin/tenants/:id/keys", tenantAuth, requireSuperAdmin, async (req: Request, res: Response) => {
     const { id } = req.params;
     try {
-      // テナント存在チェック
-      const tenantCheck = await db.query("SELECT id, name, plan, is_active FROM tenants WHERE id = $1", [id]);
+      // テナント存在チェック（in-memory登録を上書きする際に allowedOrigins/features を保持するため取得）
+      const tenantCheck = await db.query(
+        "SELECT id, name, plan, is_active, features, allowed_origins FROM tenants WHERE id = $1",
+        [id]
+      );
       if (tenantCheck.rowCount === 0) {
         return res.status(404).json({ error: "not_found", message: "テナントが見つかりません。" });
       }
@@ -570,22 +573,25 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
       );
       const row = result.rows[0];
 
-      // in-memory storeのAPIキーハッシュを更新（最新キーで上書き）
+      // in-memory storeのAPIキーハッシュを更新（最新キーで上書き）。
+      // allowedOrigins/features は固定値で潰さず、DB上の現行値を引き継ぐ
+      // （さもないとキー再発行のたびに許可オリジン設定が消える）。
       const tenantRow = tenantCheck.rows[0];
       registerTenant({
         tenantId: tenantRow.id,
         name: tenantRow.name || tenantRow.id,
         plan: tenantRow.plan || "starter",
-        features: { avatar: false, voice: false, rag: true },
+        features: (tenantRow.features as { avatar: boolean; voice: boolean; rag: boolean }) ?? { avatar: false, voice: false, rag: true },
         security: {
           apiKeyHash: keyHash,
           hashAlgorithm: "sha256",
-          allowedOrigins: [],
+          allowedOrigins: tenantRow.allowed_origins ?? [],
           rateLimit: 100,
           rateLimitWindowMs: 60_000,
         },
         enabled: true,
       });
+      setTenantApiKeyExpiry(tenantRow.id, expiresAt);
 
       // 平文キーはこのレスポンスでのみ返す（二度と取得不可）
       return res.status(201).json({
@@ -635,12 +641,14 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
         `UPDATE tenant_api_keys
          SET is_active = false, updated_at = NOW()
          WHERE id = $1 AND tenant_id = $2
-         RETURNING id, tenant_id, is_active`,
+         RETURNING id, tenant_id, is_active, key_hash`,
         [keyId, id]
       );
       if (result.rowCount === 0) {
         return res.status(404).json({ error: "not_found", message: "APIキーが見つかりません。" });
       }
+      // 失効させたキーが現在in-memoryで有効なキーと一致する場合、PM2再起動を待たず即時に無効化する
+      revokeTenantApiKeyIfCurrent(id, result.rows[0].key_hash);
       return res.json({ ok: true, id: keyId, is_active: false });
     } catch (err) {
       logger.warn("[DELETE /v1/admin/tenants/:id/keys/:keyId]", err);

--- a/src/lib/tenant-context.test.ts
+++ b/src/lib/tenant-context.test.ts
@@ -193,4 +193,80 @@ describe("APIキー失効・期限切れの即時反映", () => {
   it("returns undefined for a hash that has never been registered", () => {
     expect(getTenantByApiKeyHash("never-registered-hash")).toBeUndefined();
   });
+
+  it("境界値: expiresAt がちょうど現在時刻と一致する場合は期限切れ扱いになる（<=境界）", () => {
+    const now = Date.now();
+    setTenantApiKeyExpiry(TENANT_ID, new Date(now));
+    // Date.now() が呼び出し間で1ms進む可能性があるため、明示的に同時刻を再現する
+    const spy = jest.spyOn(Date, "now").mockReturnValue(now);
+    try {
+      expect(getTenantByApiKeyHash(KEY_HASH)).toBeUndefined();
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("境界値: expiresAt が1ミリ秒でも未来なら有効", () => {
+    setTenantApiKeyExpiry(TENANT_ID, new Date(Date.now() + 1));
+    expect(getTenantByApiKeyHash(KEY_HASH)?.tenantId).toBe(TENANT_ID);
+  });
+
+  it("setTenantApiKeyExpiry を一度も呼んでいない（Map未登録=undefined）テナントは期限切れ扱いにならない", () => {
+    const FRESH_TENANT = "test-key-no-expiry-call-tenant";
+    const FRESH_HASH = "fresh-hash-no-expiry-call";
+    registerTenant({
+      tenantId: FRESH_TENANT,
+      name: "Fresh",
+      plan: "starter",
+      features: { avatar: false, voice: false, rag: true },
+      security: { apiKeyHash: FRESH_HASH, hashAlgorithm: "sha256", allowedOrigins: [], rateLimit: 100, rateLimitWindowMs: 60_000 },
+      enabled: true,
+    });
+    // setTenantApiKeyExpiry を意図的に呼ばない — 起動時DBシード直後などを想定
+    expect(getTenantByApiKeyHash(FRESH_HASH)?.tenantId).toBe(FRESH_TENANT);
+  });
+
+  it("失効済み(apiKeyHash === '')のテナントは空文字ハッシュでは絶対に引けない（!cfg.security.apiKeyHash ガード）", () => {
+    revokeTenantApiKeyIfCurrent(TENANT_ID, KEY_HASH);
+    expect(getTenantByApiKeyHash("")).toBeUndefined();
+  });
+
+  it("イレギュラー: 同じ失効操作を2回連続で呼んでも例外を投げず、2回目は false（失効済みハッシュはもう current と一致しない）", () => {
+    const first = revokeTenantApiKeyIfCurrent(TENANT_ID, KEY_HASH);
+    const second = revokeTenantApiKeyIfCurrent(TENANT_ID, KEY_HASH);
+    expect(first).toBe(true);
+    expect(second).toBe(false);
+  });
+
+  it("イレギュラー: 失効後に同一テナントへ新キーを再登録すると、旧ハッシュは失敗し新ハッシュのみ有効になる", () => {
+    revokeTenantApiKeyIfCurrent(TENANT_ID, KEY_HASH);
+    const NEW_HASH = "reissued-key-hash";
+    registerTenant({
+      tenantId: TENANT_ID,
+      name: "Revocation Test",
+      plan: "starter",
+      features: { avatar: false, voice: false, rag: true },
+      security: { apiKeyHash: NEW_HASH, hashAlgorithm: "sha256", allowedOrigins: [], rateLimit: 100, rateLimitWindowMs: 60_000 },
+      enabled: true,
+    });
+    expect(getTenantByApiKeyHash(KEY_HASH)).toBeUndefined();
+    expect(getTenantByApiKeyHash(NEW_HASH)?.tenantId).toBe(TENANT_ID);
+  });
+
+  it("revokeTenantApiKeyIfCurrent は失効時に有効期限マップも削除する（無期限キー再発行時に古い期限が亡霊のように残らない）", () => {
+    setTenantApiKeyExpiry(TENANT_ID, new Date(Date.now() + 60_000));
+    revokeTenantApiKeyIfCurrent(TENANT_ID, KEY_HASH);
+    const NEW_HASH = "reissued-key-hash-2";
+    registerTenant({
+      tenantId: TENANT_ID,
+      name: "Revocation Test",
+      plan: "starter",
+      features: { avatar: false, voice: false, rag: true },
+      security: { apiKeyHash: NEW_HASH, hashAlgorithm: "sha256", allowedOrigins: [], rateLimit: 100, rateLimitWindowMs: 60_000 },
+      enabled: true,
+    });
+    // setTenantApiKeyExpiry を再度呼ばずに新キー登録した場合、失効時にMapが掃除されていなければ
+    // 古い期限(60秒後)が誤って新キーに適用されてしまう可能性がある — undefined（無期限扱い）が正しい
+    expect(getTenantByApiKeyHash(NEW_HASH)?.tenantId).toBe(TENANT_ID);
+  });
 });

--- a/src/lib/tenant-context.test.ts
+++ b/src/lib/tenant-context.test.ts
@@ -4,6 +4,9 @@ import {
   registerTenant,
   updateTenantEnabled,
   isOriginKnownToAnyTenant,
+  getTenantByApiKeyHash,
+  setTenantApiKeyExpiry,
+  revokeTenantApiKeyIfCurrent,
 } from "./tenant-context";
 
 describe("seedTenantsFromEnv — numbered keys", () => {
@@ -138,5 +141,56 @@ describe("isOriginKnownToAnyTenant — CORS preflight tenant-domain lookup", () 
       enabled: true,
     });
     expect(isOriginKnownToAnyTenant("https://some-random-site.example")).toBe(false);
+  });
+});
+
+describe("APIキー失効・期限切れの即時反映", () => {
+  const TENANT_ID = "test-key-revocation-tenant";
+  const KEY_HASH = "revocation-test-key-hash";
+
+  beforeEach(() => {
+    registerTenant({
+      tenantId: TENANT_ID,
+      name: "Revocation Test",
+      plan: "starter",
+      features: { avatar: false, voice: false, rag: true },
+      security: { apiKeyHash: KEY_HASH, hashAlgorithm: "sha256", allowedOrigins: [], rateLimit: 100, rateLimitWindowMs: 60_000 },
+      enabled: true,
+    });
+    setTenantApiKeyExpiry(TENANT_ID, null);
+  });
+
+  it("finds the tenant by the currently registered key hash", () => {
+    expect(getTenantByApiKeyHash(KEY_HASH)?.tenantId).toBe(TENANT_ID);
+  });
+
+  it("revokeTenantApiKeyIfCurrent invalidates a matching key immediately (no PM2 restart needed)", () => {
+    const revoked = revokeTenantApiKeyIfCurrent(TENANT_ID, KEY_HASH);
+    expect(revoked).toBe(true);
+    expect(getTenantByApiKeyHash(KEY_HASH)).toBeUndefined();
+  });
+
+  it("revokeTenantApiKeyIfCurrent does nothing when the hash does not match the current key (e.g. an already-superseded key)", () => {
+    const revoked = revokeTenantApiKeyIfCurrent(TENANT_ID, "some-other-old-key-hash");
+    expect(revoked).toBe(false);
+    expect(getTenantByApiKeyHash(KEY_HASH)?.tenantId).toBe(TENANT_ID);
+  });
+
+  it("revokeTenantApiKeyIfCurrent returns false for an unknown tenant", () => {
+    expect(revokeTenantApiKeyIfCurrent("unknown-tenant-xyz", KEY_HASH)).toBe(false);
+  });
+
+  it("treats a key as expired once its expiry time has passed", () => {
+    setTenantApiKeyExpiry(TENANT_ID, new Date(Date.now() - 1000));
+    expect(getTenantByApiKeyHash(KEY_HASH)).toBeUndefined();
+  });
+
+  it("still resolves the tenant when the expiry is in the future", () => {
+    setTenantApiKeyExpiry(TENANT_ID, new Date(Date.now() + 60_000));
+    expect(getTenantByApiKeyHash(KEY_HASH)?.tenantId).toBe(TENANT_ID);
+  });
+
+  it("returns undefined for a hash that has never been registered", () => {
+    expect(getTenantByApiKeyHash("never-registered-hash")).toBeUndefined();
   });
 });

--- a/src/lib/tenant-context.test.ts
+++ b/src/lib/tenant-context.test.ts
@@ -206,8 +206,11 @@ describe("APIキー失効・期限切れの即時反映", () => {
     }
   });
 
-  it("境界値: expiresAt が1ミリ秒でも未来なら有効", () => {
-    setTenantApiKeyExpiry(TENANT_ID, new Date(Date.now() + 1));
+  it("境界値: expiresAt がわずかでも未来なら有効", () => {
+    // 実時間比較のため 1ms 等の極小マージンはテスト実行のオーバーヘッドで
+    // フレークになる（Date.now() 取得からアサーションまでの間に経過しうる）。
+    // 「期限切れ扱いにならない」という意味を保ったまま、余裕を持たせる。
+    setTenantApiKeyExpiry(TENANT_ID, new Date(Date.now() + 5000));
     expect(getTenantByApiKeyHash(KEY_HASH)?.tenantId).toBe(TENANT_ID);
   });
 

--- a/src/lib/tenant-context.ts
+++ b/src/lib/tenant-context.ts
@@ -11,8 +11,38 @@ import { isOriginAllowed } from "../api/middleware/originCheck";
 // ---------------------------------------------------------------------------
 const tenantStore = new Map<string, TenantConfig>();
 
+// APIキーの有効期限。TenantConfig 本体には含めず、キー発行/失効時にのみ
+// registerTenant と対で更新する（型 TenantConfig は他モジュール共有のため変更しない）。
+const apiKeyExpiresAt = new Map<string, number | null>();
+
 export function registerTenant(config: TenantConfig): void {
   tenantStore.set(config.tenantId, config);
+}
+
+/**
+ * APIキー発行/更新時に有効期限を記録する。null は無期限。
+ * registerTenant と同じタイミングで呼び出すこと。
+ */
+export function setTenantApiKeyExpiry(tenantId: string, expiresAt: Date | null): void {
+  apiKeyExpiresAt.set(tenantId, expiresAt ? expiresAt.getTime() : null);
+}
+
+/**
+ * キー失効（DELETE /keys/:keyId）時に、失効対象のハッシュが現在
+ * in-memory に保持中のキーと一致する場合のみ、その場で無効化する。
+ * PM2 再起動を待たずに反映するための即時反映処理。
+ * 戻り値: in-memory 側を無効化したら true。
+ */
+export function revokeTenantApiKeyIfCurrent(tenantId: string, revokedKeyHash: string): boolean {
+  const existing = tenantStore.get(tenantId);
+  if (!existing) return false;
+  if (!safeCompare(existing.security.apiKeyHash, revokedKeyHash)) return false;
+  tenantStore.set(tenantId, {
+    ...existing,
+    security: { ...existing.security, apiKeyHash: "" },
+  });
+  apiKeyExpiresAt.delete(tenantId);
+  return true;
 }
 
 export function getTenantConfig(
@@ -32,7 +62,14 @@ export function getTenantByApiKeyHash(
 ): TenantConfig | undefined {
   const entries = Array.from(tenantStore.values());
   for (const cfg of entries) {
-    if (safeCompare(cfg.security.apiKeyHash, hash)) return cfg;
+    if (!cfg.security.apiKeyHash) continue; // 失効済み(revokeTenantApiKeyIfCurrent)
+    if (safeCompare(cfg.security.apiKeyHash, hash)) {
+      const expiresAt = apiKeyExpiresAt.get(cfg.tenantId);
+      if (expiresAt !== undefined && expiresAt !== null && expiresAt <= Date.now()) {
+        return undefined; // 稼働中に期限切れ（起動時seedはDB側でフィルタ済みだが、以降の失効を反映）
+      }
+      return cfg;
+    }
   }
   return undefined;
 }
@@ -130,6 +167,7 @@ export async function seedTenantsFromDB(pool: Pool, logger?: Logger): Promise<vo
       allowed_origins: string[];
       key_hash: string;
       rate_limit: number | null;
+      expires_at: string | null;
     }>(`
       SELECT
         t.id            AS tenant_id,
@@ -139,6 +177,7 @@ export async function seedTenantsFromDB(pool: Pool, logger?: Logger): Promise<vo
         t.features,
         t.allowed_origins,
         k.key_hash,
+        k.expires_at,
         NULL::int       AS rate_limit
       FROM tenant_api_keys k
       JOIN tenants t ON t.id = k.tenant_id
@@ -166,6 +205,7 @@ export async function seedTenantsFromDB(pool: Pool, logger?: Logger): Promise<vo
         },
         enabled: true,
       });
+      setTenantApiKeyExpiry(row.tenant_id, row.expires_at ? new Date(row.expires_at) : null);
       count++;
     }
     logger?.info({ count }, "seedTenantsFromDB: loaded tenant API keys from DB");

--- a/tests/api/admin/tenants/routes.test.ts
+++ b/tests/api/admin/tenants/routes.test.ts
@@ -2,6 +2,11 @@ import express from "express";
 import request from "supertest";
 import { registerTenantAdminRoutes } from "../../../../src/api/admin/tenants/routes";
 import { generateApiKey, hashApiKey, maskApiKey, maskApiKeyPrefix } from "../../../../src/api/admin/tenants/apiKeyUtils";
+import {
+  registerTenant as mockRegisterTenant,
+  setTenantApiKeyExpiry as mockSetTenantApiKeyExpiry,
+  revokeTenantApiKeyIfCurrent as mockRevokeTenantApiKeyIfCurrent,
+} from "../../../../src/lib/tenant-context";
 
 // tenant-context をモック
 jest.mock("../../../../src/lib/tenant-context", () => ({
@@ -120,6 +125,120 @@ describe("Tenant Admin Routes", () => {
       expect(res.status).toBe(201);
       expect(res.body.api_key).toMatch(/^rjc_/);
       expect(res.body.tenant_id).toBe("t1");
+    });
+
+    it("client_admin は403で弾かれ、キーは一切発行されない（権限境界）", async () => {
+      const callsBefore = (mockRegisterTenant as jest.Mock).mock.calls.length;
+      const res = await request(app)
+        .post("/v1/admin/tenants/t1/keys")
+        .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`);
+      expect(res.status).toBe(403);
+      expect((mockRegisterTenant as jest.Mock).mock.calls.length).toBe(callsBefore);
+    });
+
+    it("既存テナントの allowedOrigins / features を固定値で潰さず引き継ぐ（キー再発行でOrigin制限が消える事故の回帰防止）", async () => {
+      mockDb.query
+        .mockResolvedValueOnce({
+          rows: [{
+            id: "t1", name: "T1", plan: "growth", is_active: true,
+            features: { avatar: true, voice: false, rag: true },
+            allowed_origins: ["https://shop.example.com"],
+          }],
+          rowCount: 1,
+        })
+        .mockResolvedValueOnce({
+          rows: [{ id: "key-uuid", tenant_id: "t1", key_prefix: "rjc_abcd1234", is_active: true, created_at: new Date(), expires_at: null }],
+          rowCount: 1,
+        });
+      const res = await request(app)
+        .post("/v1/admin/tenants/t1/keys")
+        .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`);
+      expect(res.status).toBe(201);
+      const lastCall = (mockRegisterTenant as jest.Mock).mock.calls.at(-1)?.[0];
+      expect(lastCall.security.allowedOrigins).toEqual(["https://shop.example.com"]);
+      expect(lastCall.features).toEqual({ avatar: true, voice: false, rag: true });
+    });
+
+    it("DB側の features / allowed_origins が null（未設定）ならデフォルト値にフォールバックする", async () => {
+      mockDb.query
+        .mockResolvedValueOnce({
+          rows: [{ id: "t1", name: "T1", plan: "starter", is_active: true, features: null, allowed_origins: null }],
+          rowCount: 1,
+        })
+        .mockResolvedValueOnce({
+          rows: [{ id: "key-uuid", tenant_id: "t1", key_prefix: "rjc_abcd1234", is_active: true, created_at: new Date(), expires_at: null }],
+          rowCount: 1,
+        });
+      const res = await request(app)
+        .post("/v1/admin/tenants/t1/keys")
+        .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`);
+      expect(res.status).toBe(201);
+      const lastCall = (mockRegisterTenant as jest.Mock).mock.calls.at(-1)?.[0];
+      expect(lastCall.security.allowedOrigins).toEqual([]);
+      expect(lastCall.features).toEqual({ avatar: false, voice: false, rag: true });
+    });
+
+    it("存在しないテナントIDへのキー発行は404で、in-memory登録は一切行わない", async () => {
+      mockDb.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+      const callsBefore = (mockRegisterTenant as jest.Mock).mock.calls.length;
+      const res = await request(app)
+        .post("/v1/admin/tenants/nonexistent/keys")
+        .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`);
+      expect(res.status).toBe(404);
+      expect((mockRegisterTenant as jest.Mock).mock.calls.length).toBe(callsBefore);
+    });
+
+    it("無効化済み(is_active=false)テナントへのキー発行は403で、in-memory登録は一切行わない", async () => {
+      mockDb.query.mockResolvedValueOnce({ rows: [{ id: "t1", name: "T1", plan: "starter", is_active: false }], rowCount: 1 });
+      const callsBefore = (mockRegisterTenant as jest.Mock).mock.calls.length;
+      const res = await request(app)
+        .post("/v1/admin/tenants/t1/keys")
+        .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`);
+      expect(res.status).toBe(403);
+      expect((mockRegisterTenant as jest.Mock).mock.calls.length).toBe(callsBefore);
+    });
+
+    it("不正な expires_at 文字列は400で拒否され、キーは発行されない", async () => {
+      mockDb.query.mockResolvedValueOnce({ rows: [{ id: "t1", name: "T1", plan: "starter", is_active: true }], rowCount: 1 });
+      const callsBefore = (mockRegisterTenant as jest.Mock).mock.calls.length;
+      const res = await request(app)
+        .post("/v1/admin/tenants/t1/keys")
+        .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`)
+        .send({ expires_at: "not-a-real-date" });
+      expect(res.status).toBe(400);
+      expect((mockRegisterTenant as jest.Mock).mock.calls.length).toBe(callsBefore);
+    });
+
+    it("expires_at が空文字列の場合は「無期限」として扱われる（truthy判定の落とし穴）", async () => {
+      mockDb.query
+        .mockResolvedValueOnce({ rows: [{ id: "t1", name: "T1", plan: "starter", is_active: true }], rowCount: 1 })
+        .mockResolvedValueOnce({
+          rows: [{ id: "key-uuid", tenant_id: "t1", key_prefix: "rjc_abcd1234", is_active: true, created_at: new Date(), expires_at: null }],
+          rowCount: 1,
+        });
+      const res = await request(app)
+        .post("/v1/admin/tenants/t1/keys")
+        .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`)
+        .send({ expires_at: "" });
+      expect(res.status).toBe(201);
+      expect((mockSetTenantApiKeyExpiry as jest.Mock).mock.calls.at(-1)?.[1]).toBeNull();
+    });
+
+    it("イレギュラー: 過去日時の expires_at を指定しても発行自体は201で成功する（＝発行直後から使えない『死んだキー』が作られる、既知の挙動として固定）", async () => {
+      const pastDate = new Date(Date.now() - 86_400_000).toISOString();
+      mockDb.query
+        .mockResolvedValueOnce({ rows: [{ id: "t1", name: "T1", plan: "starter", is_active: true }], rowCount: 1 })
+        .mockResolvedValueOnce({
+          rows: [{ id: "key-uuid", tenant_id: "t1", key_prefix: "rjc_abcd1234", is_active: true, created_at: new Date(), expires_at: pastDate }],
+          rowCount: 1,
+        });
+      const res = await request(app)
+        .post("/v1/admin/tenants/t1/keys")
+        .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`)
+        .send({ expires_at: pastDate });
+      expect(res.status).toBe(201);
+      const passedExpiry = (mockSetTenantApiKeyExpiry as jest.Mock).mock.calls.at(-1)?.[1] as Date;
+      expect(passedExpiry.getTime()).toBeLessThan(Date.now());
     });
   });
 
@@ -620,6 +739,46 @@ describe("Tenant Admin Routes", () => {
         .delete("/v1/admin/tenants/t1/keys/no-key")
         .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`);
       expect(res.status).toBe(404);
+    });
+
+    it("失効させたキーのハッシュを revokeTenantApiKeyIfCurrent に正しい (tenantId, keyHash) で渡す（インメモリ即時反映の配線）", async () => {
+      mockDb.query.mockResolvedValueOnce({ rows: [{ id: "k1", tenant_id: "t1", is_active: false, key_hash: "the-real-key-hash" }], rowCount: 1 });
+      const res = await request(app)
+        .delete("/v1/admin/tenants/t1/keys/k1")
+        .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`);
+      expect(res.status).toBe(200);
+      expect(mockRevokeTenantApiKeyIfCurrent).toHaveBeenLastCalledWith("t1", "the-real-key-hash");
+    });
+
+    it("client_admin は403で弾かれ、失効処理は一切走らない（権限境界）", async () => {
+      const callsBefore = (mockRevokeTenantApiKeyIfCurrent as jest.Mock).mock.calls.length;
+      const res = await request(app)
+        .delete("/v1/admin/tenants/t1/keys/k1")
+        .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`);
+      expect(res.status).toBe(403);
+      expect((mockRevokeTenantApiKeyIfCurrent as jest.Mock).mock.calls.length).toBe(callsBefore);
+    });
+
+    it("越境: 他テナントのkeyIdを指定した場合、DBのWHERE tenant_id条件で一致せず404になり、失効処理も走らない", async () => {
+      // tenant_id=$2 の条件に一致しないシナリオ = DB側が0件を返す（実クエリのWHERE句がこの防御を担う）
+      mockDb.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+      const callsBefore = (mockRevokeTenantApiKeyIfCurrent as jest.Mock).mock.calls.length;
+      const res = await request(app)
+        .delete("/v1/admin/tenants/tenant-a/keys/key-belongs-to-tenant-b")
+        .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`);
+      expect(res.status).toBe(404);
+      expect((mockRevokeTenantApiKeyIfCurrent as jest.Mock).mock.calls.length).toBe(callsBefore);
+    });
+
+    it("イレギュラー: 同じキーを2回連続で失効させても、2回目もエラーにならず200 ok=trueを返す（べき等）", async () => {
+      mockDb.query
+        .mockResolvedValueOnce({ rows: [{ id: "k1", tenant_id: "t1", is_active: false, key_hash: "h1" }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [{ id: "k1", tenant_id: "t1", is_active: false, key_hash: "h1" }], rowCount: 1 });
+      const res1 = await request(app).delete("/v1/admin/tenants/t1/keys/k1").set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`);
+      const res2 = await request(app).delete("/v1/admin/tenants/t1/keys/k1").set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`);
+      expect(res1.status).toBe(200);
+      expect(res2.status).toBe(200);
+      expect(res2.body.ok).toBe(true);
     });
   });
 });

--- a/tests/api/admin/tenants/routes.test.ts
+++ b/tests/api/admin/tenants/routes.test.ts
@@ -224,21 +224,45 @@ describe("Tenant Admin Routes", () => {
       expect((mockSetTenantApiKeyExpiry as jest.Mock).mock.calls.at(-1)?.[1]).toBeNull();
     });
 
-    it("イレギュラー: 過去日時の expires_at を指定しても発行自体は201で成功する（＝発行直後から使えない『死んだキー』が作られる、既知の挙動として固定）", async () => {
+    it("[修正確認] 過去日時の expires_at は400で拒否され、『死んだキー』が発行されない", async () => {
       const pastDate = new Date(Date.now() - 86_400_000).toISOString();
+      mockDb.query.mockResolvedValueOnce({ rows: [{ id: "t1", name: "T1", plan: "starter", is_active: true }], rowCount: 1 });
+      const callsBefore = (mockRegisterTenant as jest.Mock).mock.calls.length;
+      const res = await request(app)
+        .post("/v1/admin/tenants/t1/keys")
+        .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`)
+        .send({ expires_at: pastDate });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("expires_at_in_past");
+      expect((mockRegisterTenant as jest.Mock).mock.calls.length).toBe(callsBefore);
+    });
+
+    it("境界値: 現在時刻ちょうどのexpires_atは『未来ではない』として400で拒否される", async () => {
+      mockDb.query.mockResolvedValueOnce({ rows: [{ id: "t1", name: "T1", plan: "starter", is_active: true }], rowCount: 1 });
+      const now = new Date();
+      const res = await request(app)
+        .post("/v1/admin/tenants/t1/keys")
+        .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`)
+        .send({ expires_at: now.toISOString() });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("expires_at_in_past");
+    });
+
+    it("未来日時のexpires_atは201で正常に発行される", async () => {
+      const futureDate = new Date(Date.now() + 86_400_000).toISOString();
       mockDb.query
         .mockResolvedValueOnce({ rows: [{ id: "t1", name: "T1", plan: "starter", is_active: true }], rowCount: 1 })
         .mockResolvedValueOnce({
-          rows: [{ id: "key-uuid", tenant_id: "t1", key_prefix: "rjc_abcd1234", is_active: true, created_at: new Date(), expires_at: pastDate }],
+          rows: [{ id: "key-uuid", tenant_id: "t1", key_prefix: "rjc_abcd1234", is_active: true, created_at: new Date(), expires_at: futureDate }],
           rowCount: 1,
         });
       const res = await request(app)
         .post("/v1/admin/tenants/t1/keys")
         .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`)
-        .send({ expires_at: pastDate });
+        .send({ expires_at: futureDate });
       expect(res.status).toBe(201);
       const passedExpiry = (mockSetTenantApiKeyExpiry as jest.Mock).mock.calls.at(-1)?.[1] as Date;
-      expect(passedExpiry.getTime()).toBeLessThan(Date.now());
+      expect(passedExpiry.getTime()).toBeGreaterThan(Date.now());
     });
   });
 

--- a/tests/api/admin/tenants/routes.test.ts
+++ b/tests/api/admin/tenants/routes.test.ts
@@ -6,6 +6,9 @@ import { generateApiKey, hashApiKey, maskApiKey, maskApiKeyPrefix } from "../../
 // tenant-context をモック
 jest.mock("../../../../src/lib/tenant-context", () => ({
   registerTenant: jest.fn(),
+  updateTenantEnabled: jest.fn(),
+  setTenantApiKeyExpiry: jest.fn(),
+  revokeTenantApiKeyIfCurrent: jest.fn(),
 }));
 
 // supabaseClient をモック（招待API用 — テストでは不要）


### PR DESCRIPTION
## 問題
1. **失効が効くのはPM2再起動後だった**: 認証は起動時seedのインメモリ `tenantStore` を参照するが、失効APIはDBの `is_active` を落とすだけ。**漏洩キーを失効させても攻撃者は再起動まで使い続けられた**
2. `expires_at` は起動時SQLでしか見ておらず、稼働中に期限切れしたキーが通り続けた
3. キー発行(`POST /keys`)が `registerTenant` に `allowedOrigins: []` `features:{...}` を固定値で渡しており、**キー再発行のたびにOrigin制限が消えていた**（securityPolicyは `allowed.length>0` のときだけOrigin強制するため、二重防御の一方が落ちる）

## 修正
- `tenant-context.ts`: `revokeTenantApiKeyIfCurrent` / `setTenantApiKeyExpiry` を追加。`getTenantByApiKeyHash` で照合時に期限判定
- `tenants/routes.ts`: 失効時にインメモリからも即座に除去。発行時はDBの既存 `features`/`allowed_origins` を引き継ぎ、`security.apiKeyHash` のみ差し替え
- レビュー指摘対応: 過去日時の `expires_at` を400で拒否（発行直後から使えない「死んだキー」の作成防止）

## テスト
失効直後に401 / 期限切れ境界（`<=` 判定の同時刻ケース）/ 失効の2回連続べき等性 / 越境keyIdは404 / **allowedOrigins・featuresの引き継ぎとnullフォールバック**（72件）。
1msマージンでフレークしていた境界値テストも決定的な値に是正。

## ⚠️ 既知の衝突
#805 (D1c) と `src/api/admin/tenants/routes.ts` のimport行で衝突する。解決策は検証済み（両importを残し、D1cが不要にした `import jwt` を削除）。

---
**由来**: 2026-08-22 ローンチ前セキュリティ監査で検出したP0/P1の修正。実装→テスト強化→マージ前レビュー指摘対応まで完了。
**検証**: 全16ブランチ統合で typecheck 0エラー / フルスイート 3974/4000 pass。残る失敗 `avatar/routes.test.ts` (20件) は無変更のmainでも同一に失敗する既存問題と実測確認済み。新規リグレッションなし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)