### PR TITLE
[LAUNCH][P2] client_adminのAPIキー自力発行+無停止ローテーション対応

### DIFF
--- a/src/api/admin/tenants/routes.ts
+++ b/src/api/admin/tenants/routes.ts
@@ -6,7 +6,7 @@ import { isAllowedAdminRole } from "../../middleware/roleAuth";
 import { Pool } from "pg";
 import { z } from "zod";
 import { supabaseAuthMiddleware } from "../../../admin/http/supabaseAuthMiddleware";
-import { registerTenant, updateTenantEnabled, updateTenantAllowedOrigins, setTenantApiKeyExpiry, revokeTenantApiKeyIfCurrent } from "../../../lib/tenant-context";
+import { registerTenant, updateTenantEnabled, updateTenantAllowedOrigins, setTenantApiKeyExpiry, revokeTenantApiKeyIfCurrent, addTenantApiKey, revokeAdditionalTenantApiKey } from "../../../lib/tenant-context";
 import { invalidateWorkspaceCache } from "../../../agent/openclaw/workspaceCache";
 import { generateApiKey, hashApiKey, maskApiKeyPrefix } from "./apiKeyUtils";
 import { supabaseAdmin } from "../../../auth/supabaseClient";
@@ -16,6 +16,28 @@ import { planHasFeature, type TenantPlan } from "../../../lib/billing/planFeatur
 import { deriveOnboardingStage, type OnboardingStageStatus } from "../agent/onboardingStage";
 
 const planValues = ["starter", "growth", "enterprise"] as const;
+
+// 日付のみの文字列("2026-01-01"等)はUTC深夜と解釈されるため、意図したタイムゾーンと
+// ズレて「まだ未来のつもりが過去判定される」事故が起きやすい。バリデーションのロジックは
+// 変えず、エラーメッセージでタイムゾーン付きISO-8601形式を案内する。
+const EXPIRES_AT_FORMAT_HINT = "expires_atはタイムゾーンを含むISO-8601形式（例: 2026-01-01T00:00:00+09:00）で指定してください。日付のみの指定はUTC深夜として解釈されます。";
+
+// APIキー発行時の expires_at 検証。super_admin向け・client_admin向け両方の
+// キー発行エンドポイントで共有する（複製しない）。
+function validateExpiresAt(
+  raw: unknown
+): { expiresAt: Date | null } | { error: string; message: string } {
+  if (!raw) return { expiresAt: null };
+  const expiresAt = new Date(raw as string);
+  if (isNaN(expiresAt.getTime())) {
+    return { error: "invalid_expires_at", message: EXPIRES_AT_FORMAT_HINT };
+  }
+  // 過去日時を許可すると、発行直後から使えない「死んだキー」が201で作れてしまう。
+  if (expiresAt.getTime() <= Date.now()) {
+    return { error: "expires_at_in_past", message: `expires_atは未来の日時である必要があります。${EXPIRES_AT_FORMAT_HINT}` };
+  }
+  return { expiresAt };
+}
 
 // GID 1216274591838389: 初回ログイン時オンボーディングの業種選択肢
 const onboardingIndustryValues = ["auto", "beauty", "food", "realestate", "retail", "other"] as const;
@@ -283,6 +305,120 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
     }
   });
 
