### PR TITLE
[LAUNCH][P2] テナント向けallowed_origins設定UIを追加

### DIFF
--- a/admin-ui/src/components/knowledge/AllowedOriginsSettings.test.tsx
+++ b/admin-ui/src/components/knowledge/AllowedOriginsSettings.test.tsx
@@ -1,0 +1,115 @@
+// LAUNCH: AllowedOriginsSettings — client_adminによるWidget許可ドメインの追加・削除
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import AllowedOriginsSettings from "./AllowedOriginsSettings";
+
+vi.mock("../../i18n/LangContext", async () => {
+  const jaModule = await import("../../i18n/ja");
+  const ja = jaModule.default as Record<string, string>;
+  const stableT = (key: string) => ja[key] ?? key;
+  return { useLang: () => ({ lang: "ja" as const, setLang: () => {}, t: stableT }) };
+});
+
+const authFetchMock = vi.fn();
+vi.mock("../../lib/api", () => ({
+  API_BASE: "http://localhost:3100",
+  authFetch: (...args: unknown[]) => authFetchMock(...args),
+}));
+
+function jsonRes(body: unknown, ok = true) {
+  return Promise.resolve({ ok, json: () => Promise.resolve(body) } as Response);
+}
+
+async function openPanel() {
+  render(<AllowedOriginsSettings tenantId="tenant-abc" />);
+  fireEvent.click(await screen.findByText("🔒 Widgetの許可ドメイン設定"));
+}
+
+describe("AllowedOriginsSettings", () => {
+  beforeEach(() => {
+    authFetchMock.mockReset();
+  });
+
+  it("既存のallowed_originsを読み込んで一覧表示する", async () => {
+    authFetchMock.mockReturnValueOnce(jsonRes({ allowed_origins: ["https://shop.example.com"] }));
+    await openPanel();
+
+    await waitFor(() => expect(screen.getByText("https://shop.example.com")).toBeTruthy());
+  });
+
+  it("空配列のときは「登録されていません」を表示する", async () => {
+    authFetchMock.mockReturnValueOnce(jsonRes({ allowed_origins: [] }));
+    await openPanel();
+
+    await waitFor(() => expect(screen.getByText("許可ドメインが登録されていません")).toBeTruthy());
+  });
+
+  it("https://始まりのURLを追加すると PATCH /v1/admin/my-tenant が呼ばれる", async () => {
+    authFetchMock.mockReturnValueOnce(jsonRes({ allowed_origins: [] }));
+    authFetchMock.mockReturnValueOnce(jsonRes({ allowed_origins: ["https://new-shop.example.com"] }));
+    await openPanel();
+
+    const input = await screen.findByPlaceholderText("https://shop.example.com");
+    fireEvent.change(input, { target: { value: "https://new-shop.example.com" } });
+    fireEvent.click(screen.getByText("追加"));
+
+    await waitFor(() => {
+      const call = authFetchMock.mock.calls.find(([, opts]) => (opts as RequestInit | undefined)?.method === "PATCH");
+      expect(call).toBeTruthy();
+      expect(call?.[0]).toBe("http://localhost:3100/v1/admin/my-tenant");
+      expect(call?.[1]).toMatchObject({ body: JSON.stringify({ allowed_origins: ["https://new-shop.example.com"] }) });
+    });
+    await waitFor(() => expect(screen.getByText("https://new-shop.example.com")).toBeTruthy());
+  });
+
+  it("http://始まりのURLはPATCHを呼ばずエラー表示する", async () => {
+    authFetchMock.mockReturnValueOnce(jsonRes({ allowed_origins: [] }));
+    await openPanel();
+
+    const input = await screen.findByPlaceholderText("https://shop.example.com");
+    fireEvent.change(input, { target: { value: "http://insecure.example.com" } });
+    fireEvent.click(screen.getByText("追加"));
+
+    expect(await screen.findByText("URLはhttps://で始まる必要があります")).toBeTruthy();
+    expect(authFetchMock.mock.calls.some(([, opts]) => (opts as RequestInit | undefined)?.method === "PATCH")).toBe(false);
+  });
+
+  it("ワイルドカードを含むURLはPATCHを呼ばずエラー表示する", async () => {
+    authFetchMock.mockReturnValueOnce(jsonRes({ allowed_origins: [] }));
+    await openPanel();
+
+    const input = await screen.findByPlaceholderText("https://shop.example.com");
+    fireEvent.change(input, { target: { value: "https://*.example.com" } });
+    fireEvent.click(screen.getByText("追加"));
+
+    expect(await screen.findByText("このフォームからはワイルドカード（*）を含むドメインは登録できません")).toBeTruthy();
+    expect(authFetchMock.mock.calls.some(([, opts]) => (opts as RequestInit | undefined)?.method === "PATCH")).toBe(false);
+  });
+
+  it("削除ボタンで対象ドメインを除いた配列をPATCHする", async () => {
+    authFetchMock.mockReturnValueOnce(jsonRes({ allowed_origins: ["https://a.example.com", "https://b.example.com"] }));
+    authFetchMock.mockReturnValueOnce(jsonRes({ allowed_origins: ["https://b.example.com"] }));
+    await openPanel();
+
+    await screen.findByText("https://a.example.com");
+    fireEvent.click(screen.getByLabelText("remove https://a.example.com"));
+
+    await waitFor(() => {
+      const call = authFetchMock.mock.calls.find(([, opts]) => (opts as RequestInit | undefined)?.method === "PATCH");
+      expect(call?.[1]).toMatchObject({ body: JSON.stringify({ allowed_origins: ["https://b.example.com"] }) });
+    });
+    await waitFor(() => expect(screen.queryByText("https://a.example.com")).toBeNull());
+  });
+
+  it("PATCH失敗時は元の一覧にロールバックしエラートーストを表示する", async () => {
+    authFetchMock.mockReturnValueOnce(jsonRes({ allowed_origins: ["https://a.example.com"] }));
+    authFetchMock.mockReturnValueOnce(jsonRes({}, false));
+    await openPanel();
+
+    await screen.findByText("https://a.example.com");
+    fireEvent.click(screen.getByLabelText("remove https://a.example.com"));
+
+    await waitFor(() => expect(screen.getByText("❌ 保存に失敗しました。もう一度お試しください。")).toBeTruthy());
+    expect(screen.getByText("https://a.example.com")).toBeTruthy();
+  });
+});

