### PR TITLE
fix(cv): conversion_attributions への INSERT が本番で100%失敗している不具合を直す

### DIFF
--- a/src/lib/ga4/ga4ConversionFetcher.ts
+++ b/src/lib/ga4/ga4ConversionFetcher.ts
@@ -1,7 +1,14 @@
 import type { Pool } from "pg";
+import { v5 as uuidv5 } from "uuid";
 import { runGa4ConversionReport } from "./ga4Client";
 import { logger } from "../logger";
 import { recordAndDedupe } from "../posthog/eventIdDedupe";
+
+// conversion_attributions.event_id は UUID 型 + UNIQUE 制約。GA4 の日次集計行は
+// 文字列キー(`ga4_${propertyId}_${date}`)しか持たないため、固定の名前空間UUIDから
+// 決定的に UUID を生成する(v5)。同じ入力から常に同じ UUID になることで
+// ON CONFLICT (event_id) の重複排除(recordAndDedupe)が同期の再実行をまたいで機能する。
+const GA4_EVENT_NAMESPACE = "3022cb2e-ebde-46c3-9de3-55221e7c9bed";
 
 export interface Ga4ConversionSummary {
   propertyId: string;
@@ -26,10 +33,12 @@ export async function fetchGa4Conversions(
     for (const row of rows) {
       await recordAndDedupe(
         {
-          eventId: `ga4_${propertyId}_${row.date}`,
+          eventId: uuidv5(`ga4:${tenantId}:${propertyId}:${row.date}`, GA4_EVENT_NAMESPACE),
           tenantId,
           source: "ga4",
           eventType: "macro",
+          // GA4 の集計コンバージョン数には購入/問い合わせ等の内訳が無いため "other"
+          conversionType: "other",
           conversionValue: row.conversions,
         },
         db,

--- a/src/lib/ga4/ga4ConversionFetcher.ts
+++ b/src/lib/ga4/ga4ConversionFetcher.ts
@@ -1,5 +1,5 @@
 import type { Pool } from "pg";
-import { v5 as uuidv5 } from "uuid";
+import { createHash } from "crypto";
 import { runGa4ConversionReport } from "./ga4Client";
 import { logger } from "../logger";
 import { recordAndDedupe } from "../posthog/eventIdDedupe";
@@ -8,7 +8,23 @@ import { recordAndDedupe } from "../posthog/eventIdDedupe";
 // 文字列キー(`ga4_${propertyId}_${date}`)しか持たないため、固定の名前空間UUIDから
 // 決定的に UUID を生成する(v5)。同じ入力から常に同じ UUID になることで
 // ON CONFLICT (event_id) の重複排除(recordAndDedupe)が同期の再実行をまたいで機能する。
+//
+// npm の `uuid` パッケージ(v13)は ESM only で、jest のデフォルト transform では
+// import できない(このファイルを経由する既存の tests/phase-a/ga4SyncRoutesAll.test.ts
+// が SyntaxError で落ちる)。jest.config.cjs の transformIgnorePatterns は
+// 全テストに影響する共有設定のため、本PRの範囲では変更せず、
+// RFC 4122 v5 を Node 標準の crypto だけで実装する(依存追加なし)。
 const GA4_EVENT_NAMESPACE = "3022cb2e-ebde-46c3-9de3-55221e7c9bed";
+
+function uuidV5(name: string, namespace: string): string {
+  const namespaceBytes = Buffer.from(namespace.replace(/-/g, ""), "hex");
+  const hash = createHash("sha1").update(namespaceBytes).update(name, "utf8").digest();
+  const bytes = Buffer.from(hash.subarray(0, 16));
+  bytes[6] = (bytes[6]! & 0x0f) | 0x50; // version 5
+  bytes[8] = (bytes[8]! & 0x3f) | 0x80; // variant (RFC 4122)
+  const hex = bytes.toString("hex");
+  return `${hex.slice(0, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}-${hex.slice(16, 20)}-${hex.slice(20, 32)}`;
+}
 
 export interface Ga4ConversionSummary {
   propertyId: string;
@@ -33,7 +49,7 @@ export async function fetchGa4Conversions(
     for (const row of rows) {
       await recordAndDedupe(
         {
-          eventId: uuidv5(`ga4:${tenantId}:${propertyId}:${row.date}`, GA4_EVENT_NAMESPACE),
+          eventId: uuidV5(`ga4:${tenantId}:${propertyId}:${row.date}`, GA4_EVENT_NAMESPACE),
           tenantId,
           source: "ga4",
           eventType: "macro",

--- a/src/lib/posthog/eventIdDedupe.ts
+++ b/src/lib/posthog/eventIdDedupe.ts
@@ -3,14 +3,22 @@ import { logger } from "../logger";
 
 export type EventSource = "r2c_db" | "ga4" | "posthog";
 export type EventRank = "A" | "B" | "C" | "D";
+// conversion_attributions.conversion_type の CHECK 制約
+// (src/api/conversion/migration_conversion_attributions.sql) と一致させる。
+export type ConversionType = "purchase" | "inquiry" | "reservation" | "signup" | "other";
 
 export interface DedupeInput {
+  // conversion_attributions.event_id は UUID 型 + UNIQUE 制約
+  // (src/api/admin/tenants/migration_phase_a.sql)。UUID 形式でない値を渡すと
+  // INSERT が失敗する。
   eventId: string;
   tenantId: string;
   source: EventSource;
+  // conversion_type は NOT NULL CHECK 制約があり省略できない。
+  // 具体的な種別が分からない呼び出し元は "other" を明示的に渡すこと。
+  conversionType: ConversionType;
   eventType?: string;
   conversionValue?: number;
-  metadataJson?: string;
 }
 
 export interface DedupeResult {
@@ -26,7 +34,7 @@ export async function recordAndDedupe(
   try {
     await db.query(
       `INSERT INTO conversion_attributions
-         (event_id, tenant_id, source, event_type, conversion_value, metadata, deduplicated_at)
+         (event_id, tenant_id, source, event_type, conversion_type, conversion_value, deduplicated_at)
        VALUES ($1, $2, $3, $4, $5, $6, NOW())
        ON CONFLICT (event_id) DO UPDATE
          SET fired_count = conversion_attributions.fired_count + 1,
@@ -36,8 +44,8 @@ export async function recordAndDedupe(
         input.tenantId,
         input.source,
         input.eventType ?? "macro",
+        input.conversionType,
         input.conversionValue ?? null,
-        input.metadataJson ?? null,
       ],
     );
 

--- a/tests/phase-a/eventIdDedupe.test.ts
+++ b/tests/phase-a/eventIdDedupe.test.ts
@@ -1,31 +1,39 @@
 // tests/phase-a/eventIdDedupe.test.ts
 import { recordAndDedupe } from "../../src/lib/posthog/eventIdDedupe";
 
+// conversion_attributions.event_id は UUID 型なので、実スキーマに近い形の
+// テストデータにする(evt-001 のような非UUID文字列は本番のINSERTで必ず失敗する)。
+const UUID_1 = "11111111-1111-1111-1111-111111111111";
+const UUID_2 = "22222222-2222-2222-2222-222222222222";
+const UUID_3 = "33333333-3333-3333-3333-333333333333";
+const UUID_4 = "44444444-4444-4444-4444-444444444444";
+const UUID_ERR = "55555555-5555-5555-5555-555555555555";
+
 function makeMockDb(insertOk: boolean, countValue: number) {
   let callCount = 0;
-  return {
-    query: jest.fn().mockImplementation(() => {
-      const i = callCount++;
-      if (i === 0) {
-        if (!insertOk) return Promise.reject(new Error("db error"));
-        return Promise.resolve({ rows: [], rowCount: 1 });
-      }
-      if (i === 1) {
-        return Promise.resolve({ rows: [{ cnt: String(countValue) }], rowCount: 1 });
-      }
-      // UPDATE rank
+  const query = jest.fn().mockImplementation(() => {
+    const i = callCount++;
+    if (i === 0) {
+      if (!insertOk) return Promise.reject(new Error("db error"));
       return Promise.resolve({ rows: [], rowCount: 1 });
-    }),
-  } as any;
+    }
+    if (i === 1) {
+      return Promise.resolve({ rows: [{ cnt: String(countValue) }], rowCount: 1 });
+    }
+    // UPDATE rank
+    return Promise.resolve({ rows: [], rowCount: 1 });
+  });
+  return { query } as any;
 }
 
 describe("recordAndDedupe", () => {
   it("returns isDuplicate=false and rank=C for first occurrence (1 source)", async () => {
     const db = makeMockDb(true, 1);
     const result = await recordAndDedupe({
-      eventId: "evt-001",
+      eventId: UUID_1,
       tenantId: "t1",
       source: "r2c_db",
+      conversionType: "purchase",
     }, db);
     expect(result.isDuplicate).toBe(false);
     expect(result.rank).toBe("C");
@@ -35,9 +43,10 @@ describe("recordAndDedupe", () => {
   it("returns isDuplicate=true and rank=B for 2 sources", async () => {
     const db = makeMockDb(true, 2);
     const result = await recordAndDedupe({
-      eventId: "evt-002",
+      eventId: UUID_2,
       tenantId: "t1",
       source: "ga4",
+      conversionType: "other",
     }, db);
     expect(result.isDuplicate).toBe(true);
     expect(result.rank).toBe("B");
@@ -47,9 +56,10 @@ describe("recordAndDedupe", () => {
   it("returns isDuplicate=true and rank=A for 3 sources", async () => {
     const db = makeMockDb(true, 3);
     const result = await recordAndDedupe({
-      eventId: "evt-003",
+      eventId: UUID_3,
       tenantId: "t1",
       source: "posthog",
+      conversionType: "inquiry",
     }, db);
     expect(result.isDuplicate).toBe(true);
     expect(result.rank).toBe("A");
@@ -59,9 +69,10 @@ describe("recordAndDedupe", () => {
   it("returns rank=D for negative conversion value (疑義あり)", async () => {
     const db = makeMockDb(true, 1);
     const result = await recordAndDedupe({
-      eventId: "evt-004",
+      eventId: UUID_4,
       tenantId: "t1",
       source: "r2c_db",
+      conversionType: "purchase",
       conversionValue: -100,
     }, db);
     expect(result.rank).toBe("D");
@@ -70,11 +81,37 @@ describe("recordAndDedupe", () => {
   it("returns safe fallback on DB error (non-blocking)", async () => {
     const db = makeMockDb(false, 1);
     const result = await recordAndDedupe({
-      eventId: "evt-err",
+      eventId: UUID_ERR,
       tenantId: "t1",
       source: "r2c_db",
+      conversionType: "purchase",
     }, db);
     expect(result.isDuplicate).toBe(false);
     expect(result.rank).toBe("C");
+  });
+
+  // 本番で INSERT が常に失敗していた不具合の回帰テスト:
+  // (1) 存在しない metadata 列を参照しない (2) conversion_type を必ず渡す
+  // (NOT NULL CHECK 制約があり省略すると INSERT が失敗する)
+  it("INSERT文が実スキーマに存在する列のみを参照する(metadata列を参照しない・conversion_typeを含む)", async () => {
+    const db = makeMockDb(true, 1);
+    await recordAndDedupe({
+      eventId: UUID_1,
+      tenantId: "t1",
+      source: "r2c_db",
+      conversionType: "signup",
+    }, db);
+
+    const [insertSql, insertArgs] = db.query.mock.calls[0];
+    expect(insertSql).toContain("conversion_type");
+    expect(insertSql).not.toContain("metadata");
+    expect(insertArgs).toEqual([
+      UUID_1,
+      "t1",
+      "r2c_db",
+      "macro",
+      "signup",
+      null,
+    ]);
   });
 });


### PR DESCRIPTION
## Asana
1217750643116556

## 背景
`recordAndDedupe` の INSERT が3点同時に壊れており、本番では毎回失敗して catch で握り潰されていた（GA4由来のCVが1件も記録できていない）。

1. 存在しない `metadata` 列にINSERTしていた
2. `conversion_type`（NOT NULL CHECK）を指定していなかった
3. `event_id` は UUID型なのに、唯一の呼び出し元 `ga4ConversionFetcher.ts` が `ga4_${propertyId}_${date}` という文字列を渡していた

## 変更
- `eventIdDedupe.ts`: `metadata` 列参照を削除。`conversionType` を必須フィールド化（CHECK制約と一致する型）
- `ga4ConversionFetcher.ts`: `eventId` を `uuid` v5 で決定的なUUIDに変更（同じ入力から常に同じ値になり、`ON CONFLICT` 重複排除が同期の再実行をまたいで機能する）。`conversionType: 'other'`（GA4集計に内訳が無いため）

## テスト
`tests/phase-a/eventIdDedupe.test.ts`:
- 全ケースをUUID形式のeventId + conversionType必須に更新
- 新規: INSERT文が実スキーマの列のみを参照する（`metadata`列を参照しない・`conversion_type`を含む）ことを固定するケースを追加

## 検証
- [x] `pnpm tsc --noEmit` クリーン
- [x] `pnpm oxlint` 新規警告なし
- [x] 関連テスト 6件全パス

## 制限事項（正直に報告）
このリポジトリには実DB統合テストの仕組み（testcontainers等）が無く、既存テストは全てモックPoolに依拠している。本PRのテストもSQL文字列とバインド引数を検証する形に留め、実Postgresへの往復検証は行っていない。新しい実DB検証基盤の導入は本PRのスコープ外と判断した。

🤖 Generated with [Claude Code](https://claude.com/claude-code)