### PR TITLE
[TEST] evaluateSessionのnull多義性/ステータスコード境界のテスト強化

### DIFF
--- a/src/agent/judge/judgeEvaluator.test.ts
+++ b/src/agent/judge/judgeEvaluator.test.ts
@@ -509,4 +509,52 @@ describe('evaluateSession', () => {
     await expect(evaluateSession('session-single-message')).rejects.toThrow(SessionTooShortError);
     expect(mockCallGroq).not.toHaveBeenCalled();
   });
+
+  it('17. [境界値] メッセージがちょうど2件 → SessionTooShortErrorはthrowされず通常通り評価される（0/1件との境界を挟んで反対側を固定する）', async () => {
+    const mockPool = makeMockPool();
+    mockGetPool.mockReturnValue(mockPool as any);
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [{ id: 'internal-uuid-boundary', tenant_id: 'tenant-a', prompt_variant_id: null }] })
+      .mockResolvedValueOnce({
+        rows: [
+          { role: 'user', content: 'こんにちは', created_at: new Date() },
+          { role: 'assistant', content: 'いらっしゃいませ', created_at: new Date() },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+    mockCallGroq.mockResolvedValueOnce(makeGroqResponse({ overall_score: 70 }));
+
+    const result = await evaluateSession('session-boundary-2msgs');
+
+    expect(result).not.toBeNull();
+    expect(mockCallGroq).toHaveBeenCalledTimes(1);
+  });
+
+  it('18. [イレギュラー] 全メッセージがassistant発言のみ（ユーザー発言ゼロ）でも評価は継続する（firstUserMsg空文字列でクラッシュしない）', async () => {
+    // 実運用では通常あり得ない（AIが先に2回連続発話するセッション構成）が、
+    // messages.length <= 1 のガードは role を見ないため、この構成でも
+    // SessionTooShortError にはならず素通りする。firstUserMsg = '' になった際に
+    // searchKnowledgeForSuggestion がスキップされ、以降の処理が例外を投げないことを固定する。
+    const mockPool = makeMockPool();
+    mockGetPool.mockReturnValue(mockPool as any);
+    mockPool.query
+      .mockResolvedValueOnce({ rows: [{ id: 'internal-uuid-noUser', tenant_id: 'tenant-a', prompt_variant_id: null }] })
+      .mockResolvedValueOnce({
+        rows: [
+          { role: 'assistant', content: 'いらっしゃいませ', created_at: new Date() },
+          { role: 'assistant', content: '何かお探しですか？', created_at: new Date() },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+    mockCallGroq.mockResolvedValueOnce(makeGroqResponse({ overall_score: 60 }));
+
+    const result = await evaluateSession('session-no-user-messages');
+
+    expect(result).not.toBeNull();
+    // searchKnowledgeForSuggestion は firstUserMsg 空文字列のためスキップされ、
+    // Gemini 呼び出しには到達すること（クラッシュせず先に進んだ証跡）
+    expect(mockCallGroq).toHaveBeenCalledTimes(1);
+  });
 });

--- a/tests/phase45/evaluationRoutes.test.ts
+++ b/tests/phase45/evaluationRoutes.test.ts
@@ -283,6 +283,93 @@ describe("1. POST /v1/admin/evaluations/trigger", () => {
     expect(checkAlreadyEvaluated).toHaveBeenCalledWith("sess-does-not-exist", "tenant-a");
     expect(checkAlreadyEvaluated).toHaveBeenCalledWith("sess-other-tenant", "tenant-a");
   });
+
+  // 壊れやすいポイント: 5つの終端ステータス(200/404/409/422/500)が互いに独立して
+  // 決まっていること — どれか1つの分岐を触った変更が他のケースを巻き込んで
+  // 意図せず変えていないかを1つの表で固定する。
+  it.each([
+    {
+      label: "200 正常評価",
+      setup: () => {
+        (checkAlreadyEvaluated as jest.Mock).mockResolvedValue(false);
+        (evaluateSession as jest.Mock).mockResolvedValue(JUDGE_RESULT);
+      },
+      expectedStatus: 200,
+    },
+    {
+      label: "404 セッション不在/他テナント",
+      setup: () => {
+        const { SessionNotFoundError } = jest.requireMock(
+          "../../src/agent/judge/judgeEvaluator",
+        ) as { SessionNotFoundError: new (sessionId: string) => Error };
+        (checkAlreadyEvaluated as jest.Mock).mockResolvedValue(false);
+        (evaluateSession as jest.Mock).mockRejectedValue(new SessionNotFoundError("sess-001"));
+      },
+      expectedStatus: 404,
+    },
+    {
+      label: "409 評価済み",
+      setup: () => {
+        (checkAlreadyEvaluated as jest.Mock).mockResolvedValue(true);
+      },
+      expectedStatus: 409,
+    },
+    {
+      label: "422 短すぎるセッション（空/1通話のみ、障害ではない）",
+      setup: () => {
+        const { SessionTooShortError } = jest.requireMock(
+          "../../src/agent/judge/judgeEvaluator",
+        ) as { SessionTooShortError: new (sessionId: string) => Error };
+        (checkAlreadyEvaluated as jest.Mock).mockResolvedValue(false);
+        (evaluateSession as jest.Mock).mockRejectedValue(new SessionTooShortError("sess-001"));
+      },
+      expectedStatus: 422,
+    },
+    {
+      label: "500 真の内部エラー（Gemini呼び出し失敗などnull返却）",
+      setup: () => {
+        (checkAlreadyEvaluated as jest.Mock).mockResolvedValue(false);
+        (evaluateSession as jest.Mock).mockResolvedValue(null);
+      },
+      expectedStatus: 500,
+    },
+  ])("$label → HTTP $expectedStatus", async ({ setup, expectedStatus }) => {
+    setup();
+
+    const res = await request(makeApp())
+      .post("/v1/admin/evaluations/trigger")
+      .send({ session_id: "sess-001" });
+
+    expect(res.status).toBe(expectedStatus);
+  });
+
+  // 既知のリスク（未修正、テストで可視化のみ）: checkAlreadyEvaluated → evaluateSession は
+  // 「確認してから実行」の非アトミックな2段階であり、conversation_evaluations テーブルには
+  // (tenant_id, session_id) の UNIQUE 制約が無い
+  // (src/agent/judge/migration_conversation_evaluations.sql 参照。judgeEvaluator.ts の
+  // INSERT ... ON CONFLICT DO NOTHING は対象となる制約が存在しないため実質no-op)。
+  // 同一セッションへの評価トリガーが競合すると、両方が checkAlreadyEvaluated=false を見て
+  // 両方が evaluateSession を実行し、Gemini呼び出し・通知・tuning_rules挿入が重複しうる
+  // (Stripe webhookで修正した二重処理と同型の問題だが、ここは未修正)。
+  // このテストはその非アトミック性をユニットテストレベルで可視化するためのものであり、
+  // 実装修正はスコープ外(親からの指示により、発見のみ・修正はしない)。
+  it("[既知のリスク・未修正] 同一session_idへの2並行トリガーは両方とも200になりうる（checkAlreadyEvaluatedがDBの一意制約でなくアプリ側の事前確認のみのため）", async () => {
+    (checkAlreadyEvaluated as jest.Mock).mockResolvedValue(false);
+    (evaluateSession as jest.Mock).mockResolvedValue(JUDGE_RESULT);
+
+    const app = makeApp();
+    const [res1, res2] = await Promise.all([
+      request(app).post("/v1/admin/evaluations/trigger").send({ session_id: "sess-race" }),
+      request(app).post("/v1/admin/evaluations/trigger").send({ session_id: "sess-race" }),
+    ]);
+
+    // 本来は「評価トリガーは冪等であってほしい」が、現状の実装ではどちらも
+    // checkAlreadyEvaluated=false を見て両方 evaluateSession まで進むため、
+    // 両方 200 になる（片方が409になるような排他制御が無い）。
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+    expect(evaluateSession).toHaveBeenCalledTimes(2);
+  });
 });
 
 // ===========================================================================


