### PR TITLE
docs(deploy): stripe_webhook_events の確認手順に claimed_at を追加

### DIFF
--- a/docs/DEPLOY_CHECKLIST.md
+++ b/docs/DEPLOY_CHECKLIST.md
@@ -265,9 +265,10 @@ ssh root@65.108.159.161 "psql \$DATABASE_URL -c 'DROP TABLE IF EXISTS sai_tasks;
 
 > **未適用。** Stripe webhook の冪等化に必要。**適用しないまま新コードをデプロイすると Stripe webhook が全件 500 になる。**
 
-`createStripeWebhookHandler` は署名検証の直後に `stripe_webhook_events` を読み書きする
-（`SELECT completed_at FROM stripe_webhook_events ...` / `INSERT ... ON CONFLICT`）。
-テーブルまたは `completed_at` 列が無いと毎回例外になり、`handler_error` で 500 を返す。
+`createStripeWebhookHandler` は署名検証の直後に `stripe_webhook_events` へ処理権獲得の
+条件付きUPSERTを発行する（`INSERT ... ON CONFLICT (event_id) DO UPDATE SET claimed_at = NOW()
+WHERE completed_at IS NULL AND (claimed_at IS NULL OR claimed_at < ...)`）。
+テーブル、または `completed_at` / `claimed_at` 列が無いと毎回例外になり、`handler_error` で 500 を返す。
 Stripe は 5xx を一定期間リトライするが、migration を当てるまで**一度も成功しない**ため、
 請求状態の更新 (`billing_status`)・支払い失敗の Slack 通知がすべて止まる。
 
@@ -293,7 +294,8 @@ ssh root@65.108.159.161 'cd /opt/rajiuce && psql "$(grep -m1 ^DATABASE_URL= .env
 # 4. Migration 実行 (CREATE TABLE IF NOT EXISTS + ADD COLUMN IF NOT EXISTS なので二重実行しても無害)
 ssh root@65.108.159.161 'cd /opt/rajiuce && psql "$(grep -m1 ^DATABASE_URL= .env | cut -d= -f2-)" -f /opt/rajiuce/src/lib/billing/migration_stripe_webhook_events.sql'
 
-# 5. 確認 — event_id(PK) / event_type(NOT NULL) / created_at / completed_at が揃っていること
+# 5. 確認 — event_id(PK) / event_type(NOT NULL) / created_at / completed_at / claimed_at の5列が揃っていること
+#    (claimed_at が無いと並行配信時の二重実行防止が効かず、UPSERTが例外になる)
 ssh root@65.108.159.161 'cd /opt/rajiuce && psql "$(grep -m1 ^DATABASE_URL= .env | cut -d= -f2-)" -c "\d stripe_webhook_events"'
 ```
 


### PR DESCRIPTION
## 問題
`docs/DEPLOY_CHECKLIST.md` の migration 確認手順が `completed_at` までしか列挙しておらず、**`claimed_at` が抜けていた**。

PR #807 のレビュー対応で、Stripe webhook の処理権獲得を条件付きUPSERTでアトミック化した際に `claimed_at` 列を追加したが、手順書はその前に書かれていたため古いまま残っていた。

## なぜ問題か
手順書の確認ステップ（`\d stripe_webhook_events` の結果を目視）で「4列揃っているのでOK」と判断できてしまうが、コードは `claimed_at` を参照する（`stripeWebhook.ts` で4箇所）。**確認に通ったのに webhook が例外で500になる**という、最も気づきにくい形の罠になっていた。

## 修正
- 確認手順を5列（`event_id` / `event_type` / `created_at` / `completed_at` / `claimed_at`）に更新し、`claimed_at` が無い場合に何が起きるかを明記
- 処理権獲得のSQL説明を現在の実装（条件付きUPSERT）に合わせて更新（旧記述は `SELECT completed_at` を使う2クエリ版のままだった）

ドキュメントのみの変更。

🤖 Generated with [Claude Code](https://claude.com/claude-code)