### PR TITLE
[TEST] rate-limit/sessionKeyのテスト強化

### DIFF
--- a/src/agent/dialog/contextStore.test.ts
+++ b/src/agent/dialog/contextStore.test.ts
@@ -74,6 +74,30 @@ describe("contextStore", () => {
     expect(trimmed[19].content).toBe("tenant-full の21件目");
   });
 
+  it("空配列でappendしても既存履歴を壊さず、Mapに空エントリとして残る（no-opではなくキーが作成される）", () => {
+    appendToSessionHistory("tenant-empty-append", "session-1", []);
+    // 空配列でも一度appendすればMapにキーは作られる（undefinedとの違いを保証）
+    expect(getSessionHistory("tenant-empty-append", "session-1")).toEqual([]);
+
+    appendToSessionHistory("tenant-empty-append", "session-1", [
+      { role: "user", content: "後続の発話" },
+    ]);
+    expect(getSessionHistory("tenant-empty-append", "session-1")).toEqual([
+      { role: "user", content: "後続の発話" },
+    ]);
+  });
+
+  it("極端に長いtenantId/sessionIdでもクラッシュせずキー生成できる", () => {
+    const longTenant = "t-" + "a".repeat(2000);
+    const longSession = "s-" + "b".repeat(2000);
+    expect(() =>
+      appendToSessionHistory(longTenant, longSession, [
+        { role: "user", content: "long key test" },
+      ])
+    ).not.toThrow();
+    expect(getSessionHistory(longTenant, longSession)).toHaveLength(1);
+  });
+
   describe("キー連結（`${tenantId}::${sessionId}`）のセパレータ衝突防止", () => {
     it("【修正確認】tenantIdに区切り文字`::`が含まれる場合は例外を投げ、衝突を未然に防ぐ", () => {
       // tenantId は作成時バリデーション(/^[a-z0-9_-]+$/)によりコロンを含まない

--- a/src/agent/dialog/salesContextStore.test.ts
+++ b/src/agent/dialog/salesContextStore.test.ts
@@ -6,6 +6,7 @@ import {
   updateSalesSessionMeta,
   type SalesSessionKey,
 } from "./salesContextStore";
+import { appendToSessionHistory, getSessionHistory } from "./contextStore";
 
 describe("salesContextStore", () => {
   const key: SalesSessionKey = {
@@ -111,6 +112,38 @@ describe("salesContextStore", () => {
       expect(getSalesSessionMeta(normalKey)).toBeUndefined();
       const saved = setSalesSessionMeta(normalKey, { currentStage: "clarify" as any });
       expect(saved.currentStage).toBe("clarify");
+    });
+
+    it("同一の内部キー文字列でも、contextStore(会話履歴)とsalesContextStore(商談ステージ)は別Mapのため互いを汚染しない", () => {
+      // 両ストアは buildTenantSessionKey で同じキー生成規則を共有するが、
+      // Map実体（sessions / sessionStore）は完全に別モジュールスコープ。
+      // 同一tenantId+sessionIdの組でも一方の書き込みが他方に漏れないことを確認する。
+      const sharedTenant = "tenant-cross-store";
+      const sharedSession = "session-cross-store";
+
+      appendToSessionHistory(sharedTenant, sharedSession, [
+        { role: "user", content: "会話履歴側の発話" },
+      ]);
+      setSalesSessionMeta(
+        { tenantId: sharedTenant, sessionId: sharedSession },
+        { currentStage: "propose" as any, lastIntent: "trial_lesson_offer" }
+      );
+
+      expect(getSessionHistory(sharedTenant, sharedSession)).toEqual([
+        { role: "user", content: "会話履歴側の発話" },
+      ]);
+      const salesMeta = getSalesSessionMeta({
+        tenantId: sharedTenant,
+        sessionId: sharedSession,
+      });
+      expect(salesMeta?.currentStage).toBe("propose");
+
+      // salesContextStoreをクリアしても会話履歴側は影響を受けない
+      clearSalesSessionMeta({ tenantId: sharedTenant, sessionId: sharedSession });
+      expect(getSalesSessionMeta({ tenantId: sharedTenant, sessionId: sharedSession })).toBeUndefined();
+      expect(getSessionHistory(sharedTenant, sharedSession)).toEqual([
+        { role: "user", content: "会話履歴側の発話" },
+      ]);
     });
   });
 });

--- a/src/lib/rate-limit.test.ts
+++ b/src/lib/rate-limit.test.ts
@@ -338,6 +338,36 @@ describe("createRateLimitMiddleware", () => {
     expect(JSON.stringify(res2.body)).not.toContain("7.7.7.7");
   });
 
+  it("getLimit returning 0 (explicit deny-all) is honored, not confused with undefined (fall through to default) — nullish-coalescing boundary", () => {
+    // `getLimit?.(key) ?? tenantCfg?.security.rateLimit ?? DEFAULT_MAX_REQUESTS` uses `??`,
+    // which only falls through on null/undefined. 0 is a valid, distinct "deny everything"
+    // signal a caller might return (e.g. a suspended-tenant plan check). If this were `||`
+    // instead of `??`, 0 would incorrectly fall through to DEFAULT_MAX_REQUESTS (100) and
+    // silently defeat the deny-all intent.
+    const mw = createRateLimitMiddleware({ stage: "tenant", getLimit: () => 0 });
+    const req = mockReq({ tenantId: "tenant-zero-limit" });
+    const res = mockRes();
+    let called = false;
+    mw(req as never, res as never, () => {
+      called = true;
+    });
+    expect(called).toBe(false);
+    expect(res.statusCode).toBe(429);
+    expect(res.headers["X-RateLimit-Limit"]).toBe("0");
+  });
+
+  it("getLimit returning undefined falls through to tenantConfig/DEFAULT (distinct from explicit 0)", () => {
+    const mw = createRateLimitMiddleware({ stage: "tenant", getLimit: () => undefined });
+    const req = mockReq({ tenantId: "tenant-undefined-limit" });
+    const res = mockRes();
+    let called = false;
+    mw(req as never, res as never, () => {
+      called = true;
+    });
+    expect(called).toBe(true);
+    expect(res.headers["X-RateLimit-Limit"]).toBe("100"); // DEFAULT_MAX_REQUESTS
+  });
+
   it("two-stage independence — same tenant hammered from many IPs: tenant-stage aggregates all of them, ip-stage does not block a fresh IP", () => {
     const tenantMw = createRateLimitMiddleware({ stage: "tenant", getLimit: () => 2 });
     const ipMw = createRateLimitMiddleware({ stage: "ip", getLimit: () => 100 });


### PR DESCRIPTION
## 背景
PR #819（rate-limit型修正+session key生成の重複解消）で実装した機能に対し、境界値・ストア間分離の観点でテストを強化する。既存の `rate-limit.test.ts` / `contextStore.test.ts` / `salesContextStore.test.ts` / `sessionKey.test.ts` は既にIP/tenant名前空間分離・コロン衝突防止・ウィンドウ境界などを厚くカバーしていたため、重複を避けて未カバーの箇所のみ追加した。

## 追加したテスト

### `src/lib/rate-limit.ts`
- `getLimit` が **0**（明示的deny-all）を返す場合と **undefined**（フォールスルー）を返す場合を区別する境界値テスト。`??`（nullish coalescing）が `||` に劣化すると `0` が誤ってDEFAULT_MAX_REQUESTS(100)にフォールスルーしてしまう回帰を検知する。**ミューテーションテストで実際にこの劣化を再現し、新規テストが失敗→修正を戻すと復帰することを確認済み。**

### `src/agent/dialog/contextStore.ts`
- 空配列でのappend（no-opではなくキーが作られることの確認）
- 極端に長いtenantId/sessionId（2000文字超）でのクラッシュ確認

### `src/agent/dialog/salesContextStore.ts`
- **同一tenantId+sessionIdでも `contextStore`（会話履歴）と `salesContextStore`（商談ステージ）は別Mapのため互いを汚染しない**ことを確認するクロスストアテスト。両ストアは`buildTenantSessionKey`で同じキー生成規則を共有するが、実体は完全に独立したモジュールスコープであることを明示的に固定。

## テスト結果
- typecheck: 0エラー
- oxlint: クリーン
- 対象4ファイル: 37/37 pass
- フルスイート実行時、`avatar/routes.test.ts`の20件が失敗するが、これは本PRと無関係な既知のflake（`global.fetch`スパイの問題、mainでも同様に発生することを確認済み）

## カバレッジギャップの指摘（実装は変更せず、報告のみ）

1. **`contextStore.ts`にTTL/クリーンアップ機構が無い**: `rate-limit.ts`の`store`は5分ごとにexpiredエントリを削除するcleanup timerを持つが、`contextStore.ts`の`sessions` Mapと`salesContextStore.ts`の`sessionStore` Mapにはそれが無い。`contextStore.ts`に至っては`delete`/`clear`関数自体が存在しない。長時間稼働するプロセスでは、ユニークな(tenantId, sessionId)の組み合わせが増え続ける限りメモリが際限なく増加する。ユニットテストでは検知できない運用リスクとして報告する。

2. **インメモリストアはプロセスローカル**: `sessions`/`sessionStore`はモジュールスコープの`Map`であり、Redis等の共有ストアではない（コード内コメントで「MVP、将来Redis等に差し替え」と明記済み）。PM2クラスターモード等でワーカーが複数プロセスに分散している場合、同一セッションのリクエストが異なるワーカーに割り振られると会話履歴/商談ステージが一貫しない可能性がある。現状の運用構成（PM2インスタンス数）次第で顕在化するかどうかが変わるため、実際のデプロイ構成を確認することを推奨する。

3. **`rate-limit.ts`のログ出力の軽微な不正確さ**: `logger?.warn({..., stage: stage ?? "tenant", ...}, "rate_limit_exceeded")` が、`stage`未指定（legacy）の場合でも`"tenant"`とログに残す。実際のバケット名前空間はlegacy=接頭辞無し、tenant段=`tenant:`接頭辞、と別物なため、ログを見て障害調査する際に誤誘導しうる。影響は軽微（運用ログの可読性のみ）だが、対応するなら`stage ?? "legacy"`等への1行修正で足りる。

マージはしていません。