### PR TITLE
docs(claude): 到達可能性をDoDに追加し、カード3層同期とapproved_atの破れを明文化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,9 @@ CLIは新セッション開始時に以下を確認・報告する（省略禁�
 - pnpm test → all pass
 - pnpm test:e2e → mobile viewport passes
 - Codex Gate → P0/P1 none
+- **追加した機能に到達する経路がある。** API を足したなら呼ぶUI/ツールが、ツールを足したなら
+  呼ばせる導線が、同じPRに入っている。「後続PRでUIを繋ぐ」は**到達しないコードを本番に置くことと同義**
+  （上の5項目は到達しないコードでも全て通る。実例は「絶対にやってはいけないこと」15）。
 
 ## Anti-Slop
 - ragExcerpt.slice(0, 200) 必須
@@ -111,7 +114,7 @@ R2C は、テナント（店舗・EC事業者）のサイトに1行で埋め込�
 | チャット送信・sessionId・履歴窓・`targetTenantId`・エラー文言 | `admin-ui/src/lib/useAgentChatTransport.ts` |
 | 会話の保存・復元 | `admin-ui/src/lib/chatSessionStore.ts` |
 | Enter送信・IME合成の扱い | `admin-ui/src/lib/utils.ts` の `shouldSubmitOnEnter` |
-| 構造化カードの追加 | `useAgentChatTransport.ts` の `card.kind` に `kind` を足す |
+| 構造化カードの追加 | **3層すべてに同じフィールド形状を書く**（サーバ／フロントの境界を跨ぐため型を共有できず手動同期）。①`actionExecutor.ts` の `*CardPayload` 型 + `ActionCardPayload` union ②`admin-ui/src/lib/useAgentChatTransport.ts` の `AgentActionCard` union ③`copilot-preview/index.tsx` の `Card` union + `a.card?.kind === "..."` の変換分岐。`kind` のみ **サーバ snake_case → クライアント camelCase** に変換し、他は `Omit<XAgentActionCard, "kind">` で再利用して二重定義を避ける（`weekly_summary` → `weeklySummary` が基準）。**1層でも漏れると型は通るのに描画されない。** |
 | エージェントのツール追加 | `src/api/admin/agent/toolDefinitions.ts` + `actionExecutor.ts` の `switch` に `case` + `copilot-preview/index.tsx` の `REAL_TOOL_LABEL`（**この3点セット**。ラベル漏れは生の英語ツール名が画面に出る。網羅性を強制するテストが無く、人力で守る唯一の箇所） |
 | ファイル添付（コンポーザの📎／ドラッグ＆ドロップ） | `admin-ui/src/lib/bookPdfUpload.ts` の検証 + `pdfUpload` カードの進捗表示を拡張。**第2の添付経路を作らない** |
 | ツール内でのプラン機能判定 | 注入済み `db` に `queryTenantPlan` + `planHasFeature`。`tenantHasFeature` は内部で `getPool()` を呼び、テストのモックPoolと食い違う |
@@ -160,7 +163,11 @@ R2C は、テナント（店舗・EC事業者）のサイトに1行で埋め込�
 | 優先度の3段階表現 | `admin-ui/src/lib/tuningPriority.ts`（閾値・代表値を他所に書かない） |
 
 **既知の破れ（是正前に触るなら前提を確認する）**: 自動生成ルールの無断有効化 / 採用済み返答が回答生成に未到達 /
-一致判定が半角カンマ区切りの部分一致のみ / ツール結果500字打ち切りによる一覧欠落。
+一致判定が半角カンマ区切りの部分一致のみ / ツール結果500字打ち切りによる一覧欠落 /
+**`approved_at` を書くのは `approveTuningRule`・`rejectTuningRule`（`evaluationsRepository.ts`、いずれも
+super_admin 専用経路）のみで、チャット経由の `updateRule` は書かない。** 店主が使える唯一の承認経路が
+承認時刻を残さないため、`approved_at` を before/after の境界に使う効果測定（`analytics/ruleEffect.ts`）は、
+チャット承認したルールを永久に「未承認」として扱う。
 詳細と受け入れ条件: `docs/TUNING_RULE_CHAT_REQUIREMENTS.md`
 
 ## 絶対にやってはいけないこと
