### PR TITLE
[SEC][P0] src/index.ts の配線統合（rate-limit 2段 / webhook登録順 / tenantId伝播）

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -127,6 +127,16 @@ if (db) {
 // ---------------------------------------------------------------------------
 app.use(requestIdMiddleware);
 app.use(securityHeadersMiddleware);
+
+// Stripe Webhook（raw body 必須 — グローバル express.json より前に登録し、
+// このルートだけ json パーサーの対象から外す。ここで先にマッチしなければ
+// req.body が object に変換されて署名検証(constructEvent)が常に失敗する）
+app.post(
+  "/v1/billing/webhook",
+  express.raw({ type: "application/json" }),
+  createStripeWebhookHandler(db, logger)
+);
+
 app.use(express.json({ limit: "1mb" }));
 
 // ---------------------------------------------------------------------------
@@ -151,11 +161,15 @@ app.use(corsMiddleware);
 //   3. tenantContext  → load TenantConfig into req
 //   4. securityPolicy → per-tenant origin / policy enforcement
 // ---------------------------------------------------------------------------
-const globalRateLimiter = createRateLimitMiddleware({ logger });
+// pre-auth: keyed by nginx X-Real-IP — catches flood traffic before tenantId
+// exists, so one client can no longer exhaust every tenant's shared bucket.
+const ipRateLimiter = createRateLimitMiddleware({ logger, stage: "ip" });
 const authMiddleware = initAuthMiddleware({
   resolveByApiKeyHash: getTenantByApiKeyHash,
 });
 const tenantContext = createTenantContextMiddleware({ logger });
+// post-auth: keyed by tenantId once authMiddleware/tenantContext resolved it.
+const tenantRateLimiter = createRateLimitMiddleware({ logger, stage: "tenant" });
 const securityPolicy = createSecurityPolicyMiddleware({ logger });
 const originCheck = createOriginCheckMiddleware(db, { logger });
 
@@ -223,9 +237,10 @@ app.get("/metrics", internalNetworkOnly, async (req, res) => {
 // Protected API routes — full middleware chain applied
 // ---------------------------------------------------------------------------
 const apiStack = [
-  globalRateLimiter,     // 1. Rate limit
+  ipRateLimiter,         // 1. Rate limit (pre-auth, IP-keyed)
   authMiddleware,        // 2. Auth → tenantId
   tenantContext,         // 3. Load TenantConfig
+  tenantRateLimiter,     // 3.5 Rate limit (post-auth, tenantId-keyed)
   securityPolicy,        // 4. Per-tenant policy (in-memory allowedOrigins)
   originCheck,           // 5. DB-backed per-tenant Origin check
   langDetectMiddleware,  // 6. Phase33: Accept-Language → req.lang
@@ -267,7 +282,8 @@ app.post("/search", ...apiStack, async (req, res) => {
   const { q } = parsed.data;
 
   try {
-    const results = await hybridSearch(q);
+    const tenantId = (req as AuthedRequest).tenantId;
+    const results = await hybridSearch(q, tenantId);
     const re = await rerank(q, results.items, 12);
     return res.json({
       ...results,
@@ -302,8 +318,9 @@ app.post("/search.v1", ...apiStack, async (req, res) => {
   const routeStr = "hybrid:es50+pg50";
 
   try {
+    const tenantId = (req as AuthedRequest).tenantId;
     const tSearch0 = Date.now();
-    const results = await hybridSearch(q);
+    const results = await hybridSearch(q, tenantId);
     const tSearch1 = Date.now();
     const search_ms = Math.max(0, tSearch1 - tSearch0);
 
@@ -377,7 +394,8 @@ app.post("/dialog/turn", ...apiStack, async (req, res) => {
   }
 
   try {
-    const turn = await runDialogTurn(parsed.data);
+    const tenantId = (req as AuthedRequest).tenantId;
+    const turn = await runDialogTurn({ ...parsed.data, tenantId });
     return res.json(turn);
   } catch (error) {
     logger.error({ error }, "[dialog] failed to run dialog turn");
@@ -542,13 +560,6 @@ if (db) initFlowLogger(db, logger);
 
 // Phase72-C: State Machine 遷移ログ
 if (db) initFlowLogger(db, logger);
-
-// Stripe Webhook（raw body 必須 — express.json より前にマッチさせること）
-app.post(
-  "/v1/billing/webhook",
-  express.raw({ type: "application/json" }),
-  createStripeWebhookHandler(db, logger)
-);
 
 // 課金管理API（super_admin / client_admin）
 // ロール検査は registerBillingAdminRoutes 内部で行うため supabaseAuthMiddleware のみ渡す

--- a/src/index.wiringInvariants.test.ts
+++ b/src/index.wiringInvariants.test.ts
@@ -1,0 +1,111 @@
+// src/index.wiringInvariants.test.ts
+//
+// src/index.ts は app.listen() を含む起動エントリポイントで、DB/ES接続などの
+// 副作用を伴うため supertest で丸ごとimportして統合テストすることができない。
+// そのためミドルウェア登録順序という「型では守れない・実行時にしか壊れない」
+// 不変条件を、ソースを直接読んで機械的に検査する(confirmPolicy.test.ts と同じ手法)。
+//
+// このファイルが守る不変条件はいずれも過去に一度壊れた実績がある:
+// - webhook登録順序: グローバル express.json が先に来ると req.body が object化され、
+//   Stripe署名検証(constructEvent)が常に失敗する(今回のC0修正の対象そのもの)。
+// - apiStackの順序: レートリミッタをauth前に置くと全テナント合算の単一バケットになる。
+// - search/dialogのtenantId伝播漏れ: legacy検索がデフォルトインデックスへ無差別に流れる。
+
+import { readFileSync } from "fs";
+import { join } from "path";
+
+const SOURCE_PATH = join(__dirname, "index.ts");
+const source = readFileSync(SOURCE_PATH, "utf-8");
+
+function firstIndexOf(pattern: RegExp): number {
+  const m = source.match(pattern);
+  if (!m || m.index === undefined) {
+    throw new Error(`pattern not found in src/index.ts: ${pattern}`);
+  }
+  return m.index;
+}
+
+describe("src/index.ts 配線の不変条件（ソース構造検査）", () => {
+  describe("Stripe webhook 登録順序", () => {
+    it("/v1/billing/webhook の登録が、グローバル express.json より前にある", () => {
+      const webhookIdx = firstIndexOf(/app\.post\(\s*["']\/v1\/billing\/webhook["']/);
+      const jsonIdx = firstIndexOf(/app\.use\(express\.json\(/);
+      expect(webhookIdx).toBeLessThan(jsonIdx);
+    });
+
+    it("webhook 登録が express.raw({ type: \"application/json\" }) を使っている（rawボディでの署名検証が前提）", () => {
+      const webhookBlock = source.slice(
+        firstIndexOf(/app\.post\(\s*["']\/v1\/billing\/webhook["']/),
+        firstIndexOf(/app\.post\(\s*["']\/v1\/billing\/webhook["']/) + 300
+      );
+      expect(webhookBlock).toMatch(/express\.raw\(\s*\{\s*type:\s*["']application\/json["']\s*\}\s*\)/);
+    });
+
+    it("webhook ルートは1箇所にしか登録されていない（重複登録による二重処理を防ぐ）", () => {
+      const matches = source.match(/app\.(post|use)\(\s*["']\/v1\/billing\/webhook["']/g) ?? [];
+      expect(matches.length).toBe(1);
+    });
+  });
+
+  describe("apiStack のミドルウェア順序（レートリミッタ2段化）", () => {
+    const apiStackMatch = source.match(/const apiStack = \[([\s\S]*?)\] as express\.RequestHandler\[\];/);
+    if (!apiStackMatch) throw new Error("apiStack literal not found in src/index.ts");
+    const apiStackBody = apiStackMatch[1];
+    // 行コメント（例: "// 1. Rate limit (pre-auth, IP-keyed)"）はカンマを含みうるため、
+    // まず行ごとに "//" 以降を切り捨ててから識別子を抽出する（単純な split(",") はコメント内の
+    // カンマで誤爆する）。
+    const order = apiStackBody
+      .split("\n")
+      .map((line) => line.split("//")[0].trim().replace(/,$/, ""))
+      .filter((name) => /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name));
+
+    it("ipRateLimiter が authMiddleware より前（認証前のIP段）", () => {
+      expect(order.indexOf("ipRateLimiter")).toBeGreaterThanOrEqual(0);
+      expect(order.indexOf("ipRateLimiter")).toBeLessThan(order.indexOf("authMiddleware"));
+    });
+
+    it("tenantRateLimiter が authMiddleware・tenantContext より後（認証後のtenant段）", () => {
+      expect(order.indexOf("tenantRateLimiter")).toBeGreaterThan(order.indexOf("authMiddleware"));
+      expect(order.indexOf("tenantRateLimiter")).toBeGreaterThan(order.indexOf("tenantContext"));
+    });
+
+    it("apiStack に旧単一リミッタ(globalRateLimiter)が残っていない（2段化の巻き戻り検出）", () => {
+      expect(order).not.toContain("globalRateLimiter");
+    });
+
+    it("securityPolicy が authMiddleware より後（テナント未確定でorigin検証しない）", () => {
+      expect(order.indexOf("securityPolicy")).toBeGreaterThan(order.indexOf("authMiddleware"));
+    });
+  });
+
+  describe("legacy 検索・対話エンドポイントへの tenantId 伝播", () => {
+    it("/search が hybridSearch に tenantId を渡している", () => {
+      const searchBlock = source.slice(
+        firstIndexOf(/app\.post\(\s*["']\/search["'],/),
+        firstIndexOf(/app\.post\(\s*["']\/search\.v1["']/)
+      );
+      expect(searchBlock).toMatch(/hybridSearch\(\s*q\s*,\s*tenantId\s*\)/);
+    });
+
+    it("/search.v1 が hybridSearch に tenantId を渡している", () => {
+      const idx = firstIndexOf(/app\.post\(\s*["']\/search\.v1["']/);
+      const block = source.slice(idx, idx + 2000);
+      expect(block).toMatch(/hybridSearch\(\s*q\s*,\s*tenantId\s*\)/);
+    });
+
+    it("/dialog/turn が runDialogTurn に tenantId を含めて渡している", () => {
+      const idx = firstIndexOf(/app\.post\(\s*["']\/dialog\/turn["']/);
+      const block = source.slice(idx, idx + 2000);
+      expect(block).toMatch(/runDialogTurn\(\s*\{\s*\.\.\.parsed\.data\s*,\s*tenantId\s*\}\s*\)/);
+    });
+
+    it("/search・/search.v1・/dialog/turn は3箇所とも (req as AuthedRequest).tenantId から取得している（body/queryからの取得を禁止 — CLAUDE.md不変条件1）", () => {
+      // AuthedRequest 経由の取得パターンが最低3回（各ルート1回ずつ）出現することを確認
+      const authedTenantIdUses = source.match(/\(req as AuthedRequest\)\.tenantId/g) ?? [];
+      expect(authedTenantIdUses.length).toBeGreaterThanOrEqual(3);
+      // body/query からの tenantId 直接取得が無いこと
+      expect(source).not.toMatch(/req\.body\.tenantId/);
+      expect(source).not.toMatch(/req\.query\.tenantId/);
+    });
+  });
+});


### PR DESCRIPTION
## ⚠️ このPRは他PRのコミットを含みます（stacked / **最後にマージしてください**）
複数タスクが `src/index.ts` の変更を必要としたため、**このファイルを単独所有するブランチ**を作って衝突を回避する設計にした。その結果、依存先の #799 (A3) / #806 (E1) / #807 (E2) / #801 (B2) のコミットを含んでいる。
それらのPRが先にマージされていれば、本PR固有の差分は `src/index.ts` + 配線テストのみになる。

## 修正内容（本PR固有）
1. **レートリミッタの2段配線**: `ipRateLimiter → authMiddleware → tenantContext → tenantRateLimiter` の順で `apiStack` に配置（#806 のロジックを使用）
2. **Stripe webhook の署名検証を復活**: `/v1/billing/webhook` をグローバル `express.json` より**前**に登録。従来は json パーサが先に body を消費するため `constructEvent` に object が渡り、**署名検証が常に失敗して課金同期が死んでいた**
3. **tenantId の伝播**: `/dialog/turn`・`/search`・`/search.v1` が `req.tenantId` を渡しておらず、`DEFAULT_TENANT_ID` や `faq_demo` にフォールバックしていた経路を是正

## テスト
`src/index.ts` は `app` をexportせずDB/ES接続の副作用を伴う起動エントリポイントのためsupertestで丸ごとimportできない。既存の `confirmPolicy.test.ts` と同じ**ソース構造検査**パターンで配線順序の不変条件を固定した。
**ミューテーション検証済み**: webhook登録順を意図的に逆転させたコピーで実行→失敗、復元→成功を確認。

## 既知の積み残し
実HTTPリクエスト経由の統合テスト（実署名検証・実429発火）は無い。`app` のexport化（`createApp()` 切り出し）が前提となる設計変更のため、後続タスクに分離。

---
**由来**: 2026-08-22 ローンチ前セキュリティ監査で検出したP0/P1の修正。実装→テスト強化→マージ前レビュー指摘対応まで完了。
**検証**: 全16ブランチ統合で typecheck 0エラー / フルスイート 3974/4000 pass。残る失敗 `avatar/routes.test.ts` (20件) は無変更のmainでも同一に失敗する既存問題と実測確認済み。新規リグレッションなし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)