### PR TITLE
test(agent): カード3層同期の機械的ガードと、承認から効果表示までの端から端までのテストを追加する

### DIFF
--- a/src/api/admin/agent/cardPayloadSync.test.ts
+++ b/src/api/admin/agent/cardPayloadSync.test.ts
@@ -1,0 +1,91 @@
+// src/api/admin/agent/cardPayloadSync.test.ts
+//
+// GID 1217752900578379 (R4): 構造化カードの3層同期を機械的に検査する。
+//
+// なぜ confirmPolicy.test.ts に含めないか: confirmPolicy.test.ts の責務は
+// 「書き込みツールの確認ゲート分類が漏れていないか」であり、カードの型同期は
+// 別の関心事(1層でも漏れると型は通るのに画面に描画されない、という別種の障害)。
+// 混ぜると「このテストが何を守っているか」がテスト名から追えなくなるため分ける。
+//
+// 3層の実体:
+//   1. サーバの型 — src/api/admin/agent/actionExecutor.ts の各 *CardPayload
+//      (kind は snake_case のシングルクォート文字列リテラル)
+//   2. transport層の型 — admin-ui/src/lib/useAgentChatTransport.ts の
+//      各 *AgentActionCard (kind は snake_case のダブルクォート文字列リテラル。
+//      サーバ側と1:1で対応するが型そのものは共有できない)
+//   3. UIの変換分岐 — admin-ui/src/pages/copilot-preview/index.tsx の
+//      `if (a.card?.kind === "...")` (サーバのcardをUI用のCard型へ変換する箇所。
+//      ここに分岐が無いと、型は通るのに何も描画されない)
+//
+// confirmPolicy.test.ts と同じ手法(readFileSync + 正規表現)で3ファイルを
+// 突き合わせ、どちらか一方だけに存在する kind を検出する。
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const ACTION_EXECUTOR_PATH = join(__dirname, 'actionExecutor.ts');
+const TRANSPORT_PATH = join(__dirname, '../../../../admin-ui/src/lib/useAgentChatTransport.ts');
+const COPILOT_PREVIEW_PATH = join(__dirname, '../../../../admin-ui/src/pages/copilot-preview/index.tsx');
+
+/** actionExecutor.ts の各 *CardPayload 型が持つ kind リテラル(シングルクォート)。 */
+function readServerCardKinds(): string[] {
+  const source = readFileSync(ACTION_EXECUTOR_PATH, 'utf8');
+  return [...source.matchAll(/^\s*kind:\s*'([a-z0-9_]+)';/gm)].map((m) => m[1]!);
+}
+
+/** useAgentChatTransport.ts の各 *AgentActionCard 型が持つ kind リテラル(ダブルクォート)。 */
+function readTransportCardKinds(): string[] {
+  const source = readFileSync(TRANSPORT_PATH, 'utf8');
+  return [...source.matchAll(/^\s*kind:\s*"([a-z0-9_]+)";/gm)].map((m) => m[1]!);
+}
+
+/**
+ * copilot-preview/index.tsx がサーバの card を UI の Card へ変換している分岐で
+ * 参照している snake_case の kind。`a.card?.kind === "..."` の形で出現する箇所を
+ * すべて拾う(weeklySummary/chat_session_list のようにチップ生成用に複数箇所で
+ * 参照されるものもあるため重複除去する)。
+ */
+function readCopilotPreviewHandledKinds(): Set<string> {
+  const source = readFileSync(COPILOT_PREVIEW_PATH, 'utf8');
+  const matches = [...source.matchAll(/a\.card\?\.kind === "([a-z0-9_]+)"/g)].map((m) => m[1]!);
+  return new Set(matches);
+}
+
+describe('cardPayloadSync: サーバ/transport/UI変換分岐の3層同期', () => {
+  it('サーバ(actionExecutor.ts)の全カードkindが、transport層(useAgentChatTransport.ts)にも存在する', () => {
+    const serverKinds = new Set(readServerCardKinds());
+    const transportKinds = new Set(readTransportCardKinds());
+    const missingInTransport = [...serverKinds].filter((k) => !transportKinds.has(k));
+    expect(missingInTransport).toEqual([]);
+  });
+
+  it('transport層(useAgentChatTransport.ts)の全カードkindが、サーバ(actionExecutor.ts)にも存在する(stale型の検出)', () => {
+    const serverKinds = new Set(readServerCardKinds());
+    const transportKinds = new Set(readTransportCardKinds());
+    const staleInTransport = [...transportKinds].filter((k) => !serverKinds.has(k));
+    expect(staleInTransport).toEqual([]);
+  });
+
+  // 回帰: T3(#876)の作業中、useAgentChatTransport.ts の RuleEffectAgentActionCard に
+  // groupLabel フィールドを追加し忘れたまま amend せずに進めていたら、型は通っても
+  // 画面に群ラベルが出ない状態でマージされていた。フィールド単位の欠落はこのテストでは
+  // 検出できない(kindの存在有無のみを見る)ため、フィールド形状はレビューで見る必要がある
+  // ことを明示しておく。
+  it('transport層の全カードkindが、UIの変換分岐(copilot-preview/index.tsx)でも処理されている(1層漏れの検出)', () => {
+    const transportKinds = new Set(readTransportCardKinds());
+    const handledKinds = readCopilotPreviewHandledKinds();
+    const unhandled = [...transportKinds].filter((k) => !handledKinds.has(k));
+    expect(unhandled).toEqual([]);
+  });
+
+  it('UIの変換分岐が参照しているkindは、すべてtransport層に実在する(削除済みkindへの参照が残っていないか)', () => {
+    const transportKinds = new Set(readTransportCardKinds());
+    const handledKinds = readCopilotPreviewHandledKinds();
+    const dangling = [...handledKinds].filter((k) => !transportKinds.has(k));
+    expect(dangling).toEqual([]);
+  });
+
+  it('サーバのカードkind一覧が空でない(パスやパターンが壊れて0件を誤って通過させていないか)', () => {
+    expect(readServerCardKinds().length).toBeGreaterThan(5);
+  });
+});

