### PR TITLE
[SEC][P1] isAdminUsableToken を認証ミドルウェアに配線する

### DIFF
--- a/src/admin/http/supabaseAuthMiddleware.test.ts
+++ b/src/admin/http/supabaseAuthMiddleware.test.ts
@@ -174,6 +174,76 @@ describe("supabaseAuthMiddleware", () => {
       expect(res.statusCode).toBe(401);
     });
 
+    it("client_adminも正しく通る", () => {
+      const token = jwt.sign({ app_metadata: { role: "client_admin", tenant_id: "t1" } }, SECRET);
+      const { req, res, next } = makeReqRes({ authorization: `Bearer ${token}` });
+
+      supabaseAuthMiddleware(req, res, next);
+
+      expect(next).toHaveBeenCalledTimes(1);
+      expect(req.supabaseUser).toMatchObject({ app_metadata: { role: "client_admin" } });
+    });
+  });
+
+  describe("isAdminUsableToken配線: 署名は正しいが管理面で使えないトークンは403", () => {
+    const SECRET = "test-secret-value";
+
+    beforeEach(() => {
+      process.env.NODE_ENV = "test";
+      process.env.SUPABASE_JWT_SECRET = SECRET;
+    });
+
+    it("purposeクレーム保持トークン（widget-session等、同じsecretで署名されうる）は403", () => {
+      const token = jwt.sign({ sub: "t1", purpose: "widget-session" }, SECRET);
+      const { req, res, next } = makeReqRes({ authorization: `Bearer ${token}` });
+
+      supabaseAuthMiddleware(req, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(403);
+      expect(req.supabaseUser).toBeUndefined();
+    });
+
+    it("purposeクレーム保持トークン（chat-test）は403", () => {
+      const token = jwt.sign({ tenant_id: "t1", purpose: "chat-test" }, SECRET);
+      const { req, res, next } = makeReqRes({ authorization: `Bearer ${token}` });
+
+      supabaseAuthMiddleware(req, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(403);
+    });
+
+    it("role='anon'（トップレベル）は403", () => {
+      const token = jwt.sign({ sub: "u1", role: "anon" }, SECRET);
+      const { req, res, next } = makeReqRes({ authorization: `Bearer ${token}` });
+
+      supabaseAuthMiddleware(req, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(403);
+    });
+
+    it("app_metadata.role='anon'は403", () => {
+      const token = jwt.sign({ sub: "u1", app_metadata: { role: "anon" } }, SECRET);
+      const { req, res, next } = makeReqRes({ authorization: `Bearer ${token}` });
+
+      supabaseAuthMiddleware(req, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(403);
+    });
+
+    it("app_metadata.roleが未知の値（super_admin/client_admin以外）は403", () => {
+      const token = jwt.sign({ sub: "u1", app_metadata: { role: "viewer" } }, SECRET);
+      const { req, res, next } = makeReqRes({ authorization: `Bearer ${token}` });
+
+      supabaseAuthMiddleware(req, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(403);
+    });
+
     it("Bearerトークンなしは401", () => {
       const { req, res, next } = makeReqRes({});
       supabaseAuthMiddleware(req, res, next);

--- a/src/admin/http/supabaseAuthMiddleware.ts
+++ b/src/admin/http/supabaseAuthMiddleware.ts
@@ -2,6 +2,8 @@
 import type { NextFunction, Request, Response } from "express";
 import jwt from "jsonwebtoken";
 import { logger } from '../../lib/logger';
+import { isAdminUsableToken } from '../../auth/jwtClaims';
+import type { SupabaseJwtPayload } from '../../auth/verifySupabaseJwt';
 
 /**
  * Supabase の JWT を検証するミドルウェア
@@ -12,7 +14,7 @@ export function supabaseAuthMiddleware(
   req: Request,
   res: Response,
   next: NextFunction
-) {
+): void {
   // development: 署名検証なしで JWT をデコードし req.supabaseUser をセットして通す
   // （roleAuthMiddleware が role を正しく解決できるようにするため decode は必須）
   // 二重条件化(ALLOW_INSECURE_DEV_AUTH併用必須)も検討したが、35箇所以上の既存呼び出し元と
@@ -29,11 +31,16 @@ export function supabaseAuthMiddleware(
       } catch {
         // decode 失敗は無視して通す
       }
-      return next();
+      next();
+      return;
     }
     const apiKey = req.headers["x-api-key"];
-    if (apiKey) return next();
-    return res.status(401).json({ error: "Missing X-Api-Key or Bearer token" });
+    if (apiKey) {
+      next();
+      return;
+    }
+    res.status(401).json({ error: "Missing X-Api-Key or Bearer token" });
+    return;
   }
 
   // SUPABASE_JWT_SECRET 未設定時の扱い:
@@ -51,35 +58,49 @@ export function supabaseAuthMiddleware(
       logger.error(
         "[supabaseAuthMiddleware] SUPABASE_JWT_SECRET が設定されていません。認証を拒否します。"
       );
-      return res.status(503).json({ error: "auth_not_configured" });
+      res.status(503).json({ error: "auth_not_configured" });
+      return;
     }
     logger.warn(
       "[supabaseAuthMiddleware] SUPABASE_JWT_SECRET が設定されていないため、認証をスキップします。"
     );
-    return next();
+    next();
+    return;
   }
 
   const authHeader = req.headers.authorization || "";
   const [, token] = authHeader.split(" ");
 
   if (!token) {
-    return res.status(401).json({ error: "Missing Bearer token" });
+    res.status(401).json({ error: "Missing Bearer token" });
+    return;
   }
 
   try {
     // algorithms を HS256 に固定する。省略すると jsonwebtoken はトークン側の alg を
     // 信用するため、alg confusion 攻撃(RS256 を名乗るトークンを HMAC 秘密鍵で検証させる等)
     // の余地が残る。verifySupabaseJwt.ts(別経路)と同じ制約をこの管理面入口にも効かせる。
-    const decoded = jwt.verify(token, secret, { algorithms: ["HS256"] });
+    const decoded = jwt.verify(token, secret, { algorithms: ["HS256"] }) as SupabaseJwtPayload;
 
-    // 必要ならここでロールチェック (e.g. decoded["role"] === "service_role" など)
-    // logger.info("[supabaseAuth] decoded =", decoded);
+    // 署名が正しいだけでは「管理面で使ってよいトークン」とは限らない
+    // （widget/anon/chat-testトークンも同じsecretで署名されうる）。
+    // purpose クレーム保持・role='anon'・super_admin/client_admin以外のroleを拒否する。
+    if (!isAdminUsableToken(decoded)) {
+      logger.warn("[supabaseAuthMiddleware] token rejected: not admin-usable", {
+        hasPurpose: Boolean((decoded as Record<string, unknown>).purpose),
+        role: decoded.app_metadata?.role ?? decoded.role,
+      });
+      res.status(403).json({ error: "forbidden", message: "この操作を行う権限がありません" });
+      return;
+    }
 
     // 型を拡張してないので any でぶら下げる
     (req as any).supabaseUser = decoded;
-    return next();
+    next();
+    return;
   } catch (err) {
     logger.warn("[supabaseAuthMiddleware] invalid token", err);
-    return res.status(401).json({ error: "Invalid token" });
+    res.status(401).json({ error: "Invalid token" });
+    return;
   }
 }

--- a/src/api/admin/chatTest/routes.ts
+++ b/src/api/admin/chatTest/routes.ts
@@ -1,5 +1,5 @@
 // src/api/admin/chatTest/routes.ts
-import type { Express, NextFunction, Request, Response } from "express";
+import type { Express, Request, Response } from "express";
 import jwt from "jsonwebtoken";
 import { logger } from '../../../lib/logger';
 import { supabaseAuthMiddleware } from "../../../admin/http/supabaseAuthMiddleware";
@@ -18,11 +18,7 @@ function isAllowedChatTestRole(role: unknown): role is AllowedChatTestRole {
 
 export function registerChatTestRoutes(app: Express): void {
   // JWT検証は共有実装(src/admin/http/supabaseAuthMiddleware.ts)に一本化。
-  const chatTestAuth = supabaseAuthMiddleware as (
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ) => void;
+  const chatTestAuth = supabaseAuthMiddleware;
 
   // GET /v1/admin/chat-test/token?tenantId=xxx
   app.get("/v1/admin/chat-test/token", chatTestAuth, async (req: Request, res: Response) => {

--- a/src/api/admin/tenants/analyticsSummaryRoutes.ts
+++ b/src/api/admin/tenants/analyticsSummaryRoutes.ts
@@ -13,11 +13,7 @@ const PERIOD_DAYS: Record<string, number> = {
 
 export function registerAnalyticsSummaryRoutes(app: Express, db: Pool): void {
   // JWT検証は共有実装(src/admin/http/supabaseAuthMiddleware.ts)に一本化。
-  const tenantAuth = supabaseAuthMiddleware as (
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ) => void;
+  const tenantAuth = supabaseAuthMiddleware;
 
   function canAccessTenant(req: Request, res: Response, tenantId: string, next: NextFunction): void {
     const su = (req as AuthedReq).supabaseUser;

--- a/src/api/admin/tenants/ga4Routes.ts
+++ b/src/api/admin/tenants/ga4Routes.ts
@@ -18,11 +18,7 @@ const connectSchema = z.object({
 export function registerGa4TenantRoutes(app: Express, db: Pool): void {
   // JWT検証は共有実装(src/admin/http/supabaseAuthMiddleware.ts)に一本化。
   // ここでは req.supabaseUser の型を AuthedReq として扱えるよう別名で束ねるのみ。
-  const tenantAuth = supabaseAuthMiddleware as (
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ) => void;
+  const tenantAuth = supabaseAuthMiddleware;
 
   function canAccessTenant(
     req: Request,

--- a/src/api/admin/tenants/notificationPreferencesRoutes.ts
+++ b/src/api/admin/tenants/notificationPreferencesRoutes.ts
@@ -14,11 +14,7 @@ const upsertPreferencesSchema = z.object({
 
 export function registerNotificationPreferencesRoutes(app: Express, db: Pool): void {
   // JWT検証は共有実装(src/admin/http/supabaseAuthMiddleware.ts)に一本化。
-  const tenantAuth = supabaseAuthMiddleware as (
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ) => void;
+  const tenantAuth = supabaseAuthMiddleware;
 
   function canAccessTenant(req: Request, res: Response, tenantId: string, next: NextFunction): void {
     const su = (req as AuthedReq).supabaseUser;

--- a/src/api/admin/tenants/posthogRoutes.ts
+++ b/src/api/admin/tenants/posthogRoutes.ts
@@ -12,11 +12,7 @@ const connectSchema = z.object({
 
 export function registerPostHogTenantRoutes(app: Express, db: Pool): void {
   // JWT検証は共有実装(src/admin/http/supabaseAuthMiddleware.ts)に一本化。
-  const tenantAuth = supabaseAuthMiddleware as (
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ) => void;
+  const tenantAuth = supabaseAuthMiddleware;
 
   function canAccessTenant(req: Request, res: Response, tenantId: string, next: NextFunction): void {
     const su = (req as AuthedReq).supabaseUser;

--- a/src/api/admin/tenants/routes.ts
+++ b/src/api/admin/tenants/routes.ts
@@ -142,11 +142,7 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
   // 無条件 next() する fail-open だった（共有実装は production で503）。テナントCRUD・
   // APIキー発行/失効・招待という最高権限面が、他ルータより弱い認証で守られていた状態。
   // alg 固定(HS256)も共有実装側に集約されている。
-  const tenantAuth = supabaseAuthMiddleware as (
-    req: Request,
-    res: Response,
-    next: NextFunction,
-  ) => void;
+  const tenantAuth = supabaseAuthMiddleware;
 
   function requireSuperAdmin(req: Request, res: Response, next: NextFunction): void {
     const su = (req as AuthedReq).supabaseUser;

--- a/src/auth/verifySupabaseJwt.ts
+++ b/src/auth/verifySupabaseJwt.ts
@@ -32,13 +32,12 @@ export function verifySupabaseJwt(
     // widget セッション/chat-test トークン (同じ secret で署名、aud クレーム無し) の検証にも
     // 共用されているため、ここでの検証は署名の正当性確認に限定する。
     // 用途ごとの許可判定 (purpose/role) は本関数では行わない。
-    // ⚠️ jwtClaims.ts の isAdminUsableToken がその判定を担う想定だが、
-    //    **現時点ではどの認証ミドルウェアからも呼ばれていない**（配線は未完了）。
-    //    「この関数を通ったトークン = 管理面で使ってよいトークン」ではないことに注意。
-    //    現状 widget/anon/chat-test トークンを管理面で弾いているのは
-    //    (a) widget は別鍵(WIDGET_JWT_SECRET)署名なのでそもそも検証を通らない
-    //    (b) roleAuthMiddleware が app_metadata.role 不在を 403 にする
-    //    の2層であり、purpose クレームによる遮断は効いていない。
+    // jwtClaims.ts の isAdminUsableToken がその判定を担う。
+    // 管理面の共通認証入口 src/admin/http/supabaseAuthMiddleware.ts の
+    // jwt.verify 成功パスで isAdminUsableToken を呼び、purpose クレーム保持
+    // トークン・role='anon'・super_admin/client_admin以外のroleを403で拒否する。
+    // 「この関数(verifySupabaseJwt)を通った」だけでは管理面で使える保証にならない点は変わらない
+    // （本関数は署名の正当性確認に限定し、用途判定は呼び出し側の責務）。
     return jwt.verify(token, jwtSecret, { algorithms: ["HS256"] }) as SupabaseJwtPayload;
   } catch (err) {
     logger.warn("[verifySupabaseJwt] invalid token:", (err as Error).message);


### PR DESCRIPTION
## Summary
- `supabaseAuthMiddleware` のJWT検証成功パスは署名の正当性のみを確認しており、widget/chat-testトークン（同じ `SUPABASE_JWT_SECRET` で署名されうる `purpose` クレーム付きトークン）や `role='anon'` トークンでも管理APIを通過できていた。
- `isAdminUsableToken`（`src/auth/jwtClaims.ts`、既存の未配線ヘルパー）をJWT検証成功パスの末尾に追加し、purposeクレーム保持・role='anon'（トップレベル/app_metadata両方）・super_admin/client_admin以外のroleを403で拒否するようにした。
- 併せて、`supabaseAuthMiddleware` の戻り値型を明示的に `void` にしたため、呼び出し6箇所に残っていた `as (req,res,next)=>void` の不要キャストを削除した（`posthogRoutes.ts` / `routes.ts` / `notificationPreferencesRoutes.ts` / `analyticsSummaryRoutes.ts` / `ga4Routes.ts` / `chatTest/routes.ts`）。
- `chatTest/routes.ts` はキャスト削除に伴い型注釈でのみ使っていた `NextFunction` importが不要になったため削除。
- `verifySupabaseJwt.ts` のコメントを、配線完了の実態に合わせて更新（「未配線」の記述を削除）。

## 影響確認
- chat-testトークン発行エンドポイント（`GET /v1/admin/chat-test/token`）は管理者JWTでの認証が必要な箇所であり、新ゲートの対象。発行された chat-test トークン自体は別ミドルウェア（`src/agent/http/authMiddleware.ts`）で検証されるフローのため、本変更による機能的な影響なし（事前確認済み）。

## Test plan
- [x] `pnpm typecheck` — 0 errors
- [x] `npx oxlint` (変更9ファイル) — 0 warnings
- [x] `pnpm jest --testPathPatterns="supabaseAuthMiddleware|jwtClaims|ai-assist|chatTest|ga4|posthog|analyticsSummary|notificationPreferences|knowledge|faqAdmin|tenants"` — 29/30 suites pass, 381/384 tests pass（残る3件の失敗は `knowledgeAttribution.test.ts` の既存フレーキーテストで、mainと完全に同一内容・本PRの変更と無関係と確認済み）
- [x] `src/admin/http/supabaseAuthMiddleware.test.ts` に新規テスト5件を追加（purposeクレーム保持×2種・role='anon'トップレベル・app_metadata.role='anon'・未知role）+ client_admin正常系1件。20/20 pass
- [x] ミューテーション確認: `isAdminUsableToken` 呼び出しを一時的に削除 → 新規テスト5件が期待通り失敗することを確認 → 復元して20/20 pass

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NgCQYt8UMPgm4HNVu7nv7z