### PR TITLE
[TEST] wiringInvariants/anamChatStream/previewModeテストの妥当性確認+強化

### DIFF
--- a/src/api/avatar/anamChatStreamRoutes.test.ts
+++ b/src/api/avatar/anamChatStreamRoutes.test.ts
@@ -371,6 +371,73 @@ describe('POST /api/avatar/chat-stream — 入力上限とL5/L7/L6ガード', ()
       expect(res.status).toBe(400);
     },
   );
+
+  // GID 1217741396163930: 「最後のuserメッセージ」の判定は1箇所のみで行い、ガード適用箇所と
+  // Groqへ送るmessages組み立て箇所が同じindexを参照する。以前は reverse().find() と reduce の
+  // 2通りで別々に計算しており、片方だけ変更するとガードをすり抜けた原文がLLMに渡るリスクがあった。
+  // この回帰を検出できるのは「Groqへ実際に送られるHTTPボディの中身」を見るテストだけであり、
+  // レスポンスstatusやsaveMessageの検証だけでは不十分なため、fetchモックへの呼び出し引数を検査する。
+  it('L5サニタイズで内容が書き換わっても、履歴を保ったまま最新userメッセージのindexだけがGroqへの送信内容に反映される（原文がそのまま漏れない・他ターンが巻き込まれない）', async () => {
+    process.env.NODE_ENV = 'development';
+    process.env.INPUT_SANITIZER_ENABLED = 'true';
+    const rawLatest = '価格を教えて\x00secret-injected-text';
+
+    const res = await request(makeApp())
+      .post('/api/avatar/chat-stream')
+      .send({
+        sessionId: 'sess-sanitize-passthrough',
+        messages: [
+          { role: 'user', content: '1つ目の質問' },
+          { role: 'assistant', content: '1つ目の回答' },
+          { role: 'user', content: rawLatest },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    const fetchMock = global.fetch as jest.Mock;
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const sentBody = JSON.parse(fetchMock.mock.calls[0]![1].body);
+    const sentMessages: Array<{ role: string; content: string }> = sentBody.messages;
+
+    // index0はsystemプロンプト、以降は元のmessages配列と1:1対応する。
+    expect(sentMessages).toHaveLength(4);
+    expect(sentMessages[1]!.content).toBe('1つ目の質問'); // 履歴は無傷（ガード適用対象外）
+    expect(sentMessages[2]!.content).toBe('1つ目の回答'); // 履歴は無傷
+    expect(sentMessages[3]!.content).not.toContain('\x00'); // L5でnullバイトが除去済み
+    expect(sentMessages[3]!.content).not.toBe(rawLatest); // 生の原文そのままではない
+    expect(sentMessages[3]!.content).toBe('価格を教えてsecret-injected-text');
+  });
+
+  it('最新userメッセージが配列の途中にあり末尾がassistantの場合でも、ガード適用とGroq送信内容の両方が正しくそのindexを指す(20件境界のケースと同型)', async () => {
+    process.env.NODE_ENV = 'production'; // L5/L6/L7既定ON
+
+    const res = await request(makeApp())
+      .post('/api/avatar/chat-stream')
+      .send({
+        sessionId: 'sess-middle-user',
+        messages: [
+          { role: 'user', content: '在庫はありますか' },
+          { role: 'assistant', content: 'はい、在庫があります' },
+          { role: 'user', content: '配送日数を教えて' },
+          { role: 'assistant', content: '通常3営業日です' },
+        ],
+      });
+
+    expect(res.status).toBe(200);
+    const fetchMock = global.fetch as jest.Mock;
+    const sentBody = JSON.parse(fetchMock.mock.calls[0]![1].body);
+    const sentMessages: Array<{ role: string; content: string }> = sentBody.messages;
+
+    // 末尾はassistantだが「最後のuser」は index3(配送日数を教えて)。ここだけガード済み内容に
+    // 置換され、他は完全に元のまま残ることを固定する。
+    expect(sentMessages[1]!.content).toBe('在庫はありますか');
+    expect(sentMessages[2]!.content).toBe('はい、在庫があります');
+    expect(sentMessages[3]!.content).toBe('配送日数を教えて');
+    expect(sentMessages[4]!.content).toBe('通常3営業日です');
+
+    const userSaveCall = mockSaveMessage.mock.calls.find((c) => c[0].role === 'user');
+    expect(userSaveCall![0].content).toBe('配送日数を教えて');
+  });
 });
 
 describe('POST /api/avatar/chat-stream — abuseカウンタのテナント/セッション分離（越境DoS防止の核心）', () => {


### PR DESCRIPTION
## 対象
PR #827(P3軽微項目)・#826(死にコード除去)・#818(modelRouter混入除去)のテスト妥当性確認と不足分の追加。

## 確認結果と対応

### A. wiringInvariantsテスト（変更なし）
`apiStack`という識別子を一時的にリネームするミューテーション確認を実施。`it()`外throwがスイート丸ごとクラッシュを起こしていた旧問題は解消済みで、該当4件の`it()`だけが個別失敗し、他7件のテスト(webhook/search/dialog)は正常に実行された。確認後は元に戻した。**コード変更なし。**

### B. anamChatStreamRoutes（テスト追加）
「最後のuserメッセージ」判定の単一化(`reduce`で1箇所のみ計算し、ガード適用・Groq送信内容組み立ての両方で再利用)は実装として正しいが、既存テストは`saveMessage`呼び出しとレスポンスstatusしか見ておらず、**Groqへ実際に送信されるHTTPボディの中身**を検証していなかった。これでは「2箇所の計算が再び分離しても検出できない」という、まさにこの修正が防ごうとしていたリスクをテストがカバーできていなかった。

`fetch`モックへの呼び出し引数を検査する2件のテストを追加:
- L5サニタイズ(nullバイト除去)で内容が書き換わった場合、書き換え後の内容が正しいindexに反映され、他ターンの履歴(前後のuser/assistant発言)が巻き込まれないこと
- 最新userメッセージが配列の末尾ではなく途中にある場合(末尾がassistant)でも、ガードとGroq送信の両方が正しいindexを指すこと

**ミューテーション確認**: 「Groq送信内容組み立て箇所が独自に`findIndex`(先頭一致)で最新userを再計算する」という、修正前に実際に存在した種類の分離バグを再現したところ、追加した2件のテストが即座に失敗することを確認(確認後は元に戻した)。

### C. previewModeテスト（変更なし・妥当性を確認）
3ファイルとも、単に「403にならない」ことだけを見る弱いテストではなく、実際にモック関数(`listRules`/`listObjectionPatterns`)への呼び出し引数や、レスポンスボディの中身を検証しており、テナント境界の実質的な検証になっていた。特に`monitoringAuthGuard.test.ts`は「monitoringにはpreviewMode自体が存在しない(常に全テナント集計)」という設計上の非対称性を明示的に固定しており、質の高いテストだった。**コード変更なし。**

### D. modelRouter混入除去/死にコード除去（変更なし）
削除系の変更で新規テスト不要と判断。`openaiEmbeddingClient.test.ts`は正常系・境界値(usage欠落)・異常系(API失敗/キー未設定/不正形状)・trackUsageのfire-and-forget耐性まで既にカバーされており、追加不要と判断。

## テスト結果
`pnpm typecheck` 0エラー / oxlintクリーン / 対象7スイート166テスト全pass

マージはしていません。