### PR TITLE
feat(agent): get_tuning_rule_effectツールでルール効果をチャットから確認する

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -264,6 +264,7 @@ const REAL_TOOL_LABEL: Record<string, string> = {
   get_legacy_ui_link: "旧管理画面への案内",
   get_analytics_summary: "会話分析サマリーの取得",
   get_conversion_summary: "成約・効果分析サマリーの取得",
+  get_tuning_rule_effect: "ルール効果の取得",
   get_avatar_status: "アバター稼働状況の取得",
   request_sai_task: "Saiへの代行依頼",
   get_sai_task_status: "Saiタスク状況の取得",

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -44,6 +44,7 @@ import { recordSaiTask, resolveSaiTaskTenant } from '../../../lib/sai/saiTaskReg
 import { trackUsage } from '../../../lib/billing/usageTracker';
 import { queryTenantPlan, planHasFeature } from '../../../lib/billing/planFeatures';
 import { fetchAnalyticsSummary, fetchConversionSummary } from '../analytics/summaryQueries';
+import { getRuleEffect } from '../analytics/ruleEffect';
 import { isOnboardingIndustry, ONBOARDING_INDUSTRY_LABELS, INDUSTRY_FAQ_TEMPLATES } from './industryFaqTemplates';
 import { buildPlacementAttributes, validateWidgetPlacement } from './widgetPlacement';
 
@@ -3585,6 +3586,71 @@ export async function executeToolCall(
       } catch (err) {
         logger.warn(`[actionExecutor] ${toolName} failed`, err);
         return truncate('分析サマリーの取得に失敗しました');
+      }
+    }
+
+    // -----------------------------------------------------------------------
+    // GID 1217752900578379 (R4): 承認済みルールの効果(DiD推定)をチャットから確認する。
+    // 母数不足のときは点推定・率・矢印を一切出さず到達条件のみ返す(CLAUDE.md 禁止34)。
+    case 'get_tuning_rule_effect': {
+      if (!tenantId) {
+        return truncate('テナントが特定できません。super_admin の場合は対象テナントを指定してください');
+      }
+      const ruleId = Number(args['rule_id']);
+      if (!Number.isFinite(ruleId)) {
+        return truncate('ルールIDを指定してください');
+      }
+
+      try {
+        const result = await getRuleEffect(db, ruleId);
+
+        if (result.status === 'rule_not_found') {
+          return truncate('指定されたルールが見つかりません');
+        }
+        // 越境防止: 他テナントのルールIDを直接指定されても、存在有無を漏らさず
+        // 「見つからない」に倒す(r2c-tenant-isolation)。
+        if (result.tenantId !== tenantId) {
+          return truncate('指定されたルールが見つかりません');
+        }
+        if (result.status === 'not_yet_approved') {
+          return truncate('このルールはまだ承認されていません。承認後に効果を確認できます');
+        }
+
+        if (result.status === 'insufficient_data') {
+          // ruleEffect.ts の4群ラベル。旧UIに同等の表示は無いためここが唯一の語彙。
+          const groupLabel: Record<string, string> = {
+            beforeTreatment: '承認前・該当する会話',
+            afterTreatment: '承認後・該当する会話',
+            beforeControl: '承認前・該当しない会話',
+            afterControl: '承認後・該当しない会話',
+          };
+          const lines = [
+            `指示ルール（ID: ${ruleId}）はまだ効果を判定できません（判定に必要な会話数が不足しています）`,
+          ];
+          for (const p of result.progress) {
+            const label = groupLabel[p.group] ?? p.group;
+            const eta = p.etaDays != null ? `、現ペースであと約${p.etaDays}日` : '';
+            lines.push(`・${label}: 現在${p.currentN}件 / 必要${p.requiredN}件${eta}`);
+          }
+          return truncate(lines.join('\n'));
+        }
+
+        // status === 'ok'
+        const { did, naiveTreatmentDelta } = result.comparison;
+        const [ciLow, ciHigh] = did.ci95;
+        const verdict = ciLow > 0 ? '効いている可能性が高いです' : ciHigh < 0 ? '逆効果の可能性があります' : 'まだ判定できません（差が誤差の範囲内です）';
+        const lines = [
+          `指示ルール（ID: ${ruleId}）の効果: ${verdict}`,
+          `推定差分: ${did.estimate}点（95%信頼区間: ${ciLow}〜${ciHigh}）`,
+          `参考（対照群との比較前の単純差分）: ${naiveTreatmentDelta}点`,
+        ];
+        if (result.truncated) {
+          lines.push(`※直近${result.analyzedSessions}件のセッションで判定しています`);
+        }
+        return truncate(lines.join('\n'));
+      } catch (err) {
+        logger.warn('[actionExecutor] get_tuning_rule_effect failed', err);
+        return truncate('ルール効果の取得に失敗しました');
       }
     }
 

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -168,6 +168,12 @@ jest.mock('../chat-history/deleteSessionRepository', () => ({
   deleteSession: (...args: any[]) => mockDeleteSession(...args),
 }));
 
