### PR TITLE
fix(measure): 集計クエリ14箇所にトラフィックフィルタを適用しE2E汚染を止める

### DIFF
--- a/admin-ui/src/pages/admin/chat-history/index.tsx
+++ b/admin-ui/src/pages/admin/chat-history/index.tsx
@@ -19,6 +19,7 @@ interface Session {
   message_count: number;
   first_message_preview: string;
   overallScore?: number;
+  source: string | null;
 }
 
 type SortBySession = "last_message_at" | "message_count" | "score";
@@ -377,6 +378,22 @@ export default function ChatHistoryPage() {
                     </span>
                   ) : (
                     <span style={{ fontSize: 12, color: "#4b5563" }}>—</span>
+                  )}
+                  {session.source && session.source !== "user" && (
+                    <span
+                      title="E2E/内部テストなど実ユーザー以外の会話"
+                      style={{
+                        padding: "3px 10px",
+                        borderRadius: 999,
+                        background: "rgba(148,163,184,0.15)",
+                        border: "1px solid rgba(148,163,184,0.3)",
+                        color: "#94a3b8",
+                        fontSize: 12,
+                        fontWeight: 600,
+                      }}
+                    >
+                      {session.source}
+                    </span>
                   )}
                 </div>
 

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -37,6 +37,7 @@ import { getSessions, getActiveEscalations, getMessages, saveMessage, resolveEsc
 import { deleteSession } from '../chat-history/deleteSessionRepository';
 import { getEvaluationsBySession } from '../evaluations/evaluationsRepository';
 import { computeKpis } from '../monitoring/routes';
+import { userSourceClause, userSourceExists } from '../analytics/summaryQueries';
 import { checkSaiMonthlyCostCeiling } from '../options/routes';
 import { submitSaiTask, getSaiTask } from '../../../lib/sai/saiClient';
 import { recordSaiTask, resolveSaiTaskTenant } from '../../../lib/sai/saiTaskRegistry';
@@ -2057,19 +2058,22 @@ export async function executeToolCall(
         const [sessionsRes, prevSessionsRes, evalRes, cvRes, faqRes, tuningRes, gapsRes] = await Promise.allSettled([
           db.query(
             `SELECT COUNT(*)::int AS n FROM chat_sessions
-             WHERE tenant_id = $1 AND started_at >= $2`,
+             WHERE tenant_id = $1 AND started_at >= $2
+               ${userSourceClause("chat_sessions")}`,
             [tenantId, weekStart],
           ),
           db.query(
             `SELECT COUNT(*)::int AS n FROM chat_sessions
              WHERE tenant_id = $1
                AND started_at >= $2
-               AND started_at < $3`,
+               AND started_at < $3
+               ${userSourceClause("chat_sessions")}`,
             [tenantId, prevWeekStart, prevWeekEnd],
           ),
           db.query(
             `SELECT AVG(score) AS avg FROM conversation_evaluations
-             WHERE tenant_id = $1 AND evaluated_at >= $2 AND score > 0`,
+             WHERE tenant_id = $1 AND evaluated_at >= $2 AND score > 0
+               ${userSourceExists("conversation_evaluations.session_id", "conversation_evaluations.tenant_id")}`,
             [tenantId, weekStart],
           ),
           db.query(

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -180,6 +180,10 @@ const mockFetchConversionSummary = jest.fn();
 jest.mock('../analytics/summaryQueries', () => ({
   fetchAnalyticsSummary: (...args: any[]) => mockFetchAnalyticsSummary(...args),
   fetchConversionSummary: (...args: any[]) => mockFetchConversionSummary(...args),
+  // PR-3: get_weekly_briefing の集計クエリにsource='user'絞り込みを追加した際に実配線した
+  userSourceClause: (alias: string) => `AND ${alias}.metadata->>'source' = 'user'`,
+  userSourceExists: (sessionIdExpr: string, tenantIdExpr: string, chatSessionsColumn = 'session_id') =>
+    `AND EXISTS (SELECT 1 FROM chat_sessions cs WHERE cs.${chatSessionsColumn} = ${sessionIdExpr} AND cs.tenant_id = ${tenantIdExpr} AND cs.metadata->>'source' = 'user')`,
 }));
 
 // logger モック
@@ -2610,6 +2614,42 @@ describe('POST /v1/admin/agent/chat', () => {
       // 修正前の条件式が紛れ込んでいないことも確認する(巻き戻しの検出)
       expect(tuningSql).not.toContain('approved_at IS NULL');
       expect(tuningSql).not.toContain('rejected_at IS NULL');
+    });
+
+    it('PR-3: 会話数(今週/前週)・品質スコアのクエリにsource="user"絞り込みが入っている', async () => {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            choices: [{
+              message: {
+                content: null,
+                tool_calls: [{
+                  id: 'call-wb-source-filter',
+                  type: 'function',
+                  function: { name: 'get_weekly_briefing', arguments: '{}' },
+                }],
+              },
+            }],
+          }),
+          text: async () => '',
+        })
+        .mockResolvedValueOnce(makeGroqResponse('今週の状況です。'));
+
+      mockQuery.mockResolvedValue({ rows: [{ n: 0 }] });
+      mockGetGaps.mockResolvedValueOnce({ gaps: [], total: 0 });
+
+      await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '今週の状況を教えて', sessionId: 'sess-source-filter' });
+
+      // Promise.allSettled の0,1,2番目(sessions/prevSessions/eval)
+      const [sessionsSql] = mockQuery.mock.calls[0]!;
+      const [prevSessionsSql] = mockQuery.mock.calls[1]!;
+      const [evalSql] = mockQuery.mock.calls[2]!;
+      expect(sessionsSql).toContain("chat_sessions.metadata->>'source' = 'user'");
+      expect(prevSessionsSql).toContain("chat_sessions.metadata->>'source' = 'user'");
+      expect(evalSql).toContain("cs.metadata->>'source' = 'user'");
     });
   });
 

--- a/src/api/admin/analytics/routes.ts
+++ b/src/api/admin/analytics/routes.ts
@@ -678,6 +678,7 @@ export function registerAnalyticsRoutes(app: Express): void {
                MAX(created_at) AS last_cv_at
              FROM conversion_attributions
              WHERE created_at > NOW() - INTERVAL '30 days'
+               ${userSourceExists("conversion_attributions.session_id", "conversion_attributions.tenant_id", "id")}
              GROUP BY tenant_id
            ) ca_stats ON ca_stats.tenant_id = t.id
            LEFT JOIN (
@@ -839,6 +840,7 @@ export function registerAnalyticsRoutes(app: Express): void {
               AND cm.role = 'assistant'
               AND cm.created_at >= NOW() - $2::interval
               ${sourceFilterClause}
+              ${userSourceClause("cs")}
           ),
           previous_period AS (
             SELECT
@@ -855,6 +857,7 @@ export function registerAnalyticsRoutes(app: Express): void {
               AND cm.created_at >= NOW() - ($2::interval * 2)
               AND cm.created_at <  NOW() - $2::interval
               ${sourceFilterClause}
+              ${userSourceClause("cs")}
           ),
           current_agg AS (
             SELECT

--- a/src/api/admin/analytics/summaryQueries.ts
+++ b/src/api/admin/analytics/summaryQueries.ts
@@ -188,7 +188,8 @@ export async function fetchAnalyticsSummary({
     `SELECT COUNT(*) AS total_knowledge_gaps
      FROM knowledge_gaps
      WHERE created_at >= NOW() - $1::interval
-     ${kgTenantClause}`,
+     ${kgTenantClause}
+     ${userSourceExists("knowledge_gaps.session_id", "knowledge_gaps.tenant_id", "id")}`,
     kgParams,
   );
 

--- a/src/api/admin/analytics/trafficSourceFilter.test.ts
+++ b/src/api/admin/analytics/trafficSourceFilter.test.ts
@@ -111,3 +111,30 @@ describe("GET /v1/admin/analytics/conversions — source='user'フィルタ", ()
     }
   });
 });
