### PR TITLE
[LAUNCH][P3] allowed_originsワイルドカード検証UI+評価トリガーUI+PM2スケールアウト文書化

### DIFF
--- a/admin-ui/src/pages/admin/chat-history/JudgeEvaluationSection.test.tsx
+++ b/admin-ui/src/pages/admin/chat-history/JudgeEvaluationSection.test.tsx
@@ -1,0 +1,186 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { JudgeEvaluationSection } from "./JudgeEvaluationSection";
+import { authFetch } from "../../../lib/api";
+import type { Evaluation } from "./types";
+
+vi.mock("../../../lib/api", () => ({
+  API_BASE: "http://localhost:3100",
+  authFetch: vi.fn(),
+}));
+
+const mockedAuthFetch = authFetch as unknown as ReturnType<typeof vi.fn>;
+
+function jsonResponse(status: number, body: unknown) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  };
+}
+
+beforeEach(() => {
+  mockedAuthFetch.mockReset();
+});
+
+describe("JudgeEvaluationSection — 未評価時のトリガーUI", () => {
+  it("evaluation が null かつ sessionId 未指定なら実行ボタンを出さない", () => {
+    render(
+      <JudgeEvaluationSection evaluation={null} isSuperAdmin={false} setEvaluation={vi.fn()} />
+    );
+    expect(screen.queryByText("今すぐ評価を実行")).toBeNull();
+  });
+
+  it("evaluation が null かつ sessionId 指定時は実行ボタンを出す", () => {
+    render(
+      <JudgeEvaluationSection
+        evaluation={null}
+        isSuperAdmin={false}
+        setEvaluation={vi.fn()}
+        sessionId="s1"
+      />
+    );
+    expect(screen.getByText("今すぐ評価を実行")).toBeTruthy();
+  });
+
+  it("200: 成功時は evaluation を更新しエラーを出さない", async () => {
+    const evaluation: Evaluation = {
+      id: 1,
+      score: 80,
+      evaluated_at: "2026-01-01T00:00:00Z",
+    };
+    mockedAuthFetch.mockResolvedValue(jsonResponse(200, { evaluation }));
+    const setEvaluation = vi.fn();
+    render(
+      <JudgeEvaluationSection
+        evaluation={null}
+        isSuperAdmin={false}
+        setEvaluation={setEvaluation}
+        sessionId="s1"
+      />
+    );
+    fireEvent.click(screen.getByText("今すぐ評価を実行"));
+
+    await waitFor(() => {
+      expect(setEvaluation).toHaveBeenCalledWith(evaluation);
+    });
+    expect(mockedAuthFetch).toHaveBeenCalledWith(
+      expect.stringContaining("/v1/admin/evaluations/trigger"),
+      expect.objectContaining({
+        method: "POST",
+        body: JSON.stringify({ session_id: "s1" }),
+      })
+    );
+  });
+
+  it("404: セッション不在/他テナントの文言を表示する", async () => {
+    mockedAuthFetch.mockResolvedValue(jsonResponse(404, { error: "セッションが見つかりません" }));
+    render(
+      <JudgeEvaluationSection
+        evaluation={null}
+        isSuperAdmin={false}
+        setEvaluation={vi.fn()}
+        sessionId="s1"
+      />
+    );
+    fireEvent.click(screen.getByText("今すぐ評価を実行"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/セッションが見つかりません/)).toBeTruthy();
+    });
+  });
+
+  it("409: 評価済みの文言を表示する", async () => {
+    mockedAuthFetch.mockResolvedValue(jsonResponse(409, { error: "already_evaluated" }));
+    render(
+      <JudgeEvaluationSection
+        evaluation={null}
+        isSuperAdmin={false}
+        setEvaluation={vi.fn()}
+        sessionId="s1"
+      />
+    );
+    fireEvent.click(screen.getByText("今すぐ評価を実行"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/既に評価済みです/)).toBeTruthy();
+    });
+  });
+
+  it("422: 会話が短すぎる旨の文言を表示する", async () => {
+    mockedAuthFetch.mockResolvedValue(
+      jsonResponse(422, { error: "session_too_short", message: "会話が短すぎるため評価対象外です" })
+    );
+    render(
+      <JudgeEvaluationSection
+        evaluation={null}
+        isSuperAdmin={false}
+        setEvaluation={vi.fn()}
+        sessionId="s1"
+      />
+    );
+    fireEvent.click(screen.getByText("今すぐ評価を実行"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/会話が短すぎるため評価対象外です/)).toBeTruthy();
+    });
+  });
+
+  it("500: 内部エラー時は汎用の失敗文言を表示する", async () => {
+    mockedAuthFetch.mockResolvedValue(jsonResponse(500, { error: "evaluation_failed" }));
+    render(
+      <JudgeEvaluationSection
+        evaluation={null}
+        isSuperAdmin={false}
+        setEvaluation={vi.fn()}
+        sessionId="s1"
+      />
+    );
+    fireEvent.click(screen.getByText("今すぐ評価を実行"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/評価の実行に失敗しました/)).toBeTruthy();
+    });
+  });
+
+  it("実行中は連打してもリクエストが1回しか飛ばない", async () => {
+    let resolveFetch: (v: unknown) => void = () => {};
+    mockedAuthFetch.mockReturnValue(
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      })
+    );
+    render(
+      <JudgeEvaluationSection
+        evaluation={null}
+        isSuperAdmin={false}
+        setEvaluation={vi.fn()}
+        sessionId="s1"
+      />
+    );
+    const button = screen.getByText("今すぐ評価を実行");
+    fireEvent.click(button);
+    fireEvent.click(button);
+    fireEvent.click(button);
+
+    expect(mockedAuthFetch).toHaveBeenCalledTimes(1);
+    resolveFetch(jsonResponse(200, { evaluation: { id: 1, score: 90, evaluated_at: "2026-01-01T00:00:00Z" } }));
+  });
+
+  it("evaluation が存在する場合は実行ボタンを出さない", () => {
+    const evaluation: Evaluation = {
+      id: 1,
+      score: 80,
+      evaluated_at: "2026-01-01T00:00:00Z",
+    };
+    render(
+      <JudgeEvaluationSection
+        evaluation={evaluation}
+        isSuperAdmin={false}
+        setEvaluation={vi.fn()}
+        sessionId="s1"
+      />
+    );
+    expect(screen.queryByText("今すぐ評価を実行")).toBeNull();
+  });
+});

