### PR TITLE
[SEC][P1] セッションストア3種にTTLを追加+flowContextStoreのキー生成を統一

### DIFF
--- a/src/agent/dialog/contextStore.test.ts
+++ b/src/agent/dialog/contextStore.test.ts
@@ -1,4 +1,9 @@
-import { appendToSessionHistory, getSessionHistory } from "./contextStore";
+import {
+  appendToSessionHistory,
+  evictExpiredSessionHistories,
+  getSessionHistory,
+  sessionHistoryCount,
+} from "./contextStore";
 
 describe("contextStore", () => {
   it("同一sessionIdでも別tenantの履歴は取得できない", () => {
@@ -128,5 +133,78 @@ describe("contextStore", () => {
         { role: "user", content: "tenant=A, session=other-session の発話" },
       ]);
     });
+  });
+});
+
+describe("contextStore — TTLによるエントリ掃き出し", () => {
+  const TTL_MS = 30 * 60 * 1000;
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("最終アクセスからTTLを超過したエントリは掃き出される", () => {
+    const t0 = Date.now();
+    const nowSpy = jest.spyOn(Date, "now").mockReturnValue(t0);
+
+    appendToSessionHistory("tenant-ttl-expire", "s1", [
+      { role: "user", content: "古い発話" },
+    ]);
+    expect(getSessionHistory("tenant-ttl-expire", "s1")).toHaveLength(1);
+    expect(sessionHistoryCount()).toBeGreaterThanOrEqual(1);
+
+    nowSpy.mockReturnValue(t0 + TTL_MS + 1);
+    expect(evictExpiredSessionHistories()).toBeGreaterThanOrEqual(1);
+    expect(getSessionHistory("tenant-ttl-expire", "s1")).toEqual([]);
+  });
+
+  it("TTLちょうどでは掃き出さない（超過して初めて削除される境界）", () => {
+    const t0 = Date.now();
+    const nowSpy = jest.spyOn(Date, "now").mockReturnValue(t0);
+
+    appendToSessionHistory("tenant-ttl-boundary", "s1", [
+      { role: "user", content: "境界値の発話" },
+    ]);
+
+    nowSpy.mockReturnValue(t0 + TTL_MS); // ちょうど TTL（> ではないので残る）
+    evictExpiredSessionHistories();
+    expect(getSessionHistory("tenant-ttl-boundary", "s1")).toHaveLength(1);
+  });
+
+  it("【最重要】読み取りでも最終アクセス時刻が更新され、継続中の会話は掃き出されない", () => {
+    // これが壊れると「会話中のユーザーの履歴がTTLで突然消える」= 修正の目的を裏切る。
+    const t0 = Date.now();
+    const nowSpy = jest.spyOn(Date, "now").mockReturnValue(t0);
+
+    appendToSessionHistory("tenant-ttl-alive", "s1", [
+      { role: "user", content: "継続中の発話" },
+    ]);
+
+    // TTLの9割時点で「読み取りだけ」行う（ユーザーが会話を続けている状況）
+    nowSpy.mockReturnValue(t0 + TTL_MS * 0.9);
+    expect(getSessionHistory("tenant-ttl-alive", "s1")).toHaveLength(1);
+
+    // 最初の書き込みからは TTL を超過しているが、直近の読み取りからは超過していない
+    nowSpy.mockReturnValue(t0 + TTL_MS * 0.9 * 2);
+    evictExpiredSessionHistories();
+
+    expect(getSessionHistory("tenant-ttl-alive", "s1")).toEqual([
+      { role: "user", content: "継続中の発話" },
+    ]);
+  });
+
+  it("定期スイープの setInterval は unref されている（プロセス終了/jestをブロックしない）", () => {
+    jest.resetModules();
+    const unref = jest.fn();
+    const setIntervalSpy = jest
+      .spyOn(global, "setInterval")
+      .mockReturnValue({ unref } as unknown as NodeJS.Timeout);
+
+    jest.isolateModules(() => {
+      require("./contextStore");
+    });
+
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), TTL_MS);
+    expect(unref).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/agent/dialog/contextStore.ts
+++ b/src/agent/dialog/contextStore.ts
@@ -6,16 +6,33 @@ import { buildTenantSessionKey } from './sessionKey'
 type SessionId = string
 type TenantId = string
 
+interface SessionEntry {
+  messages: DialogMessage[]
+  lastAccessedAt: number
+}
+
 // MVP: インメモリのセッションストア。
 // 将来 Redis 等に差し替えられるように、I/F はできるだけ単純に保つ。
-// キー生成は sessionKey.ts に一本化（salesContextStore.ts と共有）。
-const sessions = new Map<string, DialogMessage[]>()
+// キー生成は sessionKey.ts に一本化（salesContextStore.ts / flowContextStore.ts と共有）。
+const sessions = new Map<string, SessionEntry>()
 
 // 1 セッションあたり保持する最大メッセージ数（安全のため軽く絞っておく）
 const MAX_HISTORY_LENGTH = 20
 
+// widget は会話IDをページロードごとに新規発行する（public/widget.js）ため、
+// エントリ数はページビュー数とともに単調増加する。1件あたりは MAX_HISTORY_LENGTH で
+// 頭打ちでも、件数に上限が無いと max_memory_restart(512M) による PM2 再起動を招き、
+// 進行中の全会話が文脈を失う（dialogAgent はこのストアを唯一の履歴ソースにしている）。
+// スイープ方式・TTL値は middleware/inputSanitizer.ts, middleware/topicGuard.ts と揃える。
+const SESSION_ENTRY_TTL_MS = 30 * 60 * 1000 // 30 minutes
+
 export function getSessionHistory(tenantId: TenantId, sessionId: SessionId): DialogMessage[] {
-  return sessions.get(buildTenantSessionKey(tenantId, sessionId)) ?? []
+  const entry = sessions.get(buildTenantSessionKey(tenantId, sessionId))
+  if (!entry) return []
+  // 継続中の会話が TTL で消えないよう、読み取りでも最終アクセス時刻を更新する。
+  // dialogAgent は毎ターン getSessionHistory を呼ぶため、これが会話の生存signalになる。
+  entry.lastAccessedAt = Date.now()
+  return entry.messages
 }
 
 
@@ -25,15 +42,39 @@ export function appendToSessionHistory(
   messages: DialogMessage[],
 ): DialogMessage[] {
   const key = buildTenantSessionKey(tenantId, sessionId)
-  const prev = sessions.get(key) ?? []
+  const prev = sessions.get(key)?.messages ?? []
   const merged = [...prev, ...messages]
 
-  if (merged.length > MAX_HISTORY_LENGTH) {
-    const trimmed = merged.slice(merged.length - MAX_HISTORY_LENGTH)
-    sessions.set(key, trimmed)
-    return trimmed
-  }
+  const next =
+    merged.length > MAX_HISTORY_LENGTH
+      ? merged.slice(merged.length - MAX_HISTORY_LENGTH)
+      : merged
 
-  sessions.set(key, merged)
-  return merged
+  sessions.set(key, { messages: next, lastAccessedAt: Date.now() })
+  return next
 }
+
+/**
+ * TTL を超過したエントリを掃き出す。戻り値は削除件数（監視・テスト用）。
+ * inputSanitizer.evictExpiredSessions と同じ責務・同じ作法。
+ */
+export function evictExpiredSessionHistories(): number {
+  const now = Date.now()
+  let evicted = 0
+  for (const [key, entry] of sessions.entries()) {
+    if (now - entry.lastAccessedAt > SESSION_ENTRY_TTL_MS) {
+      sessions.delete(key)
+      evicted++
+    }
+  }
+  return evicted
+}
+
+/** 現在保持しているセッション数（メモリ蓄積の観測用）。 */
+export function sessionHistoryCount(): number {
+  return sessions.size
+}
+
+// Set up periodic eviction at module level
+// .unref() は必須（プロセス終了 / jest をブロックしないため）
+setInterval(evictExpiredSessionHistories, SESSION_ENTRY_TTL_MS).unref?.()

--- a/src/agent/dialog/flowContextStore.ts
+++ b/src/agent/dialog/flowContextStore.ts
@@ -1,6 +1,7 @@
 // src/agent/dialog/flowContextStore.ts
 
 import crypto from "crypto";
+import { buildTenantSessionKey } from "./sessionKey";
 
 export type FlowState = "clarify" | "answer" | "confirm" | "terminal";
 
@@ -40,10 +41,24 @@ export interface FlowSessionKey {
   conversationId: string;
 }
 
-const toInternalKey = (key: FlowSessionKey): string =>
-  `${key.tenantId}::${key.conversationId}`;
+/**
+ * TTL 掃き出し用の最終アクセス時刻を内部だけで持つ。
+ * 公開型 FlowSessionMeta の形は変えない（snapshot/peek の呼び出し側を壊さないため）。
+ */
+interface FlowSessionEntry {
+  meta: FlowSessionMeta;
+  lastAccessedAt: number;
+}
 
-const sessionStore = new Map<string, FlowSessionMeta>();
+// キー生成は sessionKey.ts に一本化（contextStore.ts / salesContextStore.ts と共有）。
+// conversationId は他ストアの sessionId と同じ役割。
+const toInternalKey = (key: FlowSessionKey): string =>
+  buildTenantSessionKey(key.tenantId, key.conversationId);
+
+const sessionStore = new Map<string, FlowSessionEntry>();
+
+// contextStore.ts と同じ理由・同じ値。middleware 側の既存スイープとも揃える。
+const SESSION_ENTRY_TTL_MS = 30 * 60 * 1000; // 30 minutes
 
 export const defaultFlowBudgets = (): FlowBudgets => ({
   maxTurnsPerSession: Number(process.env.PHASE22_MAX_TURNS ?? 12),
@@ -54,8 +69,13 @@ export const defaultFlowBudgets = (): FlowBudgets => ({
 });
 
 export function getOrInitFlowSessionMeta(key: FlowSessionKey): FlowSessionMeta {
-  const existing = sessionStore.get(toInternalKey(key));
-  if (existing) return existing;
+  const internalKey = toInternalKey(key);
+  const existing = sessionStore.get(internalKey);
+  if (existing) {
+    // 毎ターン呼ばれる経路なので、ここが flow セッションの生存signalになる。
+    existing.lastAccessedAt = Date.now();
+    return existing.meta;
+  }
 
   const now = new Date().toISOString();
   const init: FlowSessionMeta = {
@@ -67,22 +87,24 @@ export function getOrInitFlowSessionMeta(key: FlowSessionKey): FlowSessionMeta {
     recentStates: [],
     lastUpdatedAt: now,
   };
-  sessionStore.set(toInternalKey(key), init);
+  sessionStore.set(internalKey, { meta: init, lastAccessedAt: Date.now() });
   return init;
 }
 
 // Phase47-B: 副作用なしの読み取り専用 getter（reward signal 用）
+// TTL の最終アクセス時刻も更新しない（同一ターン内で getOrInit が既に更新しており、
+// 生存判定はそちらに委ねる。ここで更新すると「副作用なし」の契約が壊れる）。
 export function peekFlowSessionMeta(
   key: FlowSessionKey
 ): FlowSessionMeta | undefined {
-  return sessionStore.get(toInternalKey(key));
+  return sessionStore.get(toInternalKey(key))?.meta;
 }
 
 export function setFlowSessionMeta(
   key: FlowSessionKey,
   meta: FlowSessionMeta
 ): FlowSessionMeta {
-  sessionStore.set(toInternalKey(key), meta);
+  sessionStore.set(toInternalKey(key), { meta, lastAccessedAt: Date.now() });
   return meta;
 }
 
@@ -91,9 +113,35 @@ export function resetFlowSessionMeta(key: FlowSessionKey): void {
 }
 
 // Phase47-D: heartbeat 集計用の読み取り専用 snapshot（副作用なし）
+// 全件を走査するため、ここで最終アクセス時刻を更新すると全エントリが
+// 永久に TTL を逃れてしまう。意図的に更新しない。
 export function snapshotFlowSessionMetas(): FlowSessionMeta[] {
-  return Array.from(sessionStore.values());
+  return Array.from(sessionStore.values(), (entry) => entry.meta);
 }
+
+/**
+ * TTL を超過したエントリを掃き出す。戻り値は削除件数（監視・テスト用）。
+ * resetFlowSessionMeta は本番の呼び出し元が無く、実質この掃き出しが唯一の回収経路。
+ */
+export function evictExpiredFlowSessionMetas(): number {
+  const now = Date.now();
+  let evicted = 0;
+  for (const [key, entry] of sessionStore.entries()) {
+    if (now - entry.lastAccessedAt > SESSION_ENTRY_TTL_MS) {
+      sessionStore.delete(key);
+      evicted++;
+    }
+  }
+  return evicted;
+}
+
+/** 現在保持しているセッション数（メモリ蓄積の観測用）。 */
+export function flowSessionMetaCount(): number {
+  return sessionStore.size;
+}
+
+// .unref() は必須（プロセス終了 / jest をブロックしないため）
+setInterval(evictExpiredFlowSessionMetas, SESSION_ENTRY_TTL_MS).unref?.();
 
 /**
  * Clarify の「同一質問繰り返し」検知用シグネチャ。

--- a/src/agent/dialog/salesContextStore.test.ts
+++ b/src/agent/dialog/salesContextStore.test.ts
@@ -1,7 +1,9 @@
 import {
   clearAllSalesSessionMeta,
   clearSalesSessionMeta,
+  evictExpiredSalesSessionMetas,
   getSalesSessionMeta,
+  salesSessionMetaCount,
   setSalesSessionMeta,
   updateSalesSessionMeta,
   type SalesSessionKey,
@@ -145,5 +147,68 @@ describe("salesContextStore", () => {
         { role: "user", content: "会話履歴側の発話" },
       ]);
     });
+  });
+});
+
+describe("salesContextStore — TTLによるエントリ掃き出し", () => {
+  const TTL_MS = 30 * 60 * 1000;
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("最終アクセスからTTLを超過したエントリは掃き出される", () => {
+    const t0 = Date.now();
+    const nowSpy = jest.spyOn(Date, "now").mockReturnValue(t0);
+    const k: SalesSessionKey = { tenantId: "t-ttl-expire", sessionId: "s1" };
+
+    setSalesSessionMeta(k, { currentStage: "propose" as any });
+    expect(getSalesSessionMeta(k)).toBeDefined();
+    expect(salesSessionMetaCount()).toBeGreaterThanOrEqual(1);
+
+    nowSpy.mockReturnValue(t0 + TTL_MS + 1);
+    expect(evictExpiredSalesSessionMetas()).toBeGreaterThanOrEqual(1);
+    expect(getSalesSessionMeta(k)).toBeUndefined();
+  });
+
+  it("【最重要】読み取りでも最終アクセス時刻が更新され、継続中の会話は掃き出されない", () => {
+    const t0 = Date.now();
+    const nowSpy = jest.spyOn(Date, "now").mockReturnValue(t0);
+    const k: SalesSessionKey = { tenantId: "t-ttl-alive", sessionId: "s1" };
+
+    setSalesSessionMeta(k, { currentStage: "propose" as any });
+
+    // TTLの9割時点で「読み取りだけ」行う
+    nowSpy.mockReturnValue(t0 + TTL_MS * 0.9);
+    expect(getSalesSessionMeta(k)).toBeDefined();
+
+    // 書き込みからはTTL超過だが、直近の読み取りからは超過していない
+    nowSpy.mockReturnValue(t0 + TTL_MS * 0.9 * 2);
+    evictExpiredSalesSessionMetas();
+    expect(getSalesSessionMeta(k)?.currentStage).toBe("propose");
+  });
+
+  it("定期スイープの setInterval は unref されている", () => {
+    jest.resetModules();
+    const unref = jest.fn();
+    const setIntervalSpy = jest
+      .spyOn(global, "setInterval")
+      .mockReturnValue({ unref } as unknown as NodeJS.Timeout);
+
+    jest.isolateModules(() => {
+      require("./salesContextStore");
+    });
+
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), TTL_MS);
+    expect(unref).toHaveBeenCalledTimes(1);
+  });
+
+  it("公開型 SalesSessionMeta に内部のTTL用フィールドが漏れていない", () => {
+    // lastAccessedAt は内部エントリ側だけが持つ。呼び出し側の toEqual を壊さないこと。
+    clearAllSalesSessionMeta();
+    const k: SalesSessionKey = { tenantId: "t-shape", sessionId: "s1" };
+    const saved = setSalesSessionMeta(k, { currentStage: "propose" as any });
+    expect(getSalesSessionMeta(k)).toEqual(saved);
+    expect(Object.keys(saved)).not.toContain("lastAccessedAt");
   });
 });

--- a/src/agent/dialog/salesContextStore.ts
+++ b/src/agent/dialog/salesContextStore.ts
@@ -13,15 +13,32 @@ export interface SalesSessionKey {
   sessionId: string;
 }
 
+/**
+ * TTL 掃き出し用の最終アクセス時刻を内部だけで持つ。
+ * `lastUpdatedAt`(ISO文字列, 業務上の更新時刻) とは別物で、公開型
+ * SalesSessionMeta の形は変えない（呼び出し側の toEqual 等を壊さないため）。
+ */
+interface SalesSessionEntry {
+  meta: SalesSessionMeta;
+  lastAccessedAt: number;
+}
+
 const toInternalKey = (key: SalesSessionKey): string =>
   buildTenantSessionKey(key.tenantId, key.sessionId);
 
-const sessionStore = new Map<string, SalesSessionMeta>();
+const sessionStore = new Map<string, SalesSessionEntry>();
+
+// contextStore.ts と同じ理由・同じ値。middleware 側の既存スイープとも揃える。
+const SESSION_ENTRY_TTL_MS = 30 * 60 * 1000; // 30 minutes
 
 export function getSalesSessionMeta(
   key: SalesSessionKey
 ): SalesSessionMeta | undefined {
-  return sessionStore.get(toInternalKey(key));
+  const entry = sessionStore.get(toInternalKey(key));
+  if (!entry) return undefined;
+  // 継続中の会話が TTL で消えないよう、読み取りでも最終アクセス時刻を更新する。
+  entry.lastAccessedAt = Date.now();
+  return entry.meta;
 }
 
 export function setSalesSessionMeta(
@@ -35,7 +52,10 @@ export function setSalesSessionMeta(
     personaTags: meta.personaTags,
     lastUpdatedAt: now,
   };
-  sessionStore.set(toInternalKey(key), record);
+  sessionStore.set(toInternalKey(key), {
+    meta: record,
+    lastAccessedAt: Date.now(),
+  });
   return record;
 }
 
@@ -44,7 +64,7 @@ export function updateSalesSessionMeta(
   patch: Partial<Omit<SalesSessionMeta, "lastUpdatedAt">>
 ): SalesSessionMeta {
   const internalKey = toInternalKey(key);
-  const existing = sessionStore.get(internalKey);
+  const existing = sessionStore.get(internalKey)?.meta;
 
   const currentStage: SalesStage =
     patch.currentStage ?? existing?.currentStage ?? ("clarify" as SalesStage);
@@ -56,7 +76,7 @@ export function updateSalesSessionMeta(
     lastUpdatedAt: new Date().toISOString(),
   };
 
-  sessionStore.set(internalKey, record);
+  sessionStore.set(internalKey, { meta: record, lastAccessedAt: Date.now() });
   return record;
 }
 
@@ -67,3 +87,27 @@ export function clearSalesSessionMeta(key: SalesSessionKey): void {
 export function clearAllSalesSessionMeta(): void {
   sessionStore.clear();
 }
+
+/**
+ * TTL を超過したエントリを掃き出す。戻り値は削除件数（監視・テスト用）。
+ * 明示的な clear* は本番の呼び出し元が無く、実質この掃き出しが唯一の回収経路。
+ */
+export function evictExpiredSalesSessionMetas(): number {
+  const now = Date.now();
+  let evicted = 0;
+  for (const [key, entry] of sessionStore.entries()) {
+    if (now - entry.lastAccessedAt > SESSION_ENTRY_TTL_MS) {
+      sessionStore.delete(key);
+      evicted++;
+    }
+  }
+  return evicted;
+}
+
+/** 現在保持しているセッション数（メモリ蓄積の観測用）。 */
+export function salesSessionMetaCount(): number {
+  return sessionStore.size;
+}
+
+// .unref() は必須（プロセス終了 / jest をブロックしないため）
+setInterval(evictExpiredSalesSessionMetas, SESSION_ENTRY_TTL_MS).unref?.();

--- a/src/agent/dialog/sessionKey.test.ts
+++ b/src/agent/dialog/sessionKey.test.ts
@@ -17,3 +17,62 @@ describe("buildTenantSessionKey", () => {
     expect(buildTenantSessionKey("tenant:demo", "s1")).toBe("tenant:demo::s1");
   });
 });
+
+describe("キー生成の一本化 — 3ストアすべてが buildTenantSessionKey を経由する", () => {
+  // contextStore / salesContextStore は PR #819 で統一済み。
+  // flowContextStore だけが生のテンプレートリテラルのまま取り残されており
+  // （CLAUDE.md禁止事項6「同じ関心事を複製したまま片方だけ直す」の再発）、
+  // ここで3つ目も同じ不変条件に乗ったことを固定する。
+  it("flowContextStore: tenantIdに`::`が含まれる場合は例外を投げる", () => {
+    const {
+      getOrInitFlowSessionMeta,
+      peekFlowSessionMeta,
+      setFlowSessionMeta,
+      resetFlowSessionMeta,
+    } = require("./flowContextStore");
+
+    const badKey = { tenantId: "A::B", conversationId: "C" };
+
+    expect(() => getOrInitFlowSessionMeta(badKey)).toThrow(
+      /tenantId must not contain/
+    );
+    expect(() => peekFlowSessionMeta(badKey)).toThrow(
+      /tenantId must not contain/
+    );
+    expect(() => resetFlowSessionMeta(badKey)).toThrow(
+      /tenantId must not contain/
+    );
+    expect(() =>
+      setFlowSessionMeta(badKey, {
+        state: "answer",
+        turnIndex: 0,
+        sameStateRepeats: 0,
+        clarifyRepeats: 0,
+        confirmRepeats: 0,
+        recentStates: [],
+        lastUpdatedAt: new Date().toISOString(),
+      })
+    ).toThrow(/tenantId must not contain/);
+  });
+
+  it("flowContextStore: 通常のtenantId/conversationIdは従来どおり動作し、テナント間で分離される", () => {
+    const {
+      getOrInitFlowSessionMeta,
+      setFlowSessionMeta,
+      peekFlowSessionMeta,
+    } = require("./flowContextStore");
+
+    const a = { tenantId: "tenant-a", conversationId: "shared-conv" };
+    const b = { tenantId: "tenant-b", conversationId: "shared-conv" };
+
+    const metaA = getOrInitFlowSessionMeta(a);
+    setFlowSessionMeta(a, { ...metaA, state: "confirm", turnIndex: 3 });
+    getOrInitFlowSessionMeta(b);
+
+    expect(peekFlowSessionMeta(a)?.state).toBe("confirm");
+    expect(peekFlowSessionMeta(a)?.turnIndex).toBe(3);
+    // 同一 conversationId でも別テナントの状態は汚染されない
+    expect(peekFlowSessionMeta(b)?.state).toBe("answer");
+    expect(peekFlowSessionMeta(b)?.turnIndex).toBe(0);
+  });
+});

--- a/src/agent/orchestrator/langGraphOrchestrator.phase22.test.ts
+++ b/src/agent/orchestrator/langGraphOrchestrator.phase22.test.ts
@@ -54,3 +54,97 @@ describe("Phase22 flow control (must reach terminal)", () => {
     expect(out2.text).toContain("安全のため会話を終了");
   });
 });
+
+describe("flowContextStore — TTLによるエントリ掃き出し", () => {
+  const TTL_MS = 30 * 60 * 1000;
+  // flow セッションもインメモリMapで単調増加する（resetFlowSessionMeta の本番呼び出し元は
+  // 存在せず、TTLスイープが実質唯一の回収経路）。contextStore と同じ作法で揃える。
+  const {
+    getOrInitFlowSessionMeta,
+    setFlowSessionMeta,
+    peekFlowSessionMeta,
+    snapshotFlowSessionMetas,
+    evictExpiredFlowSessionMetas,
+    flowSessionMetaCount,
+  } = require("../dialog/flowContextStore");
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("最終アクセスからTTLを超過したエントリは掃き出される", () => {
+    const t0 = Date.now();
+    const nowSpy = jest.spyOn(Date, "now").mockReturnValue(t0);
+    const key = { tenantId: "t-flow-expire", conversationId: "c1" };
+
+    getOrInitFlowSessionMeta(key);
+    expect(peekFlowSessionMeta(key)).toBeDefined();
+    expect(flowSessionMetaCount()).toBeGreaterThanOrEqual(1);
+
+    nowSpy.mockReturnValue(t0 + TTL_MS + 1);
+    expect(evictExpiredFlowSessionMetas()).toBeGreaterThanOrEqual(1);
+    expect(peekFlowSessionMeta(key)).toBeUndefined();
+  });
+
+  it("【最重要】毎ターンの getOrInitFlowSessionMeta が生存signalになり、継続中のフローは掃き出されない", () => {
+    const t0 = Date.now();
+    const nowSpy = jest.spyOn(Date, "now").mockReturnValue(t0);
+    const key = { tenantId: "t-flow-alive", conversationId: "c1" };
+
+    getOrInitFlowSessionMeta(key);
+
+    // TTLの9割時点で次のターンが来る（langGraphOrchestrator は毎ターンこれを呼ぶ）
+    nowSpy.mockReturnValue(t0 + TTL_MS * 0.9);
+    expect(getOrInitFlowSessionMeta(key)).toBeDefined();
+
+    // 初回作成からはTTL超過だが、直近のターンからは超過していない
+    nowSpy.mockReturnValue(t0 + TTL_MS * 0.9 * 2);
+    evictExpiredFlowSessionMetas();
+    expect(peekFlowSessionMeta(key)).toBeDefined();
+  });
+
+  it("snapshotFlowSessionMetas は最終アクセス時刻を更新しない（全件を永久に延命させない）", () => {
+    // heartbeat は30分ごとに全件を走査する。ここで延命してしまうと
+    // TTLが実質無効化され、修正の意味が消える。
+    const t0 = Date.now();
+    const nowSpy = jest.spyOn(Date, "now").mockReturnValue(t0);
+    const key = { tenantId: "t-flow-snapshot", conversationId: "c1" };
+
+    getOrInitFlowSessionMeta(key);
+
+    // TTLの9割時点で heartbeat 相当の全件スナップショットを取る
+    nowSpy.mockReturnValue(t0 + TTL_MS * 0.9);
+    snapshotFlowSessionMetas();
+
+    // スナップショットは生存signalではないので、初回作成からTTL超過で掃き出される
+    nowSpy.mockReturnValue(t0 + TTL_MS + 1);
+    evictExpiredFlowSessionMetas();
+    expect(peekFlowSessionMeta(key)).toBeUndefined();
+  });
+
+  it("公開型 FlowSessionMeta に内部のTTL用フィールドが漏れていない", () => {
+    const key = { tenantId: "t-flow-shape", conversationId: "c1" };
+    const meta = getOrInitFlowSessionMeta(key);
+    expect(Object.keys(meta)).not.toContain("lastAccessedAt");
+    expect(snapshotFlowSessionMetas().every((m: Record<string, unknown>) =>
+      !Object.prototype.hasOwnProperty.call(m, "lastAccessedAt")
+    )).toBe(true);
+    setFlowSessionMeta(key, { ...meta, state: "terminal" });
+    expect(peekFlowSessionMeta(key)?.state).toBe("terminal");
+  });
+
+  it("定期スイープの setInterval は unref されている", () => {
+    jest.resetModules();
+    const unref = jest.fn();
+    const setIntervalSpy = jest
+      .spyOn(global, "setInterval")
+      .mockReturnValue({ unref } as unknown as NodeJS.Timeout);
+
+    jest.isolateModules(() => {
+      require("../dialog/flowContextStore");
+    });
+
+    expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), TTL_MS);
+    expect(unref).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## 背景

インメモリのセッションストア**3つ**に削除経路が無く、エントリ数が単調増加していた。

| ストア | 削除経路の現状 |
|---|---|
| `contextStore.ts` | 一切無い |
| `salesContextStore.ts` | `clear*` はあるが**本番の呼び出し元がゼロ**（テストのみ） |
| `flowContextStore.ts` | `reset` も**本番の呼び出し元がゼロ**（テストのみ） |

widget は会話IDを**ページロードごとに新規発行**する（`public/widget.js`）ため、エントリ数はページビュー数とともに増え続ける。1件は `MAX_HISTORY_LENGTH=20` で頭打ちでも、**件数に上限が無い**。

### 顕在化のしかた（本修正の動機）

`ecosystem.config.cjs` は `max_memory_restart: "512M"` + `--max-old-space-size=512`。
→ **OOM クラッシュではなく PM2 の定期再起動**として出る。

そして `dialogAgent.ts:56` は `getSessionHistory` を**唯一の履歴ソース**にしており、widget が送る `input.history` はフォールバックに使われない。
→ **再起動の瞬間、進行中の全会話が文脈を失う。ユーザーからは「突然話が通じなくなる」ように見える。**

傍証: `src/index.ts:770` の「Phase70K: pipelineQueue self-heal — PM2再起動で stuck した job を自動復旧」というコメントは、PM2 再起動が既に常態化していることを示す。

## 変更内容

### 1. TTL スイープ（3ストア共通）

`middleware/inputSanitizer.ts:37-49` と `middleware/topicGuard.ts:23-30` に**既にあるパターンをそのまま踏襲**（TTL値30分・スイープ方式・`.unref()` まで揃えた）。新規発明はしていない。

- 値に内部フィールド `lastAccessedAt` を持たせる（**公開型 `SalesSessionMeta` / `FlowSessionMeta` の形は変えない** — 呼び出し側の `toEqual` を壊さないため）
- **読み取り・書き込みの両方**で `lastAccessedAt` を更新
- `evictExpired*()` を export（削除件数を返す）
- `*Count()` を export（メモリ蓄積の観測用）
- `setInterval(...).unref?.()` をモジュール末尾に

**読み取りでも更新するのが要点。** 会話継続中のセッションが TTL で消えたら本末転倒になる。

意図的に**更新しない**もの:

| 関数 | 理由 |
|---|---|
| `peekFlowSessionMeta` | 「副作用なし」の既存契約を守る（同一ターン内で `getOrInit` が既に更新済み） |
| `snapshotFlowSessionMetas` | 全件走査のため、更新すると**全エントリが永久に TTL を逃れる**（heartbeat は30分ごとに全件を見る） |

### 2. flowContextStore のキー生成統一

生のテンプレートリテラルのままだった `toInternalKey` を `sessionKey.ts` の `buildTenantSessionKey` に統一。

PR #819 で `contextStore` / `salesContextStore` は統一済みだったが**3つ目が取り残されており**、CLAUDE.md 禁止事項6「同じ関心事を複製したまま片方だけ直す」の再発になっていた。これで tenantId へのコロン混入検証が3ストアすべてに効く。

## テスト

各ストアで固定した観点:
- TTL 超過での掃き出し
- 境界（**ちょうど TTL では消えない**、超過して初めて削除）
- **継続中セッションの延命**（読み取りが生存signalになること）
- `.unref()` が呼ばれていること
- 公開型に内部フィールドが漏れていないこと
- テナント分離（同一 conversationId でも別テナントは別エントリ）

### ミューテーション検証（4件、いずれも該当テストのみが失敗することを実測）

| 改変 | 結果 |
|---|---|
| `contextStore` の読み取り側 `lastAccessedAt` 更新を削除 | 【最重要】1件のみ失敗 ✅ |
| `salesContextStore` の同上 | 【最重要】1件のみ失敗 ✅ |
| `flowContextStore` の `getOrInit` 側更新を削除 | 【最重要】1件のみ失敗 ✅ |
| `snapshotFlowSessionMetas` が更新するよう改変 | snapshot 不変条件の1件のみ失敗 ✅ |

### 結果

- 関連 **10スイート / 96テスト pass**
- `pnpm typecheck` 0エラー
- `oxlint` 変更7ファイルすべて0警告（既存の警告は無関係ファイルのみ）

## スコープ外（意図的に対応せず）

- **PM2 クラスターモード対応**: 現在 `instances: 1` / `exec_mode: "fork"` のため不整合は発生しない。`instances` を増やす際は3ストア＋rate-limitバケット＋テナントレジストリが同時に壊れるため、スケールアウトの前提条件として別途ドキュメント化が必要。
- **ストアサイズの監視出力**: OpenClaw Heartbeat への相乗りを検討したが、`startOpenClawHeartbeat()` が `OPENCLAW_ENABLED === "true"` でゲートされており（`.env.example` の既定は `false`）、かつ `evaluateHeartbeat()` は `total === 0` で早期 return するため、**既定では何も出力されない**。相乗り先として不適と判断。代わりに `evictExpired*()` が削除件数を返し `*Count()` を export したので、監視方式が決まり次第すぐ配線できる状態にしてある。

## 補足

`flowContextStore` には既存のテストファイルが無いが、「新規ファイルを作らない」制約に従い、既存テストファイルに追記した:
- キー生成の統一 → `sessionKey.test.ts`（共有キービルダーのテストファイル）
- TTL / `.unref()` → `langGraphOrchestrator.phase22.test.ts`（flow セッション状態を扱う既存テスト）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgCQYt8UMPgm4HNVu7nv7z
