### PR TITLE
[SEC][P2] 死にコード除去: ALLOW_INSECURE_DEV_AUTH二重条件の名残

### DIFF
--- a/src/api/admin/knowledge/knowledgeRoutesAuthGuard.test.ts
+++ b/src/api/admin/knowledge/knowledgeRoutesAuthGuard.test.ts
@@ -46,17 +46,12 @@ import { logger } from '../../../lib/logger';
 import { registerKnowledgeAdminRoutes } from './routes';
 
 const ORIGINAL_NODE_ENV = process.env['NODE_ENV'];
-const ORIGINAL_ALLOW_INSECURE_DEV_AUTH = process.env['ALLOW_INSECURE_DEV_AUTH'];
 
 beforeAll(() => {
   process.env['NODE_ENV'] = 'development';
-  // supabaseAuthMiddleware は NODE_ENV!=='production' に加え ALLOW_INSECURE_DEV_AUTH='true'
-  // の明示指定が無いと署名検証なしデコードを行わない（fail-closed 強化）。
-  process.env['ALLOW_INSECURE_DEV_AUTH'] = 'true';
 });
 afterAll(() => {
   process.env['NODE_ENV'] = ORIGINAL_NODE_ENV;
-  process.env['ALLOW_INSECURE_DEV_AUTH'] = ORIGINAL_ALLOW_INSECURE_DEV_AUTH;
 });
 beforeEach(() => {
   jest.clearAllMocks();

--- a/src/api/admin/tenants/analyticsSummaryRoutes.test.ts
+++ b/src/api/admin/tenants/analyticsSummaryRoutes.test.ts
@@ -42,9 +42,6 @@ let app: Express;
 
 beforeAll(() => {
   process.env.NODE_ENV = "development";
-  // supabaseAuthMiddleware は NODE_ENV!=='production' に加え ALLOW_INSECURE_DEV_AUTH='true'
-  // の明示指定が無いと署名検証なしデコードを行わない（fail-closed 強化）。
-  process.env.ALLOW_INSECURE_DEV_AUTH = "true";
 });
 
 beforeEach(() => {

--- a/tests/phase-a/analyticsSummaryRoutes.test.ts
+++ b/tests/phase-a/analyticsSummaryRoutes.test.ts
@@ -35,9 +35,6 @@ function makeApp(db: any) {
   const app = express();
   app.use(express.json());
   process.env.NODE_ENV = "development";
-  // supabaseAuthMiddleware は NODE_ENV!=='production' に加え ALLOW_INSECURE_DEV_AUTH='true'
-  // の明示指定が無いと署名検証なしデコードを行わない（fail-closed 強化）。
-  process.env.ALLOW_INSECURE_DEV_AUTH = "true";
   registerAnalyticsSummaryRoutes(app, db);
   return app;
 }
@@ -47,7 +44,7 @@ function makeToken(tenantId: string) {
 }
 
 describe("GET /v1/admin/tenants/:id/analytics-summary", () => {
-  afterEach(() => { delete process.env.NODE_ENV; delete process.env.ALLOW_INSECURE_DEV_AUTH; });
+  afterEach(() => { delete process.env.NODE_ENV; });
 
   it("returns summary with conversations and CV data", async () => {
     const db = makeMockDb({

--- a/tests/phase-a/notificationPreferencesRoutes.test.ts
+++ b/tests/phase-a/notificationPreferencesRoutes.test.ts
@@ -22,9 +22,6 @@ function makeApp(db: any) {
   const app = express();
   app.use(express.json());
   process.env.NODE_ENV = "development";
-  // supabaseAuthMiddleware は NODE_ENV!=='production' に加え ALLOW_INSECURE_DEV_AUTH='true'
-  // の明示指定が無いと署名検証なしデコードを行わない（fail-closed 強化）。
-  process.env.ALLOW_INSECURE_DEV_AUTH = "true";
   registerNotificationPreferencesRoutes(app, db);
   return app;
 }
@@ -34,7 +31,7 @@ function makeToken(tenantId: string) {
 }
 
 describe("Notification Preferences Routes", () => {
-  afterEach(() => { delete process.env.NODE_ENV; delete process.env.ALLOW_INSECURE_DEV_AUTH; });
+  afterEach(() => { delete process.env.NODE_ENV; });
 
   describe("GET /v1/admin/tenants/:id/notification-preferences", () => {
     it("returns preferences list", async () => {


### PR DESCRIPTION
## 背景
supabaseAuthMiddlewareのdev-decodeは`NODE_ENV==='development'`単一条件に確定済み（D1cレビューでの二重条件案は撤回済み）。しかし4つのテストファイルに撤回済み案を前提にした`ALLOW_INSECURE_DEV_AUTH='true'`の設定行と説明コメントが残っていた（実装が参照しないため実害はないが、読者を誤誘導する死にコード）。

「[SEC][P2] レビュー積み残しの小口修正まとめ」のうち #819 で未対応だった項目。

## 変更内容
- `tests/phase-a/analyticsSummaryRoutes.test.ts`
- `tests/phase-a/notificationPreferencesRoutes.test.ts`
- `src/api/admin/tenants/analyticsSummaryRoutes.test.ts`
- `src/api/admin/knowledge/knowledgeRoutesAuthGuard.test.ts`

各ファイルの`ALLOW_INSECURE_DEV_AUTH`設定行・説明コメント・afterAll/afterEachでの後始末を削除。`NODE_ENV='development'`設定はそのまま維持。

## テスト
`pnpm jest --testPathPatterns="analyticsSummaryRoutes|notificationPreferencesRoutes|knowledgeRoutesAuthGuard"` — 4 suites / 38 tests 全pass（削除前と同じ理由でpass、挙動不変を確認）。