--- a/admin-ui/src/components/knowledge/AllowedOriginsSettings.tsx
+++ b/admin-ui/src/components/knowledge/AllowedOriginsSettings.tsx
@@ -1,0 +1,242 @@
+// admin-ui/src/components/knowledge/AllowedOriginsSettings.tsx
+// LAUNCH: client_adminが自分でWidget許可ドメイン(allowed_origins)を追加・削除できる自己設定パネル
+// (FaqHintSettingsのfetch/toastパターンを踏襲。super_adminは/admin/tenants/:idのSettingsTab
+// （ワイルドカード対応）を使うため、こちらはclient_admin専用でPATCH /v1/admin/my-tenant固定)
+
+import { useEffect, useState } from "react";
+import { authFetch, API_BASE } from "../../lib/api";
+import { useLang } from "../../i18n/LangContext";
+
+interface TenantOrigins {
+  allowed_origins?: string[] | null;
+}
+
+interface AllowedOriginsSettingsProps {
+  tenantId: string;
+}
+
+export default function AllowedOriginsSettings({ tenantId }: AllowedOriginsSettingsProps) {
+  const { t } = useLang();
+  const [open, setOpen] = useState(false);
+  const [origins, setOrigins] = useState<string[]>([]);
+  const [newOrigin, setNewOrigin] = useState("");
+  const [inputError, setInputError] = useState<string | null>(null);
+  const [loaded, setLoaded] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [toast, setToast] = useState<string | null>(null);
+
+  const endpoint = `${API_BASE}/v1/admin/my-tenant`;
+
+  useEffect(() => {
+    if (!tenantId || tenantId === "global") return;
+    authFetch(endpoint)
+      .then((r) => r.json())
+      .then((data: TenantOrigins) => {
+        setOrigins(data.allowed_origins ?? []);
+        setLoaded(true);
+      })
+      .catch(() => {});
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [endpoint, tenantId]);
+
+  const showToast = (msg: string) => {
+    setToast(msg);
+    setTimeout(() => setToast(null), 3000);
+  };
+
+  const persist = async (nextOrigins: string[]) => {
+    const prev = origins;
+    setOrigins(nextOrigins);
+    setSaving(true);
+    try {
+      const res = await authFetch(endpoint, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ allowed_origins: nextOrigins }),
+      });
+      if (!res.ok) {
+        setOrigins(prev);
+        showToast(t("knowledge.allowed_origins_save_error"));
+        return;
+      }
+      const updated = (await res.json()) as TenantOrigins;
+      setOrigins(updated.allowed_origins ?? nextOrigins);
+      showToast(t("knowledge.allowed_origins_saved"));
+    } catch {
+      setOrigins(prev);
+      showToast(t("knowledge.allowed_origins_save_error"));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleAdd = () => {
+    const candidate = newOrigin.trim();
+    if (!candidate) return;
+    if (!candidate.startsWith("https://")) {
+      setInputError(t("knowledge.allowed_origins_invalid_https"));
+      return;
+    }
+    if (candidate.includes("*")) {
+      setInputError(t("knowledge.allowed_origins_invalid_wildcard"));
+      return;
+    }
+    if (origins.includes(candidate)) {
+      setInputError(t("knowledge.allowed_origins_duplicate"));
+      return;
+    }
+    setInputError(null);
+    setNewOrigin("");
+    void persist([...origins, candidate]);
+  };
+
+  const handleRemove = (origin: string) => {
+    void persist(origins.filter((o) => o !== origin));
+  };
+
+  if (!tenantId || tenantId === "global") return null;
+
+  return (
+    <div
+      style={{
+        marginBottom: 16,
+        borderRadius: 14,
+        border: "1px solid #374151",
+        background: "rgba(15,23,42,0.4)",
+        overflow: "hidden",
+      }}
+    >
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        style={{
+          width: "100%",
+          padding: "14px 18px",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "space-between",
+          background: "transparent",
+          border: "none",
+          cursor: "pointer",
+          color: "#d1d5db",
+          fontSize: 14,
+          fontWeight: 600,
+        }}
+      >
+        <span>🔒 {t("knowledge.allowed_origins_settings_title")}</span>
+        <span style={{ color: "#6b7280", fontSize: 12 }}>{open ? "▲" : "▼"}</span>
+      </button>
+
+      {open && (
+        <div style={{ padding: "0 18px 18px" }}>
+          <p style={{ fontSize: 13, color: "#6b7280", margin: "0 0 14px", lineHeight: 1.6 }}>
+            {t("knowledge.allowed_origins_settings_desc")}
+          </p>
+
+          <div style={{ display: "flex", flexDirection: "column", gap: 8, marginBottom: 14 }}>
+            {!loaded ? null : origins.length === 0 ? (
+              <p style={{ fontSize: 13, color: "#6b7280", margin: 0 }}>{t("knowledge.allowed_origins_empty")}</p>
+            ) : (
+              origins.map((origin) => (
+                <div
+                  key={origin}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    justifyContent: "space-between",
+                    padding: "8px 12px",
+                    borderRadius: 8,
+                    border: "1px solid #374151",
+                    background: "rgba(15,23,42,0.8)",
+                  }}
+                >
+                  <span style={{ fontSize: 13, color: "#e5e7eb", wordBreak: "break-all" }}>{origin}</span>
+                  <button
+                    type="button"
+                    onClick={() => handleRemove(origin)}
+                    disabled={saving}
+                    aria-label={`remove ${origin}`}
+                    style={{
+                      marginLeft: 12,
+                      padding: "4px 10px",
+                      borderRadius: 6,
+                      border: "1px solid rgba(248,113,113,0.4)",
+                      background: "rgba(239,68,68,0.12)",
+                      color: "#fca5a5",
+                      fontSize: 12,
+                      fontWeight: 600,
+                      cursor: saving ? "not-allowed" : "pointer",
+                      opacity: saving ? 0.6 : 1,
+                      flexShrink: 0,
+                    }}
+                  >
+                    ×
+                  </button>
+                </div>
+              ))
+            )}
+          </div>
+
+          <div style={{ display: "flex", gap: 8, marginBottom: inputError ? 8 : 0 }}>
+            <input
+              type="text"
+              value={newOrigin}
+              onChange={(e) => { setNewOrigin(e.target.value); setInputError(null); }}
+              onKeyDown={(e) => { if (e.key === "Enter") { e.preventDefault(); handleAdd(); } }}
+              disabled={!loaded || saving}
+              placeholder={t("knowledge.allowed_origins_input_placeholder")}
+              style={{
+                flex: 1,
+                padding: "10px 12px",
+                borderRadius: 8,
+                border: "1px solid #374151",
+                background: "rgba(15,23,42,0.8)",
+                color: "#e5e7eb",
+                fontSize: 14,
+                boxSizing: "border-box",
+              }}
+            />
+            <button
+              type="button"
+              onClick={handleAdd}
+              disabled={!loaded || saving || !newOrigin.trim()}
+              style={{
+                padding: "10px 18px",
+                minHeight: 40,
+                borderRadius: 10,
+                border: "1px solid rgba(59,130,246,0.4)",
+                background: "rgba(59,130,246,0.18)",
+                color: "#93c5fd",
+                fontSize: 14,
+                fontWeight: 600,
+                cursor: !loaded || saving || !newOrigin.trim() ? "not-allowed" : "pointer",
+                opacity: !loaded || saving || !newOrigin.trim() ? 0.6 : 1,
+                flexShrink: 0,
+              }}
+            >
+              {t("knowledge.allowed_origins_add")}
+            </button>
+          </div>
+          {inputError && (
+            <p style={{ fontSize: 12, color: "#fca5a5", margin: "0 0 0" }}>{inputError}</p>
+          )}
+
+          {toast && (
+            <div
+              style={{
+                marginTop: 12,
+                padding: "8px 12px",
+                borderRadius: 8,
+                background: toast.startsWith("❌") ? "rgba(239,68,68,0.12)" : "rgba(34,197,94,0.12)",
+                color: toast.startsWith("❌") ? "#fca5a5" : "#86efac",
+                fontSize: 13,
+              }}
+            >
+              {toast}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/admin-ui/src/components/knowledge/KnowledgeListTab.test.tsx
+++ b/admin-ui/src/components/knowledge/KnowledgeListTab.test.tsx
@@ -212,4 +212,26 @@ describe("KnowledgeListTab", () => {
     // CATEGORY_LABEL_MAP の inventory ラベル
     expect(await screen.findByText("在庫・車両情報")).toBeTruthy();
   });
+
+  // LAUNCH: Widget許可ドメイン設定パネル（client_admin専用、super_adminは既存のSettingsTabで管理）
+  it("client_adminにはWidget許可ドメイン設定パネルが表示される", async () => {
+    vi.mocked(fetchWithAuth).mockReturnValue(mockList([]));
+    renderTab();
+
+    await waitFor(() => screen.getByText("🔒 Widgetの許可ドメイン設定"));
+  });
+
+  it("super_adminにはWidget許可ドメイン設定パネルが表示されない（/admin/tenants/:idのSettingsTabで管理するため）", async () => {
+    vi.mocked(useAuth).mockReturnValue(createAuthMock({
+      user: { id: "1", email: "admin@example.com", role: "super_admin", tenantId: "tenant-abc", tenantName: "テスト店舗" },
+      isSuperAdmin: true,
+    }));
+    vi.mocked(fetchWithAuth).mockReturnValue(mockList([]));
+    renderTab();
+
+    await waitFor(() => {
+      expect(vi.mocked(fetchWithAuth)).toHaveBeenCalled();
+    });
+    expect(screen.queryByText("🔒 Widgetの許可ドメイン設定")).toBeNull();
+  });
 });

--- a/admin-ui/src/components/knowledge/KnowledgeListTab.tsx
+++ b/admin-ui/src/components/knowledge/KnowledgeListTab.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import KnowledgeFaqEditModal, { type KnowledgeFaqItem } from "../KnowledgeFaqEditModal";
 import FaqHintSettings from "./FaqHintSettings";
+import AllowedOriginsSettings from "./AllowedOriginsSettings";
 import FaqSearchBar from "./FaqSearchBar";
 import BulkActionBar from "./BulkActionBar";
 import { Pagination } from "../common/Pagination";
@@ -293,6 +294,11 @@ export default function KnowledgeListTab({ tenantId }: { tenantId: string }) {
         isSuperAdmin={isSuperAdmin}
         onHintsLoaded={setFaqHints}
       />
+
+      {/* LAUNCH: Widget許可ドメインのテナント自己設定。
+          super_adminは/admin/tenants/:idのSettingsTab（ワイルドカード対応）で管理するため、
+          ここではclient_adminのみに表示する（二重UI防止）。 */}
+      {!isSuperAdmin && <AllowedOriginsSettings tenantId={tenantId} />}
 
       {/* 新規追加ボタン */}
       <button

--- a/admin-ui/src/i18n/en.ts
+++ b/admin-ui/src/i18n/en.ts
@@ -77,6 +77,18 @@ const en: Record<TranslationKey, string> = {
   "knowledge.faq_hint_saved": "✅ Examples saved",
   "knowledge.faq_hint_save_error": "❌ Failed to save. Please try again.",
 
+  // LAUNCH: tenant self-service widget allowed-domain settings
+  "knowledge.allowed_origins_settings_title": "Widget Allowed Domains",
+  "knowledge.allowed_origins_settings_desc": "Register the domains where the chat Widget may be embedded. Leave empty to allow all domains (development use only).",
+  "knowledge.allowed_origins_input_placeholder": "https://shop.example.com",
+  "knowledge.allowed_origins_add": "Add",
+  "knowledge.allowed_origins_empty": "No allowed domains registered",
+  "knowledge.allowed_origins_invalid_https": "URL must start with https://",
+  "knowledge.allowed_origins_invalid_wildcard": "Domains with a wildcard (*) cannot be registered from this form",
+  "knowledge.allowed_origins_duplicate": "Already registered",
+  "knowledge.allowed_origins_saved": "✅ Allowed domains saved",
+  "knowledge.allowed_origins_save_error": "❌ Failed to save. Please try again.",
+
   // Tabs
   "knowledge.tab_list": "Knowledge List",
   "knowledge.tab_text": "Text Input",

--- a/admin-ui/src/i18n/ja.ts
+++ b/admin-ui/src/i18n/ja.ts
@@ -79,6 +79,18 @@ const ja = {
   "knowledge.faq_hint_saved": "✅ 入力例を保存しました",
   "knowledge.faq_hint_save_error": "❌ 保存に失敗しました。もう一度お試しください。",
 
+  // LAUNCH: テナント自身によるWidget許可ドメイン設定
+  "knowledge.allowed_origins_settings_title": "Widgetの許可ドメイン設定",
+  "knowledge.allowed_origins_settings_desc": "チャットWidgetを設置してよいドメインを登録します。空欄のままにすると全ドメインで動作します（開発用途のみ推奨）。",
+  "knowledge.allowed_origins_input_placeholder": "https://shop.example.com",
+  "knowledge.allowed_origins_add": "追加",
+  "knowledge.allowed_origins_empty": "許可ドメインが登録されていません",
+  "knowledge.allowed_origins_invalid_https": "URLはhttps://で始まる必要があります",
+  "knowledge.allowed_origins_invalid_wildcard": "このフォームからはワイルドカード（*）を含むドメインは登録できません",
+  "knowledge.allowed_origins_duplicate": "既に登録されています",
+  "knowledge.allowed_origins_saved": "✅ 許可ドメインを保存しました",
+  "knowledge.allowed_origins_save_error": "❌ 保存に失敗しました。もう一度お試しください。",
+
   // Tabs
   "knowledge.tab_list": "ナレッジ一覧",
   "knowledge.tab_text": "テキスト入力",

--- a/src/api/admin/tenants/routes.ts
+++ b/src/api/admin/tenants/routes.ts
@@ -232,6 +232,16 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
       faq_answer_hint: z.string().max(200).nullable().optional(),
       // GID 1216274591838389: 初回ログインオンボーディングの回答業種（設定時にonboarding_completed_atも自動更新）
       onboarding_industry: z.enum(onboardingIndustryValues).optional(),
+      // LAUNCH: ウィジェット許可オリジンのテナント自己設定。super_admin用updateTenantSchemaと
+      // 同じ検証（https://始まりのみ）を使う。ワイルドカードは originCheck.ts と
+      // security-policy.ts の判定不一致を避けるためUI側で入力を拒否する想定（バックエンドは
+      // super_admin用と同じ検証のみでワイルドカード自体は文字列として許可される）。
+      allowed_origins: z
+        .array(
+          z.string().regex(/^https:\/\//, "URLはhttps://で始まる必要があります")
+        )
+        .max(20)
+        .optional(),
     });
     const parsed = bodySchema.safeParse(req.body ?? {});
     if (!parsed.success) {
@@ -266,15 +276,21 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
         setClauses.push(`onboarding_industry = $${params.length}`);
         setClauses.push(`onboarding_completed_at = NOW()`);
       }
+      if (fields.allowed_origins !== undefined) { params.push(fields.allowed_origins); setClauses.push(`allowed_origins = $${params.length}`); }
       setClauses.push(`updated_at = NOW()`);
       params.push(tenantId);
       const result = await db.query(
         `UPDATE tenants SET ${setClauses.join(", ")} WHERE id = $${params.length}
-         RETURNING id, name, features, lemonslice_agent_id, faq_question_hint, faq_answer_hint, onboarding_industry, onboarding_completed_at`,
+         RETURNING id, name, features, lemonslice_agent_id, faq_question_hint, faq_answer_hint, onboarding_industry, onboarding_completed_at, allowed_origins`,
         params
       );
       if (result.rowCount === 0) {
         return res.status(404).json({ error: "not_found", message: "テナントが見つかりません" });
+      }
+      // allowed_originsはインメモリのtenantStoreも参照されるため即時反映する
+      // （未指定なら呼ばない。空配列指定=制限全解除と未指定=変更なしを区別する）。
+      if (fields.allowed_origins !== undefined) {
+        updateTenantAllowedOrigins(tenantId, fields.allowed_origins);
       }
       return res.json(result.rows[0]);
     } catch (err) {

--- a/tests/api/admin/tenants/routes.test.ts
+++ b/tests/api/admin/tenants/routes.test.ts
@@ -667,6 +667,71 @@ describe("Tenant Admin Routes", () => {
       expect(res.status).toBe(400);
       expect(res.body.error).toBe("no_fields");
     });
+
+    // LAUNCH: allowed_originsのテナント自己設定（PR#814のupdateTenantAllowedOriginsを再利用）
+    it("client_adminがallowed_originsを更新でき、インメモリへ即時反映される", async () => {
+      mockDb.query.mockResolvedValueOnce({
+        rows: [{ id: "tenant1", name: "Test", features: {}, lemonslice_agent_id: null, allowed_origins: ["https://new-shop.example.com"] }],
+        rowCount: 1,
+      });
+      const res = await request(app)
+        .patch("/v1/admin/my-tenant")
+        .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`)
+        .send({ allowed_origins: ["https://new-shop.example.com"] });
+      expect(res.status).toBe(200);
+      expect(res.body.allowed_origins).toEqual(["https://new-shop.example.com"]);
+      expect(mockUpdateTenantAllowedOrigins).toHaveBeenLastCalledWith("tenant1", ["https://new-shop.example.com"]);
+    });
+
+    it("http://始まりのoriginは400で拒否する", async () => {
+      const res = await request(app)
+        .patch("/v1/admin/my-tenant")
+        .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`)
+        .send({ allowed_origins: ["http://insecure.example.com"] });
+      expect(res.status).toBe(400);
+      expect(mockDb.query).not.toHaveBeenCalled();
+    });
+
+    it("allowed_origins未指定の更新ではupdateTenantAllowedOriginsを呼ばない（フィールド省略と空配列の区別）", async () => {
+      const callsBefore = (mockUpdateTenantAllowedOrigins as jest.Mock).mock.calls.length;
+      mockDb.query.mockResolvedValueOnce({
+        rows: [{ id: "tenant1", name: "Test", features: {}, lemonslice_agent_id: null, onboarding_industry: "auto" }],
+        rowCount: 1,
+      });
+      const res = await request(app)
+        .patch("/v1/admin/my-tenant")
+        .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`)
+        .send({ onboarding_industry: "auto" });
+      expect(res.status).toBe(200);
+      expect((mockUpdateTenantAllowedOrigins as jest.Mock).mock.calls.length).toBe(callsBefore);
+    });
+
+    it("空配列を指定すると制限を全解除でき、インメモリにも反映される（未指定との区別）", async () => {
+      mockDb.query.mockResolvedValueOnce({
+        rows: [{ id: "tenant1", name: "Test", features: {}, lemonslice_agent_id: null, allowed_origins: [] }],
+        rowCount: 1,
+      });
+      const res = await request(app)
+        .patch("/v1/admin/my-tenant")
+        .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`)
+        .send({ allowed_origins: [] });
+      expect(res.status).toBe(200);
+      expect(mockUpdateTenantAllowedOrigins).toHaveBeenLastCalledWith("tenant1", []);
+    });
+
+    it("他テナントのoriginsは書き換えられない（tenant_idはJWTのapp_metadataからのみ取得、bodyのtenant_idは無視）", async () => {
+      mockDb.query.mockResolvedValueOnce({
+        rows: [{ id: "tenant1", name: "Test", features: {}, lemonslice_agent_id: null, allowed_origins: ["https://own.example.com"] }],
+        rowCount: 1,
+      });
+      const res = await request(app)
+        .patch("/v1/admin/my-tenant")
+        .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`)
+        .send({ allowed_origins: ["https://own.example.com"], tenant_id: "other-tenant" });
+      expect(res.status).toBe(200);
+      // JWTのtenant_id("t1")で呼ばれ、body.tenant_idは無視される
+      expect(mockUpdateTenantAllowedOrigins).toHaveBeenLastCalledWith("tenant1", ["https://own.example.com"]);
+    });
   });
 
   // Asana 1217040568430944(P7): super_adminのクライアントビュー(previewMode)からも


