### PR TITLE
[FEAT] Groq EOL検知をライブAPI照合に強化（告知見落としによる本番停止の再発防止）

### DIFF
--- a/SCRIPTS/check-groq-models-live.sh
+++ b/SCRIPTS/check-groq-models-live.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# SCRIPTS/check-groq-models-live.sh
+# EOL 検知層（ライブ照合）: Groq の /v1/models が返す「実際に配信中のモデル」と
+# src/config/groqModels.ts#ACTIVE_GROQ_MODELS を突き合わせ、
+# **コードがアクティブだと思っているのに Groq には存在しない** ID を検出する。
+#
+# なぜ必要か:
+#   姉妹スクリプト check-groq-models.sh は KNOWN_DEPRECATED_GROQ_MODELS（手動メンテのリスト）
+#   に載った ID しか検知できない。2026-08 に Groq が llama-3.3-70b-versatile /
+#   llama-3.1-8b-instant を廃止した際、誰もリストに追記しなかったため検知層は素通りし、
+#   アバターチャットが本番で全面停止した。告知の見落としがそのまま障害になる構造だった。
+#   このスクリプトは「Groq が今どれを配信しているか」を直接見るので、告知を見落としても気づける。
+#
+# 使い方:
+#   GROQ_API_KEY=... bash SCRIPTS/check-groq-models-live.sh
+#   ENV_FILE=/opt/rajiuce/.env bash SCRIPTS/check-groq-models-live.sh   # VPS 上
+#
+# 設計上の約束:
+#   - .env を source しない。プレースホルダ（KEY=<...> 等）がリダイレクトと解釈され、
+#     前後の行がコマンドとして実行されてシークレットが露出する（2026-08-08 に実際に起きた）。
+#     必要な1行だけ sed で取り出す（backup-postgres.sh / monitor-avatar-agent.sh と同じ作法）。
+#   - API キーを標準出力・標準エラー・ログに一切出さない。
+#   - 「廃止を検知した(1)」と「検知そのものに失敗した(2)」を終了コードで区別する。
+#     後者で赤くするとオオカミ少年になり、本当の廃止を見落とすため。
+#
+# 終了コード:
+#   0 = PASS       ACTIVE_GROQ_MODELS の全 ID が Groq に存在する
+#   1 = FAIL       Groq に存在しない ID がある（＝要移行。本番停止の予兆）
+#   2 = SKIP/ERROR 検知不能（キー未設定 / API 到達不可 / パース失敗）。CI を赤くしないこと。
+#
+# CI 非採用の理由:
+#   GROQ_API_KEY は GitHub Actions の secret に存在しない（2026-08 時点で登録済みなのは
+#   CLOUDFLARE_API_TOKEN / E2E_TEST_* / SLACK_WEBHOOK_URL_R2C / TEST_* / VITE_SUPABASE_* のみ）。
+#   また Groq 側の一時障害やレート制限で PR の CI が落ちると開発が止まるため、
+#   ネットワーク依存の検査を PR ごとのゲートに入れない方針。運用者が手動 / cron で回す。
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+CATALOG="$ROOT/src/config/groqModels.ts"
+ENV_FILE="${ENV_FILE:-$ROOT/.env}"
+GROQ_MODELS_URL="${GROQ_MODELS_URL:-https://api.groq.com/openai/v1/models}"
+CURL_TIMEOUT="${CURL_TIMEOUT:-25}"
+
+EXIT_PASS=0
+EXIT_FAIL=1
+EXIT_SKIP=2
+
+if [[ ! -f "$CATALOG" ]]; then
+  echo "[check-groq-models-live] catalog not found: $CATALOG" >&2
+  exit "$EXIT_SKIP"
+fi
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "[check-groq-models-live] SKIP — python3 not available (JSON パースに必要)" >&2
+  exit "$EXIT_SKIP"
+fi
+
+# --- API キーの取得（source しない。値は一切表示しない） ---------------------
+load_env_var() {
+  [[ -f "$ENV_FILE" ]] || return 0
+  sed -n "s/^$1=//p" "$ENV_FILE" 2>/dev/null | head -1 | sed 's/^"//; s/"$//' | tr -d '\r'
+}
+
+API_KEY="${GROQ_API_KEY:-}"
+if [[ -z "$API_KEY" ]]; then
+  API_KEY="$(load_env_var GROQ_API_KEY)"
+fi
+if [[ -z "$API_KEY" ]]; then
+  echo "[check-groq-models-live] SKIP — GROQ_API_KEY 未設定（env / $ENV_FILE のいずれにも無い）"
+  echo "  実行例: GROQ_API_KEY=... bash SCRIPTS/check-groq-models-live.sh"
+  exit "$EXIT_SKIP"
+fi
+
+# --- カタログから ACTIVE_GROQ_MODELS の実 ID を解決する -----------------------
+# ACTIVE 配列は `{ id: GROQ_INSTANT_8B, ... }` のように**定数名**を参照しているため、
+# 先に `export const NAME = 'value';` を集めて名前→実 ID を引けるようにする。
+CONST_MAP="$(grep -oE "^export const [A-Z0-9_]+ = '[^']+';" "$CATALOG" \
+  | sed -E "s/^export const ([A-Z0-9_]+) = '([^']+)';$/\1 \2/")"
+
+# ACTIVE_GROQ_MODELS ブロック内の `id: XXX,` から定数名を抜く。
+# 宣言行は次行から走査し、終端は単独の `] as const` 行（既存 check-groq-models.sh と同じ判定）。
+ACTIVE_CONST_NAMES="$(awk '/ACTIVE_GROQ_MODELS/{f=1; next} f && /^\] as const/{f=0} f' "$CATALOG" \
+  | grep -oE "id: [A-Z0-9_]+" | sed 's/^id: //')"
+
+if [[ -z "$ACTIVE_CONST_NAMES" ]]; then
+  echo "[check-groq-models-live] SKIP — ACTIVE_GROQ_MODELS を解釈できなかった（カタログの書式変更？）" >&2
+  exit "$EXIT_SKIP"
+fi
+
+ACTIVE_IDS=()
+UNRESOLVED=()
+while IFS= read -r cname; do
+  [[ -n "$cname" ]] || continue
+  cid="$(printf '%s\n' "$CONST_MAP" | awk -v n="$cname" '$1 == n { print $2; exit }')"
+  if [[ -z "$cid" ]]; then
+    UNRESOLVED+=("$cname")
+  else
+    ACTIVE_IDS+=("$cid")
+  fi
+done <<< "$ACTIVE_CONST_NAMES"
+
+if [[ ${#UNRESOLVED[@]} -gt 0 ]]; then
+  echo "[check-groq-models-live] SKIP — 定数を実 ID に解決できませんでした: ${UNRESOLVED[*]}" >&2
+  exit "$EXIT_SKIP"
+fi
+
+echo "[check-groq-models-live] catalog ACTIVE_GROQ_MODELS: ${#ACTIVE_IDS[@]} ids"
+
+# --- Groq /v1/models を取得（キーはヘッダにのみ渡す。出力しない） -------------
+HTTP_BODY_FILE="$(mktemp)"
+# shellcheck disable=SC2064
+trap "rm -f '$HTTP_BODY_FILE'" EXIT
+
+HTTP_CODE="$(curl -sS --max-time "$CURL_TIMEOUT" \
+  -o "$HTTP_BODY_FILE" -w '%{http_code}' \
+  -H "Authorization: Bearer ${API_KEY}" \
+  "$GROQ_MODELS_URL" 2>/dev/null || echo '000')"
+
+if [[ "$HTTP_CODE" == "000" ]]; then
+  echo "[check-groq-models-live] SKIP — Groq API へ到達できませんでした（ネットワーク / タイムアウト）" >&2
+  exit "$EXIT_SKIP"
+fi
+if [[ "$HTTP_CODE" != "200" ]]; then
+  # 401/429 等。本文にキーは含まれないが、念のため先頭のみ・短く出す。
+  echo "[check-groq-models-live] SKIP — Groq API が HTTP $HTTP_CODE を返しました（認証切れ / レート制限の可能性）" >&2
+  head -c 200 "$HTTP_BODY_FILE" >&2 || true
+  echo "" >&2
+  exit "$EXIT_SKIP"
+fi
+
+LIVE_IDS="$(python3 -c '
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+except Exception:
+    sys.exit(3)
+data = d.get("data")
+if not isinstance(data, list) or not data:
+    sys.exit(3)
+for m in data:
+    i = m.get("id")
+    if i:
+        print(i)
+' "$HTTP_BODY_FILE")"
+PY_STATUS=$?
+
+if [[ $PY_STATUS -ne 0 || -z "$LIVE_IDS" ]]; then
+  echo "[check-groq-models-live] SKIP — /v1/models のレスポンスを解釈できませんでした" >&2
+  exit "$EXIT_SKIP"
+fi
+
+LIVE_COUNT="$(printf '%s\n' "$LIVE_IDS" | grep -c . || true)"
+echo "[check-groq-models-live] Groq live models: $LIVE_COUNT ids"
+echo ""
+
+# --- 突き合わせ ---------------------------------------------------------------
+# (a) カタログにあるが Groq に無い = 廃止済み → FAIL（本番停止の予兆）
+MISSING=()
+for id in "${ACTIVE_IDS[@]}"; do
+  if ! printf '%s\n' "$LIVE_IDS" | grep -qxF "$id"; then
+    MISSING+=("$id")
+  fi
+done
+
+# (b) Groq にあるがカタログが知らない = 新モデル → 情報のみ（失敗にしない）
+UNKNOWN=()
+while IFS= read -r id; do
+  [[ -n "$id" ]] || continue
+  known=0
+  for a in "${ACTIVE_IDS[@]}"; do
+    [[ "$a" == "$id" ]] && { known=1; break; }
+  done
+  [[ $known -eq 0 ]] && UNKNOWN+=("$id")
+done <<< "$LIVE_IDS"
+
+if [[ ${#UNKNOWN[@]} -gt 0 ]]; then
+  echo "[check-groq-models-live] INFO — Groq にあるがカタログ未登録（採用検討の候補。失敗ではない）:"
+  for id in "${UNKNOWN[@]}"; do echo "    + $id"; done
+  echo ""
+fi
+
+if [[ ${#MISSING[@]} -gt 0 ]]; then
+  echo "----- DECOMMISSIONED BY GROQ (ACTIVE_GROQ_MODELS に定義されているが Groq に存在しない) -----"
+  for id in "${MISSING[@]}"; do
+    echo "  ✗ $id"
+    # そのモデルを参照している src/ の箇所を出して移行対象を名指しする。
+    HITS="$(grep -rn --include='*.ts' -F "$id" "$ROOT/src" 2>/dev/null \
+      | grep -v '\.test\.ts' \
+      | grep -v 'src/config/groqModels.ts' || true)"
+    if [[ -n "$HITS" ]]; then
+      printf '%s\n' "$HITS" | sed 's/^/      /'
+    else
+      echo "      (src/ に直接の参照なし — カタログ定義のみ)"
+    fi
+  done
+  echo ""
+  echo "[check-groq-models-live] FAIL — Groq が配信していないモデルを ACTIVE として保持しています。"
+  echo "  対応: 1) 生存モデルへ移行  2) 旧 ID を KNOWN_DEPRECATED_GROQ_MODELS へ追記"
+  echo "        3) GROQ_FALLBACK_CHAIN の退避先が生存モデルを指しているか確認"
+  exit "$EXIT_FAIL"
+fi
+
+echo "[check-groq-models-live] PASS — ACTIVE_GROQ_MODELS の全 ID が Groq に存在します。"
+exit "$EXIT_PASS"

--- a/SCRIPTS/check-groq-models-live.test.sh
+++ b/SCRIPTS/check-groq-models-live.test.sh
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# check-groq-models-live.test.sh — check-groq-models-live.sh の判定を固定する
+#
+# なぜ必要か:
+#   このスクリプトが防ぎたいのは「Groq が黙ってモデルを消し、本番が止まるまで誰も気づかない」こと。
+#   実際 2026-08 に llama-3.3-70b-versatile / llama-3.1-8b-instant が消え、
+#   手動リスト頼みの既存検知層（check-groq-models.sh）は素通りしてアバターチャットが停止した。
+#   したがって最も重要なのは 2 点:
+#     1) 廃止を検知したら必ず非ゼロで落ちること（見逃さない）
+#     2) 検知できなかっただけの時に落ちないこと（オオカミ少年にしない＝1と2を混同しない）
+#   正常系より、この 2 つの区別を厚く見る。
+#
+# 実行: bash SCRIPTS/check-groq-models-live.test.sh
+# 本物の Groq API には一切触らない（GROQ_MODELS_URL をローカルのモックへ差し替える）。
+
+set -uo pipefail
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TARGET="${SCRIPT_DIR}/check-groq-models-live.sh"
+PASS=0; FAIL=0
+
+WORK="$(mktemp -d)"
+MOCK_PID=""
+cleanup() {
+  [[ -n "$MOCK_PID" ]] && kill "$MOCK_PID" 2>/dev/null
+  rm -rf "$WORK"
+}
+trap cleanup EXIT
+
+check() {  # $1: 説明, $2: 実際, $3: 期待
+  if [[ "$2" == "$3" ]]; then
+    echo "  PASS: $1"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $1 — expected='$3' actual='$2'"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 が無いためテストをスキップします" >&2
+  exit 0
+fi
+
+# --- 検査対象のカタログを WORK に作る（本物の src/ には触らない） --------------
+mk_catalog() {  # $1: ACTIVE に入れる実 ID を空白区切りで
+  mkdir -p "${WORK}/src/config" "${WORK}/src/agent"
+  {
+    echo "// test catalog"
+    local i=0
+    for id in $1; do
+      echo "export const TEST_MODEL_${i} = '${id}';"
+      i=$((i + 1))
+    done
+    echo "export const ACTIVE_GROQ_MODELS: readonly GroqModelEntry[] = ["
+    i=0
+    for _ in $1; do
+      echo "  { id: TEST_MODEL_${i}, tier: 'instant', status: 'active' },"
+      i=$((i + 1))
+    done
+    echo "] as const;"
+  } > "${WORK}/src/config/groqModels.ts"
+  # SCRIPTS/.. を ROOT とみなすため、対象スクリプトを WORK/SCRIPTS へ複製する
+  mkdir -p "${WORK}/SCRIPTS"
+  cp "$TARGET" "${WORK}/SCRIPTS/"
+}
+
+# --- モック HTTP サーバ（/v1/models を返す） ----------------------------------
+PORT=8793
+start_mock() {  # $1: 返す JSON, $2: HTTP ステータス
+  local body="$1" code="${2:-200}"
+  printf '%s' "$body" > "${WORK}/mock_body.json"
+  printf '%s' "$code" > "${WORK}/mock_code"
+  python3 - "$WORK" "$PORT" <<'PY' &
+import http.server, socketserver, sys
+work, port = sys.argv[1], int(sys.argv[2])
+class H(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        code = int(open(f"{work}/mock_code").read().strip())
+        b = open(f"{work}/mock_body.json", "rb").read()
+        self.send_response(code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(b)))
+        self.end_headers()
+        self.wfile.write(b)
+    def log_message(self, *a): pass
+socketserver.TCPServer.allow_reuse_address = True
+with socketserver.TCPServer(("127.0.0.1", port), H) as s:
+    s.serve_forever()
+PY
+  MOCK_PID=$!
+  sleep 1.2
+}
+stop_mock() {
+  [[ -n "$MOCK_PID" ]] && kill "$MOCK_PID" 2>/dev/null
+  wait "$MOCK_PID" 2>/dev/null
+  MOCK_PID=""
+}
+
+run() {  # モック URL を向けて対象を実行し、終了コードを返す
+  GROQ_API_KEY=dummy-not-a-real-key \
+  GROQ_MODELS_URL="http://127.0.0.1:${PORT}/v1/models" \
+  ENV_FILE=/nonexistent \
+  bash "${WORK}/SCRIPTS/check-groq-models-live.sh" > "${WORK}/out.txt" 2>&1
+}
+
+LIVE_3='{"object":"list","data":[{"id":"groq/compound"},{"id":"openai/gpt-oss-20b"},{"id":"openai/gpt-oss-120b"}]}'
+
+echo "== 1. カタログの全 ID が生存 → PASS(0) =="
+mk_catalog "groq/compound openai/gpt-oss-120b"
+start_mock "$LIVE_3"
+run; rc=$?
+stop_mock
+check "ゼロで終了する" "$rc" "0"
+check "PASS と表示する" "$(grep -c 'PASS —' "${WORK}/out.txt")" "1"
+
+echo "== 2. 廃止モデルを保持 → FAIL(1) かつ ID を名指しする =="
+mk_catalog "groq/compound llama-3.3-70b-versatile"
+start_mock "$LIVE_3"
+run; rc=$?
+stop_mock
+check "1 で終了する（検知失敗の 2 と区別）" "$rc" "1"
+check "廃止 ID を名指しする" "$(grep -c 'llama-3.3-70b-versatile' "${WORK}/out.txt")" "1"
+check "生存 ID は名指ししない" "$(grep -c '✗ groq/compound' "${WORK}/out.txt")" "0"
+
+echo "== 3. Groq にあるがカタログ未登録 → 情報のみ・落とさない =="
+mk_catalog "groq/compound"
+start_mock "$LIVE_3"
+run; rc=$?
+stop_mock
+check "ゼロで終了する" "$rc" "0"
+check "INFO として出す" "$(grep -c 'INFO —' "${WORK}/out.txt")" "1"
+
+echo "== 4. API が 401 → SKIP(2)。FAIL(1) にしない =="
+mk_catalog "groq/compound llama-3.3-70b-versatile"
+start_mock '{"error":{"message":"Invalid API Key"}}' 401
+run; rc=$?
+stop_mock
+check "2 で終了する" "$rc" "2"
+check "廃止として報告しない" "$(grep -c 'DECOMMISSIONED' "${WORK}/out.txt")" "0"
+
+echo "== 5. API へ到達不能 → SKIP(2) =="
+mk_catalog "groq/compound llama-3.3-70b-versatile"
+run; rc=$?   # モックを起動しない
+check "2 で終了する" "$rc" "2"
+check "廃止として報告しない" "$(grep -c 'DECOMMISSIONED' "${WORK}/out.txt")" "0"
+
+echo "== 6. レスポンスが壊れている → SKIP(2) =="
+mk_catalog "groq/compound"
+start_mock 'not-json-at-all'
+run; rc=$?
+stop_mock
+check "2 で終了する" "$rc" "2"
+
+echo "== 7. data が空配列 → SKIP(2)。全件廃止と誤判定しない =="
+mk_catalog "groq/compound llama-3.3-70b-versatile"
+start_mock '{"object":"list","data":[]}'
+run; rc=$?
+stop_mock
+check "2 で終了する" "$rc" "2"
+check "廃止として報告しない" "$(grep -c 'DECOMMISSIONED' "${WORK}/out.txt")" "0"
+
+echo "== 8. API キーを出力に一切出さない =="
+mk_catalog "groq/compound llama-3.3-70b-versatile"
+start_mock "$LIVE_3"
+run; rc=$?
+stop_mock
+check "キー文字列が出力に無い" "$(grep -c 'dummy-not-a-real-key' "${WORK}/out.txt")" "0"
+
+echo "== 9. キー未設定 → SKIP(2)。FAIL(1) にしない =="
+mk_catalog "groq/compound llama-3.3-70b-versatile"
+start_mock "$LIVE_3"
+env -u GROQ_API_KEY GROQ_MODELS_URL="http://127.0.0.1:${PORT}/v1/models" ENV_FILE=/nonexistent \
+  bash "${WORK}/SCRIPTS/check-groq-models-live.sh" > "${WORK}/out.txt" 2>&1
+rc=$?
+stop_mock
+check "2 で終了する" "$rc" "2"
+check "廃止として報告しない" "$(grep -c 'DECOMMISSIONED' "${WORK}/out.txt")" "0"
+
+echo ""
+echo "PASS=${PASS} FAIL=${FAIL}"
+[[ "$FAIL" -eq 0 ]] || exit 1

--- a/SCRIPTS/check-groq-models.sh
+++ b/SCRIPTS/check-groq-models.sh
@@ -19,8 +19,13 @@ fi
 # 配列ブロック内の 'xxx', 行だけを拾うため、定数名で範囲を絞ってから quote 内を抜く。
 # 宣言行 (`... string[] = [`) は型注釈の `]` を含むため `next` でスキップし、
 # 終端は単独の `] as const` 行で判定する。中身の 'xxx' リテラルだけを抜く。
+#
+# 範囲開始は **宣言行 (`export const ...= [`) に限定する**こと。定数名が現れる行すべてを
+# 開始条件にすると、コメントでの言及や `new Set(KNOWN_DEPRECATED_GROQ_MODELS)` のような
+# 参照行でも範囲が開き、ACTIVE_GROQ_MODELS の `tier: 'instant'` / `status: 'active'` まで
+# 廃止 ID として拾って誤検知する（実際に発生した）。
 mapfile -t DEPRECATED < <(
-  awk '/KNOWN_DEPRECATED_GROQ_MODELS/{f=1; next} f && /^\] as const/{f=0} f' "$CATALOG" \
+  awk '/^export const KNOWN_DEPRECATED_GROQ_MODELS/{f=1; next} f && /^\] as const/{f=0} f' "$CATALOG" \
     | grep -oE "'[^']+'" | tr -d "'" | grep -vE '^$'
 )
 

--- a/src/config/groqModels.ts
+++ b/src/config/groqModels.ts
@@ -3,13 +3,31 @@
 //
 // 目的:
 //   1. 集約 — モデル ID をコード全体に散らさず、ここだけを更新すれば差し替えられる。
-//   2. EOL 検知 — Groq が decommission したモデルを KNOWN_DEPRECATED に列挙し、
-//      `SCRIPTS/check-groq-models.sh` が src/ にその文字列が混入したら CI を落とす。
+//   2. EOL 検知 — 廃止モデルが本番に残るのを 2 層で防ぐ（下記）。
+//
+// EOL 検知は 2 層構成:
+//   [静的] SCRIPTS/check-groq-models.sh
+//     KNOWN_DEPRECATED に列挙した ID が src/ (非 test) に混入したら落とす。
+//     ネットワーク非依存。security-scan.sh 経由で PR / push / 週次 CI すべてで走る。
+//     限界: リストが手動メンテなので、告知を見落とすと検知できない。
+//   [ライブ] SCRIPTS/check-groq-models-live.sh
+//     Groq の /v1/models が返す実配信リストと ACTIVE_GROQ_MODELS を突き合わせ、
+//     「コードはアクティブだと思っているが Groq には無い」ID を検出する。
+//     告知を見落としても気づける代わりにネットワークと API キーが要る。
+//     GROQ_API_KEY が GitHub Actions の secret に無いため CI には入れず、手動 / cron で回す。
+//     終了コード: 0=PASS / 1=廃止検知 / 2=検知不能（キー無し・API 到達不可。赤扱いしない）。
+//
+// なぜ 2 層必要か:
+//   2026-08 に Groq が llama-3.3-70b-versatile / llama-3.1-8b-instant を廃止した際、
+//   誰も KNOWN_DEPRECATED に追記しなかったため静的層は素通りし、
+//   アバターチャットが本番で全面停止した。ライブ層はこの取りこぼしを埋めるためにある。
 //
 // 追加・変更時のルール:
 //   - 新モデル採用: ACTIVE に定数を足し、call site をその定数経由に。
 //   - モデル廃止: Groq の deprecation 告知が出たら KNOWN_DEPRECATED に id を追記。
 //     検知層が src/ 内の残存使用を洗い出すので、移行漏れを防げる。
+//   - ACTIVE を変更したら GROQ_FALLBACK_CHAIN の退避先が生存モデルを指すか必ず確認する
+//     （2026-08 の障害では、生存モデルからの退避先が全て廃止モデルに着地する状態だった）。
 //
 // 2026-08-23 の移行:
 //   Groq が llama-3.3-70b-versatile / llama-3.1-8b-instant を配信停止したため


### PR DESCRIPTION
## 背景

2026-08、Groq が `llama-3.3-70b-versatile` と `llama-3.1-8b-instant` を廃止し、**アバターチャットが本番で全面停止**した。

問題は、このリポジトリに**既にEOL検知層があったのに検知できなかった**こと。既存の `SCRIPTS/check-groq-models.sh` は `KNOWN_DEPRECATED_GROQ_MODELS`（手動メンテのリスト）に載ったIDしか見ない。今回の2件は誰もリストに追記しなかったため素通りした。つまり**告知の見落としがそのまま障害になる構造**だった。

Groq の `/v1/models` は実際に配信中のモデルだけを返すので、これと `ACTIVE_GROQ_MODELS` を突き合わせれば告知を見落としても気づける。

## 変更

### 追加: `SCRIPTS/check-groq-models-live.sh`（ライブ照合層）

「コードはアクティブだと思っているが Groq には無い」IDを検出する。

- **終了コードで「廃止検知(1)」と「検知不能(2)」を明確に区別**。キー未設定 / API到達不可 / レスポンス破損 / `data`空 はすべて `2`。ここを混同すると赤が常態化してオオカミ少年になり、本当の廃止を見落とす
- **逆方向（Groqにあるがカタログ未登録）は INFO 止まりで落とさない**。新モデルの登場は障害ではない
- 廃止検知時は `src/` の参照箇所を `file:line` で名指しし、移行対象が即座に分かる
- `.env` は **source しない**。1行だけ `sed` で抽出する（`backup-postgres.sh` と同じ作法／2026-08-08 の秘密露出事故の教訓）。APIキーは `Authorization` ヘッダにのみ渡し、出力に一切出さない

**CIには入れない。** `GROQ_API_KEY` が GitHub Actions の secret に存在せず（登録済みは `CLOUDFLARE_API_TOKEN` / `E2E_TEST_*` / `SLACK_WEBHOOK_URL_R2C` / `TEST_*` / `VITE_SUPABASE_*` のみ）、かつ Groq 側の一時障害やレート制限で PR の CI が落ちると開発が止まるため。運用者が手動または cron で回す想定。

```bash
GROQ_API_KEY=... bash SCRIPTS/check-groq-models-live.sh
ENV_FILE=/opt/rajiuce/.env bash SCRIPTS/check-groq-models-live.sh   # VPS 上
```

### 追加: `SCRIPTS/check-groq-models-live.test.sh`

ローカルのモックHTTPサーバで9シナリオ17アサーション。**本物の Groq API には触れない。**

### 修正: `SCRIPTS/check-groq-models.sh` の範囲開始を宣言行に限定

awk の範囲開始が「定数名を含む任意の行」だったため、コメントでの言及や `new Set(KNOWN_DEPRECATED_GROQ_MODELS)` のような参照行でも範囲が開き、`ACTIVE_GROQ_MODELS` の `tier: 'instant'` / `status: 'active'` まで廃止IDとして拾う誤検知があった。

**本PRのコメント追記で実際に発生し、12件のはずが38件を誤検出した**ため、`^export const` に限定して塞いだ。正常系の抽出結果は12件のまま不変。

### `src/config/groqModels.ts`

冒頭コメントのみ変更（定数・チェーン・`KNOWN_DEPRECATED` の中身は未変更）。検知が2層になったこと、それぞれの役割・実行タイミング・終了コードを追記。あわせて「ACTIVE を変更したら `GROQ_FALLBACK_CHAIN` の退避先が生存モデルを指すか確認する」注意を追加した（今回の障害では、**生存モデルからの退避先が全て廃止モデルに着地する**状態だった）。

## 検証

**本番キーでの実照合（VPS上で実行、キーはローカルに持ち込まず）**

```
[check-groq-models-live] catalog ACTIVE_GROQ_MODELS: 6 ids
[check-groq-models-live] Groq live models: 13 ids

[check-groq-models-live] INFO — Groq にあるがカタログ未登録（採用検討の候補。失敗ではない）:
    + openai/gpt-oss-safeguard-20b
    + qwen/qwen3.6-27b
    ... (9件)

----- DECOMMISSIONED BY GROQ -----
  ✗ llama-3.1-8b-instant
  ✗ llama-3.3-70b-versatile

FAIL — Groq が配信していないモデルを ACTIVE として保持しています。
exit=1
```

実際に本番障害を起こした2件を正確に特定。**キーが出力に含まれないことも自動チェック済み**。

**テスト**: 17/17 pass。ミューテーション確認2件とも想定通り検知し、復元後に全pass。

| ミューテーション | 結果 |
|---|---|
| `SKIP(2)` を `FAIL(1)` に潰す（検知失敗と廃止を混同） | 5件失敗 |
| 未登録モデルも失敗扱いにする | 3件失敗 |

**回帰確認**: 既存 `check-groq-models.sh` は12件・PASS を維持。`security-scan.sh` 経由の統合も `[PASS]`。typecheck 0エラー、`bash -n` / shellcheck クリーン。

## 注意

`src/config/groqModels.ts` は別PR（モデル移行）と同時編集。本PRが触るのは**冒頭コメントのみ**なので領域は重ならないが、マージ順によっては軽微なコンフリクトの可能性あり。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgCQYt8UMPgm4HNVu7nv7z