### PR TITLE
[MAINT] APIキー: last_used_at をfire-and-forgetで更新

### DIFF
--- a/src/lib/tenant-context.test.ts
+++ b/src/lib/tenant-context.test.ts
@@ -1,3 +1,11 @@
+const mockPoolQuery = jest.fn().mockResolvedValue({ rows: [] });
+jest.mock("./db", () => ({
+  pool: { query: (...args: unknown[]) => mockPoolQuery(...args) },
+}));
+jest.mock("./logger", () => ({
+  logger: { warn: jest.fn(), info: jest.fn(), error: jest.fn() },
+}));
+
 import {
   seedTenantsFromEnv,
   getTenantConfig,
@@ -13,6 +21,7 @@ import {
   revokeAdditionalTenantApiKey,
   seedTenantsFromDB,
 } from "./tenant-context";
+import { logger as mockedLogger } from "./logger";
 
 describe("seedTenantsFromEnv — numbered keys", () => {
   const savedEnv: Record<string, string | undefined> = {};
@@ -696,5 +705,133 @@ describe("seedTenantsFromDB — 起動時のin-memory復元", () => {
 
   it("0件でも例外を投げない", async () => {
     await expect(seedTenantsFromDB(fakePool([]))).resolves.toBeUndefined();
+  });
+});
+
+describe("getTenantByApiKeyHash — last_used_at の非同期更新", () => {
+  beforeEach(() => {
+    mockPoolQuery.mockClear();
+    mockPoolQuery.mockResolvedValue({ rows: [] });
+    jest.useRealTimers();
+    let now = Date.now();
+    jest.spyOn(Date, "now").mockImplementation(() => now);
+    (global as unknown as { __advanceMockNow: (ms: number) => void }).__advanceMockNow = (ms: number) => {
+      now += ms;
+    };
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function advanceMockNow(ms: number): void {
+    (global as unknown as { __advanceMockNow: (ms: number) => void }).__advanceMockNow(ms);
+  }
+
+  it("有効なキーで認証成功すると last_used_at のUPDATEが発火する", () => {
+    registerTenant({
+      tenantId: "last-used-tenant-1",
+      name: "t",
+      plan: "starter",
+      features: { avatar: false, voice: false, rag: true },
+      security: { apiKeyHash: "lu-key-1", hashAlgorithm: "sha256", allowedOrigins: [], rateLimit: 100, rateLimitWindowMs: 60_000 },
+      enabled: true,
+    });
+
+    const cfg = getTenantByApiKeyHash("lu-key-1");
+
+    expect(cfg?.tenantId).toBe("last-used-tenant-1");
+    expect(mockPoolQuery).toHaveBeenCalledTimes(1);
+    expect(mockPoolQuery.mock.calls[0]?.[0]).toMatch(/UPDATE tenant_api_keys SET last_used_at/);
+    expect(mockPoolQuery.mock.calls[0]?.[1]).toEqual(["lu-key-1"]);
+  });
+
+  it("認証失敗（キー不一致）では last_used_at を更新しない", () => {
+    registerTenant({
+      tenantId: "last-used-tenant-2",
+      name: "t",
+      plan: "starter",
+      features: { avatar: false, voice: false, rag: true },
+      security: { apiKeyHash: "lu-key-2", hashAlgorithm: "sha256", allowedOrigins: [], rateLimit: 100, rateLimitWindowMs: 60_000 },
+      enabled: true,
+    });
+
+    const cfg = getTenantByApiKeyHash("wrong-key");
+
+    expect(cfg).toBeUndefined();
+    expect(mockPoolQuery).not.toHaveBeenCalled();
+  });
+
+  it("デバウンス窓内（5分未満）の連続リクエストは1回しかUPDATEしない", () => {
+    registerTenant({
+      tenantId: "last-used-tenant-3",
+      name: "t",
+      plan: "starter",
+      features: { avatar: false, voice: false, rag: true },
+      security: { apiKeyHash: "lu-key-3", hashAlgorithm: "sha256", allowedOrigins: [], rateLimit: 100, rateLimitWindowMs: 60_000 },
+      enabled: true,
+    });
+
+    getTenantByApiKeyHash("lu-key-3");
+    advanceMockNow(60_000); // 1分後
+    getTenantByApiKeyHash("lu-key-3");
+    advanceMockNow(60_000); // 2分後（累計3分、まだデバウンス窓内）
+    getTenantByApiKeyHash("lu-key-3");
+
+    expect(mockPoolQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("デバウンス窓（5分）を超えると再度UPDATEする", () => {
+    registerTenant({
+      tenantId: "last-used-tenant-4",
+      name: "t",
+      plan: "starter",
+      features: { avatar: false, voice: false, rag: true },
+      security: { apiKeyHash: "lu-key-4", hashAlgorithm: "sha256", allowedOrigins: [], rateLimit: 100, rateLimitWindowMs: 60_000 },
+      enabled: true,
+    });
+
+    getTenantByApiKeyHash("lu-key-4");
+    advanceMockNow(6 * 60 * 1000); // 6分後（デバウンス窓超過）
+    getTenantByApiKeyHash("lu-key-4");
+
+    expect(mockPoolQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it("DB書き込みが失敗しても認証結果には影響せず、warnログに落ちる", async () => {
+    registerTenant({
+      tenantId: "last-used-tenant-5",
+      name: "t",
+      plan: "starter",
+      features: { avatar: false, voice: false, rag: true },
+      security: { apiKeyHash: "lu-key-5", hashAlgorithm: "sha256", allowedOrigins: [], rateLimit: 100, rateLimitWindowMs: 60_000 },
+      enabled: true,
+    });
+    mockPoolQuery.mockRejectedValueOnce(new Error("write failed"));
+
+    const cfg = getTenantByApiKeyHash("lu-key-5");
+    expect(cfg?.tenantId).toBe("last-used-tenant-5"); // 同期的な認証結果は即座に返る（DB書き込みは待たない）
+
+    // fire-and-forgetのPromise rejectionが処理されるのを待つ
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(mockedLogger.warn).toHaveBeenCalled();
+  });
+
+  it("追加キー（無停止ローテーション）経由の認証成功でも last_used_at が更新される", () => {
+    registerTenant({
+      tenantId: "last-used-tenant-6",
+      name: "t",
+      plan: "starter",
+      features: { avatar: false, voice: false, rag: true },
+      security: { apiKeyHash: "lu-key-6-primary", hashAlgorithm: "sha256", allowedOrigins: [], rateLimit: 100, rateLimitWindowMs: 60_000 },
+      enabled: true,
+    });
+    addTenantApiKey("last-used-tenant-6", "lu-key-6-additional", null);
+
+    const cfg = getTenantByApiKeyHash("lu-key-6-additional");
+
+    expect(cfg?.tenantId).toBe("last-used-tenant-6");
+    expect(mockPoolQuery).toHaveBeenCalledTimes(1);
+    expect(mockPoolQuery.mock.calls[0]?.[1]).toEqual(["lu-key-6-additional"]);
   });
 });

--- a/src/lib/tenant-context.ts
+++ b/src/lib/tenant-context.ts
@@ -5,6 +5,8 @@ import type { Pool } from "pg";
 import type { TenantConfig } from "../types/contracts";
 import type { AuthedRequest } from "../agent/http/authMiddleware";
 import { isOriginAllowed } from "../api/middleware/originCheck";
+import { pool } from "./db";
+import { logger as appLogger } from "./logger";
 
 // ---------------------------------------------------------------------------
 // In-memory tenant registry (DB-backed via seedTenantsFromDB at startup)
@@ -125,6 +127,26 @@ function safeCompare(a: string, b: string): boolean {
   return timingSafeEqual(hashA, hashB);
 }
 
+// last_used_at のDB書き込みは認証のホットパスなので同期的に待たない。
+// 毎リクエスト書き込むと負荷になるため、同一キーハッシュに対しては
+// LAST_USED_DEBOUNCE_MS 以内の再書き込みをスキップする（インメモリのデバウンス
+// テーブルなので、PM2再起動直後は1回分の書き込みが増えるだけで実害はない）。
+const LAST_USED_DEBOUNCE_MS = 5 * 60 * 1000; // 5分
+const lastUsedWriteAttemptAt = new Map<string, number>();
+
+function touchLastUsedAt(keyHash: string): void {
+  if (!pool) return; // DATABASE_URL未設定（テスト環境等）では何もしない
+  const now = Date.now();
+  const last = lastUsedWriteAttemptAt.get(keyHash);
+  if (last !== undefined && now - last < LAST_USED_DEBOUNCE_MS) return;
+  lastUsedWriteAttemptAt.set(keyHash, now);
+  pool
+    .query(`UPDATE tenant_api_keys SET last_used_at = NOW() WHERE key_hash = $1`, [keyHash])
+    .catch((err: unknown) => {
+      appLogger.warn({ err }, "tenant-context: failed to update last_used_at (non-blocking)");
+    });
+}
+
 export function getTenantByApiKeyHash(
   hash: string
 ): TenantConfig | undefined {
@@ -135,6 +157,7 @@ export function getTenantByApiKeyHash(
       if (expiresAt !== undefined && expiresAt !== null && expiresAt <= Date.now()) {
         return undefined; // 稼働中に期限切れ（起動時seedはDB側でフィルタ済みだが、以降の失効を反映）
       }
+      touchLastUsedAt(hash);
       return cfg;
     }
     // 無停止ローテーションで追加されたキー（主キーとは独立して有効期限を持つ）。
@@ -146,6 +169,7 @@ export function getTenantByApiKeyHash(
       for (const [additionalHash, expiresAt] of additional) {
         if (!safeCompare(additionalHash, hash)) continue;
         if (expiresAt !== null && expiresAt <= Date.now()) return undefined;
+        touchLastUsedAt(hash);
         return cfg;
       }
     }


### PR DESCRIPTION
## 対応した項目

- **B-1**: `tenant_api_keys.last_used_at` を書き込むコードが存在せず、キー一覧UIで常にnull表示だった。`getTenantByApiKeyHash` の認証成功パスで fire-and-forget UPDATE を発火するようにした（5分デバウンス、DB書き込み失敗は認証結果に影響しない・warnログのみ）。

## 見送った項目（判断の根拠を明記）

- **C-2（additionalApiKeysのテナント削除時クリーンアップ）**: 見送り。テナントの「削除」機能自体がコードベースに存在しない。`updateTenantEnabled(false)` は可逆的なkill-switchであり、ここにクリーンアップを結びつけると再有効化時にローテーション追加キーが失われる回帰を招く。
- **C-3（getTenantByApiKeyHashのO(1)化）**: 見送り。既存コード（140-143行目）に「Map.getによるO(1)逆引きに置き換えるとタイミングサイドチャネルを持ち込むため採用しない」という明示的な設計判断が既に書かれている。この判断を覆す新しい根拠が無いため踏襲した。本番テナント数は4件のみで、線形探索のパフォーマンス影響も実質ゼロ。

## 変更ファイル
- `src/lib/tenant-context.ts` — `touchLastUsedAt()` 追加、`getTenantByApiKeyHash` の2つの成功パスから呼び出し
- `src/lib/tenant-context.test.ts` — `./db`/`./logger` をモックし6件のテストを追加（成功時UPDATE発火、失敗時は発火しない、デバウンス境界、DB書き込み失敗時の非ブロッキング動作、追加キー経由でも発火）

## テスト結果
- typecheck 0エラー、oxlintクリーン
- `tenant-context|tenants/routes|authMiddleware` 5スイート 216/216 pass
- ミューテーション確認: `touchLastUsedAt` 呼び出しを全て無効化し、新規6テストのうち5件が失敗することを確認→復元（残り1件は「認証失敗時は呼ばれない」ことを検証するテストで、呼び出し削除では変化しないため妥当）

マージはしていません。