### PR DESCRIPTION
## 概要
client_adminが自テナントのWidget許可ドメイン(`allowed_origins`)を、super_adminの介入なしに自分で追加・削除できるようにする。これまではsuper_adminのみが `/admin/tenants/:id` の設定タブから変更可能で、テナントは自力でWidgetの動作ドメインを増減できなかった（Asana [LAUNCH][P2] テナント向け allowed_origins 設定UIを追加する, gid 1217744071778238）。

前提タスク（allowed_originsの即時反映、PR#814）は既にmainにマージ済み。

## 変更内容

### Backend
- `PATCH /v1/admin/my-tenant` に `allowed_origins` を追加。super_admin向け `PATCH /v1/admin/tenants/:id` と同じバリデーション（`https://` 始まりのみ）を使用。
- `updateTenantAllowedOrigins()` でインメモリの `tenantStore` にも即時反映（PR#814の仕組みを再利用、PM2再起動不要）。
- フィールド省略（変更なし）と空配列指定（全ドメイン解除）を区別する。

### Frontend（Tier S: `admin-ui/src` — 人間による手動マージが必要です）
- `AllowedOriginsSettings.tsx` を新規追加し、`/admin/knowledge` ページのclient_admin向け一覧タブに埋め込み（`FaqHintSettings.tsx` と同じ折りたたみパネルのパターンを踏襲）。
- super_adminは既存の `/admin/tenants/:id` 内 `SettingsTab`（ワイルドカード対応）で管理するため、二重UIを避けてclient_adminにのみ表示。
- ワイルドカード（`*`）はこのフォームからは登録不可とし、`originCheck.ts` と `security-policy.ts` の判定不一致を避ける。

