### PR TITLE
[TEST] 招待UI+allowed_origins設定UIのテスト強化

### DIFF
--- a/admin-ui/src/components/knowledge/AllowedOriginsSettings.test.tsx
+++ b/admin-ui/src/components/knowledge/AllowedOriginsSettings.test.tsx
@@ -112,4 +112,82 @@ describe("AllowedOriginsSettings", () => {
     await waitFor(() => expect(screen.getByText("❌ 保存に失敗しました。もう一度お試しください。")).toBeTruthy());
     expect(screen.getByText("https://a.example.com")).toBeTruthy();
   });
+
+  it("通信エラー（fetch自体が例外）でもロールバックしエラートーストを表示する", async () => {
+    authFetchMock.mockReturnValueOnce(jsonRes({ allowed_origins: ["https://a.example.com"] }));
+    authFetchMock.mockImplementationOnce(() => Promise.reject(new Error("network down")));
+    await openPanel();
+
+    await screen.findByText("https://a.example.com");
+    fireEvent.click(screen.getByLabelText("remove https://a.example.com"));
+
+    await waitFor(() => expect(screen.getByText("❌ 保存に失敗しました。もう一度お試しください。")).toBeTruthy());
+    expect(screen.getByText("https://a.example.com")).toBeTruthy();
+  });
+
+  it("既に登録済みのoriginを再度追加しようとするとPATCHを呼ばずエラー表示する（重複追加防止）", async () => {
+    authFetchMock.mockReturnValueOnce(jsonRes({ allowed_origins: ["https://dup.example.com"] }));
+    await openPanel();
+
+    await screen.findByText("https://dup.example.com");
+    const input = screen.getByPlaceholderText("https://shop.example.com");
+    fireEvent.change(input, { target: { value: "https://dup.example.com" } });
+    fireEvent.click(screen.getByText("追加"));
+
+    expect(await screen.findByText("既に登録されています")).toBeTruthy();
+    expect(authFetchMock.mock.calls.some(([, opts]) => (opts as RequestInit | undefined)?.method === "PATCH")).toBe(false);
+  });
+
+  it("空白のみの入力では追加ボタンがdisabledのままPATCHを呼ばない", async () => {
+    authFetchMock.mockReturnValueOnce(jsonRes({ allowed_origins: [] }));
+    await openPanel();
+
+    const input = await screen.findByPlaceholderText("https://shop.example.com");
+    fireEvent.change(input, { target: { value: "   " } });
+
+    const addButton = screen.getByText("追加").closest("button") as HTMLButtonElement;
+    expect(addButton.disabled).toBe(true);
+    expect(authFetchMock.mock.calls.some(([, opts]) => (opts as RequestInit | undefined)?.method === "PATCH")).toBe(false);
+  });
+
+  it("tenantIdが'global'のときは初期フェッチ自体を呼ばず何も描画しない", () => {
+    const { container } = render(<AllowedOriginsSettings tenantId="global" />);
+    expect(authFetchMock).not.toHaveBeenCalled();
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("保存中（saving=true）は残っている項目の削除ボタン・追加ボタンとも disabled になり、連打しても2重にPATCHされない", async () => {
+    // 削除対象自身のボタンは楽観的更新で即座にDOMから消えるため、
+    // 「消えずに残る別のorigin」の削除ボタンで saving フラグの効果を確認する。
+    authFetchMock.mockReturnValueOnce(
+      jsonRes({ allowed_origins: ["https://a.example.com", "https://b.example.com"] })
+    );
+    let resolvePatch: (value: unknown) => void = () => {};
+    authFetchMock.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolvePatch = resolve;
+      })
+    );
+    await openPanel();
+
+    await screen.findByText("https://a.example.com");
+    fireEvent.click(screen.getByLabelText("remove https://b.example.com"));
+
+    // 保存中は残っているaの削除ボタン・追加ボタンとも disabled になる
+    const remainingRemoveButton = await screen.findByLabelText(
+      "remove https://a.example.com"
+    ) as HTMLButtonElement;
+    await waitFor(() => expect(remainingRemoveButton.disabled).toBe(true));
+    const addButton = screen.getByText("追加").closest("button") as HTMLButtonElement;
+    expect(addButton.disabled).toBe(true);
+
+    // 保存中の連打はReact側で無視される(ボタンdisabled)ため、PATCH呼び出しは1回のまま
+    fireEvent.click(remainingRemoveButton);
+    expect(
+      authFetchMock.mock.calls.filter(([, opts]) => (opts as RequestInit | undefined)?.method === "PATCH").length
+    ).toBe(1);
+
+    resolvePatch(jsonRes({ allowed_origins: ["https://a.example.com"] }));
+    await waitFor(() => expect(remainingRemoveButton.disabled).toBe(false));
+  });
 });

