### PR TITLE
[REFACTOR] groqClientのcall/callWithUsageの重複を解消（片肺修正の再発防止）

### DIFF
--- a/src/agent/llm/groqClient.fallback.test.ts
+++ b/src/agent/llm/groqClient.fallback.test.ts
@@ -301,3 +301,157 @@ describe('groqClient — gpt-oss への reasoning_effort 付与', () => {
     expect(b.reasoning_effort).toBe('low');
   });
 });
+
+// ---------------------------------------------------------------------------
+// call / callWithUsage の実装共有（重複解消の回帰防止）
+// ---------------------------------------------------------------------------
+// 2026-08-23: 以前は 2 メソッドがリクエスト組み立て・エラー分類・レスポンス検証を丸ごと
+// 複製しており、#847 の reasoning_effort 追加では同じ 2 行を両方へ手で入れる必要があった。
+// 片方を忘れてもテストが無ければ気づけない（例外にならず本文が空になるだけ）ため、
+// 「両者が同じリクエストを送り、同じ例外を投げる」ことをここで固定する。
+describe('groqClient — call と callWithUsage が実装を共有する', () => {
+  const origFetch = global.fetch;
+  const origKey = process.env.GROQ_API_KEY;
+  let fetchMock: jest.Mock;
+
+  const okResponse = () => ({
+    ok: true,
+    json: async () => ({
+      choices: [{ message: { content: 'shared-ok' } }],
+      usage: { prompt_tokens: 3, completion_tokens: 4 },
+    }),
+  });
+
+  const failing = (status: number, body: string, retryAfter: string | null = null) => ({
+    ok: false,
+    status,
+    text: async () => body,
+    headers: { get: (name: string) => (name === 'retry-after' ? retryAfter : null) },
+  });
+
+  beforeEach(() => {
+    process.env.GROQ_API_KEY = 'test-key';
+    fetchMock = jest.fn().mockResolvedValue(okResponse());
+    (global as any).fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    (global as any).fetch = origFetch;
+    if (origKey === undefined) delete process.env.GROQ_API_KEY;
+    else process.env.GROQ_API_KEY = origKey;
+  });
+
+  const params: GroqCallParams = {
+    model: GPT_OSS_120B,
+    messages: [{ role: 'user', content: 'hi' }],
+    temperature: 0.42,
+    maxTokens: 321,
+  };
+
+  it('【最重要】両者が完全に同一のリクエストを送る（片肺修正の再発防止）', async () => {
+    await groqClient.call(params);
+    const [callUrl, callInit] = fetchMock.mock.calls[0]!;
+
+    fetchMock.mockClear();
+    await groqClient.callWithUsage(params);
+    const [usageUrl, usageInit] = fetchMock.mock.calls[0]!;
+
+    expect(usageUrl).toBe(callUrl);
+    expect(usageInit.method).toBe(callInit.method);
+    expect(usageInit.headers).toEqual(callInit.headers);
+    // body は文字列として一致すること（キー順の差も許さない = 同一コードが組み立てた証明）
+    expect(usageInit.body).toBe(callInit.body);
+  });
+
+  it('デフォルト値(temperature=0 / max_tokens=512)も両者で一致する', async () => {
+    const bare: GroqCallParams = { model: GROQ_COMPOUND, messages: [{ role: 'user', content: 'x' }] };
+
+    await groqClient.call(bare);
+    const callBody = fetchMock.mock.calls[0]![1].body;
+
+    fetchMock.mockClear();
+    await groqClient.callWithUsage(bare);
+    const usageBody = fetchMock.mock.calls[0]![1].body;
+
+    expect(usageBody).toBe(callBody);
+    const parsed = JSON.parse(callBody);
+    expect(parsed.temperature).toBe(0);
+    expect(parsed.max_tokens).toBe(512);
+  });
+
+  const errorCases: Array<{ label: string; status: number; body: string; expected: new (...a: any[]) => Error }> = [
+    { label: '429', status: 429, body: 'rate limited', expected: GroqRateLimitError },
+    { label: '404 + model_not_found', status: 404, body: '{"error":{"code":"model_not_found"}}', expected: GroqModelNotFoundError },
+    { label: '404 (model_not_found でない)', status: 404, body: 'plain not found', expected: GroqBadRequestError },
+    { label: '500', status: 500, body: 'boom', expected: GroqServerError },
+    { label: '400', status: 400, body: 'bad request', expected: GroqBadRequestError },
+  ];
+
+  errorCases.forEach(({ label, status, body, expected }) => {
+    it(`${label} は call / callWithUsage の両方で同じ例外クラスになる`, async () => {
+      fetchMock.mockResolvedValue(failing(status, body));
+
+      await expect(groqClient.call(params)).rejects.toBeInstanceOf(expected);
+      await expect(groqClient.callWithUsage(params)).rejects.toBeInstanceOf(expected);
+    });
+  });
+
+  it('retry-after ヘッダの解釈が両者で一致する', async () => {
+    fetchMock.mockResolvedValue(failing(429, 'slow down', '2'));
+
+    const capture = async (fn: () => Promise<unknown>): Promise<GroqRateLimitError> => {
+      try {
+        await fn();
+      } catch (err) {
+        return err as GroqRateLimitError;
+      }
+      throw new Error('expected GroqRateLimitError to be thrown');
+    };
+
+    const fromCall = await capture(() => groqClient.call(params));
+    const fromUsage = await capture(() => groqClient.callWithUsage(params));
+
+    expect(fromCall.retryAfterMs).toBe(2000);
+    expect(fromUsage.retryAfterMs).toBe(2000);
+  });
+
+  it('content が無いレスポンスで両者とも同じメッセージのエラーを投げる', async () => {
+    fetchMock.mockResolvedValue({ ok: true, json: async () => ({ choices: [] }) });
+
+    await expect(groqClient.call(params)).rejects.toThrow('Groq API response has no message content');
+    await expect(groqClient.callWithUsage(params)).rejects.toThrow('Groq API response has no message content');
+  });
+
+  it('GROQ_API_KEY 未設定で両者とも同じエラーを投げる', async () => {
+    delete process.env.GROQ_API_KEY;
+
+    await expect(groqClient.call(params)).rejects.toThrow('GROQ_API_KEY is not set');
+    await expect(groqClient.callWithUsage(params)).rejects.toThrow('GROQ_API_KEY is not set');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('戻り値の形だけが違う: call は content のみ / callWithUsage は usage 付き', async () => {
+    await expect(groqClient.call(params)).resolves.toBe('shared-ok');
+    await expect(groqClient.callWithUsage(params)).resolves.toEqual({
+      content: 'shared-ok',
+      usage: { prompt_tokens: 3, completion_tokens: 4 },
+    });
+  });
+
+  it('usage が片方欠けている場合は undefined（callWithUsage の契約を維持）', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: 'shared-ok' } }],
+        usage: { prompt_tokens: 3 },
+      }),
+    });
+
+    await expect(groqClient.callWithUsage(params)).resolves.toEqual({
+      content: 'shared-ok',
+      usage: undefined,
+    });
+    // call 側は usage を無視して content だけ返す
+    await expect(groqClient.call(params)).resolves.toBe('shared-ok');
+  });
+});