@@ -207,12 +214,19 @@ R2C は、テナント（店舗・EC事業者）のサイトに1行で埋め込�
     （前例: `pre_dispatch` の Enterprise 制限がUIのみで `livekitTokenRoutes` に強制が無かった）。
 15. **動線として閉じていないツールを足す。** 一覧を返す手段が無いのに id 必須の `activate_avatar` だけがある状態は、
     チャットからは実行不能で「あるのに使えない」。ツールは**ユーザーが会話だけで完了できる単位**で追加する。
+    **同じことが API と UI の間でも起きる。** `GET /v1/admin/analytics/rule-effect/:ruleId` は
+    DiD推定・信頼区間・母数ゲートまで実装され全テスト緑のまま、`admin-ui` 側に呼び出しが1件も無い状態で
+    マージされた（PR #869）。**「作った」と「届いた」は別。** 実装前に「誰がどの画面から呼ぶか」を
+    1行で答えられること（Definition of Done の到達可能性）。
 16. **`AT TIME ZONE` を片側だけ書く。** `timestamptz` カラムとの比較は往復変換が必須。
     サーバTZ依存の実装は**本番でのみ実際の時刻とズレ、数値はもっともらしく出るため気づけない**
     （`src/lib/date/weekRange.ts` は process TZ に一切依存しない実装で、この事故を回避している）。
 17. **チャットに出す集計値をLLMの生成文のまま表示する。** 数値・期間・件数はサーバが構造化データ
     （card）として返し、LLMは解釈・提案のみを担う。丸め・省略・語り換えが構造的に起こり得るため
     （例: `get_weekly_briefing`。詳細: `docs/WEEKLY_SUMMARY_REQUIREMENTS.md`）。
+    `text` と `card` は**同一オブジェクトから組み立てる**（2箇所で計算すると必ず食い違う）。
+    **既知の違反**: `get_analytics_summary` / `get_conversion_summary` / `get_monitoring_summary` は
+    数値を扱いながらカード化されておらず自然文のみを返す（是正対象）。新しい数値ツールはこれらに倣わない。
 18. **チャットUIからバックエンドを直接fetchする経路を足すとき、previewMode中のテナントスコープ
     (`?tenant=`)を載せ忘れる。** エージェントツール経由の呼び出しは `targetTenantId` が自動で載るが、
     直接fetch（`generateAvatarCandidates`・`matchAvatarVoice`・`uploadUrl`のような、500字制約や
@@ -348,6 +362,10 @@ R2C は、テナント（店舗・EC事業者）のサイトに1行で埋め込�
 
 - **回帰テストを消さない。** 既に直したバグ（IME誤送信、previewMode のテナントスコープ漏れ、
   super_admin バイパス）は、テストが唯一の再発防止装置。
+- **書いた回帰テストが実際に噛むことを確認する。** 修正を一時的に戻して**そのテストが赤くなること**を
+  見てから復元する。通ることだけを確認したテストは、条件を取り違えていても緑のままになる。
+  実例: 効果測定の打ち切り開示テストは、`truncated` を `false` 固定に戻して初めて
+  「片側だけが上限を超えた場合を見ていない」ことが判明した（PR #872）。
 - **正常系だけで通さない。** 外部API・DB書き込みは「一部失敗」「全件失敗」「タイムアウト」を必ず書く。
   特に**一部失敗時に表示件数と実件数が一致すること**（黙って成功と表示しない）。
 - **権限の境界を必ずテストする。** client_admin / super_admin / previewMode の3ロールで、

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -164,10 +164,12 @@ R2C は、テナント（店舗・EC事業者）のサイトに1行で埋め込�
 
 **既知の破れ（是正前に触るなら前提を確認する）**: 自動生成ルールの無断有効化 / 採用済み返答が回答生成に未到達 /
 一致判定が半角カンマ区切りの部分一致のみ / ツール結果500字打ち切りによる一覧欠落 /
