### PR TITLE
[LAUNCH][P0] FAQ→ES同期を単一実装に集約する

### DIFF
--- a/SCRIPTS/sync-es.ts
+++ b/SCRIPTS/sync-es.ts
@@ -20,6 +20,8 @@
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const { Pool } = require("pg") as { Pool: any };
 
+import { faqEsDocId } from "../src/lib/knowledge/faqIndexSync";
+
 const pgUrl = process.env.DATABASE_URL;
 const esUrl = (process.env.ES_URL || "").replace(/\/$/, "");
 
@@ -163,7 +165,9 @@ async function bulkIndex(index: string, rows: any[]): Promise<number> {
   // バルクAPIフォーマット: action\ndoc\n 繰り返し
   const lines: string[] = [];
   for (const row of rows) {
-    const action = JSON.stringify({ index: { _index: index, _id: String(row.id) } });
+    const action = JSON.stringify({
+      index: { _index: index, _id: faqEsDocId(row.tenant_id, row.id) },
+    });
     const doc = JSON.stringify({
       tenant_id: row.tenant_id,
       question: row.question,

--- a/src/admin/http/faqAdminRoutes.ts
+++ b/src/admin/http/faqAdminRoutes.ts
@@ -4,9 +4,12 @@ import { embedText } from "../../agent/llm/openaiEmbeddingClient";
 import { pool } from "../../lib/db";
 import { supabaseAuthMiddleware } from "./supabaseAuthMiddleware";
 import { logger } from '../../lib/logger';
-import { resolveFaqWriteIndex } from "../../search/langIndex";
+import { upsertFaqToEs, deleteFaqFromEs } from "../../lib/knowledge/faqIndexSync";
 
-
+// es_doc_id 列は使用しない: 非NULL値を書き込む箇所がコードベース全体に無く、
+// 索引同期は src/lib/knowledge/faqIndexSync.ts の `${faqId}_${tenantId}` 規約に
+// 一本化されている（faqCrudRoutes.ts / actionExecutor.ts / faqImport.ts と共通）。
+// 列自体はDBに残るがコードからは参照しない。
 
 type FaqRow = {
   id: number;
@@ -14,9 +17,9 @@ type FaqRow = {
   question: string;
   answer: string;
   category: string | null;
-  es_doc_id: string | null;
   tags: string[] | null;
   is_published: boolean;
+  is_excluded_from_search?: boolean | null;
   created_at: string;
   updated_at: string;
 };
@@ -76,54 +79,6 @@ function requireFaqTenant(req: Request, res: Response, next: NextFunction): void
     req.query.tenantId = jwtTenantId;
   }
   next();
-}
-
-async function updateEsFaqDocument(row: FaqRow) {
-  try {
-    const esUrl = process.env.ES_URL;
-    // Phase69-2-E: write index を read path と同じ faq_${tenantId} に統一
-    const esFaqIndex = resolveFaqWriteIndex(row.tenant_id);
-
-    if (!esUrl) {
-      logger.warn("[updateEsFaqDocument] ES_URL is not set");
-      return;
-    }
-    if (!row.es_doc_id) {
-      logger.warn(
-        "[updateEsFaqDocument] es_doc_id is not set for FAQ id",
-        row.id
-      );
-      return;
-    }
-
-    const url = `${esUrl.replace(
-      /\/$/,
-      ""
-    )}/${esFaqIndex}/_doc/${encodeURIComponent(row.es_doc_id)}`;
-
-    const response = await fetch(url, {
-      method: "PUT",
-      headers: {
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        tenant_id: row.tenant_id,
-        question: row.question,
-        answer: row.answer,
-        category: row.category,
-        tags: row.tags,
-      }),
-    });
-
-    if (!response.ok) {
-      const text = await response.text();
-      logger.warn(
-        `[updateEsFaqDocument] Failed to update ES document ${row.es_doc_id}: status ${response.status}, response: ${text}`
-      );
-    }
-  } catch (err) {
-    logger.warn("[updateEsFaqDocument] error", err);
-  }
 }
 
 export function registerFaqAdminRoutes(app: Express) {
@@ -322,6 +277,8 @@ export function registerFaqAdminRoutes(app: Express) {
         logger.warn("[POST /admin/faqs] failed to insert embedding", err);
       }
 
+      upsertFaqToEs(row.tenant_id, row.id, row.question, row.answer, row.is_published);
+
       return res.status(201).json(row);
     } catch (err) {
       logger.error("[POST /admin/faqs] error", err);
@@ -355,7 +312,6 @@ export function registerFaqAdminRoutes(app: Express) {
           question = COALESCE($2, question),
           answer = COALESCE($3, answer),
           category = COALESCE($4, category),
-          es_doc_id = es_doc_id,
           tags = COALESCE($5, tags),
           is_published = COALESCE($6, is_published),
           updated_at = NOW()
@@ -389,11 +345,7 @@ export function registerFaqAdminRoutes(app: Express) {
 
       const row = result.rows[0];
 
-      try {
-        await updateEsFaqDocument(row);
-      } catch (err) {
-        logger.warn("[PUT /admin/faqs/:id] failed to update ES", err);
-      }
+      upsertFaqToEs(row.tenant_id, row.id, row.question, row.answer, row.is_published);
 
       try {
         const embeddingText = `${row.question}\n${row.answer}`;
@@ -478,6 +430,8 @@ export function registerFaqAdminRoutes(app: Express) {
         `,
         [tenantId, id]
       );
+
+      await deleteFaqFromEs(tenantId, id);
 
       return res.json({ ok: true, id });
     } catch (err) {

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -8,6 +8,7 @@ import {
   insertEmbeddingAsync,
   upsertToEsAsync,
 } from '../knowledge/faqCrudRoutes';
+import { deleteFaqFromEs } from '../../../lib/knowledge/faqIndexSync';
 import { FAQ_CATEGORY_IDS } from '../../../lib/knowledge/faqCategories';
 import { callGroq8bSuggestFromText, callGroq8bSuggest } from '../tuning/routes';
 import { listRules, createRule, updateRule, deleteRule, type ApprovedResponse, type RuleEvidence } from '../tuning/tuningRulesRepository';
@@ -769,6 +770,7 @@ export async function executeToolCall(
           [tenantId, id]
         );
         await db.query('DELETE FROM faq_docs WHERE id = $1 AND tenant_id = $2', [id, tenantId]);
+        await deleteFaqFromEs(tenantId, id);
 
         return truncate(`FAQ（ID: ${id}）を削除しました`);
       } catch (err) {

--- a/src/api/admin/agent/actionExecutorFaqEsSync.test.ts
+++ b/src/api/admin/agent/actionExecutorFaqEsSync.test.ts
@@ -1,0 +1,97 @@
+// src/api/admin/agent/actionExecutorFaqEsSync.test.ts
+//
+// FAQ→ES同期の一本化(GID [LAUNCH][P0])で、actionExecutor.ts の delete_faq のみが
+// ES同期を欠いていたことが判明した。それ以外の add_faq / update_faq /
+// set_faq_published / save_faq などは既に faqCrudRoutes.ts 由来の
+// insertEmbeddingAsync / upsertToEsAsync (= faqIndexSync.ts の再エクスポート) を
+// 呼んでいたため変更していない。ここでは delete_faq が deleteFaqFromEs を
+// 呼ぶことだけを確認する（他caseの回帰は既存の faqCrud/faqAdmin 系テストが担う）。
+
+jest.mock("../../../lib/logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const mockDeleteFaqFromEs = jest.fn().mockResolvedValue(undefined);
+jest.mock("../../../lib/knowledge/faqIndexSync", () => ({
+  deleteFaqFromEs: (...args: unknown[]) => mockDeleteFaqFromEs(...args),
+}));
+
+import type { Pool } from "pg";
+import { executeToolCall } from "./actionExecutor";
+
+const TENANT = "acme";
+const ACTOR = { role: "owner", email: "owner@example.com" };
+
+function makeMockPool(queryImpl: jest.Mock): Pool {
+  return { query: queryImpl } as unknown as Pool;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+});
+
+describe("executeToolCall: delete_faq → ES同期", () => {
+  it("confirmed=true で削除すると deleteFaqFromEs(tenantId, id) を呼ぶ", async () => {
+    const queryMock = jest
+      .fn()
+      // SELECT id, tenant_id, question FROM faq_docs WHERE id = $1
+      .mockResolvedValueOnce({ rows: [{ id: 7, tenant_id: TENANT, question: "Q" }] })
+      // DELETE FROM faq_embeddings ...
+      .mockResolvedValueOnce({ rows: [] })
+      // DELETE FROM faq_docs ...
+      .mockResolvedValueOnce({ rows: [] });
+    const db = makeMockPool(queryMock);
+
+    const result = await executeToolCall(
+      "delete_faq",
+      { id: 7, confirmed: true },
+      TENANT,
+      db,
+      "session-1",
+      false,
+      ACTOR
+    );
+
+    expect(result).toContain("削除しました");
+    expect(mockDeleteFaqFromEs).toHaveBeenCalledWith(TENANT, 7);
+  });
+
+  it("他テナント所有のFAQは削除せず、ESにも同期しない", async () => {
+    const queryMock = jest.fn().mockResolvedValueOnce({
+      rows: [{ id: 7, tenant_id: "other-tenant", question: "Q" }],
+    });
+    const db = makeMockPool(queryMock);
+
+    const result = await executeToolCall(
+      "delete_faq",
+      { id: 7, confirmed: true },
+      TENANT,
+      db,
+      "session-1",
+      false,
+      ACTOR
+    );
+
+    expect(result).toContain("アクセス権限がありません");
+    expect(mockDeleteFaqFromEs).not.toHaveBeenCalled();
+  });
+
+  it("confirmed未指定なら削除もES同期も実行しない", async () => {
+    const queryMock = jest.fn();
+    const db = makeMockPool(queryMock);
+
+    const result = await executeToolCall(
+      "delete_faq",
+      { id: 7 },
+      TENANT,
+      db,
+      "session-1",
+      false,
+      ACTOR
+    );
+
+    expect(result).toContain("確認が必要です");
+    expect(queryMock).not.toHaveBeenCalled();
+    expect(mockDeleteFaqFromEs).not.toHaveBeenCalled();
+  });
+});

--- a/src/api/admin/knowledge/faqCrudRoutes.ts
+++ b/src/api/admin/knowledge/faqCrudRoutes.ts
@@ -4,87 +4,27 @@
 import type { Express, NextFunction, Request, Response } from "express";
 import { Pool } from "pg";
 import { z } from "zod";
-import { embedText } from "../../../agent/llm/openaiEmbeddingClient";
 import { logger } from '../../../lib/logger';
-import { resolveFaqWriteIndex } from "../../../search/langIndex";
+import {
+  insertFaqEmbeddingAsync,
+  upsertFaqToEs,
+  syncFaqExcludedToEs,
+  deleteFaqFromEs,
+} from "../../../lib/knowledge/faqIndexSync";
+
+// 索引同期の実装は src/lib/knowledge/faqIndexSync.ts に一本化されている
+// （faqAdminRoutes.ts / actionExecutor.ts / faqImport.ts と共通）。
+// このファイルは既存の関数名を維持したまま再エクスポートし、
+// actionExecutor.ts 等の既存importを壊さない。
+export const insertEmbeddingAsync = insertFaqEmbeddingAsync;
+export const upsertToEsAsync = upsertFaqToEs;
+const syncIsExcludedToEsAsync = syncFaqExcludedToEs;
 
 /** query/header からテナントIDを解決（bodyから取得禁止 — CLAUDE.md） */
 function resolveTenantId(req: Request): string | null {
   const fromQuery = (req.query.tenant || req.query.tenant_id) as string | undefined;
   const fromHeader = req.headers["x-tenant-id"] as string | undefined;
   return fromQuery || fromHeader || null;
-}
-
-/** ESインデックスからドキュメントを削除（best-effort）
- * Phase69-2-E: write index を read path と同じ faq_${tenantId} に統一 */
-async function deleteFromEs(tenantId: string, esDocId: string): Promise<void> {
-  const esUrl = process.env.ES_URL;
-  const index = resolveFaqWriteIndex(tenantId);
-  if (!esUrl || !esDocId) return;
-  const url = `${esUrl.replace(/\/$/, "")}/${index}/_doc/${encodeURIComponent(esDocId)}`;
-  await fetch(url, { method: "DELETE" }).catch(() => {});
-}
-
-/** embedding を非同期で挿入（fire-and-forget） */
-export function insertEmbeddingAsync(
-  db: Pool,
-  tenantId: string,
-  text: string,
-  faqId: number,
-  meta: Record<string, unknown>
-): void {
-  const isExcluded = Boolean(meta.is_excluded_from_search);
-  embedText(text)
-    .then((vec) =>
-      db.query(
-        "INSERT INTO faq_embeddings (tenant_id, text, embedding, metadata, is_excluded_from_search) VALUES ($1, $2, $3::vector, $4::jsonb, $5)",
-        [tenantId, text, `[${vec.join(",")}]`, JSON.stringify(meta), isExcluded]
-      )
-    )
-    .catch((e) => logger.warn("[faqCrud] embedding insert failed", e));
-}
-
-/** ESにドキュメントをupsert（fire-and-forget） */
-export function upsertToEsAsync(
-  tenantId: string,
-  faqId: number,
-  question: string,
-  answer: string,
-  isPublished = true,
-  isExcludedFromSearch = false
-): void {
-  const esUrl = process.env.ES_URL;
-  const index = resolveFaqWriteIndex(tenantId);
-  if (!esUrl) return;
-  const doc = { tenant_id: tenantId, question, answer, faq_id: faqId, is_published: isPublished, is_excluded_from_search: isExcludedFromSearch };
-  const url = `${esUrl.replace(/\/$/, "")}/${index}/_doc/${faqId}_${tenantId}`;
-  fetch(url, {
-    method: "PUT",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(doc),
-  }).catch((e) => logger.warn("[faqCrud] ES upsert failed", e));
-}
-
-// Phase69-2 PR-C2 Round 2: ES に is_excluded_from_search を partial update で伝搬する
-// 設計判断 (Codex adversarial Round 1):
-//   - fire-and-forget: DB が source-of-truth、ES は eventual consistency
-//   - POST _update: question/answer 等を消さない partial doc 更新
-//   - pgvector layer (永続フィルター) + ES layer (今回追加) + リクエスト excluded_ids の三層防御
-/** ESインデックスの is_excluded_from_search のみ partial update（fire-and-forget） */
-function syncIsExcludedToEsAsync(
-  tenantId: string,
-  faqId: number,
-  isExcludedFromSearch: boolean
-): void {
-  const esUrl = process.env.ES_URL;
-  const index = resolveFaqWriteIndex(tenantId);
-  if (!esUrl) return;
-  const url = `${esUrl.replace(/\/$/, "")}/${index}/_update/${faqId}_${tenantId}`;
-  fetch(url, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ doc: { is_excluded_from_search: isExcludedFromSearch } }),
-  }).catch((e) => logger.warn("[faqCrud] ES is_excluded_from_search sync failed", e));
 }
 
 const listQuerySchema = z.object({
@@ -555,7 +495,7 @@ export function registerFaqCrudRoutes(
       let failed = 0;
       for (const id of ids) {
         try {
-          await deleteFromEs(tenantId, `${id}_${tenantId}`);
+          await deleteFaqFromEs(tenantId, id);
         } catch {
           failed++;
           logger.warn(`[DELETE /v1/admin/knowledge/faq/bulk] ES delete failed for id=${id}`);
@@ -674,7 +614,7 @@ export function registerFaqCrudRoutes(
       );
 
       // ES 削除（best-effort）
-      await deleteFromEs(tenantId, `${id}_${tenantId}`);
+      await deleteFaqFromEs(tenantId, id);
 
       return res.json({ ok: true, id });
     } catch (err) {

--- a/src/lib/knowledge/faqImport.test.ts
+++ b/src/lib/knowledge/faqImport.test.ts
@@ -21,6 +21,12 @@ jest.mock('../crypto/textEncrypt', () => ({
   encryptText: (s: string) => `enc(${s})`,
 }));
 
+const mockUpsertFaqToEs = jest.fn();
+jest.mock('./faqIndexSync', () => ({
+  ...jest.requireActual('./faqIndexSync'),
+  upsertFaqToEs: (...args: unknown[]) => mockUpsertFaqToEs(...args),
+}));
+
 import type { Pool } from 'pg';
 import {
   textToFaqs,
@@ -44,6 +50,7 @@ function makeMockPool(queryImpl: jest.Mock): Pool {
 beforeEach(() => {
   jest.clearAllMocks();
   mockEmbedText.mockResolvedValue([0.1, 0.2, 0.3]);
+  mockUpsertFaqToEs.mockReset();
 });
 
 describe('bigramSimilarity', () => {
@@ -273,6 +280,29 @@ describe('commitTextFaqs', () => {
     expect(insertCall[1]).toEqual(['t1', 'Q1', 'A1', 'general']);
     expect(String(insertCall[0])).toContain('VALUES ($1, $2, $3, $4, true)');
   });
+
+  // GID [LAUNCH][P0]: commitTextFaqs はテキスト取込の主力経路だが、
+  // 従来ESへの同期が一切なく「登録したのに検索でヒットしない」状態だった。
+  it('登録したFAQをupsertFaqToEsでESにも同期する', async () => {
+    const queryMock = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: 9 }] });
+    const db = makeMockPool(queryMock);
+
+    await commitTextFaqs(db, 't1', [{ question: 'Q1', answer: 'A1' }], undefined, 'text');
+
+    expect(mockUpsertFaqToEs).toHaveBeenCalledWith('t1', 9, 'Q1', 'A1', true);
+  });
+
+  it('重複スキップされたFAQはESにも同期しない', async () => {
+    const queryMock = jest.fn().mockResolvedValueOnce({ rows: [{ question: '営業時間を教えてください' }] });
+    const db = makeMockPool(queryMock);
+
+    await commitTextFaqs(db, 't1', [{ question: '営業時間は', answer: '9-18時です' }], undefined, 'text');
+
+    expect(mockUpsertFaqToEs).not.toHaveBeenCalled();
+  });
 });
 
 describe('commitScrapeFaqs', () => {
@@ -308,5 +338,29 @@ describe('commitScrapeFaqs', () => {
       '1000',
       null,
     ]);
+  });
+
+  // GID [LAUNCH][P0]: スクレイプ取込もcommitTextFaqsと同じくES同期が欠けていた主力経路。
+  it('登録したFAQをupsertFaqToEsでESにも同期する', async () => {
+    const queryMock = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ id: 5 }] });
+    const db = makeMockPool(queryMock);
+
+    await commitScrapeFaqs(
+      db,
+      't1',
+      [
+        {
+          url: 'https://example.com/p/1',
+          faqs: [{ question: 'Q1', answer: 'A1' }],
+        },
+      ],
+      undefined,
+      'scrape',
+    );
+
+    expect(mockUpsertFaqToEs).toHaveBeenCalledWith('t1', 5, 'Q1', 'A1', true);
   });
 });

--- a/src/lib/knowledge/faqImport.ts
+++ b/src/lib/knowledge/faqImport.ts
@@ -22,10 +22,9 @@
 import type { Pool } from 'pg';
 import { GROQ_VERSATILE_70B } from '../../config/groqModels';
 import { groqClient } from '../../agent/llm/groqClient';
-import { embedText } from '../../agent/llm/openaiEmbeddingClient';
-import { encryptText } from '../crypto/textEncrypt';
 import { logger } from '../logger';
 import { buildFaqCategoryPromptSection } from './faqCategories';
+import { insertFaqEmbeddingAsync, upsertFaqToEs } from './faqIndexSync';
 
 export interface FaqEntry {
   question: string;
@@ -243,7 +242,12 @@ export function bigramSimilarity(a: string, b: string): number {
 
 export const DUPLICATE_THRESHOLD = 0.6;
 
-/** embedding を非同期で挿入（fire-and-forget） */
+/**
+ * embedding を非同期で挿入（fire-and-forget）。
+ * 実装は src/lib/knowledge/faqIndexSync.ts に一本化されている。
+ * このファイルの呼び出し元（テキスト/URL取込）は元々 encryptText で本文を暗号化して
+ * いたため、その挙動を保つ薄いラッパーとして残す。
+ */
 export function insertEmbeddingAsync(
   db: Pool,
   tenantId: string,
@@ -251,14 +255,7 @@ export function insertEmbeddingAsync(
   faqId: number,
   meta: Record<string, unknown>
 ): void {
-  embedText(text)
-    .then((vec) =>
-      db.query(
-        "INSERT INTO faq_embeddings (tenant_id, text, embedding, metadata) VALUES ($1, $2, $3::vector, $4::jsonb)",
-        [tenantId, encryptText(text), `[${vec.join(",")}]`, JSON.stringify(meta)]
-      )
-    )
-    .catch((e) => logger.warn("[knowledge] embedding insert failed", e));
+  insertFaqEmbeddingAsync(db, tenantId, text, faqId, meta, { encrypt: true });
 }
 
 // ---------------------------------------------------------------------------
@@ -438,6 +435,7 @@ export async function commitTextFaqs(
         source,
         faq_id: faqId,
       });
+      upsertFaqToEs(target, faqId, faq.question.slice(0, 500), faq.answer.slice(0, 2000), true);
     } catch (err) {
       logger.error("[commit] insert failed for faq:", faq.question, err);
     }
@@ -509,6 +507,7 @@ export async function commitScrapeFaqs(
           faq_id: faqId,
           url: item.url,
         });
+        upsertFaqToEs(target, faqId, faq.question.slice(0, 500), faq.answer.slice(0, 2000), true);
       } catch (err) {
         logger.error("[scrape/commit] insert failed", err);
       }

--- a/src/lib/knowledge/faqIndexSync.test.ts
+++ b/src/lib/knowledge/faqIndexSync.test.ts
@@ -1,0 +1,218 @@
+// src/lib/knowledge/faqIndexSync.test.ts
+//
+// FAQ検索索引（ES + pgvector）を書き込む単一実装のユニットテスト。
+// faqCrudRoutes.ts / faqAdminRoutes.ts / faqImport.ts / actionExecutor.ts の
+// 4つの呼び出し元が共有するため、ここで契約（ID規約・失敗時の挙動）を固定する。
+
+jest.mock("../logger", () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+
+const mockEmbedText = jest.fn();
+jest.mock("../../agent/llm/openaiEmbeddingClient", () => ({
+  embedText: (...args: unknown[]) => mockEmbedText(...args),
+}));
+
+jest.mock("../crypto/textEncrypt", () => ({
+  encryptText: (s: string) => `enc(${s})`,
+}));
+
+import type { Pool } from "pg";
+import { logger } from "../logger";
+import {
+  faqEsDocId,
+  upsertFaqToEs,
+  deleteFaqFromEs,
+  syncFaqExcludedToEs,
+  insertFaqEmbeddingAsync,
+  countFaqIndexMismatch,
+} from "./faqIndexSync";
+
+const ES_URL = "http://es.test:9200";
+const origEsUrl = process.env.ES_URL;
+
+type Captured = { url: string; method: string; body?: string };
+let captured: Captured[];
+const originalFetch = global.fetch;
+
+function installFetchSpy(ok = true) {
+  global.fetch = jest.fn(async (input: unknown, init?: { method?: string; body?: string }) => {
+    const url = typeof input === "string" ? input : String(input);
+    captured.push({ url, method: init?.method ?? "GET", body: init?.body });
+    return {
+      ok,
+      status: ok ? 200 : 500,
+      json: async () => ({ count: 3 }),
+      text: async () => "",
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  captured = [];
+  mockEmbedText.mockResolvedValue([0.1, 0.2, 0.3]);
+  process.env.ES_URL = ES_URL;
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+});
+
+afterAll(() => {
+  if (origEsUrl !== undefined) process.env.ES_URL = origEsUrl;
+  else delete process.env.ES_URL;
+});
+
+describe("faqEsDocId", () => {
+  it("唯一のID規約: `${faqId}_${tenantId}`", () => {
+    expect(faqEsDocId("acme", 7)).toBe("7_acme");
+  });
+});
+
+describe("upsertFaqToEs", () => {
+  it("PUT /faq_<tenant>/_doc/<faqId>_<tenant> へ書き込む", async () => {
+    installFetchSpy();
+    upsertFaqToEs("acme", 7, "Q", "A", true, false);
+    await new Promise((r) => setImmediate(r));
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.method).toBe("PUT");
+    expect(captured[0]!.url).toBe(`${ES_URL}/faq_acme/_doc/7_acme`);
+    const body = JSON.parse(captured[0]!.body!);
+    expect(body).toEqual({
+      tenant_id: "acme",
+      question: "Q",
+      answer: "A",
+      faq_id: 7,
+      is_published: true,
+      is_excluded_from_search: false,
+    });
+  });
+
+  it("ES_URL未設定なら何もしない（fetchを呼ばない）", async () => {
+    delete process.env.ES_URL;
+    installFetchSpy();
+    upsertFaqToEs("acme", 7, "Q", "A");
+    await new Promise((r) => setImmediate(r));
+    expect(captured).toHaveLength(0);
+  });
+
+  it("fetch失敗はlogger.errorに記録され、例外は投げない（fire-and-forget）", async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error("network down"));
+    expect(() => upsertFaqToEs("acme", 7, "Q", "A")).not.toThrow();
+    await new Promise((r) => setImmediate(r));
+    expect(logger.error).toHaveBeenCalledWith(
+      "[faqIndexSync] ES upsert failed",
+      expect.objectContaining({ tenantId: "acme", faqId: 7 })
+    );
+  });
+});
+
+describe("deleteFaqFromEs", () => {
+  it("DELETE /faq_<tenant>/_doc/<faqId>_<tenant> を呼ぶ", async () => {
+    installFetchSpy();
+    await deleteFaqFromEs("acme", 7);
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.method).toBe("DELETE");
+    expect(captured[0]!.url).toBe(`${ES_URL}/faq_acme/_doc/7_acme`);
+  });
+
+  it("fetch失敗はthrowせずlogger.errorに記録する", async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error("network down"));
+    await expect(deleteFaqFromEs("acme", 7)).resolves.toBeUndefined();
+    expect(logger.error).toHaveBeenCalledWith(
+      "[faqIndexSync] ES delete failed",
+      expect.objectContaining({ tenantId: "acme", faqId: 7 })
+    );
+  });
+});
+
+describe("syncFaqExcludedToEs", () => {
+  it("POST /faq_<tenant>/_update/<faqId>_<tenant> へ部分更新する", async () => {
+    installFetchSpy();
+    syncFaqExcludedToEs("acme", 7, true);
+    await new Promise((r) => setImmediate(r));
+    expect(captured).toHaveLength(1);
+    expect(captured[0]!.method).toBe("POST");
+    expect(captured[0]!.url).toBe(`${ES_URL}/faq_acme/_update/7_acme`);
+    expect(JSON.parse(captured[0]!.body!)).toEqual({ doc: { is_excluded_from_search: true } });
+  });
+});
+
+describe("insertFaqEmbeddingAsync", () => {
+  it("opts省略時は平文のままINSERTする（暗号化しない）", async () => {
+    const queryMock = jest.fn().mockResolvedValue({ rows: [] });
+    const db = { query: queryMock } as unknown as Pool;
+    insertFaqEmbeddingAsync(db, "acme", "Q\nA", 7, { source: "test" });
+    await new Promise((r) => setImmediate(r));
+    expect(queryMock).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO faq_embeddings"),
+      expect.arrayContaining(["acme", "Q\nA"])
+    );
+  });
+
+  it("opts.encrypt=trueなら本文を暗号化してからINSERTする", async () => {
+    const queryMock = jest.fn().mockResolvedValue({ rows: [] });
+    const db = { query: queryMock } as unknown as Pool;
+    insertFaqEmbeddingAsync(db, "acme", "Q\nA", 7, { source: "test" }, { encrypt: true });
+    await new Promise((r) => setImmediate(r));
+    await new Promise((r) => setImmediate(r));
+    expect(queryMock).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO faq_embeddings"),
+      expect.arrayContaining(["acme", "enc(Q\nA)"])
+    );
+  });
+
+  it("meta.is_excluded_from_search を is_excluded_from_search 列に反映する", async () => {
+    const queryMock = jest.fn().mockResolvedValue({ rows: [] });
+    const db = { query: queryMock } as unknown as Pool;
+    insertFaqEmbeddingAsync(db, "acme", "Q\nA", 7, { is_excluded_from_search: true });
+    await new Promise((r) => setImmediate(r));
+    const call = queryMock.mock.calls[0]!;
+    expect(call[1]).toEqual(["acme", "Q\nA", "[0.1,0.2,0.3]", expect.any(String), true]);
+  });
+
+  it("embedText失敗はDBに書き込まずlogger.errorに記録する", async () => {
+    mockEmbedText.mockRejectedValue(new Error("openai down"));
+    const queryMock = jest.fn();
+    const db = { query: queryMock } as unknown as Pool;
+    insertFaqEmbeddingAsync(db, "acme", "Q\nA", 7, {});
+    await new Promise((r) => setImmediate(r));
+    expect(queryMock).not.toHaveBeenCalled();
+    expect(logger.error).toHaveBeenCalledWith(
+      "[faqIndexSync] embedding insert failed",
+      expect.objectContaining({ tenantId: "acme", faqId: 7 })
+    );
+  });
+});
+
+describe("countFaqIndexMismatch", () => {
+  it("DB件数とES件数を両方返す", async () => {
+    installFetchSpy();
+    const pool = {
+      query: jest.fn().mockResolvedValue({ rows: [{ c: 5 }] }),
+    } as unknown as Pool;
+    const result = await countFaqIndexMismatch(pool, "acme");
+    expect(result).toEqual({ dbCount: 5, esCount: 3 });
+  });
+
+  it("ES_URL未設定ならesCount=-1を返し、fetchしない", async () => {
+    delete process.env.ES_URL;
+    installFetchSpy();
+    const pool = {
+      query: jest.fn().mockResolvedValue({ rows: [{ c: 5 }] }),
+    } as unknown as Pool;
+    const result = await countFaqIndexMismatch(pool, "acme");
+    expect(result).toEqual({ dbCount: 5, esCount: -1 });
+    expect(captured).toHaveLength(0);
+  });
+
+  it("ESが非200を返せばesCount=-1（不整合が誤って「一致」に見えないようにする）", async () => {
+    installFetchSpy(false);
+    const pool = {
+      query: jest.fn().mockResolvedValue({ rows: [{ c: 5 }] }),
+    } as unknown as Pool;
+    const result = await countFaqIndexMismatch(pool, "acme");
+    expect(result).toEqual({ dbCount: 5, esCount: -1 });
+  });
+});

--- a/src/lib/knowledge/faqIndexSync.ts
+++ b/src/lib/knowledge/faqIndexSync.ts
@@ -1,0 +1,161 @@
+// src/lib/knowledge/faqIndexSync.ts
+//
+// FAQ の検索索引（Elasticsearch + pgvector）を書き込む唯一の実装。
+//
+// これまで faqCrudRoutes.ts / faqAdminRoutes.ts / faqImport.ts / actionExecutor.ts が
+// それぞれ個別に（あるいは一部は同期そのものを欠いたまま）ES/pgvectorへ書き込んでおり、
+// ESドキュメントIDの規約も faqCrudRoutes.ts 系の `${faqId}_${tenantId}` と、
+// faqAdminRoutes.ts の未使用 `es_doc_id` 列（常にNULLで一度も埋まらない）の
+// 2方式が並行していた。本モジュールが単一の実装・単一のID規約を持つ。
+//
+// 「検索索引の同期は"記録"ではない」— 失敗すると「登録したのに答えない」という
+// ユーザーに見える機能不全になる。fire-and-forget にはするが、失敗は
+// logger.error（warn より重大度を上げる）で残し、黙って握り潰さない。
+
+import type { Pool } from "pg";
+import { embedText } from "../../agent/llm/openaiEmbeddingClient";
+import { logger } from "../logger";
+import { resolveFaqWriteIndex } from "../../search/langIndex";
+
+/** ESドキュメントIDの唯一の生成規約。呼び出し側で文字列を組み立てさせない。 */
+export function faqEsDocId(tenantId: string, faqId: number): string {
+  return `${faqId}_${tenantId}`;
+}
+
+/** ESにFAQドキュメントをupsertする（fire-and-forget） */
+export function upsertFaqToEs(
+  tenantId: string,
+  faqId: number,
+  question: string,
+  answer: string,
+  isPublished = true,
+  isExcludedFromSearch = false
+): void {
+  const esUrl = process.env.ES_URL;
+  if (!esUrl) return;
+  const index = resolveFaqWriteIndex(tenantId);
+  const doc = {
+    tenant_id: tenantId,
+    question,
+    answer,
+    faq_id: faqId,
+    is_published: isPublished,
+    is_excluded_from_search: isExcludedFromSearch,
+  };
+  const url = `${esUrl.replace(/\/$/, "")}/${index}/_doc/${faqEsDocId(tenantId, faqId)}`;
+  fetch(url, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(doc),
+  }).catch((e) =>
+    logger.error("[faqIndexSync] ES upsert failed", { tenantId, faqId, err: e })
+  );
+}
+
+/** ESからFAQドキュメントを削除する（best-effort） */
+export async function deleteFaqFromEs(tenantId: string, faqId: number): Promise<void> {
+  const esUrl = process.env.ES_URL;
+  if (!esUrl) return;
+  const index = resolveFaqWriteIndex(tenantId);
+  const url = `${esUrl.replace(/\/$/, "")}/${index}/_doc/${faqEsDocId(tenantId, faqId)}`;
+  await fetch(url, { method: "DELETE" }).catch((e) =>
+    logger.error("[faqIndexSync] ES delete failed", { tenantId, faqId, err: e })
+  );
+}
+
+/** ESインデックスの is_excluded_from_search のみ partial update（fire-and-forget） */
+export function syncFaqExcludedToEs(
+  tenantId: string,
+  faqId: number,
+  isExcludedFromSearch: boolean
+): void {
+  const esUrl = process.env.ES_URL;
+  if (!esUrl) return;
+  const index = resolveFaqWriteIndex(tenantId);
+  const url = `${esUrl.replace(/\/$/, "")}/${index}/_update/${faqEsDocId(tenantId, faqId)}`;
+  fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ doc: { is_excluded_from_search: isExcludedFromSearch } }),
+  }).catch((e) =>
+    logger.error("[faqIndexSync] ES is_excluded_from_search sync failed", {
+      tenantId,
+      faqId,
+      err: e,
+    })
+  );
+}
+
+/**
+ * embedding を非同期でpgvectorへ挿入する（fire-and-forget）。
+ * `encrypt: true` を指定すると保存前に本文を暗号化する
+ * （呼び出し元ごとに既存の挙動を保つためのオプション。新規呼び出しでは
+ * 保存対象の性質に応じて明示的に選ぶこと。デフォルトはfalse）。
+ */
+export function insertFaqEmbeddingAsync(
+  db: Pool,
+  tenantId: string,
+  text: string,
+  faqId: number,
+  meta: Record<string, unknown>,
+  opts?: { encrypt?: boolean }
+): void {
+  const isExcluded = Boolean(meta.is_excluded_from_search);
+  embedText(text)
+    .then(async (vec) => {
+      let storedText = text;
+      if (opts?.encrypt) {
+        const { encryptText } = await import("../crypto/textEncrypt");
+        storedText = encryptText(text);
+      }
+      return db.query(
+        "INSERT INTO faq_embeddings (tenant_id, text, embedding, metadata, is_excluded_from_search) VALUES ($1, $2, $3::vector, $4::jsonb, $5)",
+        [tenantId, storedText, `[${vec.join(",")}]`, JSON.stringify(meta), isExcluded]
+      );
+    })
+    .catch((e) =>
+      logger.error("[faqIndexSync] embedding insert failed", { tenantId, faqId, err: e })
+    );
+}
+
+/**
+ * DB(faq_docs, is_published=true)とES(同条件)の件数を突き合わせる。
+ * 索引の不整合を検知するためのヘルパー。呼び出し元・定期実行(cron化)は
+ * このタスクのスコープ外。件数を返すだけで自動修復はしない。
+ */
+export async function countFaqIndexMismatch(
+  pool: Pool,
+  tenantId: string
+): Promise<{ dbCount: number; esCount: number }> {
+  const dbResult = await pool.query(
+    "SELECT COUNT(*)::int AS c FROM faq_docs WHERE tenant_id = $1 AND is_published = true",
+    [tenantId]
+  );
+  const dbCount = (dbResult.rows[0] as { c: number }).c;
+
+  const esUrl = process.env.ES_URL;
+  if (!esUrl) return { dbCount, esCount: -1 };
+  const index = resolveFaqWriteIndex(tenantId);
+  try {
+    const res = await fetch(`${esUrl.replace(/\/$/, "")}/${index}/_count`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        query: {
+          bool: {
+            filter: [
+              { term: { tenant_id: tenantId } },
+              { term: { is_published: true } },
+            ],
+          },
+        },
+      }),
+    });
+    if (!res.ok) return { dbCount, esCount: -1 };
+    const body = (await res.json()) as { count: number };
+    return { dbCount, esCount: body.count };
+  } catch (e) {
+    logger.error("[faqIndexSync] countFaqIndexMismatch ES query failed", { tenantId, err: e });
+    return { dbCount, esCount: -1 };
+  }
+}

--- a/tests/syncEsIdFormat.test.ts
+++ b/tests/syncEsIdFormat.test.ts
@@ -1,0 +1,41 @@
+// tests/syncEsIdFormat.test.ts
+//
+// SCRIPTS/sync-es.ts はスクリプト（モジュール読込時に main() が実行され、
+// process.exit / 実DB接続まで行う）のため require/import してのユニットテストは
+// 安全に行えない（jest.config.cjs が SCRIPTS/ 配下・script-style ファイルを
+// testMatch対象外にしている方針と同じ理由）。
+//
+// このテストはソースを静的に検査し、ESドキュメントIDが
+// faqCrudRoutes.ts/faqAdminRoutes.ts 系の書き込みと同じ `${faqId}_${tenantId}`
+// 規約（faqEsDocId）で組み立てられていることを保証する回帰ガードである。
+// 旧実装 `_id: String(row.id)`（tenant_idを含まない）への先祖返りを検知する。
+
+import { readFileSync } from "fs";
+import { join } from "path";
+import { faqEsDocId } from "../src/lib/knowledge/faqIndexSync";
+
+const SOURCE_PATH = join(__dirname, "..", "SCRIPTS", "sync-es.ts");
+
+describe("SCRIPTS/sync-es.ts の _id 規約", () => {
+  const source = readFileSync(SOURCE_PATH, "utf8");
+
+  it("faqIndexSync の faqEsDocId を import している", () => {
+    expect(source).toMatch(
+      /import\s*\{\s*faqEsDocId\s*\}\s*from\s*["']\.\.\/src\/lib\/knowledge\/faqIndexSync["']/
+    );
+  });
+
+  it("bulk _id は faqEsDocId(row.tenant_id, row.id) で組み立てる", () => {
+    expect(source).toMatch(/_id:\s*faqEsDocId\(row\.tenant_id,\s*row\.id\)/);
+  });
+
+  it("旧実装（tenant_idを含まない _id: String(row.id)）が復活していない", () => {
+    expect(source).not.toMatch(/_id:\s*String\(row\.id\)/);
+  });
+
+  it("faqEsDocId自体は既存の書き込みパス（faqCrudRoutes等）と同一規約", () => {
+    // sync-es.ts は countTenantDocs/bulkIndex 内で row.tenant_id, row.id を渡す前提。
+    // ここでは規約そのもの（`${faqId}_${tenantId}`）を直接固定する。
+    expect(faqEsDocId("acme", 42)).toBe("42_acme");
+  });
+});


### PR DESCRIPTION
## 概要

FAQ↔Elasticsearch(検索索引)の同期実装が4箇所に分散し、ESドキュメントID規約も2方式が並行していた問題を解消し、`src/lib/knowledge/faqIndexSync.ts`を唯一の実装として集約する。

**背景**: CLAUDE.mdの「検索索引の同期は"記録"ではない」「同じ関心事を2ファイルに複製したまま片方だけ直す禁止」に基づく是正。

## 元の呼び出し元4箇所の状態（着手前の実態調査結果）

| ファイル | 着手前の状態 |
|---|---|
| `faqCrudRoutes.ts` | 独自実装。ID規約 `${faqId}_${tenantId}`（正しい・唯一の"生きている"実装） |
| `faqAdminRoutes.ts` | 独自実装。ID規約は`faq_docs.es_doc_id`列（**コードベース全体で一度も書き込まれずNULL固定** → `updateEsFaqDocument()`は実質no-op） |
| `faqImport.ts` (`commitTextFaqs`/`commitScrapeFaqs`) | **ES同期が一切ない**。テキスト/URL取込という主力経路なのに「登録したのに検索でヒットしない」状態だった |
| `actionExecutor.ts` | チャットからのFAQ操作。8箇所の書き込みのうち`delete_faq`のみES削除を欠いていた（他7箇所は既存で`faqCrudRoutes.ts`由来の関数を正しく呼んでいた） |

**タスク原案の前提修正**: 元のタスクブリーフは`actionExecutor.ts`に「約8箇所のES同期漏れ」があると想定していたが、実際に読んだところ7/8箇所は既に正しく同期していた。grepパターン(`esClient|elasticsearch|\.index\(|\.delete\(`)が名前付き関数呼び出し(`upsertToEsAsync(...)`)にマッチしなかったための誤検知。実装は`delete_faq`の1箇所のみ修正。

## 変更内容

- **新規** `src/lib/knowledge/faqIndexSync.ts`: 単一実装。`faqEsDocId(tenantId, faqId)` = `${faqId}_${tenantId}` を唯一のID生成規約とし、`upsertFaqToEs` / `deleteFaqFromEs` / `syncFaqExcludedToEs` / `insertFaqEmbeddingAsync`（`encrypt`オプション付き）/ `countFaqIndexMismatch`（不整合検知用ヘルパー、cron化は本PRのスコープ外）を提供
- `faqCrudRoutes.ts`: ローカル実装を削除し`faqIndexSync`から import。`actionExecutor.ts`の既存importを壊さないため`insertEmbeddingAsync`/`upsertToEsAsync`の名前で再エクスポート
- `faqAdminRoutes.ts`: 常にNULLの`es_doc_id`に依存していた`updateEsFaqDocument()`を削除。POST/PUT/DELETE全ハンドラで`faqIndexSync`経由のES同期に切替（**PUTハンドラのES同期は従来機能していなかった実質的なバグ修正**）
- `faqImport.ts`: `commitTextFaqs`/`commitScrapeFaqs`に`upsertFaqToEs`呼び出しを追加（最重要の実質バグ修正）。既存の`encryptText`暗号化挙動は`insertFaqEmbeddingAsync(..., {encrypt: true})`で維持
- `actionExecutor.ts`: `delete_faq`ケースに`deleteFaqFromEs`呼び出しを追加
- `SCRIPTS/sync-es.ts`: バルク再インデックスの`_id`が`String(row.id)`でtenant_idを含まずライブ書き込みと不一致だったため、`faqEsDocId(row.tenant_id, row.id)`に統一

## 暗号化の扱いについて（意図的にスコープ外とした点）

`faqCrudRoutes.ts`の埋め込み挿入は平文保存、`faqImport.ts`は`encryptText()`で暗号化——という既存の不一致を発見したが、これは安全性に関わる判断であり本PRで一方に統一するのは避け、`insertFaqEmbeddingAsync`に`opts?: { encrypt?: boolean }`を追加して両呼び出し元の既存挙動をそれぞれ明示的に保存した。

## テスト

- 新規 `faqIndexSync.test.ts`（14件）: ID規約・ES書き込み/削除/部分更新・embedding挿入(暗号化あり/なし)・失敗時のfire-and-forget挙動・不整合検知ヘルパー
- 新規 `actionExecutorFaqEsSync.test.ts`（3件）: `delete_faq`のES同期・他テナントガード・未確認時の非実行
- 新規 `tests/syncEsIdFormat.test.ts`（4件）: `sync-es.ts`はモジュール読込時に`main()`が実行されDB接続/`process.exit`するスクリプトのため、ソースの静的検査で`_id`規約の回帰を防止
- `faqImport.test.ts`に`commitTextFaqs`/`commitScrapeFaqs`のES同期テストを追加
- 既存 `faqCrud.test.ts` / `faqCrudEsIndex.test.ts` / `faqAdminRoutes.test.ts` は無回帰（変更なしで全通過）
- 対象範囲の全テスト: **7スイート / 110件 全通過**
- `pnpm typecheck` / `npx oxlint <変更ファイル>`: エラーなし
- **mutation検証2件**（実装コードを意図的に壊し、新規テストが検知することを確認後に復元）:
  1. `faqEsDocId`のフォーマットを破壊 → 9件のテストが失敗することを確認
  2. `actionExecutor.ts`の`delete_faq`から`deleteFaqFromEs`呼び出しを削除 → 該当テストが失敗することを確認

## スコープ外（意図的）

- `faqAdminRoutes.ts`のSELECT/RETURNING句に残る`es_doc_id`列参照（常にNULLの列を選択するだけで無害、書き込みパスのバグのみが対象）
- `countFaqIndexMismatch`の定期実行(cron化)・自動修復
- 暗号化方式の統一（上記参照）