--- a/src/agent/llm/groqClient.ts
+++ b/src/agent/llm/groqClient.ts
@@ -132,128 +132,108 @@ export interface GroqClient {
 }
 
 /**
+ * `call` / `callWithUsage` が共有する実際の HTTP 実装。
+ *
+ * 2026-08-23: 以前は 2 つのメソッドが「API キー検査 → リクエスト組み立て → エラー分類 →
+ * レスポンス検証」をそれぞれ丸ごと複製しており、差分は usage を返すかどうかだけだった。
+ * PR #847 で gpt-oss の reasoning_effort を足した際、同じ 2 行を両方へ手で入れる必要があり、
+ * 片方を忘れればその経路だけ本文が空になる（例外にならない = 無言の障害）構造だった。
+ * 実装を 1 本に統合して、次に同種の変更が来たときに同じ賭けをしなくて済むようにする。
+ *
+ * NOTE: groqClient のメソッド経由（this.callWithUsage 等）ではなくモジュールレベル関数へ
+ * 委譲している。テストが jest.spyOn(groqClient, 'call') でメソッドを差し替えるため、
+ * メソッド間の相互呼び出しにすると spy の有無で挙動が変わってしまう。
+ */
+async function performGroqCall({
+  model,
+  messages,
+  temperature,
+  maxTokens,
+}: GroqCallParams): Promise<GroqCallWithUsageResult> {
+  const apiKey = process.env.GROQ_API_KEY
+  if (!apiKey) {
+    throw new Error('GROQ_API_KEY is not set')
+  }
+
+  const response = await fetch('https://api.groq.com/openai/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({
+      model,
+      messages,
+      temperature: temperature ?? 0,
+      max_tokens: maxTokens ?? 512,
+      // gpt-oss は推論トークンが max_tokens を食うため effort を絞る（groqModels.ts 参照）
+      ...groqReasoningParams(model),
+    }),
+  })
+
+  if (!response.ok) {
+    const text = await response.text();
+    const bodySnippet = text.length > 500 ? `${text.slice(0, 500)}...` : text;
+
+    const retryAfterHeader = response.headers.get('retry-after');
+    let retryAfterMs: number | undefined;
+    if (retryAfterHeader) {
+      const retryAfterSeconds = Number(retryAfterHeader);
+      if (!Number.isNaN(retryAfterSeconds) && retryAfterSeconds >= 0) {
+        retryAfterMs = retryAfterSeconds * 1000;
+      }
+    }
+
+    // 分岐順序を変えないこと: 429 → 404(model_not_found) → 5xx → その他。
+    // 404 判定を 5xx より後ろへ動かすと model_not_found の分類が変わる。
+    if (response.status === 429) {
+      throw new GroqRateLimitError(response.status, bodySnippet, retryAfterMs);
+    }
+
+    if (response.status === 404 && isModelNotFoundBody(bodySnippet)) {
+      throw new GroqModelNotFoundError(response.status, bodySnippet, model);
+    }
+
+    if (response.status >= 500) {
+      throw new GroqServerError(response.status, bodySnippet);
+    }
+
+    throw new GroqBadRequestError(response.status, bodySnippet);
+  }
+
+  const json = await response.json() as { choices?: Array<{ message?: { content?: string } }>; usage?: { prompt_tokens?: number; completion_tokens?: number } }
+
+  const content = json?.choices?.[0]?.message?.content
+  if (typeof content !== 'string') {
+    throw new Error('Groq API response has no message content')
+  }
+
+  // prompt_tokens / completion_tokens の両方が number のときだけ usage を返す。
+  // 片方でも欠けていれば undefined（callWithUsage の契約）。call からは無視される。
+  const rawUsage = json?.usage;
+  const usage: GroqUsage | undefined =
+    typeof rawUsage?.prompt_tokens === 'number' && typeof rawUsage?.completion_tokens === 'number'
+      ? { prompt_tokens: rawUsage.prompt_tokens, completion_tokens: rawUsage.completion_tokens }
+      : undefined;
+
+  return { content, usage };
+}
+
+/**
  * デフォルトの Groq クライアント実装。
  *
  * NOTE:
  * - Node 18+ で global fetch が使える前提。
  * - それ以前の環境なら、node-fetch / undici などで polyfill してください。
+ * - HTTP 実装は performGroqCall に集約済み。2 つのメソッドの違いは戻り値の形だけ。
  */
 export const groqClient: GroqClient = {
-  async call({ model, messages, temperature, maxTokens }: GroqCallParams): Promise<string> {
-    const apiKey = process.env.GROQ_API_KEY
-    if (!apiKey) {
-      throw new Error('GROQ_API_KEY is not set')
-    }
-
-    // 主の LLM 実行パスとして Groq の compound runtime を利用する
-    const response = await fetch('https://api.groq.com/openai/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({
-        model,
-        messages,
-        temperature: temperature ?? 0,
-        max_tokens: maxTokens ?? 512,
-        // gpt-oss は推論トークンが max_tokens を食うため effort を絞る（groqModels.ts 参照）
-        ...groqReasoningParams(model),
-      }),
-    })
-
-    if (!response.ok) {
-      const text = await response.text();
-      const bodySnippet = text.length > 500 ? `${text.slice(0, 500)}...` : text;
-
-      const retryAfterHeader = response.headers.get('retry-after');
-      let retryAfterMs: number | undefined;
-      if (retryAfterHeader) {
-        const retryAfterSeconds = Number(retryAfterHeader);
-        if (!Number.isNaN(retryAfterSeconds) && retryAfterSeconds >= 0) {
-          retryAfterMs = retryAfterSeconds * 1000;
-        }
-      }
-
-      if (response.status === 429) {
-        throw new GroqRateLimitError(response.status, bodySnippet, retryAfterMs);
-      }
-
-      if (response.status === 404 && isModelNotFoundBody(bodySnippet)) {
-        throw new GroqModelNotFoundError(response.status, bodySnippet, model);
-      }
-
-      if (response.status >= 500) {
-        throw new GroqServerError(response.status, bodySnippet);
-      }
-
-      throw new GroqBadRequestError(response.status, bodySnippet);
-    }
-
-    const json = await response.json() as { choices?: Array<{ message?: { content?: string } }>; usage?: { prompt_tokens?: number; completion_tokens?: number } }
-
-    const content = json?.choices?.[0]?.message?.content
-    if (typeof content !== 'string') {
-      throw new Error('Groq API response has no message content')
-    }
-
-    return content
+  async call(params: GroqCallParams): Promise<string> {
+    return (await performGroqCall(params)).content
   },
 
