### PR TITLE
[SEC][P2] rate-limitの型不一致修正+session key生成の重複解消

### DIFF
--- a/src/agent/dialog/contextStore.ts
+++ b/src/agent/dialog/contextStore.ts
@@ -1,35 +1,21 @@
 // src/agent/dialog/contextStore.ts
 
 import type { DialogMessage } from './types'
+import { buildTenantSessionKey } from './sessionKey'
 
 type SessionId = string
 type TenantId = string
 
 // MVP: インメモリのセッションストア。
 // 将来 Redis 等に差し替えられるように、I/F はできるだけ単純に保つ。
-// キーは `${tenantId}::${sessionId}` — テナントを跨いだ sessionId 衝突で
-// 履歴が相互参照されないようにする（salesContextStore.ts と同じ方式）。
+// キー生成は sessionKey.ts に一本化（salesContextStore.ts と共有）。
 const sessions = new Map<string, DialogMessage[]>()
 
 // 1 セッションあたり保持する最大メッセージ数（安全のため軽く絞っておく）
 const MAX_HISTORY_LENGTH = 20
 
-function toInternalKey(tenantId: TenantId, sessionId: SessionId): string {
-  // tenantId は作成時バリデーション(/^[a-z0-9_-]+$/、tenants/routes.ts)により
-  // コロンを含まない前提で、文字列中の最初の "::" が常に tenantId/sessionId の
-  // 境界になる（sessionId は z.string().max(128) のみで文字種制限がなく "::" を
-  // 含みうるが、それ自体は境界の一意性を壊さない）。
-  // この前提が将来のバリデーション変更等で崩れると、異なる tenantId/sessionId の
-  // 組み合わせが同一キーに衝突し履歴が混在しうるため、サイレントな衝突より
-  // 明示的な失敗を優先する防御的アサーション。
-  if (tenantId.includes('::')) {
-    throw new Error(`contextStore: tenantId must not contain "::" (got: ${tenantId})`)
-  }
-  return `${tenantId}::${sessionId}`
-}
-
 export function getSessionHistory(tenantId: TenantId, sessionId: SessionId): DialogMessage[] {
-  return sessions.get(toInternalKey(tenantId, sessionId)) ?? []
+  return sessions.get(buildTenantSessionKey(tenantId, sessionId)) ?? []
 }
 
 
@@ -38,7 +24,7 @@ export function appendToSessionHistory(
   sessionId: SessionId,
   messages: DialogMessage[],
 ): DialogMessage[] {
-  const key = toInternalKey(tenantId, sessionId)
+  const key = buildTenantSessionKey(tenantId, sessionId)
   const prev = sessions.get(key) ?? []
   const merged = [...prev, ...messages]
 

--- a/src/agent/dialog/salesContextStore.test.ts
+++ b/src/agent/dialog/salesContextStore.test.ts
@@ -95,4 +95,22 @@ describe("salesContextStore", () => {
     expect(getSalesSessionMeta(key)).toBeUndefined();
     expect(getSalesSessionMeta(anotherKey)).toBeUndefined();
   });
+
+  describe("キー生成はsessionKey.tsのbuildTenantSessionKeyに一本化されている（contextStore.tsとの重複解消）", () => {
+    it("【回帰】tenantIdに区切り文字`::`が含まれる場合は例外を投げ、衝突を未然に防ぐ（contextStore.tsと同じ挙動）", () => {
+      const badKey: SalesSessionKey = { tenantId: "A::B", sessionId: "C" };
+      expect(() =>
+        setSalesSessionMeta(badKey, { currentStage: "clarify" as any })
+      ).toThrow(/tenantId must not contain/);
+      expect(() => getSalesSessionMeta(badKey)).toThrow(/tenantId must not contain/);
+    });
+
+    it("通常のtenantId（単一コロン混在含む）は従来どおり動作する", () => {
+      // 既存フィクスチャの "tenant:demo" は単一コロンで "::" ではないため許可される
+      const normalKey: SalesSessionKey = { tenantId: "tenant:demo", sessionId: "s1" };
+      expect(getSalesSessionMeta(normalKey)).toBeUndefined();
+      const saved = setSalesSessionMeta(normalKey, { currentStage: "clarify" as any });
+      expect(saved.currentStage).toBe("clarify");
+    });
+  });
 });

