### PR TITLE
[LAUNCH][P1] テナント自身でアバターを有効化できるようにする

### DIFF
--- a/avatar-agent/.env.example
+++ b/avatar-agent/.env.example
@@ -2,6 +2,11 @@ LIVEKIT_URL=wss://your-project.livekit.cloud
 LIVEKIT_API_KEY=your-api-key
 LIVEKIT_API_SECRET=your-api-secret
 LEMONSLICE_API_KEY=your-lemonslice-key
-LEMONSLICE_AGENT_ID=agent_aee377cb0fec68ea
+# 空推奨。設定すると、テナントに有効なavatar_configが無い場合にこのエージェントが
+# 全テナント共通のフォールバック顔として使われる（resolve_avatar_identity参照）。
+# 過去にこの値がagent_aee377cb0fec68ea(R2C公式アバターではない第三者)のまま
+# 本番に残り、設定未完了テナントの訪問者全員に無関係な人物が表示された事故がある
+# （2026-08-08、docs/AVATAR_CONFIG_500_RECOVERY.md）。
+LEMONSLICE_AGENT_ID=
 FISH_AUDIO_API_KEY=your-fish-audio-key
 GROQ_API_KEY=your-groq-api-key

--- a/src/api/admin/avatar/avatarAuthGuard.test.ts
+++ b/src/api/admin/avatar/avatarAuthGuard.test.ts
@@ -19,11 +19,27 @@ import request from 'supertest';
 import { logger } from '../../../lib/logger';
 import { registerAvatarConfigRoutes } from './routes';
 
+/**
+ * このファイルはロール認可（super_admin/client_adminがブロックされないこと）のみを
+ * 検証する。activate ルートが追加したプラン制限（queryTenantPlan経由のSELECT plan
+ * FROM tenants）に空行を返すと、ロールとは無関係にplan_upgrade_requiredの403で
+ * 落ちてしまうため、そのクエリだけ有償プラン('growth')を返す。他のクエリは
+ * 従来どおり空行（rowCount:0）のままにし、既存の他テストの前提を変えない。
+ */
+function mockQueryWithPlan(): jest.Mock {
+  return jest.fn().mockImplementation((sql: string) => {
+    if (typeof sql === "string" && sql.includes("SELECT plan FROM tenants")) {
+      return Promise.resolve({ rows: [{ plan: "growth" }], rowCount: 1 });
+    }
+    return Promise.resolve({ rows: [], rowCount: 0 });
+  });
+}
+
 function makeApp(user: Record<string, unknown> | null) {
   const fakeDb = {
-    query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+    query: mockQueryWithPlan(),
     connect: jest.fn().mockResolvedValue({
-      query: jest.fn().mockResolvedValue({ rows: [], rowCount: 0 }),
+      query: mockQueryWithPlan(),
       release: jest.fn(),
     }),
   };

--- a/src/api/admin/avatar/routes.test.ts
+++ b/src/api/admin/avatar/routes.test.ts
@@ -24,9 +24,16 @@ jest.mock("../../../auth/supabaseClient", () => ({
 }));
 
 const mockTenantHasFeature = jest.fn().mockResolvedValue(true);
-jest.mock("../../../lib/billing/planFeatures", () => ({
-  tenantHasFeature: (...args: any[]) => mockTenantHasFeature(...args),
-}));
+// queryTenantPlan の既定は "growth"（avatar機能あり）。プラン制限テストのみ個別に上書きする。
+const mockQueryTenantPlan = jest.fn().mockResolvedValue("growth");
+jest.mock("../../../lib/billing/planFeatures", () => {
+  const actual = jest.requireActual("../../../lib/billing/planFeatures");
+  return {
+    tenantHasFeature: (...args: any[]) => mockTenantHasFeature(...args),
+    queryTenantPlan: (...args: any[]) => mockQueryTenantPlan(...args),
+    planHasFeature: actual.planHasFeature, // 実装をそのまま使う（純関数、モック不要）
+  };
+});
 
 // --------------------------------------------------------------------------
 // ヘルパー
@@ -119,6 +126,58 @@ describe("POST /v1/admin/avatar/configs/:id/activate", () => {
       ([sql]) => typeof sql === "string" && sql.includes("UPDATE tenants")
     );
     expect(tenantUpdate).toBeUndefined();
+  });
+
+  it("starterプランのclient_adminは403で弾かれ、DBへ一切書き込まない（旧UIの取りこぼし修正）", async () => {
+    mockQueryTenantPlan.mockResolvedValueOnce("starter");
+
+    const clientQuery = jest.fn(); // 呼ばれてはいけない
+    const db = {
+      connect: jest.fn().mockResolvedValue({
+        query: clientQuery,
+        release: jest.fn(),
+      }),
+    };
+
+    const res = await request(makeApp(db, "client_admin"))
+      .post("/v1/admin/avatar/configs/config-1/activate")
+      .set("Authorization", "Bearer dummy");
+
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("plan_upgrade_required");
+    // BEGIN すら発行されていないこと（プラン判定はトランザクション開始直後・破壊的操作の前）
+    const writeCalls = clientQuery.mock.calls.filter(
+      ([sql]) => typeof sql === "string" && /UPDATE|DELETE|INSERT/i.test(sql)
+    );
+    expect(writeCalls).toHaveLength(0);
+  });
+
+  it("super_adminはプラン制限をバイパスする（queryTenantPlanが呼ばれない）", async () => {
+    // 他テストの呼び出し履歴が残っているため、このテスト内の呼び出し有無だけを見る
+    mockQueryTenantPlan.mockClear();
+    mockQueryTenantPlan.mockResolvedValueOnce("starter"); // 呼ばれれば starter で弾かれるはずの値
+
+    const clientQuery = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [] })                      // BEGIN
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 })         // deactivate all
+      .mockResolvedValueOnce({ rows: [CONFIG_ROW], rowCount: 1 }) // activate target
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 })         // UPDATE tenants features
+      .mockResolvedValueOnce({ rows: [] });                     // COMMIT
+
+    const db = {
+      connect: jest.fn().mockResolvedValue({
+        query: clientQuery,
+        release: jest.fn(),
+      }),
+    };
+
+    const res = await request(makeApp(db, "super_admin"))
+      .post("/v1/admin/avatar/configs/config-1/activate")
+      .set("Authorization", "Bearer dummy");
+
+    expect(res.status).toBe(200);
+    expect(mockQueryTenantPlan).not.toHaveBeenCalled();
   });
 });
 