-  async callWithUsage({ model, messages, temperature, maxTokens }: GroqCallParams): Promise<GroqCallWithUsageResult> {
-    const apiKey = process.env.GROQ_API_KEY
-    if (!apiKey) {
-      throw new Error('GROQ_API_KEY is not set')
-    }
-
-    const response = await fetch('https://api.groq.com/openai/v1/chat/completions', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({
-        model,
-        messages,
-        temperature: temperature ?? 0,
-        max_tokens: maxTokens ?? 512,
-        // gpt-oss は推論トークンが max_tokens を食うため effort を絞る（groqModels.ts 参照）
-        ...groqReasoningParams(model),
-      }),
-    })
-
-    if (!response.ok) {
-      const text = await response.text();
-      const bodySnippet = text.length > 500 ? `${text.slice(0, 500)}...` : text;
-      const retryAfterHeader = response.headers.get('retry-after');
-      let retryAfterMs: number | undefined;
-      if (retryAfterHeader) {
-        const retryAfterSeconds = Number(retryAfterHeader);
-        if (!Number.isNaN(retryAfterSeconds) && retryAfterSeconds >= 0) {
-          retryAfterMs = retryAfterSeconds * 1000;
-        }
-      }
-      if (response.status === 429) throw new GroqRateLimitError(response.status, bodySnippet, retryAfterMs);
-      if (response.status === 404 && isModelNotFoundBody(bodySnippet)) {
-        throw new GroqModelNotFoundError(response.status, bodySnippet, model);
-      }
-      if (response.status >= 500) throw new GroqServerError(response.status, bodySnippet);
-      throw new GroqBadRequestError(response.status, bodySnippet);
-    }
-
-    const json = await response.json() as { choices?: Array<{ message?: { content?: string } }>; usage?: { prompt_tokens?: number; completion_tokens?: number } }
-    const content = json?.choices?.[0]?.message?.content
-    if (typeof content !== 'string') {
-      throw new Error('Groq API response has no message content')
-    }
-
-    const rawUsage = json?.usage;
-    const usage: GroqUsage | undefined =
-      typeof rawUsage?.prompt_tokens === 'number' && typeof rawUsage?.completion_tokens === 'number'
-        ? { prompt_tokens: rawUsage.prompt_tokens, completion_tokens: rawUsage.completion_tokens }
-        : undefined;
-
-    return { content, usage };
+  async callWithUsage(params: GroqCallParams): Promise<GroqCallWithUsageResult> {
+    return performGroqCall(params)
   },
 }
 


