### PR TITLE
[FIX][P0] gpt-oss の推論トークンがmax_tokensを食い潰し本文が出ない問題を修正

### DIFF
--- a/src/agent/llm/groqClient.fallback.test.ts
+++ b/src/agent/llm/groqClient.fallback.test.ts
@@ -232,3 +232,72 @@ describe('callGroqWithModelFallback — エラー系', () => {
     expect(warnMock).toHaveBeenCalledTimes(2);
   });
 });
+
+// ---------------------------------------------------------------------------
+// reasoning_effort（gpt-oss の推論トークン対策）
+// ---------------------------------------------------------------------------
+// callSpy(groqClient.call の spy)を経由せず、実際に組み立てられるリクエストボディを検証する。
+// 2026-08-23: gpt-oss は推論トークンを max_tokens から消費するため、この指定が無いと
+// 小さい max_tokens の呼び出しで本文が空になる（本番のアバターチャット無言停止の原因）。
+describe('groqClient — gpt-oss への reasoning_effort 付与', () => {
+  const origFetch = global.fetch;
+  const origKey = process.env.GROQ_API_KEY;
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    process.env.GROQ_API_KEY = 'test-key';
+    fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'ok' } }],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+      }),
+    });
+    (global as any).fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    (global as any).fetch = origFetch;
+    if (origKey === undefined) delete process.env.GROQ_API_KEY;
+    else process.env.GROQ_API_KEY = origKey;
+  });
+
+  const sentBody = () => JSON.parse(fetchMock.mock.calls[0]![1].body);
+
+  it('call: gpt-oss には reasoning_effort=low が入る', async () => {
+    await groqClient.call({ model: GPT_OSS_120B, messages: [{ role: 'user', content: 'hi' }] });
+    expect(sentBody().reasoning_effort).toBe('low');
+  });
+
+  it('callWithUsage: gpt-oss には reasoning_effort=low が入る', async () => {
+    await groqClient.callWithUsage({
+      model: GPT_OSS_20B,
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    expect(sentBody().reasoning_effort).toBe('low');
+  });
+
+  it('compound 系には付かない（無条件付与への退化を防ぐ）', async () => {
+    await groqClient.call({ model: GROQ_COMPOUND, messages: [{ role: 'user', content: 'hi' }] });
+    expect('reasoning_effort' in sentBody()).toBe(false);
+
+    fetchMock.mockClear();
+    await groqClient.call({ model: GROQ_COMPOUND_MINI, messages: [{ role: 'user', content: 'hi' }] });
+    expect('reasoning_effort' in sentBody()).toBe(false);
+  });
+
+  it('既存パラメータ(model/messages/temperature/max_tokens)を壊さない', async () => {
+    await groqClient.call({
+      model: GPT_OSS_120B,
+      messages: [{ role: 'user', content: 'hi' }],
+      temperature: 0.5,
+      maxTokens: 300,
+    });
+    const b = sentBody();
+    expect(b.model).toBe(GPT_OSS_120B);
+    expect(b.messages).toEqual([{ role: 'user', content: 'hi' }]);
+    expect(b.temperature).toBe(0.5);
+    expect(b.max_tokens).toBe(300);
+    expect(b.reasoning_effort).toBe('low');
+  });
+});

--- a/src/agent/llm/groqClient.ts
+++ b/src/agent/llm/groqClient.ts
@@ -1,6 +1,6 @@
 // src/agent/llm/groqClient.ts
 
-import { getFallbackGroqModel } from '../../config/groqModels';
+import { getFallbackGroqModel, groqReasoningParams } from '../../config/groqModels';
 
 export type GroqRole = 'system' | 'user' | 'assistant'
 
@@ -157,6 +157,8 @@ export const groqClient: GroqClient = {
         messages,
         temperature: temperature ?? 0,
         max_tokens: maxTokens ?? 512,
+        // gpt-oss は推論トークンが max_tokens を食うため effort を絞る（groqModels.ts 参照）
+        ...groqReasoningParams(model),
       }),
     })
 
