### PR TITLE
fix(tuning): 承認したルールが本番プロンプトに載らないP0を直す（D8）

### DIFF
--- a/src/agent/judge/evaluationAnalyzer.ts
+++ b/src/agent/judge/evaluationAnalyzer.ts
@@ -143,11 +143,12 @@ export async function analyzeTuningRules(
       // 一意性は uniq_tuning_rules_tenant_trigger (phase75) が DB 側で保証する。
       // is_active は必ず false で入れる。列を省略するとスキーマ既定 DEFAULT true が効いて
       // 店主の承認なしに本番の応答方針へ即反映されてしまう(CLAUDE.md「指示ルールの不変ルール」)。
+      // status='pending' も同じ理由で明示する(DEFAULT に依存しない)。
       await pool.query(
         `INSERT INTO tuning_rules
            (tenant_id, trigger_pattern, expected_behavior, priority,
-            is_active, source, suggested_at, evidence)
-         VALUES ($1, $2, $3, $4, false, 'judge', NOW(), $5::jsonb)
+            is_active, source, status, suggested_at, evidence)
+         VALUES ($1, $2, $3, $4, false, 'judge', 'pending', NOW(), $5::jsonb)
          ON CONFLICT (tenant_id, trigger_pattern) DO NOTHING`,
         [tenantId, rule.triggerPattern, rule.expectedBehavior, 0, JSON.stringify(evidence)],
       );

--- a/src/agent/judge/judgeEvaluator.ts
+++ b/src/agent/judge/judgeEvaluator.ts
@@ -412,10 +412,13 @@ export async function evaluateSession(sessionId: string, expectedTenantId?: stri
         try {
           // source='judge' を明示する。未設定だとスキーマ既定 'manual' になり、
           // 店主が作ったルールと出所を区別できなくなる(承認導線で必須の情報)。
+          // status='pending' も明示する。省略してスキーマ既定に委ねると、
+          // 既定値が将来変わった際に無審査で有効化されうる(is_active=false と
+          // 同じ理由でDEFAULTに依存しない)。
           await pool.query(
             `INSERT INTO tuning_rules
-               (tenant_id, trigger_pattern, expected_behavior, priority, is_active, source)
-             VALUES ($1, $2, $3, $4, false, 'judge')
+               (tenant_id, trigger_pattern, expected_behavior, priority, is_active, source, status)
+             VALUES ($1, $2, $3, $4, false, 'judge', 'pending')
              ON CONFLICT (tenant_id, trigger_pattern) DO NOTHING`,
             [
               tenantId,

--- a/src/api/admin/evaluations/evaluationsRepository.ts
+++ b/src/api/admin/evaluations/evaluationsRepository.ts
@@ -455,11 +455,18 @@ export interface TuningRuleWithStatus {
   id: number;
   tenant_id: string;
   status: string;
+  is_active: boolean;
   approved_at: string | null;
   rejected_at: string | null;
   updated_at: string;
 }
 
+/**
+ * D8: is_active が唯一の真実、status は承認判断の記録。
+ * 承認は status='active' と is_active=true を同一UPDATEで設定する。
+ * これを分けると「承認したのに本番のプロンプトへ入らない」事故になる
+ * (getActiveRulesForTenant は is_active しか見ない)。
+ */
 export async function approveTuningRule(
   id: number,
   tenantId: string | undefined,
@@ -476,16 +483,22 @@ export async function approveTuningRule(
   const result = await pool.query<TuningRuleWithStatus>(
     `UPDATE tuning_rules
      SET status = 'active',
+         is_active = true,
          approved_at = NOW(),
          rejected_at = NULL,
          updated_at = NOW()
      ${where}
-     RETURNING id, tenant_id, status, approved_at, rejected_at, updated_at`,
+     RETURNING id, tenant_id, status, is_active, approved_at, rejected_at, updated_at`,
     args,
   );
   return result.rows[0] ?? null;
 }
 
+/**
+ * D8: 却下は is_active=false も同時に設定する。
+ * status のみの更新だと、手動作成ルール(is_active=true)を却下しても
+ * 本番プロンプトへの注入が止まらない。
+ */
 export async function rejectTuningRule(
   id: number,
   tenantId: string | undefined,
@@ -502,11 +515,12 @@ export async function rejectTuningRule(
   const result = await pool.query<TuningRuleWithStatus>(
     `UPDATE tuning_rules
      SET status = 'rejected',
+         is_active = false,
          rejected_at = NOW(),
          approved_at = NULL,
          updated_at = NOW()
      ${where}
-     RETURNING id, tenant_id, status, approved_at, rejected_at, updated_at`,
+     RETURNING id, tenant_id, status, is_active, approved_at, rejected_at, updated_at`,
     args,
   );
   return result.rows[0] ?? null;
@@ -660,34 +674,70 @@ export async function updateSuggestedRuleStatus(
 // suggested_rules から tuning_rules へ挿入 - Stream B
 // ---------------------------------------------------------------------------
 
+/**
+ * D8: この経路は evaluation.suggested_rules（Judge提案）を人間が承認して
+ * tuning_rules へ確定する唯一の入口。ここで承認しているので is_active=true /
+ * status='active' / approved_at=NOW() を明示する。
+ *
+ * 同じ (tenant_id, trigger_pattern) の行は judgeEvaluator.ts / evaluationAnalyzer.ts
+ * が is_active=false で先に seed 済みのことが多い(uniq_tuning_rules_tenant_trigger)。
+ * 従来の ON CONFLICT DO NOTHING はこの衝突で null を返すだけで承認が失われていた。
+ * DO UPDATE に変え、その seed 行を承認済みへ更新する。
+ * ただし手動作成ルール(source='manual')と偶然同じ trigger_pattern だった場合に
+ * 上書きしないよう、更新対象は source='judge' の既存行に限定する。
+ *
+ * expectedBehavior が渡されない場合のみ trigger_pattern と同じ文言を使う
+ * (旧実装は常に同じ文言を複製しており、発火条件と応答方針が同一の不正形だった)。
+ */
 export async function insertTuningRuleFromSuggestion(
   tenantId: string,
   ruleText: string,
-  options?: { editedText?: string; editedBy?: string },
+  options?: { editedText?: string; editedBy?: string; expectedBehavior?: string },
 ): Promise<number | null> {
   const pool = getPool();
-  const finalText = options?.editedText ?? ruleText;
+  const finalTrigger = options?.editedText ?? ruleText;
   const originalText = options?.editedText ? ruleText : null;
   const editedBy = options?.editedText ? (options.editedBy ?? null) : null;
   const editedAt = options?.editedText ? "NOW()" : null;
+  const expectedBehavior = options?.expectedBehavior?.trim() || finalTrigger;
 
   if (editedAt) {
     const result = await pool.query<{ id: number }>(
       `INSERT INTO tuning_rules
          (tenant_id, trigger_pattern, expected_behavior, priority, is_active,
-          original_text, edited_by, edited_at)
-       VALUES ($1, $2, $2, 0, true, $3, $4, NOW())
-       ON CONFLICT DO NOTHING RETURNING id`,
-      [tenantId, finalText, originalText, editedBy],
+          source, status, approved_at, original_text, edited_by, edited_at)
+       VALUES ($1, $2, $3, 0, true, 'judge', 'active', NOW(), $4, $5, NOW())
+       ON CONFLICT (tenant_id, trigger_pattern) DO UPDATE SET
+         expected_behavior = EXCLUDED.expected_behavior,
+         is_active = true,
+         status = 'active',
+         approved_at = NOW(),
+         rejected_at = NULL,
+         original_text = EXCLUDED.original_text,
+         edited_by = EXCLUDED.edited_by,
+         edited_at = EXCLUDED.edited_at,
+         updated_at = NOW()
+       WHERE tuning_rules.source = 'judge'
+       RETURNING id`,
+      [tenantId, finalTrigger, expectedBehavior, originalText, editedBy],
     );
     return result.rows[0]?.id ?? null;
   } else {
     const result = await pool.query<{ id: number }>(
       `INSERT INTO tuning_rules
-         (tenant_id, trigger_pattern, expected_behavior, priority, is_active)
-       VALUES ($1, $2, $2, 0, true)
-       ON CONFLICT DO NOTHING RETURNING id`,
-      [tenantId, finalText],
+         (tenant_id, trigger_pattern, expected_behavior, priority, is_active,
+          source, status, approved_at)
+       VALUES ($1, $2, $3, 0, true, 'judge', 'active', NOW())
+       ON CONFLICT (tenant_id, trigger_pattern) DO UPDATE SET
+         expected_behavior = EXCLUDED.expected_behavior,
+         is_active = true,
+         status = 'active',
+         approved_at = NOW(),
+         rejected_at = NULL,
+         updated_at = NOW()
+       WHERE tuning_rules.source = 'judge'
+       RETURNING id`,
+      [tenantId, finalTrigger, expectedBehavior],
     );
     return result.rows[0]?.id ?? null;
   }

--- a/src/api/admin/evaluations/routes.ts
+++ b/src/api/admin/evaluations/routes.ts
@@ -301,7 +301,7 @@ export function registerEvaluationRoutes(app: Express): void {
           if (!data) {
             return res.status(404).json({ error: "評価データが見つかりません" });
           }
-          const rules = (data.evaluation as any).suggested_rules as Array<{ rule_text?: string; status?: string }> | null;
+          const rules = (data.evaluation as any).suggested_rules as Array<{ rule_text?: string; reason?: string; status?: string }> | null;
           const rule = Array.isArray(rules) ? rules[ruleIndex] : undefined;
           if (!rule) {
             return res.status(404).json({ error: "指定されたルールが見つかりません" });
@@ -311,6 +311,7 @@ export function registerEvaluationRoutes(app: Express): void {
             tuningRuleId = await insertTuningRuleFromSuggestion(data.evaluation.tenant_id, ruleText, {
               editedText: typeof edited_text === "string" ? edited_text : undefined,
               editedBy: email || undefined,
+              expectedBehavior: rule.reason,
             });
           }
         }

--- a/src/api/admin/tuning/migration_approval_state.sql
+++ b/src/api/admin/tuning/migration_approval_state.sql
@@ -1,0 +1,24 @@
+-- D8: tuning_rules の承認状態の意味を固定する（学習ループ要件定義 docs/LEARNING_LOOP_REQUIREMENTS.md §9 D8）
+--
+-- 列は追加しない・DEFAULT も変更しない。列そのものは既に存在する
+-- (is_active: migration.sql, status: migration_kpi_outcome.sql)。
+-- このマイグレーションは意味を COMMENT で明文化するだけ。
+--
+-- 決定事項:
+--   is_active が唯一の真実(本番の応答方針に入るかどうかはこの列だけで決まる)。
+--   status は承認判断の記録(pending=未判断 / active=人が承認した / rejected=人が却下した)。
+--   単独では効力を持たない。
+-- 不変条件（コード側 approveTuningRule / rejectTuningRule / updateRule の3箇所で強制）:
+--   status='active'   ⇒ is_active=true
+--   status='rejected' ⇒ is_active=false
+--   status='pending'  は is_active を拘束しない
+--
+-- データ移行は不要（本番実測 2026-08-23: tuning_rules 全7件が status='pending' で
+-- 不整合0件。status='active' かつ is_active<>true、または status='rejected' かつ
+-- is_active=true の行は存在しない）。
+
+COMMENT ON COLUMN tuning_rules.is_active IS
+  'D8: 唯一の真実。true のときだけ getActiveRulesForTenant() が本番プロンプトへ注入する。';
+
+COMMENT ON COLUMN tuning_rules.status IS
+  'D8: 承認判断の記録のみ（pending=未判断 / active=承認済み / rejected=却下済み）。単独では効力を持たない。是正: approveTuningRule/rejectTuningRule/updateRule が is_active との同時更新を保証する。';

--- a/src/api/admin/tuning/routes.ts
+++ b/src/api/admin/tuning/routes.ts
@@ -226,6 +226,9 @@ const createSchema = z.object({
   trigger_pattern: z.string().min(1).max(1000),
   expected_behavior: z.string().min(1).max(4000),
   priority: z.number().int().min(0).max(10).optional(),
+  // D8: 未指定なら zod が黙って落とし、常に DEFAULT true になっていた
+  // (作成モーダルは is_active を送っているのに受け付けていなかった)。
+  is_active: z.boolean().optional(),
   source_message_id: z.number().int().positive().nullable().optional(),
 });
 
@@ -438,7 +441,7 @@ export function registerTuningRoutes(app: Express): void {
         .json({ error: "invalid_request", details: parsed.error.issues });
     }
 
-    const { tenant_id, trigger_pattern, expected_behavior, priority, source_message_id } =
+    const { tenant_id, trigger_pattern, expected_behavior, priority, is_active, source_message_id } =
       parsed.data;
 
     // client_admin は自テナント以外 (global 含む) に作成不可
@@ -454,6 +457,7 @@ export function registerTuningRoutes(app: Express): void {
         trigger_pattern,
         expected_behavior,
         priority,
+        is_active,
         created_by: jwtEmail || undefined,
         source_message_id: source_message_id ?? null,
       });

--- a/src/api/admin/tuning/tuningRulesRepository.test.ts
+++ b/src/api/admin/tuning/tuningRulesRepository.test.ts
@@ -144,11 +144,12 @@ describe('updateRule', () => {
     expect(updateArgs[5]).toBeNull();
   });
 
-  // 壊れやすいポイント: is_active と status は呼び出し側(actionExecutor)が
-  // 独立に渡せる。statusだけ'active'を指定してis_activeを指定し忘れても、
-  // このリポジトリ層は片方だけを更新する(整合性強制は行わない設計)。
-  // 呼び出し側の責務であることをここで固定しておく。
-  it('statusのみ指定してis_activeを指定しない場合、is_active列(の引数)はnullのまま渡る', async () => {
+  // D8: is_active が唯一の真実。status で承認/却下を指定した場合は、
+  // 呼び出し側(actionExecutor)がis_activeを渡し忘れてもリポジトリ層が
+  // 自動で導出する(呼び出し側やLLMプロンプトに整合性を委ねない)。
+  // これにより「承認したのに本番プロンプトへ入らない」「却下したのに
+  // 注入され続ける」というP0を再発させない。
+  it('status="active"のみ指定してis_activeを指定しない場合、is_active列にtrueが導出されて渡る', async () => {
     mockQuery
       .mockResolvedValueOnce({ rows: [{ id: 1, tenant_id: 'tenant-abc' }] })
       .mockResolvedValueOnce({ rows: [{ id: 1, tenant_id: 'tenant-abc' }] });
@@ -156,8 +157,31 @@ describe('updateRule', () => {
     await updateRule(1, { status: 'active' }, 'tenant-abc');
 
     const [, updateArgs] = mockQuery.mock.calls[1];
-    expect(updateArgs[3]).toBeNull(); // is_active
+    expect(updateArgs[3]).toBe(true); // is_active(導出)
     expect(updateArgs[5]).toBe('active'); // status
+  });
+
+  it('status="rejected"のみ指定してis_activeを指定しない場合、is_active列にfalseが導出されて渡る', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 1, tenant_id: 'tenant-abc' }] })
+      .mockResolvedValueOnce({ rows: [{ id: 1, tenant_id: 'tenant-abc' }] });
+
+    await updateRule(1, { status: 'rejected' }, 'tenant-abc');
+
+    const [, updateArgs] = mockQuery.mock.calls[1];
+    expect(updateArgs[3]).toBe(false); // is_active(導出)
+    expect(updateArgs[5]).toBe('rejected'); // status
+  });
+
+  it('status="active" と is_active=false が同時に渡っても、statusが優先されis_activeはtrueで導出される', async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 1, tenant_id: 'tenant-abc' }] })
+      .mockResolvedValueOnce({ rows: [{ id: 1, tenant_id: 'tenant-abc' }] });
+
+    await updateRule(1, { status: 'active', is_active: false }, 'tenant-abc');
+
+    const [, updateArgs] = mockQuery.mock.calls[1];
+    expect(updateArgs[3]).toBe(true); // is_active(statusが優先)
   });
 
   it('RETURNING句にsource/status/evidence列が含まれる(P4-1で追加、承認カードの表示に必須)', async () => {

--- a/src/api/admin/tuning/tuningRulesRepository.ts
+++ b/src/api/admin/tuning/tuningRulesRepository.ts
@@ -49,6 +49,7 @@ export interface CreateRuleParams {
   trigger_pattern: string;
   expected_behavior: string;
   priority?: number;
+  is_active?: boolean;
   created_by?: string;
   source_message_id?: number | null;
 }
@@ -139,15 +140,20 @@ export async function getActiveRulesForTenant(
   return result.rows;
 }
 
-/** ルール作成。RETURNING * で作成済み行を返す。 */
+/**
+ * ルール作成。RETURNING * で作成済み行を返す。
+ * is_active は明示的に渡す(未指定時は true)。列を省略してスキーマ既定に
+ * 委ねると、作成モーダルが送る is_active=false が黙って無視される
+ * (createSchema で受け付けていなかった旧実装の再発防止)。
+ */
 export async function createRule(params: CreateRuleParams): Promise<TuningRule> {
   const pool = getPool();
 
   const result = await pool.query<TuningRule>(
     `INSERT INTO tuning_rules
-       (tenant_id, trigger_pattern, expected_behavior, priority,
+       (tenant_id, trigger_pattern, expected_behavior, priority, is_active,
         created_by, source_message_id)
-     VALUES ($1, $2, $3, $4, $5, $6)
+     VALUES ($1, $2, $3, $4, $5, $6, $7)
      RETURNING id, tenant_id, trigger_pattern, expected_behavior,
                priority, is_active, created_by, source_message_id,
                created_at, updated_at, approved_responses`,
@@ -156,6 +162,7 @@ export async function createRule(params: CreateRuleParams): Promise<TuningRule> 
       params.trigger_pattern,
       params.expected_behavior,
       params.priority ?? 0,
+      params.is_active ?? true,
       params.created_by ?? null,
       params.source_message_id ?? null,
     ],
@@ -189,6 +196,17 @@ export async function updateRule(
       ? JSON.stringify(params.approved_responses)
       : null;
 
+  // D8: is_active が唯一の真実。status で承認/却下を指定した場合はここで
+  // is_active を導出し、呼び出し側(actionExecutor / LLMプロンプト)が
+  // is_active を渡し忘れても不整合が起きないようにする。
+  // status 未指定時は従来通り params.is_active(通常のON/OFF切替)を使う。
+  const derivedIsActive =
+    params.status === "active"
+      ? true
+      : params.status === "rejected"
+        ? false
+        : (params.is_active ?? null);
+
   const result = await pool.query<TuningRule>(
     `UPDATE tuning_rules SET
        trigger_pattern   = COALESCE($1, trigger_pattern),
@@ -206,7 +224,7 @@ export async function updateRule(
       params.trigger_pattern ?? null,
       params.expected_behavior ?? null,
       params.priority ?? null,
-      params.is_active ?? null,
+      derivedIsActive,
       approvedJson,
       params.status ?? null,
       id,

--- a/tests/integration/wiring-check.test.ts
+++ b/tests/integration/wiring-check.test.ts
@@ -125,6 +125,7 @@ import {
 import { searchTool } from "../../src/agent/tools/searchTool";
 import { synthesizeAnswer } from "../../src/agent/tools/synthesisTool";
 import { getActiveRulesForTenant } from "../../src/api/admin/tuning/tuningRulesRepository";
+import { approveTuningRule } from "../../src/api/admin/evaluations/evaluationsRepository";
 import { evaluateSession, SessionNotFoundError, SessionTooShortError } from "../../src/agent/judge/judgeEvaluator";
 import { sanitizeInput } from "../../src/middleware/inputSanitizer";
 import { applyPromptFirewall } from "../../src/middleware/promptFirewall";
@@ -546,6 +547,63 @@ describe("Flow 4: チューニングルール → synthesizeAnswer → Groq prom
     expect(result.gapSignal.hitCount).toBe(0);
     // Must return a non-empty answer (gap message)
     expect(result.answer.length).toBeGreaterThan(0);
+  });
+
+  // D8/G-d: 承認したルールが実際に本番プロンプトへ入ることの端から端までの検証。
+  // これが無いと「承認 API は status だけ更新して is_active を放置」という
+  // P0(承認したのに一生本番に入らない)を単体テストでは検出できない。
+  it("D8/G-d: approveTuningRule → getActiveRulesForTenant → synthesizeAnswer のプロンプトに含まれる", async () => {
+    process.env["GROQ_API_KEY"] = "test-groq-key";
+
+    // 1) 承認 API: UPDATE 文が is_active=true を設定し、DBがそれを反映した行を返す
+    MOCK_POOL.query.mockResolvedValueOnce({
+      rows: [
+        {
+          id: MOCK_TUNING_RULE.id,
+          tenant_id: MOCK_TUNING_RULE.tenant_id,
+          status: "active",
+          is_active: true,
+          approved_at: new Date().toISOString(),
+          rejected_at: null,
+          updated_at: new Date().toISOString(),
+        },
+      ],
+    });
+    const approved = await approveTuningRule(MOCK_TUNING_RULE.id, MOCK_TUNING_RULE.tenant_id);
+    expect(approved).not.toBeNull();
+    expect(approved!.is_active).toBe(true);
+    const [approveSql] = MOCK_POOL.query.mock.calls[MOCK_POOL.query.mock.calls.length - 1]!;
+    expect(approveSql).toContain("is_active = true");
+
+    // 2) 本番プロンプト注入の唯一の入口。承認直後の状態(is_active=true)を
+    //    DBが返す想定で、実際にそのルールが取得できることを確認する。
+    MOCK_POOL.query.mockResolvedValueOnce({ rows: [MOCK_TUNING_RULE] });
+    const activeRules = await getActiveRulesForTenant(MOCK_TUNING_RULE.tenant_id);
+    expect(activeRules).toEqual([MOCK_TUNING_RULE]);
+
+    // 3) synthesizeAnswer: 承認済みルールが生成プロンプト文字列に実際に含まれる
+    MOCK_POOL.query.mockResolvedValueOnce({
+      rows: [{ system_prompt: null, system_prompt_variants: null }],
+      rowCount: 1,
+    });
+    jest.spyOn(
+      require("../../src/api/admin/tuning/tuningRulesRepository"),
+      "getActiveRulesForTenant"
+    ).mockResolvedValueOnce([MOCK_TUNING_RULE]);
+    (groqClient.callWithUsage as jest.Mock).mockResolvedValueOnce({
+      content: "返品は7日以内です。",
+    });
+
+    await synthesizeAnswer({
+      query: "返品について教えてください",
+      items: [MOCK_HIT],
+      tenantId: MOCK_TUNING_RULE.tenant_id,
+    });
+
+    const groqCallArgs = (groqClient.callWithUsage as jest.Mock).mock.calls[0][0];
+    expect(groqCallArgs.messages[0].content).toContain(MOCK_TUNING_RULE.expected_behavior);
+
+    delete process.env["GROQ_API_KEY"];
   });
 });
 

--- a/tests/phase52/rule-edit-approve.test.ts
+++ b/tests/phase52/rule-edit-approve.test.ts
@@ -96,7 +96,7 @@ describe("1. 承認（edited_textなし）— AI原文をそのまま保存", ()
     expect(mockInsertTuningRuleFromSuggestion).toHaveBeenCalledWith(
       "tenant-a",
       "AI原文ルール",
-      { editedText: undefined, editedBy: "admin@example.com" },
+      { editedText: undefined, editedBy: "admin@example.com", expectedBehavior: "スコアが低い" },
     );
     expect(mockUpdateSuggestedRuleStatus).toHaveBeenCalledWith(1, 0, "approved", undefined);
   });
@@ -117,7 +117,7 @@ describe("2. 承認（edited_textあり）— 編集後テキストを保存", (
     expect(mockInsertTuningRuleFromSuggestion).toHaveBeenCalledWith(
       "tenant-a",
       "AI原文ルール",
-      { editedText: "編集後のルールテキスト", editedBy: "admin@example.com" },
+      { editedText: "編集後のルールテキスト", editedBy: "admin@example.com", expectedBehavior: "スコアが低い" },
     );
   });
 });


### PR DESCRIPTION
## Asana
1217750591794866

## 背景
`docs/LEARNING_LOOP_REQUIREMENTS.md` D8 の実装。本番 `tuning_rules` は7件・全て `status='pending'`・不整合0件のためデータ移行は不要。

2つのP0を修正:
- `approveTuningRule` が `status='active'` のみ更新し `is_active` を放置していたため、Judge由来ルール(`is_active=false`)を承認しても本番プロンプトに一生入らなかった
- `rejectTuningRule` が `is_active` を下げないため、手動作成ルールを却下しても本番プロンプトへの注入が止まらなかった

## 変更
- `evaluationsRepository.ts`: `approveTuningRule`/`rejectTuningRule` に `is_active` の同時更新を追加。`insertTuningRuleFromSuggestion` の `ON CONFLICT DO NOTHING` を `DO UPDATE`（`source='judge'`行のみ対象）に変更し、`trigger_pattern`と`expected_behavior`の重複代入も修正
- `evaluations/routes.ts`: `reason` を `expectedBehavior` として渡す
- `tuningRulesRepository.ts`: `updateRule` が `status` 指定時に `is_active` を導出（statusが優先）。`createRule`/`CreateRuleParams` が `is_active` を受け付け
- `tuning/routes.ts`: `createSchema` に `is_active` を追加（作成モーダルが送る値が黙って無視されていたバグの根本原因）
- `judgeEvaluator.ts`/`evaluationAnalyzer.ts`: `status='pending'` を明示
- `migration_approval_state.sql`（新規、**未適用**）: `COMMENT ON COLUMN` のみ。ADD COLUMN・DEFAULT変更なし

## テスト
- `tuningRulesRepository.test.ts`: 「整合性強制を行わない設計」の固定を反転
- `rule-edit-approve.test.ts`: `expectedBehavior` 検証を追加
- `tests/integration/wiring-check.test.ts`: 承認→`getActiveRulesForTenant`→プロンプト注入を1本で通すテストを追加(G-d)

## 検証
- [x] `pnpm tsc --noEmit` クリーン
- [x] `pnpm oxlint` 新規警告なし
- [x] 関連テスト 710件全パス

## 注意
`migration_approval_state.sql` は人手適用が必要（CLAUDE.md 禁止8: migration自動実行禁止）。本PRはコメント追加のみで既存データへの影響はない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)