### PR TITLE
[SEC][P3] レビュー積み残しの軽微項目（wiringInvariants/anamChatStream/previewModeテスト）

### DIFF
--- a/src/api/admin/monitoring/monitoringAuthGuard.test.ts
+++ b/src/api/admin/monitoring/monitoringAuthGuard.test.ts
@@ -11,13 +11,14 @@ jest.mock('../../../admin/http/supabaseAuthMiddleware', () => ({
   },
 }));
 jest.mock('../../../lib/db', () => ({
-  getPool: () => null,
+  getPool: jest.fn(() => null),
   pool: null,
 }));
 
 import express from 'express';
 import request from 'supertest';
 import { logger } from '../../../lib/logger';
+import { getPool } from '../../../lib/db';
 import { registerMonitoringRoutes, computeKpis } from './routes';
 
 function makeApp(user: Record<string, unknown> | null) {
@@ -165,5 +166,36 @@ describe('computeKpis — DB例外はそのまま伝播する(呼び出し元の
   it('DBクエリが例外を投げると computeKpis も reject する（握りつぶさない）', async () => {
     const db = { query: jest.fn().mockRejectedValue(new Error('relation "chat_sessions" does not exist')) };
     await expect(computeKpis(db, null)).rejects.toThrow();
+  });
+});
+
+// tuning/objection-patterns と異なり、monitoring KPIs には super_admin 向けの
+// 「?tenant= で対象テナントを指定してプレビューする」経路が存在しない
+// (routes.ts: `tenantFilter = isSuperAdmin ? null : jwtTenantId` — クエリを一切見ない)。
+// この非対称性を明示的にテストで固定し、将来誰かがクエリパースを追加した際に
+// 「対象テナント指定のはずが全テナント集計のまま」という無自覚な回帰を防ぐ。
+describe('monitoring — previewMode: super_adminにテナント指定プレビュー経路が無いことの固定', () => {
+  it('super_admin が ?tenant=other-tenant を付けても、DBには常に tenantFilter=null(全テナント集計)で問い合わせる', async () => {
+    const queries: Array<{ sql: string; params: unknown[] }> = [];
+    const fakeDb = {
+      query: jest.fn(async (sql: string, params: unknown[]) => {
+        queries.push({ sql, params });
+        if (sql.includes('COUNT(*) AS total')) return { rows: [{ total: '10' }] };
+        if (sql.includes('COUNT(*) AS completed')) return { rows: [{ completed: '5' }] };
+        if (sql.includes('fallback_count')) return { rows: [{ fallback_count: '1' }] };
+        return { rows: [] };
+      }),
+    };
+    (getPool as jest.Mock).mockReturnValueOnce(fakeDb);
+
+    const app = makeApp({ app_metadata: { role: 'super_admin' }, email: 't@t.com' });
+    const res = await request(app).get(`${PATH}?tenant=other-tenant`);
+
+    expect(res.status).toBe(200);
+    const fallbackCall = queries.find((q) => q.sql.includes('fallback_count'));
+    expect(fallbackCall).toBeDefined();
+    // tenantFilter=null なら fallback クエリに tenant_id 条件が入らない
+    // (computeKpis の既存テストが固定している契約と同じ)。
+    expect(fallbackCall!.sql).not.toContain('tenant_id');
   });
 });

--- a/src/api/admin/objection-patterns/objectionPatternsAuthGuard.test.ts
+++ b/src/api/admin/objection-patterns/objectionPatternsAuthGuard.test.ts
@@ -140,6 +140,29 @@ describe('objection-patterns — GET list: query tenantId cross-tenant guard', (
     await request(app).get('/v1/admin/objection-patterns?tenantId=t2');
     expect(listObjectionPatterns).toHaveBeenCalledWith('t2');
   });
