### PR TITLE
[SEC][P0] evaluateSessionの多重発火を修正（KPI汚染・Gemini二重呼び出し）

### DIFF
--- a/docs/DEPLOY_CHECKLIST.md
+++ b/docs/DEPLOY_CHECKLIST.md
@@ -145,6 +145,8 @@ VITE_SUPABASE_ANON_KEY=YOUR_ANON_KEY
 | `src/api/conversion/migration_aaas_source.sql` | conversion_attributions の source CHECK に aaas_site_change 追加 + tenants.aaas_client_id 追加（Asana GID 1215614330355126） | ✅ (2026-08-16 実機確認) |
 | `src/lib/billing/migration_stripe_webhook_events.sql` | stripe_webhook_events テーブル新規作成（Stripe webhook の event.id 冪等化。同一イベント再送での二重処理を防ぐ） | ⬜ 未適用 |
 | `src/lib/billing/migration_stripe_webhook_events.sql` | 同ファイル: `completed_at` カラム追加（2状態管理。ハンドラ失敗後の再送で副作用が永久にスキップされる問題の解消）。**テーブル作成分を先に適用済みの環境でも、この列のために再実行が必要** | ⬜ 未適用 |
+| `src/migrations/phase75_conversation_evaluations_unique.sql` | 重複評価行の削除 + `UNIQUE(tenant_id, session_id)` 追加。judge の `ON CONFLICT` がターゲット無しで実質no-opだったため同一セッションの評価が重複し、KPI平均が下振れしていた。**★migration → デプロイの順。逆順は評価INSERTが全件失敗** | ⬜ 未適用 |
+| `src/migrations/phase75_tuning_rules_unique.sql` | 重複ルールの削除 + `UNIQUE(tenant_id, trigger_pattern)` 追加。同上（`evaluationAnalyzer` がコメントで謳っていた一意性がDB側に無かった）。**★migration → デプロイの順** | ⬜ 未適用 |
 
 ### Phase A Day 2 migration 実行手順
 
@@ -303,6 +305,62 @@ ssh root@65.108.159.161 'cd /opt/rajiuce && psql "$(grep -m1 ^DATABASE_URL= .env
 同一イベントを手動再送すると 2回目は `{"received":true,"duplicate":true}` になる。
 
 **ロールバック**: 新規テーブルのみで既存テーブルへの変更が無いため、コードを戻せばテーブルは無害な残骸になる。
+
+### phase75 judge 一意制約 migration 実行手順
+
+> **未適用。** judge 評価の多重登録を止めるために必要。
+> **★これまでの migration と適用順序が逆。「migration → デプロイ」で当てること。**
+
+`judgeEvaluator.ts` / `evaluationAnalyzer.ts` の INSERT は
+`ON CONFLICT (tenant_id, session_id)` / `ON CONFLICT (tenant_id, trigger_pattern)` と
+**ターゲットを明示**するようになった。対応する一意インデックスが無い状態でこのコードが動くと
+Postgres が `there is no unique or exclusion constraint matching the ON CONFLICT specification`
+を返し、**評価の保存と提案ルールの保存が全件失敗する**（チャット自体は止まらないが、
+Judge 評価機能が無言で死ぬ。管理画面の手動トリガーは 500）。
+
+**先に migration を当てられる。** この2本は既存テーブルにしか触れず、新コードに依存しないため、
+rsync を待たずローカルから stdin で流し込める。中間状態を作らずに済むので、この順で当てること。
+
+```bash
+# 1. バックアップ (必須。重複削除は元に戻せない)
+ssh root@65.108.159.161 'cd /opt/rajiuce && pg_dump "$(grep -m1 ^DATABASE_URL= .env | cut -d= -f2-)" > /opt/backups/pre_phase75_judge_unique_$(date +%Y%m%d_%H%M).sql'
+
+# 2. 適用前の確認 — 重複がどれだけあるか / 消える行に人の判断が乗っていないか
+#    ★各SQLファイル冒頭の「1. 事前確認」のクエリを実行し、結果を目視してから 3 へ進む。
+#      特に「削除対象に承認済みルールが含まれていないか」は 0 件であることを確認する。
+#      0 件でない場合は、そのまま流さず残す行の優先順位を見直すこと。
+ssh root@65.108.159.161 'cd /opt/rajiuce && psql "$(grep -m1 ^DATABASE_URL= .env | cut -d= -f2-)" -c "
+  SELECT tenant_id, session_id, COUNT(*) AS dup FROM conversation_evaluations
+  GROUP BY tenant_id, session_id HAVING COUNT(*) > 1 ORDER BY dup DESC LIMIT 20;"'
+
+# 3. Migration 実行 (デプロイ前。ローカルのファイルを stdin で流す)
+ssh root@65.108.159.161 'cd /opt/rajiuce && psql "$(grep -m1 ^DATABASE_URL= .env | cut -d= -f2-)"' \
+  < src/migrations/phase75_conversation_evaluations_unique.sql
+ssh root@65.108.159.161 'cd /opt/rajiuce && psql "$(grep -m1 ^DATABASE_URL= .env | cut -d= -f2-)"' \
+  < src/migrations/phase75_tuning_rules_unique.sql
+
+# 4. 確認 — 一意インデックスが2本とも表示されること
+#    (SQL内にシングルクォートを持ち込まないよう \d で確認する)
+ssh root@65.108.159.161 'cd /opt/rajiuce && psql "$(grep -m1 ^DATABASE_URL= .env | cut -d= -f2-)" -c "\d conversation_evaluations" -c "\d tuning_rules" | grep -E "uniq_conv_eval_session|uniq_tuning_rules_tenant_trigger"'
+
+# 5. デプロイ
+bash SCRIPTS/deploy-vps.sh
+```
+
+**動作確認**: デプロイ後、`JUDGE_AUTO_EVALUATE=true` の状態で会話を1本終端まで進め、
+`conversation_evaluations` に**1行だけ**入ること。ターン予算(既定12)を超えて会話を続けても
+行が増えないこと（従来は1ターンごとに増えていた）。
+
+```bash
+ssh root@65.108.159.161 'cd /opt/rajiuce && psql "$(grep -m1 ^DATABASE_URL= .env | cut -d= -f2-)" -c "
+  SELECT session_id, COUNT(*) FROM conversation_evaluations
+  GROUP BY session_id ORDER BY COUNT(*) DESC LIMIT 5;"'
+```
+
+**ロールバック**: `DROP INDEX uniq_conv_eval_session;` / `DROP INDEX uniq_tuning_rules_tenant_trigger;`
+でインデックスは戻せるが、**重複削除した行は戻らない**（手順1のバックアップから復旧すること）。
+なお、インデックスを落とすなら **コードも同時に戻す**こと（ターゲット付き ON CONFLICT が
+残ったままインデックスだけ消すと INSERT が全件失敗する）。
 
 ### 本番500の解消 migration 実行手順 (2026-08-16 実測、Asana 1217530758061266)
 

--- a/src/agent/judge/evaluationAnalyzer.test.ts
+++ b/src/agent/judge/evaluationAnalyzer.test.ts
@@ -5,6 +5,9 @@ jest.mock('../llm/groqClient', () => ({
   callGroqWith429Retry: jest.fn(),
 }));
 
+import fs from 'fs';
+import path from 'path';
+
 import { callGroqWith429Retry } from '../llm/groqClient';
 import { analyzeTuningRules } from './evaluationAnalyzer';
 import type { ConversationEvaluation } from './evaluationRepository';
