### PR TITLE
[MAINT] judge: usageContext計上+自動評価のテナント対称化

### DIFF
--- a/src/agent/judge/judgeEvaluator.test.ts
+++ b/src/agent/judge/judgeEvaluator.test.ts
@@ -158,6 +158,13 @@ describe('evaluateSession', () => {
     const insertCall = mockPool.query.mock.calls[3]!;
     expect(insertCall[1]).toContain('tenant-abc');
     expect(insertCall[1]).toContain('session-123');
+
+    // callGeminiJudge が正しい tenantId を usageContext として渡していること
+    // （billable:false は維持=Stripe請求には含めないが、テナント別消費量として計上する）
+    expect(mockCallGroq).toHaveBeenCalledWith(
+      expect.any(String),
+      { tenantId: 'tenant-abc', billable: false },
+    );
   });
 
   it('2. low score triggers tuning_rules insert (score < 60)', async () => {

--- a/src/agent/judge/judgeEvaluator.ts
+++ b/src/agent/judge/judgeEvaluator.ts
@@ -301,7 +301,7 @@ export async function evaluateSession(sessionId: string, expectedTenantId?: stri
     for (let attempt = 0; attempt < 2; attempt++) {
       try {
         const fullPrompt = `厳格な営業チャット品質評価Judgeです。指定されたJSON形式のみで回答します。\n\n${prompt}${knowledgeAppendix}`;
-        const raw = await callGeminiJudge(fullPrompt);
+        const raw = await callGeminiJudge(fullPrompt, { tenantId, billable: false });
         result = parseJudgeResponse(raw);
         break;
       } catch (err) {

--- a/src/agent/orchestrator/flowControl.phase72c.test.ts
+++ b/src/agent/orchestrator/flowControl.phase72c.test.ts
@@ -7,6 +7,8 @@ jest.mock('../../lib/analytics/flowLogger', () => ({
   initFlowLogger: jest.fn(),
 }));
 
+import { readFileSync } from 'fs';
+import { join } from 'path';
 import { logFlowTransition } from '../../lib/analytics/flowLogger';
 import { applyPhase22FlowAfterGeneration } from './flowControl';
 import { resetFlowSessionMeta, getOrInitFlowSessionMeta, defaultFlowBudgets } from '../dialog/flowContextStore';
@@ -130,5 +132,23 @@ describe('flowControl.ts — logFlowTransition フック (Phase72-C)', () => {
     }
     // forcedTerminal が返らないケース（ループ条件が満たされない環境）でも落とさない
     expect(true).toBe(true);
+  });
+});
+
+// evaluateSession は dynamic import + setImmediate の fire-and-forget で呼ばれるため
+// supertest/直接呼び出しでは到達しにくい。wiringInvariants.test.ts と同じ手法(ソース構造検査)で、
+// tenantId 引数の伝播漏れを防ぐ。
+describe('evaluateSession 呼び出しのテナントID伝播（ソース構造検査）', () => {
+  const source = readFileSync(join(__dirname, 'flowControl.ts'), 'utf-8');
+
+  it('全ての evaluateSession(sid, ...) 呼び出しが tenantId を渡している', () => {
+    const bareCalls = source.match(/evaluateSession\(sid\)/g) ?? [];
+    expect(bareCalls).toHaveLength(0);
+
+    const calls = source.match(/evaluateSession\(sid,\s*[^)]+\)/g) ?? [];
+    expect(calls.length).toBeGreaterThanOrEqual(2);
+    for (const call of calls) {
+      expect(call).toMatch(/evaluateSession\(sid,\s*flowKey\.tenantId\)/);
+    }
   });
 });

--- a/src/agent/orchestrator/flowControl.ts
+++ b/src/agent/orchestrator/flowControl.ts
@@ -357,7 +357,7 @@ export function applyPhase22FlowAfterGeneration(params: {
       const sid = input.conversationId;
       setImmediate(() => {
         import('../judge/judgeEvaluator').then(({ evaluateSession }) =>
-          evaluateSession(sid),
+          evaluateSession(sid, flowKey.tenantId),
         ).catch((err: unknown) => {
           logger.warn({ err, sessionId: sid }, 'judge.auto.failed (non-blocking)');
         });
@@ -425,7 +425,7 @@ export function applyPhase22FlowAfterGeneration(params: {
       const sid = input.conversationId;
       setImmediate(() => {
         import('../judge/judgeEvaluator').then(({ evaluateSession }) =>
-          evaluateSession(sid),
+          evaluateSession(sid, flowKey.tenantId),
         ).catch((err: unknown) => {
           logger.warn({ err, sessionId: sid }, 'judge.auto.failed (non-blocking)');
         });

--- a/src/agent/orchestrator/langGraphOrchestrator.phase22.test.ts
+++ b/src/agent/orchestrator/langGraphOrchestrator.phase22.test.ts
@@ -1,5 +1,7 @@
 // src/agent/orchestrator/langGraphOrchestrator.phase22.test.ts
 
+import { readFileSync } from "fs";
+import { join } from "path";
 import { resetFlowSessionMeta } from "../dialog/flowContextStore";
 import { runDialogGraph } from "./langGraphOrchestrator";
 
@@ -58,3 +60,22 @@ describe("Phase22 flow control (must reach terminal)", () => {
 // flowContextStore のTTL掃き出し検証は ./flowContextStore.test.ts (agent/dialog配下) に
 // 集約した。#837 で専用テストファイルが無かったためこのファイルに間借りしていたが、
 // ここに移動した。
+
+// evaluateSession は dynamic import + setImmediate の fire-and-forget で呼ばれるため
+// supertest/直接呼び出しでは到達しにくい。wiringInvariants.test.ts と同じ手法(ソース構造検査)で、
+// tenantId 引数の伝播漏れ(=手動trigger経路だけがテナント検証を通す非対称)を防ぐ。
+describe("evaluateSession 呼び出しのテナントID伝播（ソース構造検査）", () => {
+  const source = readFileSync(join(__dirname, "langGraphOrchestrator.ts"), "utf-8");
+
+  it("全ての evaluateSession(sid, ...) 呼び出しが tenantId を渡している", () => {
+    const bareCalls = source.match(/evaluateSession\(sid\)/g) ?? [];
+    expect(bareCalls).toHaveLength(0);
+
+    const calls = source.match(/evaluateSession\(sid,\s*[^)]+\)/g) ?? [];
+    expect(calls.length).toBeGreaterThanOrEqual(5);
+    for (const call of calls) {
+      expect(call).toMatch(/evaluateSession\(sid,\s*(input\.tenantId|flowKey\.tenantId)\)/);
+    }
+  });
+});
+

--- a/src/agent/orchestrator/langGraphOrchestrator.ts
+++ b/src/agent/orchestrator/langGraphOrchestrator.ts
@@ -104,7 +104,7 @@ export async function runDialogGraph(
       const sid = input.conversationId;
       setImmediate(() => {
         import('../judge/judgeEvaluator').then(({ evaluateSession }) =>
-          evaluateSession(sid),
+          evaluateSession(sid, input.tenantId),
         ).catch((err: unknown) => {
           logger.warn({ err, sessionId: sid }, 'judge.auto.failed (non-blocking)');
         });
@@ -160,7 +160,7 @@ export async function runDialogGraph(
         const sid = input.conversationId;
         setImmediate(() => {
           import('../judge/judgeEvaluator').then(({ evaluateSession }) =>
-            evaluateSession(sid),
+            evaluateSession(sid, input.tenantId),
           ).catch((err: unknown) => {
             logger.warn({ err, sessionId: sid }, 'judge.auto.failed (non-blocking)');
           });
@@ -199,7 +199,7 @@ export async function runDialogGraph(
         const sid = input.conversationId;
         setImmediate(() => {
           import('../judge/judgeEvaluator').then(({ evaluateSession }) =>
-            evaluateSession(sid),
+            evaluateSession(sid, input.tenantId),
           ).catch((err: unknown) => {
             logger.warn({ err, sessionId: sid }, 'judge.auto.failed (non-blocking)');
           });
@@ -239,7 +239,7 @@ export async function runDialogGraph(
         const sid = input.conversationId;
         setImmediate(() => {
           import('../judge/judgeEvaluator').then(({ evaluateSession }) =>
-            evaluateSession(sid),
+            evaluateSession(sid, input.tenantId),
           ).catch((err: unknown) => {
             logger.warn({ err, sessionId: sid }, 'judge.auto.failed (non-blocking)');
           });
@@ -280,7 +280,7 @@ export async function runDialogGraph(
         const sid = input.conversationId;
         setImmediate(() => {
           import('../judge/judgeEvaluator').then(({ evaluateSession }) =>
-            evaluateSession(sid),
+            evaluateSession(sid, input.tenantId),
           ).catch((err: unknown) => {
             logger.warn({ err, sessionId: sid }, 'judge.auto.failed (non-blocking)');
           });


### PR DESCRIPTION
## 対応した2件（当初計画の3件中）

### B-2: judge の Gemini呼び出しが usageContext 未指定
`judgeEvaluator.ts` の `callGeminiJudge(fullPrompt)` に tenantId を usageContext として渡すよう修正。従来は `tenantId:'unknown'` で計上され、テナント別の消費量が見えなかった（`billable:false` は維持、Stripe請求対象には含めない）。

### B-4: 自動評価7箇所が tenantId を渡していない
`langGraphOrchestrator.ts`(5箇所) / `flowControl.ts`(2箇所) の `evaluateSession(sid)` を `evaluateSession(sid, tenantId)` に統一。手動trigger経路（`evaluations/routes.ts`）だけがテナント検証を通す非対称を解消。**セキュリティ上の変更はない**（tenantIdは元々セッション行由来で検証されるため、越境は元々起きない）。

## 見送った1件: B-3（judge の通知重複排除）

`notifications.ts` の `notificationExists()` を judge の通知2箇所に追加する予定だったが、**実装前の調査時点と現在で前提が変わっていた**ため見送った。

- #839（`fix(judge): evaluateSessionの多重発火を止める`）で、1b（`already_evaluated` の EXISTS 判定による早期return）と 6a（`ON CONFLICT` 敗者の早期return、通知コードより前）により、**同一セッションで通知コードに複数回到達する経路は既に構造的に閉じている**
- 実装してみたところ、`notificationExists()` の DB呼び出しが `judgeEvaluator.test.ts` の厳密な順序付きモック（`mockResolvedValueOnce` 連鎖、`../../lib/db` を共有）に割り込み、8件の既存テストを破壊した
- 実利益ゼロ・テスト破壊コストのみのため実装を取り消した

## テスト

- `judgeEvaluator.test.ts` の既存テスト1に usageContext のアサーションを追加
- `langGraphOrchestrator.phase22.test.ts` / `flowControl.phase72c.test.ts` に、`wiringInvariants.test.ts` と同じ手法（ソース構造検査）で「全ての `evaluateSession(sid, ...)` 呼び出しに tenantId が渡っている」ことを固定するテストを追加（`evaluateSession` は dynamic import + `setImmediate` の fire-and-forget のため、通常の呼び出しテストでは到達しにくい）

**結果**: 対象5スイート 70/70 pass、typecheck 0エラー、oxlintクリーン。ミューテーション3件（usageContext削除・langGraphOrchestrator側tenantId削除・flowControl側tenantId削除）いずれも新規テストが検出→復元して全pass。

マージ・Asana操作は行っていません。