--- a/admin-ui/src/pages/admin/tenants/InviteTab.test.tsx
+++ b/admin-ui/src/pages/admin/tenants/InviteTab.test.tsx
@@ -118,4 +118,123 @@ describe("InviteTab", () => {
       expect(screen.getByText(/通信エラーが発生しました/)).toBeTruthy();
     });
   });
+
+  it("not_found: テナント不在時の専用文言", async () => {
+    mockedAuthFetch.mockResolvedValue(jsonResponse(404, { error: "not_found" }));
+    render(<InviteTab tenantId="t1" />);
+    fireEvent.change(screen.getByLabelText("招待するメールアドレス"), {
+      target: { value: "z@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /招待メールを送信/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText("テナントが見つかりません。")).toBeTruthy();
+    });
+  });
+
+  it("503: Supabase Admin未設定時の専用文言（bodyにerrorコードが無くてもstatusだけで判定する）", async () => {
+    mockedAuthFetch.mockResolvedValue(jsonResponse(503, {}));
+    render(<InviteTab tenantId="t1" />);
+    fireEvent.change(screen.getByLabelText("招待するメールアドレス"), {
+      target: { value: "w@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /招待メールを送信/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/招待機能が現在利用できません/)).toBeTruthy();
+    });
+  });
+
+  it("未知のエラーコードでもbody.messageがあればそのまま表示する", async () => {
+    mockedAuthFetch.mockResolvedValue(
+      jsonResponse(422, { error: "some_future_error_code", message: "将来追加されるエラー文言" })
+    );
+    render(<InviteTab tenantId="t1" />);
+    fireEvent.change(screen.getByLabelText("招待するメールアドレス"), {
+      target: { value: "future@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /招待メールを送信/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText("将来追加されるエラー文言")).toBeTruthy();
+    });
+  });
+
+  it("errorコードもmessageも無い失敗（例: JSONパース不能なbody）では最終フォールバック文言を表示する", async () => {
+    mockedAuthFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      json: async () => {
+        throw new Error("not json");
+      },
+    });
+    render(<InviteTab tenantId="t1" />);
+    fireEvent.change(screen.getByLabelText("招待するメールアドレス"), {
+      target: { value: "broken@example.com" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /招待メールを送信/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText("招待処理に失敗しました。時間をおいて再度お試しください。")).toBeTruthy();
+    });
+  });
+
+  it("Enterキー押下でも送信できる", async () => {
+    mockedAuthFetch.mockResolvedValue(jsonResponse(201, { ok: true }));
+    render(<InviteTab tenantId="t1" />);
+    const input = screen.getByLabelText("招待するメールアドレス");
+    fireEvent.change(input, { target: { value: "enter@example.com" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(mockedAuthFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("前後に空白を含むメールはtrimしてから送信・バリデーションする", async () => {
+    mockedAuthFetch.mockResolvedValue(jsonResponse(201, { ok: true }));
+    render(<InviteTab tenantId="t1" />);
+    fireEvent.change(screen.getByLabelText("招待するメールアドレス"), {
+      target: { value: "  padded@example.com  " },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /招待メールを送信/ }));
+
+    await waitFor(() => {
+      expect(mockedAuthFetch).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ body: JSON.stringify({ email: "padded@example.com" }) })
+      );
+    });
+  });
+
+  it("送信中に連打しても二重送信しない（submitting中はボタンがdisabledになりhandleSubmitも早期returnする）", async () => {
+    let resolveFetch: (value: unknown) => void = () => {};
+    mockedAuthFetch.mockReturnValue(
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      })
+    );
+    render(<InviteTab tenantId="t1" />);
+    fireEvent.change(screen.getByLabelText("招待するメールアドレス"), {
+      target: { value: "double@example.com" },
+    });
+    const button = screen.getByRole("button", { name: /招待メールを送信/ });
+    fireEvent.click(button);
+    // 送信中はボタンがdisabledになる
+    await waitFor(() => expect((button as HTMLButtonElement).disabled).toBe(true));
+    // disabled状態でのクリックはReact Testing Library上も発火しうるため、
+    // handleSubmit内のsubmittingガードで二重送信されないことを直接確認する
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    resolveFetch(jsonResponse(201, { ok: true }));
+    // 成功後はメール欄がクリアされ isValid=false になるためボタンは
+    // 「未入力」理由で再びdisabledになる(submitting起因ではない)。
+    // ここでは submitting ラベルが解除されたことと、fetchが1回しか
+    // 呼ばれていないこと(二重送信防止)を確認する。
+    await waitFor(() => expect(screen.getByRole("button", { name: /招待メールを送信/ })).toBeTruthy());
+    expect(screen.queryByText("送信中…")).toBeNull();
+
+    expect(mockedAuthFetch).toHaveBeenCalledTimes(1);
+  });
 });