+
+describe("GET /v1/admin/analytics/cv-status — source='user'フィルタ (PR-3)", () => {
+  it("conversion_attributions のCVカウントにsource='user'絞り込みが入っている", async () => {
+    const res = await request(makeApp()).get("/v1/admin/analytics/cv-status");
+    expect(res.status).toBe(200);
+
+    const allSql = mockQuery.mock.calls.map((c) => c[0] as string);
+    const caQuery = allSql.find((sql) => /FROM conversion_attributions/.test(sql));
+    expect(caQuery).toBeDefined();
+    expect(caQuery).toContain(USER_SOURCE_SQL);
+  });
+});
+
+describe("GET /v1/admin/analytics/knowledge-attribution — source='user'フィルタ (PR-3)", () => {
+  it("current_period・previous_period 両方のCTEにsource='user'絞り込みが入っている", async () => {
+    const res = await request(makeApp()).get(
+      "/v1/admin/analytics/knowledge-attribution?tenant_id=carnation",
+    );
+    expect(res.status).toBe(200);
+
+    const allSql = mockQuery.mock.calls.map((c) => c[0] as string);
+    const kaQuery = allSql.find((sql) => /current_period AS/.test(sql));
+    expect(kaQuery).toBeDefined();
+    // current_period・previous_period 両方のCTEに絞り込みが入っている(2箇所)ことを確認
+    expect(kaQuery!.split(USER_SOURCE_SQL).length - 1).toBe(2);
+  });
+});

--- a/src/api/admin/chat-history/chatHistoryRepository.sessions.test.ts
+++ b/src/api/admin/chat-history/chatHistoryRepository.sessions.test.ts
@@ -1,0 +1,52 @@
+// src/api/admin/chat-history/chatHistoryRepository.sessions.test.ts
+// GID 1216970103691946 (PR-3): getSessions が管理画面でe2e/実ユーザーを見分けられるよう
+// SELECT に metadata.source を含めて返すことの検証。
+
+const mockQuery = jest.fn();
+jest.mock("../../../lib/db", () => ({
+  getPool: () => ({ query: (...args: unknown[]) => mockQuery(...args) }),
+}));
+
+import { getSessions } from "./chatHistoryRepository";
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+describe("getSessions: source列", () => {
+  it("SELECT文にs.metadata->>'source' AS sourceを含む", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ count: "0" }] }) // COUNT
+      .mockResolvedValueOnce({ rows: [] }); // list
+
+    await getSessions({ tenantId: "carnation" });
+
+    const [listSql] = mockQuery.mock.calls[1]!;
+    expect(listSql).toContain("s.metadata->>'source' AS source");
+  });
+
+  it("結果行のsourceフィールドをそのまま返す(呼び出し元でe2e/user等を判定できる)", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ count: "1" }] })
+      .mockResolvedValueOnce({
+        rows: [
+          {
+            id: "uuid-1",
+            tenant_id: "carnation",
+            session_id: "s1",
+            started_at: "2026-08-01T00:00:00.000Z",
+            last_message_at: "2026-08-01T00:01:00.000Z",
+            message_count: 2,
+            outcome: null,
+            outcome_recorded_at: null,
+            source: "e2e",
+            first_message_preview: "こんにちは",
+          },
+        ],
+      });
+
+    const result = await getSessions({ tenantId: "carnation" });
+
+    expect(result.sessions[0]!.source).toBe("e2e");
+  });
+});

--- a/src/api/admin/chat-history/chatHistoryRepository.ts
+++ b/src/api/admin/chat-history/chatHistoryRepository.ts
@@ -113,6 +113,8 @@ export interface SessionSummary {
   // Phase52f: コンバージョン記録
   outcome: string | null;
   outcome_recorded_at: string | null;
+  // GID 1216970103691946: e2e/chat-test/実ユーザーを画面上で見分けるため
+  source: string | null;
 }
 
 const VALID_SORT_BY = ['last_message_at', 'message_count', 'score'] as const;