--- a/admin-ui/src/pages/admin/chat-history/JudgeEvaluationSection.tsx
+++ b/admin-ui/src/pages/admin/chat-history/JudgeEvaluationSection.tsx
@@ -1,18 +1,62 @@
-import type { Dispatch, SetStateAction } from "react";
+import { useState, type Dispatch, type SetStateAction } from "react";
 import type { Evaluation } from "./types";
 import { SuggestedRulesCard } from "./SuggestedRulesCard";
+import { authFetch, API_BASE } from "../../../lib/api";
 
 // ─── Judge評価セクション（AI品質評価） ─────────────────────────────────────────
+
+// POST /v1/admin/evaluations/trigger のレスポンスに応じたフィードバック文言。
+// 200/404/409/422/500 の意味論は Phase45(#823/#829) と Phase75(#839) で確定済み。
+function triggerErrorMessage(status: number, body: { error?: string; message?: string } | null): string {
+  switch (status) {
+    case 404:
+      return "セッションが見つかりません（削除された、または他テナントのセッションの可能性があります）";
+    case 409:
+      return "既に評価済みです（画面を更新してください）";
+    case 422:
+      return body?.message ?? "会話が短すぎるため評価対象外です";
+    default:
+      return "評価の実行に失敗しました。しばらくしてから再度お試しください";
+  }
+}
 
 export function JudgeEvaluationSection({
   evaluation,
   isSuperAdmin,
   setEvaluation,
+  sessionId,
 }: {
   evaluation: Evaluation | null;
   isSuperAdmin: boolean;
   setEvaluation: Dispatch<SetStateAction<Evaluation | null>>;
+  sessionId?: string;
 }) {
+  const [triggering, setTriggering] = useState(false);
+  const [triggerError, setTriggerError] = useState<string | null>(null);
+
+  const handleTrigger = async () => {
+    if (!sessionId || triggering) return;
+    setTriggering(true);
+    setTriggerError(null);
+    try {
+      const res = await authFetch(`${API_BASE}/v1/admin/evaluations/trigger`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ session_id: sessionId }),
+      });
+      const body = await res.json().catch(() => null);
+      if (res.ok) {
+        setEvaluation(body?.evaluation ?? null);
+        return;
+      }
+      setTriggerError(triggerErrorMessage(res.status, body));
+    } catch {
+      setTriggerError("通信に失敗しました。しばらくしてから再度お試しください");
+    } finally {
+      setTriggering(false);
+    }
+  };
+
   return (
     <div
       style={{
@@ -27,11 +71,38 @@ export function JudgeEvaluationSection({
         🤖 AI品質評価 (Judge)
       </p>
       {evaluation == null ? (
-        <span style={{
-          display: "inline-flex", alignItems: "center", padding: "4px 12px",
-          borderRadius: 999, fontSize: 12, fontWeight: 700,
-          background: "rgba(107,114,128,0.15)", border: "1px solid rgba(107,114,128,0.3)", color: "var(--muted-foreground)",
-        }}>未評価</span>
+        <div style={{ display: "flex", flexDirection: "column", gap: 10, alignItems: "flex-start" }}>
+          <span style={{
+            display: "inline-flex", alignItems: "center", padding: "4px 12px",
+            borderRadius: 999, fontSize: 12, fontWeight: 700,
+            background: "rgba(107,114,128,0.15)", border: "1px solid rgba(107,114,128,0.3)", color: "var(--muted-foreground)",
+          }}>未評価</span>
+          {sessionId && (
+            <button
+              type="button"
+              onClick={() => void handleTrigger()}
+              disabled={triggering}
+              style={{
+                padding: "8px 16px",
+                minHeight: 36,
+                borderRadius: 8,
+                border: "1px solid rgba(96,165,250,0.4)",
+                background: triggering ? "rgba(96,165,250,0.1)" : "rgba(96,165,250,0.15)",
+                color: "#93c5fd",
+                fontSize: 13,
+                fontWeight: 600,
+                cursor: triggering ? "not-allowed" : "pointer",
+              }}
+            >
+              {triggering ? "評価を実行中…" : "今すぐ評価を実行"}
+            </button>
+          )}
+          {triggerError && (
+            <p style={{ margin: 0, fontSize: 12, color: "#fca5a5", lineHeight: 1.5 }}>
+              {triggerError}
+            </p>
+          )}
+        </div>
       ) : (() => {
         const overall = evaluation.overall_score ?? evaluation.score;
         const scoreColor = overall >= 80 ? "#4ade80" : overall >= 60 ? "#fbbf24" : "#f87171";

--- a/admin-ui/src/pages/admin/chat-history/[sessionId].tsx
+++ b/admin-ui/src/pages/admin/chat-history/[sessionId].tsx
@@ -507,6 +507,7 @@ export default function ChatHistorySessionPage() {
             evaluation={evaluation}
             isSuperAdmin={isSuperAdmin}
             setEvaluation={setEvaluation}
+            sessionId={sessionId}
           />
 
           {/* 営業結果入力（Client Adminのみ表示） */}

--- a/admin-ui/src/pages/admin/tenants/SettingsTab.test.tsx
+++ b/admin-ui/src/pages/admin/tenants/SettingsTab.test.tsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { SettingsTab } from "./SettingsTab";
+import type { TenantDetail } from "./types";
+
+vi.mock("../../../i18n/LangContext", () => ({
+  useLang: () => ({ t: (key: string) => key }),
+}));
+
+function makeTenant(overrides: Partial<TenantDetail> = {}): TenantDetail {
+  return {
+    id: "t1",
+    name: "Test Tenant",
+    plan: "growth",
+    status: "active",
+    createdAt: "2026-01-01T00:00:00Z",
+    widgetTitle: "Chat",
+    widgetColor: "#000000",
+    allowed_origins: [],
+    billing_enabled: false,
+    billing_free_from: null,
+    billing_free_until: null,
+    features: {} as TenantDetail["features"],
+    lemonslice_agent_id: null,
+    conversion_types: [],
+    ...overrides,
+  } as TenantDetail;
+}
+
+describe("SettingsTab — allowed_origins バリデーション", () => {
+  let onSave: (data: {
+    name: string;
+    status: "active" | "inactive";
+    allowed_origins: string[];
+    system_prompt?: string;
+    tenant_contact_email?: string | null;
+  }) => Promise<void>;
+  let onBillingUpdate: (updated: TenantDetail) => void;
+  let updateBilling: (
+    tenantId: string,
+    billing_enabled: boolean,
+    billing_free_from: string | null,
+    billing_free_until: string | null
+  ) => Promise<TenantDetail>;
+  let onSaveMock: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    onSaveMock = vi.fn().mockResolvedValue(undefined);
+    onSave = onSaveMock as unknown as typeof onSave;
+    onBillingUpdate = vi.fn();
+    updateBilling = vi.fn() as unknown as typeof updateBilling;
+  });
+
+  function renderTab(tenant = makeTenant()) {
+    return render(
+      <SettingsTab
+        tenant={tenant}
+        isSuperAdmin={true}
+        onSave={onSave}
+        onBillingUpdate={onBillingUpdate}
+        updateBilling={updateBilling}
+      />
+    );
+  }
+
+  function getOriginsTextarea(): HTMLTextAreaElement {
+    // allowed_origins のテキストエリアはこのタブで唯一の textarea ではないため、
+    // placeholder で特定する(SettingsTab.tsx の allowed_origins_placeholder キー由来)。
+    const textareas = screen.getAllByRole("textbox") as HTMLTextAreaElement[];
+    const el = textareas.find((t) => t.tagName === "TEXTAREA" && t.value !== undefined);
+    // 最初の textarea が allowed_origins(system_prompt より前に描画される)
+    return (el ?? textareas[0]) as HTMLTextAreaElement;
+  }
+
+  function submit() {
+    const button = screen.getByText("tenant_detail.save_settings");
+    fireEvent.click(button);
+  }
+
+  it("https:// 始まりでないURLは保存前に拒否される", () => {
+    renderTab();
+    const textarea = getOriginsTextarea();
+    fireEvent.change(textarea, { target: { value: "http://insecure.example.com" } });
+    submit();
+
+    expect(screen.getByText(/URLはhttps:\/\/で始まる必要があります/)).toBeTruthy();
+    expect(onSaveMock).not.toHaveBeenCalled();
+  });
+
+  it("https://*.example.com（サブドメインワイルドカード）は許可される", async () => {
+    renderTab();
+    const textarea = getOriginsTextarea();
+    fireEvent.change(textarea, { target: { value: "https://*.example.com" } });
+    submit();
+
+    await waitFor(() => {
+      expect(onSaveMock).toHaveBeenCalledWith(
+        expect.objectContaining({ allowed_origins: ["https://*.example.com"] })
+      );
+    });
+  });
+
+  it("https://*（全一致ワイルドカード）は保存前に拒否される", () => {
+    renderTab();
+    const textarea = getOriginsTextarea();
+    fireEvent.change(textarea, { target: { value: "https://*" } });
+    submit();
+
+    expect(
+      screen.getByText(/ワイルドカードは https:\/\/\*\.example\.com の形のみ使用できます/)
+    ).toBeTruthy();
+    expect(onSaveMock).not.toHaveBeenCalled();
+  });
+
+  it("https://*evil.com（先頭ラベル以外のワイルドカード）は保存前に拒否される", () => {
+    renderTab();
+    const textarea = getOriginsTextarea();
+    fireEvent.change(textarea, { target: { value: "https://*evil.com" } });
+    submit();
+
+    expect(
+      screen.getByText(/ワイルドカードは https:\/\/\*\.example\.com の形のみ使用できます/)
+    ).toBeTruthy();
+    expect(onSaveMock).not.toHaveBeenCalled();
+  });
+
+  it("https://*.a.*.com（ワイルドカード2個）は保存前に拒否される", () => {
+    renderTab();
+    const textarea = getOriginsTextarea();
+    fireEvent.change(textarea, { target: { value: "https://*.a.*.com" } });
+    submit();
+
+    expect(
+      screen.getByText(/ワイルドカードは https:\/\/\*\.example\.com の形のみ使用できます/)
+    ).toBeTruthy();
+    expect(onSaveMock).not.toHaveBeenCalled();
+  });
+
+  it("通常のhttps URLとワイルドカードの混在は、通常URLが妥当なら保存される", async () => {
+    renderTab();
+    const textarea = getOriginsTextarea();
+    fireEvent.change(textarea, {
+      target: { value: "https://shop.example.com\nhttps://*.example.com" },
+    });
+    submit();
+
+    await waitFor(() => {
+      expect(onSaveMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          allowed_origins: ["https://shop.example.com", "https://*.example.com"],
+        })
+      );
+    });
+  });
+});

--- a/admin-ui/src/pages/admin/tenants/SettingsTab.tsx
+++ b/admin-ui/src/pages/admin/tenants/SettingsTab.tsx
@@ -39,9 +39,21 @@ export function SettingsTab({
   const handleSave = async (e: React.FormEvent) => {
     e.preventDefault();
     const allowed_origins = parseOrigins(originsText);
-    const invalid = allowed_origins.filter((u) => !u.startsWith("https://"));
-    if (invalid.length > 0) {
-      setError(`URLはhttps://で始まる必要があります: ${invalid[0]}`);
+    const invalidHttps = allowed_origins.filter((u) => !u.startsWith("https://"));
+    if (invalidHttps.length > 0) {
+      setError(`URLはhttps://で始まる必要があります: ${invalidHttps[0]}`);
+      return;
+    }
+    // バックエンド(originCheck.ts の isValidOriginPattern)と同じ形のみ許可する。
+    // ワイルドカードは「先頭ラベルが *. のサブドメイン指定」のみで、https://* や
+    // https://*evil.com は保存時に400で拒否される — ここで先に弾いて即時フィードバックする。
+    const invalidWildcard = allowed_origins.filter(
+      (u) => u.includes("*") && !/^https:\/\/\*\.[^*/]+$/.test(u)
+    );
+    if (invalidWildcard.length > 0) {
+      setError(
+        `ワイルドカードは https://*.example.com の形のみ使用できます: ${invalidWildcard[0]}`
+      );
       return;
     }
     setSaving(true);

--- a/docs/DEPLOY_CHECKLIST.md
+++ b/docs/DEPLOY_CHECKLIST.md
@@ -492,6 +492,23 @@ curl -s -o /dev/null -w "%{http_code}\n" -H "Authorization: Bearer $SA_TOKEN" "h
 リストアを選ぶこと。`conversation_flow_logs` は新規テーブルのため
 `DROP TABLE IF EXISTS conversation_flow_logs;` で戻せる。
 
+## PM2 instances を増やす前に (現在は instances:1 / fork モードのため未対応)
+
+`ecosystem.config.cjs` の `rajiuce-api` は現在 `instances: 1` / `exec_mode: "fork"`。
+将来スケールアウトのために `instances` を1より大きくする、または `exec_mode: "cluster"` に
+変更する場合、以下4つのプロセスローカルなインメモリ状態が**プロセスごとに別々の値を持ち、
+同時に不整合を起こす**。1つでも対応漏れがあると、リクエストがどのワーカーに振られるかで
+挙動が変わる不具合になる。
+
+| 状態 | 場所 | 増やすと何が起きるか | 対応の方向性 |
+|---|---|---|---|
+| 会話履歴3ストア | `src/agent/dialog/{contextStore,salesContextStore,flowContextStore}.ts` | 同一セッションの続きが別ワーカーに振られると会話履歴が消えたように見える | Redis 等の外部ストアへ移行、または L4(ロードバランサ)でセッションIDによる sticky routing |
+| rate-limit バケット | `src/lib/rate-limit.ts` | 上限がワーカー数倍に緩む(各ワーカーが独立してカウントするため) | Redis 等の外部カウンタへ移行 |
+| テナントレジストリ | `src/lib/tenant-context.ts` (`tenantStore`, `additionalApiKeys`) | キー発行・失効・allowed_origins更新の即時反映(#809/#814/#824/#836)が反映されたワーカーとされていないワーカーで割れる | PM2 の `pm2 reload` はゼロダウンタイムでワーカーを順次再起動するため、DB更新をトリガーに全ワーカーへブロードキャストする仕組み(pub/sub 等)が必要 |
+
+**現状の結論**: `instances:1` のままである限り対応不要。上記表は「増やすと決めた時」の
+着手前チェックリストとして残す。
+
 ## トラブルシューティング
 
 | 症状 | 対処 |


### PR DESCRIPTION
## 概要
未対応リスク一覧のP3(UI/ドキュメント)3件に対応する。

## 対応内容

### D-1: SettingsTab.tsx にワイルドカード形式検証を追加
`originCheck.ts` の `isValidOriginPattern`（#835で確定）と判定結果が一致する
正規表現(`/^https:\/\/\*\.[^*/]+$/`)をフロント側にも追加。`https://*` 等は
送信前にUIでエラー表示するようになった(従来は送信して初めて400)。

i18nの説明文言(`tenant_detail.allowed_origins_desc`)は既に
「ワイルドカード可: https://*.example.com」と実仕様どおりだったため変更なし。

### D-2: 評価トリガーUIを追加
`POST /v1/admin/evaluations/trigger` を呼ぶUIがadmin-uiに存在せずcurl運用に
なっていた。既存の `JudgeEvaluationSection.tsx`(chat-history詳細画面)の
「未評価」表示に「今すぐ評価を実行」ボタンを追加。

200/404/409/422/500(#823/#829/#839で確定済みの意味論)それぞれに応じた
フィードバック文言を表示する。連打してもリクエストは1回のみ。

### D-3: PM2スケールアウトの前提条件を文書化
`DEPLOY_CHECKLIST.md` に、`instances` を1より大きくする前に対応が必要な
4つのインメモリ状態(セッションストア3種/rate-limitバケット/テナント
レジストリ)を明記。現在は `instances:1` のため対応不要、将来の着手前
チェックリストとして記録。

## テスト
- `SettingsTab.test.tsx`(新規): 6件。https://*, https://*evil.com,
  https://*.a.*.com の拒否、https://*.example.com の許可を固定
- `JudgeEvaluationSection.test.tsx`(新規): 9件。5ステータスそれぞれの
  フィードバック文言、連打時の1回のみ発火を固定
- typecheck 0エラー / oxlintクリーン / admin-ui全体 542/542 pass
- ミューテーション確認2件(ワイルドカード検証の無効化→3件失敗、トリガー
  ボタン非表示化→7件失敗)、いずれも復元後に全pass

## Tier S
`admin-ui/src` を含むため、手動マージが必要です。

マージ・Asana操作は行っていません。