### PR TITLE
[FIX][P0] 廃止されたGroqモデル2件をgpt-oss-120bへ移行しフォールバックチェーンを修復

### DIFF
--- a/src/agent/judge/conversationJudge.test.ts
+++ b/src/agent/judge/conversationJudge.test.ts
@@ -68,7 +68,7 @@ describe('evaluateConversation', () => {
     expect(result.evaluationAxes.customer_reaction).toBe(85);
     expect(result.evaluationAxes.stage_progression).toBe(80);
     expect(result.evaluationAxes.contraindication_compliance).toBe(85);
-    expect(result.modelUsed).toBe('llama-3.3-70b-versatile');
+    expect(result.modelUsed).toBe('openai/gpt-oss-120b');
   });
 
   it('2. JSONパースエラー1回目 → リトライして成功', async () => {

--- a/src/agent/judge/conversationJudge.ts
+++ b/src/agent/judge/conversationJudge.ts
@@ -1,13 +1,13 @@
 // src/agent/judge/conversationJudge.ts
-// Phase45: Judge評価エンジン - Groq 70b (llama-3.3-70b-versatile) で会話を評価
+// Phase45: Judge評価エンジン - Groq 経由の openai/gpt-oss-120b で会話を評価
 
-import { GROQ_VERSATILE_70B } from '../../config/groqModels';
+import { GPT_OSS_120B } from '../../config/groqModels';
 import pino from 'pino';
 import { callGroqWith429Retry } from '../llm/groqClient';
 
 const logger = pino();
 
-const JUDGE_MODEL = GROQ_VERSATILE_70B;
+const JUDGE_MODEL = GPT_OSS_120B;
 
 export interface JudgeInput {
   tenantId: string;

--- a/src/agent/judge/evaluationAnalyzer.ts
+++ b/src/agent/judge/evaluationAnalyzer.ts
@@ -1,7 +1,7 @@
 // src/agent/judge/evaluationAnalyzer.ts
 // Phase45: 評価結果を分析してチューニングルールを提案する
 
-import { GROQ_INSTANT_8B } from '../../config/groqModels';
+import { GPT_OSS_120B } from '../../config/groqModels';
 import { Pool } from 'pg';
 import pino from 'pino';
 import { callGroqWith429Retry } from '../llm/groqClient';
@@ -9,7 +9,7 @@ import { createEvaluationRepository } from './evaluationRepository';
 
 const logger = pino();
 
-const ANALYZER_MODEL = GROQ_INSTANT_8B;
+const ANALYZER_MODEL = GPT_OSS_120B;
 
 export interface SuggestedRule {
   triggerPattern: string;

--- a/src/agent/judge/evaluationRepository.ts
+++ b/src/agent/judge/evaluationRepository.ts
@@ -1,7 +1,7 @@
 // src/agent/judge/evaluationRepository.ts
 // Phase45: Judge評価結果のDBリポジトリ
 
-import { GROQ_VERSATILE_70B } from '../../config/groqModels';
+import { GPT_OSS_120B } from '../../config/groqModels';
 import { Pool } from 'pg';
 import { getPool as _getDefaultPool } from '../../lib/db';
 
@@ -87,7 +87,7 @@ export function createEvaluationRepository(pool?: InstanceType<typeof Pool>) {
           JSON.stringify(evaluation.failedPrinciples),
           JSON.stringify(evaluation.evaluationAxes),
           evaluation.notes ?? null,
-          evaluation.modelUsed ?? GROQ_VERSATILE_70B,
+          evaluation.modelUsed ?? GPT_OSS_120B,
         ],
       );
       return rowToEvaluation(result.rows[0]!);

--- a/src/agent/llm/groqClient.fallback.test.ts
+++ b/src/agent/llm/groqClient.fallback.test.ts
@@ -12,7 +12,7 @@ import {
   GroqCallParams,
   groqClient,
 } from './groqClient';
-import { GROQ_VERSATILE_70B, GROQ_INSTANT_8B, GPT_OSS_120B, GPT_OSS_20B, GROQ_VERSATILE_70B as VERSATILE } from '../../config/groqModels';
+import { GPT_OSS_120B, GPT_OSS_20B, GROQ_COMPOUND, GROQ_COMPOUND_MINI } from '../../config/groqModels';
 
 function makeParams(model: string): GroqCallParams {
   return {
@@ -84,58 +84,58 @@ describe('callGroqWithModelFallback — 正常系', () => {
   it('最初の呼び出しが成功した場合はそのまま返す', async () => {
     callSpy.mockResolvedValueOnce('ok-response');
 
-    const result = await callGroqWithModelFallback(makeParams(GROQ_VERSATILE_70B), { logger });
+    const result = await callGroqWithModelFallback(makeParams(GPT_OSS_120B), { logger });
 
     expect(result).toBe('ok-response');
     expect(callSpy).toHaveBeenCalledTimes(1);
-    expect(callSpy).toHaveBeenCalledWith(expect.objectContaining({ model: GROQ_VERSATILE_70B }));
+    expect(callSpy).toHaveBeenCalledWith(expect.objectContaining({ model: GPT_OSS_120B }));
     // 最初の試行が成功した場合は warn を出さない
     expect(warnMock).not.toHaveBeenCalled();
   });
 
   it('1 回 model_not_found → フォールバック先で成功', async () => {
-    const notFoundError = new GroqModelNotFoundError(404, '{"error":"model_not_found"}', GROQ_VERSATILE_70B);
+    const notFoundError = new GroqModelNotFoundError(404, '{"error":"model_not_found"}', GPT_OSS_120B);
     callSpy
       .mockRejectedValueOnce(notFoundError)
       .mockResolvedValueOnce('fallback-response');
 
-    const result = await callGroqWithModelFallback(makeParams(GROQ_VERSATILE_70B), { logger });
+    const result = await callGroqWithModelFallback(makeParams(GPT_OSS_120B), { logger });
 
     expect(result).toBe('fallback-response');
     expect(callSpy).toHaveBeenCalledTimes(2);
     // 2 回目はフォールバック先モデルで呼ばれること
-    expect(callSpy).toHaveBeenNthCalledWith(2, expect.objectContaining({ model: GROQ_INSTANT_8B }));
+    expect(callSpy).toHaveBeenNthCalledWith(2, expect.objectContaining({ model: GPT_OSS_20B }));
   });
 
   it('フォールバック発生時に warn ログが出力される（無言フォールバック禁止）', async () => {
-    const notFoundError = new GroqModelNotFoundError(404, '{"error":"model_not_found"}', GROQ_VERSATILE_70B);
+    const notFoundError = new GroqModelNotFoundError(404, '{"error":"model_not_found"}', GPT_OSS_120B);
     callSpy
       .mockRejectedValueOnce(notFoundError)
       .mockResolvedValueOnce('ok');
 
-    await callGroqWithModelFallback(makeParams(GROQ_VERSATILE_70B), { logger });
+    await callGroqWithModelFallback(makeParams(GPT_OSS_120B), { logger });
 
     expect(warnMock).toHaveBeenCalledTimes(1);
     expect(warnMock.mock.calls[0][0]).toMatchObject({
-      originalModel: GROQ_VERSATILE_70B,
-      failedModel: GROQ_VERSATILE_70B,
-      fallbackModel: GROQ_INSTANT_8B,
+      originalModel: GPT_OSS_120B,
+      failedModel: GPT_OSS_120B,
+      fallbackModel: GPT_OSS_20B,
     });
     expect(warnMock.mock.calls[0][1]).toMatch(/groq-fallback/);
   });
 
   it('フォールバック成功後に info ログが出力される', async () => {
-    const notFoundError = new GroqModelNotFoundError(404, '{"error":"model_not_found"}', GROQ_VERSATILE_70B);
+    const notFoundError = new GroqModelNotFoundError(404, '{"error":"model_not_found"}', GPT_OSS_120B);
     callSpy
       .mockRejectedValueOnce(notFoundError)
       .mockResolvedValueOnce('ok');
 
-    await callGroqWithModelFallback(makeParams(GROQ_VERSATILE_70B), { logger });
+    await callGroqWithModelFallback(makeParams(GPT_OSS_120B), { logger });
 
     expect(infoMock).toHaveBeenCalledTimes(1);
     expect(infoMock.mock.calls[0][0]).toMatchObject({
-      originalModel: GROQ_VERSATILE_70B,
-      resolvedModel: GROQ_INSTANT_8B,
+      originalModel: GPT_OSS_120B,
+      resolvedModel: GPT_OSS_20B,
     });
   });
 
@@ -152,15 +152,15 @@ describe('callGroqWithModelFallback — 正常系', () => {
   });
 
   it('onFallback コールバックが呼ばれる', async () => {
-    const notFoundError = new GroqModelNotFoundError(404, '{"error":"model_not_found"}', GROQ_VERSATILE_70B);
+    const notFoundError = new GroqModelNotFoundError(404, '{"error":"model_not_found"}', GPT_OSS_120B);
     callSpy
       .mockRejectedValueOnce(notFoundError)
       .mockResolvedValueOnce('ok');
 
     const onFallback = jest.fn();
-    await callGroqWithModelFallback(makeParams(GROQ_VERSATILE_70B), { logger, onFallback });
+    await callGroqWithModelFallback(makeParams(GPT_OSS_120B), { logger, onFallback });
 
-    expect(onFallback).toHaveBeenCalledWith(GROQ_VERSATILE_70B, GROQ_INSTANT_8B);
+    expect(onFallback).toHaveBeenCalledWith(GPT_OSS_120B, GPT_OSS_20B);
   });
 });
 
@@ -172,7 +172,7 @@ describe('callGroqWithModelFallback — エラー系', () => {
     const serverError = new GroqServerError(500, 'internal error');
     callSpy.mockRejectedValueOnce(serverError);
 
-    await expect(callGroqWithModelFallback(makeParams(GROQ_VERSATILE_70B), { logger }))
+    await expect(callGroqWithModelFallback(makeParams(GPT_OSS_120B), { logger }))
       .rejects.toBeInstanceOf(GroqServerError);
 
     expect(callSpy).toHaveBeenCalledTimes(1);
@@ -183,7 +183,7 @@ describe('callGroqWithModelFallback — エラー系', () => {
     const rateLimitError = new GroqRateLimitError(429, 'rate limit exceeded');
     callSpy.mockRejectedValueOnce(rateLimitError);
 
-    await expect(callGroqWithModelFallback(makeParams(GROQ_VERSATILE_70B), { logger }))
+    await expect(callGroqWithModelFallback(makeParams(GPT_OSS_120B), { logger }))
       .rejects.toBeInstanceOf(GroqRateLimitError);
 
     expect(callSpy).toHaveBeenCalledTimes(1);
@@ -193,17 +193,17 @@ describe('callGroqWithModelFallback — エラー系', () => {
     const badRequestError = new GroqBadRequestError(400, 'bad request');
     callSpy.mockRejectedValueOnce(badRequestError);
 
-    await expect(callGroqWithModelFallback(makeParams(GROQ_VERSATILE_70B), { logger }))
+    await expect(callGroqWithModelFallback(makeParams(GPT_OSS_120B), { logger }))
       .rejects.toBeInstanceOf(GroqBadRequestError);
 
     expect(callSpy).toHaveBeenCalledTimes(1);
   });
 
-  it('チェーン終端（GROQ_INSTANT_8B）はフォールバック先なしでエラーを投げる', async () => {
-    const notFoundError = new GroqModelNotFoundError(404, '{"error":"model_not_found"}', GROQ_INSTANT_8B);
+  it('チェーン終端（GPT_OSS_20B）はフォールバック先なしでエラーを投げる', async () => {
+    const notFoundError = new GroqModelNotFoundError(404, '{"error":"model_not_found"}', GPT_OSS_20B);
     callSpy.mockRejectedValue(notFoundError);
 
-    await expect(callGroqWithModelFallback(makeParams(GROQ_INSTANT_8B), { logger }))
+    await expect(callGroqWithModelFallback(makeParams(GPT_OSS_20B), { logger }))
       .rejects.toBeInstanceOf(GroqModelNotFoundError);
 
     // フォールバック試行なし（チェーン終端なので 1 回のみ）
@@ -214,19 +214,20 @@ describe('callGroqWithModelFallback — エラー系', () => {
   });
 
   it('フォールバック先でも model_not_found になった場合にチェーンを辿る', async () => {
-    // GPT_OSS_120B → GPT_OSS_20B → GROQ_VERSATILE_70B と辿る
-    const notFoundFor120b = new GroqModelNotFoundError(404, '{"error":"model_not_found"}', GPT_OSS_120B);
-    const notFoundFor20b = new GroqModelNotFoundError(404, '{"error":"model_not_found"}', GPT_OSS_20B);
+    // GROQ_COMPOUND → GROQ_COMPOUND_MINI → GPT_OSS_120B と辿る
+    const notFoundForCompound = new GroqModelNotFoundError(404, '{"error":"model_not_found"}', GROQ_COMPOUND);
+    const notFoundForMini = new GroqModelNotFoundError(404, '{"error":"model_not_found"}', GROQ_COMPOUND_MINI);
     callSpy
-      .mockRejectedValueOnce(notFoundFor120b)
-      .mockRejectedValueOnce(notFoundFor20b)
+      .mockRejectedValueOnce(notFoundForCompound)
+      .mockRejectedValueOnce(notFoundForMini)
       .mockResolvedValueOnce('final-fallback');
 
-    const result = await callGroqWithModelFallback(makeParams(GPT_OSS_120B), { logger });
+    const result = await callGroqWithModelFallback(makeParams(GROQ_COMPOUND), { logger });
 
     expect(result).toBe('final-fallback');
     expect(callSpy).toHaveBeenCalledTimes(3);
-    expect(callSpy).toHaveBeenNthCalledWith(3, expect.objectContaining({ model: GROQ_VERSATILE_70B }));
+    expect(callSpy).toHaveBeenNthCalledWith(2, expect.objectContaining({ model: GROQ_COMPOUND_MINI }));
+    expect(callSpy).toHaveBeenNthCalledWith(3, expect.objectContaining({ model: GPT_OSS_120B }));
     // warn は 2 回（各フォールバック発生時）
     expect(warnMock).toHaveBeenCalledTimes(2);
   });

--- a/src/agent/memory/memoryDistiller.ts
+++ b/src/agent/memory/memoryDistiller.ts
@@ -7,7 +7,7 @@
 import pino from "pino";
 
 import { groqClient } from "../llm/groqClient";
-import { GROQ_VERSATILE_70B } from "../../config/groqModels";
+import { GPT_OSS_120B } from "../../config/groqModels";
 import { embedText } from "../llm/openaiEmbeddingClient";
 import {
   isLearnedMemoryWriteEnabled,
@@ -55,7 +55,7 @@ async function distillConversation(
     .join("\n");
 
   const raw = await groqClient.call({
-    model: GROQ_VERSATILE_70B,
+    model: GPT_OSS_120B,
     messages: [
       { role: "system", content: DISTILL_SYSTEM_PROMPT },
       { role: "user", content: conversationLog },
@@ -128,7 +128,7 @@ export async function distillAndPromote(
       embedding,
       sourceSessionId: sessionId,
       judgeScore,
-      metadata: { distilled_by: GROQ_VERSATILE_70B },
+      metadata: { distilled_by: GPT_OSS_120B },
     };
 
     const repo = createLearnedMemoryRepository();

--- a/src/agent/objection/objectionDetector.ts
+++ b/src/agent/objection/objectionDetector.ts
@@ -1,7 +1,7 @@
 // src/agent/objection/objectionDetector.ts
 // Phase46: 会話履歴から反論→対応→肯定パターンを自動検出し、objection_patternsに蓄積
 
-import { GROQ_INSTANT_8B } from '../../config/groqModels';
+import { GPT_OSS_120B } from '../../config/groqModels';
 import { Pool } from 'pg';
 import pino from 'pino';
 import { callGroqWith429Retry } from '../llm/groqClient';
@@ -94,7 +94,7 @@ export async function saveObjectionPatterns(
     try {
       const normalized = await callGroqWith429Retry(
         {
-          model: GROQ_INSTANT_8B,
+          model: GPT_OSS_120B,
           messages: [
             {
               role: 'system',

--- a/src/agent/psychology/principleDetector.ts
+++ b/src/agent/psychology/principleDetector.ts
@@ -2,7 +2,7 @@
 // Phase44: 心理学原則検出器
 // キーワードマッチング + Groq 8b LLMフォールバック
 
-import { GROQ_INSTANT_8B } from '../../config/groqModels';
+import { GPT_OSS_120B } from '../../config/groqModels';
 import { groqClient } from '../llm/groqClient';
 
 const KEYWORD_MAP: Record<string, string[]> = {
@@ -24,7 +24,7 @@ export interface PrincipleDetectionResult {
 
 /**
  * 直近3件のユーザーメッセージからキーワードマッチで心理学原則を検出する。
- * マッチなし → Groq 8b (llama-3.1-8b-instant) でLLM判定（フォールバック）。
+ * マッチなし → Groq 経由の openai/gpt-oss-120b でLLM判定（フォールバック）。
  * salesStage が propose/recommend/close の場合、最低1原則を返す。
  *
  * セキュリティ: LLMに渡すメッセージ内容は slice(0,500) でトリミング
@@ -82,7 +82,7 @@ async function detectWithLlm(
 
   try {
     const response = await groqClient.call({
-      model: GROQ_INSTANT_8B,
+      model: GPT_OSS_120B,
       messages: [
         {
           role: "system",

--- a/src/agent/tools/synthesisTool.ts
+++ b/src/agent/tools/synthesisTool.ts
@@ -1,6 +1,6 @@
 // src/agent/tools/synthesisTool.ts
 
-import { GROQ_VERSATILE_70B } from '../../config/groqModels';
+import { GPT_OSS_120B } from '../../config/groqModels';
 import type { RerankItem } from '../types';
 import { groqClient, type GroqUsage } from '../llm/groqClient';
 import {
@@ -125,7 +125,7 @@ const BASE_SYSTEM_PROMPT = `あなたは中古車販売店のAIコンシェル�
 - FAQ情報が不十分な場合は「詳しくはお問い合わせください」と案内する`;
 
 /**
- * Groq LLM（llama-3.3-70b-versatile）で自然な日本語回答を生成する。
+ * Groq LLM（openai/gpt-oss-120b）で自然な日本語回答を生成する。
  * tenantId が指定された場合、アクティブなチューニングルールをシステムプロンプトに注入する。
  * APIキー未設定・エラー時は箇条書きフォールバックを返す。
  */
@@ -263,7 +263,7 @@ export async function synthesizeAnswer(input: SynthesisInput): Promise<Synthesis
       : `お客様の質問: ${query}\n上記の応答ルールに従って、お客様の質問に自然な日本語で回答してください。`;
 
     const synthResult = await groqClient.callWithUsage({
-      model: GROQ_VERSATILE_70B,
+      model: GPT_OSS_120B,
       messages: [
         { role: 'system', content: systemPrompt },
         { role: 'user', content: userPrompt },

--- a/src/api/admin/agent/agentRoutes.ts
+++ b/src/api/admin/agent/agentRoutes.ts
@@ -13,7 +13,7 @@ import { requiresConfirmation, WRITE_TOOL_RISK_TIERS } from './confirmPolicy';
 import { trackUsage } from '../../../lib/billing/usageTracker';
 import { recordAgentMetric, type AgentMetricInput } from '../../../lib/metrics/agentMetrics';
 import { recordAgentSettingsChange } from './agentAuditLog';
-import { GROQ_VERSATILE_70B } from '../../../config/groqModels';
+import { GPT_OSS_120B } from '../../../config/groqModels';
 import { isUnanswered } from '../ai-assist/systemPrompt';
 
 // ---------------------------------------------------------------------------
@@ -305,7 +305,7 @@ async function callGroqWithTools(
       Authorization: `Bearer ${apiKey}`,
     },
     body: JSON.stringify({
-      model: GROQ_VERSATILE_70B,
+      model: GPT_OSS_120B,
       messages,
       tools,
       tool_choice: 'auto',
@@ -342,7 +342,7 @@ async function callGroqFinal(messages: GroqMessage[]): Promise<{ reply: string; 
       Authorization: `Bearer ${apiKey}`,
     },
     body: JSON.stringify({
-      model: GROQ_VERSATILE_70B,
+      model: GPT_OSS_120B,
       messages,
       max_tokens: 512,
       temperature: 0.2,
@@ -566,7 +566,7 @@ async function runStreamingHop(
   if (!apiKey) throw new Error('GROQ_API_KEY not configured');
 
   const body: Record<string, unknown> = {
-    model: GROQ_VERSATILE_70B,
+    model: GPT_OSS_120B,
     messages,
     max_tokens: 1024,
     temperature: 0.2,
@@ -904,7 +904,7 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
             trackUsage({
               tenantId: effectiveTenantId,
               requestId: `admin-agent-${sessionId}-${Date.now()}`,
-              model: GROQ_VERSATILE_70B,
+              model: GPT_OSS_120B,
               inputTokens: totalPromptTokens,
               outputTokens: totalCompletionTokens,
               featureUsed: 'admin_agent',
@@ -943,7 +943,7 @@ export function registerAdminAgentRoutes(app: Express, db: Pool): void {
         trackUsage({
           tenantId: effectiveTenantId,
           requestId: `admin-agent-${sessionId}-${Date.now()}`,
-          model: GROQ_VERSATILE_70B,
+          model: GPT_OSS_120B,
           inputTokens: totalPromptTokens,
           outputTokens: totalCompletionTokens,
           featureUsed: 'admin_agent',

--- a/src/api/admin/agent/engagementSuggest.ts
+++ b/src/api/admin/agent/engagementSuggest.ts
@@ -2,7 +2,7 @@
 // Phase3: 自然文からお客様への声がけ(trigger_rules)を構造化提案する。
 // tuning/routes.ts の callGroq8bSuggestFromText と同型のパターン。
 
-import { GROQ_INSTANT_8B } from '../../../config/groqModels';
+import { GPT_OSS_120B } from '../../../config/groqModels';
 import { trackUsage } from '../../../lib/billing/usageTracker';
 
 export type EngagementTriggerType = 'scroll_depth' | 'idle_time' | 'exit_intent' | 'page_url_match';
@@ -93,7 +93,7 @@ trigger_type は次の4種類から最も適切なものを1つ選んでくだ�
         Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify({
-        model: process.env.GROQ_MODEL_8B ?? GROQ_INSTANT_8B,
+        model: process.env.GROQ_MODEL_8B ?? GPT_OSS_120B,
         messages: [{ role: 'user', content: prompt }],
         temperature: 0.4,
         max_tokens: 400,
@@ -114,7 +114,7 @@ trigger_type は次の4種類から最も適切なものを1つ選んでくだ�
       trackUsage({
         tenantId,
         requestId: `admin-engagement-suggest:${tenantId}:${Date.now()}`,
-        model: process.env.GROQ_MODEL_8B ?? GROQ_INSTANT_8B,
+        model: process.env.GROQ_MODEL_8B ?? GPT_OSS_120B,
         inputTokens: data.usage?.prompt_tokens ?? 0,
         outputTokens: data.usage?.completion_tokens ?? 0,
         featureUsed: 'admin_engagement_suggest',

--- a/src/api/admin/ai-assist/routes.ts
+++ b/src/api/admin/ai-assist/routes.ts
@@ -3,7 +3,7 @@
 // Phase43 P2: インテント振り分け + RAG統合
 // POST /v1/admin/ai-assist/chat
 
-import { GROQ_INSTANT_8B, GROQ_VERSATILE_70B } from '../../../config/groqModels';
+import { GPT_OSS_120B } from '../../../config/groqModels';
 import type { Express, Request, Response } from "express";
 import { z } from "zod";
 import { supabaseAuthMiddleware } from "../../../admin/http/supabaseAuthMiddleware";
@@ -63,7 +63,7 @@ async function detectIntent(message: string, tenantId: string): Promise<Intent> 
         Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify({
-        model: GROQ_INSTANT_8B,
+        model: GPT_OSS_120B,
         messages: [
           {
             role: "user",
@@ -85,7 +85,7 @@ async function detectIntent(message: string, tenantId: string): Promise<Intent> 
       trackUsage({
         tenantId,
         requestId: `admin-ai-assist-intent:${tenantId}:${Date.now()}`,
-        model: GROQ_INSTANT_8B,
+        model: GPT_OSS_120B,
         inputTokens: data.usage?.prompt_tokens ?? 0,
         outputTokens: data.usage?.completion_tokens ?? 0,
         featureUsed: "admin_ai_assist",
@@ -99,7 +99,7 @@ async function detectIntent(message: string, tenantId: string): Promise<Intent> 
 }
 
 // ---------------------------------------------------------------------------
-// Groq LLM 呼び出し（llama-3.1-8b-instant）— admin_guide モード
+// Groq LLM 呼び出し（openai/gpt-oss-120b）— admin_guide モード
 // ---------------------------------------------------------------------------
 
 async function callGroq8b(userMessage: string, tenantId: string): Promise<string> {
@@ -113,7 +113,7 @@ async function callGroq8b(userMessage: string, tenantId: string): Promise<string
       Authorization: `Bearer ${apiKey}`,
     },
     body: JSON.stringify({
-      model: GROQ_INSTANT_8B,
+      model: GPT_OSS_120B,
       messages: [
         { role: "system", content: ADMIN_AI_SYSTEM_PROMPT },
         { role: "user", content: userMessage },
@@ -134,7 +134,7 @@ async function callGroq8b(userMessage: string, tenantId: string): Promise<string
     trackUsage({
       tenantId,
       requestId: `admin-ai-assist-guide:${tenantId}:${Date.now()}`,
-      model: GROQ_INSTANT_8B,
+      model: GPT_OSS_120B,
       inputTokens: data.usage?.prompt_tokens ?? 0,
       outputTokens: data.usage?.completion_tokens ?? 0,
       featureUsed: "admin_ai_assist",
@@ -145,7 +145,7 @@ async function callGroq8b(userMessage: string, tenantId: string): Promise<string
 }
 
 // ---------------------------------------------------------------------------
-// Groq LLM 呼び出し（llama-3.3-70b-versatile）— business_faq モード
+// Groq LLM 呼び出し（openai/gpt-oss-120b）— business_faq モード
 // ---------------------------------------------------------------------------
 
 async function callGroq70b(userMessage: string, ragContext: string, tenantId: string): Promise<string> {
@@ -173,7 +173,7 @@ ${ragContext}`
       Authorization: `Bearer ${apiKey}`,
     },
     body: JSON.stringify({
-      model: GROQ_VERSATILE_70B,
+      model: GPT_OSS_120B,
       messages: [
         { role: "system", content: systemPrompt },
         { role: "user", content: userMessage },
@@ -194,7 +194,7 @@ ${ragContext}`
     trackUsage({
       tenantId,
       requestId: `admin-ai-assist-faq:${tenantId}:${Date.now()}`,
-      model: GROQ_VERSATILE_70B,
+      model: GPT_OSS_120B,
       inputTokens: data.usage?.prompt_tokens ?? 0,
       outputTokens: data.usage?.completion_tokens ?? 0,
       featureUsed: "admin_ai_assist",

--- a/src/api/admin/avatar/generationRoutes.ts
+++ b/src/api/admin/avatar/generationRoutes.ts
@@ -2,7 +2,7 @@
 
 // Phase41: Avatar Customization Studio — 画像生成・声マッチング・プロンプト生成API
 
-import { GROQ_VERSATILE_70B } from '../../../config/groqModels';
+import { GPT_OSS_120B } from '../../../config/groqModels';
 import type { Express, NextFunction, Request, Response } from "express";
 
 type AvatarReq = Request & { supabaseUser?: Record<string, unknown>; requestId?: string };
@@ -28,7 +28,7 @@ async function callGroqLLM(system: string, user: string): Promise<string> {
       Authorization: `Bearer ${apiKey}`,
     },
     body: JSON.stringify({
-      model: GROQ_VERSATILE_70B,
+      model: GPT_OSS_120B,
       messages: [
         { role: "system", content: system },
         { role: "user", content: user },
@@ -366,7 +366,7 @@ JSONのみ返してください。`,
           tenantId,
           requestId,
           featureUsed: "avatar_config_voice",
-          model: GROQ_VERSATILE_70B,
+          model: GPT_OSS_120B,
           inputTokens: 0,
           outputTokens: 0,
         });
@@ -541,7 +541,7 @@ JSONのみ返してください。`,
           tenantId,
           requestId,
           featureUsed: "avatar_config_prompt",
-          model: GROQ_VERSATILE_70B,
+          model: GPT_OSS_120B,
           inputTokens: 0,
           outputTokens: 0,
         });

--- a/src/api/admin/feedback/feedbackAI.ts
+++ b/src/api/admin/feedback/feedbackAI.ts
@@ -1,7 +1,7 @@
 // src/api/admin/feedback/feedbackAI.ts
 // Phase62: FAQチャット代行提案 + 試算フロー統合
 
-import { GROQ_INSTANT_8B } from '../../../config/groqModels';
+import { GPT_OSS_120B } from '../../../config/groqModels';
 import { sanitizeOutput } from "../../../lib/security/inputSanitizer";
 import { trackUsage } from "../../../lib/billing/usageTracker";
 import { logger } from '../../../lib/logger';
@@ -10,7 +10,7 @@ import { estimateOptionPrice } from './optionEstimator';
 import { getPool } from '../../../lib/db';
 import { createNotification } from '../../../lib/notifications';
 
-const FEEDBACK_AI_MODEL = process.env.FEEDBACK_AI_MODEL ?? GROQ_INSTANT_8B;
+const FEEDBACK_AI_MODEL = process.env.FEEDBACK_AI_MODEL ?? GPT_OSS_120B;
 
 // ---------------------------------------------------------------------------
 // システムプロンプト（Phase62: 代行案内ルール追加）

--- a/src/api/admin/feedback/optionEstimator.ts
+++ b/src/api/admin/feedback/optionEstimator.ts
@@ -1,7 +1,7 @@
 // src/api/admin/feedback/optionEstimator.ts
 // Phase62: オプションサービス料金試算（Groq 70B呼び出し）
 
-import { GROQ_VERSATILE_70B } from '../../../config/groqModels';
+import { GPT_OSS_120B } from '../../../config/groqModels';
 import { logger } from '../../../lib/logger';
 import { trackUsage } from '../../../lib/billing/usageTracker';
 
@@ -54,7 +54,7 @@ export async function estimateOptionPrice(
         Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify({
-        model: process.env.GROQ_MODEL_70B ?? GROQ_VERSATILE_70B,
+        model: process.env.GROQ_MODEL_70B ?? GPT_OSS_120B,
         messages: [
           { role: 'system', content: ESTIMATE_SYSTEM_PROMPT },
           { role: 'user', content: userPrompt },
@@ -80,7 +80,7 @@ export async function estimateOptionPrice(
       trackUsage({
         tenantId,
         requestId: `admin-option-estimator:${tenantId}:${Date.now()}`,
-        model: process.env.GROQ_MODEL_70B ?? GROQ_VERSATILE_70B,
+        model: process.env.GROQ_MODEL_70B ?? GPT_OSS_120B,
         inputTokens: data.usage?.prompt_tokens ?? 0,
         outputTokens: data.usage?.completion_tokens ?? 0,
         featureUsed: 'admin_option_estimator',

--- a/src/api/admin/tuning/routes.ts
+++ b/src/api/admin/tuning/routes.ts
@@ -2,7 +2,7 @@
 
 // Phase38 Step4-BE: チューニングルール CRUD API
 
-import { GROQ_INSTANT_8B } from '../../../config/groqModels';
+import { GPT_OSS_120B } from '../../../config/groqModels';
 import type { Express, Request, Response } from "express";
 import type { AuthedReq } from "../../middleware/roleAuth";
 import { roleAuthMiddleware } from "../../middleware/roleAuth";
@@ -100,7 +100,7 @@ ${knowledgePart}${rulesPart}${crossTenantPart}${researchPart}
         Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify({
-        model: process.env.GROQ_MODEL_8B ?? GROQ_INSTANT_8B,
+        model: process.env.GROQ_MODEL_8B ?? GPT_OSS_120B,
         messages: [{ role: "user", content: prompt }],
         temperature: 0.4,
         max_tokens: 400,
@@ -178,7 +178,7 @@ ${knowledgePart}${rulesPart}${crossTenantPart}
         Authorization: `Bearer ${apiKey}`,
       },
       body: JSON.stringify({
-        model: process.env.GROQ_MODEL_8B ?? GROQ_INSTANT_8B,
+        model: process.env.GROQ_MODEL_8B ?? GPT_OSS_120B,
         messages: [{ role: "user", content: prompt }],
         temperature: 0.4,
         max_tokens: 400,
@@ -352,7 +352,7 @@ export function registerTuningRoutes(app: Express): void {
         trackUsage({
           tenantId,
           requestId: `admin-tuning-suggest:${Date.now()}`,
-          model: process.env.GROQ_MODEL_8B ?? GROQ_INSTANT_8B,
+          model: process.env.GROQ_MODEL_8B ?? GPT_OSS_120B,
           inputTokens: Math.ceil(promptChars / 4),
           outputTokens: Math.ceil(outputChars / 4),
           featureUsed: 'admin_tuning',

--- a/src/api/admin/tuning/testResponseRoutes.ts
+++ b/src/api/admin/tuning/testResponseRoutes.ts
@@ -1,7 +1,7 @@
 // src/api/admin/tuning/testResponseRoutes.ts
 // Phase6-B: チューニングルール LLMテスト返答生成API
 
-import { GROQ_VERSATILE_70B } from '../../../config/groqModels';
+import { GPT_OSS_120B } from '../../../config/groqModels';
 import type { Express, Request, Response } from "express";
 import type { AuthedReq } from "../../middleware/roleAuth";
 import { supabaseAuthMiddleware } from "../../../admin/http/supabaseAuthMiddleware";
@@ -9,7 +9,7 @@ import { getPool } from "../../../lib/db";
 import { logger } from "../../../lib/logger";
 import { trackUsage } from "../../../lib/billing/usageTracker";
 
-const GROQ_MODEL_70B = GROQ_VERSATILE_70B;
+const GROQ_MODEL_70B = GPT_OSS_120B;
 
 // ---------------------------------------------------------------------------
 // ALLOWED_ROLES whitelist

--- a/src/api/avatar/anamChatStreamRoutes.test.ts
+++ b/src/api/avatar/anamChatStreamRoutes.test.ts
@@ -190,7 +190,7 @@ describe('POST /api/avatar/chat-stream — usage計測(trackUsage)', () => {
     expect(mockTrackUsage).toHaveBeenCalledWith({
       tenantId: 'carnation',
       requestId: 'req-usage-ok',
-      model: 'llama-3.3-70b-versatile',
+      model: 'openai/gpt-oss-120b',
       inputTokens: 42,
       outputTokens: 7,
       featureUsed: 'chat',

--- a/src/api/avatar/anamChatStreamRoutes.ts
+++ b/src/api/avatar/anamChatStreamRoutes.ts
@@ -7,7 +7,7 @@
 //   Anam JS SDKのcreateTalkMessageStream()でTTS化される。
 
 import { randomUUID } from 'node:crypto';
-import { GROQ_VERSATILE_70B } from '../../config/groqModels';
+import { GPT_OSS_120B, getFallbackGroqModel } from '../../config/groqModels';
 import type { Express, Request, Response, RequestHandler } from 'express';
 import type { AuthedRequest } from '../../agent/http/authMiddleware';
 import { logger } from '../../lib/logger';
@@ -33,10 +33,12 @@ const GROQ_API_BASE = 'https://api.groq.com/openai/v1/chat/completions';
 function trackAnamChatUsage(params: {
   tenantId: string;
   requestId: string;
+  /** 実際に応答を返したモデル。フォールバックが起きた場合は退避先が入る。 */
+  model: string;
   inputTokens: number | undefined;
   outputTokens: number | undefined;
 }): void {
-  const { tenantId, requestId, inputTokens, outputTokens } = params;
+  const { tenantId, requestId, model, inputTokens, outputTokens } = params;
   if (inputTokens === undefined || outputTokens === undefined) {
     // Groqがusageチャンクを返さないまま完了/中断した場合。
     // silentに0計上せず、原価・請求が過少になり得ることを可視化する。
@@ -48,7 +50,7 @@ function trackAnamChatUsage(params: {
   trackUsage({
     tenantId,
     requestId,
-    model: GROQ_VERSATILE_70B,
+    model,
     inputTokens: inputTokens ?? 0,
     outputTokens: outputTokens ?? 0,
     featureUsed: 'chat',
@@ -190,29 +192,70 @@ export function registerAnamChatStreamRoutes(app: Express, apiStack: RequestHand
     res.setHeader('Connection', 'keep-alive');
 
     try {
-      const groqRes = await fetch(GROQ_API_BASE, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-          'Authorization': `Bearer ${groqApiKey}`,
-        },
-        body: JSON.stringify({
-          model: GROQ_VERSATILE_70B,
-          messages: groqMessages,
-          stream: true,
-          // usage計測: 最終チャンクにusage(prompt_tokens/completion_tokens)を含めてもらう。
-          stream_options: { include_usage: true },
-          max_tokens: 150,
-          temperature: 0.7,
-        }),
-      });
+      // モデル配信停止(404 model_not_found)時は groqModels.ts のフォールバックチェーンを辿る。
+      // 共通の callGroqWithModelFallback は非ストリーミング(Promise<string>)のためここでは使えない。
+      // ただし 404 判定は本文を1バイトも書き出す前に確定するので、この位置での退避は安全
+      // (ストリーム開始後は応答を撤回できないため、退避もしない)。
+      let candidateModel: string | null = GPT_OSS_120B;
+      let groqRes: Awaited<ReturnType<typeof fetch>> | undefined;
+      const attemptedModels: string[] = [];
 
-      if (!groqRes.ok) {
-        const errText = await groqRes.text();
-        logger.error(`[anamChatStream] Groq API error ${groqRes.status}: ${errText.slice(0, 200)}`);
+      while (candidateModel !== null) {
+        attemptedModels.push(candidateModel);
+        const attempt = await fetch(GROQ_API_BASE, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${groqApiKey}`,
+          },
+          body: JSON.stringify({
+            model: candidateModel,
+            messages: groqMessages,
+            stream: true,
+            // usage計測: 最終チャンクにusage(prompt_tokens/completion_tokens)を含めてもらう。
+            stream_options: { include_usage: true },
+            max_tokens: 150,
+            temperature: 0.7,
+          }),
+        });
+
+        if (attempt.ok) {
+          groqRes = attempt;
+          break;
+        }
+
+        const errText = await attempt.text();
+        const isModelNotFound =
+          attempt.status === 404 && errText.includes('model_not_found');
+
+        if (!isModelNotFound) {
+          // モデル不在以外の失敗は退避しても直らないため、そのまま返す。
+          logger.error(
+            `[anamChatStream] Groq API error ${attempt.status}: ${errText.slice(0, 200)}`,
+          );
+          res.write(JSON.stringify({ error: 'LLM error' }) + '\n');
+          return res.end();
+        }
+
+        const nextModel = getFallbackGroqModel(candidateModel);
+        // 無言フォールバック禁止: 退避も打ち切りも必ずログに残す。
+        logger.warn(
+          { requestId: req.requestId, tenantId, failedModel: candidateModel, nextModel },
+          '[anamChatStream] model_not_found — falling back to next catalog model',
+        );
+        candidateModel = nextModel;
+      }
+
+      if (!groqRes || candidateModel === null) {
+        logger.error(
+          { requestId: req.requestId, tenantId, attemptedModels },
+          '[anamChatStream] all fallback models returned model_not_found — giving up',
+        );
         res.write(JSON.stringify({ error: 'LLM error' }) + '\n');
         return res.end();
       }
+
+      const resolvedModel: string = candidateModel;
 
       const reader = groqRes.body?.getReader();
       if (!reader) {
@@ -265,7 +308,7 @@ export function registerAnamChatStreamRoutes(app: Express, apiStack: RequestHand
         // ストリームが正常完了/中断のどちらでも、ここまでに得たusage(未取得ならundefined)で計上する。
         // requestId(req.requestId)は1リクエストにつき固定なので、再接続で二重にPOSTされない限り
         // 二重計上は発生しない。二重POST自体はusage_logsのrequest_id UNIQUE制約で防がれる。
-        trackAnamChatUsage({ tenantId, requestId: req.requestId, inputTokens, outputTokens });
+        trackAnamChatUsage({ tenantId, requestId: req.requestId, model: resolvedModel, inputTokens, outputTokens });
       }
 
       res.end();

--- a/src/api/chat/route.ts
+++ b/src/api/chat/route.ts
@@ -1,4 +1,4 @@
-import { GROQ_VERSATILE_70B } from '../../config/groqModels';
+import { GPT_OSS_120B } from '../../config/groqModels';
 import type { Request, Response } from "express";
 import type { Logger } from "pino";
 import { z } from "zod";
@@ -21,7 +21,7 @@ import { checkTopic } from "../../middleware/topicGuard";
 import { guardOutput } from "../../middleware/outputGuard";
 
 // チャットリクエストで使用するデフォルトLLMモデル名（コスト計算用）
-const CHAT_LLM_MODEL = process.env.LLM_CHAT_MODEL ?? GROQ_VERSATILE_70B;
+const CHAT_LLM_MODEL = process.env.LLM_CHAT_MODEL ?? GPT_OSS_120B;
 
 // ---------------------------------------------------------------------------
 // ナレッジギャップ検出

--- a/src/api/internal/usageRoutes.test.ts
+++ b/src/api/internal/usageRoutes.test.ts
@@ -93,7 +93,7 @@ describe("POST /api/internal/usage", () => {
     );
   });
 
-  it("inputTokens/outputTokens/model/featureUsed省略時は後方互換のデフォルト値(0/0/GROQ_VERSATILE_70B/avatar)を使う", async () => {
+  it("inputTokens/outputTokens/model/featureUsed省略時は後方互換のデフォルト値(0/0/GPT_OSS_120B/avatar)を使う", async () => {
     await request(makeApp())
       .post("/api/internal/usage")
       .set("X-Internal-Request", "1")
@@ -103,7 +103,7 @@ describe("POST /api/internal/usage", () => {
       expect.objectContaining({
         inputTokens: 0,
         outputTokens: 0,
-        model: "llama-3.3-70b-versatile",
+        model: "openai/gpt-oss-120b",
         featureUsed: "avatar",
         ttsTextBytes: 100,
       }),

--- a/src/api/internal/usageRoutes.ts
+++ b/src/api/internal/usageRoutes.ts
@@ -6,7 +6,7 @@
 //
 // Body: { tenantId, requestId?, ttsTextBytes?, ttsModel?, avatarCredits?, avatarSessionMs? }
 
-import { GROQ_VERSATILE_70B } from '../../config/groqModels';
+import { GPT_OSS_120B } from '../../config/groqModels';
 import type { Express, Request, Response } from 'express';
 import { INTERNAL_REQUEST_HEADER } from '../../lib/metrics/kpiDefinitions';
 import { trackUsage, type FeatureUsed } from '../../lib/billing/usageTracker';
@@ -42,7 +42,7 @@ export function registerInternalUsageRoutes(app: Express): void {
     trackUsage({
       tenantId,
       requestId: rid,
-      model: typeof model === 'string' && model ? model : GROQ_VERSATILE_70B,
+      model: typeof model === 'string' && model ? model : GPT_OSS_120B,
       inputTokens: typeof inputTokens === 'number' && inputTokens >= 0 ? inputTokens : 0,
       outputTokens: typeof outputTokens === 'number' && outputTokens >= 0 ? outputTokens : 0,
       featureUsed: resolvedFeature,

--- a/src/config/groqModels.test.ts
+++ b/src/config/groqModels.test.ts
@@ -5,16 +5,22 @@ import {
   ACTIVE_GROQ_MODELS,
   ACTIVE_GROQ_MODEL_IDS,
   KNOWN_DEPRECATED_GROQ_MODELS,
-  GROQ_INSTANT_8B,
-  GROQ_VERSATILE_70B,
+  GROQ_FALLBACK_CHAIN,
+  GPT_OSS_120B,
+  GPT_OSS_20B,
+  GROQ_COMPOUND,
+  GROQ_COMPOUND_MINI,
   isDeprecatedGroqModel,
   assertActiveGroqModel,
+  getFallbackGroqModel,
 } from './groqModels';
 
 describe('groqModels catalog', () => {
   it('アクティブ定数は実モデル ID と一致する（集約後も値が変わらない回帰ガード）', () => {
-    expect(GROQ_INSTANT_8B).toBe('llama-3.1-8b-instant');
-    expect(GROQ_VERSATILE_70B).toBe('llama-3.3-70b-versatile');
+    expect(GPT_OSS_120B).toBe('openai/gpt-oss-120b');
+    expect(GPT_OSS_20B).toBe('openai/gpt-oss-20b');
+    expect(GROQ_COMPOUND).toBe('groq/compound');
+    expect(GROQ_COMPOUND_MINI).toBe('groq/compound-mini');
   });
 
   it('アクティブモデルは1件も EOL リストに含まれない', () => {
@@ -23,12 +29,77 @@ describe('groqModels catalog', () => {
     }
   });
 
+  it('ACTIVE と KNOWN_DEPRECATED は交差しない（同一 ID が両方に載る矛盾の防止）', () => {
+    const active = new Set(ACTIVE_GROQ_MODEL_IDS);
+    const overlap = KNOWN_DEPRECATED_GROQ_MODELS.filter((id) => active.has(id));
+    expect(overlap).toEqual([]);
+  });
+
   it('ACTIVE_GROQ_MODELS の status は全て active', () => {
     expect(ACTIVE_GROQ_MODELS.every((m) => m.status === 'active')).toBe(true);
   });
 
   it('ID に重複がない', () => {
     expect(new Set(ACTIVE_GROQ_MODEL_IDS).size).toBe(ACTIVE_GROQ_MODEL_IDS.length);
+  });
+
+  it('2026-08-23 に配信停止された 2 モデルは EOL リストに載っている', () => {
+    // 本番でアバターチャットを停止させた 2 件。カタログから消しただけでは
+    // 検知層(SCRIPTS/check-groq-models.sh)が再混入を防げないため、明示的に固定する。
+    expect(isDeprecatedGroqModel('llama-3.3-70b-versatile')).toBe(true);
+    expect(isDeprecatedGroqModel('llama-3.1-8b-instant')).toBe(true);
+  });
+});
+
+describe('GROQ_FALLBACK_CHAIN', () => {
+  it('【最重要】全ての退避先がアクティブモデルである', () => {
+    // 2026-08-23 の本番障害の直接原因: 退避先が既に配信停止された llama 系を指しており、
+    // 「生きているモデルから退避すると必ず死んだモデルに着地する」構造になっていた。
+    // 404 時の救済機構が、逆に全経路を確実な失敗へ導いていた。
+    const active = new Set(ACTIVE_GROQ_MODEL_IDS);
+    for (const [from, to] of Object.entries(GROQ_FALLBACK_CHAIN)) {
+      expect(active.has(to)).toBe(true);
+      // 退避元もカタログに存在しないと、そのエントリは到達不能な死んだ設定になる
+      expect(active.has(from)).toBe(true);
+    }
+  });
+
+  it('退避先が EOL モデルを指していない', () => {
+    for (const to of Object.values(GROQ_FALLBACK_CHAIN)) {
+      expect(isDeprecatedGroqModel(to)).toBe(false);
+    }
+  });
+
+  it('チェーンを辿っても循環せず必ず終端に到達する', () => {
+    for (const start of ACTIVE_GROQ_MODEL_IDS) {
+      const visited = new Set<string>([start]);
+      let current: string | null = start;
+      while (current !== null) {
+        const next: string | null = getFallbackGroqModel(current);
+        if (next === null) break;
+        expect(visited.has(next)).toBe(false); // 循環していないこと
+        visited.add(next);
+        current = next;
+      }
+      // 終端に到達している（無限ループで抜けていない）
+      expect(current === null || getFallbackGroqModel(current) === null).toBe(true);
+    }
+  });
+
+  it('自分自身へフォールバックするエントリが無い', () => {
+    for (const [from, to] of Object.entries(GROQ_FALLBACK_CHAIN)) {
+      expect(from).not.toBe(to);
+    }
+  });
+
+  it('主力 120B は 20B へ退避し、20B が終端', () => {
+    expect(getFallbackGroqModel(GPT_OSS_120B)).toBe(GPT_OSS_20B);
+    expect(getFallbackGroqModel(GPT_OSS_20B)).toBeNull();
+  });
+
+  it('compound 系は汎用モデルへ抜けられる', () => {
+    expect(getFallbackGroqModel(GROQ_COMPOUND)).toBe(GROQ_COMPOUND_MINI);
+    expect(getFallbackGroqModel(GROQ_COMPOUND_MINI)).toBe(GPT_OSS_120B);
   });
 });
 
@@ -39,7 +110,7 @@ describe('isDeprecatedGroqModel', () => {
   });
 
   it('アクティブ / 未知のモデルは false', () => {
-    expect(isDeprecatedGroqModel(GROQ_VERSATILE_70B)).toBe(false);
+    expect(isDeprecatedGroqModel(GPT_OSS_120B)).toBe(false);
     expect(isDeprecatedGroqModel('some-future-model')).toBe(false);
   });
 
@@ -50,10 +121,12 @@ describe('isDeprecatedGroqModel', () => {
 
 describe('assertActiveGroqModel', () => {
   it('アクティブモデルは通過する', () => {
-    expect(() => assertActiveGroqModel(GROQ_INSTANT_8B)).not.toThrow();
+    expect(() => assertActiveGroqModel(GPT_OSS_120B)).not.toThrow();
+    expect(() => assertActiveGroqModel(GPT_OSS_20B)).not.toThrow();
   });
 
   it('EOL モデルは例外を投げる', () => {
     expect(() => assertActiveGroqModel('llama-3.1-70b-versatile')).toThrow(/decommissioned/);
+    expect(() => assertActiveGroqModel('llama-3.3-70b-versatile')).toThrow(/decommissioned/);
   });
 });

--- a/src/config/groqModels.ts
+++ b/src/config/groqModels.ts
@@ -10,14 +10,20 @@
 //   - 新モデル採用: ACTIVE に定数を足し、call site をその定数経由に。
 //   - モデル廃止: Groq の deprecation 告知が出たら KNOWN_DEPRECATED に id を追記。
 //     検知層が src/ 内の残存使用を洗い出すので、移行漏れを防げる。
+//
+// 2026-08-23 の移行:
+//   Groq が llama-3.3-70b-versatile / llama-3.1-8b-instant を配信停止したため
+//   (実測: /v1/models に存在せず 404 model_not_found)、両者を openai/gpt-oss-120b へ集約した。
+//   Groq に残る汎用チャットモデルは gpt-oss 系と compound 系のみで、Llama 系の汎用モデルは無い。
+//   8B 相当の安価枠を gpt-oss-20b ではなく 120b に寄せたのは、20b が低い max_tokens 下で
+//   推論トークンを使い切って本文が空になり、JSON 出力用途(objectionDetector 等)が
+//   無言で機能停止する挙動を実測したため。
 
 /** 現在アクティブな Groq チャットモデル（実機で呼び出している実 ID）。値は実 ID と完全一致させること。 */
-export const GROQ_INSTANT_8B = 'llama-3.1-8b-instant';
-export const GROQ_VERSATILE_70B = 'llama-3.3-70b-versatile';
 export const GROQ_COMPOUND = 'groq/compound';
 export const GROQ_COMPOUND_MINI = 'groq/compound-mini';
 
-/** gpt-oss（Groq 経由）— アーキテクチャ上の 20B / 120B。 */
+/** gpt-oss（Groq 経由）— アーキテクチャ上の 20B / 120B。汎用チャットの主力は 120B。 */
 export const GPT_OSS_20B = 'openai/gpt-oss-20b';
 export const GPT_OSS_120B = 'openai/gpt-oss-120b';
 
@@ -26,14 +32,12 @@ export type GroqModelStatus = 'active' | 'deprecated';
 export interface GroqModelEntry {
   id: string;
   /** 用途の目安。集約後の選定で参照する。 */
-  tier: 'instant' | 'versatile' | 'compound' | 'compound-mini' | 'oss-20b' | 'oss-120b';
+  tier: 'compound' | 'compound-mini' | 'oss-20b' | 'oss-120b';
   status: GroqModelStatus;
 }
 
 /** アクティブモデルのレジストリ（COST マップ・テスト・検知層が参照する単一の真実）。 */
 export const ACTIVE_GROQ_MODELS: readonly GroqModelEntry[] = [
-  { id: GROQ_INSTANT_8B, tier: 'instant', status: 'active' },
-  { id: GROQ_VERSATILE_70B, tier: 'versatile', status: 'active' },
   { id: GROQ_COMPOUND, tier: 'compound', status: 'active' },
   { id: GROQ_COMPOUND_MINI, tier: 'compound-mini', status: 'active' },
   { id: GPT_OSS_20B, tier: 'oss-20b', status: 'active' },
@@ -48,7 +52,10 @@ export const ACTIVE_GROQ_MODEL_IDS: readonly string[] = ACTIVE_GROQ_MODELS.map((
  * 出典: Groq deprecations (https://console.groq.com/docs/deprecations)。
  */
 export const KNOWN_DEPRECATED_GROQ_MODELS: readonly string[] = [
-  'llama-3.1-70b-versatile', // → llama-3.3-70b-versatile に移行済み
+  // 2026-08-23 実測で /v1/models から消滅を確認（告知の見落としにより本番障害化した2件）。
+  'llama-3.3-70b-versatile', // → openai/gpt-oss-120b に移行済み
+  'llama-3.1-8b-instant', // → openai/gpt-oss-120b に移行済み
+  'llama-3.1-70b-versatile', // → llama-3.3-70b-versatile 経由で openai/gpt-oss-120b へ
   'llama3-70b-8192',
   'llama3-8b-8192',
   'mixtral-8x7b-32768',
@@ -86,24 +93,26 @@ export function assertActiveGroqModel(model: string): void {
  * モデルが 404 / model_not_found エラーを返した際のフォールバックチェーン。
  *
  * キー: 優先モデルの ID
- * 値: 退避先モデルの ID（カタログの ACTIVE_GROQ_MODELS 内のみ許可）
+ * 値: 退避先モデルの ID
  *
  * 設計方針:
- *   - 高性能モデルから汎用モデルへ段階的に下げる。
- *   - 最後は必ず llama-3.1-8b-instant（最小/最安）。
- *   - 120B 系は compound に退避（ANTI-SLOP: 120B は複雑クエリ/safety のみ使用）。
- *   - チェーンは最大 2 段。無限ループ防止のため resolve 時に検証する。
+ *   - **退避先は必ず ACTIVE_GROQ_MODEL_IDS の中から選ぶこと。**
+ *     2026-08-23 まで、退避先が既に配信停止された llama 系を指しており、
+ *     「生きているモデルから退避すると必ず死んだモデルに着地する」状態だった。
+ *     404 時の救済のための仕組みが、逆に全経路を確実な失敗へ導いていた。
+ *     この不変条件は groqModels.test.ts が機械的に検証する。
+ *   - compound 系 → 汎用の gpt-oss-120b へ抜けられるようにする。
+ *   - 終端は gpt-oss-20b（Groq に残る唯一の他の汎用チャットモデル）。
+ *     20b は JSON 用途では不安定だが、緊急退避先としては「何も返さない」より良い。
+ *   - 無限ループ防止のため resolve 側(callGroqWithModelFallback)で visited 検証する。
  */
 export const GROQ_FALLBACK_CHAIN: Readonly<Record<string, string>> = {
-  // gpt-oss 系: EOL 通知前の緊急退避
+  // 主力 120B → 20B（終端）
   [GPT_OSS_120B]: GPT_OSS_20B,
-  [GPT_OSS_20B]: GROQ_VERSATILE_70B,
-  // compound 系
+  // compound 系 → mini → 汎用 120B
   [GROQ_COMPOUND]: GROQ_COMPOUND_MINI,
-  [GROQ_COMPOUND_MINI]: GROQ_VERSATILE_70B,
-  // versatile → instant
-  [GROQ_VERSATILE_70B]: GROQ_INSTANT_8B,
-  // instant: これ以上退避先なし（チェーン終端）
+  [GROQ_COMPOUND_MINI]: GPT_OSS_120B,
+  // gpt-oss-20b: これ以上退避先なし（チェーン終端）
 };
 
 /**

--- a/src/lib/book-pipeline/structurizer.ts
+++ b/src/lib/book-pipeline/structurizer.ts
@@ -3,7 +3,7 @@
 // Phase44: Groq 8b を使った 6 フィールド構造化モジュール
 // CLAUDE.md: 書籍内容をログに出力しない
 
-import { GROQ_INSTANT_8B } from '../../config/groqModels';
+import { GPT_OSS_120B } from '../../config/groqModels';
 import { groqClient } from "../../agent/llm/groqClient";
 import type { TextChunk } from "./chunkSplitter";
 import type { SchemaField } from "./contentAnalyzer";
@@ -27,7 +27,7 @@ export interface StructurizerDeps {
   schema?: SchemaField[];
 }
 
-const MODEL = GROQ_INSTANT_8B;
+const MODEL = GPT_OSS_120B;
 const DELAY_MS = 200; // Groq レート制限対策
 
 const BASE_SYSTEM_PROMPT = `あなたは書籍コンテンツのFAQ化アシスタントです。

--- a/src/lib/knowledge/faqImport.ts
+++ b/src/lib/knowledge/faqImport.ts
@@ -20,7 +20,7 @@
 // （actionExecutor.ts は今後もこのファイルではなく routes.ts から textToFaqs を import する）。
 
 import type { Pool } from 'pg';
-import { GROQ_VERSATILE_70B } from '../../config/groqModels';
+import { GPT_OSS_120B } from '../../config/groqModels';
 import { groqClient } from '../../agent/llm/groqClient';
 import { logger } from '../logger';
 import { buildFaqCategoryPromptSection } from './faqCategories';
@@ -43,7 +43,7 @@ export async function textToFaqs(
   categoryOverride?: string | null,
   existingQuestions?: string[]
 ): Promise<FaqEntry[]> {
-  const model = process.env.GROQ_FAQ_GEN_MODEL ?? GROQ_VERSATILE_70B;
+  const model = process.env.GROQ_FAQ_GEN_MODEL ?? GPT_OSS_120B;
 
   const existingSection =
     existingQuestions && existingQuestions.length > 0

--- a/src/lib/posthog/llmAnalyticsTracker.ts
+++ b/src/lib/posthog/llmAnalyticsTracker.ts
@@ -3,8 +3,8 @@ import { logger } from "../logger";
 import {
   GROQ_COMPOUND,
   GROQ_COMPOUND_MINI,
-  GROQ_VERSATILE_70B,
-  GROQ_INSTANT_8B,
+  GPT_OSS_120B,
+  GPT_OSS_20B,
 } from "../../config/groqModels";
 
 export interface LlmAnalyticsEvent {
@@ -20,8 +20,10 @@ export interface LlmAnalyticsEvent {
 const COST_PER_1K: Record<string, { input: number; output: number }> = {
   [GROQ_COMPOUND]: { input: 0.0009, output: 0.0009 },
   [GROQ_COMPOUND_MINI]: { input: 0.0006, output: 0.0006 },
-  [GROQ_VERSATILE_70B]: { input: 0.00059, output: 0.00079 },
-  [GROQ_INSTANT_8B]: { input: 0.00005, output: 0.00008 },
+  // 単価は src/lib/billing/costCalculator.ts (per 1M) を per 1K に換算した値。
+  // 旧 llama-3.3-70b / llama-3.1-8b の 2 行は配信停止に伴い gpt-oss へ集約した。
+  [GPT_OSS_120B]: { input: 0.00015, output: 0.0006 },
+  [GPT_OSS_20B]: { input: 0.000075, output: 0.0003 },
 };
 
 function estimateCostUsd(

--- a/src/types/contracts.ts
+++ b/src/types/contracts.ts
@@ -2,7 +2,7 @@
 // types/contracts.ts の内容を src/ 以下に取り込んだもの。
 // tsconfig の rootDir: src に合わせるため、ここで再定義する。
 
-import type { GROQ_INSTANT_8B, GROQ_VERSATILE_70B } from '../config/groqModels';
+import type { GPT_OSS_120B } from '../config/groqModels';
 
 export interface TenantConfig {
   tenantId: string;
@@ -56,7 +56,7 @@ export interface ChatAction {
 }
 
 // Groq モデル ID は src/config/groqModels.ts が単一の正典。型もそこから導出する。
-export type GroqModel = typeof GROQ_INSTANT_8B | typeof GROQ_VERSATILE_70B;
+export type GroqModel = typeof GPT_OSS_120B;
 
 export interface RagContextItem {
   score: number;


### PR DESCRIPTION
## ⚠️ 本番障害の復旧PRです

**現在、本番のアバターチャット (`/api/avatar/chat-stream`) が全面停止しています。** 正常な問い合わせでも `{"error":"LLM error"}` が返る状態で、これはその復旧です。

## 原因

Groq が `llama-3.3-70b-versatile` と `llama-3.1-8b-instant` の配信を停止した。本番APIキーで `/v1/models` を実測した結果、現在利用可能な13モデルのいずれにも含まれていない（**Groq に汎用チャット可能な Llama 系は1つも残っていない**）。

```
Groq API error 404: The model `llama-3.3-70b-versatile` does not exist or you do not have access to it.
```

### EOL検知層がすり抜けた理由

`SCRIPTS/check-groq-models.sh` は `KNOWN_DEPRECATED_GROQ_MODELS` の**手動リスト**を参照する。今回の2件は誰もリストに追記しなかったため検知されなかった。手動リストの更新漏れがそのまま本番障害になる構造。

## フォールバック機構が逆効果になっていた

これが今回もっとも問題だった点。旧チェーンは:

```
gpt-oss-120b → gpt-oss-20b → llama-3.3-70b-versatile ❌ → llama-3.1-8b-instant ❌（終端）
compound     → compound-mini → llama-3.3-70b-versatile ❌ → ...
```

**生きているモデルから退避しようとすると、必ず死んだモデルに着地する。** 404時の救済のために作られた仕組みが、逆に全経路を確実な失敗へ導いていた。

## 移行先の選定（本番APIキーで実測して比較）

3用途（RAG回答生成・アバター会話・JSON分類）でベンチマークした結果:

| モデル | RAG | JSON分類 | 判定 |
|---|---|---|---|
| **openai/gpt-oss-120b** | 0.39s (in=206/out=124) | ✅ 正しく生成 | **採用** |
| openai/gpt-oss-20b | 0.29s（最速） | ❌ **本文が空**（max_tokens を推論に使い切る） | 緊急退避先のみ |
| groq/compound | 0.62s | — | ❌ 入力トークン**6.5倍**膨張(206→1342) |
| groq/compound-mini | 0.55s | ✅ | ❌ 入力3.5倍膨張 |
| qwen/qwen3.6-27b | 1.35s | — | ❌ `<think>` が本文に混入し回答未完成 |

compound 系を採用しなかった理由はもう一つあり、`normalizeModelKey` のどの条件にも該当せず `undefined` を返すため、**採用すると `trackUsage` の原価計算が破綻する**（従量課金なので計上が唯一の守り）。

`GROQ_INSTANT_8B` の call site も 20b ではなく 120b に寄せた。主な用途 (`objectionDetector` / `principleDetector`) がまさに JSON 出力であり、20b だと**無言で機能停止する**ため。

## 変更内容

- 廃止2モデルを `KNOWN_DEPRECATED_GROQ_MODELS` へ追加（検知層で再混入を防ぐ）
- 全 call site を `GPT_OSS_120B` へ移行。定数 `GROQ_VERSATILE_70B` / `GROQ_INSTANT_8B` は**名前が実体と食い違うため廃止**し、既存の `GPT_OSS_120B` に統合（新定数を増やさない方針）
- フォールバックチェーンを生存モデルのみで張り直し（`120B → 20B` 終端、compound 系は汎用へ抜けられるように）
- `anamChatStreamRoutes` にストリーミング対応のモデルフォールバックを実装
- `trackUsage` が**実際に応答したモデル**を記録するよう修正（退避時に原価計上がずれる問題）
- `llmAnalyticsTracker` の単価を `costCalculator` の正典値に合わせ、重複キーを解消

## 回帰防止

**「フォールバック先が必ず `ACTIVE_GROQ_MODEL_IDS` に含まれる」**という不変条件を機械的に検証するテストを追加した。今回の障害の直接原因を構造的に再発させない。あわせて ACTIVE と KNOWN_DEPRECATED が交差しないこと、チェーンが循環せず終端に到達することも固定した。

## 検証

- `bash SCRIPTS/check-groq-models.sh` → **PASS**（実装だけでなく、古いモデル名を書いたコメント5箇所も是正）
- typecheck 0エラー / oxlint 警告なし
- 対象9スイート **227/227 pass**
- ミューテーション2件とも想定通り検知:
  - 退避先を死んだモデルに戻す → 3件失敗（「最重要」不変条件テストを含む）
  - 廃止モデルを ACTIVE に復活 → 2件失敗

## 温存した箇所

`costCalculator.test.ts` / `usageTracker.test.ts` の旧モデル文字列は**意図的に残した**。過去の `usage_logs` 行に旧IDが記録されているため、`normalizeModelKey` は引き続きそれらを正しく扱える必要がある。`usageRoutes.test.ts` も、呼び出し側が明示送信した値の pass-through を検証する箇所は変更していない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgCQYt8UMPgm4HNVu7nv7z