### PR DESCRIPTION
## 動機（実害が出た直後の再発防止）

PR #847 で gpt-oss の推論トークン対策として `reasoning_effort` を追加した際、**`groqClient.call` と `groqClient.callWithUsage` の両方へ同じ2行を手で入れる必要があった。**

片方を忘れても例外にはならず、**その経路だけ本文が空になる無言の障害**になる。実際にこの性質（gpt-oss が推論トークンで `max_tokens` を食い潰す）で本番のアバターチャットが停止し、復旧に2回のデプロイを要した。次に同種の変更が来たときに同じ賭けをしたくない。

## 何が重複していたか

2つのメソッドは以下を丸ごと複製しており、**差分は `usage` を返すかどうかだけ**だった。

| 重複箇所 | 規模 |
|---|---|
| `GROQ_API_KEY` の存在チェック | 同一 |
| `fetch` のリクエスト組み立て | **完全に同一**（`model` / `messages` / `temperature ?? 0` / `max_tokens ?? 512` / `...groqReasoningParams(model)`） |
| エラー分類 | **約25行が丸ごと同一**（`bodySnippet` 500文字切り詰め、`retry-after` パース、429→5xx→404→その他の分岐） |
| レスポンス検証 | 同一（エラーメッセージ文字列まで） |

## 変更内容

