### PR TITLE
[SEC][P2] evaluateSessionのnull多義性を解消（空セッションと内部エラーを区別）

### DIFF
--- a/src/agent/judge/judgeEvaluator.test.ts
+++ b/src/agent/judge/judgeEvaluator.test.ts
@@ -42,7 +42,7 @@ jest.mock('../openclaw/rewardBridge', () => ({
 import { callGeminiJudge } from '../../lib/gemini/client';
 import { getPool } from '../../lib/db';
 import { readFile } from 'fs/promises';
-import { evaluateSession, SessionNotFoundError, SessionTenantMismatchError } from './judgeEvaluator';
+import { evaluateSession, SessionNotFoundError, SessionTenantMismatchError, SessionTooShortError } from './judgeEvaluator';
 import { sendRewardSignal } from '../openclaw/rewardBridge';
 import {
   getOrInitFlowSessionMeta,
@@ -486,5 +486,27 @@ describe('evaluateSession', () => {
       rows: [{ id: 'internal-1', tenant_id: 'tenant-b', prompt_variant_id: null }],
     });
     await expect(evaluateSession('other-tenant-session', 'tenant-a')).rejects.toBeInstanceOf(SessionTenantMismatchError);
+  });
+
+  it('15. [境界値] メッセージが0件のセッション → SessionTooShortErrorをthrowする（nullを返さない）', async () => {
+    const mockPool = makeMockPool();
+    mockGetPool.mockReturnValue(mockPool as any);
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [{ id: 'internal-uuid-empty', tenant_id: 'tenant-a', prompt_variant_id: null }] })
+      .mockResolvedValueOnce({ rows: [] }); // messages: 0件
+
+    await expect(evaluateSession('session-empty')).rejects.toThrow(SessionTooShortError);
+    expect(mockCallGroq).not.toHaveBeenCalled();
+  });
+
+  it('16. [境界値] メッセージが1件のみのセッション → SessionTooShortErrorをthrowする（nullを返さない）', async () => {
+    const mockPool = makeMockPool();
+    mockGetPool.mockReturnValue(mockPool as any);
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [{ id: 'internal-uuid-2', tenant_id: 'tenant-a', prompt_variant_id: null }] })
+      .mockResolvedValueOnce({ rows: [{ role: 'user', content: 'こんにちは', created_at: new Date() }] });
+
+    await expect(evaluateSession('session-single-message')).rejects.toThrow(SessionTooShortError);
+    expect(mockCallGroq).not.toHaveBeenCalled();
   });
 });

--- a/src/agent/judge/judgeEvaluator.ts
+++ b/src/agent/judge/judgeEvaluator.ts
@@ -41,6 +41,19 @@ export class SessionNotFoundError extends Error {
   }
 }
 