## 変更ファイル
- `src/api/admin/tenants/routes.ts`
- `tests/api/admin/tenants/routes.test.ts`（新規5テスト）
- `admin-ui/src/components/knowledge/AllowedOriginsSettings.tsx`（新規）
- `admin-ui/src/components/knowledge/AllowedOriginsSettings.test.tsx`（新規7テスト）
- `admin-ui/src/components/knowledge/KnowledgeListTab.tsx`
- `admin-ui/src/components/knowledge/KnowledgeListTab.test.tsx`（新規2テスト）
- `admin-ui/src/i18n/ja.ts` / `en.ts`

## 他ブランチとの衝突可能性
`src/api/admin/tenants/routes.ts` は `fix/tenant-self-service-api-keys` ブランチも同時に触っています（import行への関数追加＋PATCHハンドラ直後への新規ルート3本の追加）。今回の変更（bodySchemaフィールド追加・SET句・RETURNING句）とは編集領域が重ならないため、通常のマージで解決できる想定です。

## テスト結果
- backend: `pnpm typecheck` 0エラー / `npx oxlint` クリーン / `pnpm jest --testPathPatterns="api/admin/tenants/routes"` 80/80 pass
- frontend: `pnpm typecheck` 0エラー / `npx oxlint` クリーン / `npx vitest run` 全37ファイル 506/506 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)