--- a/admin-ui/src/pages/admin/tenants/[id].test.tsx
+++ b/admin-ui/src/pages/admin/tenants/[id].test.tsx
@@ -195,3 +195,60 @@ describe("TenantDetailPage — エラー意味論(500 vs 404 vs 401)", () => {
     await waitFor(() => expect(screen.getByText("login-page")).toBeTruthy());
   });
 });
+
+// LAUNCH: テナント招待UI(InviteTab)のロール境界。招待タブはsuper_admin専用。
+// このファイルの他テストは useAuth を isSuperAdmin: true 固定でモックしているため、
+// client_admin視点は vi.doMock + vi.resetModules で個別に上書きする。
+describe("TenantDetailPage — 招待タブのロール境界", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockGetSession.mockReset().mockResolvedValue(okSession);
+    mockApiKeysAuthFetch.mockReset().mockResolvedValue(jsonResponse(200, { keys: [] }));
+  });
+
+  it("super_adminには✉️ 招待タブが表示される(デフォルトモック=isSuperAdmin:true)", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      jsonResponse(200, {
+        id: "carnation", name: "carnation", plan: "starter", is_active: true,
+        allowed_origins: [], billing_enabled: false, billing_free_from: null,
+        billing_free_until: null, features: { avatar: false, voice: false, rag: true },
+        lemonslice_agent_id: null, conversion_types: [],
+      }),
+    );
+    renderPage();
+    await waitFor(() => expect(screen.getByText("⚙️ 設定")).toBeTruthy());
+    expect(screen.getByText("✉️ 招待")).toBeTruthy();
+  });
+
+  it("client_admin(isSuperAdmin:false)には✉️ 招待タブがそもそも一覧に現れない", async () => {
+    vi.resetModules();
+    vi.doMock("../../../auth/useAuth", () => ({
+      useAuth: () => ({ enterPreview: vi.fn(), isSuperAdmin: false }),
+    }));
+    const { default: TenantDetailPageAsClientAdmin } = await import("./[id]");
+
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      jsonResponse(200, {
+        id: "carnation", name: "carnation", plan: "starter", is_active: true,
+        allowed_origins: [], billing_enabled: false, billing_free_from: null,
+        billing_free_until: null, features: { avatar: false, voice: false, rag: true },
+        lemonslice_agent_id: null, conversion_types: [],
+      }),
+    );
+
+    render(
+      <MemoryRouter initialEntries={["/admin/tenants/carnation"]}>
+        <Routes>
+          <Route path="/admin/tenants/:id" element={<TenantDetailPageAsClientAdmin />} />
+        </Routes>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(screen.getByText("⚙️ 設定")).toBeTruthy());
+    expect(screen.queryByText("✉️ 招待")).toBeNull();
+    // タブ一覧に無いのに加え、activeTab側にも isSuperAdmin ガードが二重にかかっている
+    // ([id].tsx: {activeTab === "invite" && isSuperAdmin && <InviteTab .../>})ため、
+    // 万一タブ状態が"invite"のまま来ても本文は描画されない。
+    expect(screen.queryByText("client_admin を招待")).toBeNull();
+  });
+});

