### PR TITLE
chore(groq): 未使用のローカル変数を削除

### DIFF
--- a/src/agent/llm/groqClient.ts
+++ b/src/agent/llm/groqClient.ts
@@ -259,7 +259,6 @@ export async function callGroqWith429Retry(
 ): Promise<string> {
   const { maxRetries = 1, baseBackoffMs = 200, logger } = options;
 
-  const now = Date.now();
   const remainingBackoff = getGroqGlobalBackoffRemainingMs();
   if (remainingBackoff > 0) {
     // すでにグローバル backoff 中の場合は、実際の API コールを行わずに即座に 429 相当で返す。


### PR DESCRIPTION
## 概要
`callGroqWith429Retry` の `const now = Date.now()` が宣言後に一度も参照されていなかった。
直後に呼ぶ `getGroqGlobalBackoffRemainingMs()` が内部で独自に `Date.now()` を取得しているため不要。

PR #848（groqClient重複解消）のレビュー時に見つかった軽微な清掃項目。

## テスト
- typecheck 0エラー
- oxlint クリーン
- `groqClient.test.ts` 33/33 pass