### PR TITLE
[LAUNCH][P0] allowed_origins の更新をインメモリに即時反映する

### DIFF
--- a/src/api/admin/tenants/routes.ts
+++ b/src/api/admin/tenants/routes.ts
@@ -6,7 +6,7 @@ import { isAllowedAdminRole } from "../../middleware/roleAuth";
 import { Pool } from "pg";
 import { z } from "zod";
 import { supabaseAuthMiddleware } from "../../../admin/http/supabaseAuthMiddleware";
-import { registerTenant, updateTenantEnabled, setTenantApiKeyExpiry, revokeTenantApiKeyIfCurrent } from "../../../lib/tenant-context";
+import { registerTenant, updateTenantEnabled, updateTenantAllowedOrigins, setTenantApiKeyExpiry, revokeTenantApiKeyIfCurrent } from "../../../lib/tenant-context";
 import { invalidateWorkspaceCache } from "../../../agent/openclaw/workspaceCache";
 import { generateApiKey, hashApiKey, maskApiKeyPrefix } from "./apiKeyUtils";
 import { supabaseAdmin } from "../../../auth/supabaseClient";
@@ -451,6 +451,11 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
       // in-memory store を即時同期 (is_active 変更が次リクエストから有効になる)
       if (fields.is_active !== undefined) {
         updateTenantEnabled(id, fields.is_active);
+      }
+      // allowed_origins も同様。未指定なら呼ばない（フィールド省略と空配列指定を区別する）。
+      // これが無いとCORS許可ドメインの追加/削除がPM2再起動まで反映されなかった。
+      if (fields.allowed_origins !== undefined) {
+        updateTenantAllowedOrigins(id, fields.allowed_origins);
       }
       // Phase47-C: system_prompt 変更時は OpenClaw Workspace キャッシュを無効化
       if (fields.system_prompt !== undefined) {

--- a/src/lib/tenant-context.test.ts
+++ b/src/lib/tenant-context.test.ts
@@ -3,6 +3,7 @@ import {
   getTenantConfig,
   registerTenant,
   updateTenantEnabled,
+  updateTenantAllowedOrigins,
   isOriginKnownToAnyTenant,
   getTenantByApiKeyHash,
   setTenantApiKeyExpiry,
@@ -98,6 +99,63 @@ describe("updateTenantEnabled — kill-switch in-memory sync", () => {
     expect(cfg?.name).toBe("Kill Switch Test");
     expect(cfg?.plan).toBe("starter");
     expect(cfg?.security.apiKeyHash).toBe("dummyhash");
+  });
+});
+
+describe("updateTenantAllowedOrigins — CORS allowlist in-memory sync (PATCH live reload)", () => {
+  const TENANT_ID = "test-origins-live-reload-tenant";
+
+  beforeEach(() => {
+    registerTenant({
+      tenantId: TENANT_ID,
+      name: "Origins Live Reload Test",
+      plan: "starter",
+      features: { avatar: false, voice: false, rag: true },
+      security: {
+        apiKeyHash: "origins-test-hash",
+        hashAlgorithm: "sha256",
+        allowedOrigins: ["https://old-shop.example.com"],
+        rateLimit: 100,
+        rateLimitWindowMs: 60_000,
+      },
+      enabled: true,
+    });
+  });
+
+  it("PATCH直後、再起動なしで新規ドメインが isOriginKnownToAnyTenant に反映される", () => {
+    expect(isOriginKnownToAnyTenant("https://new-shop.example.com")).toBe(false);
+
+    const result = updateTenantAllowedOrigins(TENANT_ID, ["https://new-shop.example.com"]);
+
+    expect(result).toBe(true);
+    expect(isOriginKnownToAnyTenant("https://new-shop.example.com")).toBe(true);
+  });
+
+  it("ドメインを外す方向の更新も即座に反映される（旧ドメインが二度と許可されない）", () => {
+    expect(isOriginKnownToAnyTenant("https://old-shop.example.com")).toBe(true);
+
+    updateTenantAllowedOrigins(TENANT_ID, []);
+
+    expect(isOriginKnownToAnyTenant("https://old-shop.example.com")).toBe(false);
+  });
+
+  it("空配列は「オリジン制限なし」ではなく、DBの値どおりそのまま書き込む（呼び出し元がフィールド省略と区別する責務を持つ）", () => {
+    updateTenantAllowedOrigins(TENANT_ID, []);
+    expect(getTenantConfig(TENANT_ID)?.security.allowedOrigins).toEqual([]);
+  });
+
+  it("存在しないtenantIdに対してもno-opで例外を投げず、falseを返す", () => {
+    expect(() => updateTenantAllowedOrigins("non-existent-tenant-xyz", ["https://x.example.com"])).not.toThrow();
+    const result = updateTenantAllowedOrigins("non-existent-tenant-xyz", ["https://x.example.com"]);
+    expect(result).toBe(false);
+  });
+
+  it("allowedOrigins以外のTenantConfigフィールド（apiKeyHash等）を巻き込まない", () => {
+    updateTenantAllowedOrigins(TENANT_ID, ["https://new-shop.example.com"]);
+    const cfg = getTenantConfig(TENANT_ID);
+    expect(cfg?.security.apiKeyHash).toBe("origins-test-hash");
+    expect(cfg?.name).toBe("Origins Live Reload Test");
+    expect(cfg?.enabled).toBe(true);
   });
 });
 

