### PR TITLE
[FIX][P1] テナント一覧のAPI契約不一致を修正（フィルタ/ソート/表示が全て機能していなかった問題）

### DIFF
--- a/admin-ui/src/pages/admin/tenants/index.test.tsx
+++ b/admin-ui/src/pages/admin/tenants/index.test.tsx
@@ -1,0 +1,185 @@
+// 回帰テスト: GET /v1/admin/tenants の応答形状 (is_active/created_at/api_key_count)
+// と Tenant 型のフィールド名の不一致により、フィルタ・ソート・状態バッジ・APIキー件数・
+// 作成日表示が全て機能しなくなっていた問題の修正確認。
+// [id].test.tsx と同じパターンで supabase の getSession をモックする
+// （このページ独自の authFetch は lib/api ではなく supabase から直接トークンを取る）。
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, fireEvent } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import TenantsPage from "./index";
+
+const mockGetSession = vi.fn();
+
+vi.mock("../../../lib/supabaseClient", () => ({
+  supabase: {
+    auth: {
+      getSession: (...args: unknown[]) => mockGetSession(...args),
+      refreshSession: () => Promise.resolve({ data: { session: null } }),
+    },
+  },
+}));
+
+vi.mock("react-router-dom", async () => {
+  const actual = await vi.importActual("react-router-dom");
+  return { ...actual, useNavigate: () => vi.fn() };
+});
+
+vi.mock("../../../i18n/LangContext", async () => {
+  const jaModule = await import("../../../i18n/ja");
+  const ja = jaModule.default as Record<string, string>;
+  const stableT = (key: string, vars?: Record<string, string | number>) => {
+    let text = ja[key] ?? key;
+    if (vars) {
+      for (const [k, v] of Object.entries(vars)) {
+        text = text.replace(new RegExp(`\\{${k}\\}`, "g"), String(v));
+      }
+    }
+    return text;
+  };
+  return {
+    useLang: () => ({ lang: "ja" as const, setLang: () => {}, t: stableT }),
+  };
+});
+
+const okSession = { data: { session: { access_token: "test-token" } } };
+
+function jsonResponse(status: number, body: unknown): Response {
+  return { ok: status >= 200 && status < 300, status, json: () => Promise.resolve(body) } as Response;
+}
+
+// GET /v1/admin/tenants の実際の応答形状（is_active/created_at/api_key_count、snake_case）
+function makeTenant(overrides: Record<string, unknown> = {}) {
+  return {
+    id: "carnation",
+    name: "カーネーション",
+    plan: "starter" as const,
+    is_active: true,
+    api_key_count: 2,
+    created_at: "2026-03-14T00:00:00Z",
+    billing_enabled: false,
+    billing_free_from: null,
+    billing_free_until: null,
+    ...overrides,
+  };
+}
+
+function renderPage() {
+  return render(
+    <MemoryRouter initialEntries={["/admin/tenants"]}>
+      <TenantsPage />
+    </MemoryRouter>
+  );
+}
+
+describe("TenantsPage — API応答形状とUIフィールドの整合性", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    mockGetSession.mockResolvedValue(okSession);
+  });
+
+  it("is_active=true のテナントを「有効」バッジで表示する（status由来の誤判定が無いこと）", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, { tenants: [makeTenant({ is_active: true })] })
+    );
+    renderPage();
+    await waitFor(() => expect(screen.getByText("有効")).toBeTruthy());
+  });
+
+  it("is_active=false のテナントを「無効」バッジで表示する", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, { tenants: [makeTenant({ is_active: false })] })
+    );
+    renderPage();
+    await waitFor(() => expect(screen.getByText("無効")).toBeTruthy());
+  });
+
+  it("api_key_count を実際の件数で表示する（0固定のバグの回帰防止）", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, { tenants: [makeTenant({ api_key_count: 3 })] })
+    );
+    renderPage();
+    await waitFor(() => expect(screen.getByText("APIキー: 3件")).toBeTruthy());
+  });
+
+  it("api_key_count が0のテナントは「APIキー: 0件」と表示する", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, { tenants: [makeTenant({ api_key_count: 0 })] })
+    );
+    renderPage();
+    await waitFor(() => expect(screen.getByText("APIキー: 0件")).toBeTruthy());
+  });
+
+  it("created_at を「作成日: -」ではなく実際の日付で表示する（NaN比較バグの回帰防止）", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, { tenants: [makeTenant({ created_at: "2026-03-14T00:00:00Z" })] })
+    );
+    renderPage();
+    await waitFor(() => {
+      const el = screen.getByText(/作成日:/);
+      expect(el.textContent).not.toContain("作成日: -");
+      expect(el.textContent).toContain("2026");
+    });
+  });
+
+  it("id を旧slugの代わりに表示する（DBに存在しないslug列を参照しない）", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, { tenants: [makeTenant({ id: "carnation" })] })
+    );
+    renderPage();
+    await waitFor(() => expect(screen.getByText("carnation")).toBeTruthy());
+  });
+
+  it('「有効のみ」フィルタで is_active=false のテナントを除外する（フィルタ0件バグの回帰防止）', async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, {
+        tenants: [
+          makeTenant({ id: "active-tenant", name: "有効テナント", is_active: true }),
+          makeTenant({ id: "inactive-tenant", name: "無効テナント", is_active: false }),
+        ],
+      })
+    );
+    renderPage();
+    await waitFor(() => expect(screen.getByText("有効テナント")).toBeTruthy());
+    expect(screen.getByText("無効テナント")).toBeTruthy();
+
+    fireEvent.click(screen.getByText("有効のみ"));
+
+    await waitFor(() => expect(screen.queryByText("無効テナント")).toBeNull());
+    expect(screen.getByText("有効テナント")).toBeTruthy();
+  });
+
+  it('「無効のみ」フィルタで is_active=true のテナントを除外する', async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, {
+        tenants: [
+          makeTenant({ id: "active-tenant", name: "有効テナント", is_active: true }),
+          makeTenant({ id: "inactive-tenant", name: "無効テナント", is_active: false }),
+        ],
+      })
+    );
+    renderPage();
+    await waitFor(() => expect(screen.getByText("有効テナント")).toBeTruthy());
+
+    fireEvent.click(screen.getByText("無効のみ"));
+
+    await waitFor(() => expect(screen.queryByText("有効テナント")).toBeNull());
+    expect(screen.getByText("無効テナント")).toBeTruthy();
+  });
+
+  it("作成日ソートを created_at の実日付で正しく並べ替える（NaN比較で常に0だったバグの回帰防止）", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue(
+      jsonResponse(200, {
+        tenants: [
+          makeTenant({ id: "older", name: "古いテナント", created_at: "2026-01-01T00:00:00Z" }),
+          makeTenant({ id: "newer", name: "新しいテナント", created_at: "2026-06-01T00:00:00Z" }),
+        ],
+      })
+    );
+    renderPage();
+    await waitFor(() => expect(screen.getByText("新しいテナント")).toBeTruthy());
+
+    // 既定は created_at 降順 → 新しい方が先に描画される
+    const names = screen.getAllByText(/テナント$/).map((el) => el.textContent);
+    expect(names.indexOf("新しいテナント")).toBeLessThan(names.indexOf("古いテナント"));
+  });
+});