--- a/tests/api/admin/tenants/routes.test.ts
+++ b/tests/api/admin/tenants/routes.test.ts
@@ -736,6 +736,64 @@ describe("Tenant Admin Routes", () => {
       // JWTのtenant_id("t1")で呼ばれ、body.tenant_idは無視される
       expect(mockUpdateTenantAllowedOrigins).toHaveBeenLastCalledWith("tenant1", ["https://own.example.com"]);
     });
+
+    it("originsが21件（max=20超過）だと400で拒否しDBを触らない", async () => {
+      const tooMany = Array.from({ length: 21 }, (_, i) => `https://o${i}.example.com`);
+      const res = await request(app)
+        .patch("/v1/admin/my-tenant")
+        .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`)
+        .send({ allowed_origins: tooMany });
+      expect(res.status).toBe(400);
+      expect(mockDb.query).not.toHaveBeenCalled();
+    });
+
+    it("originsがちょうど20件（境界値）なら受理される", async () => {
+      const exactly20 = Array.from({ length: 20 }, (_, i) => `https://o${i}.example.com`);
+      mockDb.query.mockResolvedValueOnce({
+        rows: [{ id: "tenant1", name: "Test", features: {}, lemonslice_agent_id: null, allowed_origins: exactly20 }],
+        rowCount: 1,
+      });
+      const res = await request(app)
+        .patch("/v1/admin/my-tenant")
+        .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`)
+        .send({ allowed_origins: exactly20 });
+      expect(res.status).toBe(200);
+    });
+
+    it("allowed_originsが配列でない（文字列単体）場合は400で拒否する", async () => {
+      const res = await request(app)
+        .patch("/v1/admin/my-tenant")
+        .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`)
+        .send({ allowed_origins: "https://not-an-array.example.com" });
+      expect(res.status).toBe(400);
+      expect(mockDb.query).not.toHaveBeenCalled();
+    });
+
+    it("配列内に1件でもhttps://で始まらない値が混ざっていると全体を400で拒否する（部分適用しない）", async () => {
+      const res = await request(app)
+        .patch("/v1/admin/my-tenant")
+        .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`)
+        .send({ allowed_origins: ["https://ok.example.com", "ftp://bad.example.com"] });
+      expect(res.status).toBe(400);
+      expect(mockDb.query).not.toHaveBeenCalled();
+    });
+
+    // 既知のギャップ（コード内コメントで明示済み）: バックエンドの検証は https:// プレフィックスの
+    // 正規表現のみで、ワイルドカード(*)自体は文字列として通ってしまう。フロント(AllowedOriginsSettings.tsx)
+    // 側でのみ拒否している。originCheck.ts / security-policy.ts のワイルドカード展開判定不一致を
+    // 避けるための意図的な設計だが、フロントを経由しない直接API呼び出し(curl等)では素通りする。
+    // この既知の挙動を「知らずに壊す」ことを防ぐためのピン留めテスト。
+    it("[既知のギャップ] ワイルドカードを含むoriginはバックエンド単体のバリデーションでは通ってしまう（フロント側でのみ拒否）", async () => {
+      mockDb.query.mockResolvedValueOnce({
+        rows: [{ id: "tenant1", name: "Test", features: {}, lemonslice_agent_id: null, allowed_origins: ["https://*.example.com"] }],
+        rowCount: 1,
+      });
+      const res = await request(app)
+        .patch("/v1/admin/my-tenant")
+        .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`)
+        .send({ allowed_origins: ["https://*.example.com"] });
+      expect(res.status).toBe(200);
+    });
   });
 
   // Asana 1217040568430944(P7): super_adminのクライアントビュー(previewMode)からも