+  // POST /v1/admin/my-tenant/keys — Client Admin専用: 自テナントのAPIキーを自力発行する。
+  // super_admin向け POST /v1/admin/tenants/:id/keys と異なり、in-memory側は
+  // registerTenant(既存キーを上書き)ではなく addTenantApiKey(既存キーを維持したまま追加)を
+  // 使う。旧キーはclient_adminが明示的に失効させるまで有効のまま＝無停止ローテーション。
+  app.post("/v1/admin/my-tenant/keys", tenantAuth, requireAdminRole, async (req: Request, res: Response) => {
+    const su = (req as AuthedReq).supabaseUser;
+    const tenantId = su?.app_metadata?.tenant_id as string | undefined;
+    if (!tenantId) {
+      return res.status(403).json({ error: "forbidden", message: "テナントIDが見つかりません" });
+    }
+    try {
+      const tenantCheck = await db.query("SELECT id, is_active FROM tenants WHERE id = $1", [tenantId]);
+      if (tenantCheck.rowCount === 0) {
+        return res.status(404).json({ error: "not_found", message: "テナントが見つかりません。" });
+      }
+      if (!tenantCheck.rows[0].is_active) {
+        return res.status(403).json({ error: "tenant_disabled", message: "無効なテナントにはAPIキーを発行できません。" });
+      }
+
+      const expiresAtResult = validateExpiresAt(req.body?.expires_at);
+      if ("error" in expiresAtResult) {
+        return res.status(400).json({ error: expiresAtResult.error, message: expiresAtResult.message });
+      }
+      const expiresAt = expiresAtResult.expiresAt;
+
+      const plainKey = generateApiKey();
+      const keyHash = hashApiKey(plainKey);
+      const keyPrefix = plainKey.slice(0, 12);
+
+      const result = await db.query(
+        `INSERT INTO tenant_api_keys (tenant_id, key_hash, key_prefix, is_active, expires_at)
+         VALUES ($1, $2, $3, true, $4)
+         RETURNING id, tenant_id, key_prefix, is_active, created_at, expires_at`,
+        [tenantId, keyHash, keyPrefix, expiresAt]
+      );
+      const row = result.rows[0];
+
+      // 既存キー(主キー・追加キー問わず)を失効させず、新キーを追加で有効化する。
+      // addTenantApiKey は tenantStore に既存エントリがある場合のみ true を返す
+      // （DB-onlyテナント=in-memory未登録の場合は静かにスキップ。DBが正なので発行自体は成功扱い）。
+      addTenantApiKey(tenantId, keyHash, expiresAt);
+
+      // 平文キーはこのレスポンスでのみ返す（二度と取得不可）
+      return res.status(201).json({
+        api_key: plainKey,
+        tenant_id: row.tenant_id,
+        created_at: row.created_at,
+        expires_at: row.expires_at,
+        id: row.id,
+      });
+    } catch (err) {
+      logger.warn("[POST /v1/admin/my-tenant/keys]", err);
+      return res.status(500).json({ error: "APIキー発行に失敗しました" });
+    }
+  });
+
+  // GET /v1/admin/my-tenant/keys — Client Admin専用: 自テナントのAPIキー一覧（マスク表示）
+  app.get("/v1/admin/my-tenant/keys", tenantAuth, requireAdminRole, async (req: Request, res: Response) => {
+    const su = (req as AuthedReq).supabaseUser;
+    const tenantId = su?.app_metadata?.tenant_id as string | undefined;
+    if (!tenantId) {
+      return res.status(403).json({ error: "forbidden", message: "テナントIDが見つかりません" });
+    }
+    try {
+      const result = await db.query(
+        `SELECT id, key_prefix, is_active, created_at, expires_at, last_used_at
+         FROM tenant_api_keys
+         WHERE tenant_id = $1
+         ORDER BY created_at DESC`,
+        [tenantId]
+      );
+      const keys = (result.rows as Array<{ id: string; key_prefix: string; is_active: boolean; created_at: string; expires_at: string | null; last_used_at: string | null }>).map((row) => ({
+        ...row,
+        prefix: maskApiKeyPrefix(row.key_prefix),
+      }));
+      return res.json({ keys, total: keys.length });
+    } catch (err) {
+      logger.warn("[GET /v1/admin/my-tenant/keys]", err);
+      return res.status(500).json({ error: "APIキー一覧の取得に失敗しました" });
+    }
+  });
+
+  // DELETE /v1/admin/my-tenant/keys/:keyId — Client Admin専用: 自テナントのAPIキーを失効する
+  app.delete("/v1/admin/my-tenant/keys/:keyId", tenantAuth, requireAdminRole, async (req: Request, res: Response) => {
+    const su = (req as AuthedReq).supabaseUser;
+    const tenantId = su?.app_metadata?.tenant_id as string | undefined;
+    if (!tenantId) {
+      return res.status(403).json({ error: "forbidden", message: "テナントIDが見つかりません" });
+    }
+    const { keyId } = req.params;
+    try {
+      // tenant_id = $2 で自テナント以外のキーIDを指定されても404にする(越境防止)
+      const result = await db.query(
+        `UPDATE tenant_api_keys
+         SET is_active = false, updated_at = NOW()
+         WHERE id = $1 AND tenant_id = $2
+         RETURNING id, tenant_id, is_active, key_hash`,
+        [keyId, tenantId]
+      );
+      if (result.rowCount === 0) {
+        return res.status(404).json({ error: "not_found", message: "APIキーが見つかりません。" });
+      }
+      const revokedHash = result.rows[0].key_hash;
+      // 主キーであれば revokeTenantApiKeyIfCurrent、無停止ローテーションで追加された
+      // キーであれば revokeAdditionalTenantApiKey が反応する。両方試して即時反映する。
+      revokeTenantApiKeyIfCurrent(tenantId, revokedHash);
+      revokeAdditionalTenantApiKey(tenantId, revokedHash);
+      return res.json({ ok: true, id: keyId, is_active: false });
+    } catch (err) {
+      logger.warn("[DELETE /v1/admin/my-tenant/keys/:keyId]", err);
+      return res.status(500).json({ error: "APIキー無効化に失敗しました" });
+    }
+  });
+
   // GET /v1/admin/tenants
   app.get("/v1/admin/tenants", tenantAuth, requireSuperAdmin, async (_req: Request, res: Response) => {
     try {
@@ -537,15 +673,11 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
       }
 
       // expires_at (オプション: body.expires_at)
-      const expiresAtRaw = req.body?.expires_at;
-      const expiresAt = expiresAtRaw ? new Date(expiresAtRaw) : null;
-      if (expiresAt && isNaN(expiresAt.getTime())) {
-        return res.status(400).json({ error: "invalid_expires_at", message: "expires_atの日時形式が不正です。" });
+      const expiresAtResult = validateExpiresAt(req.body?.expires_at);
+      if ("error" in expiresAtResult) {
+        return res.status(400).json({ error: expiresAtResult.error, message: expiresAtResult.message });
       }
-      // 過去日時を許可すると、発行直後から使えない「死んだキー」が201で作れてしまう。
-      if (expiresAt && expiresAt.getTime() <= Date.now()) {
-        return res.status(400).json({ error: "expires_at_in_past", message: "expires_atは未来の日時である必要があります。" });
-      }
+      const expiresAt = expiresAtResult.expiresAt;
 
       const plainKey = generateApiKey();
       const keyHash = hashApiKey(plainKey);

--- a/src/lib/tenant-context.test.ts
+++ b/src/lib/tenant-context.test.ts
@@ -8,6 +8,8 @@ import {
   getTenantByApiKeyHash,
   setTenantApiKeyExpiry,
   revokeTenantApiKeyIfCurrent,
+  addTenantApiKey,
+  revokeAdditionalTenantApiKey,
 } from "./tenant-context";
 
 describe("seedTenantsFromEnv — numbered keys", () => {
@@ -329,5 +331,99 @@ describe("APIキー失効・期限切れの即時反映", () => {
     // setTenantApiKeyExpiry を再度呼ばずに新キー登録した場合、失効時にMapが掃除されていなければ
     // 古い期限(60秒後)が誤って新キーに適用されてしまう可能性がある — undefined（無期限扱い）が正しい
     expect(getTenantByApiKeyHash(NEW_HASH)?.tenantId).toBe(TENANT_ID);
+  });
+});
+
+describe("addTenantApiKey / revokeAdditionalTenantApiKey — 無停止ローテーション", () => {
+  const TENANT_ID = "test-multikey-tenant";
+  const PRIMARY_HASH = "multikey-primary-hash";
+  const ADDITIONAL_HASH = "multikey-additional-hash";
+
+  beforeEach(() => {
+    registerTenant({
+      tenantId: TENANT_ID,
+      name: "Multikey Test",
+      plan: "starter",
+      features: { avatar: false, voice: false, rag: true },
+      security: { apiKeyHash: PRIMARY_HASH, hashAlgorithm: "sha256", allowedOrigins: [], rateLimit: 100, rateLimitWindowMs: 60_000 },
+      enabled: true,
+    });
+    setTenantApiKeyExpiry(TENANT_ID, null);
+  });
+
+  it("addTenantApiKey で追加したキーは主キーと同時に有効になる", () => {
+    const added = addTenantApiKey(TENANT_ID, ADDITIONAL_HASH, null);
+    expect(added).toBe(true);
+    expect(getTenantByApiKeyHash(PRIMARY_HASH)?.tenantId).toBe(TENANT_ID);
+    expect(getTenantByApiKeyHash(ADDITIONAL_HASH)?.tenantId).toBe(TENANT_ID);
+  });
+
+  it("addTenantApiKey は tenantStore に存在しない未知テナントには false を返す", () => {
+    expect(addTenantApiKey("unknown-tenant-xyz", "some-hash", null)).toBe(false);
+  });
+
+  it("追加キーには独立した有効期限を設定できる（主キーの期限には影響しない）", () => {
+    addTenantApiKey(TENANT_ID, ADDITIONAL_HASH, new Date(Date.now() - 1000)); // 既に期限切れ
+    expect(getTenantByApiKeyHash(ADDITIONAL_HASH)).toBeUndefined(); // 追加キーは期限切れ
+    expect(getTenantByApiKeyHash(PRIMARY_HASH)?.tenantId).toBe(TENANT_ID); // 主キーは無期限のまま有効
+  });
+
+  it("追加キーが未来の期限なら有効に解決される", () => {
+    addTenantApiKey(TENANT_ID, ADDITIONAL_HASH, new Date(Date.now() + 60_000));
+    expect(getTenantByApiKeyHash(ADDITIONAL_HASH)?.tenantId).toBe(TENANT_ID);
+  });
+
+  it("revokeAdditionalTenantApiKey は追加キーのみ失効させ、主キーは有効なまま", () => {
+    addTenantApiKey(TENANT_ID, ADDITIONAL_HASH, null);
+    const revoked = revokeAdditionalTenantApiKey(TENANT_ID, ADDITIONAL_HASH);
+    expect(revoked).toBe(true);
+    expect(getTenantByApiKeyHash(ADDITIONAL_HASH)).toBeUndefined();
+    expect(getTenantByApiKeyHash(PRIMARY_HASH)?.tenantId).toBe(TENANT_ID);
+  });
+
+  it("revokeAdditionalTenantApiKey は主キーのハッシュを渡しても何もしない（担当範囲外のハッシュ）", () => {
+    const revoked = revokeAdditionalTenantApiKey(TENANT_ID, PRIMARY_HASH);
+    expect(revoked).toBe(false);
+    expect(getTenantByApiKeyHash(PRIMARY_HASH)?.tenantId).toBe(TENANT_ID);
+  });
+
+  it("revokeAdditionalTenantApiKey は存在しない追加キーに対して false を返す", () => {
+    expect(revokeAdditionalTenantApiKey(TENANT_ID, "never-added-hash")).toBe(false);
+  });
+
+  it("複数の追加キーを同時に有効化でき、個別に失効させられる", () => {
+    const hashB = "multikey-additional-hash-b";
+    const hashC = "multikey-additional-hash-c";
+    addTenantApiKey(TENANT_ID, ADDITIONAL_HASH, null);
+    addTenantApiKey(TENANT_ID, hashB, null);
+    addTenantApiKey(TENANT_ID, hashC, null);
+    expect(getTenantByApiKeyHash(ADDITIONAL_HASH)?.tenantId).toBe(TENANT_ID);
+    expect(getTenantByApiKeyHash(hashB)?.tenantId).toBe(TENANT_ID);
+    expect(getTenantByApiKeyHash(hashC)?.tenantId).toBe(TENANT_ID);
+
+    revokeAdditionalTenantApiKey(TENANT_ID, hashB);
+    expect(getTenantByApiKeyHash(hashB)).toBeUndefined();
+    // 他の2本(主キー含む)は無傷
+    expect(getTenantByApiKeyHash(PRIMARY_HASH)?.tenantId).toBe(TENANT_ID);
+    expect(getTenantByApiKeyHash(ADDITIONAL_HASH)?.tenantId).toBe(TENANT_ID);
+    expect(getTenantByApiKeyHash(hashC)?.tenantId).toBe(TENANT_ID);
+  });
+
+  it("主キーを revokeTenantApiKeyIfCurrent で失効させても、追加キーは影響を受けず有効なまま", () => {
+    addTenantApiKey(TENANT_ID, ADDITIONAL_HASH, null);
+    const revoked = revokeTenantApiKeyIfCurrent(TENANT_ID, PRIMARY_HASH);
+    expect(revoked).toBe(true);
+    expect(getTenantByApiKeyHash(PRIMARY_HASH)).toBeUndefined();
+    expect(getTenantByApiKeyHash(ADDITIONAL_HASH)?.tenantId).toBe(TENANT_ID);
+  });
+
+  it("同じハッシュを addTenantApiKey で2回登録しても例外にならず、後勝ちの期限で上書きされる", () => {
+    addTenantApiKey(TENANT_ID, ADDITIONAL_HASH, new Date(Date.now() + 60_000));
+    addTenantApiKey(TENANT_ID, ADDITIONAL_HASH, null); // 無期限に上書き
+    expect(getTenantByApiKeyHash(ADDITIONAL_HASH)?.tenantId).toBe(TENANT_ID);
+  });
+
+  it("未登録テナントの追加キーMapに対する getTenantByApiKeyHash 探索は例外を投げない", () => {
+    expect(getTenantByApiKeyHash("hash-with-no-additional-keys-anywhere")).toBeUndefined();
   });
 });

--- a/src/lib/tenant-context.ts
+++ b/src/lib/tenant-context.ts
@@ -15,6 +15,51 @@ const tenantStore = new Map<string, TenantConfig>();
 // registerTenant と対で更新する（型 TenantConfig は他モジュール共有のため変更しない）。
 const apiKeyExpiresAt = new Map<string, number | null>();
 
+// 無停止ローテーション用の「追加キー」。TenantConfig.security.apiKeyHash は
+// 引き続き単一の「主キー」を保持する（authMiddleware.ts等の既存参照を壊さない）。
+// client_adminが新キーを発行しても旧キー(主キー)を即座に失効させたくない場合、
+// 新キーはここに追加され、主キーと並行して有効になる。
+// tenantId -> (keyHash -> expiresAtMs|null)
+const additionalApiKeys = new Map<string, Map<string, number | null>>();
+
+/**
+ * 主キーを失効させずに、追加のAPIキーを有効化する（無停止ローテーション）。
+ * テナントが tenantStore に存在しない場合は false を返す。
+ */
+export function addTenantApiKey(
+  tenantId: string,
+  keyHash: string,
+  expiresAt: Date | null
+): boolean {
+  if (!tenantStore.has(tenantId)) return false;
+  let keys = additionalApiKeys.get(tenantId);
+  if (!keys) {
+    keys = new Map<string, number | null>();
+    additionalApiKeys.set(tenantId, keys);
+  }
+  keys.set(keyHash, expiresAt ? expiresAt.getTime() : null);
+  return true;
+}
+
+/**
+ * 追加キー（主キー以外）を失効させる。対象が追加キーに存在しない場合は
+ * 何もせず false を返す（主キーの失効は revokeTenantApiKeyIfCurrent が担当）。
+ */
+export function revokeAdditionalTenantApiKey(
+  tenantId: string,
+  keyHash: string
+): boolean {
+  const keys = additionalApiKeys.get(tenantId);
+  if (!keys) return false;
+  for (const existingHash of keys.keys()) {
+    if (safeCompare(existingHash, keyHash)) {
+      keys.delete(existingHash);
+      return true;
+    }
+  }
+  return false;
+}
+
 export function registerTenant(config: TenantConfig): void {
   tenantStore.set(config.tenantId, config);
 }
@@ -62,13 +107,24 @@ export function getTenantByApiKeyHash(
 ): TenantConfig | undefined {
   const entries = Array.from(tenantStore.values());
   for (const cfg of entries) {
-    if (!cfg.security.apiKeyHash) continue; // 失効済み(revokeTenantApiKeyIfCurrent)
-    if (safeCompare(cfg.security.apiKeyHash, hash)) {
+    if (cfg.security.apiKeyHash && safeCompare(cfg.security.apiKeyHash, hash)) {
       const expiresAt = apiKeyExpiresAt.get(cfg.tenantId);
       if (expiresAt !== undefined && expiresAt !== null && expiresAt <= Date.now()) {
         return undefined; // 稼働中に期限切れ（起動時seedはDB側でフィルタ済みだが、以降の失効を反映）
       }
       return cfg;
+    }
+    // 無停止ローテーションで追加されたキー（主キーとは独立して有効期限を持つ）。
+    // 引き続き safeCompare による定数時間比較で線形探索する（Map.getによる
+    // O(1)逆引きに置き換えると、既に呼び出し側でハッシュ化済みとはいえ
+    // タイミング差を持ち込むため採用しない）。
+    const additional = additionalApiKeys.get(cfg.tenantId);
+    if (additional) {
+      for (const [additionalHash, expiresAt] of additional) {
+        if (!safeCompare(additionalHash, hash)) continue;
+        if (expiresAt !== null && expiresAt <= Date.now()) return undefined;
+        return cfg;
+      }
     }
   }
   return undefined;

--- a/tests/api/admin/tenants/routes.test.ts
+++ b/tests/api/admin/tenants/routes.test.ts
@@ -7,6 +7,8 @@ import {
   setTenantApiKeyExpiry as mockSetTenantApiKeyExpiry,
   revokeTenantApiKeyIfCurrent as mockRevokeTenantApiKeyIfCurrent,
   updateTenantAllowedOrigins as mockUpdateTenantAllowedOrigins,
+  addTenantApiKey as mockAddTenantApiKey,
+  revokeAdditionalTenantApiKey as mockRevokeAdditionalTenantApiKey,
 } from "../../../../src/lib/tenant-context";
 
 // tenant-context をモック
@@ -16,6 +18,8 @@ jest.mock("../../../../src/lib/tenant-context", () => ({
   updateTenantAllowedOrigins: jest.fn(),
   setTenantApiKeyExpiry: jest.fn(),
   revokeTenantApiKeyIfCurrent: jest.fn(),
+  addTenantApiKey: jest.fn(),
+  revokeAdditionalTenantApiKey: jest.fn(),
 }));
 
 // supabaseClient をモック（招待API用 — テストでは不要）
@@ -854,6 +858,168 @@ describe("Tenant Admin Routes", () => {
       expect(res1.status).toBe(200);
       expect(res2.status).toBe(200);
       expect(res2.body.ok).toBe(true);
+    });
+  });
+
+  describe("POST /v1/admin/my-tenant/keys", () => {
+    it("client_admin が自テナントのキーを発行できる（201, rjc_始まり）", async () => {
+      mockDb.query
+        .mockResolvedValueOnce({ rows: [{ id: "tenant1", is_active: true }], rowCount: 1 })
+        .mockResolvedValueOnce({
+          rows: [{ id: "key-uuid", tenant_id: "tenant1", key_prefix: "rjc_abcd1234", is_active: true, created_at: new Date(), expires_at: null }],
+          rowCount: 1,
+        });
+      const res = await request(app)
+        .post("/v1/admin/my-tenant/keys")
+        .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`);
+      expect(res.status).toBe(201);
+      expect(res.body.api_key).toMatch(/^rjc_/);
+      expect(res.body.tenant_id).toBe("tenant1");
+    });
+
+    it("registerTenant(上書き)ではなく addTenantApiKey(追加)を呼ぶ — 既存キーを失効させない無停止ローテーション", async () => {
+      mockDb.query
+        .mockResolvedValueOnce({ rows: [{ id: "tenant1", is_active: true }], rowCount: 1 })
+        .mockResolvedValueOnce({
+          rows: [{ id: "key-uuid", tenant_id: "tenant1", key_prefix: "rjc_abcd1234", is_active: true, created_at: new Date(), expires_at: null }],
+          rowCount: 1,
+        });
+      const registerCallsBefore = (mockRegisterTenant as jest.Mock).mock.calls.length;
+      const res = await request(app)
+        .post("/v1/admin/my-tenant/keys")
+        .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`);
+      expect(res.status).toBe(201);
+      expect((mockRegisterTenant as jest.Mock).mock.calls.length).toBe(registerCallsBefore);
+      expect(mockAddTenantApiKey).toHaveBeenLastCalledWith("tenant1", expect.any(String), null);
+    });
+
+    it("tenant_id claim が無い場合は403で、キーは一切発行されない", async () => {
+      const callsBefore = (mockAddTenantApiKey as jest.Mock).mock.calls.length;
+      const res = await request(app)
+        .post("/v1/admin/my-tenant/keys")
+        .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`); // tenant_id claim なし
+      expect(res.status).toBe(403);
+      expect((mockAddTenantApiKey as jest.Mock).mock.calls.length).toBe(callsBefore);
+    });
+
+    it("越境不可: JWTのtenant_id以外のテナントにキーを発行することはできない（bodyでの指定は無視される）", async () => {
+      mockDb.query
+        .mockResolvedValueOnce({ rows: [{ id: "tenant1", is_active: true }], rowCount: 1 })
+        .mockResolvedValueOnce({
+          rows: [{ id: "key-uuid", tenant_id: "tenant1", key_prefix: "rjc_abcd1234", is_active: true, created_at: new Date(), expires_at: null }],
+          rowCount: 1,
+        });
+      const res = await request(app)
+        .post("/v1/admin/my-tenant/keys")
+        .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`)
+        .send({ tenant_id: "other-tenant" });
+      expect(res.status).toBe(201);
+      // DB問い合わせは常にJWT由来のtenantIdで行われる（bodyのtenant_idは無視）
+      expect(mockDb.query.mock.calls[0][1]).toEqual(["tenant1"]);
+    });
+
+    it("無効化済み(is_active=false)テナントへのキー発行は403で、追加登録は一切行わない", async () => {
+      mockDb.query.mockResolvedValueOnce({ rows: [{ id: "tenant1", is_active: false }], rowCount: 1 });
+      const callsBefore = (mockAddTenantApiKey as jest.Mock).mock.calls.length;
+      const res = await request(app)
+        .post("/v1/admin/my-tenant/keys")
+        .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`);
+      expect(res.status).toBe(403);
+      expect((mockAddTenantApiKey as jest.Mock).mock.calls.length).toBe(callsBefore);
+    });
+
+    it("不正な expires_at は400で拒否され、タイムゾーン付きISO-8601形式を案内するメッセージを返す", async () => {
+      mockDb.query.mockResolvedValueOnce({ rows: [{ id: "tenant1", is_active: true }], rowCount: 1 });
+      const res = await request(app)
+        .post("/v1/admin/my-tenant/keys")
+        .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`)
+        .send({ expires_at: "not-a-real-date" });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("invalid_expires_at");
+      expect(res.body.message).toMatch(/ISO-8601/);
+      expect(res.body.message).toMatch(/タイムゾーン/);
+    });
+
+    it("過去日時のexpires_atは400で拒否され、案内メッセージにタイムゾーンの注意書きを含む", async () => {
+      const pastDate = new Date(Date.now() - 86_400_000).toISOString();
+      mockDb.query.mockResolvedValueOnce({ rows: [{ id: "tenant1", is_active: true }], rowCount: 1 });
+      const res = await request(app)
+        .post("/v1/admin/my-tenant/keys")
+        .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`)
+        .send({ expires_at: pastDate });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe("expires_at_in_past");
+      expect(res.body.message).toMatch(/ISO-8601/);
+    });
+  });
+
+  describe("GET /v1/admin/my-tenant/keys", () => {
+    it("client_admin が自テナントのキー一覧をマスク表示で取得できる", async () => {
+      mockDb.query.mockResolvedValueOnce({
+        rows: [{ id: "k1", key_prefix: "rjc_abcd1234", is_active: true, created_at: new Date(), expires_at: null, last_used_at: null }],
+      });
+      const res = await request(app)
+        .get("/v1/admin/my-tenant/keys")
+        .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`);
+      expect(res.status).toBe(200);
+      expect(res.body.keys[0].prefix).toMatch(/\*\*\*\*$/);
+      expect(mockDb.query.mock.calls[0][1]).toEqual(["tenant1"]);
+    });
+
+    it("super_admin以外・client_admin以外(viewer等)は403", async () => {
+      const viewerToken = makeDevJwt({ sub: "u", app_metadata: { role: "viewer", tenant_id: "tenant1" } });
+      const res = await request(app)
+        .get("/v1/admin/my-tenant/keys")
+        .set("Authorization", `Bearer ${viewerToken}`);
+      expect(res.status).toBe(403);
+    });
+  });
+
+  describe("DELETE /v1/admin/my-tenant/keys/:keyId", () => {
+    it("client_admin が自テナントのキーを失効できる", async () => {
+      mockDb.query.mockResolvedValueOnce({ rows: [{ id: "k1", tenant_id: "tenant1", is_active: false, key_hash: "h1" }], rowCount: 1 });
+      const res = await request(app)
+        .delete("/v1/admin/my-tenant/keys/k1")
+        .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`);
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+    });
+
+    it("主キー・追加キーの両方の失効経路を試す（どちらが一致するか呼び出し時点では分からないため）", async () => {
+      mockDb.query.mockResolvedValueOnce({ rows: [{ id: "k1", tenant_id: "tenant1", is_active: false, key_hash: "h1" }], rowCount: 1 });
+      const res = await request(app)
+        .delete("/v1/admin/my-tenant/keys/k1")
+        .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`);
+      expect(res.status).toBe(200);
+      expect(mockRevokeTenantApiKeyIfCurrent).toHaveBeenLastCalledWith("tenant1", "h1");
+      expect(mockRevokeAdditionalTenantApiKey).toHaveBeenLastCalledWith("tenant1", "h1");
+    });
+
+    it("存在しないキーは404", async () => {
+      mockDb.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+      const res = await request(app)
+        .delete("/v1/admin/my-tenant/keys/no-key")
+        .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`);
+      expect(res.status).toBe(404);
+    });
+
+    it("越境不可: 他テナントのkeyIdはWHERE tenant_id条件で一致せず404になり、失効処理も走らない", async () => {
+      mockDb.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
+      const callsBefore = (mockRevokeTenantApiKeyIfCurrent as jest.Mock).mock.calls.length;
+      const res = await request(app)
+        .delete("/v1/admin/my-tenant/keys/key-belongs-to-other-tenant")
+        .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`);
+      expect(res.status).toBe(404);
+      expect((mockRevokeTenantApiKeyIfCurrent as jest.Mock).mock.calls.length).toBe(callsBefore);
+      // DBクエリのtenant_id条件が常にJWT由来のtenant_id("tenant1")であることを確認
+      expect(mockDb.query.mock.calls[0][1]).toEqual(["key-belongs-to-other-tenant", "tenant1"]);
+    });
+
+    it("tenant_id claim が無い場合は403", async () => {
+      const res = await request(app)
+        .delete("/v1/admin/my-tenant/keys/k1")
+        .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`);
+      expect(res.status).toBe(403);
     });
   });
 });


### PR DESCRIPTION
## 概要
client_admin が super_admin を介さず自テナントのAPIキーを発行・失効できるようにする。あわせて無停止ローテーション(新キー発行後も旧キーが失効するまで両方有効)と、expires_atのタイムゾーン誤解を防ぐエラーメッセージ改善を行う。

## 実装内容
### A. client_admin向けキー発行・失効エンドポイント
`PATCH /v1/admin/my-tenant` と同じ「自テナントのみ」認可パターン(`tenantAuth` + `requireAdminRole`、tenantIdはJWTの`app_metadata.tenant_id`のみから導出)で追加:
- `POST /v1/admin/my-tenant/keys` — キー発行
- `GET /v1/admin/my-tenant/keys` — キー一覧(マスク表示)
- `DELETE /v1/admin/my-tenant/keys/:keyId` — キー失効(DB側 `WHERE tenant_id=$2` で越境不可)

既存の `generateApiKey` / `hashApiKey` / `maskApiKeyPrefix`(`apiKeyUtils.ts`)をそのまま再利用。

### B. 複数キーの同時有効化(無停止ローテーション)
`tenant-context.ts` に `additionalApiKeys: Map<tenantId, Map<hash, expiresAtMs|null>>` を新設。
- `addTenantApiKey(tenantId, hash, expiresAt)` — 主キーを保持したまま追加キーを有効化
- `revokeAdditionalTenantApiKey(tenantId, hash)` — 追加キーのみを失効
- `getTenantByApiKeyHash` は主キー・追加キーの両方を、引き続き `safeCompare`(SHA-256 + `timingSafeEqual`)による定数時間の線形探索でチェック(`Map.get`によるO(1)逆引きは非定数時間比較を再導入するため不採用)

`TenantConfig.security.apiKeyHash: string` の型は変更していない(authMiddleware.ts等の既存参照への影響を避けるため)。client_admin発行の新キーは `addTenantApiKey` で追加され、super_adminの既存キー発行(`registerTenant`で主キー上書き)とは独立して動く。

### C. expires_atのタイムゾーン問題
`new Date(expiresAtRaw)` は日付のみの文字列をUTC深夜と解釈するため、意図とズレて「過去判定」される事故が起きやすい。バリデーションロジック自体は変更せず、エラーメッセージにタイムゾーン付きISO-8601形式の案内を追加。super_admin向け既存エンドポイントとの重複を避けるため `validateExpiresAt()` ヘルパーに共通化。

## 受入基準
- [x] client_adminが自テナントのキーのみ発行・失効できる(越境不可をテストで確認)
- [x] 新キー発行後、旧キーが失効するまで両方が有効
- [x] 明示的な失効は即座に反映される
- [x] 期限切れ判定が複数キーでも個別に正しく動く
- [x] 既存のsuper_admin向けキー発行・失効テストが壊れていない(104件全通過)

## 禁止事項の遵守
- 新規ファイルは作っていない
- super_admin向けの既存エンドポイントの挙動・テストは変更していない

## Test plan
- [x] `npx tsc --noEmit` — 0エラー
- [x] `npx oxlint` — 変更ファイルclean
- [x] `npx jest --testPathPatterns="tenant-context|tenants/routes"` — 129/129 pass(既存104件+新規25件)
- [x] ミューテーションテスト2回(tenant-context.ts / routes.ts)で新規テストが実際に回帰を検知することを確認、復元後に再度green
- [x] フルスイート実行 — 失敗22件は本PRが一切触れていない `avatar/routes.test.ts`(単独実行でも20件失敗する既存の既知問題)と `conversion-type-api.test.ts`(単独実行では7/7 pass、フルスイートでのみクロスファイル汚染で失敗)に限定されることを確認済み

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>