### PR DESCRIPTION
## 背景
PR #823（evaluateSessionのnull多義性解消）のテストを、境界値・イレギュラー操作・カバレッジギャップの観点で強化する。

## 追加したテスト

### judgeEvaluator.test.ts
- **17. ちょうど2件のメッセージ**: SessionTooShortErrorの境界のすぐ外側。0/1件（既存test 15,16）と対で固定し、境界の両側を明示的にテストする。
- **18. 全メッセージがassistant発言のみ**: ユーザー発言ゼロという通常あり得ない構成でも、firstUserMsgが空文字列のままクラッシュせず評価が継続することを確認。

### evaluationRoutes.test.ts
- **5ステータスの独立性テーブル**: 200/404/409/422/500が互いに独立して決まることを`it.each`で1箇所に固定。どれかの分岐を触った変更が他を巻き込んでいないかを機械的に検出できる。
- **[既知のリスク・未修正] 並行トリガーのテスト**: `checkAlreadyEvaluated`→`evaluateSession`が非アトミックな「確認してから実行」パターンであることを可視化。調査の結果、`conversation_evaluations`テーブルに`(tenant_id, session_id)`のUNIQUE制約が存在せず、`judgeEvaluator.ts`の`INSERT ... ON CONFLICT DO NOTHING`は対象となる制約が無いため実質no-opであることを確認した（`src/agent/judge/migration_conversation_evaluations.sql`参照）。同一セッションへの評価トリガーが競合すると、両方が`checkAlreadyEvaluated=false`を見て両方評価を実行しうる（Gemini呼び出し・通知・tuning_rules挿入の重複）。**実装修正はスコープ外のため今回は行っていない。**

## テスト結果
- typecheck: 0エラー
- oxlint: クリーン
- `judgeEvaluator|evaluationRoutes|evaluations` 関連スイート: 5 suites / 137 tests 全pass

## ミューテーション検証
1. `messages.length <= 1` → `< 1` に緩めると、test 16（1件境界）のみ失敗しtest 17（2件）は影響を受けないことを確認（境界の両側が独立して固定されている証跡）→ 復元
2. 422のレスポンスコードを500に変えると、ステータス独立性テーブルの422行のみが失敗することを確認 → 復元

いずれもテスト追加前は検出できなかった劣化パターン。

**マージはしない。**