@@ -248,6 +250,7 @@ export async function getSessions(
        s.message_count,
        s.outcome,
        s.outcome_recorded_at,
+       s.metadata->>'source' AS source,
        COALESCE(LEFT(m.content, 50), '') AS first_message_preview
      FROM chat_sessions s
      LEFT JOIN LATERAL (

--- a/src/api/admin/monitoring/computeKpis.test.ts
+++ b/src/api/admin/monitoring/computeKpis.test.ts
@@ -1,0 +1,38 @@
+// src/api/admin/monitoring/computeKpis.test.ts
+// PR-3 (GID 1216970103691946): KPI監視ダッシュボードの3クエリ全てに
+// source='user'絞り込みが入っていることの検証。
+
+import { computeKpis } from "./routes";
+
+function makeDb(responses: Array<{ rows: any[] }>) {
+  let i = 0;
+  const query = jest.fn().mockImplementation(() => Promise.resolve(responses[i++] ?? { rows: [] }));
+  return { query };
+}
+
+describe("computeKpis — source='user'フィルタ", () => {
+  it("総セッション数・完了セッション数・フォールバック検出の3クエリ全てにsource='user'絞り込みが入っている", async () => {
+    const db = makeDb([
+      { rows: [{ total: "10" }] },
+      { rows: [{ completed: "8" }] },
+      { rows: [{ fallback_count: "1" }] },
+    ]);
+
+    await computeKpis(db, null);
+
+    expect(db.query).toHaveBeenCalledTimes(3);
+    for (const call of db.query.mock.calls) {
+      const [sql] = call as [string, unknown[]];
+      expect(sql).toContain("metadata->>'source' = 'user'");
+    }
+  });
+
+  it("total=0のときは早期returnし、完了/フォールバッククエリは発行しない", async () => {
+    const db = makeDb([{ rows: [{ total: "0" }] }]);
+
+    const result = await computeKpis(db, null);
+
+    expect(result).toEqual({ completionRate: 100, fallbackRate: 0, totalSessions: 0 });
+    expect(db.query).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/api/admin/monitoring/routes.ts
+++ b/src/api/admin/monitoring/routes.ts
@@ -4,6 +4,7 @@
 import type { Express, Request, Response } from "express";
 import { supabaseAuthMiddleware } from "../../../admin/http/supabaseAuthMiddleware";
 import { logger } from "../../../lib/logger";
+import { userSourceClause } from "../analytics/summaryQueries";
 
 // ---------------------------------------------------------------------------
 // ALLOWED_ROLES whitelist (Phase69-1.5 PR-C4 v2)
@@ -42,7 +43,8 @@ export async function computeKpis(
   const totalRes = await db.query(
     `SELECT COUNT(*) AS total
      FROM chat_sessions
-     WHERE started_at >= NOW() - $1::INTERVAL ${tenantClause}`,
+     WHERE started_at >= NOW() - $1::INTERVAL ${tenantClause}
+       ${userSourceClause("chat_sessions")}`,
     params
   );
   const total = parseInt(totalRes.rows[0]?.total ?? "0", 10);
@@ -57,7 +59,8 @@ export async function computeKpis(
      FROM chat_sessions
      WHERE started_at >= NOW() - $1::INTERVAL
        AND message_count >= 2
-       ${tenantClause}`,
+       ${tenantClause}
+       ${userSourceClause("chat_sessions")}`,
     params
   );
   const completed = parseInt(completedRes.rows[0]?.completed ?? "0", 10);
@@ -81,7 +84,8 @@ export async function computeKpis(
      WHERE cm.role = 'assistant'
        AND cm.created_at >= NOW() - $1::INTERVAL
        AND (${fallbackCondition})
-       ${tenantFilter ? `AND cm.tenant_id = $2` : ""}`,
+       ${tenantFilter ? `AND cm.tenant_id = $2` : ""}
+       ${userSourceClause("cs")}`,
     fallbackParams
   );
   const fallbackCount = parseInt(fallbackRes.rows[0]?.fallback_count ?? "0", 10);

--- a/src/api/admin/tenants/analyticsSummaryRoutes.test.ts
+++ b/src/api/admin/tenants/analyticsSummaryRoutes.test.ts
@@ -76,6 +76,18 @@ describe("GET /v1/admin/tenants/:id/analytics-summary", () => {
     }
   });
 
+  it("PR-3 (GID 1216970103691946): chat_sessions のクエリにsource='user'絞り込みが入っている", async () => {
+    await request(app)
+      .get("/v1/admin/tenants/carnation/analytics-summary?period=last_30d")
+      .set("Authorization", `Bearer ${SUPER_ADMIN_TOKEN}`);
+
+    const sqls = chatSessionSql();
+    expect(sqls.length).toBeGreaterThan(0);
+    for (const sql of sqls) {
+      expect(sql).toContain("chat_sessions.metadata->>'source' = 'user'");
+    }
+  });
+
   it("全クエリが tenant_id で絞られる（テナント越境しない）", async () => {
     await request(app)
       .get("/v1/admin/tenants/carnation/analytics-summary?period=last_30d")

--- a/src/api/admin/tenants/analyticsSummaryRoutes.ts
+++ b/src/api/admin/tenants/analyticsSummaryRoutes.ts
@@ -4,6 +4,7 @@ import type { AuthedReq } from "../../middleware/roleAuth";
 import { getMonthlyLLMUsageFromPostHog } from "../../../lib/billing/posthogUsageTracker";
 import { logger } from "../../../lib/logger";
 import { supabaseAuthMiddleware } from "../../../admin/http/supabaseAuthMiddleware";
+import { userSourceClause } from "../analytics/summaryQueries";
 
 const PERIOD_DAYS: Record<string, number> = {
   last_7d: 7,
@@ -58,7 +59,8 @@ export function registerAnalyticsSummaryRoutes(app: Express, db: Pool): void {
                -- chat_sessions に created_at は存在しない。セッション開始時刻は started_at
                -- (chat-history/migration.sql)。created_at を参照していたため
                -- GET /v1/admin/tenants/:id/analytics-summary が常時500だった。
-               AND started_at >= NOW() - ($3::text)::interval`,
+               AND started_at >= NOW() - ($3::text)::interval
+               ${userSourceClause("chat_sessions")}`,
             [tenantId, days, interval],
           ),
           db.query<{ source: string; cnt: string }>(

--- a/src/api/admin/variants/variantsRepository.test.ts
+++ b/src/api/admin/variants/variantsRepository.test.ts
@@ -1,0 +1,92 @@
+// src/api/admin/variants/variantsRepository.test.ts
+// PR-3: getVariantStats のsource='user'絞り込みと、母数不足(会話0件)時に
+// avg_score を 0 ではなく null で返すこと(CLAUDE.md 禁止34)の検証。
+
+const mockQuery = jest.fn();
+jest.mock("../../../lib/db", () => ({
+  getPool: () => ({ query: (...args: unknown[]) => mockQuery(...args) }),
+}));
+
+import { getVariantStats } from "./variantsRepository";
+
+beforeEach(() => {
+  mockQuery.mockReset();
+});
+
+describe("getVariantStats", () => {
+  it("variantが1件も無ければDBに問い合わせず空配列を返す", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ system_prompt_variants: [] }] });
+
+    const result = await getVariantStats("tenant-a", 30);
+
+    expect(result).toEqual([]);
+    expect(mockQuery).toHaveBeenCalledTimes(1); // listVariantsの1回のみ
+  });
+
+  it("集計クエリにsource='user'絞り込みが入っている", async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ system_prompt_variants: [{ id: "v1", name: "標準", prompt: "p", weight: 100 }] }],
+      })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await getVariantStats("tenant-a", 30);
+
+    const [statsSql] = mockQuery.mock.calls[1]!;
+    expect(statsSql).toContain("cs.metadata->>'source' = 'user'");
+  });
+
+  it("会話が0件(統計行なし)のvariantはavg_score:null・conversation_count:0を返す(0ではなくnull)", async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ system_prompt_variants: [{ id: "v1", name: "標準", prompt: "p", weight: 100 }] }],
+      })
+      .mockResolvedValueOnce({ rows: [] }); // 統計クエリの結果が空(GROUP BYで行が無い)
+
+    const result = await getVariantStats("tenant-a", 30);
+
+    expect(result).toEqual([
+      { id: "v1", name: "標準", weight: 100, avg_score: null, conversation_count: 0 },
+    ]);
+  });
+
+  it("評価が1件もついていないvariant(AVG(score)がSQL上でNULL)もavg_score:nullを返す", async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ system_prompt_variants: [{ id: "v1", name: "標準", prompt: "p", weight: 100 }] }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ prompt_variant_id: "v1", avg_score: null, conversation_count: "3" }],
+      });
+
+    const result = await getVariantStats("tenant-a", 30);
+
+    expect(result[0]).toEqual({
+      id: "v1",
+      name: "標準",
+      weight: 100,
+      avg_score: null,
+      conversation_count: 3,
+    });
+  });
+
+  it("評価が付いているvariantは実数のavg_scoreを返す", async () => {
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{ system_prompt_variants: [{ id: "v1", name: "標準", prompt: "p", weight: 100 }] }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ prompt_variant_id: "v1", avg_score: "82.5", conversation_count: "10" }],
+      });
+
+    const result = await getVariantStats("tenant-a", 30);
+
+    expect(result[0]).toEqual({
+      id: "v1",
+      name: "標準",
+      weight: 100,
+      avg_score: 82.5,
+      conversation_count: 10,
+    });
+  });
+});

--- a/src/api/admin/variants/variantsRepository.ts
+++ b/src/api/admin/variants/variantsRepository.ts
@@ -3,6 +3,7 @@
 // tenants.system_prompt_variants は JSONB カラム: [{ id, name, prompt, weight }]
 
 import { getPool } from "../../../lib/db";
+import { userSourceClause } from "../analytics/summaryQueries";
 
 // ---------------------------------------------------------------------------
 // 型定義
@@ -19,7 +20,8 @@ export interface VariantStatRow {
   id: string;
   name: string;
   weight: number;
-  avg_score: number;
+  // CLAUDE.md 禁止34: 母数不足(会話0件)を数値0と区別するためnullを許容する
+  avg_score: number | null;
   conversation_count: number;
 }
 
@@ -76,12 +78,12 @@ export async function getVariantStats(
   // chat_sessions + conversation_evaluations で variant別集計
   const result = await pool.query<{
     prompt_variant_id: string;
-    avg_score: string;
+    avg_score: string | null;
     conversation_count: string;
   }>(
     `SELECT
        cs.prompt_variant_id,
-       COALESCE(AVG(e.score), 0) AS avg_score,
+       AVG(e.score) AS avg_score,
        COUNT(DISTINCT cs.id) AS conversation_count
      FROM chat_sessions cs
      LEFT JOIN conversation_evaluations e ON e.session_id = cs.session_id
@@ -89,14 +91,17 @@ export async function getVariantStats(
        -- chat_sessions の時刻列は started_at(created_at は存在しない)
        AND cs.started_at >= NOW() - INTERVAL '${days} days'
        AND cs.prompt_variant_id IS NOT NULL
+       ${userSourceClause("cs")}
      GROUP BY cs.prompt_variant_id`,
     [tenantId],
   );
 
-  const statsMap: Record<string, { avg_score: number; conversation_count: number }> = {};
+  // CLAUDE.md 禁止34: 母数不足(評価が1件も無い)ときの avg_score は 0 ではなく null
+  // (AVGはグループ内が全てNULLなら自動的にNULLを返すため、COALESCEで0に丸めない)
+  const statsMap: Record<string, { avg_score: number | null; conversation_count: number }> = {};
   for (const row of result.rows) {
     statsMap[row.prompt_variant_id] = {
-      avg_score: parseFloat(row.avg_score),
+      avg_score: row.avg_score != null ? parseFloat(row.avg_score) : null,
       conversation_count: parseInt(row.conversation_count, 10),
     };
   }
@@ -105,7 +110,7 @@ export async function getVariantStats(
     id: v.id,
     name: v.name,
     weight: v.weight,
-    avg_score: statsMap[v.id]?.avg_score ?? 0,
+    avg_score: statsMap[v.id]?.avg_score ?? null,
     conversation_count: statsMap[v.id]?.conversation_count ?? 0,
   }));
 }

--- a/src/api/conversion/abResultsOutcomeSync.test.ts
+++ b/src/api/conversion/abResultsOutcomeSync.test.ts
@@ -1,5 +1,8 @@
 // src/api/conversion/abResultsOutcomeSync.test.ts
 // GID 1216978855735482: アバター効果A/Bテスト基盤 — 成果の遅延反映
+// PR-3訂正(GID 1216970103691946): metadata列の存在を動的確認する
+// information_schemaクエリは誤った前提(列が無いかもしれない)に基づいていたため撤去。
+// sourceフィルタは常時付与される(2クエリのみ発行)。
 
 import { reconcileAbResultOutcomes } from './abResultsOutcomeSync';
 
@@ -18,62 +21,36 @@ function makePool(queryResponses: Array<{ rows: any[]; rowCount?: number } | Err
 }
 
 describe('reconcileAbResultOutcomes', () => {
-  it('metadata列が存在しない場合はsourceフィルタ無しでUPDATEを2本発行する', async () => {
+  it('UPDATEを2本発行し、両方にsourceフィルタ(source=user OR NULL)が常に付与される', async () => {
     const pool = makePool([
-      { rows: [{ exists: false }] }, // information_schema
       { rows: [], rowCount: 3 }, // reached_two_plus_exchanges UPDATE
       { rows: [], rowCount: 1 }, // converted UPDATE
     ]);
     await reconcileAbResultOutcomes(pool as any, 42);
 
-    expect(pool.query).toHaveBeenCalledTimes(3);
-    const [reachedSql] = pool.calls[1] as [string, unknown[]];
-    const [convertedSql] = pool.calls[2] as [string, unknown[]];
-    expect(reachedSql).not.toContain("metadata->>'source'");
-    expect(convertedSql).not.toContain("metadata->>'source'");
+    expect(pool.query).toHaveBeenCalledTimes(2);
+    const [reachedSql] = pool.calls[0] as [string, unknown[]];
+    const [convertedSql] = pool.calls[1] as [string, unknown[]];
+    expect(reachedSql).toContain("cs.metadata->>'source' = 'user'");
+    expect(reachedSql).toContain("cs.metadata->>'source' IS NULL");
+    expect(convertedSql).toContain("cs.metadata->>'source' = 'user'");
+    expect(convertedSql).toContain("cs.metadata->>'source' IS NULL");
     expect(reachedSql).toContain('message_count >=');
     expect(convertedSql).toContain('outcome <> ALL(');
   });
 
-  it('metadata列が存在する場合はsourceフィルタ(source=user OR NULL)を付与する', async () => {
-    const pool = makePool([
-      { rows: [{ exists: true }] },
-      { rows: [], rowCount: 0 },
-      { rows: [], rowCount: 0 },
-    ]);
-    await reconcileAbResultOutcomes(pool as any, 42);
-
-    const [reachedSql] = pool.calls[1] as [string, unknown[]];
-    const [convertedSql] = pool.calls[2] as [string, unknown[]];
-    expect(reachedSql).toContain("cs.metadata->>'source' = 'user'");
-    expect(reachedSql).toContain("cs.metadata->>'source' IS NULL");
-    expect(convertedSql).toContain("cs.metadata->>'source' = 'user'");
-  });
-
-  it('information_schemaクエリが例外を投げても列なし扱い(false)にフォールバックし、UPDATEは実行される', async () => {
-    const pool = makePool([
-      new Error('information_schema unavailable'),
-      { rows: [], rowCount: 0 },
-      { rows: [], rowCount: 0 },
-    ]);
-    await expect(reconcileAbResultOutcomes(pool as any, 42)).resolves.toBeUndefined();
-    expect(pool.query).toHaveBeenCalledTimes(3);
-  });
-
   it('reached_two_plus_exchangesのUPDATEはexperimentIdと閾値(4)をパラメータに渡す', async () => {
     const pool = makePool([
-      { rows: [{ exists: false }] },
       { rows: [], rowCount: 0 },
       { rows: [], rowCount: 0 },
     ]);
     await reconcileAbResultOutcomes(pool as any, 42);
-    const [, params] = pool.calls[1] as [string, unknown[]];
+    const [, params] = pool.calls[0] as [string, unknown[]];
     expect(params).toEqual([42, 4]);
   });
 
   it('1本目のUPDATEが失敗すると例外がそのまま伝播する（呼び出し元でtry/catchする設計）', async () => {
     const pool = makePool([
-      { rows: [{ exists: false }] },
       new Error('update failed'),
     ]);
     await expect(reconcileAbResultOutcomes(pool as any, 42)).rejects.toThrow('update failed');
@@ -85,13 +62,12 @@ describe('reconcileAbResultOutcomes', () => {
     // PostgresはUUID=TEXTの暗黙キャストを行わずエラーになる。r.session_id::text で
     // 明示キャストしていることを確認する（実DBでの型エラー再発防止の回帰テスト）。
     const pool = makePool([
-      { rows: [{ exists: false }] },
       { rows: [], rowCount: 0 },
       { rows: [], rowCount: 0 },
     ]);
     await reconcileAbResultOutcomes(pool as any, 42);
-    const [reachedSql] = pool.calls[1] as [string, unknown[]];
-    const [convertedSql] = pool.calls[2] as [string, unknown[]];
+    const [reachedSql] = pool.calls[0] as [string, unknown[]];
+    const [convertedSql] = pool.calls[1] as [string, unknown[]];
     expect(reachedSql).toContain('r.session_id::text = cs.session_id');
     expect(convertedSql).toContain('r.session_id::text = cs.session_id');
   });

--- a/src/api/conversion/abResultsOutcomeSync.ts
+++ b/src/api/conversion/abResultsOutcomeSync.ts
@@ -12,15 +12,18 @@
 //     conversion_typesはテナントごとにカスタム可能なため厳密ではないが、CV率は
 //     判定に使わない副次指標のため許容する（タスク仕様）。
 //
-// GID 1216995497... (lane-instrumentのトラフィック分離と並行): chat_sessions.metadata.source
-// が導入され次第 source='user' のみを対象にする契約。カラムがまだ存在しない間は
-// フィルタを適用しない（未設定を許容）。カラムの有無は毎回 information_schema で
-// 確認する（結果APIは高頻度エンドポイントではないため許容できるオーバーヘッド）。
+// GID 1216970103691946: chat_sessions.metadata.source='user' のみを対象にする。
+// metadata 列は chat_sessions の初期migrationから存在するため列の有無を動的確認
+// する必要はない（PR-3訂正: 従来の information_schema 動的チェックは
+// 「列がまだ無いかもしれない」という誤った前提に基づいていたため撤去した）。
+// source が未設定(過去データ)のセッションは許容する(OR IS NULL)。
 //
 // GID 1216978855735482 かつ chat_sessions の作成経路・metadata記録そのものには
 // 一切触れていない（読み取り専用の突合のみ）。
 
 import type { Pool } from 'pg';
+
+const USER_SOURCE_FILTER = `AND (cs.metadata->>'source' = 'user' OR cs.metadata->>'source' IS NULL)`;
 
 const TWO_PLUS_EXCHANGES_MESSAGE_COUNT = 4;
 
@@ -28,26 +31,6 @@ const TWO_PLUS_EXCHANGES_MESSAGE_COUNT = 4;
 // のデフォルト値と一致させる）。カスタムconversion_typesのテナントでは不正確になりうるが、
 // CV率は副次指標(記録のみ・判定に使わない)のため許容する。
 const NON_CONVERTING_OUTCOMES = ['離脱', '不明'];
-
-/**
- * chat_sessions に metadata カラムが存在するか確認する。
- * TODO(GID 1216978855735482 / lane-instrument連携): metadata.source 列が入り次第、
- * 下記の存在チェックを廃止し常に `AND (cs.metadata->>'source' = 'user' OR cs.metadata->>'source' IS NULL)`
- * を適用してよい。現状は移行期間中のため動的に判定する。
- */
-async function chatSessionsHasMetadataColumn(pool: Pick<Pool, 'query'>): Promise<boolean> {
-  try {
-    const result = await pool.query<{ exists: boolean }>(
-      `SELECT EXISTS (
-         SELECT 1 FROM information_schema.columns
-         WHERE table_name = 'chat_sessions' AND column_name = 'metadata'
-       ) AS exists`,
-    );
-    return result.rows[0]?.exists === true;
-  } catch {
-    return false;
-  }
-}
 
 /**
  * 指定experimentの未解決(reached_two_plus_exchanges IS NULL)露出行をchat_sessionsと突合し、
@@ -60,11 +43,6 @@ export async function reconcileAbResultOutcomes(
   pool: Pick<Pool, 'query'>,
   experimentId: number,
 ): Promise<void> {
-  const hasMetadata = await chatSessionsHasMetadataColumn(pool);
-  const sourceFilter = hasMetadata
-    ? `AND (cs.metadata->>'source' = 'user' OR cs.metadata->>'source' IS NULL)`
-    : '';
-
   // 2往復以上に到達した行: reached_two_plus_exchanges を true に更新
   // NOTE: ab_results.session_id は UUID型だが chat_sessions.session_id は TEXT型
   // （widget側でcrypto.randomUUID()により常にUUID形式の値が入るが、カラム型としては
@@ -78,7 +56,7 @@ export async function reconcileAbResultOutcomes(
        AND r.session_id::text = cs.session_id
        AND r.reached_two_plus_exchanges IS NOT TRUE
        AND cs.message_count >= $2
-       ${sourceFilter}`,
+       ${USER_SOURCE_FILTER}`,
     [experimentId, TWO_PLUS_EXCHANGES_MESSAGE_COUNT],
   );
 
@@ -92,7 +70,7 @@ export async function reconcileAbResultOutcomes(
        AND r.converted IS NOT TRUE
        AND cs.outcome IS NOT NULL
        AND cs.outcome <> ALL($2::text[])
-       ${sourceFilter}`,
+       ${USER_SOURCE_FILTER}`,
     [experimentId, NON_CONVERTING_OUTCOMES],
   );
 }

--- a/src/api/hermes-mcp/hermesMcpRepository.test.ts
+++ b/src/api/hermes-mcp/hermesMcpRepository.test.ts
@@ -49,6 +49,14 @@ describe("searchConversations", () => {
     expect(args).toEqual(["carnation", 50]); // デフォルトlimit=50
   });
 
+  it("PR-3: 学習データ汚染防止のためsource='user'以外のセッションを常に除外する", async () => {
+    const query = mockQuery([]);
+    await searchConversations({ tenantId: "carnation" });
+
+    const [sql] = query.mock.calls[0];
+    expect(sql).toContain("s.metadata->>'source' = 'user'");
+  });
+
   it("query指定時: ILIKE条件を追加する", async () => {
     const query = mockQuery([]);
     await searchConversations({ tenantId: "carnation", query: "保証" });

--- a/src/api/hermes-mcp/hermesMcpRepository.ts
+++ b/src/api/hermes-mcp/hermesMcpRepository.ts
@@ -6,6 +6,7 @@
 // このファイルは「同意済みと確認された tenantId」を渡された前提で動く。
 
 import { getPool } from "../../lib/db";
+import { userSourceClause } from "../admin/analytics/summaryQueries";
 
 export interface HermesConversationMessage {
   sessionId: string; // chat_sessions.session_id (アプリ側の文字列ID)
@@ -39,7 +40,12 @@ export async function searchConversations(
   const pool = getPool();
   const limit = Math.min(params.limit ?? DEFAULT_LIMIT, MAX_LIMIT);
 
-  const conditions: string[] = [`s.tenant_id = $1`];
+  // 学習データ汚染防止: Hermesにはe2e/chat-test由来のセッションを一切渡さない
+  // (userSourceClauseは"AND ..."形式を返すため、conditions配列の要素としてはAND抜きで積む)
+  const conditions: string[] = [
+    `s.tenant_id = $1`,
+    userSourceClause("s").replace(/^AND /, ""),
+  ];
   const args: unknown[] = [params.tenantId];
 
   if (params.query?.trim()) {

--- a/src/lib/crossTenantContext.test.ts
+++ b/src/lib/crossTenantContext.test.ts
@@ -1,0 +1,41 @@
+// src/lib/crossTenantContext.test.ts
+// PR-3 (GID 1216970103691946): クロステナント匿名集計にsource='user'絞り込みが
+// 入っていることの検証(e2eセッションの評価・CV実績が全テナント統計に混入しないため)。
+
+const mockQuery = jest.fn();
+jest.mock("./db", () => ({
+  pool: { query: (...args: unknown[]) => mockQuery(...args) },
+}));
+jest.mock("./logger", () => ({
+  logger: { warn: jest.fn() },
+}));
+
+import { getCrossTenantContext, _clearCacheForTesting } from "./crossTenantContext";
+
+beforeEach(() => {
+  mockQuery.mockReset();
+  _clearCacheForTesting();
+  // fetchAvgScores / fetchTopPsychologyPrinciples / fetchCommonGapPatterns /
+  // fetchEffectiveRulePatterns の4クエリすべてに安全に応答する汎用モック
+  mockQuery.mockResolvedValue({ rows: [] });
+});
+
+describe("getCrossTenantContext — source='user'フィルタ", () => {
+  it("平均スコア集計(conversation_evaluations)にsource='user'絞り込みが入っている", async () => {
+    await getCrossTenantContext();
+
+    const allSql = mockQuery.mock.calls.map((c) => c[0] as string);
+    const avgScoreSql = allSql.find((sql) => /FROM conversation_evaluations/.test(sql));
+    expect(avgScoreSql).toBeDefined();
+    expect(avgScoreSql).toContain("metadata->>'source' = 'user'");
+  });
+
+  it("心理原則ランキング集計(conversion_attributions)にsource='user'絞り込みが入っている", async () => {
+    await getCrossTenantContext();
+
+    const allSql = mockQuery.mock.calls.map((c) => c[0] as string);
+    const principlesSql = allSql.find((sql) => /FROM conversion_attributions/.test(sql));
+    expect(principlesSql).toBeDefined();
+    expect(principlesSql).toContain("metadata->>'source' = 'user'");
+  });
+});

--- a/src/lib/crossTenantContext.ts
+++ b/src/lib/crossTenantContext.ts
@@ -11,6 +11,7 @@
 
 import { pool } from './db';
 import { logger } from './logger';
+import { userSourceExists } from '../api/admin/analytics/summaryQueries';
 
 // ─── 型定義 ─────────────────────────────────────────────────────────────────
 
@@ -71,6 +72,7 @@ async function fetchAvgScores(): Promise<{ avgScores: CrossTenantContext['avgSco
         COUNT(DISTINCT tenant_id)                        AS total_tenants
       FROM conversation_evaluations
       WHERE evaluated_at > NOW() - INTERVAL '90 days'
+      ${userSourceExists("conversation_evaluations.session_id", "conversation_evaluations.tenant_id")}
     `);
     const row = result.rows[0];
     if (!row || row.total_tenants === '0' || row.total_tenants === 0) {
@@ -106,6 +108,7 @@ async function fetchTopPsychologyPrinciples(): Promise<CrossTenantContext['topPs
         )                                 AS cv_rate
       FROM conversion_attributions
       WHERE created_at > NOW() - INTERVAL '90 days'
+      ${userSourceExists("conversion_attributions.session_id", "conversion_attributions.tenant_id", "id")}
       GROUP BY principle
       HAVING COUNT(*) >= 5
       ORDER BY cv_rate DESC

--- a/tests/phase58/abTestRoutes.test.ts
+++ b/tests/phase58/abTestRoutes.test.ts
@@ -175,8 +175,10 @@ describe('PATCH /v1/admin/ab/experiments/:id/status', () => {
 
 describe('GET /v1/admin/ab/experiments/:id/results', () => {
   // GID 1216978855735482: reconcileAbResultOutcomes が結果集計の直前に呼ばれるようになった。
-  // 呼び出し順序: [0]tenant_id+min_sample_size取得 [1]metadata列存在確認
-  // [2]reached_two_plus_exchanges UPDATE [3]converted UPDATE [4]集計SELECT
+  // 呼び出し順序: [0]tenant_id+min_sample_size取得
+  // [1]reached_two_plus_exchanges UPDATE [2]converted UPDATE [3]集計SELECT
+  // PR-3訂正(GID 1216970103691946): metadata列存在確認(information_schema)は
+  // 「列がまだ無いかもしれない」という誤った前提に基づいていたため撤去済み。
   function queryResponsesWithReconcile(
     minSampleSize: number,
     aggregationRows: any[],
@@ -184,7 +186,6 @@ describe('GET /v1/admin/ab/experiments/:id/results', () => {
   ) {
     return [
       { rows: [{ tenant_id: tenantId, min_sample_size: minSampleSize }], rowCount: 1 },
-      { rows: [{ exists: false }] }, // metadata列なし（未移行環境を模す）
       { rows: [], rowCount: 0 }, // reached_two_plus_exchanges UPDATE
       { rows: [], rowCount: 0 }, // converted UPDATE
       { rows: aggregationRows },
@@ -234,14 +235,12 @@ describe('GET /v1/admin/ab/experiments/:id/results', () => {
   });
 
   it('reconcile自体が例外を投げても集計は継続する(best-effort)', async () => {
-    // metadata列存在確認は内部でtry/catch済みのため常に成功扱い(false)になる。
     // 1本目のUPDATE(reached_two_plus_exchanges)が例外を投げると reconcileAbResultOutcomes
     // 全体がその場でrejectし、2本目のUPDATE(converted)は呼ばれない。呼び出し元(results
     // ハンドラ)のtry/catchがこれを吸収し、次の実クエリ(集計SELECT)に進む。
     const { app } = makeApp({
       queryResponses: [
         { rows: [{ tenant_id: 'tenant-a', min_sample_size: 10 }], rowCount: 1 },
-        { rows: [{ exists: false }] },
         new Error('update failed'),
         { rows: [{ variant: 'a', exposed: 20, reached_two_plus: 10, converted: 5, avg_judge_score: 70 }] },
       ],


### PR DESCRIPTION
## Asana
1217750660031204

**⚠️ このPRは #858 (PR-2) の上にスタックしています。base を `feature/learning-loop-pr2-source` にしているため、まず #858 をマージしてから本PRをmainにマージしてください。** (PR-2のescalateSession変更・chatHistoryRepository.tsへの依存があるため。PR-2を先にマージしないと本番の実ユーザーセッションまでフィルタで落ちるリスクがあります — 詳細は元Asanaチケットの「前提: PR-2完了後に着手すること。逆順だと実ユーザーまで落ちる」を参照)

## 背景
E2E テストが本番 API(api.r2c.biz)を直接叩いており、E2E/chat-test由来のセッションが本番指標(継続率・CV率・Judgeスコア・KPI監視・週次ブリーフィング等)に混ざっていた。唯一の実装(`summaryQueries.ts` の `userSourceClause`/`userSourceExists`)を、未適用だった14箇所に適用する。

## 適用箇所(14箇所)
- `analytics/routes.ts`: knowledge-attribution(current/previous期間CTE 2箇所)、cv-status
- `analytics/summaryQueries.ts`: knowledge_gaps 集計
- `monitoring/routes.ts`: `computeKpis` の3クエリ(総セッション数・完了数・フォールバック検出)
- `variants/variantsRepository.ts`: `getVariantStats`
- `tenants/analyticsSummaryRoutes.ts`: テナント詳細アナリティクスタブの会話数集計
- `agent/actionExecutor.ts`: 週次ブリーフィングの3クエリ(会話数・前週比・品質スコア)
- `lib/crossTenantContext.ts`: 平均スコア集計・心理原則ランキングの2クエリ
- `hermes-mcp/hermesMcpRepository.ts`: `searchConversations`(Hermesの学習データ汚染防止、最重要。同意チェックとは独立した二重の防御)
- `chat-history/chatHistoryRepository.ts`: `getSessions` — SELECTに`source`を追加し、管理画面(admin-ui chat-history一覧)でe2e/実ユーザーを見分けられるようにする
- `conversion/abResultsOutcomeSync.ts`: 「metadata列がまだ無いかもしれない」という誤った前提の `information_schema` 動的チェックを撤去(metadata列は初期migrationから存在する)。`OR source IS NULL` の移行期許容ロジック自体は維持

## CLAUDE.md 禁止34の是正
`variantsRepository.ts` の `getVariantStats` が会話0件のvariantに `avg_score: 0` を返していた(母数不足を実数0と区別できない)のを是正。`AVG(score)` がSQL上でNULLの場合は `avg_score: null` を返すよう変更(`VariantStatRow.avg_score: number | null`)。

## 移行リスク(明記)
`userSourceClause`/`Exists`は `metadata->>'source' = 'user'` でNULLを落とす。過去データ(source未設定)を持つ既存テナントは、上記14箇所の数値が今回のリリースで下がる(実ユーザー分は正しく残るが、集計対象外だったe2e/未タグ付けの水増し分が消える)。`conversion/abResultsOutcomeSync.ts` のみ既存の設計判断を踏襲し `OR source IS NULL` を維持しているため対象外。

## テスト
- `trafficSourceFilter.test.ts`: knowledge-attribution・cv-status の2件を列挙に追加
- 新規: `chatHistoryRepository.sessions.test.ts`, `computeKpis.test.ts`, `variantsRepository.test.ts`, `crossTenantContext.test.ts`
- 既存テスト更新: `agentRoutes.test.ts`(週次ブリーフィングのsourceフィルタ回帰テスト追加、`jest.mock('../analytics/summaryQueries')`に`userSourceClause`/`Exists`を追加)、`analyticsSummaryRoutes.test.ts`、`hermesMcpRepository.test.ts`、`abResultsOutcomeSync.test.ts`(information_schema撤去に伴うクエリ本数変更に追随)、`tests/phase58/abTestRoutes.test.ts`(同上)
- admin-ui: chat-history一覧にsourceバッジ(user以外のみ表示)を追加
- backend typecheck / jest(全件、既知のpre-existing失敗1件[`avatar/routes.test.ts`の`global.fetch`スパイ、origin/mainでも同一]を除き緑) / admin-ui typecheck / vitest(551件)緑
- oxlint(対象ファイルのみ、既存ブランチ比較で新規warning無し)

🤖 Generated with [Claude Code](https://claude.com/claude-code)