+// get_tuning_rule_effect が使う依存をモック(GID 1217752900578379, R4)
+const mockGetRuleEffect = jest.fn();
+jest.mock('../analytics/ruleEffect', () => ({
+  getRuleEffect: (...args: any[]) => mockGetRuleEffect(...args),
+}));
+
 // get_monitoring_summary が使う依存をモック
 const mockComputeKpis = jest.fn();
 jest.mock('../monitoring/routes', () => ({
@@ -6657,6 +6663,272 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(res.body.actions[0].result).toContain('総合95点');
       expect(res.body.actions[0].result).toContain('所見: 最新の再評価');
       expect(res.body.actions[0].result).not.toContain('古い評価');
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // get_tuning_rule_effect（GID 1217752900578379, R4: ルール効果測定のチャット接続）
+  // 統計計算そのものは ruleEffect.test.ts で純関数として検証済みのため、ここでは
+  // ツール層の分岐(越境防止・母数不足時に数値を出さない・エラー処理)のみを確認する。
+  // -------------------------------------------------------------------------
+  describe('get_tuning_rule_effect', () => {
+    function toolCallResponse(id: string, name: string, args: Record<string, unknown> = {}) {
+      return {
+        ok: true,
+        json: async () => ({
+          choices: [{
+            message: {
+              content: null,
+              tool_calls: [{ id, type: 'function', function: { name, arguments: JSON.stringify(args) } }],
+            },
+          }],
+        }),
+        text: async () => '',
+      };
+    }
+
+    beforeEach(() => {
+      mockGetRuleEffect.mockReset();
+    });
+
+    it('母数充足(ok)のときはDiD推定値・信頼区間・参考差分をtextで返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-re-1', 'get_tuning_rule_effect', { rule_id: 42 }))
+        .mockResolvedValueOnce(makeGroqResponse('効果はこちらです。'));
+
+      mockGetRuleEffect.mockResolvedValueOnce({
+        status: 'ok',
+        ruleId: 42,
+        tenantId: 'tenant-abc',
+        approvedAt: '2026-08-01T00:00:00.000Z',
+        truncated: false,
+        analyzedSessions: 40,
+        comparison: {
+          minSampleSize: 5,
+          groups: {},
+          did: { estimate: 5.2, ci95: [1.1, 9.3] },
+          naiveTreatmentDelta: 8.5,
+        },
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルール42の効果を教えて', sessionId: 'sess-re-01' });
+
+      expect(res.status).toBe(200);
+      expect(mockGetRuleEffect).toHaveBeenCalledWith(expect.anything(), 42);
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain('効いている可能性が高いです');
+      expect(result).toContain('5.2点');
+      expect(result).toContain('1.1〜9.3');
+      expect(result).not.toContain('直近'); // truncated=falseのときは打ち切り注記を出さない
+    });
+
+    it('信頼区間の上限が0未満のときは「逆効果の可能性」と返す(断定語を使わない)', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-re-2', 'get_tuning_rule_effect', { rule_id: 42 }))
+        .mockResolvedValueOnce(makeGroqResponse('効果はこちらです。'));
+
+      mockGetRuleEffect.mockResolvedValueOnce({
+        status: 'ok', ruleId: 42, tenantId: 'tenant-abc', approvedAt: '2026-08-01T00:00:00.000Z',
+        truncated: false, analyzedSessions: 40,
+        comparison: { minSampleSize: 5, groups: {}, did: { estimate: -6, ci95: [-10, -2] }, naiveTreatmentDelta: -3 },
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルール42の効果を教えて', sessionId: 'sess-re-02' });
+
+      expect(res.body.actions[0].result).toContain('逆効果の可能性があります');
+      expect(res.body.actions[0].result).not.toContain('効いている');
+      expect(res.body.actions[0].result).not.toContain('改善しました');
+      expect(res.body.actions[0].result).not.toContain('効果あり');
+    });
+
+    it('信頼区間が0をまたぐときは「まだ判定できません」と返す(誤った自信を与えない)', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-re-3', 'get_tuning_rule_effect', { rule_id: 42 }))
+        .mockResolvedValueOnce(makeGroqResponse('効果はこちらです。'));
+
+      mockGetRuleEffect.mockResolvedValueOnce({
+        status: 'ok', ruleId: 42, tenantId: 'tenant-abc', approvedAt: '2026-08-01T00:00:00.000Z',
+        truncated: false, analyzedSessions: 40,
+        comparison: { minSampleSize: 5, groups: {}, did: { estimate: 2, ci95: [-3, 7] }, naiveTreatmentDelta: 2 },
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルール42の効果を教えて', sessionId: 'sess-re-03' });
+
+      expect(res.body.actions[0].result).toContain('まだ判定できません');
+    });
+
+    // CLAUDE.md 禁止34: 母数不足のときは差分・率・パーセント・矢印を一切出さず到達条件のみ返す。
+    it('回帰: 母数不足(insufficient_data)のときは到達条件のみを返し、率・%・矢印を一切出さない', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-re-4', 'get_tuning_rule_effect', { rule_id: 42 }))
+        .mockResolvedValueOnce(makeGroqResponse('まだ判定できません。'));
+
+      mockGetRuleEffect.mockResolvedValueOnce({
+        status: 'insufficient_data',
+        ruleId: 42,
+        tenantId: 'tenant-abc',
+        approvedAt: '2026-08-01T00:00:00.000Z',
+        truncated: false,
+        analyzedSessions: 6,
+        minSampleSize: 5,
+        progress: [
+          { group: 'afterTreatment', currentN: 2, requiredN: 5, etaDays: 10 },
+          { group: 'beforeControl', currentN: 4, requiredN: 5, etaDays: null },
+        ],
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルール42の効果を教えて', sessionId: 'sess-re-04' });
+
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain('現在2件 / 必要5件');
+      expect(result).toContain('あと約10日');
+      expect(result).toContain('現在4件 / 必要5件');
+      expect(result).not.toMatch(/%/);
+      expect(result).not.toMatch(/[↑↓]/);
+      expect(result).not.toContain('効果なし');
+      expect(result).not.toContain('改善');
+      expect(result).not.toContain('悪化');
+    });
+
+    it('etaDaysがnullの群は見込み日数を出さない(before群は観測期間固定のため)', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-re-5', 'get_tuning_rule_effect', { rule_id: 42 }))
+        .mockResolvedValueOnce(makeGroqResponse('まだ判定できません。'));
+
+      mockGetRuleEffect.mockResolvedValueOnce({
+        status: 'insufficient_data', ruleId: 42, tenantId: 'tenant-abc', approvedAt: '2026-08-01T00:00:00.000Z',
+        truncated: false, analyzedSessions: 3, minSampleSize: 5,
+        progress: [{ group: 'beforeTreatment', currentN: 3, requiredN: 5, etaDays: null }],
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルール42の効果を教えて', sessionId: 'sess-re-05' });
+
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain('現在3件 / 必要5件');
+      expect(result).not.toContain('あと約');
+    });
+
+    it('truncated=trueのときは「直近N件で判定しています」を明示する(無言の打ち切り禁止)', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-re-6', 'get_tuning_rule_effect', { rule_id: 42 }))
+        .mockResolvedValueOnce(makeGroqResponse('効果はこちらです。'));
+
+      mockGetRuleEffect.mockResolvedValueOnce({
+        status: 'ok', ruleId: 42, tenantId: 'tenant-abc', approvedAt: '2026-08-01T00:00:00.000Z',
+        truncated: true, analyzedSessions: 5000,
+        comparison: { minSampleSize: 5, groups: {}, did: { estimate: 5, ci95: [1, 9] }, naiveTreatmentDelta: 5 },
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルール42の効果を教えて', sessionId: 'sess-re-06' });
+
+      expect(res.body.actions[0].result).toContain('直近5000件のセッションで判定しています');
+    });
+
+    it('未承認(not_yet_approved)のルールは効果を判定できない旨を返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-re-7', 'get_tuning_rule_effect', { rule_id: 42 }))
+        .mockResolvedValueOnce(makeGroqResponse('まだ承認されていません。'));
+
+      mockGetRuleEffect.mockResolvedValueOnce({ status: 'not_yet_approved', ruleId: 42, tenantId: 'tenant-abc' });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルール42の効果を教えて', sessionId: 'sess-re-07' });
+
+      expect(res.body.actions[0].result).toContain('まだ承認されていません');
+    });
+
+    it('存在しないルールIDは「見つかりません」を返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-re-8', 'get_tuning_rule_effect', { rule_id: 9999 }))
+        .mockResolvedValueOnce(makeGroqResponse('見つかりませんでした。'));
+
+      mockGetRuleEffect.mockResolvedValueOnce({ status: 'rule_not_found' });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルール9999の効果を教えて', sessionId: 'sess-re-08' });
+
+      expect(res.body.actions[0].result).toContain('見つかりません');
+    });
+
+    // 越境防止: 他テナントのルールIDを直接指定されても、存在有無を漏らさず「見つからない」に倒す
+    it('回帰: 他テナントのルールIDを指定しても、存在有無を漏らさず「見つかりません」を返す', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-re-9', 'get_tuning_rule_effect', { rule_id: 77 }))
+        .mockResolvedValueOnce(makeGroqResponse('見つかりませんでした。'));
+
+      mockGetRuleEffect.mockResolvedValueOnce({
+        status: 'ok', ruleId: 77, tenantId: 'tenant-zzz', approvedAt: '2026-08-01T00:00:00.000Z',
+        truncated: false, analyzedSessions: 40,
+        comparison: { minSampleSize: 5, groups: {}, did: { estimate: 5, ci95: [1, 9] }, naiveTreatmentDelta: 5 },
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルール77の効果を教えて', sessionId: 'sess-re-09' });
+
+      const result = res.body.actions[0].result as string;
+      expect(result).toContain('見つかりません');
+      expect(result).not.toContain('5点'); // 他テナントの数値が漏れていない
+    });
+
+    it('getRuleEffectが例外を投げても500にならず、失敗を伝える', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-re-10', 'get_tuning_rule_effect', { rule_id: 42 }))
+        .mockResolvedValueOnce(makeGroqResponse('取得に失敗しました。'));
+
+      mockGetRuleEffect.mockRejectedValueOnce(new Error('connection terminated'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルール42の効果を教えて', sessionId: 'sess-re-10' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('失敗');
+    });
+
+    it('rule_idが数値でない場合はgetRuleEffectを呼ばずに案内する', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-re-11', 'get_tuning_rule_effect', { rule_id: 'abc' }))
+        .mockResolvedValueOnce(makeGroqResponse('ルールIDを教えてください。'));
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'そのルールの効果を教えて', sessionId: 'sess-re-11' });
+
+      expect(mockGetRuleEffect).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('ルールIDを指定してください');
+    });
+
+    it('会話本文がtext/cardいずれにも含まれない(Anti-Slop、ruleEffect.ts自体が本文を返さない契約に依存)', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-re-12', 'get_tuning_rule_effect', { rule_id: 42 }))
+        .mockResolvedValueOnce(makeGroqResponse('効果はこちらです。'));
+
+      mockGetRuleEffect.mockResolvedValueOnce({
+        status: 'ok', ruleId: 42, tenantId: 'tenant-abc', approvedAt: '2026-08-01T00:00:00.000Z',
+        truncated: false, analyzedSessions: 40,
+        comparison: { minSampleSize: 5, groups: {}, did: { estimate: 5, ci95: [1, 9] }, naiveTreatmentDelta: 5 },
+      });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'ルール42の効果を教えて', sessionId: 'sess-re-12' });
+
+      expect(JSON.stringify(res.body)).not.toContain('返品したい');
     });
   });
 