--- a/src/agent/dialog/salesContextStore.ts
+++ b/src/agent/dialog/salesContextStore.ts
@@ -1,4 +1,5 @@
 import type { SalesStage } from "../orchestrator/sales/salesStageMachine";
+import { buildTenantSessionKey } from "./sessionKey";
 
 export interface SalesSessionMeta {
   currentStage: SalesStage;
@@ -13,7 +14,7 @@ export interface SalesSessionKey {
 }
 
 const toInternalKey = (key: SalesSessionKey): string =>
-  `${key.tenantId}::${key.sessionId}`;
+  buildTenantSessionKey(key.tenantId, key.sessionId);
 
 const sessionStore = new Map<string, SalesSessionMeta>();
 

--- a/src/agent/dialog/sessionKey.test.ts
+++ b/src/agent/dialog/sessionKey.test.ts
@@ -1,0 +1,19 @@
+import { buildTenantSessionKey } from "./sessionKey";
+
+describe("buildTenantSessionKey", () => {
+  it("tenantIdとsessionIdを`::`で連結する", () => {
+    expect(buildTenantSessionKey("tenant-a", "session-1")).toBe("tenant-a::session-1");
+  });
+
+  it("tenantIdに`::`が含まれる場合は例外を投げる", () => {
+    expect(() => buildTenantSessionKey("A::B", "C")).toThrow(/tenantId must not contain/);
+  });
+
+  it("sessionIdに`::`が含まれてもtenantIdがコロンを含まなければ例外を投げない（境界はtenantId側の不変条件で守られる）", () => {
+    expect(buildTenantSessionKey("A", "B::C")).toBe("A::B::C");
+  });
+
+  it("tenantIdの単一コロンは許可する（`::`の二重コロンのみを検知する）", () => {
+    expect(buildTenantSessionKey("tenant:demo", "s1")).toBe("tenant:demo::s1");
+  });
+});

--- a/src/agent/dialog/sessionKey.ts
+++ b/src/agent/dialog/sessionKey.ts
@@ -1,0 +1,22 @@
+// src/agent/dialog/sessionKey.ts
+//
+// テナントスコープのインメモリセッションストア（contextStore.ts / salesContextStore.ts）が
+// 共通で使う内部キー生成。`${tenantId}::${sessionId}` 形式の連結ロジックが2ファイルに
+// 別々に複製されており、片方（contextStore.ts）にだけ防御的アサーションが入っていた
+// （CLAUDE.md禁止事項6「同じ関心事を2ファイルに複製したまま片方だけ直す」の実例）。
+
+/**
+ * tenantId は作成時バリデーション(/^[a-z0-9_-]+$/、tenants/routes.ts)により
+ * コロンを含まない前提で、文字列中の最初の "::" が常に tenantId/sessionId の
+ * 境界になる（sessionId は z.string().max(128) のみで文字種制限がなく "::" を
+ * 含みうるが、それ自体は境界の一意性を壊さない）。
+ * この前提が将来のバリデーション変更等で崩れると、異なる tenantId/sessionId の
+ * 組み合わせが同一キーに衝突し履歴が混在しうるため、サイレントな衝突より
+ * 明示的な失敗を優先する防御的アサーション。
+ */
+export function buildTenantSessionKey(tenantId: string, sessionId: string): string {
+  if (tenantId.includes('::')) {
+    throw new Error('session key: tenantId must not contain "::"')
+  }
+  return `${tenantId}::${sessionId}`
+}

--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -54,15 +54,29 @@ function countRecentRequests(
 }
 
 export interface RateLimitOptions {
-  /** Override per-tenant limit. Falls back to TenantConfig or DEFAULT. */
-  getLimit?: (tenantId: string) => number | undefined;
+  /**
+   * Override the limit for a resolved bucket key. Falls back to TenantConfig
+   * or DEFAULT. The key is the *prefixed* bucket key actually used to bucket
+   * requests (e.g. `tenant:acme`, `ip:1.2.3.4`, or the unprefixed legacy
+   * `acme` / `anonymous` when `stage` is unset) — NOT a raw tenantId. A
+   * callback written as `(tenantId) => plans[tenantId]` will silently miss
+   * (`plans['tenant:acme']` is undefined) and fall through to DEFAULT with
+   * no error, so treat the argument as an opaque key, not a tenantId.
+   */
+  getLimit?: (key: string) => number | undefined;
   logger?: Logger;
   /**
    * 'ip'    — pre-auth stage: key by nginx-injected X-Real-IP (flood/DDoS
    *           protection before tenantId is known). Falls back to req.ip
    *           when the header is absent (e.g. direct/local requests).
-   * 'tenant'— post-auth stage: key by tenantId (current default behavior).
-   * unset   — legacy behavior, identical to 'tenant' (backward compatible).
+   * 'tenant'— post-auth stage: key by tenantId, prefixed `tenant:` to keep
+   *           its namespace independent from the 'ip' stage's `ip:` prefix.
+   * unset   — legacy/back-compat: keys by the *unprefixed* tenantId
+   *           (`authed.tenantId ?? "anonymous"`). This is NOT the same
+   *           bucket namespace as 'tenant' (which prefixes with `tenant:`) —
+   *           the two stages share no buckets. New call sites must specify
+   *           `stage` explicitly; leave this branch only for pre-existing
+   *           unmigrated callers.
    */
   stage?: "ip" | "tenant";
 }


### PR DESCRIPTION
## 問題

### 1. rate-limit.ts の getLimit 型不一致
`getLimit` オプションの型宣言が `(tenantId: string) => number | undefined` のままだが、`stage` 導入後（PR #806）の実引数は接頭辞付きキー（`tenant:acme` / `ip:1.2.3.4`）。現状 `getLimit` を渡す呼び出し元はコードベースに無く実害は無いが、将来プラン別上限を `(tenantId) => plans[tenantId]` と書くと、`plans['tenant:acme']` が `undefined` で**黙って既定値にフォールバックする**（例外もログも出ない）罠になる。

### 2. session key生成の重複（CLAUDE.md禁止事項6の実例）
`contextStore.ts` の `toInternalKey` には、tenantIdへの `::` 混入を検知する防御的アサーションが入っていた（テナント境界の衝突防止）が、同じ関心（`${tenantId}::${sessionId}` 形式のキー生成）を持つ `salesContextStore.ts` には同じ検証が無かった。

## 修正
- `rate-limit.ts`: `getLimit` の引数名を `key` に改め、JSDocに接頭辞付きキーである旨を明記。`stage`未指定（legacy）が `stage:'tenant'` と同一バケットではない（接頭辞の有無で名前空間が違う）ことも、不正確だったコメントを訂正
- `src/agent/dialog/sessionKey.ts`（新規）に `buildTenantSessionKey` を切り出し、`contextStore.ts` と `salesContextStore.ts` の両方から使うよう統一

## テスト
`pnpm typecheck` 0エラー、`oxlint` 0件、5スイート42/42 pass。ミューテーション検証: `buildTenantSessionKey` のコロン検証を無効化すると4件失敗、復元で18/18 pass を実測。

既存の `salesContextStore.test.ts` フィクスチャ（`tenantId: "tenant:demo"`）が単一コロンを含むため、新検証（`::`の二重コロンのみ検知）で壊れないことを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)