--- a/src/lib/tenant-context.ts
+++ b/src/lib/tenant-context.ts
@@ -100,6 +100,26 @@ export function updateTenantEnabled(tenantId: string, enabled: boolean): boolean
   return true;
 }
 
+/**
+ * Update only `security.allowedOrigins` of an existing in-memory tenant.
+ * Used by PATCH /v1/admin/tenants/:id to propagate a DB change instantly,
+ * so a new origin (or a removed one) takes effect without a PM2 restart.
+ * Call only when the PATCH body explicitly included `allowed_origins` —
+ * passing `[]` means "no origins configured" (as stored in the DB) and is
+ * written as-is; the distinction between "field omitted" and "set to []"
+ * must be made by the caller before invoking this function.
+ * Returns true if tenant was found in store, false if not (DB-only tenant).
+ */
+export function updateTenantAllowedOrigins(tenantId: string, origins: string[]): boolean {
+  const existing = tenantStore.get(tenantId);
+  if (!existing) return false;
+  tenantStore.set(tenantId, {
+    ...existing,
+    security: { ...existing.security, allowedOrigins: origins },
+  });
+  return true;
+}
+
 
 // ---------------------------------------------------------------------------
 // Seed from environment (TENANT_CONFIGS_JSON or individual vars)

--- a/tests/api/admin/tenants/routes.test.ts
+++ b/tests/api/admin/tenants/routes.test.ts
@@ -6,12 +6,14 @@ import {
   registerTenant as mockRegisterTenant,
   setTenantApiKeyExpiry as mockSetTenantApiKeyExpiry,
   revokeTenantApiKeyIfCurrent as mockRevokeTenantApiKeyIfCurrent,
+  updateTenantAllowedOrigins as mockUpdateTenantAllowedOrigins,
 } from "../../../../src/lib/tenant-context";
 
 // tenant-context をモック
 jest.mock("../../../../src/lib/tenant-context", () => ({
   registerTenant: jest.fn(),
   updateTenantEnabled: jest.fn(),
+  updateTenantAllowedOrigins: jest.fn(),
   setTenantApiKeyExpiry: jest.fn(),
   revokeTenantApiKeyIfCurrent: jest.fn(),
 }));
