### PR TITLE
fix(tuning): チャット承認でtuning_rules.approved_atを記録する(R4前提)

### DIFF
--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -2134,10 +2134,12 @@ export async function executeToolCall(
             [tenantId],
           ),
           // weeklyReportGenerator(Phase46)からの唯一の引き継ぎ指標。
-          // P4-1で修正: 以前は approved_at/rejected_at (どのコードパスからも
-          // 更新されない列)を見ており、店主が作った通常のルールも含めて
-          // 全件を「承認待ち」として数えていた。AI提案(source IN ('judge','hermes'))
-          // かつ未承認(is_active=false)かつ却下されていない件数に修正する。
+          // P4-1で修正: 以前は approved_at/rejected_at を見ており、店主が作った通常の
+          // ルール(is_active=true, approved_at=NULLのまま)も含めて全件を「承認待ち」として
+          // 数えていた。AI提案(source IN ('judge','hermes'))かつ未承認(is_active=false)かつ
+          // 却下されていない件数に修正する。approved_at/rejected_at は現在 updateRule
+          // (GID 1217752900578379, R4)も更新するようになったが、この集計はAI提案の
+          // 未承認件数を数えるのが目的で判定にis_active/statusしか使わないため無関係。
           // R6: Hermes提案もtuning_rulesの同じ棚に着地するため、同じ集計に含める。
           db.query(
             `SELECT COUNT(*)::int AS n FROM tuning_rules

--- a/src/api/admin/tuning/tuningRulesRepository.test.ts
+++ b/src/api/admin/tuning/tuningRulesRepository.test.ts
@@ -215,6 +215,83 @@ describe('updateRule', () => {
     const [, updateArgs] = mockQuery.mock.calls[1];
     expect(updateArgs[4]).toBe(JSON.stringify([{ text: '2年です', style: 'plain', approved_at: '' }]));
   });
+
+  // GID 1217752900578379 (R4): approveTuningRule/rejectTuningRule と対称に、
+  // チャット経由の承認(status経由のupdateRule)でも approved_at/rejected_at を記録する。
+  // これが無いと ruleEffect.ts の before/after 境界(approved_at)が永久にNULLのままになり、
+  // チャット承認したルールの効果測定が not_yet_approved から進まない。
+  describe('approved_at / rejected_at の記録(R4)', () => {
+    it('回帰: status="active"を指定すると、approved_atはCOALESCEで初回承認のみ埋め、再承認では上書きしない', async () => {
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ id: 1, tenant_id: 'tenant-abc' }] })
+        .mockResolvedValueOnce({ rows: [{ id: 1, tenant_id: 'tenant-abc', status: 'active' }] });
+
+      await updateRule(1, { status: 'active' }, 'tenant-abc');
+
+      const [updateSql] = mockQuery.mock.calls[1];
+      // NOW()直書きではなくCOALESCE(approved_at, NOW())であること = 既存値があれば上書きしない
+      expect(updateSql).toMatch(/approved_at\s*=\s*CASE WHEN \$6 = 'active'\s*THEN COALESCE\(approved_at, NOW\(\)\)/);
+    });
+
+    it('回帰: status="active"は同時にrejected_atをNULLに戻す(承認↔却下の対称性、両方非NULLの行を作らない)', async () => {
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ id: 1, tenant_id: 'tenant-abc' }] })
+        .mockResolvedValueOnce({ rows: [{ id: 1, tenant_id: 'tenant-abc' }] });
+
+      await updateRule(1, { status: 'active' }, 'tenant-abc');
+
+      const [updateSql] = mockQuery.mock.calls[1];
+      expect(updateSql).toMatch(/rejected_at\s*=\s*CASE WHEN \$6 = 'rejected'[\s\S]*?WHEN \$6 = 'active'\s*THEN NULL/);
+    });
+
+    it('回帰: status="rejected"を指定すると、approved_atはNULLに戻り、rejected_atがCOALESCEで初回のみ埋まる', async () => {
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ id: 1, tenant_id: 'tenant-abc' }] })
+        .mockResolvedValueOnce({ rows: [{ id: 1, tenant_id: 'tenant-abc', status: 'rejected' }] });
+
+      await updateRule(1, { status: 'rejected' }, 'tenant-abc');
+
+      const [updateSql] = mockQuery.mock.calls[1];
+      expect(updateSql).toMatch(/approved_at\s*=\s*CASE WHEN \$6 = 'active'[\s\S]*?WHEN \$6 = 'rejected'\s*THEN NULL/);
+      expect(updateSql).toMatch(/rejected_at\s*=\s*CASE WHEN \$6 = 'rejected'\s*THEN COALESCE\(rejected_at, NOW\(\)\)/);
+    });
+
+    it('statusを指定しない通常編集では、approved_at/rejected_atともにELSE分岐で既存値を維持する(数値は動かさない)', async () => {
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ id: 1, tenant_id: 'tenant-abc' }] })
+        .mockResolvedValueOnce({ rows: [{ id: 1, tenant_id: 'tenant-abc' }] });
+
+      await updateRule(1, { is_active: true }, 'tenant-abc');
+
+      const [updateSql, updateArgs] = mockQuery.mock.calls[1];
+      expect(updateSql).toMatch(/approved_at\s*=\s*CASE WHEN \$6 = 'active'[\s\S]*?ELSE approved_at END/);
+      expect(updateSql).toMatch(/rejected_at\s*=\s*CASE WHEN \$6 = 'rejected'[\s\S]*?ELSE rejected_at END/);
+      expect(updateArgs[5]).toBeNull(); // $6=null → いずれのCASEもELSE分岐に落ちる
+    });
+
+    it('RETURNING句にapproved_at/rejected_at列が含まれる(呼び出し元がその場で効果測定に使うため)', async () => {
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ id: 1, tenant_id: 'tenant-abc' }] })
+        .mockResolvedValueOnce({ rows: [{ id: 1, tenant_id: 'tenant-abc' }] });
+
+      await updateRule(1, { status: 'active' }, 'tenant-abc');
+
+      const [updateSql] = mockQuery.mock.calls[1];
+      expect(updateSql).toMatch(/RETURNING[\s\S]*approved_at, rejected_at/);
+    });
+
+    it('UPDATE文のプレースホルダは$7のままで、承認記録のために新しい引数を増やしていない', async () => {
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ id: 1, tenant_id: 'tenant-abc' }] })
+        .mockResolvedValueOnce({ rows: [{ id: 1, tenant_id: 'tenant-abc' }] });
+
+      await updateRule(1, { status: 'active' }, 'tenant-abc');
+
+      const [updateSql, updateArgs] = mockQuery.mock.calls[1];
+      expect(updateSql).toContain('WHERE id = $7');
+      expect(updateArgs).toHaveLength(7);
+    });
+  });
 });
 
 // D7: 採用済み返答(approved_responses)が回答生成経路(getActiveRulesForTenant →

--- a/src/api/admin/tuning/tuningRulesRepository.ts
+++ b/src/api/admin/tuning/tuningRulesRepository.ts
@@ -37,6 +37,9 @@ export interface TuningRule {
   source?: string;
   status?: string;
   evidence?: RuleEvidence | null;
+  /** GID 1217752900578379 (R4): before/after の分岐点。updateRule では初回承認時のみ NOW() を入れる(再承認で上書きしない)。 */
+  approved_at?: string | null;
+  rejected_at?: string | null;
 }
 
 export interface ListRulesFilters {
@@ -225,11 +228,24 @@ export async function updateRule(
        is_active         = COALESCE($4, is_active),
        approved_responses = CASE WHEN $5::text IS NOT NULL THEN $5::jsonb ELSE approved_responses END,
        status            = COALESCE($6, status),
+       -- GID 1217752900578379 (R4): approveTuningRule/rejectTuningRule と対称の記録を、
+       -- チャット経由の承認(status='active'/'rejected')でも行う。効果測定(ruleEffect.ts)は
+       -- approved_at を before/after の境界に使うため、これが無いとチャット承認したルールが
+       -- 永久に「未承認」として扱われる。初回承認で固定し、再承認では上書きしない
+       -- (COALESCE(approved_at, NOW())。観測期間の起点をずらさないため)。却下時はNULLに戻し、
+       -- approved_at/rejected_at が同時に非NULLになる状態を作らない(承認↔却下の対称性)。
+       approved_at       = CASE WHEN $6 = 'active'   THEN COALESCE(approved_at, NOW())
+                                 WHEN $6 = 'rejected' THEN NULL
+                                 ELSE approved_at END,
+       rejected_at       = CASE WHEN $6 = 'rejected' THEN COALESCE(rejected_at, NOW())
+                                 WHEN $6 = 'active'   THEN NULL
+                                 ELSE rejected_at END,
        updated_at        = NOW()
      WHERE id = $7
      RETURNING id, tenant_id, trigger_pattern, expected_behavior,
                priority, is_active, created_by, source_message_id,
-               created_at, updated_at, approved_responses, source, status, evidence`,
+               created_at, updated_at, approved_responses, source, status, evidence,
+               approved_at, rejected_at`,
     [
       params.trigger_pattern ?? null,
       params.expected_behavior ?? null,


### PR DESCRIPTION
## Summary
Asanaタスク T1 (GID 1217752902899422)。R4(ルール効果測定)の前提修正。

- `updateRule`(チャット経由の承認)が `approved_at`/`rejected_at` を書いておらず、`approveTuningRule`/`rejectTuningRule`(旧UI経由)とだけ非対称だった
- 効果測定 `ruleEffect.ts` は `approved_at` を before/after 境界に使うため、店主がチャットで承認したルールが永久に `not_yet_approved` のままだった
- 初回承認で `COALESCE(approved_at, NOW())` により固定、再承認では上書きしない。却下時は `approved_at` をNULLに戻す(承認と対称)
- `UpdateRuleParams` は変更せず、既存の `$6`(status)からSQL内で導出したため引数配列が変わらず、既存の `toHaveBeenCalledWith` 完全一致assertが無傷

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `tuningRulesRepository.test.ts` 29/29 green(回帰6本を新規追加)
- [x] revert検証: `COALESCE(approved_at, NOW())` を `NOW()` 直書きに戻すと回帰テストが赤くなることを確認 → 復元
- [x] `agentRoutes.test.ts:2617` の `expect(tuningSql).not.toContain('approved_at IS NULL')` — green(クエリ本体は触っていない)
- [x] `npx oxlint` — clean
- [x] agent/tuning/evaluations 一括実行で確認した2件の失敗(SAI task timeout / voice復元)は、`git stash` した無修正状態でも再現する既知のflaky(`agentRoutes.test.ts`単体実行時の分離不全)で、本PRとは無関係