+/**
+ * セッションが存在し所有権も一致するが、会話が0〜1通のみで評価対象にならない場合に投げる。
+ * これは障害ではなく正常な「評価対象外」状態のため、呼び出し元(routes.ts)は
+ * 500(evaluation_failed)ではなく422で理由を返す。Gemini呼び出し失敗など
+ * 真の内部エラー（null を返す経路）とは区別する。
+ */
+export class SessionTooShortError extends Error {
+  constructor(sessionId: string) {
+    super(`session ${sessionId} has too few messages to evaluate`);
+    this.name = 'SessionTooShortError';
+  }
+}
+
 const JUDGE_MODEL = process.env['GEMINI_MODEL'] ?? 'gemini-2.5-flash';
 
 const FALLBACK_PROMPT_TEMPLATE = `あなたは営業チャットAIの品質評価Judgeです。
@@ -187,7 +200,7 @@ export async function evaluateSession(sessionId: string, expectedTenantId?: stri
     // 2b. Skip evaluation for empty/single-message sessions
     if (messages.length <= 1) {
       logger.warn({ sessionId, messageCount: messages.length }, 'judgeEvaluator: skipping empty/single-message session');
-      return null;
+      throw new SessionTooShortError(sessionId);
     }
 
     // 3. Build conversation log — content sliced to 200 chars (Anti-Slop rule)
@@ -398,7 +411,11 @@ export async function evaluateSession(sessionId: string, expectedTenantId?: stri
 
     return result;
   } catch (err) {
-    if (err instanceof SessionTenantMismatchError || err instanceof SessionNotFoundError) throw err;
+    if (
+      err instanceof SessionTenantMismatchError ||
+      err instanceof SessionNotFoundError ||
+      err instanceof SessionTooShortError
+    ) throw err;
     logger.error({ err, sessionId }, 'judgeEvaluator: unexpected error in evaluateSession');
     return null;
   }

--- a/src/api/admin/evaluations/routes.ts
+++ b/src/api/admin/evaluations/routes.ts
@@ -210,10 +210,15 @@ export function registerEvaluationRoutes(app: Express): void {
       }
       return res.json({ evaluation: result });
     } catch (err) {
-      const { SessionTenantMismatchError, SessionNotFoundError } = await import("../../../agent/judge/judgeEvaluator");
+      const { SessionTenantMismatchError, SessionNotFoundError, SessionTooShortError } = await import("../../../agent/judge/judgeEvaluator");
       // 「不在」と「他テナントのもの」を同一の404にし、存在確認オラクルにしない。
       if (err instanceof SessionTenantMismatchError || err instanceof SessionNotFoundError) {
         return res.status(404).json({ error: "セッションが見つかりません" });
+      }
+      // 会話が短すぎて評価対象外なのは障害ではない。500(evaluation_failed)と
+      // 区別し、理由が分かる422で返す。
+      if (err instanceof SessionTooShortError) {
+        return res.status(422).json({ error: "session_too_short", message: "会話が短すぎるため評価対象外です" });
       }
       logger.warn("[POST /v1/admin/evaluations/trigger]", err);
       return res.status(500).json({ error: "評価の実行に失敗しました" });

--- a/tests/integration/wiring-check.test.ts
+++ b/tests/integration/wiring-check.test.ts
@@ -125,7 +125,7 @@ import {
 import { searchTool } from "../../src/agent/tools/searchTool";
 import { synthesizeAnswer } from "../../src/agent/tools/synthesisTool";
 import { getActiveRulesForTenant } from "../../src/api/admin/tuning/tuningRulesRepository";
-import { evaluateSession, SessionNotFoundError } from "../../src/agent/judge/judgeEvaluator";
+import { evaluateSession, SessionNotFoundError, SessionTooShortError } from "../../src/agent/judge/judgeEvaluator";
 import { sanitizeInput } from "../../src/middleware/inputSanitizer";
 import { applyPromptFirewall } from "../../src/middleware/promptFirewall";
 import { guardOutput } from "../../src/middleware/outputGuard";
@@ -442,7 +442,7 @@ describe("Flow 3: Judge evaluateSession → Gemini → DB persistence", () => {
     expect(callGeminiJudge).not.toHaveBeenCalled();
   });
 
-  it("evaluateSession skips evaluation for single-message sessions", async () => {
+  it("evaluateSession throws SessionTooShortError for single-message sessions (障害ではなく評価対象外を示すため、nullではなくthrow)", async () => {
     MOCK_POOL.query
       .mockResolvedValueOnce({
         rows: [{ id: "internal-uuid-2", tenant_id: "test-tenant" }],
@@ -453,9 +453,7 @@ describe("Flow 3: Judge evaluateSession → Gemini → DB persistence", () => {
         rowCount: 1,
       });
 
-    const result = await evaluateSession(SESSION_ID);
-
-    expect(result).toBeNull();
+    await expect(evaluateSession(SESSION_ID)).rejects.toThrow(SessionTooShortError);
     expect(callGeminiJudge).not.toHaveBeenCalled();
   });
 });

--- a/tests/phase45/evaluationRoutes.test.ts
+++ b/tests/phase45/evaluationRoutes.test.ts
@@ -27,6 +27,7 @@ jest.mock("../../src/agent/judge/judgeEvaluator", () => ({
   evaluateSession: jest.fn(),
   SessionTenantMismatchError: class SessionTenantMismatchError extends Error {},
   SessionNotFoundError: class SessionNotFoundError extends Error {},
+  SessionTooShortError: class SessionTooShortError extends Error {},
 }));
 
 import {
@@ -177,7 +178,7 @@ describe("1. POST /v1/admin/evaluations/trigger", () => {
     expect(evaluateSession).not.toHaveBeenCalled();
   });
 
-  it("returns 500 when evaluateSession returns null (e.g. 空/1通話のみで評価をスキップした場合。'不在'とは区別される — 下記オラクル防止テスト参照)", async () => {
+  it("returns 500 when evaluateSession returns null (真の内部エラー、例: Gemini呼び出し失敗。空/1通話のみのケースはSessionTooShortErrorで区別される — 下記参照)", async () => {
     (checkAlreadyEvaluated as jest.Mock).mockResolvedValue(false);
     (evaluateSession as jest.Mock).mockResolvedValue(null);
 
@@ -187,6 +188,23 @@ describe("1. POST /v1/admin/evaluations/trigger", () => {
 
     expect(res.status).toBe(500);
     expect(res.body.error).toBe("evaluation_failed");
+  });
+
+  it("returns 422 (not 500) when evaluateSession throws SessionTooShortError — 空/1通話のみのセッションは障害ではなく評価対象外として区別する", async () => {
+    const { SessionTooShortError } = jest.requireMock(
+      "../../src/agent/judge/judgeEvaluator",
+    ) as { SessionTooShortError: new (sessionId: string) => Error };
+    (checkAlreadyEvaluated as jest.Mock).mockResolvedValue(false);
+    (evaluateSession as jest.Mock).mockRejectedValue(
+      new SessionTooShortError("sess-001"),
+    );
+
+    const res = await request(makeApp())
+      .post("/v1/admin/evaluations/trigger")
+      .send({ session_id: "sess-001" });
+
+    expect(res.status).toBe(422);
+    expect(res.body.error).toBe("session_too_short");
   });
 
   it("returns 400 when session_id is missing", async () => {

--- a/tests/phase52/judge-empty-session.test.ts
+++ b/tests/phase52/judge-empty-session.test.ts
@@ -29,7 +29,7 @@ jest.mock("../../src/lib/crossTenantContext", () => ({
 import { callGeminiJudge } from "../../src/lib/gemini/client";
 import { getPool } from "../../src/lib/db";
 import { readFile } from "fs/promises";
-import { evaluateSession } from "../../src/agent/judge/judgeEvaluator";
+import { evaluateSession, SessionTooShortError } from "../../src/agent/judge/judgeEvaluator";
 
 const mockCallGemini = callGeminiJudge as jest.MockedFunction<typeof callGeminiJudge>;
 const mockGetPool = getPool as jest.MockedFunction<typeof getPool>;
@@ -66,7 +66,7 @@ beforeEach(() => {
 });
 
 describe("evaluateSession — 空/単一メッセージセッションのスキップ", () => {
-  it("1. 0メッセージのセッション → null を返す（Gemini呼び出しなし）", async () => {
+  it("1. 0メッセージのセッション → SessionTooShortError を投げる（Gemini呼び出しなし）", async () => {
     const mockPool = makeMockPool();
     mockGetPool.mockReturnValue(mockPool);
 
@@ -74,13 +74,11 @@ describe("evaluateSession — 空/単一メッセージセッションのスキ�
       .mockResolvedValueOnce({ rows: [{ id: "internal-uuid-empty", tenant_id: "tenant-a" }] })
       .mockResolvedValueOnce({ rows: [] }); // 0 messages
 
-    const result = await evaluateSession("session-empty");
-
-    expect(result).toBeNull();
+    await expect(evaluateSession("session-empty")).rejects.toThrow(SessionTooShortError);
     expect(mockCallGemini).not.toHaveBeenCalled();
   });
 
-  it("2. 1メッセージのセッション → null を返す（Gemini呼び出しなし）", async () => {
+  it("2. 1メッセージのセッション → SessionTooShortError を投げる（Gemini呼び出しなし）", async () => {
     const mockPool = makeMockPool();
     mockGetPool.mockReturnValue(mockPool);
 
@@ -90,9 +88,7 @@ describe("evaluateSession — 空/単一メッセージセッションのスキ�
         rows: [{ role: "user", content: "こんにちは", created_at: new Date() }],
       }); // 1 message only
 
-    const result = await evaluateSession("session-single");
-
-    expect(result).toBeNull();
+    await expect(evaluateSession("session-single")).rejects.toThrow(SessionTooShortError);
     expect(mockCallGemini).not.toHaveBeenCalled();
   });
 


### PR DESCRIPTION
## 概要
`evaluateSession` は「空/1通話のみで評価対象外」と「Gemini呼び出し失敗などの真の内部エラー」を、これまで同じ `null` 返却（→ ルート層で 500 `evaluation_failed`）に潰していた。前者は障害ではないため、専用の `SessionTooShortError` をthrowし、ルート層で 422 `session_too_short` を返すよう区別した。

## 変更点
- `src/agent/judge/judgeEvaluator.ts`: `SessionTooShortError` を新設。空/1通話セッション判定（`messages.length <= 1`）を `return null` から `throw new SessionTooShortError(sessionId)` に変更。outer catch の rethrow リストに追加。Gemini失敗・DB失敗時の `null` 返却は変更なし。
- `src/api/admin/evaluations/routes.ts`: トリガーエンドポイントの catch に `SessionTooShortError` ハンドリングを追加し 422 を返す。既存の 404（不在/他テナント）・500（真の内部エラー）は変更なし。
- `tests/integration/wiring-check.test.ts`: 旧 `null` 契約を検証していた既存テストを新仕様（`rejects.toThrow(SessionTooShortError)`）に書き換え。
- `src/agent/judge/judgeEvaluator.test.ts`: 0件/1件メッセージセッションで `SessionTooShortError` がthrowされることを検証する新規テストを2件追加。
- `tests/phase45/evaluationRoutes.test.ts`: トリガーエンドポイントが `SessionTooShortError` に対して422を返すこと、Gemini失敗（null）は引き続き500を返すこと、の両方を検証する新規テストを追加。mockモジュールに `SessionTooShortError` を追加。

## ステータスコード選定
422 Unprocessable Entity — リクエスト自体は正当（セッションは存在し所有権も一致）だが、会話が短すぎて評価という処理を実行できないため。500ではなく処理不能を意味する422が適切と判断。

## テスト結果
- `pnpm typecheck`: 0 errors
- `judgeEvaluator.test.ts`: 16/16 pass（新規2件含む）
- `tests/phase45/evaluationRoutes.test.ts`: 24/24 pass（新規1件含む）
- `tests/integration/wiring-check.test.ts`: 25/25 pass（書き換え1件含む）
- `npx oxlint` on 変更ファイル: エラーなし（既存の未使用importの警告のみ、本PRとは無関係）

※ 上記テストを `judgeEvaluator|evaluationRoutes|evaluations` パターンで一括実行すると、本PRと無関係な他テストファイル（`evaluations — ALLOWED_ROLES whitelist` 等）がランダムに5秒タイムアウトで落ちることがあるのを確認済み。単体実行では全て安定してpassし、失敗するテスト名も毎回異なるため、環境要因（並行実行時の負荷）による既存のflakinessであり本PRのリグレッションではない。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>