@@ -744,6 +746,55 @@ describe("Tenant Admin Routes", () => {
       expect(res.status).toBe(200);
       expect(res.body.faq_question_hint).toBe("例: 保証期間は？");
       expect(res.body.faq_answer_hint).toBe("例: 3年間です");
+    });
+
+    it("allowed_originsを更新した場合、updateTenantAllowedOriginsを(tenantId, origins)で呼びインメモリを即時反映する（PM2再起動なしでCORSが通る配線）", async () => {
+      mockDb.query
+        .mockResolvedValueOnce({ rows: [{ id: "t1", plan: "starter", features: {}, billing_enabled: false, is_active: true }], rowCount: 1 })
+        .mockResolvedValueOnce({
+          rows: [{ id: "t1", name: "T1", plan: "starter", is_active: true, allowed_origins: ["https://new-shop.example.com"] }],
+          rowCount: 1,
+        })
+        .mockResolvedValue({ rows: [], rowCount: 0 });
+      const res = await request(app)
+        .patch("/v1/admin/tenants/t1")
+        .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`)
+        .send({ allowed_origins: ["https://new-shop.example.com"] });
+      expect(res.status).toBe(200);
+      expect(mockUpdateTenantAllowedOrigins).toHaveBeenLastCalledWith("t1", ["https://new-shop.example.com"]);
+    });
+
+    it("allowed_originsを含まない更新では updateTenantAllowedOrigins を呼ばない（フィールド省略と空配列指定の区別）", async () => {
+      mockDb.query
+        .mockResolvedValueOnce({ rows: [{ id: "t1", plan: "starter", features: {}, billing_enabled: false, is_active: true }], rowCount: 1 })
+        .mockResolvedValueOnce({
+          rows: [{ id: "t1", name: "更新後の名前", plan: "starter", is_active: true }],
+          rowCount: 1,
+        })
+        .mockResolvedValue({ rows: [], rowCount: 0 });
+      const callsBefore = (mockUpdateTenantAllowedOrigins as jest.Mock).mock.calls.length;
+      const res = await request(app)
+        .patch("/v1/admin/tenants/t1")
+        .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`)
+        .send({ name: "更新後の名前" });
+      expect(res.status).toBe(200);
+      expect((mockUpdateTenantAllowedOrigins as jest.Mock).mock.calls.length).toBe(callsBefore);
+    });
+
+    it("allowed_originsを空配列で更新すると、空配列のままupdateTenantAllowedOriginsに渡る（全ドメイン解除の意図を保持する）", async () => {
+      mockDb.query
+        .mockResolvedValueOnce({ rows: [{ id: "t1", plan: "starter", features: {}, billing_enabled: false, is_active: true }], rowCount: 1 })
+        .mockResolvedValueOnce({
+          rows: [{ id: "t1", name: "T1", plan: "starter", is_active: true, allowed_origins: [] }],
+          rowCount: 1,
+        })
+        .mockResolvedValue({ rows: [], rowCount: 0 });
+      const res = await request(app)
+        .patch("/v1/admin/tenants/t1")
+        .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`)
+        .send({ allowed_origins: [] });
+      expect(res.status).toBe(200);
+      expect(mockUpdateTenantAllowedOrigins).toHaveBeenLastCalledWith("t1", []);
     });
   });
 


### PR DESCRIPTION
## 問題
`PATCH /v1/admin/tenants/:id` で `allowed_origins` を更新してもDBのみが更新され、CORS判定が参照するインメモリ `tenantStore` は起動時seedのままだった。**新規テナントのドメイン開通にPM2再起動が必要**な状態。

## 修正
- `tenant-context.ts` に `updateTenantAllowedOrigins` を追加。既存の `updateTenantEnabled`（kill-switch用、PR #809 の `revokeTenantApiKeyIfCurrent` と同系統）と同じパターンで `allowedOrigins` のみを書き換える。`registerTenant` は使わない（tenant設定全体を上書きし `apiKeyHash` 等を巻き込む事故になるため）
- PATCHハンドラの `is_active` 即時反映と同じ箇所に、`allowed_origins` がフィールドに含まれる場合のみ呼び出す配線を追加（フィールド省略と空配列指定を区別。空配列はDBの値どおりそのまま書き込む）

## 調査結果
`features` はインメモリ経由ではなく `livekitTokenRoutes.ts` がDBから直接SELECTしているため、同種の即時反映は不要（スコープ外として確認のみ）。

## テスト
- `tenant-context.test.ts`: 新規ドメインの即時反映、削除方向の即時反映、空配列とフィールド省略の区別、存在しないtenantIdでno-op、他フィールドを巻き込まないこと
- `tests/api/admin/tenants/routes.test.ts`: PATCHハンドラが正しい引数で呼ぶこと、フィールド省略時は呼ばないこと、空配列時も呼ぶこと
- **ミューテーション検証済み**: 呼び出しを削除すると新規3テストが検出（2 failed）、復元で104/104 pass

104/104 pass、typecheck 0エラー、oxlint 0件。

🤖 Generated with [Claude Code](https://claude.com/claude-code)