--- a/src/api/admin/tuning/tuningRulesRepository.test.ts
+++ b/src/api/admin/tuning/tuningRulesRepository.test.ts
@@ -13,6 +13,7 @@ import {
   buildTuningPromptSection,
   type TuningRule,
 } from './tuningRulesRepository';
+import { getRuleEffect } from '../analytics/ruleEffect';
 
 describe('listRules', () => {
   beforeEach(() => {
@@ -390,5 +391,68 @@ describe('buildTuningPromptSection — 採用済み返答の注入(D7)', () => {
 
     expect(output).toContain('あ'.repeat(300));
     expect(output).not.toContain('あ'.repeat(301));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GID 1217752900578379 (R4): 端から端まで — チャット承認(updateRule)が書いた
+// approved_at を、効果測定(ruleEffect.ts の getRuleEffect)が実際に読めることを
+// 1本で通す。単体テストがモジュール内で閉じていたために「機能は完成・テストは
+// 緑・ロードマップは完了」のまま配線が切れていた前例が複数あるため
+// (CLAUDE.md「端から端までを1本書く」)、updateRule と getRuleEffect という
+// 別モジュールの関数が同じ tuning_rules 行を介して正しく繋がることを検証する。
+// getRuleEffect は db を引数で受け取れる設計のため、updateRule が使う
+// getPool()モック(mockQuery)をそのまま共有DBとして渡せる。
+// ---------------------------------------------------------------------------
+describe('端から端まで: チャット承認(updateRule) → 効果測定(getRuleEffect)', () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it('回帰: status="active"で承認すると、直後にgetRuleEffectを呼んでもnot_yet_approvedを返さない', async () => {
+    // 1. チャット承認: updateRule(id, { status: 'active' }, tenantId)
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ id: 42, tenant_id: 'tenant-abc' }] }) // 所有権確認SELECT
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 42, tenant_id: 'tenant-abc', trigger_pattern: '返品', expected_behavior: '7日以内に対応',
+          status: 'active', approved_at: '2026-08-20T00:00:00.000Z',
+        }],
+      }); // UPDATE...RETURNING(承認時刻が入る)
+
+    const updated = await updateRule(42, { status: 'active' }, 'tenant-abc');
+    expect(updated?.approved_at).toBe('2026-08-20T00:00:00.000Z');
+
+    // 2. 直後に効果を確認: getRuleEffect(db, ruleId)
+    //    fetchRuleMeta が読む approved_at は、上記1で書き込まれた値と同じにする
+    //    (別モジュールが同じ行を正しく読めることの検証。値の一致自体が本テストの主眼)。
+    mockQuery
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 42, tenant_id: 'tenant-abc', trigger_pattern: '返品',
+          created_at: '2026-08-01T00:00:00.000Z', approved_at: '2026-08-20T00:00:00.000Z',
+        }],
+      }) // fetchRuleMeta
+      .mockResolvedValueOnce({ rows: [] }); // fetchCandidateSessions(まだ会話が無い状態)
+
+    const result = await getRuleEffect({ query: mockQuery } as any, 42);
+
+    // not_yet_approved のまま止まっていない = updateRule の書き込みを getRuleEffect が
+    // 正しく読めている。会話がまだ無いため insufficient_data に進む(これも正しい挙動)。
+    expect(result.status).not.toBe('not_yet_approved');
+    expect(result.status).toBe('insufficient_data');
+  });
+
+  it('承認前(approved_atがNULLのまま)にgetRuleEffectを呼ぶとnot_yet_approvedを返す(対照: 承認していれば進むことの裏付け)', async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [{
+        id: 42, tenant_id: 'tenant-abc', trigger_pattern: '返品',
+        created_at: '2026-08-01T00:00:00.000Z', approved_at: null,
+      }],
+    });
+
+    const result = await getRuleEffect({ query: mockQuery } as any, 42);
+
+    expect(result.status).toBe('not_yet_approved');
   });
 });