-**`approved_at` を書くのは `approveTuningRule`・`rejectTuningRule`（`evaluationsRepository.ts`、いずれも
-super_admin 専用経路）のみで、チャット経由の `updateRule` は書かない。** 店主が使える唯一の承認経路が
-承認時刻を残さないため、`approved_at` を before/after の境界に使う効果測定（`analytics/ruleEffect.ts`）は、
-チャット承認したルールを永久に「未承認」として扱う。
+**`approved_at` を書くのは `approveTuningRule`・`rejectTuningRule`（`evaluationsRepository.ts`）のみで、
+チャット経由の `updateRule` は書かない。** 前者のエンドポイント自体は `super_admin` / `client_admin`
+双方に開いているが（`evaluations/routes.ts` の `ALLOWED_EVALUATION_ROLES`）、呼び出す旧UI
+（`AIReportTab.tsx` / `SuggestedRulesCard.tsx`）が super_admin 限定のため、店主が実際に使える唯一の
+承認経路（チャット）だけが承認時刻を残さない。`approved_at` を before/after の境界に使う効果測定
+（`analytics/ruleEffect.ts`）は、チャット承認したルールを永久に「未承認」として扱う。
 詳細と受け入れ条件: `docs/TUNING_RULE_CHAT_REQUIREMENTS.md`
 
 ## 絶対にやってはいけないこと


### PR DESCRIPTION
## Summary

学習ループ PR-13〜17 とその是正（PR #872）のレビューで判明した、CLAUDE.md の**記述不足と事実誤り**を是正する。

ご指摘の観点（目的・スコープ／設計方針／禁止事項／テスト／命名・エラーハンドリング）に対応する章は**すでに786行のCLAUDE.mdに存在**していたため、新規の並行文書は作らず既存章へ追記した（同じ関心事を2ファイルに複製＝禁止6を自ら踏まないため）。差分は20行。

### 訂正（放置すると次の実装者が必ず踏む）

| # | 箇所 | 内容 |
|---|---|---|
| 1 | 実装の置き場所「構造化カードの追加」 | `useAgentChatTransport.ts` の1層しか書かれておらず**実態と異なる**。実際は `actionExecutor`(`*CardPayload` + union) / `useAgentChatTransport`(`AgentActionCard`) / `copilot-preview`(`Card` union + 変換分岐) の**3層手動同期**。`kind` のみ snake_case→camelCase 変換。**1層漏れると型は通るのに描画されない** |
| 2 | 指示ルール「既知の破れ」 | `approved_at` を追記。CLAUDE.md は「承認状態を書くのは3点」と書いているが、**`approved_at` を書くのは super_admin 専用の2経路のみ**。店主が使えるチャット経由の `updateRule` は書かないため、`approved_at` を before/after 境界に使う効果測定が**チャット承認したルールを永久に未承認扱いする** |

### 追記

| # | 箇所 | 内容 |
|---|---|---|
| 3 | Definition of Done | **到達可能性**を追加。既存5項目（typecheck/lint/test/e2e/Codex Gate）は**到達しないコードでも全て通る** |
| 4 | 禁止15 | 「動線として閉じていないツール」を **API/UI 間**へ拡張。`rule-effect` API が DiD推定・信頼区間まで実装され全テスト緑のまま、呼び出し0件でマージされた実例（PR #869）を記録 |
| 5 | 禁止17 | `text` と `card` は同一オブジェクト由来であること、および**未カード化の既知違反3ツール**（`get_analytics_summary` / `get_conversion_summary` / `get_monitoring_summary`）を名指し |
| 6 | テストの最低ライン | **書いた回帰テストが実際に噛むことを revert で確認する**。実例として、PR #872 の打ち切り開示テストが「片側だけ超過」を見ていなかった件 |

### あえて追記しなかったもの

母数不足時に数値を出さない（禁止34）／点推定を単独で出さない／効果計測で新テーブルを作らない（禁止32）／提案インボックスを増やさない（禁止31）／`/copilot-preview` に super_admin 機能を足さない／新規APIを作らないをテストで固定／端から端まで1本／ツール命名 snake_case・500字truncate — **いずれも記載済み**のため重複させない。

「自APIをHTTPで自己呼び出ししない」は汎用的すぎ実害も未発生のため、禁止リストの希釈を避けて見送った。

## Test plan

- [x] ドキュメントのみの変更（`CLAUDE.md` 1ファイル、コード変更なし）
- [x] 記載した実装事実は現物のコードで確認済み（3層のカード型定義・`approved_at` を書く箇所の全grep・未カード化3ツールの戻り値）
- [x] 参照PR番号を `git log` で確認（#869 = rule-effect実装、#872 = 是正）