+
+  // previewMode(super_adminが?tenantId=経由でテナント代理操作するケース)の境界テスト:
+  // 自分自身のJWT tenant_id(t1)とは別のテナント(t2)を指定した際、レスポンスがt2のデータ
+  // のみになり、actor自身のtenant_id(t1)のコンテキストと混ざらないことを固定する。
+  it('previewMode: super_admin(自身はt1)がt2をプレビューすると、t2スコープのレスポンスのみが返る', async () => {
+    const app = makeApp({ app_metadata: { role: 'super_admin', tenant_id: 't1' }, email: 't@t.com' });
+    (listObjectionPatterns as jest.Mock).mockResolvedValueOnce([
+      { id: 1, tenant_id: 't2', pattern: 'preview-only' },
+    ]);
+    const res = await request(app).get('/v1/admin/objection-patterns?tenantId=t2');
+    expect(res.status).toBe(200);
+    expect(listObjectionPatterns).toHaveBeenCalledWith('t2');
+    expect(listObjectionPatterns).not.toHaveBeenCalledWith('t1');
+    expect(res.body.patterns).toEqual([{ id: 1, tenant_id: 't2', pattern: 'preview-only' }]);
+  });
+
+  // :id ルート(GET/DELETE)にはpreviewMode(クエリでのテナント指定)が存在しないことを
+  // 明示的に固定する。既存の「DELETE — super_adminは常にtenantId=undefined」テストと対をなす。
+  it('previewMode不在の確認: GET /:id はsuper_adminに?tenantId=を渡してもtenantId=undefinedのまま(常に全テナント検索)', async () => {
+    const app = makeApp({ app_metadata: { role: 'super_admin', tenant_id: 't1' }, email: 't@t.com' });
+    await request(app).get('/v1/admin/objection-patterns/123?tenantId=t2');
+    expect(getObjectionPattern).toHaveBeenCalledWith(123, undefined);
+  });
 });
 
 describe('objection-patterns — :id boundary/malformed input', () => {

--- a/src/api/admin/tuning/tuningAuthGuard.test.ts
+++ b/src/api/admin/tuning/tuningAuthGuard.test.ts
@@ -51,6 +51,7 @@ import request from 'supertest';
 import { logger } from '../../../lib/logger';
 import { registerTuningRoutes } from './routes';
 import { registerTestResponseRoutes } from './testResponseRoutes';
+import { listRules } from './tuningRulesRepository';
 
 // ---------------------------------------------------------------------------
 // App factories
@@ -189,6 +190,32 @@ describe('tuning routes — allow-path: client_admin passes ANY_ADMIN routes', (
     const app = makeApp({ role: 'client_admin', tenant_id: 'tenant-a' });
     const res = await request(app).delete('/v1/admin/tuning-rules/1');
     expect(res.status).not.toBe(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// previewMode: super_adminが?tenant=経由でテナント代理操作するケースの境界テスト
+// ---------------------------------------------------------------------------
+
+describe('tuning routes — previewMode: super_adminの?tenant=プレビュー', () => {
+  it('super_admin(自身のtenant_idはtenant-a)が?tenant=tenant-bを指定すると、listRulesはtenant-bでフィルタされる(actor自身のテナントにフォールバックしない)', async () => {
+    const app = makeApp({ role: 'super_admin', tenant_id: 'tenant-a' });
+    await request(app).get('/v1/admin/tuning-rules?tenant=tenant-b');
+    expect(listRules).toHaveBeenCalledWith('tenant-b', expect.anything());
+    expect(listRules).not.toHaveBeenCalledWith('tenant-a', expect.anything());
+  });
+
+  it('super_adminが?tenant=を指定しない場合は未指定(全テナント)でlistRulesが呼ばれる', async () => {
+    const app = makeApp({ role: 'super_admin', tenant_id: 'tenant-a' });
+    await request(app).get('/v1/admin/tuning-rules');
+    expect(listRules).toHaveBeenCalledWith(undefined, expect.anything());
+  });
+
+  it('client_adminは?tenant=を指定しても無視され、常にJWTのtenant_idでフィルタされる(他テナントのぞき見不可)', async () => {
+    const app = makeApp({ role: 'client_admin', tenant_id: 'tenant-a' });
+    await request(app).get('/v1/admin/tuning-rules?tenant=tenant-b');
+    expect(listRules).toHaveBeenCalledWith('tenant-a', expect.anything());
+    expect(listRules).not.toHaveBeenCalledWith('tenant-b', expect.anything());
   });
 });
 

--- a/src/api/avatar/anamChatStreamRoutes.ts
+++ b/src/api/avatar/anamChatStreamRoutes.ts
@@ -93,7 +93,14 @@ export function registerAnamChatStreamRoutes(app: Express, apiStack: RequestHand
       isChatTestToken: (req as any).isChatTestToken === true,
     });
 
-    const latestUserMessage = [...messages].reverse().find((m) => m.role === 'user');
+    // 「最後のuserメッセージ」の判定はここ1箇所のみで行う。以前はガード適用箇所(index 96)と
+    // groqMessages組み立て箇所(旧index 171)で別々に(reverse().find() とreduceで)計算しており、
+    // 片方だけ変更するとガードをすり抜けた原文がLLMに渡るリスクがあった(GID 1217741396163930)。
+    const latestUserMessageIndex = messages.reduce<number>(
+      (lastIdx, m, i) => (m.role === 'user' ? i : lastIdx),
+      -1
+    );
+    const latestUserMessage = latestUserMessageIndex >= 0 ? messages[latestUserMessageIndex] : undefined;
 
     // L5/L7/L6: RAGを介さないGroq直呼び出し経路にも、通常チャット(/api/chat)と同じ
     // 入力ガードを適用する。abuseカウンタはconversationId等の共有バケットではなく
@@ -167,11 +174,8 @@ export function registerAnamChatStreamRoutes(app: Express, apiStack: RequestHand
 - マークダウンや箇条書きは使わないでください（音声化されるため）
 - 専門用語は避け、わかりやすい言葉で説明してください`;
 
-    // 直近ユーザー発言のみ、L5/L7/L6ガード済みの内容に差し替える（履歴は元のまま）
-    const latestUserMessageIndex = messages.reduce(
-      (lastIdx, m, i) => (m.role === 'user' ? i : lastIdx),
-      -1
-    );
+    // 直近ユーザー発言のみ、L5/L7/L6ガード済みの内容に差し替える（履歴は元のまま）。
+    // latestUserMessageIndex は冒頭で1回だけ計算したものを再利用する。
     const groqMessages: Array<{ role: 'system' | 'user' | 'assistant'; content: string }> = [
       { role: 'system', content: systemPrompt },
       ...messages.map((m, i) => ({

--- a/src/index.wiringInvariants.test.ts
+++ b/src/index.wiringInvariants.test.ts
@@ -48,32 +48,42 @@ describe("src/index.ts 配線の不変条件（ソース構造検査）", () => 
   });
 
   describe("apiStack のミドルウェア順序（レートリミッタ2段化）", () => {
-    const apiStackMatch = source.match(/const apiStack = \[([\s\S]*?)\] as express\.RequestHandler\[\];/);
-    if (!apiStackMatch) throw new Error("apiStack literal not found in src/index.ts");
-    const apiStackBody = apiStackMatch[1];
-    // 行コメント（例: "// 1. Rate limit (pre-auth, IP-keyed)"）はカンマを含みうるため、
-    // まず行ごとに "//" 以降を切り捨ててから識別子を抽出する（単純な split(",") はコメント内の
-    // カンマで誤爆する）。
-    const order = apiStackBody
-      .split("\n")
-      .map((line) => line.split("//")[0].trim().replace(/,$/, ""))
-      .filter((name) => /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name));
+    // apiStack リテラルの解析を it() の内側に置く: describe 直下（it の外）で throw すると
+    // スイート読み込み自体がクラッシュし、他の describe のテストまで巻き込んで
+    // 「何が壊れたか」が読み取れなくなる。it() 内の失敗として報告されるよう、
+    // 解析をこの関数に閉じ込めて各 it() から呼び出す。
+    function getApiStackOrder(): string[] {
+      const apiStackMatch = source.match(/const apiStack = \[([\s\S]*?)\] as express\.RequestHandler\[\];/);
+      if (!apiStackMatch) throw new Error("apiStack literal not found in src/index.ts");
+      const apiStackBody = apiStackMatch[1];
+      // 行コメント（例: "// 1. Rate limit (pre-auth, IP-keyed)"）はカンマを含みうるため、
+      // まず行ごとに "//" 以降を切り捨ててから識別子を抽出する（単純な split(",") はコメント内の
+      // カンマで誤爆する）。
+      return apiStackBody
+        .split("\n")
+        .map((line) => line.split("//")[0].trim().replace(/,$/, ""))
+        .filter((name) => /^[A-Za-z_$][A-Za-z0-9_$]*$/.test(name));
+    }
 
     it("ipRateLimiter が authMiddleware より前（認証前のIP段）", () => {
+      const order = getApiStackOrder();
       expect(order.indexOf("ipRateLimiter")).toBeGreaterThanOrEqual(0);
       expect(order.indexOf("ipRateLimiter")).toBeLessThan(order.indexOf("authMiddleware"));
     });
 
     it("tenantRateLimiter が authMiddleware・tenantContext より後（認証後のtenant段）", () => {
+      const order = getApiStackOrder();
       expect(order.indexOf("tenantRateLimiter")).toBeGreaterThan(order.indexOf("authMiddleware"));
       expect(order.indexOf("tenantRateLimiter")).toBeGreaterThan(order.indexOf("tenantContext"));
     });
 
     it("apiStack に旧単一リミッタ(globalRateLimiter)が残っていない（2段化の巻き戻り検出）", () => {
+      const order = getApiStackOrder();
       expect(order).not.toContain("globalRateLimiter");
     });
 
     it("securityPolicy が authMiddleware より後（テナント未確定でorigin検証しない）", () => {
+      const order = getApiStackOrder();
       expect(order.indexOf("securityPolicy")).toBeGreaterThan(order.indexOf("authMiddleware"));
     });
   });


### PR DESCRIPTION
## 概要
Asanaタスク「[SEC][P3] レビュー積み残しの軽微項目」のうち3件を実装。

## 変更内容

### A. wiringInvariantsテストのスイート例外死対策
`src/index.wiringInvariants.test.ts`: apiStackリテラルの正規表現マッチとthrowが`describe`直下（`it()`の外）にあり、`apiStack`をリネームするとスイート全体がクラッシュしていた。解析を`getApiStackOrder()`関数に閉じ込め、各`it()`内から呼ぶ形に変更。通常のテスト失敗として報告されるようになる。

### B. anamChatStreamRoutesの最終userメッセージ二重計算の解消
`src/api/avatar/anamChatStreamRoutes.ts`: 「配列内の最後のuserメッセージ」を`reverse().find()`とreduceの2箇所で別々に計算していた。片方だけ変更されるとガード済み本文が別メッセージに差し込まれるリスクがあったため、reduce一本化に統合。

### C. previewModeのロール境界テスト追加
D1a/D1bで追加したroleAuth配線テストがclient_admin/super_adminの2ロールのみカバーしており、previewMode（super_adminが`?tenant=`/`?tenantId=`経由でテナント代理操作するケース）のテストが無かった。
- `tuningAuthGuard.test.ts`: super_adminの`?tenant=`プレビューがactor自身のtenant_idにフォールバックしないこと、client_adminは`?tenant=`を無視されることを固定
- `objectionPatternsAuthGuard.test.ts`: previewMode時のレスポンス分離、`:id`ルートにpreviewModeが存在しないことを固定
- `monitoringAuthGuard.test.ts`: monitoringには同等のpreviewMode経路が存在しないこと（`?tenant=`を渡してもtenantFilter=null固定）を明示的にテストで固定

新規テストファイルは作成せず、既存ファイルへの追記のみ。

## テスト結果
- `pnpm typecheck`: 0エラー
- `npx oxlint`: 対象5ファイル 0警告
- `pnpm jest --testPathPatterns="wiringInvariants|anamChatStream|tuningAuthGuard|objection-patterns|monitoring"`: 154/154 pass
- ミューテーション確認:
  - anamChatStreamの一本化した`latestUserMessageIndex`計算を破壊 → 11件失敗（復元で全pass）
  - wiringInvariantsのapiStack検出正規表現を破壊 → 4件が**通常のテスト失敗として**報告され、他7件は影響を受けず（修正前は18件全滅のスイートクラッシュだった）

## 禁止事項の遵守
- 新規ファイルは作成していない
- wiringInvariants/anamChatStream/roleAuthの実装ロジック自体は変更していない（構造改善とテスト追加のみ）