### PR TITLE
feat(agent): ルール効果カードの型を3層(サーバ/transport/UI予約)に定義する

### DIFF
--- a/admin-ui/src/lib/useAgentChatTransport.ts
+++ b/admin-ui/src/lib/useAgentChatTransport.ts
@@ -25,8 +25,9 @@ export type AnsweredFrom = "faq_list" | "tool_action" | "general";
 
 // バックエンド(actionExecutor.ts の各 *CardPayload)が自然文に添えて返す構造化カード。
 // card を返すのは get_legacy_ui_link / get_tuning_rules / get_weekly_briefing /
-// get_chat_sessions / get_chat_session_messages / get_conversation_evaluation のみで、
-// 他のツールは従来どおり result の自然文のみ。フィールド形はサーバ側の型と1:1で対応させる
+// get_chat_sessions / get_chat_session_messages / get_conversation_evaluation /
+// get_knowledge_gaps / get_tuning_rule_effect のみで、他のツールは従来どおり
+// result の自然文のみ。フィールド形はサーバ側の型と1:1で対応させる
 // (型定義箇所はサーバ/ここの2箇所に限る)。
 export type ConversationEvaluationAgentActionCard = {
   kind: "conversation_evaluation";
@@ -134,6 +135,30 @@ export type WeeklySummaryAgentActionCard = {
   gaps: { total: number; top: Array<{ id: number; question: string }> } | null;
 };
 
+// GID 1217752900578379 (R4): ルール効果(DiD推定)カード。フィールド形状は
+// src/api/admin/agent/actionExecutor.ts の RuleEffectCardPayload と1対1に保つ。
+// comparison/progress は互いに排他(母数充足時はcomparisonのみ非null)。
+export type RuleEffectAgentActionCard = {
+  kind: "rule_effect";
+  ruleId: number;
+  approvedAt: string;
+  truncated: boolean;
+  analyzedSessions: number;
+  comparison: {
+    didEstimate: number;
+    ci95Low: number;
+    ci95High: number;
+    naiveTreatmentDelta: number;
+  } | null;
+  progress: Array<{
+    group: string;
+    groupLabel: string;
+    currentN: number;
+    requiredN: number;
+    etaDays: number | null;
+  }> | null;
+};
+
 export type AgentActionCard =
   | LegacyLinkAgentActionCard
   | AvatarPresetAgentActionCard
@@ -144,7 +169,8 @@ export type AgentActionCard =
   | ChatSessionListAgentActionCard
   | ChatSessionMessagesAgentActionCard
   | ConversationEvaluationAgentActionCard
-  | KnowledgeGapsListAgentActionCard;
+  | KnowledgeGapsListAgentActionCard
+  | RuleEffectAgentActionCard;
 
 export type AgentAction = { tool: string; result: string; card?: AgentActionCard };
 

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -454,6 +454,35 @@ export type KnowledgeGapsListCardPayload = {
   totalCount: number;
 };
 
+// GID 1217752900578379 (R4): ルール効果(DiD推定)カード。
+// ruleEffect.ts のAPIレスポンスはトップレベルsnake_case・comparison内camelCaseが
+// 混在しているが(既存の歪みでスコープ外)、カードはここで一貫したcamelCaseに吸収する。
+// comparison/progress は互いに排他(母数充足時はcomparisonのみ、不足時はprogressのみ)。
+// 母数不足時は数値を0埋めせずnullにする(WeeklySummaryCardPayloadと同じ規約)。
+// 3層同期(useAgentChatTransport.ts の RuleEffectAgentActionCard /
+// copilot-preview/index.tsx の Card union)はこのフィールド形状と一致させること。
+export type RuleEffectCardPayload = {
+  kind: 'rule_effect';
+  ruleId: number;
+  approvedAt: string;
+  truncated: boolean;
+  analyzedSessions: number;
+  comparison: {
+    didEstimate: number;
+    ci95Low: number;
+    ci95High: number;
+    naiveTreatmentDelta: number;
+  } | null;
+  progress: Array<{
+    group: string;
+    /** 店主向けの日本語ラベル。旧UIに同等表示が無いためここが唯一の語彙(フロントに辞書を二重持ちしない)。 */
+    groupLabel: string;
+    currentN: number;
+    requiredN: number;
+    etaDays: number | null;
+  }> | null;
+};
+
 export type ActionCardPayload =
   | LegacyLinkCardPayload
   | AvatarPresetCardPayload
@@ -464,7 +493,8 @@ export type ActionCardPayload =
   | ChatSessionListCardPayload
   | ChatSessionMessagesCardPayload
   | ConversationEvaluationCardPayload
-  | KnowledgeGapsListCardPayload;
+  | KnowledgeGapsListCardPayload
+  | RuleEffectCardPayload;
 
 // ツール結果は既定では素の文字列で、構造化データを添えるツールだけが
 // { text, card } 形を返す。card は text の置き換えではなく追加である
@@ -3617,37 +3647,72 @@ export async function executeToolCall(
         }
 
         if (result.status === 'insufficient_data') {
-          // ruleEffect.ts の4群ラベル。旧UIに同等の表示は無いためここが唯一の語彙。
+          // ruleEffect.ts の4群ラベル。旧UIに同等の表示は無いためここが唯一の語彙
+          // (フロントに同じ辞書を二重持ちさせない。ConversationEvaluationCardPayload の
+          // axes[].label / ChatSessionMessagesCardPayload の roleLabel と同じ作法)。
           const groupLabel: Record<string, string> = {
             beforeTreatment: '承認前・該当する会話',
             afterTreatment: '承認後・該当する会話',
             beforeControl: '承認前・該当しない会話',
             afterControl: '承認後・該当しない会話',
           };
+          const card: RuleEffectCardPayload = {
+            kind: 'rule_effect',
+            ruleId,
+            approvedAt: result.approvedAt,
+            truncated: result.truncated,
+            analyzedSessions: result.analyzedSessions,
+            comparison: null,
+            progress: result.progress.map((p) => ({
+              group: p.group,
+              groupLabel: groupLabel[p.group] ?? p.group,
+              currentN: p.currentN,
+              requiredN: p.requiredN,
+              etaDays: p.etaDays,
+            })),
+          };
           const lines = [
             `指示ルール（ID: ${ruleId}）はまだ効果を判定できません（判定に必要な会話数が不足しています）`,
           ];
-          for (const p of result.progress) {
-            const label = groupLabel[p.group] ?? p.group;
+          for (const p of card.progress!) {
             const eta = p.etaDays != null ? `、現ペースであと約${p.etaDays}日` : '';
-            lines.push(`・${label}: 現在${p.currentN}件 / 必要${p.requiredN}件${eta}`);
+            lines.push(`・${p.groupLabel}: 現在${p.currentN}件 / 必要${p.requiredN}件${eta}`);
           }
-          return truncate(lines.join('\n'));
+          return { text: truncate(lines.join('\n')), card };
         }
 
         // status === 'ok'
         const { did, naiveTreatmentDelta } = result.comparison;
         const [ciLow, ciHigh] = did.ci95;
-        const verdict = ciLow > 0 ? '効いている可能性が高いです' : ciHigh < 0 ? '逆効果の可能性があります' : 'まだ判定できません（差が誤差の範囲内です）';
+        const card: RuleEffectCardPayload = {
+          kind: 'rule_effect',
+          ruleId,
+          approvedAt: result.approvedAt,
+          truncated: result.truncated,
+          analyzedSessions: result.analyzedSessions,
+          comparison: {
+            didEstimate: did.estimate,
+            ci95Low: ciLow,
+            ci95High: ciHigh,
+            naiveTreatmentDelta,
+          },
+          progress: null,
+        };
+        const verdict =
+          card.comparison!.ci95Low > 0
+            ? '効いている可能性が高いです'
+            : card.comparison!.ci95High < 0
+              ? '逆効果の可能性があります'
+              : 'まだ判定できません（差が誤差の範囲内です）';
         const lines = [
           `指示ルール（ID: ${ruleId}）の効果: ${verdict}`,
-          `推定差分: ${did.estimate}点（95%信頼区間: ${ciLow}〜${ciHigh}）`,
-          `参考（対照群との比較前の単純差分）: ${naiveTreatmentDelta}点`,
+          `推定差分: ${card.comparison!.didEstimate}点（95%信頼区間: ${card.comparison!.ci95Low}〜${card.comparison!.ci95High}）`,
+          `参考（対照群との比較前の単純差分）: ${card.comparison!.naiveTreatmentDelta}点`,
         ];
-        if (result.truncated) {
-          lines.push(`※直近${result.analyzedSessions}件のセッションで判定しています`);
+        if (card.truncated) {
+          lines.push(`※直近${card.analyzedSessions}件のセッションで判定しています`);
         }
-        return truncate(lines.join('\n'));
+        return { text: truncate(lines.join('\n')), card };
       } catch (err) {
         logger.warn('[actionExecutor] get_tuning_rule_effect failed', err);
         return truncate('ルール効果の取得に失敗しました');

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -6722,6 +6722,16 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(result).toContain('5.2点');
       expect(result).toContain('1.1〜9.3');
       expect(result).not.toContain('直近'); // truncated=falseのときは打ち切り注記を出さない
+      // text と card は同一オブジェクトから組み立てる(2箇所で別計算しない)
+      expect(res.body.actions[0].card).toEqual({
+        kind: 'rule_effect',
+        ruleId: 42,
+        approvedAt: '2026-08-01T00:00:00.000Z',
+        truncated: false,
+        analyzedSessions: 40,
+        comparison: { didEstimate: 5.2, ci95Low: 1.1, ci95High: 9.3, naiveTreatmentDelta: 8.5 },
+        progress: null,
+      });
     });
 
     it('信頼区間の上限が0未満のときは「逆効果の可能性」と返す(断定語を使わない)', async () => {
@@ -6796,6 +6806,13 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(result).not.toContain('効果なし');
       expect(result).not.toContain('改善');
       expect(result).not.toContain('悪化');
+      // 回帰: card側も母数不足時はcomparisonがnullで、数値(0埋め)が混入していない
+      const card = res.body.actions[0].card;
+      expect(card.comparison).toBeNull();
+      expect(card.progress).toEqual([
+        { group: 'afterTreatment', groupLabel: '承認後・該当する会話', currentN: 2, requiredN: 5, etaDays: 10 },
+        { group: 'beforeControl', groupLabel: '承認前・該当しない会話', currentN: 4, requiredN: 5, etaDays: null },
+      ]);
     });
 
     it('etaDaysがnullの群は見込み日数を出さない(before群は観測期間固定のため)', async () => {


### PR DESCRIPTION
## Summary
Asanaタスク T3 (GID 1217752822378591)。**PR #875(T2)のスタックPRです。先にT2をマージしてください。**

数値をLLMの生成文ではなくサーバの構造化データで返せるようにする(CLAUDE.md禁止17)。描画は次PR(T4)。本PRは型定義とtext/cardの同時組み立てのみ。

- `actionExecutor.ts`: `RuleEffectCardPayload` を定義し `ActionCardPayload` unionに追加。`ruleEffect.ts` の既存レスポンス(トップレベルsnake_case/comparison内camelCase混在)をカード層で吸収し一貫camelCaseにする。母数不足時は `comparison` をnull、充足時は `progress` をnullにし0埋めしない(`WeeklySummaryCardPayload` と同じ規約)
- `get_tuning_rule_effect` のcaseをtext/card両方を返すよう変更。textはcardオブジェクトから導出し、2箇所で別々に計算しない(食い違い防止)
- `useAgentChatTransport.ts`: `RuleEffectAgentActionCard` を `AgentActionCard` unionに追加(サーバ側の型と1:1)

## Test plan
- [x] `npx tsc --noEmit`(サーバ) / `npx tsc -b --noEmit`(admin-ui) — clean
- [x] card検証を含むテスト2本を拡張、12/12 green
- [x] revert検証: `insufficient_data` 時に `comparison` を0埋めするバグを再現すると新規assertionが赤くなることを確認 → 復元
- [x] `npx oxlint` — clean