### PR TITLE
[SEC][P0] CORS fail-open解消+Bearer解析の流儀統一

### DIFF
--- a/src/admin/http/supabaseAuthMiddleware.test.ts
+++ b/src/admin/http/supabaseAuthMiddleware.test.ts
@@ -183,6 +183,36 @@ describe("supabaseAuthMiddleware", () => {
       expect(next).toHaveBeenCalledTimes(1);
       expect(req.supabaseUser).toMatchObject({ app_metadata: { role: "client_admin" } });
     });
+
+    it("Bearerスキームでない Authorization ヘッダ（Basic）は401（スキーム名を見ずに2番目のトークンを取ってしまう回帰防止）", () => {
+      const token = jwt.sign({ app_metadata: { role: "super_admin" } }, SECRET);
+      const { req, res, next } = makeReqRes({ authorization: `Basic ${token}` });
+
+      supabaseAuthMiddleware(req, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(401);
+      expect(res.body).toEqual({ error: "Missing Bearer token" });
+    });
+
+    it("未知のスキーム名（Foo）も401", () => {
+      const token = jwt.sign({ app_metadata: { role: "super_admin" } }, SECRET);
+      const { req, res, next } = makeReqRes({ authorization: `Foo ${token}` });
+
+      supabaseAuthMiddleware(req, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(401);
+    });
+
+    it("Authorization ヘッダが 'Bearer' のみ（トークン本体なし）は401", () => {
+      const { req, res, next } = makeReqRes({ authorization: "Bearer" });
+
+      supabaseAuthMiddleware(req, res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(401);
+    });
   });
 
   describe("isAdminUsableToken配線: 署名は正しいが管理面で使えないトークンは403", () => {
@@ -356,17 +386,16 @@ describe("supabaseAuthMiddleware", () => {
       expect(res.statusCode).toBe(401);
     });
 
-    // 実装は Authorization ヘッダを split(" ") して2番目のトークンを取るだけで、
-    // "Bearer" というスキーム名自体は検証していない。そのため大文字小文字はおろか
-    // スキーム名が何であっても(例: "token xxx")署名済みトークンなら通ってしまう。
-    // HTTPの仕様上は非準拠だが、実害はjwt.verifyが最終防御のため無い。
-    // 仕様変更でスキーム検証が追加された際に気づけるよう、現状の挙動を固定する。
-    it("スキーム名は検証されない: 'bearer'(小文字)でも有効な署名済みトークンなら通る（現状仕様の固定。将来スキーム検証を追加する場合は要更新）", () => {
+    // スキーム名を startsWith("Bearer ") で検証するようになった（developmentバイパス
+    // と同じチェックに統一）。大文字小文字違いのスキーム名は401になる
+    // （以前は split(" ") で2番目の要素を無条件にトークン扱いしていたため通っていた）。
+    it("スキーム名は大文字小文字を区別する: 'bearer'(小文字)は署名済みトークンでも401", () => {
       const token = jwt.sign({ sub: "u1", app_metadata: { role: "super_admin" } }, SECRET);
       const { req, res, next } = makeReqRes({ authorization: `bearer ${token}` });
       supabaseAuthMiddleware(req, res, next);
-      expect(next).toHaveBeenCalledTimes(1);
-      expect(req.supabaseUser).toMatchObject({ app_metadata: { role: "super_admin" } });
+      expect(next).not.toHaveBeenCalled();
+      expect(res.statusCode).toBe(401);
+      expect(res.body).toEqual({ error: "Missing Bearer token" });
     });
   });
 });

--- a/src/admin/http/supabaseAuthMiddleware.ts
+++ b/src/admin/http/supabaseAuthMiddleware.ts
@@ -68,8 +68,16 @@ export function supabaseAuthMiddleware(
     return;
   }
 
+  // スキーム名を検証せず空白区切りの2番目をトークン扱いすると、
+  // `Basic xxx` / `Foo xxx` のような非Bearerヘッダでも token が取れてしまう
+  // (最終的に jwt.verify が弾くため実害は無いが、上のdevelopment分岐と同じ
+  // startsWith("Bearer ") チェックに揃える)。
   const authHeader = req.headers.authorization || "";
-  const [, token] = authHeader.split(" ");
+  if (!authHeader.startsWith("Bearer ")) {
+    res.status(401).json({ error: "Missing Bearer token" });
+    return;
+  }
+  const token = authHeader.slice("Bearer ".length).trim();
 
   if (!token) {
     res.status(401).json({ error: "Missing Bearer token" });

--- a/src/lib/cors.test.ts
+++ b/src/lib/cors.test.ts
@@ -25,7 +25,16 @@ function mockRes() {
 const nextFn: NextFunction = jest.fn();
 
 describe("corsMiddleware", () => {
-  beforeEach(() => jest.clearAllMocks());
+  let savedNodeEnv: string | undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    savedNodeEnv = process.env.NODE_ENV;
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = savedNodeEnv;
+  });
 
   it("reflects origin when in the global allowlist", () => {
     const mw = createCorsMiddleware({ defaultAllowedOrigins: ["https://admin.r2c.biz"] });
@@ -65,12 +74,56 @@ describe("corsMiddleware", () => {
     expect(res.headers["Access-Control-Allow-Origin"]).toBeUndefined();
   });
 
-  it("reflects any origin when the global allowlist is empty (dev wildcard mode)", () => {
+  it("reflects any origin when the global allowlist is empty (dev wildcard mode, development/test only)", () => {
+    process.env.NODE_ENV = "test";
     const mw = createCorsMiddleware({ defaultAllowedOrigins: [] });
     const req = mockReq({ headers: { origin: "https://anything.example" } });
     const res = mockRes();
     mw(req, res, nextFn);
     expect(res.headers["Access-Control-Allow-Origin"]).toBe("https://anything.example");
+  });
+
+  it("does NOT reflect any origin when the global allowlist is empty in production (fail-safe; config drift must not open CORS to everyone)", () => {
+    process.env.NODE_ENV = "production";
+    const mw = createCorsMiddleware({ defaultAllowedOrigins: [] });
+    const req = mockReq({ headers: { origin: "https://anything.example" } });
+    const res = mockRes();
+    mw(req, res, nextFn);
+    expect(res.headers["Access-Control-Allow-Origin"]).toBeUndefined();
+  });
+
+  it("in production with empty allowlist, still reflects an origin known to a tenant", () => {
+    process.env.NODE_ENV = "production";
+    const mw = createCorsMiddleware({
+      defaultAllowedOrigins: [],
+      isKnownTenantOrigin: (origin) => origin === "https://tenant.example.com",
+    });
+    const req = mockReq({ headers: { origin: "https://tenant.example.com" } });
+    const res = mockRes();
+    mw(req, res, nextFn);
+    expect(res.headers["Access-Control-Allow-Origin"]).toBe("https://tenant.example.com");
+  });
+
+  it("warns at middleware creation when ALLOWED_ORIGINS is empty outside dev wildcard mode", () => {
+    process.env.NODE_ENV = "production";
+    const warn = jest.fn();
+    createCorsMiddleware({ defaultAllowedOrigins: [], logger: { warn } as any });
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain("ALLOWED_ORIGINS");
+  });
+
+  it("does not warn when ALLOWED_ORIGINS is empty but dev wildcard mode is active", () => {
+    process.env.NODE_ENV = "development";
+    const warn = jest.fn();
+    createCorsMiddleware({ defaultAllowedOrigins: [], logger: { warn } as any });
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("does not warn when ALLOWED_ORIGINS is configured", () => {
+    process.env.NODE_ENV = "production";
+    const warn = jest.fn();
+    createCorsMiddleware({ defaultAllowedOrigins: ["https://admin.r2c.biz"], logger: { warn } as any });
+    expect(warn).not.toHaveBeenCalled();
   });
 
   it("ends the response with 204 for OPTIONS without calling next()", () => {

--- a/src/lib/cors.ts
+++ b/src/lib/cors.ts
@@ -15,6 +15,21 @@ export interface CorsOptions {
   logger?: Logger;
 }
 
+/**
+ * `defaultAllowedOrigins` が空(=ALLOWED_ORIGINS env未設定)のとき、development/test では
+ * 全オリジンを許可する「dev wildcard mode」を維持する。ただしこれを production にまで
+ * 適用すると、env設定漏れが「テナント登録の有無に関わらず全オリジン許可+
+ * Access-Control-Allow-Credentials:true」という fail-open になる
+ * (isKnownTenantOrigin によるテナント単位の絞り込みごと迂回されるため)。
+ * securityLayerConfig.ts と同じ考え方で、known でない環境は「本番かもしれない」側に倒す
+ * (fail-safe)。
+ */
+const DEV_WILDCARD_ENVS = new Set(["development", "test"]);
+
+function isDevWildcardModeActive(): boolean {
+  return DEV_WILDCARD_ENVS.has(process.env["NODE_ENV"] ?? "");
+}
+
 const SAFE_METHODS = new Set(["GET", "HEAD", "OPTIONS"]);
 const ALLOWED_HEADERS = [
   "Content-Type",
@@ -44,6 +59,13 @@ const EXPOSED_HEADERS = [
 export function createCorsMiddleware(opts: CorsOptions = {}) {
   const allowedSet = new Set(opts.defaultAllowedOrigins ?? []);
 
+  if (allowedSet.size === 0 && !isDevWildcardModeActive()) {
+    opts.logger?.warn(
+      "[cors] ALLOWED_ORIGINS が未設定です。テナント登録済みのオリジンのみ許可します" +
+        "（isKnownTenantOrigin）。意図した設定か確認してください。"
+    );
+  }
+
   return function corsMiddleware(
     req: Request,
     res: Response,
@@ -53,9 +75,9 @@ export function createCorsMiddleware(opts: CorsOptions = {}) {
 
     const isAllowed =
       !!origin &&
-      (allowedSet.size === 0 ||
-        allowedSet.has(origin) ||
-        (opts.isKnownTenantOrigin?.(origin) ?? false));
+      (allowedSet.has(origin) ||
+        (opts.isKnownTenantOrigin?.(origin) ?? false) ||
+        (allowedSet.size === 0 && isDevWildcardModeActive()));
 
     if (isAllowed) {
       res.setHeader("Access-Control-Allow-Origin", origin as string);


### PR DESCRIPTION
## 対応する2件（P0セキュリティ）

### A-1: cors.ts の allowedSet.size===0 で全オリジン許可
`ALLOWED_ORIGINS` env未設定だと無条件で全オリジンに `Access-Control-Allow-Origin` が
`Access-Control-Allow-Credentials: true` 付きで反射されていた。既存テストで
「dev wildcard mode」として意図的にドキュメント化された挙動だったため、単純削除ではなく
#838(securityLayerConfig.ts)と同じfail-safeパターンを踏襲: development/testのみ
wildcard維持、それ以外(production含む)はisKnownTenantOrigin(テナント登録済みオリジン)
のみで判定。env設定漏れをmiddleware生成時にwarnログで検知できるようにした。

本番の`ALLOWED_ORIGINS`は現在設定済み(非空)のため、今回の変更で本番の挙動は変わらない。
将来env設定が漏れた場合の"fail-open"を防ぐ回帰防止。

### A-2: supabaseAuthMiddleware.ts の Bearer 解析が2流儀併存
developmentバイパス(27行目)は`startsWith("Bearer ")`でスキーム名を検証しているのに、
通常経路(72行目)は`split(" ")`の2番目を無条件にトークン扱いしていた
(`Basic xxx`等の非Bearerヘッダでもtokenが取れる。最終的にjwt.verifyが弾くため実害は
限定的だが、同一ファイル内の一貫性の欠如)。27行目と同じチェックに統一した。

既存テスト「スキーム名は検証されない: 'bearer'(小文字)でも...現状仕様の固定。将来
スキーム検証を追加する場合は要更新」というコメント付きテストが、まさに今回の変更で
想定されていた更新対象だったため、新仕様(大文字小文字を区別する`Bearer `のみ許可)に
書き換えた。

## テスト結果
- typecheck 0エラー
- `src/lib/cors.test.ts` + `src/admin/http/supabaseAuthMiddleware.test.ts`: 44/44 pass
- ミューテーション確認2件: fail-safe極性反転→1件失敗、Bearer検証を戻す→3件失敗、いずれも復元後全pass

## 禁止事項の遵守
- 新規ファイルなし
- `isKnownTenantOrigin`/`isOriginAllowed`(#835で修正済み)のロジックは変更していない
- マージ・Asana操作は行っていない