@@ -143,8 +146,8 @@ describe('analyzeTuningRules', () => {
     expect(insertCalls.length).toBeGreaterThan(0);
     // source='judge' が含まれていること
     expect(insertCalls[0][0]).toContain("'judge'");
-    // ON CONFLICT DO NOTHING が含まれていること
-    expect(insertCalls[0][0]).toContain('ON CONFLICT DO NOTHING');
+    // ON CONFLICT が一意制約のターゲット付きで含まれていること（詳細は test 4）
+    expect(insertCalls[0][0]).toContain('ON CONFLICT (tenant_id, trigger_pattern) DO NOTHING');
   });
 
   it('3c. INSERT文でis_activeがfalseに明示される（列を省略するとスキーマ既定DEFAULT trueで無断有効化されるため）', async () => {
@@ -178,19 +181,64 @@ describe('analyzeTuningRules', () => {
     expect(persistedEvidence).toEqual(result[0]!.evidence);
   });
 
-  it('4. 重複ルールは挿入されない（ON CONFLICT DO NOTHING）', async () => {
+  it('4. 重複ルールは挿入されない — ON CONFLICT が一意制約のターゲットを明示している', async () => {
+    // 旧テストは「SQL文字列に ON CONFLICT DO NOTHING が含まれること」しか見ていなかった。
+    // ターゲット無しの ON CONFLICT は SERIAL の id にしか反応できず実質 no-op なので、
+    // 重複が入り放題の状態でもこのテストは通り続けていた（誤った安心感）。
+    // 重複排除が本当に効く条件は「ターゲットが実在の一意制約と一致していること」なので、
+    // そこを検証する。
     const mockRepo = createMockRepo(sampleEvaluations);
     const mockPool = createMockPool();
     mockCallGroq.mockResolvedValueOnce(mockRulesResponse);
 
     await analyzeTuningRules('tenant-test', mockRepo as any, mockPool as any);
 
-    // INSERT文に ON CONFLICT DO NOTHING が含まれていること
-    const calls = (mockPool.query as jest.Mock).mock.calls;
-    for (const call of calls) {
-      if (call[0].includes('INSERT')) {
-        expect(call[0]).toContain('ON CONFLICT DO NOTHING');
-      }
+    const insertCalls = (mockPool.query as jest.Mock).mock.calls.filter(
+      (call: any[]) => typeof call[0] === 'string' && call[0].includes('INSERT INTO tuning_rules'),
+    );
+    expect(insertCalls.length).toBeGreaterThan(0);
+
+    for (const call of insertCalls) {
+      // ターゲット無しの `ON CONFLICT DO NOTHING` は退行とみなす
+      expect(call[0]).not.toMatch(/ON CONFLICT\s+DO NOTHING/);
+      expect(call[0]).toMatch(/ON CONFLICT\s*\(\s*tenant_id\s*,\s*trigger_pattern\s*\)\s*DO NOTHING/);
     }
+  });
+
+  it('5. ON CONFLICT のターゲットが phase75 マイグレーションの一意インデックスと一致している（コードとスキーマの乖離防止）', () => {
+    // ON CONFLICT のターゲットは、実在する一意制約と一致しないと Postgres が
+    // 「there is no unique or exclusion constraint matching the ON CONFLICT specification」
+    // を返して INSERT が全て失敗する。コード側だけ・スキーマ側だけを直す片肺変更を防ぐため、
+    // 両者を突き合わせる。
+    const migrationPath = path.join(__dirname, '../../migrations/phase75_tuning_rules_unique.sql');
+    const migration = fs.readFileSync(migrationPath, 'utf-8');
+
+    // マイグレーションが (tenant_id, trigger_pattern) の UNIQUE INDEX を作っていること
+    expect(migration).toMatch(
+      /CREATE UNIQUE INDEX[\s\S]*?ON tuning_rules\s*\(\s*tenant_id\s*,\s*trigger_pattern\s*\)/,
+    );
+
+    // コード側の ON CONFLICT ターゲットが同じ列の組であること
+    const analyzerSrc = fs.readFileSync(path.join(__dirname, 'evaluationAnalyzer.ts'), 'utf-8');
+    expect(analyzerSrc).toMatch(/ON CONFLICT\s*\(\s*tenant_id\s*,\s*trigger_pattern\s*\)/);
+
+    const judgeSrc = fs.readFileSync(path.join(__dirname, 'judgeEvaluator.ts'), 'utf-8');
+    expect(judgeSrc).toMatch(/ON CONFLICT\s*\(\s*tenant_id\s*,\s*trigger_pattern\s*\)/);
+  });
+
+  it('6. conversation_evaluations 側も同様にコードとスキーマが一致している', () => {
+    const migrationPath = path.join(
+      __dirname,
+      '../../migrations/phase75_conversation_evaluations_unique.sql',
+    );
+    const migration = fs.readFileSync(migrationPath, 'utf-8');
+    expect(migration).toMatch(
+      /CREATE UNIQUE INDEX[\s\S]*?ON conversation_evaluations\s*\(\s*tenant_id\s*,\s*session_id\s*\)/,
+    );
+
+    const judgeSrc = fs.readFileSync(path.join(__dirname, 'judgeEvaluator.ts'), 'utf-8');
+    expect(judgeSrc).toMatch(/ON CONFLICT\s*\(\s*tenant_id\s*,\s*session_id\s*\)\s*DO NOTHING/);
+    // ターゲット無しの退行が残っていないこと
+    expect(judgeSrc).not.toMatch(/ON CONFLICT\s+DO NOTHING/);
   });
 });

--- a/src/agent/judge/evaluationAnalyzer.ts
+++ b/src/agent/judge/evaluationAnalyzer.ts
@@ -137,7 +137,10 @@ export async function analyzeTuningRules(
     };
 
     try {
-      // ON CONFLICT DO NOTHING で重複防止（trigger_pattern と tenant_id でユニーク判定）
+      // ON CONFLICT で重複防止（trigger_pattern と tenant_id でユニーク判定）。
+      // ターゲットを明示する。無指定だと SERIAL の id にしか反応できず、
+      // このコメントが謳う一意判定が実際には一度も効いていなかった。
+      // 一意性は uniq_tuning_rules_tenant_trigger (phase75) が DB 側で保証する。
       // is_active は必ず false で入れる。列を省略するとスキーマ既定 DEFAULT true が効いて
       // 店主の承認なしに本番の応答方針へ即反映されてしまう(CLAUDE.md「指示ルールの不変ルール」)。
       await pool.query(
@@ -145,7 +148,7 @@ export async function analyzeTuningRules(
            (tenant_id, trigger_pattern, expected_behavior, priority,
             is_active, source, suggested_at, evidence)
          VALUES ($1, $2, $3, $4, false, 'judge', NOW(), $5::jsonb)
-         ON CONFLICT DO NOTHING`,
+         ON CONFLICT (tenant_id, trigger_pattern) DO NOTHING`,
         [tenantId, rule.triggerPattern, rule.expectedBehavior, 0, JSON.stringify(evidence)],
       );
 

--- a/src/agent/judge/judgeEvaluator.test.ts
+++ b/src/agent/judge/judgeEvaluator.test.ts
@@ -42,7 +42,7 @@ jest.mock('../openclaw/rewardBridge', () => ({
 import { callGeminiJudge } from '../../lib/gemini/client';
 import { getPool } from '../../lib/db';
 import { readFile } from 'fs/promises';
-import { evaluateSession, SessionNotFoundError, SessionTenantMismatchError, SessionTooShortError } from './judgeEvaluator';
+import { evaluateSession, SessionNotFoundError, SessionTenantMismatchError, SessionTooShortError, SessionAlreadyEvaluatedError } from './judgeEvaluator';
 import { sendRewardSignal } from '../openclaw/rewardBridge';
 import {
   getOrInitFlowSessionMeta,
@@ -129,7 +129,7 @@ describe('evaluateSession', () => {
       // Phase60-A: tuning_rules SELECT
       .mockResolvedValueOnce({ rows: [] })
       // INSERT conversation_evaluations
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
 
     mockCallGroq.mockResolvedValueOnce(makeGroqResponse({
       overall_score: 75,
@@ -175,7 +175,7 @@ describe('evaluateSession', () => {
       // Phase60-A: tuning_rules SELECT
       .mockResolvedValueOnce({ rows: [] })
       // INSERT conversation_evaluations
-      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 })
       // INSERT tuning_rules
       .mockResolvedValueOnce({ rows: [] });
 
@@ -217,7 +217,7 @@ describe('evaluateSession', () => {
       // Phase60-A: tuning_rules SELECT
       .mockResolvedValueOnce({ rows: [] })
       // INSERT conversation_evaluations
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
 
     mockCallGroq.mockResolvedValueOnce(makeGroqResponse({
       overall_score: 82,
@@ -290,7 +290,7 @@ describe('evaluateSession', () => {
       // Phase60-A: tuning_rules SELECT
       .mockResolvedValueOnce({ rows: [] })
       // INSERT conversation_evaluations
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
 
     mockCallGroq.mockResolvedValueOnce(makeGroqResponse({ overall_score: 70 }));
 
@@ -323,7 +323,7 @@ describe('evaluateSession', () => {
       // Phase60-A: tuning_rules SELECT
       .mockResolvedValueOnce({ rows: [] })
       // INSERT conversation_evaluations
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
 
     mockCallGroq.mockResolvedValueOnce(makeGroqResponse({ overall_score: 75 }));
 
@@ -366,7 +366,7 @@ describe('evaluateSession', () => {
       // Phase60-A: tuning_rules SELECT
       .mockResolvedValueOnce({ rows: [] })
       // INSERT conversation_evaluations
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
 
     mockCallGroq.mockResolvedValueOnce(makeGroqResponse({ overall_score: 80 }));
 
@@ -556,5 +556,221 @@ describe('evaluateSession', () => {
     // searchKnowledgeForSuggestion は firstUserMsg 空文字列のためスキップされ、
     // Gemini 呼び出しには到達すること（クラッシュせず先に進んだ証跡）
     expect(mockCallGroq).toHaveBeenCalledTimes(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // 多重評価ガード（Phase75）
+  //
+  // 自動評価は langGraphOrchestrator / flowControl の計7箇所から fire-and-forget で
+  // 叩かれる。ターン予算超過セッションでは turnIndex > maxTurnsPerSession が以降ずっと
+  // 真になるため、ユーザーが発言するたびに何度でも再発火する（並行性を伴わない決定的な
+  // 多重実行）。Gemini の二重課金と、重複行による KPI 平均の下振れを防ぐ。
+  // -------------------------------------------------------------------------
+
+  it('19. [多重発火防止] 既に評価済みのセッションは SessionAlreadyEvaluatedError をthrowし、Geminiを呼ばない', async () => {
+    const mockPool = makeMockPool();
+    mockGetPool.mockReturnValue(mockPool as any);
+    // chat_sessions + EXISTS(conversation_evaluations) を1クエリで返す
+    mockPool.query.mockResolvedValueOnce({
+      rows: [{
+        id: 'internal-uuid-dup',
+        tenant_id: 'tenant-a',
+        prompt_variant_id: null,
+        already_evaluated: true,
+      }],
+    });
+
+    await expect(evaluateSession('session-already-done')).rejects.toThrow(SessionAlreadyEvaluatedError);
+
+    // 最重要: Gemini に到達していないこと（二重課金が起きない証跡）
+    expect(mockCallGroq).not.toHaveBeenCalled();
+    // messages 取得にも進まない = 後続クエリを一切発行していない
+    expect(mockPool.query).toHaveBeenCalledTimes(1);
+  });
+
+  it('20. [多重発火防止] 未評価(already_evaluated=false)なら従来どおり評価が走る（ガードが常時発火しないことの反対側を固定）', async () => {
+    const mockPool = makeMockPool();
+    mockGetPool.mockReturnValue(mockPool as any);
+    mockPool.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'internal-uuid-fresh',
+          tenant_id: 'tenant-a',
+          prompt_variant_id: null,
+          already_evaluated: false,
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          { role: 'user', content: 'こんにちは', created_at: new Date() },
+          { role: 'assistant', content: 'いらっしゃいませ', created_at: new Date() },
+        ],
+      })
+      // tuning_rules SELECT
+      .mockResolvedValueOnce({ rows: [] })
+      // INSERT conversation_evaluations
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+    mockCallGroq.mockResolvedValueOnce(makeGroqResponse({ overall_score: 70 }));
+
+    const result = await evaluateSession('session-fresh');
+
+    expect(result).not.toBeNull();
+    expect(mockCallGroq).toHaveBeenCalledTimes(1);
+  });
+
+  it('21. [多重発火防止] 予算超過セッションを何度evaluateしても Gemini は1回だけ（決定的な再発火のシミュレーション）', async () => {
+    // langGraphOrchestrator は「終端到達」ごとに evaluateSession を叩く。
+    // 予算超過後は毎ターン再発火するため、同じ sessionId で複数回呼ばれる状況を再現する。
+    const mockPool = makeMockPool();
+    mockGetPool.mockReturnValue(mockPool as any);
+
+    // 1回目は未評価 → 通常評価。2回目以降は評価済み → ガードで打ち切り。
+    let evaluated = false;
+    mockPool.query.mockImplementation((sql: string) => {
+      if (typeof sql === 'string' && sql.includes('FROM chat_sessions')) {
+        return Promise.resolve({
+          rows: [{
+            id: 'internal-uuid-budget',
+            tenant_id: 'tenant-a',
+            prompt_variant_id: null,
+            already_evaluated: evaluated,
+          }],
+        });
+      }
+      if (typeof sql === 'string' && sql.includes('FROM chat_messages')) {
+        return Promise.resolve({
+          rows: [
+            { role: 'user', content: 'まだ続けたい', created_at: new Date() },
+            { role: 'assistant', content: '承知しました', created_at: new Date() },
+          ],
+        });
+      }
+      if (typeof sql === 'string' && sql.includes('INSERT INTO conversation_evaluations')) {
+        evaluated = true; // 以降のセッション取得は already_evaluated=true を返す
+        return Promise.resolve({ rows: [], rowCount: 1 });
+      }
+      return Promise.resolve({ rows: [] });
+    });
+    mockCallGroq.mockResolvedValue(makeGroqResponse({ overall_score: 70 }));
+
+    // 13ターン目
+    const first = await evaluateSession('session-over-budget');
+    expect(first).not.toBeNull();
+
+    // 14・15ターン目（ユーザーが発言し続けた場合の再発火）
+    await expect(evaluateSession('session-over-budget')).rejects.toThrow(SessionAlreadyEvaluatedError);
+    await expect(evaluateSession('session-over-budget')).rejects.toThrow(SessionAlreadyEvaluatedError);
+
+    // Gemini 課金は1回だけ
+    expect(mockCallGroq).toHaveBeenCalledTimes(1);
+  });
+
+  it('22. [同時実行] INSERTがON CONFLICTで弾かれた敗者は、評価結果は返すが副作用(tuning_rules/通知/reward)をスキップする', async () => {
+    // 事前チェック(1b)は「確認してから実行」なので、真に並行した2本は両方すり抜けうる。
+    // 行を入れられるのは片方だけなので、敗者は rowCount=0 で検知して副作用を止める。
+    const mockPool = makeMockPool();
+    mockGetPool.mockReturnValue(mockPool as any);
+    mockPool.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'internal-uuid-race',
+          tenant_id: 'tenant-race',
+          prompt_variant_id: 'v-race',
+          already_evaluated: false,
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          { role: 'user', content: '雑な対応だな', created_at: new Date() },
+          { role: 'assistant', content: 'すみません', created_at: new Date() },
+        ],
+      })
+      // tuning_rules SELECT
+      .mockResolvedValueOnce({ rows: [] })
+      // INSERT conversation_evaluations → 競合で0行（敗者）
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 });
+    // 低スコア = 本来なら tuning_rules INSERT・通知・gap検出が走る条件
+    mockCallGroq.mockResolvedValueOnce(makeGroqResponse({ overall_score: 20 }));
+
+    const result = await evaluateSession('session-race-loser');
+    await flushFireAndForget();
+
+    // 評価自体は成立しているので結果は返す
+    expect(result).not.toBeNull();
+    expect(result!.overall_score).toBe(20);
+
+    // 副作用は一切追加で走らない: クエリはINSERTまでの4本で打ち切られている
+    expect(mockPool.query).toHaveBeenCalledTimes(4);
+    // reward signal も送られない（勝者側が送るため）
+    expect(mockSendRewardSignal).not.toHaveBeenCalled();
+  });
+
+  it('23. [同時実行] 勝者(rowCount=1)は従来どおり副作用が走る（22の反対側を固定）', async () => {
+    const mockPool = makeMockPool();
+    mockGetPool.mockReturnValue(mockPool as any);
+    mockPool.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'internal-uuid-winner',
+          tenant_id: 'tenant-winner',
+          prompt_variant_id: 'v-win',
+          already_evaluated: false,
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          { role: 'user', content: '雑な対応だな', created_at: new Date() },
+          { role: 'assistant', content: 'すみません', created_at: new Date() },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      // INSERT conversation_evaluations → 1行入った（勝者）
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 })
+      // INSERT tuning_rules
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+    mockCallGroq.mockResolvedValueOnce(makeGroqResponse({ overall_score: 20 }));
+
+    const result = await evaluateSession('session-race-winner');
+    await flushFireAndForget();
+
+    expect(result).not.toBeNull();
+    // tuning_rules INSERT まで進んでいる（敗者の4本との差分が副作用の有無）
+    expect(mockPool.query.mock.calls.length).toBeGreaterThan(4);
+    const tuningInsertCall = mockPool.query.mock.calls[4]!;
+    expect(tuningInsertCall[0]).toContain('INSERT INTO tuning_rules');
+    expect(mockSendRewardSignal).toHaveBeenCalledTimes(1);
+  });
+
+  it('24. [ON CONFLICTターゲット] 両INSERTが一意制約のターゲットを明示している（無指定だとSERIAL idにしか反応せずno-opになる回帰の防止）', async () => {
+    const mockPool = makeMockPool();
+    mockGetPool.mockReturnValue(mockPool as any);
+    mockPool.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'internal-uuid-conflict',
+          tenant_id: 'tenant-c',
+          prompt_variant_id: null,
+          already_evaluated: false,
+        }],
+      })
+      .mockResolvedValueOnce({
+        rows: [
+          { role: 'user', content: 'ひどい', created_at: new Date() },
+          { role: 'assistant', content: '申し訳ありません', created_at: new Date() },
+        ],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 });
+    mockCallGroq.mockResolvedValueOnce(makeGroqResponse({ overall_score: 20 }));
+
+    await evaluateSession('session-conflict-target');
+    await flushFireAndForget();
+
+    const evalInsertSql = mockPool.query.mock.calls[3]![0] as string;
+    expect(evalInsertSql).toMatch(/ON CONFLICT\s*\(\s*tenant_id\s*,\s*session_id\s*\)\s*DO NOTHING/);
+
+    const ruleInsertSql = mockPool.query.mock.calls[4]![0] as string;
+    expect(ruleInsertSql).toMatch(/ON CONFLICT\s*\(\s*tenant_id\s*,\s*trigger_pattern\s*\)\s*DO NOTHING/);
   });
 });

--- a/src/agent/judge/judgeEvaluator.ts
+++ b/src/agent/judge/judgeEvaluator.ts
@@ -54,6 +54,26 @@ export class SessionTooShortError extends Error {
   }
 }
 
+/**
+ * すでに評価済みのセッションを再評価しようとした場合に投げる。
+ *
+ * 自動評価の呼び出し元(langGraphOrchestrator / flowControl)は「終端到達」を検知するたびに
+ * evaluateSession を fire-and-forget で叩くが、ターン予算超過セッションでは
+ * `turnIndex > maxTurnsPerSession` が以降ずっと真になるため、ユーザーが発言するたびに
+ * 何度でも再発火する(並行性を伴わない決定的な多重実行)。Gemini課金の二重発生と、
+ * conversation_evaluations の重複行による KPI 平均の下振れを防ぐため、
+ * Gemini を呼ぶ前にこのガードで打ち切る。
+ *
+ * 障害ではなく「もう終わっている」という正常状態なので、呼び出し元(routes.ts)は
+ * 500 ではなく 409(already_evaluated)に変換する。
+ */
+export class SessionAlreadyEvaluatedError extends Error {
+  constructor(sessionId: string) {
+    super(`session ${sessionId} has already been evaluated`);
+    this.name = 'SessionAlreadyEvaluatedError';
+  }
+}
+
 const JUDGE_MODEL = process.env['GEMINI_MODEL'] ?? 'gemini-2.5-flash';
 
 const FALLBACK_PROMPT_TEMPLATE = `あなたは営業チャットAIの品質評価Judgeです。
@@ -94,6 +114,11 @@ interface ChatSessionRow {
   id: string;
   tenant_id: string;
   prompt_variant_id: string | null;
+  /**
+   * 同一 (tenant_id, session_id) の評価行が既にあるか。
+   * セッション取得と同じクエリの EXISTS で解決し、多重評価ガードの往復を増やさない。
+   */
+  already_evaluated: boolean;
 }
 
 function clamp(v: number): number {
@@ -168,8 +193,16 @@ export async function evaluateSession(sessionId: string, expectedTenantId?: stri
     const pool = getPool();
 
     // 1. Fetch internal id + tenant_id from chat_sessions (session_id is the public text key)
+    //    併せて「このセッションが既に評価済みか」を EXISTS で同時に引く(1b のガード用)。
     const sessionResult = await pool.query<ChatSessionRow>(
-      'SELECT id, tenant_id, prompt_variant_id FROM chat_sessions WHERE session_id = $1 LIMIT 1',
+      `SELECT s.id, s.tenant_id, s.prompt_variant_id,
+              EXISTS (
+                SELECT 1 FROM conversation_evaluations ce
+                WHERE ce.tenant_id = s.tenant_id AND ce.session_id = s.session_id
+              ) AS already_evaluated
+         FROM chat_sessions s
+        WHERE s.session_id = $1
+        LIMIT 1`,
       [sessionId],
     );
     if (sessionResult.rows.length === 0) {
@@ -188,6 +221,19 @@ export async function evaluateSession(sessionId: string, expectedTenantId?: stri
     if (expectedTenantId !== undefined && tenantId !== expectedTenantId) {
       logger.warn({ sessionId }, 'judgeEvaluator: tenant mismatch, refusing evaluation');
       throw new SessionTenantMismatchError(sessionId);
+    }
+
+    // 1b. 多重評価ガード: Gemini を呼ぶ前に既評価を弾く。
+    //     自動評価は「終端到達」ごとに fire-and-forget で叩かれるが、ターン予算超過後は
+    //     毎ターン再発火するため、ここで止めないと Gemini 課金と重複行が積み上がる。
+    //     呼び出し元が7箇所あるため、各呼び出し側ではなくこの関数内に寄せて漏れを防ぐ。
+    //     判定は 1. のセッション取得と同じクエリ内の EXISTS で済ませており、
+    //     往復を増やしていない。
+    //     真の同時実行はこの事前チェックをすり抜けうるが、その最終防波堤は
+    //     conversation_evaluations の UNIQUE(tenant_id, session_id) + ON CONFLICT が担う。
+    if (sessionResult.rows[0]!.already_evaluated === true) {
+      logger.info({ sessionId, tenantId }, 'judgeEvaluator: session already evaluated, skipping');
+      throw new SessionAlreadyEvaluatedError(sessionId);
     }
 
     // 2. Fetch all messages using internal UUID (chat_messages.session_id → chat_sessions.id)
@@ -271,8 +317,13 @@ export async function evaluateSession(sessionId: string, expectedTenantId?: stri
       return null;
     }
 
-    // 6. Persist evaluation with new columns (INSERT ... ON CONFLICT DO NOTHING)
-    await pool.query(
+    // 6. Persist evaluation with new columns.
+    //    ON CONFLICT のターゲットを明示する。以前は無指定で、SERIAL の id にしか反応できず
+    //    実質 no-op だった(= 重複行がそのまま入っていた)。
+    //    ★このターゲット指定は UNIQUE(tenant_id, session_id) の存在が前提。
+    //     マイグレーション未適用の状態でこのコードをデプロイすると INSERT が全て失敗する。
+    //     必ず migration → deploy の順で適用すること(docs/DEPLOY_CHECKLIST.md 参照)。
+    const insertResult = await pool.query(
       `INSERT INTO conversation_evaluations
          (tenant_id, session_id, score,
           used_principles, effective_principles, failed_principles, evaluation_axes,
@@ -283,7 +334,7 @@ export async function evaluateSession(sessionId: string, expectedTenantId?: stri
           '[]'::jsonb, '[]'::jsonb, '[]'::jsonb, '{}'::jsonb,
           $4, $5, $6, $7,
           $8::jsonb, $9::jsonb, $10, $11)
-       ON CONFLICT DO NOTHING`,
+       ON CONFLICT (tenant_id, session_id) DO NOTHING`,
       [
         tenantId,
         sessionId,
@@ -298,6 +349,18 @@ export async function evaluateSession(sessionId: string, expectedTenantId?: stri
         JUDGE_MODEL,
       ],
     );
+
+    // 6a. 同時実行の敗者はここで打ち切る。1b のガードは「確認してから実行」なので
+    //     真に並行した2本は両方すり抜けうるが、行を入れられるのは片方だけ。
+    //     敗者がこのまま進むと tuning_rules・通知・蒸留・reward が二重に走るため、
+    //     評価結果は返しつつ副作用だけをスキップする。
+    if ((insertResult.rowCount ?? 0) === 0) {
+      logger.info(
+        { sessionId, tenantId },
+        'judgeEvaluator: evaluation row already persisted by a concurrent run, skipping side effects',
+      );
+      return result;
+    }
 
     // 6b. Phase71-A: 高スコア会話を learned_memory に蒸留 (fire-and-forget)
     //     書込み Feature Flag + スコア閾値のガードは distillAndPromote 内で行う。
@@ -353,7 +416,7 @@ export async function evaluateSession(sessionId: string, expectedTenantId?: stri
             `INSERT INTO tuning_rules
                (tenant_id, trigger_pattern, expected_behavior, priority, is_active, source)
              VALUES ($1, $2, $3, $4, false, 'judge')
-             ON CONFLICT DO NOTHING`,
+             ON CONFLICT (tenant_id, trigger_pattern) DO NOTHING`,
             [
               tenantId,
               rule.rule_text,
@@ -414,7 +477,8 @@ export async function evaluateSession(sessionId: string, expectedTenantId?: stri
     if (
       err instanceof SessionTenantMismatchError ||
       err instanceof SessionNotFoundError ||
-      err instanceof SessionTooShortError
+      err instanceof SessionTooShortError ||
+      err instanceof SessionAlreadyEvaluatedError
     ) throw err;
     logger.error({ err, sessionId }, 'judgeEvaluator: unexpected error in evaluateSession');
     return null;

--- a/src/api/admin/evaluations/routes.ts
+++ b/src/api/admin/evaluations/routes.ts
@@ -210,10 +210,15 @@ export function registerEvaluationRoutes(app: Express): void {
       }
       return res.json({ evaluation: result });
     } catch (err) {
-      const { SessionTenantMismatchError, SessionNotFoundError, SessionTooShortError } = await import("../../../agent/judge/judgeEvaluator");
+      const { SessionTenantMismatchError, SessionNotFoundError, SessionTooShortError, SessionAlreadyEvaluatedError } = await import("../../../agent/judge/judgeEvaluator");
       // 「不在」と「他テナントのもの」を同一の404にし、存在確認オラクルにしない。
       if (err instanceof SessionTenantMismatchError || err instanceof SessionNotFoundError) {
         return res.status(404).json({ error: "セッションが見つかりません" });
+      }
+      // 上の checkAlreadyEvaluated をすり抜けた同時実行の敗者。事前チェックと同じ409に揃える
+      // (評価済みは障害ではないので500にしない)。
+      if (err instanceof SessionAlreadyEvaluatedError) {
+        return res.status(409).json({ error: "already_evaluated" });
       }
       // 会話が短すぎて評価対象外なのは障害ではない。500(evaluation_failed)と
       // 区別し、理由が分かる422で返す。

--- a/src/migrations/phase75_conversation_evaluations_unique.sql
+++ b/src/migrations/phase75_conversation_evaluations_unique.sql
@@ -1,0 +1,110 @@
+-- Phase75: conversation_evaluations に (tenant_id, session_id) の UNIQUE 制約を追加
+--
+-- 背景:
+--   judgeEvaluator.ts の INSERT は `ON CONFLICT DO NOTHING` をターゲット無しで書いていたが、
+--   このテーブルの唯一の一意制約は SERIAL の id だけだった。SERIAL は採番のたびに新しい値を
+--   取るため衝突しえず、結果としてこの ON CONFLICT は完全な no-op で、同一セッションの
+--   評価行が何行でも入っていた。
+--
+--   実害は Gemini の二重課金よりも KPI 汚染の方が大きい。evaluationsRepository の
+--   AVG(score) / COUNT(*) は DISTINCT 無しで集計するため、重複したセッションはその回数だけ
+--   平均に重み付けされる。そして重複しやすいのはターン予算を超えた長い会話、つまり
+--   低スコアになりがちなセッションなので、テナントに見せている品質平均が構造的に下振れする。
+--
+-- ★適用順序の厳守:
+--   このマイグレーションは judgeEvaluator.ts の
+--   `ON CONFLICT (tenant_id, session_id) DO NOTHING` より先に適用すること。
+--   逆順にすると Postgres が
+--   「there is no unique or exclusion constraint matching the ON CONFLICT specification」
+--   を返し、全ての評価 INSERT が失敗する。詳細は docs/DEPLOY_CHECKLIST.md を参照。
+
+-- ============================================================
+-- 1. 事前確認 (手動実行して結果を目視してから 2 へ進むこと)
+-- ============================================================
+-- 重複がどれだけあるか:
+--   SELECT tenant_id, session_id, COUNT(*) AS dup_count
+--   FROM conversation_evaluations
+--   GROUP BY tenant_id, session_id
+--   HAVING COUNT(*) > 1
+--   ORDER BY dup_count DESC;
+--
+-- 削除対象に承認済みルールが含まれていないか (0件であることを確認する):
+--   WITH ranked AS (
+--     SELECT id, suggested_rules,
+--            ROW_NUMBER() OVER (
+--              PARTITION BY tenant_id, session_id
+--              ORDER BY
+--                (CASE WHEN jsonb_typeof(suggested_rules) = 'array'
+--                       THEN EXISTS (SELECT 1 FROM jsonb_array_elements(suggested_rules) e
+--                                    WHERE jsonb_exists(e, 'status'))
+--                       ELSE false END) DESC,
+--                evaluated_at DESC NULLS LAST,
+--                id DESC
+--            ) AS rn
+--     FROM conversation_evaluations
+--   )
+--   SELECT COUNT(*) FROM ranked
+--   WHERE rn > 1
+--     AND jsonb_typeof(suggested_rules) = 'array'
+--     AND EXISTS (SELECT 1 FROM jsonb_array_elements(suggested_rules) e
+--                 WHERE jsonb_exists(e, 'status'));
+
+-- ============================================================
+-- 2. 重複行の削除 (UNIQUE INDEX を張る前に必須。残さないと index 作成自体が失敗する)
+-- ============================================================
+-- 残す行の優先順位:
+--   (1) suggested_rules に status(approved/rejected) が付いている行
+--       = 人間が承認/却下の判断を下した行。これを消すと運用者の作業が消える
+--   (2) 次に evaluated_at が新しい行
+--   (3) 最後に id が大きい行 (tie-break)
+WITH ranked AS (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (
+      PARTITION BY tenant_id, session_id
+      ORDER BY
+        -- CASE で型を先に確かめる。jsonb_array_elements は配列以外を渡すとエラーになり、
+        -- 1行でも配列以外があるとマイグレーション全体が途中で落ちるため。
+        (CASE WHEN jsonb_typeof(suggested_rules) = 'array'
+              THEN EXISTS (
+                SELECT 1 FROM jsonb_array_elements(suggested_rules) e
+                WHERE jsonb_exists(e, 'status')
+              )
+              ELSE false END) DESC,
+        evaluated_at DESC NULLS LAST,
+        id DESC
+    ) AS rn
+  FROM conversation_evaluations
+)
+DELETE FROM conversation_evaluations
+WHERE id IN (SELECT id FROM ranked WHERE rn > 1);
+
+-- ============================================================
+-- 3. UNIQUE 制約 (ON CONFLICT (tenant_id, session_id) のターゲット)
+-- ============================================================
+-- 1セッションにつき1評価。phase71_learned_memory.sql の
+-- uniq_learned_memory_session と同じ考え方。
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_conv_eval_session
+  ON conversation_evaluations (tenant_id, session_id);
+
+COMMENT ON INDEX uniq_conv_eval_session IS
+  'Phase75: 1セッション1評価。judgeEvaluator の ON CONFLICT (tenant_id, session_id) のターゲット。KPI集計(AVG/COUNT)が重複行で歪むのを防ぐ。';
+
+-- ============================================================
+-- 4. 適用後の確認 (手動実行)
+-- ============================================================
+-- インデックスが張られたか:
+--   SELECT indexname FROM pg_indexes
+--   WHERE tablename = 'conversation_evaluations' AND indexname = 'uniq_conv_eval_session';
+--
+-- 重複が消えたか (0件であること):
+--   SELECT COUNT(*) FROM (
+--     SELECT 1 FROM conversation_evaluations
+--     GROUP BY tenant_id, session_id HAVING COUNT(*) > 1
+--   ) d;
+
+-- ============================================================
+-- ロールバック
+-- ============================================================
+-- DROP INDEX IF EXISTS uniq_conv_eval_session;
+-- ※削除した重複行は戻らない。適用前に必ず pg_dump でバックアップを取ること。

--- a/src/migrations/phase75_tuning_rules_unique.sql
+++ b/src/migrations/phase75_tuning_rules_unique.sql
@@ -1,0 +1,110 @@
+-- Phase75: tuning_rules に (tenant_id, trigger_pattern) の UNIQUE 制約を追加
+--
+-- 背景:
+--   judgeEvaluator.ts の tuning_rules INSERT も conversation_evaluations と同じく
+--   ターゲット無しの `ON CONFLICT DO NOTHING` で、SERIAL の id にしか反応できず no-op だった。
+--   evaluationAnalyzer.ts は「trigger_pattern と tenant_id でユニーク判定」とコメントで
+--   明言しているが、その制約は DB に存在しなかった。低スコア評価が繰り返されるたびに
+--   同じ提案ルールが積み上がる。
+--
+-- ★このマイグレーションは conversation_evaluations 側より慎重に扱うこと:
+--   tuning_rules の行には運用者の作業結果が乗っている
+--   (approved_at / rejected_at / edited_by / edited_at / original_text / approved_responses)。
+--   重複削除でこれらを失わないよう、下の ORDER BY は「人が触った行」を最優先で残す。
+--
+-- ★適用順序の厳守:
+--   judgeEvaluator.ts の `ON CONFLICT (tenant_id, trigger_pattern) DO NOTHING` より
+--   先に適用すること。逆順だと提案ルールの INSERT が全て失敗する
+--   (judgeEvaluator 側は try/catch で握って warn ログに落とすため、
+--    評価自体は成功するが提案ルールだけが静かに保存されなくなる)。
+
+-- ============================================================
+-- 1. 事前確認 (手動実行して結果を目視してから 2 へ進むこと)
+-- ============================================================
+-- 重複の実数:
+--   SELECT tenant_id, trigger_pattern, COUNT(*) AS dup_count
+--   FROM tuning_rules
+--   GROUP BY tenant_id, trigger_pattern
+--   HAVING COUNT(*) > 1
+--   ORDER BY dup_count DESC;
+--
+-- 削除対象に「人が触った行」が含まれていないか (0件であることを確認する):
+--   WITH ranked AS (
+--     SELECT id, approved_at, rejected_at, edited_at, approved_responses,
+--            ROW_NUMBER() OVER (
+--              PARTITION BY tenant_id, trigger_pattern
+--              ORDER BY
+--                (approved_at IS NOT NULL) DESC,
+--                (rejected_at IS NOT NULL) DESC,
+--                (edited_at IS NOT NULL) DESC,
+--                (CASE WHEN jsonb_typeof(approved_responses) = 'array'
+--                       THEN jsonb_array_length(approved_responses) > 0
+--                       ELSE false END) DESC,
+--                is_active DESC,
+--                id DESC
+--            ) AS rn
+--     FROM tuning_rules
+--   )
+--   SELECT COUNT(*) FROM ranked
+--   WHERE rn > 1
+--     AND (approved_at IS NOT NULL OR rejected_at IS NOT NULL OR edited_at IS NOT NULL
+--          OR (jsonb_typeof(approved_responses) = 'array'
+--              AND jsonb_array_length(approved_responses) > 0));
+--
+-- btree のインデックスサイズ上限(約2704バイト)に触れる長い trigger_pattern が無いか
+-- (0件であること。あれば UNIQUE INDEX 作成が失敗するので、先に該当行を短縮/削除する):
+--   SELECT id, tenant_id, length(trigger_pattern) AS len
+--   FROM tuning_rules
+--   WHERE octet_length(trigger_pattern) > 2000
+--   ORDER BY len DESC;
+
+-- ============================================================
+-- 2. 重複行の削除
+-- ============================================================
+-- 残す行の優先順位: 承認済み > 却下済み > 編集済み > 採用返答あり > 有効 > id が大きい
+WITH ranked AS (
+  SELECT
+    id,
+    ROW_NUMBER() OVER (
+      PARTITION BY tenant_id, trigger_pattern
+      ORDER BY
+        (approved_at IS NOT NULL) DESC,
+        (rejected_at IS NOT NULL) DESC,
+        (edited_at IS NOT NULL) DESC,
+        -- jsonb_array_length は配列以外でエラーになるため型を先に確かめる
+        (CASE WHEN jsonb_typeof(approved_responses) = 'array'
+              THEN jsonb_array_length(approved_responses) > 0
+              ELSE false END) DESC,
+        is_active DESC,
+        id DESC
+    ) AS rn
+  FROM tuning_rules
+)
+DELETE FROM tuning_rules
+WHERE id IN (SELECT id FROM ranked WHERE rn > 1);
+
+-- ============================================================
+-- 3. UNIQUE 制約 (ON CONFLICT (tenant_id, trigger_pattern) のターゲット)
+-- ============================================================
+CREATE UNIQUE INDEX IF NOT EXISTS uniq_tuning_rules_tenant_trigger
+  ON tuning_rules (tenant_id, trigger_pattern);
+
+COMMENT ON INDEX uniq_tuning_rules_tenant_trigger IS
+  'Phase75: 同一テナント内で trigger_pattern は一意。judgeEvaluator の ON CONFLICT (tenant_id, trigger_pattern) のターゲット。evaluationAnalyzer が前提にしていた一意性を DB 側で保証する。';
+
+-- ============================================================
+-- 4. 適用後の確認 (手動実行)
+-- ============================================================
+--   SELECT indexname FROM pg_indexes
+--   WHERE tablename = 'tuning_rules' AND indexname = 'uniq_tuning_rules_tenant_trigger';
+--
+--   SELECT COUNT(*) FROM (
+--     SELECT 1 FROM tuning_rules
+--     GROUP BY tenant_id, trigger_pattern HAVING COUNT(*) > 1
+--   ) d;
+
+-- ============================================================
+-- ロールバック
+-- ============================================================
+-- DROP INDEX IF EXISTS uniq_tuning_rules_tenant_trigger;
+-- ※削除した重複行は戻らない。適用前に必ず pg_dump でバックアップを取ること。

--- a/tests/phase45/evaluationRoutes.test.ts
+++ b/tests/phase45/evaluationRoutes.test.ts
@@ -28,6 +28,7 @@ jest.mock("../../src/agent/judge/judgeEvaluator", () => ({
   SessionTenantMismatchError: class SessionTenantMismatchError extends Error {},
   SessionNotFoundError: class SessionNotFoundError extends Error {},
   SessionTooShortError: class SessionTooShortError extends Error {},
+  SessionAlreadyEvaluatedError: class SessionAlreadyEvaluatedError extends Error {},
 }));
 
 import {
@@ -326,6 +327,20 @@ describe("1. POST /v1/admin/evaluations/trigger", () => {
       expectedStatus: 422,
     },
     {
+      label: "409 事前チェックをすり抜けた同時実行の敗者（evaluateSession側のガードが発火）",
+      setup: () => {
+        const { SessionAlreadyEvaluatedError } = jest.requireMock(
+          "../../src/agent/judge/judgeEvaluator",
+        ) as { SessionAlreadyEvaluatedError: new (sessionId: string) => Error };
+        // 事前チェックは「まだ評価されていない」と判断したが、その後に別実行が先に評価を終えた
+        (checkAlreadyEvaluated as jest.Mock).mockResolvedValue(false);
+        (evaluateSession as jest.Mock).mockRejectedValue(
+          new SessionAlreadyEvaluatedError("sess-001"),
+        );
+      },
+      expectedStatus: 409,
+    },
+    {
       label: "500 真の内部エラー（Gemini呼び出し失敗などnull返却）",
       setup: () => {
         (checkAlreadyEvaluated as jest.Mock).mockResolvedValue(false);
@@ -343,19 +358,27 @@ describe("1. POST /v1/admin/evaluations/trigger", () => {
     expect(res.status).toBe(expectedStatus);
   });
 
-  // 既知のリスク（未修正、テストで可視化のみ）: checkAlreadyEvaluated → evaluateSession は
-  // 「確認してから実行」の非アトミックな2段階であり、conversation_evaluations テーブルには
-  // (tenant_id, session_id) の UNIQUE 制約が無い
-  // (src/agent/judge/migration_conversation_evaluations.sql 参照。judgeEvaluator.ts の
-  // INSERT ... ON CONFLICT DO NOTHING は対象となる制約が存在しないため実質no-op)。
-  // 同一セッションへの評価トリガーが競合すると、両方が checkAlreadyEvaluated=false を見て
-  // 両方が evaluateSession を実行し、Gemini呼び出し・通知・tuning_rules挿入が重複しうる
-  // (Stripe webhookで修正した二重処理と同型の問題だが、ここは未修正)。
-  // このテストはその非アトミック性をユニットテストレベルで可視化するためのものであり、
-  // 実装修正はスコープ外(親からの指示により、発見のみ・修正はしない)。
-  it("[既知のリスク・未修正] 同一session_idへの2並行トリガーは両方とも200になりうる（checkAlreadyEvaluatedがDBの一意制約でなくアプリ側の事前確認のみのため）", async () => {
+  // Phase75で修正済み。routes側の checkAlreadyEvaluated → evaluateSession は依然として
+  // 「確認してから実行」の非アトミックな2段階だが、多重実行は下の3層で止まるようになった:
+  //   1層目: routes の checkAlreadyEvaluated（速い409。ほとんどのケースはここで止まる）
+  //   2層目: evaluateSession 内のガード（セッション取得時のEXISTSで既評価を検知。
+  //          Gemini呼び出しより前なので二重課金が起きない。自動評価の7経路もここで守られる）
+  //   3層目: conversation_evaluations の UNIQUE(tenant_id, session_id) + ON CONFLICT
+  //          （真に並行した2本が1・2層をすり抜けても、行を入れられるのは片方だけ。
+  //            敗者は rowCount=0 を見て tuning_rules・通知・reward をスキップする）
+  // このテストは routes 層に排他制御が無いこと自体は変わっていない（＝1層目をすり抜けた側は
+  // 2層目に委ねる設計である）ことを固定する。
+  it("[多層防御] routes層は同一session_idの2並行トリガーを止めないが、evaluateSession側のガードが409に落とす", async () => {
+    const { SessionAlreadyEvaluatedError } = jest.requireMock(
+      "../../src/agent/judge/judgeEvaluator",
+    ) as { SessionAlreadyEvaluatedError: new (sessionId: string) => Error };
+
+    // 2本とも事前チェックは「未評価」を見る（routes層は競合を検知できない）
     (checkAlreadyEvaluated as jest.Mock).mockResolvedValue(false);
-    (evaluateSession as jest.Mock).mockResolvedValue(JUDGE_RESULT);
+    // 先着1本だけが評価に成功し、後続は evaluateSession 内のガードで弾かれる
+    (evaluateSession as jest.Mock)
+      .mockResolvedValueOnce(JUDGE_RESULT)
+      .mockRejectedValueOnce(new SessionAlreadyEvaluatedError("sess-race"));
 
     const app = makeApp();
     const [res1, res2] = await Promise.all([
@@ -363,12 +386,11 @@ describe("1. POST /v1/admin/evaluations/trigger", () => {
       request(app).post("/v1/admin/evaluations/trigger").send({ session_id: "sess-race" }),
     ]);
 
-    // 本来は「評価トリガーは冪等であってほしい」が、現状の実装ではどちらも
-    // checkAlreadyEvaluated=false を見て両方 evaluateSession まで進むため、
-    // 両方 200 になる（片方が409になるような排他制御が無い）。
-    expect(res1.status).toBe(200);
-    expect(res2.status).toBe(200);
+    // routes層は2本とも evaluateSession まで通す（1層目では止まらない）
     expect(evaluateSession).toHaveBeenCalledTimes(2);
+    // 結果は「片方が200・片方が409」に落ち着く（両方200にはならない）
+    const statuses = [res1.status, res2.status].sort();
+    expect(statuses).toEqual([200, 409]);
   });
 });
 

--- a/tests/phase52/judge-empty-session.test.ts
+++ b/tests/phase52/judge-empty-session.test.ts
@@ -97,14 +97,17 @@ describe("evaluateSession — 空/単一メッセージセッションのスキ�
     mockGetPool.mockReturnValue(mockPool);
 
     mockPool.query
-      .mockResolvedValueOnce({ rows: [{ id: "internal-uuid-two", tenant_id: "tenant-a" }] })
+      .mockResolvedValueOnce({
+        rows: [{ id: "internal-uuid-two", tenant_id: "tenant-a", already_evaluated: false }],
+      })
       .mockResolvedValueOnce({
         rows: [
           { role: "user", content: "商品の価格を教えて", created_at: new Date() },
           { role: "assistant", content: "こちらが価格表です。", created_at: new Date() },
         ],
       })
-      .mockResolvedValueOnce({ rows: [] }); // INSERT evaluations
+      .mockResolvedValueOnce({ rows: [] }) // tuning_rules SELECT
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 }); // INSERT evaluations
 
     mockCallGemini.mockResolvedValueOnce(makeGeminiResponse(72));
 
@@ -120,7 +123,9 @@ describe("evaluateSession — 空/単一メッセージセッションのスキ�
     mockGetPool.mockReturnValue(mockPool);
 
     mockPool.query
-      .mockResolvedValueOnce({ rows: [{ id: "internal-uuid-three", tenant_id: "tenant-b" }] })
+      .mockResolvedValueOnce({
+        rows: [{ id: "internal-uuid-three", tenant_id: "tenant-b", already_evaluated: false }],
+      })
       .mockResolvedValueOnce({
         rows: [
           { role: "user", content: "予算は100万円です", created_at: new Date() },
@@ -128,7 +133,8 @@ describe("evaluateSession — 空/単一メッセージセッションのスキ�
           { role: "user", content: "詳しく教えてください", created_at: new Date() },
         ],
       })
-      .mockResolvedValueOnce({ rows: [] }); // INSERT evaluations
+      .mockResolvedValueOnce({ rows: [] }) // tuning_rules SELECT
+      .mockResolvedValueOnce({ rows: [], rowCount: 1 }); // INSERT evaluations
 
     mockCallGemini.mockResolvedValueOnce(makeGeminiResponse(85));
 


### PR DESCRIPTION
> [!CAUTION]
> **マージ後、デプロイ前に DB マイグレーションの手動適用が必要です。**
> しかも今回は **「migration → デプロイ」の順**（既存の sai_tasks / stripe_webhook_events とは**逆**）。
> 逆順で当てると Postgres が `there is no unique or exclusion constraint matching the ON CONFLICT specification` を返し、**評価の保存が全件失敗**します（チャット自体は止まりませんが Judge 評価機能が無言で死にます）。
> 手順は `docs/DEPLOY_CHECKLIST.md` の「phase75 judge 一意制約 migration 実行手順」に記載。
> この2本は既存テーブルにしか触れず新コードに依存しないため、rsync を待たずローカルから stdin で流し込めます（中間状態を作らずに済みます）。

## 何が起きていたか

本番は `JUDGE_AUTO_EVALUATE=true`（VPSで実測確認済み）のため、以下は**現在進行形で発生していました**。

### 1. 決定的な多重発火（並行性すら不要）

`langGraphOrchestrator.ts:78-81` の予算超過判定は

```ts
const turnIndex = flow.turnIndex + 1;        // 単調増加
if (turnIndex > budgets.maxTurnsPerSession)  // 「超過」判定
```

で、`turnIndex` が増え続けるため予算超過後は**以降ずっと真**になります。この終端分岐から `evaluateSession` が fire-and-forget で叩かれるので、ユーザーが発言するたびに 13ターン目・14ターン目…と**毎回フル評価（Gemini呼び出し込み）が走っていました**。競合ではなく素のロジックです。

`evaluateSession` の自動呼び出しは計7箇所（`langGraphOrchestrator` ×5 / `flowControl` ×2）あり、**いずれも既評価チェックを通していませんでした**。

### 2. `ON CONFLICT` が実質 no-op

`conversation_evaluations` / `tuning_rules` の一意制約は `SERIAL` の `id` だけでした。ターゲット無しの `ON CONFLICT DO NOTHING` は**決して衝突しない `id` にしか反応できない**ため、重複行がそのまま入り続けていました。

`evaluationAnalyzer.ts:140` は「trigger_pattern と tenant_id でユニーク判定」とコメントで明言していましたが、**その制約は DB に存在しませんでした**。

### 3. 実害 — 一番大きいのはコストではなく KPI 汚染

`evaluationsRepository.ts:175` の `AVG(score)` / `COUNT(*)` は `DISTINCT` 無しで集計します。重複したセッションは**その回数だけ平均に重み付け**されます。そして重複しやすいのは予算超過した長い会話 = **低スコアになりがちなセッション**。結果として、**テナントに見せている品質平均が構造的に下振れ**していました。

他に二重になっていたもの: Gemini 呼び出し（課金）、`tuning_rules` 行、管理画面のベル通知、learned_memory 蒸留、OpenClaw reward。

## 対処（多層防御）

| 層 | 内容 | 効く範囲 |
|---|---|---|
| 1 | `routes.ts` の既存 `checkAlreadyEvaluated` | 手動トリガーの大半（速い409） |
| 2 | **`evaluateSession` 内の既評価ガード（新規）** | **自動評価の7経路すべて。Gemini呼び出しより前なので二重課金が起きない** |
| 3 | **`UNIQUE` + ターゲット付き `ON CONFLICT`（新規）** | 真に並行した2本。敗者は副作用をスキップ |

- ガードは呼び出し元7箇所ではなく**関数内に寄せて**漏れを防いでいます。判定はセッション取得と**同じクエリの `EXISTS`** で行うため、**DB往復は増えていません**。
- 「既評価」の表現は専用例外 `SessionAlreadyEvaluatedError` を追加しました。既存の `SessionNotFoundError` / `SessionTenantMismatchError` / `SessionTooShortError` と同じ設計に揃えるためです（`null` に寄せると #823 で解消した「Gemini失敗と正常スキップの多義性」が再発します）。`routes.ts` は事前チェックと同じ **409** に変換します。
- 敗者（`rowCount === 0`）は評価結果は返しつつ、`tuning_rules` 挿入・通知・蒸留・reward だけをスキップします。

## マイグレーション

| ファイル | 内容 |
|---|---|
| `src/migrations/phase75_conversation_evaluations_unique.sql` | 重複削除 + `UNIQUE(tenant_id, session_id)` |
| `src/migrations/phase75_tuning_rules_unique.sql` | 重複削除 + `UNIQUE(tenant_id, trigger_pattern)` |

**重複削除は人の判断が乗った行を優先して残します。**
- 評価側: `suggested_rules[i].status`（承認/却下済み）がある行 → 次に新しい行
- ルール側: 承認済み > 却下済み > 編集済み > 採用返答あり > 有効 > 新しい行

`tuning_rules` は `approved_at` / `edited_by` / `approved_responses` など**運用者の作業結果**が乗っているため、評価側より慎重な優先順位にしています。両ファイルとも冒頭に**事前確認クエリ**を用意しており、「削除対象に人の判断が乗った行が含まれていないか（0件であること）」を目視してから流す手順です。

`jsonb_array_elements` / `jsonb_array_length` は配列以外を渡すとエラーになり1行でもあると全体が落ちるため、`CASE WHEN jsonb_typeof(...) = 'array'` で型を先に確かめています。

## テスト

- **新規6件**: 多重発火防止（既評価でGeminiを呼ばない／予算超過セッションを何度叩いてもGeminiは1回）、同時実行の勝者・敗者、`ON CONFLICT` ターゲットの明示
- **`evaluationAnalyzer.test.ts` の是正**: 「SQL文字列に `ON CONFLICT DO NOTHING` が含まれること」しか見ておらず、**制約が無くても通り続ける誤った安心感**でした。ターゲットがマイグレーションの一意インデックスと**一致すること**を検証する形（コードとスキーマの乖離防止）に変えています。
- **既存モックの是正**: `judgeEvaluator.test.ts` / `judge-empty-session.test.ts` のモックが pg の `rowCount` を返しておらず、また `judge-empty-session.test.ts` は4クエリ中3つしかモックしていませんでした（従来は INSERT の戻り値を使っていなかったため露見していなかった）。実挙動に合わせています。

**ミューテーション検証3件**（いずれも復元済み）:
- 既評価ガードを無効化 → テスト19・21が失敗
- `ON CONFLICT` ターゲットを削除 → 2件失敗
- 敗者の早期returnを削除 → テスト22が失敗

typecheck 0エラー / oxlint クリーン / 対象21スイート **358テスト全pass**。

## 残る関連課題（本PRのスコープ外）

- `langGraphOrchestrator` の終端分岐は**根本原因**として残っています（`flow.state === 'terminal'` でも再入するため、`logFlowTransition` と `flow.terminal_reached` ログも毎ターン重複）。本PRは全7経路を守るガード側で塞いでおり、根本修正は制御フロー変更でphase22テストへの影響が読みきれないため分離しました。
- 上記に伴い、予算超過セッションでは自動評価の `.catch()` が `judge.auto.failed` を毎ターン warn 出力します（実害は無いがログノイズ）。
- 自動評価は `expectedTenantId` を渡していません（`tenantId` はセッション行由来なので越境はしません）。
- Gemini の judge 呼び出しは `usageContext` 未指定で `tenantId:'unknown'` / `billable:false` として計上されています（別件の計上漏れ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgCQYt8UMPgm4HNVu7nv7z