### PR DESCRIPTION
## Summary
Asanaタスク T6 (GID 1217752826110642)。**PR #878(T5)のスタックPRです。T2→T3→T4→T5の順にマージしてから本PRをレビューしてください。これがR4実装の最終PRです。**

「機能は完成・テストは緑・ロードマップは完了」のまま配線が切れていた前例(rule-effect APIが呼び出し0件でマージされた件、PR #869)の再発防止。

- **[新規]** `cardPayloadSync.test.ts`: `confirmPolicy.test.ts` と同じ readFileSync 手法で、サーバ/transport/UI変換分岐の3層に現れるカードkind文字列を突き合わせる。`confirmPolicy.test.ts` とは別関心事(確認ゲート分類の網羅性 vs カード型同期)のため新規ファイルとした
- `tuningRulesRepository.test.ts`: 「端から端まで」describeを追加。`updateRule`(チャット承認)と`getRuleEffect`(効果測定)という別モジュールの関数が、`getRuleEffect`のdb引数注入可能な設計を利用して同じモックDBを共有し、承認直後に効果測定が`not_yet_approved`を返さないことを1本で検証する

これで学習ループ R4「変更の効果が測れる」のDoD②が満たされます。

## Test plan
- [x] `npx tsc --noEmit` — clean
- [x] `cardPayloadSync.test.ts` 5/5 green。revert検証: transport層のkindを1つ壊すと2テストが赤くなることを確認 → 復元
- [x] `tuningRulesRepository.test.ts` 31/31 green(端から端まで2本含む)。revert検証: `fetchRuleMeta`の承認判定を壊すとテストが赤くなることを確認 → 復元
- [x] `src/api/admin/{agent,tuning,analytics,evaluations}` 一括: 30スイート985/985 green(既存回帰なし)
- [x] `npx oxlint` — clean