@@ -215,6 +217,8 @@ export const groqClient: GroqClient = {
         messages,
         temperature: temperature ?? 0,
         max_tokens: maxTokens ?? 512,
+        // gpt-oss は推論トークンが max_tokens を食うため effort を絞る（groqModels.ts 参照）
+        ...groqReasoningParams(model),
       }),
     })
 

--- a/src/api/admin/agent/agentRoutes.ts
+++ b/src/api/admin/agent/agentRoutes.ts
@@ -13,7 +13,7 @@ import { requiresConfirmation, WRITE_TOOL_RISK_TIERS } from './confirmPolicy';
 import { trackUsage } from '../../../lib/billing/usageTracker';
 import { recordAgentMetric, type AgentMetricInput } from '../../../lib/metrics/agentMetrics';
 import { recordAgentSettingsChange } from './agentAuditLog';
-import { GPT_OSS_120B } from '../../../config/groqModels';
+import { GPT_OSS_120B, groqReasoningParams } from '../../../config/groqModels';
 import { isUnanswered } from '../ai-assist/systemPrompt';
 
 // ---------------------------------------------------------------------------
@@ -306,6 +306,8 @@ async function callGroqWithTools(
     },
     body: JSON.stringify({
       model: GPT_OSS_120B,
+      // gpt-oss は推論トークンが max_tokens を食う（groqModels.ts 参照）
+      ...groqReasoningParams(GPT_OSS_120B),
       messages,
       tools,
       tool_choice: 'auto',
@@ -343,6 +345,8 @@ async function callGroqFinal(messages: GroqMessage[]): Promise<{ reply: string; 
     },
     body: JSON.stringify({
       model: GPT_OSS_120B,
+      // gpt-oss は推論トークンが max_tokens を食う（groqModels.ts 参照）
+      ...groqReasoningParams(GPT_OSS_120B),
       messages,
       max_tokens: 512,
       temperature: 0.2,
@@ -567,6 +571,8 @@ async function runStreamingHop(
 
   const body: Record<string, unknown> = {
     model: GPT_OSS_120B,
+    // gpt-oss は推論トークンが max_tokens を食う（groqModels.ts 参照）
+    ...groqReasoningParams(GPT_OSS_120B),
     messages,
     max_tokens: 1024,
     temperature: 0.2,

--- a/src/api/admin/agent/engagementSuggest.ts
+++ b/src/api/admin/agent/engagementSuggest.ts
@@ -2,7 +2,7 @@
 // Phase3: 自然文からお客様への声がけ(trigger_rules)を構造化提案する。
 // tuning/routes.ts の callGroq8bSuggestFromText と同型のパターン。
 
-import { GPT_OSS_120B } from '../../../config/groqModels';
+import { GPT_OSS_120B, groqReasoningParams } from '../../../config/groqModels';
 import { trackUsage } from '../../../lib/billing/usageTracker';
 
 export type EngagementTriggerType = 'scroll_depth' | 'idle_time' | 'exit_intent' | 'page_url_match';
@@ -94,6 +94,8 @@ trigger_type は次の4種類から最も適切なものを1つ選んでくだ�
       },
       body: JSON.stringify({
         model: process.env.GROQ_MODEL_8B ?? GPT_OSS_120B,
+        // gpt-oss は推論トークンが max_tokens を食う（groqModels.ts 参照）
+        ...groqReasoningParams(process.env.GROQ_MODEL_8B ?? GPT_OSS_120B),
         messages: [{ role: 'user', content: prompt }],
         temperature: 0.4,
         max_tokens: 400,

--- a/src/api/admin/ai-assist/routes.ts
+++ b/src/api/admin/ai-assist/routes.ts
@@ -3,7 +3,7 @@
 // Phase43 P2: インテント振り分け + RAG統合
 // POST /v1/admin/ai-assist/chat
 
-import { GPT_OSS_120B } from '../../../config/groqModels';
+import { GPT_OSS_120B, groqReasoningParams } from '../../../config/groqModels';
 import type { Express, Request, Response } from "express";
 import { z } from "zod";
 import { supabaseAuthMiddleware } from "../../../admin/http/supabaseAuthMiddleware";
@@ -64,6 +64,8 @@ async function detectIntent(message: string, tenantId: string): Promise<Intent> 
       },
       body: JSON.stringify({
         model: GPT_OSS_120B,
+        // gpt-oss は推論トークンが max_tokens を食う（groqModels.ts 参照）
+        ...groqReasoningParams(GPT_OSS_120B),
         messages: [
           {
             role: "user",
@@ -71,7 +73,11 @@ async function detectIntent(message: string, tenantId: string): Promise<Intent> 
           },
         ],
         temperature: 0,
-        max_tokens: 20,
+        // gpt-oss は reasoning_effort:'low' でも推論に 18〜31 tokens 使う（実測、プロンプト依存）。
+        // 旧値 20 では推論だけで使い切って finish_reason='length' / content='' になり、
+        // 下の raw.includes() が常に false → 無言で "admin_guide" に誤分類していた。
+        // 64 なら実測 43 tokens (推論31+本文) で収まり余裕がある。
+        max_tokens: 64,
       }),
     });
 
@@ -114,6 +120,8 @@ async function callGroq8b(userMessage: string, tenantId: string): Promise<string
     },
     body: JSON.stringify({
       model: GPT_OSS_120B,
+      // gpt-oss は推論トークンが max_tokens を食う（groqModels.ts 参照）
+      ...groqReasoningParams(GPT_OSS_120B),
       messages: [
         { role: "system", content: ADMIN_AI_SYSTEM_PROMPT },
         { role: "user", content: userMessage },
@@ -174,6 +182,8 @@ ${ragContext}`
     },
     body: JSON.stringify({
       model: GPT_OSS_120B,
+      // gpt-oss は推論トークンが max_tokens を食う（groqModels.ts 参照）
+      ...groqReasoningParams(GPT_OSS_120B),
       messages: [
         { role: "system", content: systemPrompt },
         { role: "user", content: userMessage },

--- a/src/api/admin/avatar/generationRoutes.ts
+++ b/src/api/admin/avatar/generationRoutes.ts
@@ -2,7 +2,7 @@
 
 // Phase41: Avatar Customization Studio — 画像生成・声マッチング・プロンプト生成API
 
-import { GPT_OSS_120B } from '../../../config/groqModels';
+import { GPT_OSS_120B, groqReasoningParams } from '../../../config/groqModels';
 import type { Express, NextFunction, Request, Response } from "express";
 
 type AvatarReq = Request & { supabaseUser?: Record<string, unknown>; requestId?: string };
@@ -29,6 +29,8 @@ async function callGroqLLM(system: string, user: string): Promise<string> {
     },
     body: JSON.stringify({
       model: GPT_OSS_120B,
+      // gpt-oss は推論トークンが max_tokens を食う（groqModels.ts 参照）
+      ...groqReasoningParams(GPT_OSS_120B),
       messages: [
         { role: "system", content: system },
         { role: "user", content: user },

--- a/src/api/admin/feedback/feedbackAI.ts
+++ b/src/api/admin/feedback/feedbackAI.ts
@@ -1,7 +1,7 @@
 // src/api/admin/feedback/feedbackAI.ts
 // Phase62: FAQチャット代行提案 + 試算フロー統合
 
-import { GPT_OSS_120B } from '../../../config/groqModels';
+import { GPT_OSS_120B, groqReasoningParams } from '../../../config/groqModels';
 import { sanitizeOutput } from "../../../lib/security/inputSanitizer";
 import { trackUsage } from "../../../lib/billing/usageTracker";
 import { logger } from '../../../lib/logger';
@@ -205,6 +205,8 @@ export async function generateFeedbackReply(
         },
         body: JSON.stringify({
           model: FEEDBACK_AI_MODEL,
+          // gpt-oss は推論トークンが max_tokens を食う（groqModels.ts 参照）
+          ...groqReasoningParams(FEEDBACK_AI_MODEL),
           messages: [
             { role: 'system', content: SYSTEM_PROMPT },
             { role: 'user', content: userMessage },

--- a/src/api/admin/feedback/optionEstimator.ts
+++ b/src/api/admin/feedback/optionEstimator.ts
@@ -1,7 +1,7 @@
 // src/api/admin/feedback/optionEstimator.ts
 // Phase62: オプションサービス料金試算（Groq 70B呼び出し）
 
-import { GPT_OSS_120B } from '../../../config/groqModels';
+import { GPT_OSS_120B, groqReasoningParams } from '../../../config/groqModels';
 import { logger } from '../../../lib/logger';
 import { trackUsage } from '../../../lib/billing/usageTracker';
 
@@ -55,6 +55,8 @@ export async function estimateOptionPrice(
       },
       body: JSON.stringify({
         model: process.env.GROQ_MODEL_70B ?? GPT_OSS_120B,
+        // gpt-oss は推論トークンが max_tokens を食う（groqModels.ts 参照）
+        ...groqReasoningParams(process.env.GROQ_MODEL_70B ?? GPT_OSS_120B),
         messages: [
           { role: 'system', content: ESTIMATE_SYSTEM_PROMPT },
           { role: 'user', content: userPrompt },

--- a/src/api/admin/tuning/routes.ts
+++ b/src/api/admin/tuning/routes.ts
@@ -2,7 +2,7 @@
 
 // Phase38 Step4-BE: チューニングルール CRUD API
 
-import { GPT_OSS_120B } from '../../../config/groqModels';
+import { GPT_OSS_120B, groqReasoningParams } from '../../../config/groqModels';
 import type { Express, Request, Response } from "express";
 import type { AuthedReq } from "../../middleware/roleAuth";
 import { roleAuthMiddleware } from "../../middleware/roleAuth";
@@ -101,6 +101,8 @@ ${knowledgePart}${rulesPart}${crossTenantPart}${researchPart}
       },
       body: JSON.stringify({
         model: process.env.GROQ_MODEL_8B ?? GPT_OSS_120B,
+        // gpt-oss は推論トークンが max_tokens を食う（groqModels.ts 参照）
+        ...groqReasoningParams(process.env.GROQ_MODEL_8B ?? GPT_OSS_120B),
         messages: [{ role: "user", content: prompt }],
         temperature: 0.4,
         max_tokens: 400,
@@ -179,6 +181,8 @@ ${knowledgePart}${rulesPart}${crossTenantPart}
       },
       body: JSON.stringify({
         model: process.env.GROQ_MODEL_8B ?? GPT_OSS_120B,
+        // gpt-oss は推論トークンが max_tokens を食う（groqModels.ts 参照）
+        ...groqReasoningParams(process.env.GROQ_MODEL_8B ?? GPT_OSS_120B),
         messages: [{ role: "user", content: prompt }],
         temperature: 0.4,
         max_tokens: 400,

--- a/src/api/admin/tuning/testResponseRoutes.ts
+++ b/src/api/admin/tuning/testResponseRoutes.ts
@@ -1,7 +1,7 @@
 // src/api/admin/tuning/testResponseRoutes.ts
 // Phase6-B: チューニングルール LLMテスト返答生成API
 
-import { GPT_OSS_120B } from '../../../config/groqModels';
+import { GPT_OSS_120B, groqReasoningParams } from '../../../config/groqModels';
 import type { Express, Request, Response } from "express";
 import type { AuthedReq } from "../../middleware/roleAuth";
 import { supabaseAuthMiddleware } from "../../../admin/http/supabaseAuthMiddleware";
@@ -102,6 +102,8 @@ ${systemPrompt || "(未設定)"}
       },
       body: JSON.stringify({
         model: GROQ_MODEL_70B,
+        // gpt-oss は推論トークンが max_tokens を食う（groqModels.ts 参照）
+        ...groqReasoningParams(GROQ_MODEL_70B),
         messages: [{ role: "user", content: prompt }],
         temperature: 0.7,
         max_tokens: 1200,

--- a/src/api/avatar/anamChatStreamRoutes.test.ts
+++ b/src/api/avatar/anamChatStreamRoutes.test.ts
@@ -507,3 +507,55 @@ describe('POST /api/avatar/chat-stream — abuseカウンタのテナント/セ�
     expect(tenantBFirstOffense.status).toBe(400);
   });
 });
+
+describe('POST /api/avatar/chat-stream — gpt-oss の reasoning_effort', () => {
+  // 2026-08-23: gpt-oss は推論トークンを max_tokens から消費する。この指定が無いと
+  // max_tokens=150 のうち 136 を推論が食い、本文が1バイトも出ないまま
+  // HTTP 200 / size=0 で返る（本番でアバターチャットが無言停止した実際の症状）。
+  it('Groqへ送るボディに reasoning_effort=low が入る', async () => {
+    (global as any).fetch = jest.fn().mockResolvedValue(makeGroqStreamResponse(['はい']));
+
+    const res = await request(makeApp())
+      .post('/api/avatar/chat-stream')
+      .send({ messages: [{ role: 'user', content: '営業時間は' }], sessionId: 'sess-re-1' });
+
+    expect(res.status).toBe(200);
+    const fetchMock = global.fetch as jest.Mock;
+    const sentBody = JSON.parse(fetchMock.mock.calls[0]![1].body);
+    expect(sentBody.reasoning_effort).toBe('low');
+    // 既存パラメータを壊していないこと
+    expect(sentBody.model).toBe('openai/gpt-oss-120b');
+    expect(sentBody.stream).toBe(true);
+    expect(sentBody.stream_options).toEqual({ include_usage: true });
+    expect(sentBody.max_tokens).toBe(150);
+    expect(sentBody.temperature).toBe(0.7);
+  });
+
+  it('404で退避した2回目のリクエストにも reasoning_effort が付く（退避先も gpt-oss のため）', async () => {
+    const notFound = {
+      ok: false,
+      status: 404,
+      text: async () => JSON.stringify({ error: { code: 'model_not_found' } }),
+    };
+    (global as any).fetch = jest
+      .fn()
+      .mockResolvedValueOnce(notFound as any)
+      .mockResolvedValueOnce(makeGroqStreamResponse(['はい']) as any);
+
+    const res = await request(makeApp())
+      .post('/api/avatar/chat-stream')
+      .send({ messages: [{ role: 'user', content: '営業時間は' }], sessionId: 'sess-re-2' });
+
+    expect(res.status).toBe(200);
+    const fetchMock = global.fetch as jest.Mock;
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+
+    const first = JSON.parse(fetchMock.mock.calls[0]![1].body);
+    const second = JSON.parse(fetchMock.mock.calls[1]![1].body);
+    expect(first.model).toBe('openai/gpt-oss-120b');
+    expect(second.model).toBe('openai/gpt-oss-20b'); // フォールバックチェーンの退避先
+    // 退避後に設定が抜け落ちると、退避先で同じ無言停止が起きる
+    expect(first.reasoning_effort).toBe('low');
+    expect(second.reasoning_effort).toBe('low');
+  });
+});

--- a/src/api/avatar/anamChatStreamRoutes.ts
+++ b/src/api/avatar/anamChatStreamRoutes.ts
@@ -7,7 +7,7 @@
 //   Anam JS SDKのcreateTalkMessageStream()でTTS化される。
 
 import { randomUUID } from 'node:crypto';
-import { GPT_OSS_120B, getFallbackGroqModel } from '../../config/groqModels';
+import { GPT_OSS_120B, getFallbackGroqModel, groqReasoningParams } from '../../config/groqModels';
 import type { Express, Request, Response, RequestHandler } from 'express';
 import type { AuthedRequest } from '../../agent/http/authMiddleware';
 import { logger } from '../../lib/logger';
@@ -216,6 +216,9 @@ export function registerAnamChatStreamRoutes(app: Express, apiStack: RequestHand
             stream_options: { include_usage: true },
             max_tokens: 150,
             temperature: 0.7,
+            // gpt-oss は推論トークンが max_tokens を食い、これが無いと本文が出ない。
+            // 退避先(20b)も gpt-oss 系なので、ループ内で候補ごとに評価する。
+            ...groqReasoningParams(candidateModel),
           }),
         });
 

--- a/src/config/groqModels.test.ts
+++ b/src/config/groqModels.test.ts
@@ -13,6 +13,9 @@ import {
   isDeprecatedGroqModel,
   assertActiveGroqModel,
   getFallbackGroqModel,
+  isGptOssModel,
+  groqReasoningParams,
+  GPT_OSS_REASONING_EFFORT,
 } from './groqModels';
 
 describe('groqModels catalog', () => {
@@ -128,5 +131,58 @@ describe('assertActiveGroqModel', () => {
   it('EOL モデルは例外を投げる', () => {
     expect(() => assertActiveGroqModel('llama-3.1-70b-versatile')).toThrow(/decommissioned/);
     expect(() => assertActiveGroqModel('llama-3.3-70b-versatile')).toThrow(/decommissioned/);
+  });
+});
+
+describe('isGptOssModel / groqReasoningParams', () => {
+  it('gpt-oss 系を判定する', () => {
+    expect(isGptOssModel(GPT_OSS_120B)).toBe(true);
+    expect(isGptOssModel(GPT_OSS_20B)).toBe(true);
+  });
+
+  it('gpt-oss 以外は判定しない（無条件付与への退化を防ぐ）', () => {
+    expect(isGptOssModel(GROQ_COMPOUND)).toBe(false);
+    expect(isGptOssModel(GROQ_COMPOUND_MINI)).toBe(false);
+    expect(isGptOssModel('whisper-large-v3')).toBe(false);
+    expect(isGptOssModel('qwen/qwen3.6-27b')).toBe(false);
+  });
+
+  it('env override で provider prefix が変わっても拾う（完全一致では取りこぼす経路）', () => {
+    // GROQ_MODEL_8B / LLM_MODEL_120B / FEEDBACK_AI_MODEL 等に別 prefix の ID が入りうる。
+    // costCalculator.normalizeModelKey と同じ includes 判定であることの固定。
+    expect(isGptOssModel('groq/gpt-oss-20b')).toBe(true);
+    expect(isGptOssModel('GPT-OSS-120B')).toBe(true);
+    expect(isGptOssModel('gpt-oss-120b-128k')).toBe(true);
+  });
+
+  it('gpt-oss には reasoning_effort を返す', () => {
+    expect(groqReasoningParams(GPT_OSS_120B)).toEqual({
+      reasoning_effort: GPT_OSS_REASONING_EFFORT,
+    });
+    expect(GPT_OSS_REASONING_EFFORT).toBe('low');
+  });
+
+  it("'none' は使わない（Groq 未サポートで本文が一切返らないことを実測済み）", () => {
+    expect(GPT_OSS_REASONING_EFFORT).not.toBe('none');
+  });
+
+  it('gpt-oss 以外には空オブジェクトを返す（spread しても何も足さない）', () => {
+    expect(groqReasoningParams(GROQ_COMPOUND)).toEqual({});
+    expect(groqReasoningParams(GROQ_COMPOUND_MINI)).toEqual({});
+    // spread した結果に reasoning_effort キー自体が生えないこと
+    const body = { model: GROQ_COMPOUND, ...groqReasoningParams(GROQ_COMPOUND) };
+    expect('reasoning_effort' in body).toBe(false);
+  });
+
+  it('フォールバックチェーン上の全モデルで判定が一貫する（退避先で設定が消えない）', () => {
+    // 120b → 20b の退避時、退避先も gpt-oss なので reasoning_effort が付き続ける必要がある。
+    for (const [from, to] of Object.entries(GROQ_FALLBACK_CHAIN)) {
+      if (isGptOssModel(from)) {
+        expect(groqReasoningParams(from)).toHaveProperty('reasoning_effort');
+      }
+      if (isGptOssModel(to)) {
+        expect(groqReasoningParams(to)).toHaveProperty('reasoning_effort');
+      }
+    }
   });
 });

--- a/src/config/groqModels.ts
+++ b/src/config/groqModels.ts
@@ -141,3 +141,48 @@ export const GROQ_FALLBACK_CHAIN: Readonly<Record<string, string>> = {
 export function getFallbackGroqModel(model: string): string | null {
   return GROQ_FALLBACK_CHAIN[model] ?? null;
 }
+
+/**
+ * gpt-oss 系に付与する reasoning_effort。
+ *
+ * gpt-oss は推論(reasoning)トークンを生成し、それが max_tokens に算入される。
+ * Llama 系にこの挙動は無かったため、コードベースの max_tokens は
+ * 「本文だけが出る」前提で小さくチューニングされていた。
+ * 2026-08-23 の gpt-oss 移行後、推論が予算を食い潰して本文が出なくなった。
+ *
+ * 実測 (openai/gpt-oss-120b, streaming, 同一プロンプト):
+ *   max_tokens=150 指定なし → completion 150 / reasoning 136 / 本文 11 文字で途切れ
+ *   max_tokens=150 + 'low'  → completion  45 / reasoning  10 / 本文 完結
+ *   max_tokens=300 + 'low'  → completion  53 / reasoning   8 / 本文 完結
+ *
+ * 'none' は Groq 側でサポートされておらず、指定すると本文が一切返らない（実測）。使用禁止。
+ * max_tokens を一律に増やす対処は、原価が増える上に
+ * 「推論量が振れると本文が消える」脆さが残るため採らない。
+ */
+export const GPT_OSS_REASONING_EFFORT = 'low' as const;
+
+/**
+ * モデルが gpt-oss 系（推論トークンを生成する）かどうか。
+ *
+ * 判定を `includes('gpt-oss')` にしているのは costCalculator.normalizeModelKey と同じ理由で、
+ * env override (LLM_MODEL_20B/120B, GROQ_MODEL_8B, FEEDBACK_AI_MODEL 等) によって
+ * provider prefix 付きの ID が渡りうるため。定数との完全一致では取りこぼす。
+ */
+export function isGptOssModel(model: string): boolean {
+  return model.toLowerCase().includes('gpt-oss');
+}
+
+/**
+ * Groq chat completions のリクエストボディに展開する追加パラメータを返す。
+ *
+ * gpt-oss 系にのみ reasoning_effort を付ける。compound 系や将来のモデルに
+ * 無条件で付けると壊れうるため、対象を絞ったうえで呼び出し側は spread するだけにする。
+ *
+ * 使い方:
+ *   body: JSON.stringify({ model, messages, max_tokens: 300, ...groqReasoningParams(model) })
+ */
+export function groqReasoningParams(
+  model: string,
+): { reasoning_effort?: typeof GPT_OSS_REASONING_EFFORT } {
+  return isGptOssModel(model) ? { reasoning_effort: GPT_OSS_REASONING_EFFORT } : {};
+}


### PR DESCRIPTION
## ⚠️ 本番障害の復旧PR

**アバターチャットは現在も応答を返せていない。** PR #845 で廃止モデルを `openai/gpt-oss-120b` へ移行しデプロイ済みだが、失敗の形が変わっただけで未復旧:

| | 症状 |
|---|---|
| #845 移行前 | `{"error":"LLM error"}`（404 model_not_found） |
| #845 移行後（現在） | **HTTP 200 / `text/event-stream` / size=0**（本文が1バイトも出ない。サーバーログにエラーも出ない） |

## 根本原因

**gpt-oss は推論(reasoning)トークンを生成し、それが `max_tokens` に算入される。** Llama 系にこの挙動は無かったため、コードベースの `max_tokens` は「本文だけが出る」前提で小さくチューニングされており、移行後は推論が予算を食い潰して本文が出なくなった。

### 実測（`openai/gpt-oss-120b`、streaming、同一プロンプト）

| 条件 | completion_tokens | reasoning_tokens | 本文 |
|---|---|---|---|
| `max_tokens=150`（実装値） | 150 | **136** | 11文字で途切れ |
| `max_tokens=800` | 103 | 82 | 完結 |
| `max_tokens=150` + `reasoning_effort:"low"` | 45 | **10** | ✅ 完結 |
| `max_tokens=300` + `reasoning_effort:"low"` | 53 | 8 | ✅ 完結 |
| `reasoning_effort:"none"` | — | — | ❌ **本文が出ない**（Groq 未サポート。使用禁止） |

## 対策

`reasoning_effort: 'low'` を **gpt-oss 系にのみ** 付与する。判定と付与を `groqModels.ts` の `isGptOssModel` / `groqReasoningParams` に集約し、各呼び出し側は spread するだけにした。

- `max_tokens` を一律に増やす対処は採らない — 原価が増える上に「推論量が振れると本文が消える」脆さが残るため
- 判定は `costCalculator.normalizeModelKey` と同じ `includes('gpt-oss')`。env override（`GROQ_MODEL_8B` / `LLM_MODEL_120B` / `FEEDBACK_AI_MODEL` 等）で provider prefix が変わる経路を取りこぼさないため、定数の完全一致にはしていない

## 適用範囲（当初想定より広い）

指示された2経路だけでなく、`grep -rn "api.groq.com"` で洗い出した**全ての Groq chat completions ボディ**が対象だった。#845 の移行で**これら全てが `GPT_OSS_120B` を使うようになっていた**ため:

- `agent/llm/groqClient.ts`（`call` / `callWithUsage` の2箇所）
- `api/avatar/anamChatStreamRoutes.ts`（ストリーミング。**退避先の 20b も gpt-oss なのでループ内で候補ごとに評価**）
- `admin/ai-assist/routes.ts`, `admin/agent/agentRoutes.ts`, `admin/agent/engagementSuggest.ts`, `admin/tuning/routes.ts`, `admin/tuning/testResponseRoutes.ts`, `admin/feedback/feedbackAI.ts`, `admin/feedback/optionEstimator.ts`, `admin/avatar/generationRoutes.ts`

`trackUsage({ model })` の計上呼び出しや、画像/音声生成の `model:`（`leonardo-photorealistic` 等）は**対象外**として除外済み（1件ずつ目視確認）。`ocrPipeline.ts` は Qwen、`perplexityProvider.ts` は Perplexity のため対象外。

## `max_tokens` の調整は1箇所のみ

`ai-assist/routes.ts` の intent 判定を **20 → 64**。

`reasoning_effort:'low'` でも推論に 18〜31 tokens 使う（実測・プロンプト依存）ため、20 では推論だけで使い切って `finish_reason='length'` / `content=''` になる。直後の `raw.includes("business_faq")` が常に false となり、**無言で `"admin_guide"` に誤分類**していた（例外にならないため気づけない）。実測で 64 なら 43 tokens（推論31+本文）で収まる。

他の `max_tokens`（150/300/400/512/1024/1200）は実測レンジに対して余裕があり未変更。

## テスト

- `groqModels.test.ts`: 判定ヘルパーの単体テスト（gpt-oss → true / compound・whisper・qwen → false / env override の prefix 変化 / `'none'` を使わないこと / フォールバックチェーン上で判定が一貫すること）
- `groqClient.fallback.test.ts`: `global.fetch` をモックし**実際に組み立てられるボディ**を検証（既存テストは `groqClient.call` を spy するため body を見ていなかった）
- `anamChatStreamRoutes.test.ts`: 送信ボディに `reasoning_effort` が入ること + **404 退避後の2回目のリクエストにも付くこと**（退避先で設定が抜けると同じ無言停止が再発する）

結果: typecheck 0エラー / oxlint 新規警告なし（既存2件は main でも再現） / 対象25スイート **926/926 pass**

**ミューテーション検証2件**（いずれも復元後に全pass）:
1. 付与を無効化 → 3スイート横断で **7件失敗**
2. 無条件付与に退化 → 「compound には付かない」テスト **2件失敗**

## 本番APIでの最終確認

実装が送るボディと同一条件（`max_tokens=150` + `reasoning_effort:'low'`、streaming）を本番キーで実行:

```
completion=80 reasoning=18 content_len=74
本文: 'はい、当店の営業時間は月曜から金曜の午前9時から午後6時、土曜は午前10時から午後4時です。日曜はお休みとなっております。ご来店お待ちしております！'
```

✅ 本文が返ることを確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgCQYt8UMPgm4HNVu7nv7z
