### PR TITLE
feat(widget): 「Powered by R2C」バッジを追加し、Growth以上で非表示にできるようにする

### DIFF
--- a/admin-ui/src/lib/planFeatures.test.ts
+++ b/admin-ui/src/lib/planFeatures.test.ts
@@ -25,6 +25,9 @@ describe("planHasFeature", () => {
     ["starter", "pre_dispatch", false],
     ["growth", "pre_dispatch", false],
     ["enterprise", "pre_dispatch", true],
+    ["starter", "hide_branding", false],
+    ["growth", "hide_branding", true],
+    ["enterprise", "hide_branding", true],
   ] as const)("%s プランで %s = %s", (plan, feature, expected) => {
     expect(planHasFeature(plan, feature)).toBe(expected);
   });

--- a/admin-ui/src/lib/planFeatures.ts
+++ b/admin-ui/src/lib/planFeatures.ts
@@ -26,7 +26,8 @@ export type GatedFeature =
   | "deep_research"
   | "premium_avatar"
   | "sai_task"
-  | "pre_dispatch";
+  | "pre_dispatch"
+  | "hide_branding";
 
 const FEATURE_MIN_PLAN: Record<GatedFeature, TenantPlan> = {
   avatar: "growth",
@@ -39,6 +40,8 @@ const FEATURE_MIN_PLAN: Record<GatedFeature, TenantPlan> = {
   sai_task: "enterprise",
   // GID 1216944004404664: 事前ディスパッチ(アバター高速表示)はLP表記どおりEnterprise限定
   pre_dispatch: "enterprise",
+  // ウィジェットの「Powered by R2C」バッジ非表示権。Growth以上の特典として料金表に明記する。
+  hide_branding: "growth",
 };
 
 /**

--- a/public/lp/from-chat/index.html
+++ b/public/lp/from-chat/index.html
@@ -1,0 +1,181 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>今のAIチャットについて — R2C</title>
+  <meta name="description" content="今お使いだったAIチャットは「R2C」です。あなたのサイトにも、24時間365日働くAI接客を導入できます。">
+  <meta name="robots" content="noindex">
+  <style>
+    :root {
+      --bg: #050508;
+      --accent: #7c3aed;
+      --accent-light: #8b5cf6;
+      --muted: #94a3b8;
+    }
+    * { box-sizing: border-box; }
+    html { -webkit-text-size-adjust: 100%; }
+    body {
+      background-color: var(--bg);
+      color: #fff;
+      font-family: system-ui, -apple-system, "Hiragino Sans", "Hiragino Kaku Gothic ProN", sans-serif;
+      margin: 0;
+      min-height: 100vh;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      padding: 24px;
+      line-height: 1.7;
+    }
+    .card {
+      max-width: 480px;
+      width: 100%;
+      text-align: center;
+    }
+    .badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 8px;
+      background: rgba(124, 58, 237, 0.12);
+      border: 1px solid rgba(139, 92, 246, 0.3);
+      border-radius: 999px;
+      padding: 6px 16px;
+      margin-bottom: 28px;
+      font-size: 13px;
+      color: #c4b5fd;
+      font-weight: 600;
+    }
+    .logo-dot {
+      width: 34px;
+      height: 34px;
+      border-radius: 50%;
+      background: linear-gradient(135deg, #7c3aed, #8b5cf6);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-weight: 800;
+      font-size: 14px;
+      color: #fff;
+      margin: 0 auto 20px;
+    }
+    h1 {
+      font-size: clamp(22px, 5vw, 30px);
+      font-weight: 800;
+      line-height: 1.4;
+      margin: 0 0 16px;
+      letter-spacing: -0.5px;
+    }
+    .gradient-text {
+      background: linear-gradient(135deg, #8b5cf6, #d946ef, #06b6d4);
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+    p {
+      font-size: 16px;
+      color: #e5e7eb;
+      margin: 0 0 14px;
+    }
+    p.muted {
+      color: var(--muted);
+      font-size: 15px;
+    }
+    .glass-card {
+      background: rgba(255, 255, 255, 0.04);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 14px;
+      padding: 22px 20px;
+      margin: 28px 0;
+      text-align: left;
+    }
+    .glass-card ul {
+      list-style: none;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      gap: 12px;
+    }
+    .glass-card li {
+      display: flex;
+      gap: 10px;
+      font-size: 15px;
+      color: #e5e7eb;
+    }
+    .glass-card li span {
+      color: #4ade80;
+      flex-shrink: 0;
+    }
+    .cta {
+      display: block;
+      background: linear-gradient(135deg, #7c3aed, #8b5cf6);
+      color: #fff;
+      text-decoration: none;
+      font-weight: 700;
+      font-size: 16px;
+      padding: 16px 24px;
+      min-height: 44px;
+      border-radius: 10px;
+      margin-bottom: 14px;
+    }
+    .cta-secondary {
+      display: inline-block;
+      color: #c4b5fd;
+      text-decoration: none;
+      font-weight: 600;
+      font-size: 14px;
+      padding: 12px 16px;
+      min-height: 44px;
+      line-height: 20px;
+    }
+    footer {
+      margin-top: 32px;
+      font-size: 12px;
+      color: var(--muted);
+    }
+    footer a {
+      color: var(--muted);
+    }
+    @media (prefers-color-scheme: light) {
+      /* このページは常にダークテーマで固定表示する(LP本体 public/lp/index.html と同じ扱い)。 */
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="logo-dot">R2C</div>
+    <div class="badge">💬 今、お話しされていたAIについて</div>
+
+    <h1>それは<span class="gradient-text">R2C</span>という<br>AI接客サービスです</h1>
+    <p class="muted">このサイトに導入されているAIチャットは、R2Cが提供しています。</p>
+
+    <div class="glass-card">
+      <ul>
+        <li><span>✓</span>24時間365日、休まず接客</li>
+        <li><span>✓</span>気になることをすぐ聞ける</li>
+        <li><span>✓</span>導入サイトの情報にもとづいて答える(でたらめを言わない)</li>
+      </ul>
+    </div>
+
+    <p>ご自身のサイトにも、同じようにAI接客を導入できます。</p>
+
+    <a class="cta" href="/lp/index.html#contact" id="cta-primary">自分のサイトにも導入したい →</a>
+    <a class="cta-secondary" href="/lp/index.html">R2Cについてもっと詳しく見る</a>
+
+    <footer>
+      <p class="muted" style="margin:0;">R2C（RAJIUSEC） / <a href="/lp/index.html">r2c.biz</a></p>
+    </footer>
+  </div>
+
+  <script>
+    // バッジ経由の流入(utm_source等・r2c_ref)を、問い合わせ導線まで引き継ぐ。
+    // 新しい問い合わせ経路は作らず、既存LPの #contact フォームへそのまま渡すだけ。
+    (function () {
+      var q = window.location.search;
+      if (!q) return;
+      var cta = document.getElementById('cta-primary');
+      if (cta) cta.href = '/lp/index.html' + q + '#contact';
+    })();
+  </script>
+</body>
+</html>

--- a/public/widget.js
+++ b/public/widget.js
@@ -45,6 +45,11 @@
   var _rajiuceTenantCfg = (typeof window !== 'undefined' && window.__RAJIUCE_TENANT_CFG__) || {};
   var abExperimentId = _rajiuceTenantCfg.abExperimentId || null;
   var abVariant = _rajiuceTenantCfg.abVariant || null;
+  // 「Powered by R2C」バッジ。fail-safe: 静的 /widget.js 埋め込み等で _rajiuceTenantCfg が
+  // 空オブジェクトの場合、showBrandingBadge は undefined になり !== false で true 側に倒れる
+  // （plan判定不能時は「表示する」が安全なデフォルト）。badgeUrl が無ければ描画しない。
+  var showBrandingBadge = _rajiuceTenantCfg.showBrandingBadge !== false;
+  var badgeUrl = _rajiuceTenantCfg.badgeUrl || null;
   var _abExposureSent = false;
   var accentColor = currentScript ? (currentScript.getAttribute('data-accent-color') || '#2563eb') : '#2563eb';
   var greetingText = currentScript ? (currentScript.getAttribute('data-greeting') || 'ご質問はお気軽にどうぞ') : 'ご質問はお気軽にどうぞ';
@@ -496,6 +501,28 @@
     '  align-items: flex-end;',
     '  flex-shrink: 0;',
     '}',
+    /* 「Powered by R2C」バッジ。視覚サイズは小さく、タップ領域は padding で44px確保する */
+    '.r2c-badge {',
+    '  padding: 2px 12px;',
+    '  text-align: center;',
+    '  background: #fff;',
+    '  border-top: 1px solid #f1f5f9;',
+    '  flex-shrink: 0;',
+    '}',
+    '.r2c-badge a {',
+    '  display: inline-flex;',
+    '  align-items: center;',
+    '  justify-content: center;',
+    '  min-height: 44px;',
+    '  padding: 0 10px;',
+    '  font-size: 11px;',
+    '  color: #94a3b8;',
+    '  text-decoration: none;',
+    '  font-weight: 500;',
+    '  letter-spacing: 0.01em;',
+    '}',
+    '.r2c-badge a:hover { color: #64748b; }',
+    '.r2c-badge a:focus-visible { outline: 2px solid #93c5fd; outline-offset: 2px; border-radius: 4px; }',
     'textarea {',
     '  flex: 1;',
     '  min-height: 44px;',
@@ -998,6 +1025,28 @@
   sendBtn.appendChild(SEND_SVG.cloneNode(true));
   var inputArea = el('div', { className: 'input-area', role: 'form', 'aria-label': 'メッセージ入力フォーム' }, [textarea, micBtn, sendBtn]);
   panel.appendChild(inputArea);
+
+  /* --- 「Powered by R2C」バッジ（パネル最終要素。tab順は入力欄より後） ---
+   * showBrandingBadge / badgeUrl は widgetGenerator.ts が plan 判定込みで注入する
+   * fail-safe な値（判定不能時は表示する側に倒れる）。badgeUrl が無ければ描画しない。
+   * EU AI Act 第50条の「AIと対話している」開示も兼ねる文言にする。
+   * rel="nofollow sponsored" は widget が多数のテナントサイトに配布される link scheme
+   * 対策として必須（付けないと r2c.biz 側が Google のペナルティ対象になる）。
+   * noreferrer は付けない（Referer が消えて流入計測が片肺になるため）。
+   */
+  if (showBrandingBadge && badgeUrl) {
+    var badgeLink = el('a', {
+      href: badgeUrl,
+      target: '_blank',
+      rel: 'nofollow sponsored noopener',
+      'aria-label': 'AIチャット by R2C（R2Cのサイトを新しいタブで開きます）',
+    }, 'AIチャット by R2C');
+    badgeLink.addEventListener('click', function () {
+      if (_tracker) _tracker.track('branding_badge_click', { tenant_id: tenantId });
+    });
+    var badgeRow = el('div', { className: 'r2c-badge' }, [badgeLink]);
+    panel.appendChild(badgeRow);
+  }
 
   shadow.appendChild(panel);
 

--- a/src/api/events/eventRoutes.ts
+++ b/src/api/events/eventRoutes.ts
@@ -20,6 +20,8 @@ import {
 const VALID_EVENT_TYPES = [
   'page_view', 'scroll_depth', 'idle_time', 'product_view',
   'exit_intent', 'chat_open', 'chat_message', 'chat_conversion',
+  // 「Powered by R2C」バッジのクリック（widget.js）
+  'branding_badge_click',
 ] as const;
 
 const EventSchema = z.object({

--- a/src/api/widget/routes.test.ts
+++ b/src/api/widget/routes.test.ts
@@ -126,3 +126,105 @@ describe('GET /widget/:tenantSlug.js', () => {
     expect(res.body.error).toBe('widget_generation_failed');
   });
 });
+
+describe('GET /widget/:tenantSlug.js — 「Powered by R2C」バッジ (PR-B)', () => {
+  beforeEach(() => {
+    (generateWidgetJs as jest.Mock).mockClear();
+  });
+
+  it('plan=starter → バッジを表示する(showBrandingBadge=true)', async () => {
+    const db = makePool([
+      { rows: [{ id: 'tenant-a', is_active: true, features: {}, plan: 'starter' }], rowCount: 1 },
+    ]);
+    const app = makeApp(db);
+    await request(app).get('/widget/tenant-a.js');
+    const config = (generateWidgetJs as jest.Mock).mock.calls[0][0];
+    expect(config.showBrandingBadge).toBe(true);
+  });
+
+  it('plan=growth → バッジを表示しない(showBrandingBadge=false)', async () => {
+    const db = makePool([
+      { rows: [{ id: 'tenant-a', is_active: true, features: {}, plan: 'growth' }], rowCount: 1 },
+    ]);
+    const app = makeApp(db);
+    await request(app).get('/widget/tenant-a.js');
+    const config = (generateWidgetJs as jest.Mock).mock.calls[0][0];
+    expect(config.showBrandingBadge).toBe(false);
+  });
+
+  it('plan=enterprise → バッジを表示しない', async () => {
+    const db = makePool([
+      { rows: [{ id: 'tenant-a', is_active: true, features: {}, plan: 'enterprise' }], rowCount: 1 },
+    ]);
+    const app = makeApp(db);
+    await request(app).get('/widget/tenant-a.js');
+    const config = (generateWidgetJs as jest.Mock).mock.calls[0][0];
+    expect(config.showBrandingBadge).toBe(false);
+  });
+
+  it('plan=NULL(未設定) → fail-safeで「表示する」側に倒れる', async () => {
+    const db = makePool([
+      { rows: [{ id: 'tenant-a', is_active: true, features: {}, plan: null }], rowCount: 1 },
+    ]);
+    const app = makeApp(db);
+    await request(app).get('/widget/tenant-a.js');
+    const config = (generateWidgetJs as jest.Mock).mock.calls[0][0];
+    expect(config.showBrandingBadge).toBe(true);
+  });
+
+  it('plan=未知の文字列 → fail-safeで「表示する」側に倒れる(Starterへ「昇格」しない)', async () => {
+    const db = makePool([
+      { rows: [{ id: 'tenant-a', is_active: true, features: {}, plan: 'gold' }], rowCount: 1 },
+    ]);
+    const app = makeApp(db);
+    await request(app).get('/widget/tenant-a.js');
+    const config = (generateWidgetJs as jest.Mock).mock.calls[0][0];
+    expect(config.showBrandingBadge).toBe(true);
+  });
+
+  it('badgeUrl に UTM 4種 + r2c_ref(テナントID) が付与され、着地先が /lp/from-chat/ である', async () => {
+    const db = makePool([
+      { rows: [{ id: 'tenant-a', is_active: true, features: {}, plan: 'starter' }], rowCount: 1 },
+    ]);
+    const app = makeApp(db);
+    await request(app).get('/widget/tenant-a.js');
+    const config = (generateWidgetJs as jest.Mock).mock.calls[0][0];
+    const url = new URL(config.badgeUrl);
+    expect(url.pathname).toBe('/lp/from-chat/');
+    expect(url.searchParams.get('utm_source')).toBe('widget');
+    expect(url.searchParams.get('utm_medium')).toBe('badge');
+    expect(url.searchParams.get('utm_campaign')).toBe('powered_by');
+    expect(url.searchParams.get('r2c_ref')).toBe('tenant-a');
+  });
+});
+
+describe('GET /widget/:tenantSlug.js — バッジが表示されない既知の経路(仕様として固定)', () => {
+  // CLAUDE.md 絶対にやってはいけないこと 38: この3経路は本PRでは是正せず、
+  // 仕様として明示的に固定する。将来これを直す場合は、直したことが分かるように
+  // このテストを書き換えること(黙って挙動が変わらないようにする)。
+
+  it('①静的 /widget.js + data-tenant 埋め込みはこのルートを経由しない(プラン判定なし)', () => {
+    // このルート(GET /widget/:tenantSlug.js)はテナントごとの動的生成専用。
+    // 静的埋め込みは public/widget.js を直接配信するため、そもそもこのハンドラを通らない。
+    // ここでは「動的ルートがバッジ制御の唯一の経路である」ことを明記するのみ(実行不要)。
+    expect(true).toBe(true);
+  });
+
+  it('②db===nullのとき /widget.js へフォールバックし、バッジ制御ロジックを経由しない(fail-open)', async () => {
+    const app = makeApp(null);
+    const res = await request(app).get('/widget/tenant-a.js');
+    expect(res.status).toBe(302);
+    expect(res.headers.location).toBe('/widget.js');
+    // このリダイレクト先(静的widget.js)はプラン判定を経由しないため、
+    // plan由来のbadgeUrl/showBrandingBadgeは注入されない。
+  });
+
+  it('③レスポンスは Cache-Control: max-age=86400 のため、プラン変更の反映に最大24時間かかる', async () => {
+    const db = makePool([
+      { rows: [{ id: 'tenant-a', is_active: true, features: {}, plan: 'growth' }], rowCount: 1 },
+    ]);
+    const app = makeApp(db);
+    const res = await request(app).get('/widget/tenant-a.js');
+    expect(res.headers['cache-control']).toBe('public, max-age=86400');
+  });
+});

--- a/src/api/widget/routes.ts
+++ b/src/api/widget/routes.ts
@@ -10,9 +10,28 @@ import type { Express, Request, Response } from "express";
 import { Pool } from "pg";
 import { generateWidgetJs } from "./widgetGenerator";
 import { resolveAvatarAssignment } from "../conversion/avatarAbExperiment";
+import { planHasFeature } from "../../lib/billing/planFeatures";
 
 const API_BASE_URL =
   process.env.API_BASE_URL ?? "https://api.r2c.biz";
+
+// ウィジェットの「Powered by R2C」バッジの遷移先（LPトップではなく専用着地ページ）。
+// r2c.biz は admin-ui/LP と別ホストなので API_BASE_URL とは独立に持つ。
+const LP_BASE_URL = process.env.LP_BASE_URL ?? "https://r2c.biz";
+
+/**
+ * バッジのリンクURL（UTM + テナント識別子付き）を組み立てる。
+ * rel="nofollow sponsored" はリンク自体（widget.js側）に付与する。ここではURLのみ。
+ */
+function buildBadgeUrl(tenantId: string): string {
+  const params = new URLSearchParams({
+    utm_source: "widget",
+    utm_medium: "badge",
+    utm_campaign: "powered_by",
+    r2c_ref: tenantId,
+  });
+  return `${LP_BASE_URL}/lp/from-chat/?${params.toString()}`;
+}
 
 export function registerWidgetRoutes(app: Express, db: Pool | null): void {
   app.get("/widget/:tenantSlug.js", async (req: Request, res: Response) => {
@@ -25,7 +44,7 @@ export function registerWidgetRoutes(app: Express, db: Pool | null): void {
 
     try {
       const result = await db.query(
-        `SELECT id, is_active, features
+        `SELECT id, is_active, features, plan
          FROM tenants
          WHERE id = $1`,
         [tenantSlug]
@@ -53,6 +72,10 @@ export function registerWidgetRoutes(app: Express, db: Pool | null): void {
       const stickyKey = `${req.ip ?? "unknown"}:${tenant.id}`;
       const assignment = await resolveAvatarAssignment(db, tenant.id, stickyKey, defaultAvatarEnabled);
 
+      // planHasFeature は plan が null/未知/未設定のとき starter 相当に倒れる（fail-safe）ため、
+      // hide_branding を満たさない = true となりバッジは「表示する」側に自然に倒れる。
+      const showBrandingBadge = !planHasFeature(tenant.plan, "hide_branding");
+
       const js = await generateWidgetJs({
         tenantId: tenant.id,
         apiBaseUrl: API_BASE_URL,
@@ -60,6 +83,8 @@ export function registerWidgetRoutes(app: Express, db: Pool | null): void {
         themeColor: "#22c55e",
         abExperimentId: assignment.experimentId,
         abVariant: assignment.variant,
+        showBrandingBadge,
+        badgeUrl: buildBadgeUrl(tenant.id),
       });
 
       res.set("Content-Type", "application/javascript; charset=utf-8");

--- a/src/api/widget/widgetGenerator.test.ts
+++ b/src/api/widget/widgetGenerator.test.ts
@@ -120,3 +120,63 @@ describe("widgetGenerator — WIDGET_JWT_SECRET 分離 (B3)", () => {
     });
   });
 });
+
+describe("widgetGenerator — 「Powered by R2C」バッジ設定の注入 (PR-B)", () => {
+  const originalEnv = { ...process.env };
+
+  // javascript-obfuscator が使える(stringArray:true)と URL 文字列が符号化され
+  // toContain での検証ができなくなるため、この describe では毎回モジュールを
+  // リセットして require を失敗させ、必ず catch 節（生の configBlock + source）を通す。
+  // ファイル冒頭のコメント「obfuscator の有無に依存しない安定したテストにする」と同じ方針。
+  // 静的 import した generateWidgetJs は reset 前の古いモジュールを指したままになるため、
+  // このブロックでは各テスト内で fresh に require し直す。
+  function freshGenerateWidgetJs() {
+    jest.resetModules();
+    // virtual:true は付けない — javascript-obfuscator は実在パッケージ(devDep)であり、
+    // virtual指定はJestのモジュール解決と衝突して無視される（実モジュールが使われてしまう）。
+    jest.doMock("javascript-obfuscator", () => {
+      throw new Error("javascript-obfuscator not available in test");
+    });
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return (require("./widgetGenerator") as typeof import("./widgetGenerator"))
+      .generateWidgetJs;
+  }
+
+  beforeEach(() => {
+    process.env.WIDGET_JWT_SECRET = "s";
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    jest.dontMock("javascript-obfuscator");
+    jest.resetModules();
+  });
+
+  it("showBrandingBadge / badgeUrl 未指定時は既定値(true / null)で埋め込まれる", async () => {
+    const out = await freshGenerateWidgetJs()(BASE_CONFIG);
+    expect(out).toContain("showBrandingBadge: true");
+    expect(out).toContain("badgeUrl: null");
+  });
+
+  it("showBrandingBadge: false, badgeUrl 指定時はそのまま埋め込まれる", async () => {
+    const out = await freshGenerateWidgetJs()({
+      ...BASE_CONFIG,
+      showBrandingBadge: false,
+      badgeUrl: "https://r2c.biz/lp/from-chat/?utm_source=widget&r2c_ref=tenant-a",
+    });
+    expect(out).toContain("showBrandingBadge: false");
+    expect(out).toContain(
+      '"https://r2c.biz/lp/from-chat/?utm_source=widget&r2c_ref=tenant-a"'
+    );
+  });
+
+  it("showBrandingBadge: true, badgeUrl 指定時はそのまま埋め込まれる", async () => {
+    const out = await freshGenerateWidgetJs()({
+      ...BASE_CONFIG,
+      showBrandingBadge: true,
+      badgeUrl: "https://r2c.biz/lp/from-chat/?r2c_ref=tenant-a",
+    });
+    expect(out).toContain("showBrandingBadge: true");
+    expect(out).toContain('"https://r2c.biz/lp/from-chat/?r2c_ref=tenant-a"');
+  });
+});

--- a/src/api/widget/widgetGenerator.ts
+++ b/src/api/widget/widgetGenerator.ts
@@ -16,6 +16,10 @@ export interface TenantWidgetConfig {
   abExperimentId?: number | null;
   /** GID 1216978855735482: アバターA/Bテストの割当variant（実験が無ければnull） */
   abVariant?: "a" | "b" | null;
+  /** 「Powered by R2C」バッジを表示するか（Growth以上は非表示。fail-safeで未設定時はtrue側） */
+  showBrandingBadge?: boolean;
+  /** バッジのリンク先（着地ページ、UTM + テナント識別子付き） */
+  badgeUrl?: string;
 }
 
 const WIDGET_SRC_PATH = path.resolve(process.cwd(), "public", "widget.js");
@@ -65,6 +69,8 @@ export async function generateWidgetJs(config: TenantWidgetConfig): Promise<stri
     avatarEnabled: ${JSON.stringify(config.avatarEnabled ?? false)},
     abExperimentId: ${JSON.stringify(config.abExperimentId ?? null)},
     abVariant: ${JSON.stringify(config.abVariant ?? null)},
+    showBrandingBadge: ${JSON.stringify(config.showBrandingBadge ?? true)},
+    badgeUrl: ${JSON.stringify(config.badgeUrl ?? null)},
     _wt: ${JSON.stringify(token)}
   };
   if (typeof window !== "undefined") {

--- a/src/lib/billing/planFeatures.test.ts
+++ b/src/lib/billing/planFeatures.test.ts
@@ -32,6 +32,9 @@ describe("planHasFeature", () => {
     ["starter", "pre_dispatch", false],
     ["growth", "pre_dispatch", false],
     ["enterprise", "pre_dispatch", true],
+    ["starter", "hide_branding", false],
+    ["growth", "hide_branding", true],
+    ["enterprise", "hide_branding", true],
   ] as const)("%s プランで %s = %s", (plan, feature, expected) => {
     expect(planHasFeature(plan, feature)).toBe(expected);
   });

--- a/src/lib/billing/planFeatures.ts
+++ b/src/lib/billing/planFeatures.ts
@@ -35,7 +35,8 @@ export type GatedFeature =
   | "deep_research"
   | "premium_avatar"
   | "sai_task"
-  | "pre_dispatch";
+  | "pre_dispatch"
+  | "hide_branding";
 
 const FEATURE_MIN_PLAN: Record<GatedFeature, TenantPlan> = {
   avatar: "growth",
@@ -48,6 +49,8 @@ const FEATURE_MIN_PLAN: Record<GatedFeature, TenantPlan> = {
   sai_task: "enterprise",
   // GID 1216944004404664: 事前ディスパッチ(アバター高速表示)はLP表記どおりEnterprise限定
   pre_dispatch: "enterprise",
+  // ウィジェットの「Powered by R2C」バッジ非表示権。Growth以上の特典として料金表に明記する。
+  hide_branding: "growth",
 };
 
 function rank(plan: string | null | undefined): number {

--- a/tests/phase55/eventRoutes.test.ts
+++ b/tests/phase55/eventRoutes.test.ts
@@ -68,6 +68,23 @@ describe('POST /api/events', () => {
       expect(res.status).toBe(202);
       expect(res.body.accepted).toBe(1);
     });
+
+    // PR-B: 「Powered by R2C」バッジのクリック計測。第2の送信経路ではなく、
+    // 既存の behavioral_events / POST /api/events をそのまま使う（widget.js の _tracker.track 経由）。
+    it('branding_badge_click → 202 + accepted:1（既存 behavioral_events 経路をそのまま使う）', async () => {
+      const { app, mockDb } = makeApp({});
+      const res = await request(app)
+        .post('/api/events')
+        .send({
+          visitor_id: 'vid-a',
+          session_id: 'sid-a',
+          events: [{ event_type: 'branding_badge_click', event_data: { tenant_id: 'tenant-a' } }],
+        });
+
+      expect(res.status).toBe(202);
+      expect(res.body.accepted).toBe(1);
+      expect(mockDb.query).toHaveBeenCalledTimes(1);
+    });
   });
 
   describe('認証エラー', () => {


### PR DESCRIPTION
## 何を

ウィジェットに「Powered by R2C」バッジを追加し、Growth以上のプランで非表示にできるようにする。Asana [1217759268133485](https://app.asana.com/0/1213607637045514/1217759268133485)。

## なぜ

R2C には製品自身が新規を連れてくる導線が無く、獲得が営業に完全依存している。プラン間のアップグレード動機も「機能の欠如」しかない。バッジで「消したければ Growth」という引きの動機を作る。

広告収入は目的ではない。R2C は正式ローンチ前で実ユーザー母数が小さい(直近30日で13セッション)ため、**率や統計的有意差での判定はしない**。成功指標はアップグレード件数の絶対値・「バッジを消したい」という問い合わせの発生。ガードレールは carnation の会話ログを目視して体験劣化がないこと(既存の R0 本番検証と同じ手法)。

## 変更内容

| ファイル | 内容 |
|---|---|
| `src/lib/billing/planFeatures.ts` / `admin-ui/src/lib/planFeatures.ts` | `GatedFeature` に `hide_branding`(Growth以上)を追加。**`PLAN_RANK`/`TenantPlan` は変更しない** |
| `src/api/widget/routes.ts` | SELECT に `plan` を追加。`planHasFeature` の結果からバッジ表示可否と着地URL(UTM+テナントID)を算出 |
| `src/api/widget/widgetGenerator.ts` | `showBrandingBadge` / `badgeUrl` を設定ブロックに注入 |
| `public/widget.js` | バッジDOM/CSS追加。タップ領域44px、`rel="nofollow sponsored noopener"`、EU AI Act第50条の開示を兼ねる文言。クリックは既存 `_tracker.track()` 経由(第2の送信経路なし) |
| `src/api/events/eventRoutes.ts` | `VALID_EVENT_TYPES` に `branding_badge_click` を追加 |
| `public/lp/from-chat/index.html`(新規) | バッジの着地ページ。LPトップへは飛ばさず、既存 `#contact` フォームへUTMを引き継ぐ(新しい問い合わせ経路を作らない) |

## fail-safe

`plan` が NULL/未知/DB例外のとき、バッジは**表示する側**に倒れる(`hide_branding` は starter ランク未達で `false` → `showBrandingBadge=true`)。`PLAN_RANK` 自体は変更していないため、Starter への「昇格」は発生しない(CLAUDE.md 絶対にやってはいけないこと37)。

## 既知の未解決(仕様として明示・テストで固定)

- 静的 `/widget.js` + `data-tenant` 埋め込みはこのルートを経由せず、プラン判定なし
- `db===null` 時は `/widget.js` へフォールバックし、バッジ制御を経由しない(fail-open)
- `Cache-Control: max-age=86400` のため、プラン変更の反映に最大24時間かかる

(CLAUDE.md 絶対にやってはいけないこと38。是正は別PRの判断)

## テスト

- `src/lib/billing/planFeatures.test.ts` / `admin-ui/src/lib/planFeatures.test.ts`: `hide_branding` の境界(starter=false/growth=true/enterprise=true)
- `src/api/widget/routes.test.ts`: プラン別バッジ表示、plan=NULL/未知文字列でのfail-safe、badgeUrlのUTM検証、上記3つの既知経路を仕様として固定
- `src/api/widget/widgetGenerator.test.ts`: showBrandingBadge/badgeUrlの注入(javascript-obfuscatorを明示的に無効化し決定的に検証)
- `tests/phase55/eventRoutes.test.ts`: `branding_badge_click` の受理

## Gate結果

- `pnpm typecheck`: 0 errors
- `pnpm lint`: 0 warnings(53/63、変更ファイルに新規警告なし)
- `pnpm test`: 変更した4テストファイルは単体実行で全件パス。フルスイート実行時に `EADDRNOTAVAIL` による失敗が出るが、**変更を退避した状態(main相当)でも同種の失敗が43スイート発生することを確認済み**で、既存の環境要因(ポート枯渇)であり本PRの回帰ではない
- `admin-ui`: `tsc -b` 0 errors、`vitest run src/lib/planFeatures.test.ts` 38/38 pass
- Codex Gate: PR作成後の自動フローに委ねる(未実行)

## 未着手

`tests/e2e/` の 390px モバイルspec追記(タップ領域・入力欄との重なり確認)は未実施。

## レビュー観点

`admin-ui/src` を含むため Tier S。auto-merge を待たず手動マージが必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NF9b7Ew1PiYJmfP5wfs99h