--- a/src/api/admin/avatar/routes.ts
+++ b/src/api/admin/avatar/routes.ts
@@ -9,7 +9,7 @@ import { supabaseAdmin } from "../../../auth/supabaseClient";
 import multer from 'multer';
 import { logger } from '../../../lib/logger';
 import { trackUsage } from '../../../lib/billing/usageTracker';
-import { tenantHasFeature } from '../../../lib/billing/planFeatures';
+import { tenantHasFeature, queryTenantPlan, planHasFeature } from '../../../lib/billing/planFeatures';
 import { resolveEffectiveTenantId } from '../../middleware/roleAuth';
 import { adoptVoiceForConfig } from './fishVoiceModel';
 
@@ -658,6 +658,23 @@ export function registerAvatarConfigRoutes(app: Express, db: any): void {
         const effectiveTenantId = isSuperAdmin
           ? (req.query["tenant"] as string || tenantId)
           : tenantId;
+
+        // プラン制限（LP料金表 Growth〜: AIアバター）。actionExecutor.ts の
+        // activate_avatar ツールと同じ基準・同じ実装パターンを適用する
+        // （チャット経由は既にゲートされているのに旧UIだけ素通りする不整合を解消）。
+        // 注入済み client を使う（tenantHasFeature 経由だと内部で getPool() の
+        // 実Poolを使ってしまい、テストのモックPoolと食い違うため queryTenantPlan を直接使う）。
+        // super_adminはプラン制限をバイパスする（他ツールと同じ規則）。
+        if (!isSuperAdmin) {
+          const plan = await queryTenantPlan(client, effectiveTenantId);
+          if (!planHasFeature(plan, "avatar")) {
+            await client.query("ROLLBACK");
+            return res.status(403).json({
+              error: "plan_upgrade_required",
+              message: "アバター機能はGrowthプラン以上でご利用いただけます。",
+            });
+          }
+        }
 
         // 全て deactivate
         await client.query(

--- a/src/api/avatar/livekitTokenRoutes.test.ts
+++ b/src/api/avatar/livekitTokenRoutes.test.ts
@@ -204,7 +204,7 @@ describe("POST /api/avatar/room-token", () => {
     it("avatarConfigId 未指定 (undefined) は素通し (fallback Q3 へ)", async () => {
       mockQuery
         .mockResolvedValueOnce({ rows: [TENANT_ROW], rowCount: 1 })
-        .mockResolvedValueOnce({ rows: [] });
+        .mockResolvedValueOnce({ rows: [{ image_url: "https://example.com/img.png", name: "Rei" }] });
 
       const app = makeApp("tenant-a");
       const res = await request(app)
@@ -218,7 +218,7 @@ describe("POST /api/avatar/room-token", () => {
     it("avatarConfigId が null は素通し (fallback Q3 へ)", async () => {
       mockQuery
         .mockResolvedValueOnce({ rows: [TENANT_ROW], rowCount: 1 })
-        .mockResolvedValueOnce({ rows: [] });
+        .mockResolvedValueOnce({ rows: [{ image_url: "https://example.com/img.png", name: "Rei" }] });
 
       const app = makeApp("tenant-a");
       const res = await request(app)
@@ -254,7 +254,7 @@ describe("POST /api/avatar/room-token", () => {
       expect(sql).toContain("is_active = true");
     });
 
-    it("is_active アバターがない場合は imageUrl=null で enabled=true を返す", async () => {
+    it("is_active アバターがない場合は reason=no_active_config で enabled=false を返す（テナント自力有効化の裏面: 設定完了までは起動しない）", async () => {
       mockQuery
         .mockResolvedValueOnce({ rows: [TENANT_ROW], rowCount: 1 })
         .mockResolvedValueOnce({ rows: [] });
@@ -264,8 +264,9 @@ describe("POST /api/avatar/room-token", () => {
         .post("/api/avatar/room-token")
         .send({});
 
-      expect(res.body.enabled).toBe(true);
-      expect(res.body.imageUrl).toBeNull();
+      expect(res.body.enabled).toBe(false);
+      expect(res.body.reason).toBe("no_active_config");
+      expect(mockCreateDispatch).not.toHaveBeenCalled();
     });
   });
 
@@ -290,7 +291,7 @@ describe("POST /api/avatar/room-token", () => {
     it("avatarConfigId 未指定時: createRoom の metadata は undefined", async () => {
       mockQuery
         .mockResolvedValueOnce({ rows: [TENANT_ROW], rowCount: 1 })
-        .mockResolvedValueOnce({ rows: [] });
+        .mockResolvedValueOnce({ rows: [{ image_url: "https://example.com/img.png", name: "Rei" }] });
 
       const app = makeApp("tenant-a");
       await request(app)
@@ -336,7 +337,7 @@ describe("POST /api/avatar/room-token", () => {
           rows: [{ ...TENANT_ROW, features: { avatar: true, pre_dispatch: true } }],
           rowCount: 1,
         })
-        .mockResolvedValueOnce({ rows: [] }) // Q3: avatarConfigId 未指定 → fallback
+        .mockResolvedValueOnce({ rows: [{ image_url: "https://example.com/img.png", name: "Rei" }] }) // Q3: avatarConfigId 未指定 → fallback
         .mockResolvedValueOnce({ rows: [{ plan: "enterprise" }] }); // queryTenantPlan
 
       const app = makeApp("tenant-a");
@@ -363,7 +364,7 @@ describe("POST /api/avatar/room-token", () => {
           rows: [{ ...TENANT_ROW, features: { avatar: true, pre_dispatch: false } }],
           rowCount: 1,
         })
-        .mockResolvedValueOnce({ rows: [] }); // Q3 fallback
+        .mockResolvedValueOnce({ rows: [{ image_url: "https://example.com/img.png", name: "Rei" }] }); // Q3 fallback
 
       const app = makeApp("tenant-a");
       const res = await request(app)
@@ -386,7 +387,7 @@ describe("POST /api/avatar/room-token", () => {
           rows: [{ ...TENANT_ROW, features: { avatar: true } }],
           rowCount: 1,
         })
-        .mockResolvedValueOnce({ rows: [] }); // Q3 fallback
+        .mockResolvedValueOnce({ rows: [{ image_url: "https://example.com/img.png", name: "Rei" }] }); // Q3 fallback
 
       const app = makeApp("tenant-a");
       const res = await request(app)
@@ -414,7 +415,7 @@ describe("POST /api/avatar/room-token", () => {
             rows: [{ ...TENANT_ROW, features: { avatar: true, pre_dispatch: true } }],
             rowCount: 1,
           })
-          .mockResolvedValueOnce({ rows: [] }) // Q3 fallback
+          .mockResolvedValueOnce({ rows: [{ image_url: "https://example.com/img.png", name: "Rei" }] }) // Q3 fallback
           .mockResolvedValueOnce({ rows: [{ plan }] }); // queryTenantPlan
 
         const app = makeApp("tenant-a");
@@ -436,7 +437,7 @@ describe("POST /api/avatar/room-token", () => {
           rows: [{ ...TENANT_ROW, features: { avatar: true, pre_dispatch: true } }],
           rowCount: 1,
         })
-        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [{ image_url: "https://example.com/img.png", name: "Rei" }] })
         .mockResolvedValueOnce({ rows: [{ plan: "enterprise" }] });
 
       const app = makeApp("tenant-a");
@@ -457,7 +458,7 @@ describe("POST /api/avatar/room-token", () => {
           rows: [{ ...TENANT_ROW, features: { avatar: true, pre_dispatch: true } }],
           rowCount: 1,
         })
-        .mockResolvedValueOnce({ rows: [] }) // Q3 fallback
+        .mockResolvedValueOnce({ rows: [{ image_url: "https://example.com/img.png", name: "Rei" }] }) // Q3 fallback
         .mockRejectedValueOnce(new Error("db down")); // queryTenantPlan内部でcatchされstarter扱いになる
 
       const app = makeApp("tenant-a");
@@ -480,7 +481,7 @@ describe("POST /api/avatar/room-token", () => {
             rows: [{ ...TENANT_ROW, features: { avatar: true, pre_dispatch: false } }],
             rowCount: 1,
           })
-          .mockResolvedValueOnce({ rows: [] }); // Q3 fallback
+          .mockResolvedValueOnce({ rows: [{ image_url: "https://example.com/img.png", name: "Rei" }] }); // Q3 fallback
         // pre_dispatch=false なので queryTenantPlan は呼ばれない(connect=trueの経路はplan判定を経由しない)
 
         const app = makeApp("tenant-a");
@@ -502,7 +503,7 @@ describe("POST /api/avatar/room-token", () => {
           rows: [{ ...TENANT_ROW, features: { avatar: true, pre_dispatch: true } }],
           rowCount: 1,
         })
-        .mockResolvedValueOnce({ rows: [] }) // Q3 fallback
+        .mockResolvedValueOnce({ rows: [{ image_url: "https://example.com/img.png", name: "Rei" }] }) // Q3 fallback
         .mockResolvedValueOnce({ rows: [{ plan: "starter" }] }); // queryTenantPlan → starterなのでpreDispatchEnabled=false
 
       const app = makeApp("tenant-a");
@@ -553,16 +554,51 @@ describe("POST /api/avatar/room-token", () => {
       expect(res.body.reason).toBe("avatar_disabled");
     });
 
-    it("lemonslice_agent_id 未設定 → reason=agent_not_configured", async () => {
-      mockQuery.mockResolvedValueOnce({
-        rows: [{ ...TENANT_ROW, lemonslice_agent_id: null }],
-        rowCount: 1,
-      });
+    it("lemonslice_agent_id 未設定でも active な avatar_config があれば有効化される（テナント自力有効化）", async () => {
+      // lemonslice_agent_id は PATCH /my-tenant から書けず、super_adminしか設定できない
+      // ダミー列（agent.py は実際には使わない）。テナントは自力でここまで到達できる必要がある。
+      mockQuery
+        .mockResolvedValueOnce({
+          rows: [{ ...TENANT_ROW, lemonslice_agent_id: null }],
+          rowCount: 1,
+        })
+        .mockResolvedValueOnce({
+          rows: [{ image_url: "https://example.com/img.png", name: "Haruka" }],
+        });
+
+      const res = await request(makeApp("tenant-a")).post("/api/avatar/room-token").send({});
+
+      expect(res.body.enabled).toBe(true);
+      expect(res.body.agentId).toBeNull();
+      expect(res.body.imageUrl).toBe("https://example.com/img.png");
+    });
+
+    it("active な avatar_config が無い（configId未指定の通常経路） → reason=no_active_config、第三者の顔にフォールバックしない", async () => {
+      mockQuery
+        .mockResolvedValueOnce({ rows: [TENANT_ROW], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [] }); // Q3: 0件
 
       const res = await request(makeApp("tenant-a")).post("/api/avatar/room-token").send({});
 
       expect(res.body.enabled).toBe(false);
-      expect(res.body.reason).toBe("agent_not_configured");
+      expect(res.body.reason).toBe("no_active_config");
+      // dispatch されていないこと（無関係な第三者の顔で起動しない）
+      expect(mockCreateRoom).not.toHaveBeenCalled();
+      expect(mockCreateDispatch).not.toHaveBeenCalled();
+    });
+
+    it("avatarConfigId 明示指定時に見つからない場合は既存挙動のまま（enabled:true, imageUrl:null）— no_active_configの対象外", async () => {
+      const UUID_MISSING = "11111111-2222-3333-4444-555555555555";
+      mockQuery
+        .mockResolvedValueOnce({ rows: [TENANT_ROW], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [] });
+
+      const res = await request(makeApp("tenant-a"))
+        .post("/api/avatar/room-token")
+        .send({ avatarConfigId: UUID_MISSING });
+
+      expect(res.body.enabled).toBe(true);
+      expect(res.body.imageUrl).toBeNull();
     });
 
     it("LiveKit 環境変数が未設定 → reason=livekit_not_configured", async () => {
@@ -589,7 +625,7 @@ describe("POST /api/avatar/room-token", () => {
     it("正常時は reason を含まず enabled=true を返す（後方互換）", async () => {
       mockQuery
         .mockResolvedValueOnce({ rows: [TENANT_ROW], rowCount: 1 })
-        .mockResolvedValueOnce({ rows: [] });
+        .mockResolvedValueOnce({ rows: [{ image_url: "https://example.com/img.png", name: "Rei" }] });
 
       const res = await request(makeApp("tenant-a")).post("/api/avatar/room-token").send({});
 

--- a/src/api/avatar/livekitTokenRoutes.ts
+++ b/src/api/avatar/livekitTokenRoutes.ts
@@ -129,16 +129,16 @@ export function registerLiveKitTokenRoutes(
       }
 
       const avatarEnabled = row.features?.avatar === true;
+      // lemonslice_agent_id は avatar-agent (Python) の実際の顔解決には使われない
+      // （agent.py は avatar_configs テーブルの is_active な行を見る）。
+      // 純粋な情報フィールドとしてレスポンスに残すが、ゲート判定には使わない
+      // （テナント自身は PATCH /my-tenant からこの列を書けず、書けるsuper_adminが
+      //  代行しない限りアバターが永久に起動できなかった）。
       const agentId = row.lemonslice_agent_id?.trim() || null;
 
       if (!avatarEnabled) {
         logger.warn(`[livekitTokenRoutes] avatar feature disabled for tenant: ${tenantId}`);
         return res.status(403).json({ error: 'Avatar not enabled for this tenant', enabled: false, reason: "avatar_disabled" });
-      }
-
-      if (!agentId) {
-        logger.warn(`[livekitTokenRoutes] lemonslice_agent_id missing for tenant: ${tenantId}`);
-        return res.json({ enabled: false, reason: "agent_not_configured" });
       }
 
       // LiveKit 環境変数チェック
@@ -198,6 +198,17 @@ export function registerLiveKitTokenRoutes(
         if (avatarErr?.code !== "42P01") {
           logger.warn("[livekitTokenRoutes] avatar_configs query warn:", avatarErr?.message);
         }
+      }
+
+      // active な avatar_config が無いままエージェントを dispatch すると、agent.py が
+      // 顔を解決できず15秒でタイムアウトする（無駄なLiveKit dispatch）か、env
+      // LEMONSLICE_AGENT_ID フォールバックで無関係な第三者の顔が出る事故経路になる。
+      // features.avatar=true でも「設定未完了」を明示して早期returnする。
+      // ただし avatarConfigId 明示指定時（テスト用途の特定アバタープレビュー）は対象外 —
+      // 指定IDが見つからない場合の挙動は既存のまま変更しない（別のテスト観点のため）。
+      if (!requestedAvatarConfigId && !imageUrl) {
+        logger.warn(`[livekitTokenRoutes] no active avatar_config for tenant: ${tenantId}`);
+        return res.json({ enabled: false, reason: "no_active_config" });
       }
 
       // GID 1216945619969548: features.pre_dispatch はテナント側フラグに過ぎず、


### PR DESCRIPTION
## 問題
管理画面でアバターを有効化しても、エンドユーザーには出ない。`tenants.lemonslice_agent_id` が未設定だと起動をブロックする実装になっていたが、この列は super_admin の `PATCH /v1/admin/tenants/:id` からしか書けず、`PATCH /my-tenant` には存在しない。**しかも avatar-agent (Python) はこの列を実際には使わない**（`avatar_configs` テーブルの `is_active=true` な行を見る）。つまり実装と無関係な純粋なダミーゲートで、super_admin が代行しない限りテナントは永久にアバターを起動できなかった。

## 変更

### 1. `src/api/avatar/livekitTokenRoutes.ts` — ダミーゲートの撤去
- `lemonslice_agent_id` 未設定による `agent_not_configured` 早期returnを削除
- 代わりに、`avatar_configs` の active な行が無い場合を明示的に `no_active_config` として早期return（configId未指定の通常経路のみ。管理者プレビュー用の `avatarConfigId` 明示指定経路は既存挙動を変えていない）
- これにより、有効な設定が無いテナントの LiveKit dispatch 自体を止められる（agent.py が顔を解決できず15秒タイムアウトする無駄な dispatch も防止）

### 2. `src/api/admin/avatar/routes.ts` — 旧UI activateのプランゲート追加
チャット経由の `activate_avatar` ツール（`actionExecutor.ts`）は既に `planHasFeature(plan,'avatar')` で Growth未満を弾いているが、旧UIの `POST /configs/:id/activate` には同じゲートが無く、starterプランでも直接有効化できていた。同じ判定パターン（`queryTenantPlan` を注入済みclientで直接呼ぶ — `tenantHasFeature` は `getPool()` 経由でテストのモックPoolと食い違う既知の罠のため回避）を適用し、super_adminはバイパス。

### 3. `avatar-agent/.env.example` — 第三者エージェントIDの既定値を空に
調査の結果、**Asanaタスクが前提としていた「env fallbackで第三者の顔が出る」問題は commit `c9cf5526`（2026-08-08）で既に修正済み**でした（ハードコード既定値を削除し、取得成功かつ有効config無しの場合のみ運用者が明示設定した値を使う設計に変更済み）。ただし `.env.example` には当時の第三者ID `agent_aee377cb0fec68ea` が既定値のまま残っており、同コミットのメッセージが「権限設定により編集不可、要手動対応」と明記していた未完了項目でした。新規デプロイがこの例をそのままコピーする事故を防ぐため空にしています。`agent.py` 自体は変更していません（既に正しい設計）。

## テスト
- `livekitTokenRoutes.test.ts`: 33/33 pass（既存の `enabled:true, imageUrl:null` 契約を持つテスト（avatarConfigId明示指定時のプレビュー用途）は維持し、通常経路のみ新しい `no_active_config` 契約に更新）
- `admin/avatar/routes.test.ts`: activate関連4/4 pass（starterプラン403・super_adminバイパスの新規テスト2件を追加）。フルファイル実行の残り20件失敗は無変更のmainでも同一に発生する既知flake（`global.fetch`スパイ）と件数一致を確認済み、新規リグレッションなし
- Python (`test_avatar_identity.py`): `livekit` モジュールがローカル未インストールのため import エラーで実行不可（先行コミットと同一の既知の制約）。ただし `agent.py` 自体は無変更のため、既存のテストカバレッジに影響なし

## デプロイ時の対応（コードでは実施不可）
本番 `avatar-agent/.env` の `LEMONSLICE_AGENT_ID` が `agent_aee377cb0fec68ea`（または他の値）のまま残っている場合、空にすることを推奨します。Part A の Node 側ゲートにより通常経路では到達しなくなりましたが、念のため。

pnpm typecheck 0エラー、oxlint 新規警告なし。

🤖 Generated with [Claude Code](https://claude.com/claude-code)