### PR TITLE
chore(agents): Evaluator の必須チェックに3項目を追加(PR-A縮小版)

### DIFF
--- a/.claude/agents/Evaluator.md
+++ b/.claude/agents/Evaluator.md
@@ -20,6 +20,9 @@ Generator の差分（`git diff origin/main...HEAD`）をレビューし、**GO 
    - ragExcerpt の 200 字 truncate 漏れ / console.log(ragContent) 混入
    - 新規ルートに auth + role + tenant の **3層ガード**が揃っているか（PR #262 教訓: supabaseAuthMiddleware の import だけでは不十分）
    - 共有テーブルクエリの `OR tenant_id='global'` 規約一貫性
+   - **copilot ツールの3点セット**: 新規/変更ツールが `toolDefinitions.ts` の定義・`actionExecutor.ts` の `case`・`copilot-preview/index.tsx` の `REAL_TOOL_LABEL` の3箇所すべてに揃っているか（`confirmPolicy.test.ts` は未分類しか検出しないため、ラベル漏れは機械チェックに乗らない。学習ループ監査 2026-08-23 で判明）
+   - **状態遷移はテストのモックではなく実装コードで確認する**: 「承認したら本番に反映される」等の状態遷移を扱う変更は、テストのモック戻り値ではなく実際のUPDATE文・呼び出し先の絞り込み条件（例: `getActiveRulesForTenant` の `WHERE is_active=true`）を読んで、承認処理が同じ列を更新しているか確認する（`tuning_rules.status`/`is_active` の二重管理でP0が発生した実例。学習ループ監査 2026-08-23）
+   - **集計クエリのトラフィックフィルタ**: `chat_sessions`/`conversation_evaluations` を読む新規/変更クエリが `src/api/admin/analytics/summaryQueries.ts` の `userSourceClause`/`userSourceExists` を経由しているか（独自の `metadata->>'source'` 判定文字列を書いていないか）
 3. **機械チェック**:
    ```bash
    pnpm lint --max-warnings 80   # oxlint（ESLintではない）


### PR DESCRIPTION
## Asana
1217750660034838（.claude/hooks・settings.json部分は対象外。理由は下記）

## 背景・スコープ変更の理由
当初 PR-A は `.claude/hooks/*.sh` + `settings.json` の新設と、`check-gates`/`verify-wiring` スキル・`consistency-verifier`/`measurement-auditor` エージェントの新設を予定していた。実装着手時に以下が判明したためスコープを縮小した。

1. **`.claude/settings.json` は `permissions.deny` で `Edit(.claude/settings.json)` / `Edit(.claude/hooks/*)` を明示的に禁止している**（このリポジトリ自身の安全装置）。これを回避して編集することはしない。
2. **`.claude/agents/gate-runner.md` が Gate 1〜3 一括実行を既に担っており**、`check-gates` スキルは完全な重複になる。
3. **`.claude/agents/Evaluator.md` が「セキュリティ・anti-slop・lint・dead code の機械チェック+静的レビュー」を既に担っており**、`verify-wiring`/`consistency-verifier`/`measurement-auditor` で意図した内容は、新規エージェントを増やすのではなく Evaluator の既存チェックリストを拡張するのが既存の設計（Planner→Generator→Evaluator→Tester パイプライン）に合致する。

## 変更
`Evaluator.md` の必須チェック項目2（セキュリティ/anti-slop）に3項目追加（いずれも今回の学習ループ監査で実際に踏んだP0が根拠）:
- copilot ツールの3点セット(`toolDefinitions.ts`/`actionExecutor.ts`の`case`/`copilot-preview/index.tsx`の`REAL_TOOL_LABEL`)がすべて揃っているか
- 状態遷移を扱う変更はテストのモック戻り値ではなく実際のUPDATE文・絞り込み条件を読んで確認する（`tuning_rules`の`status`/`is_active`二重管理でP0が発生した実例、本PR群のPR-8参照）
- 集計クエリが`summaryQueries.ts`の`userSourceClause`/`userSourceExists`を経由しているか

## レビュー観点
- 追加した3項目が既存のチェックリストの形式・粒度と合っているか
- `.claude/hooks`/`settings.json` 部分をスコープ外にした判断への異論の有無

🤖 Generated with [Claude Code](https://claude.com/claude-code)