--- a/src/api/admin/agent/confirmPolicy.ts
+++ b/src/api/admin/agent/confirmPolicy.ts
@@ -122,6 +122,7 @@ export const NON_WRITE_TOOLS: readonly string[] = [
   'get_legacy_ui_link',
   'get_analytics_summary',
   'get_conversion_summary',
+  'get_tuning_rule_effect',
   // suggest_* / generate_* はLLMを呼ぶため課金は発生するが、永続化はしない下書き生成。
   'suggest_tuning_rule',
   'suggest_faq',

--- a/src/api/admin/agent/toolDefinitions.ts
+++ b/src/api/admin/agent/toolDefinitions.ts
@@ -1413,4 +1413,26 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
       },
     },
   },
+  {
+    type: 'function',
+    function: {
+      name: 'get_tuning_rule_effect',
+      description:
+        '承認済みの指示ルールが実際に効いているかを、承認前後のJudgeスコア比較（DiD推定）で' +
+        '確認する読み取り専用ツール。「このルール効いてる?」「効果を教えて」と聞かれた時に使う。' +
+        '判定に十分な会話数が無い場合は数値を出さず、あと何件・何日でわかりそうかを返す' +
+        '（母数不足のときに断定的な数値を出すと誤った自信を与えるため）。まだ承認されていないルールは' +
+        '効果を判定できない旨を返す。',
+      parameters: {
+        type: 'object',
+        properties: {
+          rule_id: {
+            type: 'number',
+            description: '指示ルールのID。get_tuning_rules が返す一覧の id をそのまま指定する',
+          },
+        },
+        required: ['rule_id'],
+      },
+    },
+  },
 ];


