### PR TITLE
[SEC][P0] origin照合ロジックを統合しワイルドカードを厳格化（越境CORS影響の遮断）

### DIFF
--- a/admin-ui/src/components/knowledge/AllowedOriginsSettings.tsx
+++ b/admin-ui/src/components/knowledge/AllowedOriginsSettings.tsx
@@ -77,6 +77,9 @@ export default function AllowedOriginsSettings({ tenantId }: AllowedOriginsSetti
       setInputError(t("knowledge.allowed_origins_invalid_https"));
       return;
     }
+    // ワイルドカードは super_admin のテナント設定画面(SettingsTab)専用の機能とし、
+    // テナント自己申告のこのフォームでは一律拒否する（バックエンドは
+    // https://*.example.com の形なら受け付けるが、UIとしてはより厳しい側に倒す）。
     if (candidate.includes("*")) {
       setInputError(t("knowledge.allowed_origins_invalid_wildcard"));
       return;

--- a/src/api/admin/tenants/routes.ts
+++ b/src/api/admin/tenants/routes.ts
@@ -14,8 +14,24 @@ import { DEFAULT_AVATARS } from "../avatar/routes";
 import { logger } from '../../../lib/logger';
 import { planHasFeature, type TenantPlan } from "../../../lib/billing/planFeatures";
 import { deriveOnboardingStage, type OnboardingStageStatus } from "../agent/onboardingStage";
+import { isValidOriginPattern } from "../../middleware/originCheck";
 
 const planValues = ["starter", "growth", "enterprise"] as const;
+
+// 許可オリジンの検証。super_admin用(updateTenantSchema)と client_admin 自己申告用
+// (PATCH /v1/admin/my-tenant)で同一インスタンスを共有し、片方だけ緩いという事故を防ぐ。
+// 判定本体は originCheck.ts の isValidOriginPattern に置き、照合ロジックと同じ定義を使う。
+const allowedOriginsSchema = z
+  .array(
+    z
+      .string()
+      .refine(isValidOriginPattern, {
+        message:
+          "URLはhttps://で始まる必要があります。ワイルドカードは https://*.example.com の形式のみ使用できます",
+      })
+  )
+  .max(20)
+  .optional();
 
 // 日付のみの文字列("2026-01-01"等)はUTC深夜と解釈されるため、意図したタイムゾーンと
 // ズレて「まだ未来のつもりが過去判定される」事故が起きやすい。バリデーションのロジックは
@@ -65,12 +81,7 @@ const updateTenantSchema = z.object({
   name: z.string().min(1).max(100).optional(),
   plan: z.enum(planValues).optional(),
   is_active: z.boolean().optional(),
-  allowed_origins: z
-    .array(
-      z.string().regex(/^https:\/\//, "URLはhttps://で始まる必要があります")
-    )
-    .max(20)
-    .optional(),
+  allowed_origins: allowedOriginsSchema,
   // Phase38 Step6: テナント固有システムプロンプト（空文字でリセット可）
   system_prompt: z.string().max(5000).optional(),
   // Phase39: 課金管理（Super Adminのみ）
@@ -251,15 +262,10 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
       // GID 1216274591838389: 初回ログインオンボーディングの回答業種（設定時にonboarding_completed_atも自動更新）
       onboarding_industry: z.enum(onboardingIndustryValues).optional(),
       // LAUNCH: ウィジェット許可オリジンのテナント自己設定。super_admin用updateTenantSchemaと
-      // 同じ検証（https://始まりのみ）を使う。ワイルドカードは originCheck.ts と
-      // security-policy.ts の判定不一致を避けるためUI側で入力を拒否する想定（バックエンドは
-      // super_admin用と同じ検証のみでワイルドカード自体は文字列として許可される）。
-      allowed_origins: z
-        .array(
-          z.string().regex(/^https:\/\//, "URLはhttps://で始まる必要があります")
-        )
-        .max(20)
-        .optional(),
+      // 同一のスキーマインスタンスを共有する（片方だけ検証が緩い状態を作らないため）。
+      // client_admin向けフォーム(AllowedOriginsSettings.tsx)はワイルドカードを一律拒否する
+      // より厳しいUIだが、バックエンドはここで安全な形(https://*.example.com)のみ通す。
+      allowed_origins: allowedOriginsSchema,
     });
     const parsed = bodySchema.safeParse(req.body ?? {});
     if (!parsed.success) {

--- a/src/api/middleware/originCheck.test.ts
+++ b/src/api/middleware/originCheck.test.ts
@@ -1,7 +1,7 @@
 // src/api/middleware/originCheck.test.ts
 
 import type { NextFunction, Request, Response } from "express";
-import { createOriginCheckMiddleware, isOriginAllowed } from "./originCheck";
+import { createOriginCheckMiddleware, isOriginAllowed, isValidOriginPattern } from "./originCheck";
 
 function mockDb(allowedOrigins: string[]) {
   return {
@@ -34,6 +34,64 @@ describe("isOriginAllowed", () => {
 
   it("rejects non-matching origin", () => {
     expect(isOriginAllowed("https://evil.com", ["https://example.com"])).toBe(false);
+  });
+
+  // --- ワイルドカードの厳格化 ---------------------------------------------
+  // `https://*` は tenant-context.ts の isOriginKnownToAnyTenant 経由で CORS に効くため、
+  // 1テナントが登録するだけで全テナントの Access-Control-Allow-Origin が任意オリジンを
+  // 反射するようになる。照合側でも無効化して二重に塞ぐ。
+  it("does not treat a bare https://* as a match-all pattern", () => {
+    expect(isOriginAllowed("https://evil.com", ["https://*"])).toBe(false);
+    expect(isOriginAllowed("https://anything.at.all", ["https://*"])).toBe(false);
+  });
+
+  it("does not expand a mid-label wildcard (https://*evil.com must not match notevil.com)", () => {
+    expect(isOriginAllowed("https://notevil.com", ["https://*evil.com"])).toBe(false);
+  });
+
+  it("rejects patterns with more than one wildcard", () => {
+    expect(isOriginAllowed("https://a.b.com", ["https://*.a.*.com"])).toBe(false);
+  });
+
+  it("matches nested subdomains under a subdomain wildcard", () => {
+    expect(isOriginAllowed("https://a.b.example.com", ["https://*.example.com"])).toBe(true);
+  });
+
+  it("does not match the apex domain under a subdomain wildcard", () => {
+    expect(isOriginAllowed("https://example.com", ["https://*.example.com"])).toBe(false);
+  });
+
+  it("does not match an empty label under a subdomain wildcard", () => {
+    expect(isOriginAllowed("https://.example.com", ["https://*.example.com"])).toBe(false);
+  });
+
+  // 既存のエスケープ順序(`.`→`\.` を先、`*` 展開を後)が壊れていないことの回帰防止。
+  // 壊れると https://x.example.com.evil.com が https://*.example.com にマッチしてしまう。
+  it("does not match a suffix-smuggling origin", () => {
+    expect(
+      isOriginAllowed("https://x.example.com.evil.com", ["https://*.example.com"])
+    ).toBe(false);
+  });
+});
+
+describe("isValidOriginPattern", () => {
+  it.each([
+    "https://example.com",
+    "https://shop.example.com",
+    "https://*.example.com",
+  ])("accepts %s", (value) => {
+    expect(isValidOriginPattern(value)).toBe(true);
+  });
+
+  it.each([
+    "https://*",
+    "https://*evil.com",
+    "https://*.a.*.com",
+    "https://*.example.com/path",
+    "http://example.com",
+    "example.com",
+  ])("rejects %s", (value) => {
+    expect(isValidOriginPattern(value)).toBe(false);
   });
 });
 

--- a/src/api/middleware/originCheck.ts
+++ b/src/api/middleware/originCheck.ts
@@ -13,16 +13,44 @@ interface OriginCheckOptions {
 }
 
 /**
+ * ワイルドカードを許可する唯一の形は「ホスト先頭ラベルを `*` に置き換えたサブドメイン指定」。
+ *
+ *   OK: https://*.example.com  → https://sub.example.com / https://a.b.example.com
+ *   NG: https://*              → 全 https オリジンにマッチしてしまう
+ *   NG: https://*evil.com      → https://notevil.com にもマッチしてしまう
+ *   NG: https://*.a.*.com      → `*` は1個まで
+ *
+ * 形を縛る理由: allowedOrigins は tenant-context.ts の isOriginKnownToAnyTenant 経由で
+ * CORS(cors.ts)にも使われる。1テナントが `https://*` を登録するだけで、全テナントに対して
+ * 任意オリジンが Access-Control-Allow-Origin に反射される(しかも credentials 付き)。
+ * 保存時バリデーション(admin/tenants/routes.ts)と二重に効かせることで、手動UPDATE等で
+ * 入り込んだ危険なパターンも照合側で無効化する。
+ */
+const SAFE_WILDCARD_PATTERN = /^https:\/\/\*\.[^*/]+$/;
+
+/**
+ * allowedOrigins に保存してよい形かどうか。保存時バリデーションと照合の双方で使う。
+ * ワイルドカードを含まない値は https:// 始まりであれば許可する(既存データ互換)。
+ */
+export function isValidOriginPattern(value: string): boolean {
+  if (!value.startsWith("https://")) return false;
+  if (!value.includes("*")) return true;
+  return SAFE_WILDCARD_PATTERN.test(value);
+}
+
+/**
  * ワイルドカードパターンにOriginが一致するか確認。
  * 例: "https://*.example.com" → https://sub.example.com にマッチ
  */
 function matchesPattern(origin: string, pattern: string): boolean {
   if (pattern === origin) return true;
-  if (pattern.includes("*")) {
-    const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, ".*");
-    return new RegExp(`^${escaped}$`).test(origin);
-  }
-  return false;
+  if (!pattern.includes("*")) return false;
+  // 危険な形は照合対象にしない(保存時に弾いているが、過去データ・手動UPDATEへの保険)
+  if (!SAFE_WILDCARD_PATTERN.test(pattern)) return false;
+  // エスケープ(`.`→`\.`)を先に済ませてから `*` を展開する順序を保つ。
+  // 展開先を `.*` ではなく `[^/]+` にして、空マッチとパス混入を防ぐ。
+  const escaped = pattern.replace(/[.+?^${}()|[\]\\]/g, "\\$&").replace(/\*/g, "[^/]+");
+  return new RegExp(`^${escaped}$`).test(origin);
 }
 
 export function isOriginAllowed(origin: string, allowedOrigins: string[]): boolean {

--- a/src/lib/security-policy.test.ts
+++ b/src/lib/security-policy.test.ts
@@ -1,5 +1,6 @@
 import type { NextFunction, Response } from "express";
 import { createSecurityPolicyMiddleware } from "./security-policy";
+import { isOriginAllowed } from "../api/middleware/originCheck";
 import type { AuthedRequest } from "../agent/http/authMiddleware";
 import type { TenantConfig } from "../types/contracts";
 
@@ -90,4 +91,85 @@ describe("securityPolicyMiddleware", () => {
     mw(req as any, mockRes(), nextFn);
     expect(nextFn).toHaveBeenCalled();
   });
+
+  // 以前は完全一致(allowed.includes)だったため、UIが案内する
+  // `https://*.example.com` は securityPolicy(apiStackで先に走る)で必ず403になり、
+  // 後段の originCheck.ts が持つワイルドカード対応は到達しなかった。
+  it("honours a subdomain wildcard (previously always 403 here)", () => {
+    const req = mockReq({
+      tenantConfig: {
+        ...baseTenant,
+        security: { ...baseTenant.security, allowedOrigins: ["https://*.example.com"] },
+      },
+      headers: { origin: "https://shop.example.com" },
+    });
+    mw(req as any, mockRes(), nextFn);
+    expect(nextFn).toHaveBeenCalled();
+  });
+
+  it("still rejects an origin outside the wildcard", () => {
+    const req = mockReq({
+      tenantConfig: {
+        ...baseTenant,
+        security: { ...baseTenant.security, allowedOrigins: ["https://*.example.com"] },
+      },
+      headers: { origin: "https://evil.com" },
+    });
+    const res = mockRes();
+    mw(req as any, res, nextFn);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(nextFn).not.toHaveBeenCalled();
+  });
+
+  it("does not honour a bare https:// wildcard as match-all", () => {
+    const req = mockReq({
+      tenantConfig: {
+        ...baseTenant,
+        security: { ...baseTenant.security, allowedOrigins: ["https://*"] },
+      },
+      headers: { origin: "https://evil.com" },
+    });
+    const res = mockRes();
+    mw(req as any, res, nextFn);
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(nextFn).not.toHaveBeenCalled();
+  });
+});
+
+// securityPolicy(インメモリ) と originCheck(DB) が同じ判定に収束したことの証明。
+// 片方だけワイルドカードを解釈する状態に戻ると、この表のどこかが必ず食い違う。
+describe("securityPolicy / originCheck 判定の一致", () => {
+  const mw = createSecurityPolicyMiddleware();
+
+  const cases: Array<[origin: string, allowed: string[], expected: boolean]> = [
+    ["https://app.example.com", ["https://app.example.com"], true],
+    ["https://shop.example.com", ["https://*.example.com"], true],
+    ["https://a.b.example.com", ["https://*.example.com"], true],
+    ["https://example.com", ["https://*.example.com"], false],
+    ["https://evil.com", ["https://*.example.com"], false],
+    ["https://x.example.com.evil.com", ["https://*.example.com"], false],
+    ["https://evil.com", ["https://*"], false],
+    ["https://notevil.com", ["https://*evil.com"], false],
+  ];
+
+  it.each(cases)(
+    "origin=%s allowed=%j → allowed=%s (両実装で一致)",
+    (origin, allowed, expected) => {
+      // originCheck 側の純関数
+      expect(isOriginAllowed(origin, allowed)).toBe(expected);
+
+      // securityPolicy 側(ミドルウェア経由)
+      const next = jest.fn();
+      const res = mockRes();
+      const req = mockReq({
+        tenantConfig: {
+          ...baseTenant,
+          security: { ...baseTenant.security, allowedOrigins: allowed },
+        },
+        headers: { origin },
+      });
+      mw(req as any, res, next);
+      expect(next.mock.calls.length > 0).toBe(expected);
+    }
+  );
 });

--- a/src/lib/security-policy.ts
+++ b/src/lib/security-policy.ts
@@ -1,6 +1,7 @@
 import type { NextFunction, Request, Response } from "express";
 import type { Logger } from "pino";
 import type { AuthedRequest } from "../agent/http/authMiddleware";
+import { isOriginAllowed } from "../api/middleware/originCheck";
 
 export interface SecurityPolicyOptions {
   logger?: Logger;
@@ -52,10 +53,14 @@ export function createSecurityPolicyMiddleware(
     }
 
     // --- Origin enforcement ---
+    // 照合は originCheck.ts の isOriginAllowed に一本化する。以前はここだけ完全一致
+    // (allowed.includes)で、DB側の originCheck.ts だけがワイルドカードを解釈していた。
+    // securityPolicy の方が apiStack で先に走るため、UIが案内している
+    // `https://*.example.com` は実テナントでは常に403になり機能していなかった。
     const allowed = config.security.allowedOrigins;
     if (allowed.length > 0) {
       const origin = req.headers.origin;
-      if (origin && !allowed.includes(origin)) {
+      if (origin && !isOriginAllowed(origin, allowed)) {
         opts.logger?.warn(
           {
             tenantId: authed.tenantId,

--- a/src/lib/tenant-context.test.ts
+++ b/src/lib/tenant-context.test.ts
@@ -202,6 +202,32 @@ describe("isOriginKnownToAnyTenant — CORS preflight tenant-domain lookup", () 
     });
     expect(isOriginKnownToAnyTenant("https://some-random-site.example")).toBe(false);
   });
+
+  // この関数は cors.ts の isKnownTenantOrigin に配線されており、true を返すと
+  // Access-Control-Allow-Origin に当該オリジンが credentials 付きで反射される。
+  // 1テナントが `https://*` を保存するだけで全テナント分のCORSが緩む越境影響があったため、
+  // 照合側(originCheck.ts)でこの形を無効化した。その遮断がここで効くことを固定する。
+  it("does not leak a bare https://* wildcard into the cross-tenant CORS lookup", () => {
+    registerTenant({
+      tenantId: "greedy-wildcard-tenant",
+      name: "Greedy Wildcard Tenant",
+      plan: "starter",
+      features: { avatar: false, voice: false, rag: true },
+      security: {
+        apiKeyHash: "dummyhash-greedy",
+        hashAlgorithm: "sha256",
+        allowedOrigins: ["https://*"],
+        rateLimit: 100,
+        rateLimitWindowMs: 60_000,
+      },
+      enabled: true,
+    });
+
+    expect(isOriginKnownToAnyTenant("https://attacker.example")).toBe(false);
+    expect(isOriginKnownToAnyTenant("https://unrelated-tenant-site.example")).toBe(false);
+    // 正規に登録された他テナントのオリジンは引き続き通る
+    expect(isOriginKnownToAnyTenant("https://shop.example.com")).toBe(true);
+  });
 });
 
 describe("APIキー失効・期限切れの即時反映", () => {

--- a/tests/api/admin/tenants/routes.test.ts
+++ b/tests/api/admin/tenants/routes.test.ts
@@ -778,12 +778,10 @@ describe("Tenant Admin Routes", () => {
       expect(mockDb.query).not.toHaveBeenCalled();
     });
 
-    // 既知のギャップ（コード内コメントで明示済み）: バックエンドの検証は https:// プレフィックスの
-    // 正規表現のみで、ワイルドカード(*)自体は文字列として通ってしまう。フロント(AllowedOriginsSettings.tsx)
-    // 側でのみ拒否している。originCheck.ts / security-policy.ts のワイルドカード展開判定不一致を
-    // 避けるための意図的な設計だが、フロントを経由しない直接API呼び出し(curl等)では素通りする。
-    // この既知の挙動を「知らずに壊す」ことを防ぐためのピン留めテスト。
-    it("[既知のギャップ] ワイルドカードを含むoriginはバックエンド単体のバリデーションでは通ってしまう（フロント側でのみ拒否）", async () => {
+    // 安全な形のワイルドカード(サブドメイン指定)はバックエンドでも許可する。
+    // client_admin向けフォーム(AllowedOriginsSettings.tsx)はUIとしてより厳しく
+    // 一律拒否するが、API契約としてはこの形を通す。
+    it("サブドメインワイルドカード(https://*.example.com)は許可する", async () => {
       mockDb.query.mockResolvedValueOnce({
         rows: [{ id: "tenant1", name: "Test", features: {}, lemonslice_agent_id: null, allowed_origins: ["https://*.example.com"] }],
         rowCount: 1,
@@ -793,6 +791,22 @@ describe("Tenant Admin Routes", () => {
         .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`)
         .send({ allowed_origins: ["https://*.example.com"] });
       expect(res.status).toBe(200);
+    });
+
+    // `https://*` は isOriginKnownToAnyTenant(tenant-context.ts) 経由で CORS に効くため、
+    // 1テナントが保存するだけで全テナント分の Access-Control-Allow-Origin が任意オリジンを
+    // credentials 付きで反射するようになる。フロントを経由しないcurl等での保存を塞ぐ。
+    it.each([
+      ["https://*", "全オリジンにマッチする貪欲なワイルドカード"],
+      ["https://*evil.com", "ラベル途中のワイルドカード(notevil.comにもマッチする)"],
+      ["https://*.a.*.com", "ワイルドカード2個"],
+    ])("危険な形のワイルドカード %s を400で拒否する（%s）", async (origin) => {
+      const res = await request(app)
+        .patch("/v1/admin/my-tenant")
+        .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`)
+        .send({ allowed_origins: [origin] });
+      expect(res.status).toBe(400);
+      expect(mockDb.query).not.toHaveBeenCalled();
     });
   });
 
@@ -922,6 +936,36 @@ describe("Tenant Admin Routes", () => {
         .send({ allowed_origins: [] });
       expect(res.status).toBe(200);
       expect(mockUpdateTenantAllowedOrigins).toHaveBeenLastCalledWith("t1", []);
+    });
+
+    // super_admin 側と client_admin 側(PATCH /v1/admin/my-tenant)は同一のスキーマ
+    // インスタンスを共有する。片方だけ緩いという状態を作らないことをここで固定する。
+    it.each([
+      ["https://*", "全オリジンにマッチする貪欲なワイルドカード"],
+      ["https://*evil.com", "ラベル途中のワイルドカード"],
+      ["https://*.a.*.com", "ワイルドカード2個"],
+    ])("危険な形のワイルドカード %s を400で拒否する（%s）", async (origin) => {
+      const res = await request(app)
+        .patch("/v1/admin/tenants/t1")
+        .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`)
+        .send({ allowed_origins: [origin] });
+      expect(res.status).toBe(400);
+    });
+
+    it("サブドメインワイルドカード(https://*.example.com)はsuper_adminでも許可する（UIが案内している形）", async () => {
+      mockDb.query
+        .mockResolvedValueOnce({ rows: [{ id: "t1", plan: "starter", features: {}, billing_enabled: false, is_active: true }], rowCount: 1 })
+        .mockResolvedValueOnce({
+          rows: [{ id: "t1", name: "T1", plan: "starter", is_active: true, allowed_origins: ["https://*.example.com"] }],
+          rowCount: 1,
+        })
+        .mockResolvedValue({ rows: [], rowCount: 0 });
+      const res = await request(app)
+        .patch("/v1/admin/tenants/t1")
+        .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`)
+        .send({ allowed_origins: ["https://*.example.com"] });
+      expect(res.status).toBe(200);
+      expect(mockUpdateTenantAllowedOrigins).toHaveBeenLastCalledWith("t1", ["https://*.example.com"]);
     });
   });
 


### PR DESCRIPTION
## 背景

origin 照合ロジックが **2つ並存**しており、片方だけワイルドカードを解釈していた。

| | `originCheck.ts` (DB) | `security-policy.ts` (インメモリ) |
|---|---|---|
| 方式 | ワイルドカード展開 (`*`→`.*`) | `allowed.includes(origin)` 完全一致 |

`src/index.ts:244-245` の apiStack では **厳しい `securityPolicy` が先**に走るため、
admin-ui が案内している `https://*.example.com`（`ja.ts:263` 「ワイルドカード可」、
placeholder にも事前入力）は実テナントで**常に403**になり、サイレントに機能していなかった。

### 越境するセキュリティ影響

`matchesPattern` は `*` を `.*` に展開するため、実測で以下が成立していた:

```
https://*          → ^https://.*$   … 全httpsオリジンにマッチ
https://*evil.com  → https://notevil.com にもマッチ
```

この値は `tenant-context.ts:139-144` の `isOriginKnownToAnyTenant` が
**全テナント横断**で使い、`cors.ts:56-58` の `isKnownTenantOrigin` に配線されている。
→ **1テナントが `https://*` を保存するだけで、サービス全体の
`Access-Control-Allow-Origin` が任意オリジンを `credentials: true` 付きで反射する。**

実リクエストは各テナントの `securityPolicy` が403にするため直接のデータ流出には
至らないが、1テナントの自己申告操作がサービス全体のCORS姿勢を劣化させる。

保存時バリデーションは super_admin (`routes.ts:68-73`) / client_admin (`routes.ts:257-262`)
とも `^https:\/\/` のプレフィックスしか見ておらず、フロント（`AllowedOriginsSettings.tsx`）
だけが `*` を拒否していたため、**curl 等の直接呼び出しでは素通り**していた。

## 変更内容

1. **照合を一本化** — `security-policy.ts` の完全一致を `isOriginAllowed()` に統合。
   ワイルドカードが宣伝どおり機能するようになり、インメモリ/DB で挙動が変わる不整合も解消。
2. **ワイルドカードを厳格化** — サブドメイン位置（`https://*.example.com`）のみ許可。
   展開先も `.*` → `[^/]+` にして空マッチとパス混入を防止。
   エスケープ順序（`.`→`\.` を先、`*` 展開を後）という既存の正しい処理は維持。
3. **保存時バリデーションを共有** — `isValidOriginPattern` を `originCheck.ts` に追加し、
   super_admin 用と client_admin 用の zod スキーマが**同一インスタンス**を共有。
   片方だけ緩いという事故（CLAUDE.md 禁止事項6「片肺修正」）を構造的に防ぐ。
4. **多層防御** — 照合側でも危険な形を無効化し、手動 UPDATE 等で入り込んだ値に備える。

### 統合後の仕様

| パターン | 判定 |
|---|---|
| `https://example.com` | 完全一致のみ |
| `https://*.example.com` | ✅ `sub.example.com` / `a.b.example.com` にマッチ |
| `https://*.example.com` | ❌ apex (`example.com`)、`.example.com`(空ラベル)、`x.example.com.evil.com` |
| `https://*` | ❌ **保存時400 / 照合でも無効** |
| `https://*evil.com` | ❌ **保存時400 / 照合でも無効** |
| `https://*.a.*.com` | ❌ **保存時400 / 照合でも無効** |

## 既存データへの影響: なし

本番 `tenants.allowed_origins` を監査済み。4テナントとも `*` を含まない:

```
carnation   | {https://admin.r2c.biz,https://api.r2c.biz}
demo        | {}
lp-demo     | {https://api.r2c.biz/lp/}
r2c_default | {}
```

## admin-ui の扱い（Tier S）

`AllowedOriginsSettings.tsx`（client_admin 自己申告フォーム）は従来どおり
**ワイルドカードを一律拒否**する、より厳しい UI のまま維持し、
「ワイルドカードは super_admin 専用機能」という設計意図をコメントで明記した。
super_admin 側（`SettingsTab.tsx`）はクライアント側検証を持たないプレーンな
textarea でバックエンド検証に依存しているため、変更不要。

## テスト

- backend: **192/192 pass**（`--runInBand`）、typecheck 0 エラー、oxlint クリーン
- admin-ui: **527/527 pass**（38ファイル）、typecheck 0 エラー
- 並列実行時に出る `socket hang up` は本リポジトリ既知のワーカー汚染。
  単体では3回連続 86/86 pass、`--runInBand` では 192/192 pass で再現しないことを確認済み。

### ミューテーション検証

危険な形のガードを外し展開を `.*` に戻すと、**7件が3層すべてで失敗**することを実測:

- 純関数 (`isOriginAllowed`) — 3件
- ミドルウェア (`securityPolicy`) — 1件
- 越境CORSルックアップ (`isOriginKnownToAnyTenant`) — 1件
- 両実装の判定一致テーブル — 2件

復元後に全件 pass することも確認済み。

## スコープ外の所見

- `lp-demo` の `https://api.r2c.biz/lp/` はパス付き。Origin ヘッダは決してパスを
  含まないため、この設定は元々どのリクエストにもマッチしない（別途要確認）。
- `cors.ts:56` の `allowedSet.size === 0`（`ALLOWED_ORIGINS` env 未設定時に全オリジン許可）
  という既存の穴は本PRのスコープ外のため未変更。
