### PR TITLE
[SEC][P0] APIキーのin-memory/DB整合性を修正（失効の片肺・再起動での消失）

### DIFF
--- a/src/api/admin/tenants/routes.test.ts
+++ b/src/api/admin/tenants/routes.test.ts
@@ -4,7 +4,7 @@
 import express from "express";
 import request from "supertest";
 import { registerTenantAdminRoutes } from "./routes";
-import { registerTenant, setTenantApiKeyExpiry, revokeTenantApiKeyIfCurrent } from "../../../lib/tenant-context";
+import { registerTenant, setTenantApiKeyExpiry, revokeTenantApiKey } from "../../../lib/tenant-context";
 
 // --------------------------------------------------------------------------
 // モック
@@ -18,7 +18,10 @@ jest.mock("../../../lib/tenant-context", () => ({
   registerTenant: jest.fn(),
   updateTenantEnabled: jest.fn(),
   setTenantApiKeyExpiry: jest.fn(),
-  revokeTenantApiKeyIfCurrent: jest.fn(),
+  revokeTenantApiKey: jest.fn(),
+  // 既定は false = in-memory 未登録(DB-onlyテナント)。個別テストで true に上書きする。
+  addTenantApiKey: jest.fn().mockReturnValue(false),
+  updateTenantAllowedOrigins: jest.fn(),
 }));
 
 jest.mock("../../../agent/openclaw/workspaceCache", () => ({
@@ -480,7 +483,7 @@ describe("POST /v1/admin/tenants/:id/keys — in-memory登録がDBの現行設�
     jest.clearAllMocks();
   });
 
-  it("DB上の allowed_origins / features を registerTenant にそのまま引き継ぐ（固定値で上書きしない）", async () => {
+  it("in-memory未登録(DB-onlyテナント)では、DB上の allowed_origins / features を registerTenant にそのまま引き継ぐ（固定値で上書きしない）", async () => {
     const dbQuery = jest
       .fn()
       // テナント存在チェック（features/allowed_originsも取得）
@@ -551,7 +554,7 @@ describe("DELETE /v1/admin/tenants/:id/keys/:keyId — PM2再起動を待たず�
     jest.clearAllMocks();
   });
 
-  it("失効したキーのハッシュで revokeTenantApiKeyIfCurrent を呼ぶ", async () => {
+  it("失効したキーのハッシュで revokeTenantApiKey を呼ぶ（主キー・追加キーを区別しない単一入口）", async () => {
     const dbQuery = jest.fn().mockResolvedValueOnce({
       rows: [{ id: "key-1", tenant_id: "tenant-a", is_active: false, key_hash: "the-revoked-key-hash" }],
       rowCount: 1,
@@ -563,10 +566,10 @@ describe("DELETE /v1/admin/tenants/:id/keys/:keyId — PM2再起動を待たず�
       .set("Authorization", "Bearer dummy");
 
     expect(res.status).toBe(200);
-    expect(revokeTenantApiKeyIfCurrent).toHaveBeenCalledWith("tenant-a", "the-revoked-key-hash");
+    expect(revokeTenantApiKey).toHaveBeenCalledWith("tenant-a", "the-revoked-key-hash");
   });
 
-  it("存在しないキーIDは404で、revokeTenantApiKeyIfCurrentは呼ばれない", async () => {
+  it("存在しないキーIDは404で、revokeTenantApiKeyは呼ばれない", async () => {
     const dbQuery = jest.fn().mockResolvedValueOnce({ rows: [], rowCount: 0 });
     const db = { query: dbQuery };
 
@@ -575,6 +578,6 @@ describe("DELETE /v1/admin/tenants/:id/keys/:keyId — PM2再起動を待たず�
       .set("Authorization", "Bearer dummy");
 
     expect(res.status).toBe(404);
-    expect(revokeTenantApiKeyIfCurrent).not.toHaveBeenCalled();
+    expect(revokeTenantApiKey).not.toHaveBeenCalled();
   });
 });

--- a/src/api/admin/tenants/routes.ts
+++ b/src/api/admin/tenants/routes.ts
@@ -6,7 +6,7 @@ import { isAllowedAdminRole } from "../../middleware/roleAuth";
 import { Pool } from "pg";
 import { z } from "zod";
 import { supabaseAuthMiddleware } from "../../../admin/http/supabaseAuthMiddleware";
-import { registerTenant, updateTenantEnabled, updateTenantAllowedOrigins, setTenantApiKeyExpiry, revokeTenantApiKeyIfCurrent, addTenantApiKey, revokeAdditionalTenantApiKey } from "../../../lib/tenant-context";
+import { registerTenant, updateTenantEnabled, updateTenantAllowedOrigins, setTenantApiKeyExpiry, revokeTenantApiKey, addTenantApiKey } from "../../../lib/tenant-context";
 import { invalidateWorkspaceCache } from "../../../agent/openclaw/workspaceCache";
 import { generateApiKey, hashApiKey, maskApiKeyPrefix } from "./apiKeyUtils";
 import { supabaseAdmin } from "../../../auth/supabaseClient";
@@ -420,10 +420,8 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
         return res.status(404).json({ error: "not_found", message: "APIキーが見つかりません。" });
       }
       const revokedHash = result.rows[0].key_hash;
-      // 主キーであれば revokeTenantApiKeyIfCurrent、無停止ローテーションで追加された
-      // キーであれば revokeAdditionalTenantApiKey が反応する。両方試して即時反映する。
-      revokeTenantApiKeyIfCurrent(tenantId, revokedHash);
-      revokeAdditionalTenantApiKey(tenantId, revokedHash);
+      // 主キー・追加キーのどちらでも失効させる（revokeTenantApiKey が両方を見る）
+      revokeTenantApiKey(tenantId, revokedHash);
       return res.json({ ok: true, id: keyId, is_active: false });
     } catch (err) {
       logger.warn("[DELETE /v1/admin/my-tenant/keys/:keyId]", err);
@@ -777,8 +775,10 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
       if (result.rowCount === 0) {
         return res.status(404).json({ error: "not_found", message: "APIキーが見つかりません。" });
       }
-      // 失効させたキーが現在in-memoryで有効なキーと一致する場合、PM2再起動を待たず即時に無効化する
-      revokeTenantApiKeyIfCurrent(id, result.rows[0].key_hash);
+      // 失効させたキーを in-memory からも即時に落とす。主キーだけでなく
+      // client_admin が無停止ローテーションで追加したキーも対象にする
+      // （以前は主キーのみを見ており、追加キーがDB上inactiveでも認証が通り続けていた）。
+      revokeTenantApiKey(id, result.rows[0].key_hash);
       return res.json({ ok: true, id: keyId, is_active: false });
     } catch (err) {
       logger.warn("[DELETE /v1/admin/tenants/:id/keys/:keyId]", err);

--- a/src/api/admin/tenants/routes.ts
+++ b/src/api/admin/tenants/routes.ts
@@ -701,25 +701,31 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
       );
       const row = result.rows[0];
 
-      // in-memory storeのAPIキーハッシュを更新（最新キーで上書き）。
-      // allowedOrigins/features は固定値で潰さず、DB上の現行値を引き継ぐ
-      // （さもないとキー再発行のたびに許可オリジン設定が消える）。
+      // 意味論: このエンドポイントはキーを「追加」する（既存キーは失効しない）。
+      // DBのINSERT・UIのキー一覧(個別に失効ボタンを持つ)・client_admin側の
+      // POST /my-tenant/keys がいずれも追加型であり、in-memory だけが
+      // registerTenant による「上書き」だったため、旧キーが
+      // DB上は is_active=true のまま in-memory から消えて 401 になっていた。
       const tenantRow = tenantCheck.rows[0];
-      registerTenant({
-        tenantId: tenantRow.id,
-        name: tenantRow.name || tenantRow.id,
-        plan: tenantRow.plan || "starter",
-        features: (tenantRow.features as { avatar: boolean; voice: boolean; rag: boolean }) ?? { avatar: false, voice: false, rag: true },
-        security: {
-          apiKeyHash: keyHash,
-          hashAlgorithm: "sha256",
-          allowedOrigins: tenantRow.allowed_origins ?? [],
-          rateLimit: 100,
-          rateLimitWindowMs: 60_000,
-        },
-        enabled: true,
-      });
-      setTenantApiKeyExpiry(tenantRow.id, expiresAt);
+      if (!addTenantApiKey(tenantRow.id, keyHash, expiresAt)) {
+        // in-memory 未登録(DB-onlyテナント)の場合のみ、新キーを主キーとして登録する。
+        // allowedOrigins/features は固定値で潰さず、DB上の現行値を引き継ぐ。
+        registerTenant({
+          tenantId: tenantRow.id,
+          name: tenantRow.name || tenantRow.id,
+          plan: tenantRow.plan || "starter",
+          features: (tenantRow.features as { avatar: boolean; voice: boolean; rag: boolean }) ?? { avatar: false, voice: false, rag: true },
+          security: {
+            apiKeyHash: keyHash,
+            hashAlgorithm: "sha256",
+            allowedOrigins: tenantRow.allowed_origins ?? [],
+            rateLimit: 100,
+            rateLimitWindowMs: 60_000,
+          },
+          enabled: true,
+        });
+        setTenantApiKeyExpiry(tenantRow.id, expiresAt);
+      }
 
       // 平文キーはこのレスポンスでのみ返す（二度と取得不可）
       return res.status(201).json({

--- a/src/lib/tenant-context.test.ts
+++ b/src/lib/tenant-context.test.ts
@@ -8,6 +8,7 @@ import {
   getTenantByApiKeyHash,
   setTenantApiKeyExpiry,
   revokeTenantApiKeyIfCurrent,
+  revokeTenantApiKey,
   addTenantApiKey,
   revokeAdditionalTenantApiKey,
 } from "./tenant-context";
@@ -482,6 +483,53 @@ describe("addTenantApiKey / revokeAdditionalTenantApiKey — 無停止ローテ�
     // (super_adminが自分のキー発行前に旧キーを明示的にDELETEしていれば起きないが、
     //  ルートの実装はそれを強制していない — 既知のリスクとして報告する)
     expect(getTenantByApiKeyHash(PRIMARY_HASH)).toBeUndefined();
+  });
+
+  // --- revokeTenantApiKey: 失効の単一入口（主キー・追加キーを区別せず落とす） ---
+  // 以前は呼び出し側が revokeTenantApiKeyIfCurrent と revokeAdditionalTenantApiKey を
+  // 個別に呼ぶ形で、super_admin の DELETE が前者しか呼んでいなかった。その結果
+  // 「DBは is_active=false なのに in-memory では認証が通り続ける」fail-open が発生していた。
+
+  it("revokeTenantApiKey は追加キーを失効させる（super_adminのDELETEで発生していたfail-openの回帰防止）", () => {
+    addTenantApiKey(TENANT_ID, ADDITIONAL_HASH, null);
+    expect(getTenantByApiKeyHash(ADDITIONAL_HASH)?.tenantId).toBe(TENANT_ID);
+
+    const revoked = revokeTenantApiKey(TENANT_ID, ADDITIONAL_HASH);
+
+    expect(revoked).toBe(true);
+    // ここが本丸: 追加キーが in-memory からも落ちていること
+    expect(getTenantByApiKeyHash(ADDITIONAL_HASH)).toBeUndefined();
+    // 主キーは巻き添えにしない
+    expect(getTenantByApiKeyHash(PRIMARY_HASH)?.tenantId).toBe(TENANT_ID);
+  });
+
+  it("revokeTenantApiKey は主キーも失効させる（主キー用の経路も同じ入口で賄える）", () => {
+    addTenantApiKey(TENANT_ID, ADDITIONAL_HASH, null);
+
+    const revoked = revokeTenantApiKey(TENANT_ID, PRIMARY_HASH);
+
+    expect(revoked).toBe(true);
+    expect(getTenantByApiKeyHash(PRIMARY_HASH)).toBeUndefined();
+    // 追加キーは巻き添えにしない
+    expect(getTenantByApiKeyHash(ADDITIONAL_HASH)?.tenantId).toBe(TENANT_ID);
+  });
+
+  it("revokeTenantApiKey は在籍しないハッシュには false を返す（DBだけにある行を失効させた場合）", () => {
+    expect(revokeTenantApiKey(TENANT_ID, "hash-that-was-never-in-memory")).toBe(false);
+    // 既存キーには影響しない
+    expect(getTenantByApiKeyHash(PRIMARY_HASH)?.tenantId).toBe(TENANT_ID);
+  });
+
+  it("revokeTenantApiKey で複数の追加キーを1本ずつ失効させても、残りは有効なまま", () => {
+    const hashB = "revoke-unified-hash-b";
+    addTenantApiKey(TENANT_ID, ADDITIONAL_HASH, null);
+    addTenantApiKey(TENANT_ID, hashB, null);
+
+    revokeTenantApiKey(TENANT_ID, ADDITIONAL_HASH);
+
+    expect(getTenantByApiKeyHash(ADDITIONAL_HASH)).toBeUndefined();
+    expect(getTenantByApiKeyHash(hashB)?.tenantId).toBe(TENANT_ID);
+    expect(getTenantByApiKeyHash(PRIMARY_HASH)?.tenantId).toBe(TENANT_ID);
   });
 
   it("結線確認: 実際のAPIキー生成(generateApiKey)→ハッシュ化(hashApiKey)→addTenantApiKey→getTenantByApiKeyHashの一連の流れが、POSTルートと同じ手順で成立する", () => {

--- a/src/lib/tenant-context.test.ts
+++ b/src/lib/tenant-context.test.ts
@@ -11,6 +11,7 @@ import {
   revokeTenantApiKey,
   addTenantApiKey,
   revokeAdditionalTenantApiKey,
+  seedTenantsFromDB,
 } from "./tenant-context";
 
 describe("seedTenantsFromEnv — numbered keys", () => {
@@ -554,5 +555,128 @@ describe("addTenantApiKey / revokeAdditionalTenantApiKey — 無停止ローテ�
     // 失効させれば同じ平文キーはもう認証できない
     revokeAdditionalTenantApiKey(TENANT_ID, keyHash);
     expect(getTenantByApiKeyHash(authHash)).toBeUndefined();
+  });
+});
+
+describe("seedTenantsFromDB — 起動時のin-memory復元", () => {
+  // このパスは従来テストが1本も無く、PM2再起動のたびに
+  // 「テナントごと1本のキーしか復元されない」バグが検出されないままだった。
+
+  type SeedRow = {
+    tenant_id: string;
+    name: string;
+    plan: string;
+    is_active: boolean;
+    features: Record<string, boolean>;
+    allowed_origins: string[];
+    key_hash: string;
+    rate_limit: number | null;
+    expires_at: string | null;
+  };
+
+  const row = (over: Partial<SeedRow> & Pick<SeedRow, "tenant_id" | "key_hash">): SeedRow => ({
+    name: over.tenant_id,
+    plan: "starter",
+    is_active: true,
+    features: { avatar: false, voice: false, rag: true },
+    allowed_origins: [],
+    rate_limit: null,
+    expires_at: null,
+    ...over,
+  });
+
+  /** pool.query だけを持つ最小のフェイク（seedTenantsFromDB が使うのはこれだけ） */
+  const fakePool = (rows: SeedRow[]) =>
+    ({ query: jest.fn().mockResolvedValue({ rows, rowCount: rows.length }) }) as unknown as Parameters<typeof seedTenantsFromDB>[0];
+
+  it("1テナントに複数のアクティブキーがある場合、全キーを復元する（再起動でローテーションキーが消えない）", async () => {
+    const TENANT = "seed-multi-key-tenant";
+    await seedTenantsFromDB(
+      fakePool([
+        row({ tenant_id: TENANT, key_hash: "seed-key-newest" }),
+        row({ tenant_id: TENANT, key_hash: "seed-key-older" }),
+        row({ tenant_id: TENANT, key_hash: "seed-key-oldest" }),
+      ])
+    );
+
+    // 3本すべてが認証に使える = 無停止ローテーションが再起動を跨いで成立する
+    expect(getTenantByApiKeyHash("seed-key-newest")?.tenantId).toBe(TENANT);
+    expect(getTenantByApiKeyHash("seed-key-older")?.tenantId).toBe(TENANT);
+    expect(getTenantByApiKeyHash("seed-key-oldest")?.tenantId).toBe(TENANT);
+  });
+
+  it("SQLの先頭行(ORDER BYで最新)が主キーになる — 復元後の主キーが非決定的にならない", async () => {
+    const TENANT = "seed-primary-order-tenant";
+    await seedTenantsFromDB(
+      fakePool([
+        row({ tenant_id: TENANT, key_hash: "seed-primary-expected" }),
+        row({ tenant_id: TENANT, key_hash: "seed-primary-not-expected" }),
+      ])
+    );
+
+    expect(getTenantConfig(TENANT)?.security.apiKeyHash).toBe("seed-primary-expected");
+  });
+
+  it("複数テナントを取り違えずに復元する（キーがテナント間で混ざらない）", async () => {
+    await seedTenantsFromDB(
+      fakePool([
+        row({ tenant_id: "seed-tenant-a", key_hash: "seed-a-key1" }),
+        row({ tenant_id: "seed-tenant-a", key_hash: "seed-a-key2" }),
+        row({ tenant_id: "seed-tenant-b", key_hash: "seed-b-key1" }),
+      ])
+    );
+
+    expect(getTenantByApiKeyHash("seed-a-key1")?.tenantId).toBe("seed-tenant-a");
+    expect(getTenantByApiKeyHash("seed-a-key2")?.tenantId).toBe("seed-tenant-a");
+    expect(getTenantByApiKeyHash("seed-b-key1")?.tenantId).toBe("seed-tenant-b");
+  });
+
+  it("追加キーは行ごとの expires_at を保持する（期限切れの追加キーは復元後も認証できない）", async () => {
+    const TENANT = "seed-expiry-tenant";
+    await seedTenantsFromDB(
+      fakePool([
+        row({ tenant_id: TENANT, key_hash: "seed-expiry-primary" }),
+        row({ tenant_id: TENANT, key_hash: "seed-expiry-valid", expires_at: new Date(Date.now() + 600_000).toISOString() }),
+        row({ tenant_id: TENANT, key_hash: "seed-expiry-stale", expires_at: new Date(Date.now() - 1_000).toISOString() }),
+      ])
+    );
+
+    expect(getTenantByApiKeyHash("seed-expiry-valid")?.tenantId).toBe(TENANT);
+    // 期限切れの行がDBの WHERE をすり抜けて届いても、in-memory側で弾く
+    expect(getTenantByApiKeyHash("seed-expiry-stale")).toBeUndefined();
+  });
+
+  it("env由来で登録済みのテナントはDBで上書きしない（キーも足さない — envが唯一の情報源）", async () => {
+    const TENANT = "seed-env-precedence-tenant";
+    registerTenant({
+      tenantId: TENANT,
+      name: "From Env",
+      plan: "enterprise",
+      features: { avatar: true, voice: true, rag: true },
+      security: { apiKeyHash: "env-key-hash", hashAlgorithm: "sha256", allowedOrigins: [], rateLimit: 100, rateLimitWindowMs: 60_000 },
+      enabled: true,
+    });
+
+    await seedTenantsFromDB(
+      fakePool([
+        row({ tenant_id: TENANT, key_hash: "db-key-should-be-ignored", name: "From DB", plan: "starter" }),
+      ])
+    );
+
+    expect(getTenantConfig(TENANT)?.name).toBe("From Env");
+    expect(getTenantConfig(TENANT)?.security.apiKeyHash).toBe("env-key-hash");
+    expect(getTenantByApiKeyHash("db-key-should-be-ignored")).toBeUndefined();
+  });
+
+  it("DB接続に失敗しても例外を投げずに起動を継続する（起動をブロックしない）", async () => {
+    const failingPool = {
+      query: jest.fn().mockRejectedValue(new Error("connection refused")),
+    } as unknown as Parameters<typeof seedTenantsFromDB>[0];
+
+    await expect(seedTenantsFromDB(failingPool)).resolves.toBeUndefined();
+  });
+
+  it("0件でも例外を投げない", async () => {
+    await expect(seedTenantsFromDB(fakePool([]))).resolves.toBeUndefined();
   });
 });

--- a/src/lib/tenant-context.test.ts
+++ b/src/lib/tenant-context.test.ts
@@ -458,32 +458,24 @@ describe("addTenantApiKey / revokeAdditionalTenantApiKey — 無停止ローテ�
     expect(getTenantByApiKeyHash(RESCUE_HASH)?.tenantId).toBe(TENANT_ID);
   });
 
-  it("既知のリスク: super_admin向けPOST /tenants/:id/keysのregisterTenant(上書き)は、client_adminが無停止ローテーションで追加した副キーには影響しないが、旧・主キーはDB側is_active=trueのままin-memoryでは無効化される", () => {
+  it("super_admin のキー発行後も旧・主キーと副キーが有効なまま（DB上activeなのに認証できないキーを作らない）", () => {
     // client_adminが無停止ローテーションで追加キーを発行済みの状態を再現
     addTenantApiKey(TENANT_ID, ADDITIONAL_HASH, null);
 
-    // super_adminが自分のエンドポイント(POST /tenants/:id/keys)で新しい主キーを発行すると、
-    // ルート実装は addTenantApiKey ではなく registerTenant を呼ぶ(既存実装のまま)。
-    const SUPER_ADMIN_NEW_HASH = "multikey-superadmin-overwrite-hash";
-    registerTenant({
-      tenantId: TENANT_ID,
-      name: "Multikey Test",
-      plan: "starter",
-      features: { avatar: false, voice: false, rag: true },
-      security: { apiKeyHash: SUPER_ADMIN_NEW_HASH, hashAlgorithm: "sha256", allowedOrigins: [], rateLimit: 100, rateLimitWindowMs: 60_000 },
-      enabled: true,
-    });
+    // super_adminのPOST /tenants/:id/keysは、in-memory登録済みテナントに対しては
+    // registerTenant(上書き)ではなく addTenantApiKey(追加)を使う。
+    // DBのINSERT・UIのキー一覧・client_admin側POSTと同じ「追加」の意味論。
+    const SUPER_ADMIN_NEW_HASH = "multikey-superadmin-added-hash";
+    const added = addTenantApiKey(TENANT_ID, SUPER_ADMIN_NEW_HASH, null);
+    expect(added).toBe(true);
 
-    // 新しい主キーは有効
+    // 新しいキーは有効
     expect(getTenantByApiKeyHash(SUPER_ADMIN_NEW_HASH)?.tenantId).toBe(TENANT_ID);
-    // client_adminが追加した副キーは無停止ローテーションの約束どおり生き残る
+    // client_adminが追加した副キーも生き残る
     expect(getTenantByApiKeyHash(ADDITIONAL_HASH)?.tenantId).toBe(TENANT_ID);
-    // 旧・主キーはtenantStoreから消えるため in-memory では二度と認証できない。
-    // DB(tenant_api_keys.is_active)側はこの操作だけでは更新されないため、
-    // 「DB上はactiveなのに実際には使えないキー」というdesyncが生まれる。
-    // (super_adminが自分のキー発行前に旧キーを明示的にDELETEしていれば起きないが、
-    //  ルートの実装はそれを強制していない — 既知のリスクとして報告する)
-    expect(getTenantByApiKeyHash(PRIMARY_HASH)).toBeUndefined();
+    // 旧・主キーも生き残る。DB側は is_active=true のままなので、
+    // in-memory だけが先に消えて「DB上はactiveなのに401」になる desync が起きない。
+    expect(getTenantByApiKeyHash(PRIMARY_HASH)?.tenantId).toBe(TENANT_ID);
   });
 
   // --- revokeTenantApiKey: 失効の単一入口（主キー・追加キーを区別せず落とす） ---

--- a/src/lib/tenant-context.ts
+++ b/src/lib/tenant-context.ts
@@ -44,6 +44,10 @@ export function addTenantApiKey(
 /**
  * 追加キー（主キー以外）を失効させる。対象が追加キーに存在しない場合は
  * 何もせず false を返す（主キーの失効は revokeTenantApiKeyIfCurrent が担当）。
+ *
+ * 注意: 呼び出し側が「主キーか追加キーか」を判断する必要はない。
+ * DELETE ハンドラからは必ず revokeTenantApiKey() を使うこと
+ * （片方だけ呼ぶと失効漏れになる。実際に super_admin 側で発生した）。
  */
 export function revokeAdditionalTenantApiKey(
   tenantId: string,
@@ -58,6 +62,25 @@ export function revokeAdditionalTenantApiKey(
     }
   }
   return false;
+}
+
+/**
+ * テナントのAPIキーを、主キー・追加キーのどちらであっても失効させる。
+ *
+ * DBで is_active=false にしたキーを in-memory からも即座に落とすための
+ * 単一の入口。主キー用(revokeTenantApiKeyIfCurrent)と追加キー用
+ * (revokeAdditionalTenantApiKey)を個別に呼ぶ形だと、呼び出し側の一方が
+ * 片方しか呼ばず「DBはinactiveなのに認証は通り続ける」fail-open を招くため
+ * （super_admin の DELETE で実際に発生）、失効の呼び出し口はこの関数に統一する。
+ *
+ * 戻り値: in-memory 側で実際に無効化したら true。
+ */
+export function revokeTenantApiKey(tenantId: string, revokedKeyHash: string): boolean {
+  // 両方に問い合わせる。短絡評価にすると主キーがヒットした時点で
+  // 追加キー側が評価されず、同一ハッシュが両方に残る事故を見逃す。
+  const revokedPrimary = revokeTenantApiKeyIfCurrent(tenantId, revokedKeyHash);
+  const revokedAdditional = revokeAdditionalTenantApiKey(tenantId, revokedKeyHash);
+  return revokedPrimary || revokedAdditional;
 }
 
 export function registerTenant(config: TenantConfig): void {

--- a/src/lib/tenant-context.ts
+++ b/src/lib/tenant-context.ts
@@ -283,31 +283,64 @@ export async function seedTenantsFromDB(pool: Pool, logger?: Logger): Promise<vo
       WHERE k.is_active = true
         AND (k.expires_at IS NULL OR k.expires_at > NOW())
         AND t.is_active = true
+      ORDER BY t.id, k.created_at DESC, k.key_hash
     `);
 
-    let count = 0;
+    // このSELECTは「アクティブなキー1本につき1行」を返すため、N本のキーを持つ
+    // テナントはN行に現れる。テナント単位にまとめてから登録する。
+    const rowsByTenant = new Map<string, typeof result.rows>();
     for (const row of result.rows) {
-      const existing = tenantStore.get(row.tenant_id);
-      // env-var entries take precedence over DB entries
-      if (existing) continue;
+      const rows = rowsByTenant.get(row.tenant_id);
+      if (rows) rows.push(row);
+      else rowsByTenant.set(row.tenant_id, [row]);
+    }
+
+    let tenantCount = 0;
+    let keyCount = 0;
+    for (const [tenantId, rows] of rowsByTenant) {
+      // env-var entries take precedence over DB entries.
+      // seedTenantsFromEnv() が先に走るため、env で定義済みのテナントは
+      // 設定もキー集合も env が唯一の情報源とみなし、DB側は一切足さない
+      // （キーだけ足すと env で意図的に絞ったキー集合を DB が広げてしまう）。
+      if (tenantStore.has(tenantId)) continue;
+
+      // ORDER BY で最新キーが先頭に来る。ORDER BY が無いとPostgresの
+      // 物理行順・プラン依存で「どれが主キーになるか」が再起動ごとに変わり、
+      // 引退させたはずの旧キーが主キーとして復活しうる。
+      const [primary, ...additional] = rows;
+      if (!primary) continue;
+
       registerTenant({
-        tenantId: row.tenant_id,
-        name: row.name || row.tenant_id,
-        plan: (["starter", "growth", "enterprise"].includes(row.plan) ? row.plan : "starter") as TenantConfig["plan"],
-        features: (row.features as TenantConfig["features"]) ?? { avatar: false, voice: false, rag: true },
+        tenantId: primary.tenant_id,
+        name: primary.name || primary.tenant_id,
+        plan: (["starter", "growth", "enterprise"].includes(primary.plan) ? primary.plan : "starter") as TenantConfig["plan"],
+        features: (primary.features as TenantConfig["features"]) ?? { avatar: false, voice: false, rag: true },
         security: {
-          apiKeyHash: row.key_hash,
+          apiKeyHash: primary.key_hash,
           hashAlgorithm: "sha256",
-          allowedOrigins: row.allowed_origins ?? [],
-          rateLimit: row.rate_limit ?? 100,
+          allowedOrigins: primary.allowed_origins ?? [],
+          rateLimit: primary.rate_limit ?? 100,
           rateLimitWindowMs: 60_000,
         },
         enabled: true,
       });
-      setTenantApiKeyExpiry(row.tenant_id, row.expires_at ? new Date(row.expires_at) : null);
-      count++;
+      setTenantApiKeyExpiry(tenantId, primary.expires_at ? new Date(primary.expires_at) : null);
+
+      // 残りのアクティブキーも復元する。これが無いと、client_admin が無停止
+      // ローテーションで追加したキーが PM2 再起動のたびに消え、DB上は
+      // is_active=true のまま認証できなくなる（ローテーション機能が
+      // プロセス内でしか成立しない）。
+      for (const row of additional) {
+        addTenantApiKey(tenantId, row.key_hash, row.expires_at ? new Date(row.expires_at) : null);
+      }
+
+      tenantCount++;
+      keyCount += rows.length;
     }
-    logger?.info({ count }, "seedTenantsFromDB: loaded tenant API keys from DB");
+    logger?.info(
+      { count: tenantCount, keyCount },
+      "seedTenantsFromDB: loaded tenant API keys from DB"
+    );
   } catch (err) {
     logger?.warn({ err }, "seedTenantsFromDB: failed to load tenants from DB");
   }

--- a/tests/api/admin/tenants/routes.test.ts
+++ b/tests/api/admin/tenants/routes.test.ts
@@ -268,6 +268,50 @@ describe("Tenant Admin Routes", () => {
       const passedExpiry = (mockSetTenantApiKeyExpiry as jest.Mock).mock.calls.at(-1)?.[1] as Date;
       expect(passedExpiry.getTime()).toBeGreaterThan(Date.now());
     });
+
+    // --- 追加型の意味論（DB・UI・client_admin側と揃える） ---
+    // 以前は in-memory だけが registerTenant による「上書き」で、旧キーが
+    // DB上 is_active=true のまま in-memory から消え 401 になっていた。
+
+    it("in-memory登録済みのテナントには addTenantApiKey で追加し、registerTenant(上書き)は呼ばない", async () => {
+      // addTenantApiKey が true = tenantStore に既存エントリがある（＝追加で足せた）
+      (mockAddTenantApiKey as jest.Mock).mockReturnValueOnce(true);
+      mockDb.query
+        .mockResolvedValueOnce({ rows: [{ id: "t1", name: "T1", plan: "starter", is_active: true, features: null, allowed_origins: null }], rowCount: 1 })
+        .mockResolvedValueOnce({
+          rows: [{ id: "key-uuid", tenant_id: "t1", key_prefix: "rjc_abcd1234", is_active: true, created_at: new Date(), expires_at: null }],
+          rowCount: 1,
+        });
+      const registerCallsBefore = (mockRegisterTenant as jest.Mock).mock.calls.length;
+
+      const res = await request(app)
+        .post("/v1/admin/tenants/t1/keys")
+        .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`);
+
+      expect(res.status).toBe(201);
+      expect(mockAddTenantApiKey).toHaveBeenLastCalledWith("t1", expect.any(String), null);
+      // 上書きしない = 既存キーが in-memory から消えない
+      expect((mockRegisterTenant as jest.Mock).mock.calls.length).toBe(registerCallsBefore);
+    });
+
+    it("in-memory未登録(DB-onlyテナント)の場合のみ registerTenant で主キーとして登録する", async () => {
+      // addTenantApiKey が false = tenantStore に未登録
+      (mockAddTenantApiKey as jest.Mock).mockReturnValueOnce(false);
+      mockDb.query
+        .mockResolvedValueOnce({ rows: [{ id: "t-db-only", name: "DBOnly", plan: "starter", is_active: true, features: null, allowed_origins: null }], rowCount: 1 })
+        .mockResolvedValueOnce({
+          rows: [{ id: "key-uuid", tenant_id: "t-db-only", key_prefix: "rjc_abcd1234", is_active: true, created_at: new Date(), expires_at: null }],
+          rowCount: 1,
+        });
+
+      const res = await request(app)
+        .post("/v1/admin/tenants/t-db-only/keys")
+        .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`);
+
+      expect(res.status).toBe(201);
+      const lastCall = (mockRegisterTenant as jest.Mock).mock.calls.at(-1)?.[0];
+      expect(lastCall.tenantId).toBe("t-db-only");
+    });
   });
 
   describe("GET /v1/admin/tenants/:id/keys", () => {

--- a/tests/api/admin/tenants/routes.test.ts
+++ b/tests/api/admin/tenants/routes.test.ts
@@ -5,10 +5,9 @@ import { generateApiKey, hashApiKey, maskApiKey, maskApiKeyPrefix } from "../../
 import {
   registerTenant as mockRegisterTenant,
   setTenantApiKeyExpiry as mockSetTenantApiKeyExpiry,
-  revokeTenantApiKeyIfCurrent as mockRevokeTenantApiKeyIfCurrent,
+  revokeTenantApiKey as mockRevokeTenantApiKey,
   updateTenantAllowedOrigins as mockUpdateTenantAllowedOrigins,
   addTenantApiKey as mockAddTenantApiKey,
-  revokeAdditionalTenantApiKey as mockRevokeAdditionalTenantApiKey,
 } from "../../../../src/lib/tenant-context";
 
 // tenant-context をモック
@@ -17,9 +16,8 @@ jest.mock("../../../../src/lib/tenant-context", () => ({
   updateTenantEnabled: jest.fn(),
   updateTenantAllowedOrigins: jest.fn(),
   setTenantApiKeyExpiry: jest.fn(),
-  revokeTenantApiKeyIfCurrent: jest.fn(),
+  revokeTenantApiKey: jest.fn(),
   addTenantApiKey: jest.fn(),
-  revokeAdditionalTenantApiKey: jest.fn(),
 }));
 
 // supabaseClient をモック（招待API用 — テストでは不要）
@@ -949,27 +947,27 @@ describe("Tenant Admin Routes", () => {
         .delete("/v1/admin/tenants/t1/keys/k1")
         .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`);
       expect(res.status).toBe(200);
-      expect(mockRevokeTenantApiKeyIfCurrent).toHaveBeenLastCalledWith("t1", "the-real-key-hash");
+      expect(mockRevokeTenantApiKey).toHaveBeenLastCalledWith("t1", "the-real-key-hash");
     });
 
     it("client_admin は403で弾かれ、失効処理は一切走らない（権限境界）", async () => {
-      const callsBefore = (mockRevokeTenantApiKeyIfCurrent as jest.Mock).mock.calls.length;
+      const callsBefore = (mockRevokeTenantApiKey as jest.Mock).mock.calls.length;
       const res = await request(app)
         .delete("/v1/admin/tenants/t1/keys/k1")
         .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`);
       expect(res.status).toBe(403);
-      expect((mockRevokeTenantApiKeyIfCurrent as jest.Mock).mock.calls.length).toBe(callsBefore);
+      expect((mockRevokeTenantApiKey as jest.Mock).mock.calls.length).toBe(callsBefore);
     });
 
     it("越境: 他テナントのkeyIdを指定した場合、DBのWHERE tenant_id条件で一致せず404になり、失効処理も走らない", async () => {
       // tenant_id=$2 の条件に一致しないシナリオ = DB側が0件を返す（実クエリのWHERE句がこの防御を担う）
       mockDb.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
-      const callsBefore = (mockRevokeTenantApiKeyIfCurrent as jest.Mock).mock.calls.length;
+      const callsBefore = (mockRevokeTenantApiKey as jest.Mock).mock.calls.length;
       const res = await request(app)
         .delete("/v1/admin/tenants/tenant-a/keys/key-belongs-to-tenant-b")
         .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`);
       expect(res.status).toBe(404);
-      expect((mockRevokeTenantApiKeyIfCurrent as jest.Mock).mock.calls.length).toBe(callsBefore);
+      expect((mockRevokeTenantApiKey as jest.Mock).mock.calls.length).toBe(callsBefore);
     });
 
     it("イレギュラー: 同じキーを2回連続で失効させても、2回目もエラーにならず200 ok=trueを返す（べき等）", async () => {
@@ -1108,14 +1106,13 @@ describe("Tenant Admin Routes", () => {
       expect(res.body.ok).toBe(true);
     });
 
-    it("主キー・追加キーの両方の失効経路を試す（どちらが一致するか呼び出し時点では分からないため）", async () => {
+    it("主キー・追加キーを区別しない単一の失効入口(revokeTenantApiKey)に委譲する", async () => {
       mockDb.query.mockResolvedValueOnce({ rows: [{ id: "k1", tenant_id: "tenant1", is_active: false, key_hash: "h1" }], rowCount: 1 });
       const res = await request(app)
         .delete("/v1/admin/my-tenant/keys/k1")
         .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`);
       expect(res.status).toBe(200);
-      expect(mockRevokeTenantApiKeyIfCurrent).toHaveBeenLastCalledWith("tenant1", "h1");
-      expect(mockRevokeAdditionalTenantApiKey).toHaveBeenLastCalledWith("tenant1", "h1");
+      expect(mockRevokeTenantApiKey).toHaveBeenLastCalledWith("tenant1", "h1");
     });
 
     it("存在しないキーは404", async () => {
@@ -1128,12 +1125,12 @@ describe("Tenant Admin Routes", () => {
 
     it("越境不可: 他テナントのkeyIdはWHERE tenant_id条件で一致せず404になり、失効処理も走らない", async () => {
       mockDb.query.mockResolvedValueOnce({ rows: [], rowCount: 0 });
-      const callsBefore = (mockRevokeTenantApiKeyIfCurrent as jest.Mock).mock.calls.length;
+      const callsBefore = (mockRevokeTenantApiKey as jest.Mock).mock.calls.length;
       const res = await request(app)
         .delete("/v1/admin/my-tenant/keys/key-belongs-to-other-tenant")
         .set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`);
       expect(res.status).toBe(404);
-      expect((mockRevokeTenantApiKeyIfCurrent as jest.Mock).mock.calls.length).toBe(callsBefore);
+      expect((mockRevokeTenantApiKey as jest.Mock).mock.calls.length).toBe(callsBefore);
       // DBクエリのtenant_id条件が常にJWT由来のtenant_id("tenant1")であることを確認
       expect(mockDb.query.mock.calls[0][1]).toEqual(["key-belongs-to-other-tenant", "tenant1"]);
     });
@@ -1149,14 +1146,14 @@ describe("Tenant Admin Routes", () => {
       mockDb.query
         .mockResolvedValueOnce({ rows: [{ id: "k1", tenant_id: "tenant1", is_active: false, key_hash: "h1" }], rowCount: 1 })
         .mockResolvedValueOnce({ rows: [{ id: "k1", tenant_id: "tenant1", is_active: false, key_hash: "h1" }], rowCount: 1 });
-      const callsBefore = (mockRevokeTenantApiKeyIfCurrent as jest.Mock).mock.calls.length;
+      const callsBefore = (mockRevokeTenantApiKey as jest.Mock).mock.calls.length;
       const res1 = await request(app).delete("/v1/admin/my-tenant/keys/k1").set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`);
       const res2 = await request(app).delete("/v1/admin/my-tenant/keys/k1").set("Authorization", `Bearer ${CLIENT_ADMIN_TOKEN}`);
       expect(res1.status).toBe(200);
       expect(res2.status).toBe(200);
       // UPDATE文にis_active=trueの条件が無いため、DB側は既にfalseの行でも再度一致しRETURNINGされる。
       // クライアントから見て「失効操作」が失敗せず安全に繰り返せることを保証する。
-      expect((mockRevokeTenantApiKeyIfCurrent as jest.Mock).mock.calls.length - callsBefore).toBe(2);
+      expect((mockRevokeTenantApiKey as jest.Mock).mock.calls.length - callsBefore).toBe(2);
     });
   });
 

--- a/tests/api/admin/tenants/routes.test.ts
+++ b/tests/api/admin/tenants/routes.test.ts
@@ -985,7 +985,7 @@ describe("Tenant Admin Routes", () => {
       expect(res.status).toBe(404);
     });
 
-    it("失効させたキーのハッシュを revokeTenantApiKeyIfCurrent に正しい (tenantId, keyHash) で渡す（インメモリ即時反映の配線）", async () => {
+    it("失効させたキーのハッシュを revokeTenantApiKey に正しい (tenantId, keyHash) で渡す（インメモリ即時反映の配線）", async () => {
       mockDb.query.mockResolvedValueOnce({ rows: [{ id: "k1", tenant_id: "t1", is_active: false, key_hash: "the-real-key-hash" }], rowCount: 1 });
       const res = await request(app)
         .delete("/v1/admin/tenants/t1/keys/k1")


### PR DESCRIPTION
## 背景

PR #824 で client_admin の無停止ローテーションを入れたが、in-memory のキー射影が DB の形（`tenant_api_keys` = 複数行・行ごとに `is_active`/`expires_at`）と食い違っており、3つの問題があった。**DB スキーマは「1テナントN本アクティブ」を正しく表現できているため、マイグレーションは不要。**

## 問題と修正

### B: 失効の片肺（fail-open / セキュリティ）— #824 が新規に作り込んだ

`DELETE /v1/admin/tenants/:id/keys/:keyId`（super_admin）は `revokeTenantApiKeyIfCurrent`（主キー用）しか呼んでおらず、client_admin がローテーションで追加した副キーを失効させても **DB は `is_active=false` になるのに in-memory では有効なまま**だった。PM2 再起動まで失効済みキーで認証が通り続ける。client_admin 側は両方呼んでいたため、CLAUDE.md 禁止事項の「片肺修正」がそのまま穴になっていた。

→ 呼び出し側が主キー/追加キーを判断する構造自体をやめ、両方を見る **`revokeTenantApiKey()` を単一の失効入口**として新設し、両ハンドラをそこに寄せた。以後どちらか片方だけ直る事故は構造的に起きない。

### C: 再起動でローテーションキーが消える — #824 以前から存在

`seedTenantsFromDB` の SELECT は「アクティブキー1本につき1行」を返すが、ループ内の `if (existing) continue;` が「env 由来なら上書きしない」ガードと「同一テナントの2行目以降」を区別できておらず、**テナントごとに最初の1行しか採用されていなかった**。しかも `ORDER BY` が無いため、どの行が残るかは Postgres の物理行順・プラン依存で、**引退させたはずの旧キーが主キーとして復活しうる**。

→ 行をテナント単位にまとめ、`ORDER BY t.id, k.created_at DESC, k.key_hash` で最新キーを主キーに固定した上で、残りのアクティブキーも `addTenantApiKey` で復元する。env 優先の意図は維持（env 定義済みテナントには DB のキーを一切足さない — 足すと env で絞ったキー集合を DB が広げてしまうため）。

### A: DB上activeなのに401になるキー — #824 以前から存在

`POST /v1/admin/tenants/:id/keys` は DB には行を INSERT する（既存行は `is_active=true` のまま）一方、in-memory は `registerTenant` で主キーを**上書き**していた。旧キーは「DB上は有効なのに in-memory から消えて401」になる。

→ DB（複数行・個別に失効可）、管理UIのキー一覧（キーごとに失効ボタンを持つ）、client_admin 側 POST がいずれも「追加」型であり、**in-memory だけが「置換」型**で食い違っていた。**追加型に揃えた。** in-memory 未登録の DB-only テナントに対してのみ従来どおり `registerTenant` で主キーとして登録する（`addTenantApiKey` の戻り値で分岐）。

## テスト

`seedTenantsFromDB` は**従来テストが1本も無かった**ため新規に固定：複数キー復元 / 主キーの決定性 / テナント間の混線防止 / 期限保持 / env優先 / DB障害時の起動継続。

- 3スイート 158 tests 全pass、typecheck 0エラー、oxlint クリーン
- ミューテーション検証3件とも想定どおり失敗→復元を確認
  - 失効を主キーのみに戻す → fail-open 回帰テスト2件が失敗
  - 追加キーの復元を落とす → seed テスト3件が失敗
  - `registerTenant` 無条件上書きに戻す → 追加意味論テスト1件が失敗
- 旧挙動を「既知のリスク」として固定していたテストは、desync が起きないことを確認するテストに書き換え

フルスイートで落ちる `avatar/routes.test.ts`(20件) は `global.fetch` spy の既存問題で本PRの変更ファイルを一切参照しない。`agentRoutes.test.ts`(1件) は単体実行では 505/505 pass するクロスファイル汚染。

## 影響

- マイグレーション不要
- `TenantConfig` 型は不変（`src/types/contracts.ts` 利用側への波及なし）
- `registerTenant` / `revokeTenantApiKeyIfCurrent` / `revokeAdditionalTenantApiKey` は export のまま（`revokeTenantApiKey` が推奨入口）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgCQYt8UMPgm4HNVu7nv7z