### PR DESCRIPTION
## Summary
Asanaタスク T2 (GID 1217752902900002)。既存の `getRuleEffect`(PR #869)をチャットから呼べるようにする第一歩。この段階ではカードを作らずtextのみ(カードは次PR: T3/T4)。

- `toolDefinitions.ts`: `get_tuning_rule_effect` を追加(`rule_id` 必須)
- `actionExecutor.ts`: `getRuleEffect` を関数として直接呼ぶ(自APIへHTTPしない)。越境チェックをcase内で行い、他テナントのIDは存在有無を漏らさず「見つかりません」に倒す。母数不足時は率・%・矢印を一切出さず到達条件のみ返す(CLAUDE.md禁止34)。信頼区間の符号で「効いている/逆効果/まだ判定できません」の3値に翻訳し、断定語は使わない
- `confirmPolicy.ts` / `copilot-preview/index.tsx` の `REAL_TOOL_LABEL`: 必須3点セットの登録(`confirmPolicy.test.ts` が機械検査)

**⚠️ `admin-ui/src` を1行(REAL_TOOL_LABEL)含むため Tier S です。hkobayashi の手動マージが必要です。**

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `agentRoutes.test.ts` に `describe('get_tuning_rule_effect')` を追加、12/12 green
- [x] `confirmPolicy.test.ts` 23/23 green(3点セット登録の機械検査)
- [x] revert検証: 越境チェックを外すと「他テナントのルールIDを指定しても見つかりませんを返す」テストが赤くなることを確認 → 復元
- [x] revert検証: 母数不足時に%を計算するコードを混ぜると「率・%・矢印を一切出さない」テストが赤くなることを確認 → 復元
- [x] `npx oxlint` — clean
- [x] `agentRoutes.ts` の `UNTRUSTED_TEXT_READ_TOOLS` には追加していない(`getRuleEffect` は会話本文を返さない契約。Anti-Slopテストで固定済み)