--- a/admin-ui/src/pages/admin/tenants/index.tsx
+++ b/admin-ui/src/pages/admin/tenants/index.tsx
@@ -11,11 +11,11 @@ import { supabase } from "../../../lib/supabaseClient";
 interface Tenant {
   id: string;
   name: string;
-  slug: string;
   plan: "starter" | "growth" | "enterprise";
-  status: "active" | "inactive";
-  apiKeyCount: number;
-  createdAt: string;
+  is_active: boolean;
+  // POST /v1/admin/tenants (作成直後) は集計を含まないため未定義になりうる。
+  api_key_count?: number;
+  created_at: string;
   billing_enabled?: boolean;
   billing_free_from?: string | null;
   billing_free_until?: string | null;
@@ -253,7 +253,7 @@ function CreateTenantModal({ onClose, onSuccess }: CreateModalProps) {
 
 // ─── メインページ ─────────────────────────────────────────────────────────────
 
-type SortByTenant = "name" | "createdAt";
+type SortByTenant = "name" | "created_at";
 
 export default function TenantsPage() {
   const navigate = useNavigate();
@@ -268,7 +268,7 @@ export default function TenantsPage() {
   // 検索・ソート・フィルター
   const [search, setSearch] = useState("");
   const [debouncedSearch, setDebouncedSearch] = useState("");
-  const [sortBy, setSortBy] = useState<SortByTenant>("createdAt");
+  const [sortBy, setSortBy] = useState<SortByTenant>("created_at");
   const [sortOrder, setSortOrder] = useState<"asc" | "desc">("desc");
   const [statusFilter, setStatusFilter] = useState<"" | "active" | "inactive">("");
   const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -290,7 +290,8 @@ export default function TenantsPage() {
 
   const filteredTenants = tenants
     .filter((t) => {
-      if (statusFilter && t.status !== statusFilter) return false;
+      if (statusFilter === "active" && !t.is_active) return false;
+      if (statusFilter === "inactive" && t.is_active) return false;
       if (debouncedSearch && !t.name.toLowerCase().includes(debouncedSearch.toLowerCase())) return false;
       return true;
     })
@@ -299,7 +300,7 @@ export default function TenantsPage() {
       if (sortBy === "name") {
         cmp = a.name.localeCompare(b.name, locale);
       } else {
-        cmp = new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+        cmp = new Date(a.created_at).getTime() - new Date(b.created_at).getTime();
       }
       return sortOrder === "asc" ? cmp : -cmp;
     });
@@ -472,7 +473,7 @@ export default function TenantsPage() {
         <div style={{ display: "flex", gap: 8, alignItems: "center", marginLeft: 8 }}>
           <span style={{ fontSize: 12, color: "var(--muted-foreground)" }}>並び替え:</span>
           <SortableHeader label="名前" sortKey="name" currentSortBy={sortBy} currentSortOrder={sortOrder} onSort={handleSort} />
-          <SortableHeader label="作成日" sortKey="createdAt" currentSortBy={sortBy} currentSortOrder={sortOrder} onSort={handleSort} />
+          <SortableHeader label="作成日" sortKey="created_at" currentSortBy={sortBy} currentSortOrder={sortOrder} onSort={handleSort} />
         </div>
         <span style={{ marginLeft: "auto", fontSize: 13, color: "var(--muted-foreground)", whiteSpace: "nowrap" }}>
           全{tenants.length}件中{" "}
@@ -551,12 +552,12 @@ export default function TenantsPage() {
                         borderRadius: 999,
                         fontSize: 11,
                         fontWeight: 700,
-                        background: tenant.status === "active" ? "rgba(34,197,94,0.15)" : "rgba(107,114,128,0.2)",
-                        color: tenant.status === "active" ? "#4ade80" : "#9ca3af",
-                        border: `1px solid ${tenant.status === "active" ? "rgba(74,222,128,0.3)" : "rgba(107,114,128,0.3)"}`,
+                        background: tenant.is_active ? "rgba(34,197,94,0.15)" : "rgba(107,114,128,0.2)",
+                        color: tenant.is_active ? "#4ade80" : "#9ca3af",
+                        border: `1px solid ${tenant.is_active ? "rgba(74,222,128,0.3)" : "rgba(107,114,128,0.3)"}`,
                       }}
                     >
-                      {tenant.status === "active" ? t("tenants.status_active") : t("tenants.status_inactive")}
+                      {tenant.is_active ? t("tenants.status_active") : t("tenants.status_inactive")}
                     </span>
                     {/* 課金バッジ */}
                     {(() => {
@@ -586,7 +587,7 @@ export default function TenantsPage() {
                     })()}
                   </div>
                   <div style={{ fontSize: 13, color: "var(--muted-foreground)" }}>
-                    slug: <span style={{ fontFamily: "monospace", color: "var(--muted-foreground)" }}>{tenant.slug}</span>
+                    slug: <span style={{ fontFamily: "monospace", color: "var(--muted-foreground)" }}>{tenant.id}</span>
                   </div>
                 </div>
 
@@ -601,12 +602,12 @@ export default function TenantsPage() {
                   }}
                 >
                   <div>
-                    <span style={{ color: "var(--muted-foreground)" }}>{t("tenants.api_keys", { n: tenant.apiKeyCount ?? 0 })}</span>
+                    <span style={{ color: "var(--muted-foreground)" }}>{t("tenants.api_keys", { n: tenant.api_key_count ?? 0 })}</span>
                   </div>
                   <div>
                     <span style={{ color: "var(--muted-foreground)" }}>
                       {(() => {
-                        const d = tenant.createdAt ? new Date(tenant.createdAt) : null;
+                        const d = tenant.created_at ? new Date(tenant.created_at) : null;
                         const dateStr = d && !isNaN(d.getTime())
                           ? d.toLocaleDateString(locale, { year: "numeric", month: "short", day: "numeric" })
                           : "-";

--- a/src/api/admin/tenants/routes.ts
+++ b/src/api/admin/tenants/routes.ts
@@ -439,7 +439,13 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
   app.get("/v1/admin/tenants", tenantAuth, requireSuperAdmin, async (_req: Request, res: Response) => {
     try {
       const result = await db.query(
-        `SELECT id, name, plan, is_active, allowed_origins, system_prompt, billing_enabled, billing_free_from, billing_free_until, features, conversion_types, created_at, updated_at FROM tenants ORDER BY created_at DESC`
+        `SELECT t.id, t.name, t.plan, t.is_active, t.allowed_origins, t.system_prompt,
+                t.billing_enabled, t.billing_free_from, t.billing_free_until, t.features,
+                t.conversion_types, t.created_at, t.updated_at,
+                (SELECT COUNT(*)::int FROM tenant_api_keys k
+                 WHERE k.tenant_id = t.id AND k.is_active) AS api_key_count
+         FROM tenants t
+         ORDER BY t.created_at DESC`
       );
       return res.json({ tenants: result.rows, total: result.rows.length });
     } catch (err) {

--- a/tests/api/admin/tenants/routes.test.ts
+++ b/tests/api/admin/tenants/routes.test.ts
@@ -83,6 +83,33 @@ describe("Tenant Admin Routes", () => {
       expect(res.status).toBe(200);
       expect(res.body.tenants).toHaveLength(1);
     });
+
+    it("includes api_key_count reflecting only active keys", async () => {
+      // carnation相当: アクティブ2件・失効1件 → api_key_countは2
+      mockDb.query.mockResolvedValueOnce({
+        rows: [
+          { id: "carnation", name: "Carnation", plan: "starter", is_active: true, created_at: new Date(), updated_at: new Date(), api_key_count: 2 },
+          { id: "empty-tenant", name: "Empty", plan: "starter", is_active: true, created_at: new Date(), updated_at: new Date(), api_key_count: 0 },
+        ],
+      });
+      const res = await request(app)
+        .get("/v1/admin/tenants")
+        .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`);
+      expect(res.status).toBe(200);
+      expect(res.body.tenants[0].api_key_count).toBe(2);
+      expect(res.body.tenants[1].api_key_count).toBe(0);
+    });
+
+    it("aggregates api_key_count via a subquery scoped to active keys per tenant", async () => {
+      mockDb.query.mockResolvedValueOnce({ rows: [] });
+      await request(app)
+        .get("/v1/admin/tenants")
+        .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`);
+      const sql = mockDb.query.mock.calls[0][0] as string;
+      expect(sql).toMatch(/tenant_api_keys/);
+      expect(sql).toMatch(/api_key_count/);
+      expect(sql).toMatch(/k\.is_active/);
+    });
   });
 
   describe("POST /v1/admin/tenants", () => {


### PR DESCRIPTION
## 背景

`GET /v1/admin/tenants` の応答（DB由来のsnake_case: `is_active`/`created_at`）と、admin-uiの`Tenant`型（camelCase: `status`/`createdAt`/`apiKeyCount`、DBに存在しない`slug`）が食い違っており、以下が全て機能していなかった（本番で実機確認済み）:

- テナントの有効/無効バッジ → 全テナント「無効」表示
- 「有効のみ/無効のみ」フィルタ → 常に0件
- 「作成日」ソート → `NaN`比較で機能せず
- APIキー件数表示 → 常に「0件」（一覧APIがそもそも集計を返していない）
- slug列（表示欄） → 空

実データ: 本番DBは4テナント全て`is_active=true`、`carnation`はAPIキー3本（うち2本有効）。

## 変更内容

### バックエンド (`src/api/admin/tenants/routes.ts`)
`GET /v1/admin/tenants` のSELECTに、テナントごとの**有効なAPIキー数**をサブクエリで集計する`api_key_count`列を追加。失効済みキーを含めると運用者を誤解させるため、有効キーのみをカウントする設計とした。

### フロントエンド (`admin-ui/src/pages/admin/tenants/index.tsx`)
`Tenant`型を、既に正しく動いている`billing_enabled`等と同じsnake_caseに統一:
- `status: "active"|"inactive"` → `is_active: boolean`
- `createdAt` → `created_at`
- `apiKeyCount` → `api_key_count?`（POST応答には無いため任意）
- `slug` → 削除。DBに列自体が存在せず、`createTenant`も内部で`id`をslugとして送信しているため、表示は`tenant.id`に統一

フィルタ・ソート・バッジ・APIキー件数・作成日の全参照箇所を追随。テナント作成フォームの入力欄（変数名`slug`）はそのまま変更していない。

### テスト
既存の`index.test.tsx`が無かったため新規作成（このバグ自体が「一覧ページのテストが存在しなかった」ことに起因するため、この1ファイルに限り例外的に新規作成）。実際のAPI応答形状を模したフィクスチャで、フィルタ・ソート・バッジ・件数・id表示の9ケースを検証。ミューテーション確認済み（フィルタ/ソートを旧実装に戻すと該当テストが確実に失敗することを実測）。

バックエンドは`tenant_api_keys`テーブルの実スキーマ（#836/#843で整理済み）を踏襲し、新規マイグレーションは追加していない。

## テスト結果
- typecheck: 0エラー（backend/admin-ui両方）
- oxlint: 警告なし
- backend: `tests/api/admin/tenants/routes.test.ts` 112/112 pass
- admin-ui: 新規テスト 9/9 pass、全体回帰 41ファイル 551/551 pass

Tier S（`admin-ui/src`）を含むため手動マージが必要です。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>