HTTP 実装を `performGroqCall` に統合し、2メソッドは戻り値の形だけを変える薄いラッパーにした。

```ts
export const groqClient: GroqClient = {
  async call(params) { return (await performGroqCall(params)).content },
  async callWithUsage(params) { return performGroqCall(params) },
}
```

**`this` 経由の相互呼び出しではなくモジュールレベル関数へ委譲している。** `groqClient.fallback.test.ts` が `jest.spyOn(groqClient, 'call')` でメソッドを差し替えるため、メソッド間呼び出しにすると spy の有無で挙動が変わってしまう。

## 振る舞いは不変

- 戻り値型（`Promise<string>` / `Promise<GroqCallWithUsageResult>`）
- 投げる例外クラスと**分岐順序**（429 → 404+model_not_found → 5xx → その他）
- エラーメッセージ文字列
- `usage` の抽出条件（`prompt_tokens` と `completion_tokens` の両方が number のときだけ返す）
- `GroqClient` インターフェース、`callGroqWith429Retry` / `callGroqWithModelFallback` は未変更

**既存テストは1行も変更していない**（＝振る舞いを変えていない証明）。

## 追加した回帰防止テスト（12件）

- **【最重要】両者が完全に同一のリクエストを送る** — URL / method / headers に加え、**body を文字列として一致比較**（キー順の差も許さない＝同一コードが組み立てた証明）
- デフォルト値（`temperature=0` / `max_tokens=512`）も両者で一致
- 429 / 404(model_not_found) / 404(その他) / 500 / 400 が**両者で同じ例外クラス**
- `retry-after` の解釈、`content` 欠落エラー、`GROQ_API_KEY` 未設定エラーが両者で一致
- 戻り値の形だけが違うこと / `usage` 片方欠損時は `undefined`

## 検証

- typecheck 0エラー / oxlint 新規警告なし（既存2件は `main` でも同一に再現することを確認済み）
- `groqClient.fallback.test.ts` + `groqModels.test.ts`: **57/57 pass**
- `groqClient` を使う下流10スイート（objectionDetector / principleDetector / conversationJudge / evaluationAnalyzer / memoryDistiller / faqImport / book-pipeline / wiring-check 他）: **164/164 pass**

**ミューテーション検証2件**（いずれも復元後に全pass）:

1. 統合後の**1箇所**から `...groqReasoningParams(model)` を除去 → **`call` と `callWithUsage` の両方のテストが失敗（3件）**。統合前は同じ変更に2箇所の修正が必要だったので、これが「1箇所直せば両方に効く」構造になった証明
2. `call` だけ `maxTokens` の既定値を分岐させ重複時代への退化を模擬 → 「両者のリクエストが一致する」テストが失敗

## 補足: フルスイートの失敗について

フルスイートでは5スイートが落ちるが、`main` でも同数（別の顔ぶれ）が落ちる既知のクロスファイル汚染。本ブランチで落ちた4件を単独実行すると全て pass し、`analyticsAuthGuard` は `main` 単独でも pass することを確認済み。本PR起因の退行ではない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgCQYt8UMPgm4HNVu7nv7z