### PR DESCRIPTION
## 背景
PR #822（テナント招待UI）・#825（allowed_origins設定UI）のテストを、正常系だけでなく境界値・異常系・イレギュラー操作の観点で強化する。

## 追加したテスト

### InviteTab (`InviteTab.test.tsx`)
- `not_found` / `503`（Supabase Admin未設定）の専用文言分岐
- 未知のエラーコードでも `body.message` があれば表示するフォールバック
- エラーコードもmessageも無い（JSON parse失敗含む）場合の最終フォールバック文言
- Enterキー押下での送信
- メールアドレスの前後空白trim確認
- 送信中の連打で二重送信されないこと（`submitting`ガード）

### `[id].tsx` — 招待タブのロール境界（新規）
- super_adminには✉️招待タブが表示される
- client_admin(`isSuperAdmin:false`)には✉️招待タブがタブ一覧にも現れず、本文（`activeTab==="invite"`側の二重ガード）も描画されないことを確認

### AllowedOriginsSettings (`AllowedOriginsSettings.test.tsx`)
- 通信例外（fetch自体が例外）時のロールバック+エラートースト
- 既に登録済みのoriginを再度追加しようとした場合の重複防止（PATCH自体を呼ばない）
- 空白のみ入力では追加ボタンがdisabledのまま
- `tenantId="global"` では初期フェッチ自体を呼ばず何も描画しない
- 保存中（saving=true）は残っている項目の削除ボタン・追加ボタンとも disabled になり、連打してもPATCHが2重に飛ばないこと

### バックエンド `PATCH /v1/admin/my-tenant`（`tests/api/admin/tenants/routes.test.ts`）
- `allowed_origins` が21件（`.max(20)`超過）で400拒否、ちょうど20件は受理される境界値
- 配列でない値（文字列単体）を400で拒否
- 配列内に1件でも `https://` で始まらない値が混ざると全体を400で拒否（部分適用しない）
- **既知のギャップのピン留め**: ワイルドカード(`*`)を含むoriginはバックエンド単体のバリデーション（`https://`プレフィックスの正規表現のみ）では通ってしまう（フロント側でのみ拒否している設計を、コード内コメントの記述通りに固定）

## 発見したカバレッジギャップ（今回のスコープでは未対応、報告のみ）
- 上記の「ワイルドカードはバックエンドを素通りする」は既知・意図的な設計だが、フロントを経由しない直接API呼び出し（curl等）からは実際にワイルドカード付きoriginを登録できてしまう。将来的には `originCheck.ts` / `security-policy.ts` のワイルドカード展開判定を統一した上でバックエンド側でも拒否するのが望ましい（今回は既存の設計判断を尊重しテスト側で固定するに留めた）。

## テスト結果
- backend: `pnpm typecheck` 0エラー、`pnpm jest --testPathPatterns="tenants/routes"` 99/99 pass
- frontend: `npx tsc -b --force` 0エラー、`npx vitest run`（admin-ui全体）38ファイル527テスト全pass
- ミューテーション検証: `.max(20)`→`.max(21)`緩和で境界値テストが正しく失敗することを確認→復元。`AllowedOriginsSettings.tsx`の重複チェックを一時削除して重複防止テストが正しく失敗することを確認→復元

## Tier S
`admin-ui/src` を含むため、マージは人間の手動確認が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)