### PR TITLE
[LAUNCH][P2] テナント招待UIを実装する

### DIFF
--- a/admin-ui/src/pages/admin/tenants/InviteTab.test.tsx
+++ b/admin-ui/src/pages/admin/tenants/InviteTab.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { InviteTab } from "./InviteTab";
+import { authFetch } from "../../../lib/api";
+
+vi.mock("../../../lib/api", () => ({
+  API_BASE: "http://localhost:3100",
+  authFetch: vi.fn(),
+}));
+
+const mockedAuthFetch = authFetch as unknown as ReturnType<typeof vi.fn>;
+
+function jsonResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  };
+}
+
+beforeEach(() => {
+  mockedAuthFetch.mockReset();
+});
+
+describe("InviteTab", () => {
+  it("メール未入力では送信ボタンが無効", () => {
+    render(<InviteTab tenantId="t1" />);
+    const button = screen.getByRole("button", { name: /招待メールを送信/ });
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("不正なメール形式では送信ボタンが無効でバリデーションメッセージが出る", () => {
+    render(<InviteTab tenantId="t1" />);
+    const input = screen.getByLabelText("招待するメールアドレス");
+    fireEvent.change(input, { target: { value: "not-an-email" } });
+
+    const button = screen.getByRole("button", { name: /招待メールを送信/ });
+    expect((button as HTMLButtonElement).disabled).toBe(true);
+    expect(screen.getByText(/有効なメールアドレスを入力してください/)).toBeTruthy();
+  });
+
+  it("送信成功時に成功メッセージを表示し、入力欄をクリアする", async () => {
+    mockedAuthFetch.mockResolvedValue(
+      jsonResponse(201, { ok: true, userId: "u1", email: "new@example.com", tenantId: "t1", role: "client_admin" })
+    );
+    render(<InviteTab tenantId="t1" />);
+    const input = screen.getByLabelText("招待するメールアドレス") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "new@example.com" } });
+    fireEvent.click(screen.getByRole("button", { name: /招待メールを送信/ }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("status").textContent).toMatch(/招待しました/);
+    });
+    expect(input.value).toBe("");
+    expect(mockedAuthFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/v1/admin/tenants/t1/invite"),
+      expect.objectContaining({ method: "POST" })
+    );
+  });
+
+  it("metadata_update_failed: 招待は送信済みだがロール設定失敗、という中間状態を明示する", async () => {
+    mockedAuthFetch.mockResolvedValue(
+      jsonResponse(500, {
+        error: "metadata_update_failed",
+        message: "招待メールは送信しましたが、ロール設定に失敗しました。手動で設定してください。",
+      })
+    );
+    render(<InviteTab tenantId="t1" />);
+    fireEvent.change(screen.getByLabelText("招待するメールアドレス"), {
+      target: { value: "half@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /招待メールを送信/ }));
+
+    await waitFor(() => {
+      const status = screen.getByRole("status").textContent ?? "";
+      expect(status).toMatch(/招待メールは送信されました/);
+      expect(status).toMatch(/ロール設定に失敗/);
+    });
+  });
+
+  it("invite_failed: backendのmessageをそのまま表示する", async () => {
+    mockedAuthFetch.mockResolvedValue(
+      jsonResponse(400, { error: "invite_failed", message: "既に招待済みのユーザーです。" })
+    );
+    render(<InviteTab tenantId="t1" />);
+    fireEvent.change(screen.getByLabelText("招待するメールアドレス"), {
+      target: { value: "dup@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /招待メールを送信/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText("既に招待済みのユーザーです。")).toBeTruthy();
+    });
+  });
+
+  it("tenant_disabled: テナント無効化時の専用文言", async () => {
+    mockedAuthFetch.mockResolvedValue(jsonResponse(403, { error: "tenant_disabled" }));
+    render(<InviteTab tenantId="t1" />);
+    fireEvent.change(screen.getByLabelText("招待するメールアドレス"), {
+      target: { value: "x@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /招待メールを送信/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/無効化されているため/)).toBeTruthy();
+    });
+  });
+
+  it("通信エラー（fetch自体が例外）でも汎用エラー文言を表示する", async () => {
+    mockedAuthFetch.mockRejectedValue(new Error("network down"));
+    render(<InviteTab tenantId="t1" />);
+    fireEvent.change(screen.getByLabelText("招待するメールアドレス"), {
+      target: { value: "y@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /招待メールを送信/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/通信エラーが発生しました/)).toBeTruthy();
+    });
+  });
+});

--- a/admin-ui/src/pages/admin/tenants/InviteTab.tsx
+++ b/admin-ui/src/pages/admin/tenants/InviteTab.tsx
@@ -1,0 +1,162 @@
+import { useState } from "react";
+import { authFetch, API_BASE } from "../../../lib/api";
+import { CARD_STYLE } from "./types";
+
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+interface InviteResponse {
+  error?: string;
+  message?: string;
+  ok?: boolean;
+  email?: string;
+}
+
+/**
+ * 招待APIは「メール送信」→「app_metadataへのrole/tenant_id設定」の2段階で、
+ * ロールバックが無い（POST /:id/invite、backend側の既知の弱さ）。
+ * metadata_update_failed は「招待メールは送信済みだがロール未設定」という
+ * 中間状態を表すため、他の失敗（招待自体が届いていない）と文言を分ける。
+ */
+function messageFor(status: number, body: InviteResponse | null): string {
+  if (body?.error === "metadata_update_failed") {
+    return `招待メールは送信されました（${body.email ?? ""}）が、ロール設定に失敗しました。手動で設定するか、管理者にお問い合わせください。`;
+  }
+  if (body?.error === "invite_failed") {
+    return body.message ?? "招待メールの送信に失敗しました。時間をおいて再度お試しください。";
+  }
+  if (body?.error === "tenant_disabled") {
+    return "このテナントは無効化されているため、ユーザーを招待できません。";
+  }
+  if (body?.error === "not_found") {
+    return "テナントが見つかりません。";
+  }
+  if (status === 503) {
+    return "招待機能が現在利用できません（Supabase Admin未設定）。管理者にお問い合わせください。";
+  }
+  if (body?.message) {
+    return body.message;
+  }
+  return "招待処理に失敗しました。時間をおいて再度お試しください。";
+}
+
+export function InviteTab({ tenantId }: { tenantId: string }) {
+  const [email, setEmail] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [result, setResult] = useState<
+    { kind: "success"; message: string } | { kind: "error"; message: string } | null
+  >(null);
+
+  const trimmed = email.trim();
+  const isValid = EMAIL_PATTERN.test(trimmed);
+
+  const handleSubmit = async () => {
+    if (!isValid || submitting) return;
+    setSubmitting(true);
+    setResult(null);
+    try {
+      const res = await authFetch(`${API_BASE}/v1/admin/tenants/${tenantId}/invite`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email: trimmed }),
+      });
+      let body: InviteResponse | null = null;
+      try {
+        body = (await res.json()) as InviteResponse;
+      } catch {
+        body = null;
+      }
+      if (res.ok) {
+        setResult({
+          kind: "success",
+          message: `${trimmed} を client_admin として招待しました。招待メールをご確認ください。`,
+        });
+        setEmail("");
+      } else {
+        setResult({ kind: "error", message: messageFor(res.status, body) });
+      }
+    } catch {
+      setResult({
+        kind: "error",
+        message: "通信エラーが発生しました。しばらく待ってからもう一度お試しください。",
+      });
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <div style={CARD_STYLE}>
+      <h3 style={{ margin: "0 0 8px", fontSize: 16, fontWeight: 700 }}>
+        client_admin を招待
+      </h3>
+      <p style={{ margin: "0 0 16px", fontSize: 13, color: "var(--muted-foreground)" }}>
+        メールアドレスを入力すると、このテナントの client_admin として招待メールが送信されます。
+      </p>
+
+      <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+        <input
+          type="email"
+          value={email}
+          placeholder="user@example.com"
+          onChange={(e) => setEmail(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") handleSubmit();
+          }}
+          style={{
+            flex: 1,
+            minWidth: 240,
+            padding: "10px 12px",
+            borderRadius: 8,
+            border: "1px solid var(--border)",
+            background: "var(--background)",
+            color: "var(--foreground)",
+            fontSize: 14,
+          }}
+          aria-label="招待するメールアドレス"
+        />
+        <button
+          type="button"
+          onClick={handleSubmit}
+          disabled={!isValid || submitting}
+          style={{
+            padding: "10px 20px",
+            borderRadius: 8,
+            border: "none",
+            background: !isValid || submitting ? "var(--muted)" : "var(--primary)",
+            color: !isValid || submitting ? "var(--muted-foreground)" : "var(--primary-foreground)",
+            fontWeight: 600,
+            fontSize: 14,
+            cursor: !isValid || submitting ? "not-allowed" : "pointer",
+          }}
+        >
+          {submitting ? "送信中…" : "招待メールを送信"}
+        </button>
+      </div>
+
+      {trimmed.length > 0 && !isValid && (
+        <p style={{ margin: "8px 0 0", fontSize: 12, color: "var(--destructive, #dc2626)" }}>
+          有効なメールアドレスを入力してください。
+        </p>
+      )}
+
+      {result && (
+        <div
+          role="status"
+          style={{
+            marginTop: 16,
+            padding: "10px 14px",
+            borderRadius: 8,
+            fontSize: 13,
+            background:
+              result.kind === "success"
+                ? "rgba(34, 197, 94, 0.12)"
+                : "rgba(220, 38, 38, 0.12)",
+            color: result.kind === "success" ? "#16a34a" : "#dc2626",
+          }}
+        >
+          {result.message}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/admin-ui/src/pages/admin/tenants/[id].tsx
+++ b/admin-ui/src/pages/admin/tenants/[id].tsx
@@ -23,6 +23,7 @@ import { SettingsTab } from "./SettingsTab";
 import { TenantDetailHeader } from "./TenantDetailHeader";
 import { TenantDetailTabs } from "./TenantDetailTabs";
 import { SettingsHistoryTab } from "./SettingsHistoryTab";
+import { InviteTab } from "./InviteTab";
 import type { TenantFeatures, TenantDetail, ApiKey, TabId } from "./types";
 
 // ─── 型定義 (TenantFeatures, TenantDetail, ApiKey は ./types に移動) ──────────
@@ -255,6 +256,7 @@ export default function TenantDetailPage() {
         { id: "ab-test", label: "🔬 A/Bテスト" },
         { id: "objection-patterns", label: "💬 反論パターン" },
         { id: "settings-history", label: "設定変更履歴" },
+        { id: "invite", label: "✉️ 招待" },
       ]
     : baseTabs;
 
@@ -371,6 +373,9 @@ export default function TenantDetailPage() {
           )}
           {activeTab === "settings-history" && isSuperAdmin && (
             <SettingsHistoryTab tenantId={tenantId} />
+          )}
+          {activeTab === "invite" && isSuperAdmin && (
+            <InviteTab tenantId={tenantId} />
           )}
           {activeTab === "conversion" && tenant && (
             <ConversionTypesTab

--- a/admin-ui/src/pages/admin/tenants/types.ts
+++ b/admin-ui/src/pages/admin/tenants/types.ts
@@ -74,7 +74,7 @@ export const CARD_STYLE: CSSProperties = {
 
 // ─── タブID（[id].tsx から移動） ──────────────────────────────────────────────
 
-export type TabId = "settings" | "apikeys" | "embed" | "avatar" | "ai-report" | "ab-test" | "objection-patterns" | "conversion" | "deep-research" | "tuning" | "test" | "ga4" | "posthog" | "analytics" | "billing-info" | "notification-prefs" | "settings-history";
+export type TabId = "settings" | "apikeys" | "embed" | "avatar" | "ai-report" | "ab-test" | "objection-patterns" | "conversion" | "deep-research" | "tuning" | "test" | "ga4" | "posthog" | "analytics" | "billing-info" | "notification-prefs" | "settings-history" | "invite";
 
 // ─── スタイル定数（[id].tsx から移動） ────────────────────────────────────────
 


### PR DESCRIPTION
## 概要
super_admin向けテナント詳細画面に「招待」タブを追加。既存の `POST /v1/admin/tenants/:id/invite`（Supabase招待メール送信 → app_metadataへのrole/tenant_id設定、の2段階・ロールバック無し）を呼び出し、各レスポンスに応じた文言を出し分ける。

## 変更内容
- `admin-ui/src/pages/admin/tenants/InviteTab.tsx`（新規）: メール入力 → 送信 → 結果表示のシンプルなフォーム。email形式バリデーションで送信ボタンを無効化。
- `admin-ui/src/pages/admin/tenants/InviteTab.test.tsx`（新規）: 7ケース
  - 未入力/不正メール形式で送信ボタン無効
  - 送信成功で成功メッセージ表示＋入力欄クリア
  - `metadata_update_failed`（招待メール送信済み・ロール設定失敗の中間状態）専用文言
  - `invite_failed` はbackendの `message` をそのまま表示
  - `tenant_disabled` 専用文言
  - 通信エラー（fetch自体が例外）で汎用文言
- `admin-ui/src/pages/admin/tenants/[id].tsx`: `InviteTab` のimportとタブ登録（super_admin限定タブ群の末尾）
- `admin-ui/src/pages/admin/tenants/types.ts`: `TabId` に `"invite"` を追加

## Tier S 注記
`admin-ui/src` の変更のため、Mergify自動マージ対象外です。**hkobayashiによる手動マージが必要**。

## テスト結果
- `npx tsc -b --force`: エラー0件
- `npx vitest run src/pages/admin/tenants/InviteTab.test.tsx`: 7/7 pass
- 回帰確認（admin-ui全体）: `Test Files 37 passed (37)` / `Tests 504 passed (504)`
- `npx eslint` (変更4ファイル): エラー1件検出も `[id].tsx:150` の `as any` は本PRの変更範囲外の既存コード（差分に含まれない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)