### PR TITLE
chore(knowledge): 書き手のいない is_global の読み取り・描画を撤去する

### DIFF
--- a/admin-ui/src/components/knowledge/KnowledgeListTab.tsx
+++ b/admin-ui/src/components/knowledge/KnowledgeListTab.tsx
@@ -19,7 +19,6 @@ interface KnowledgeItem {
   category: string | null;
   tags: string[] | null;
   is_published?: boolean;
-  is_global?: boolean;
   is_excluded_from_search?: boolean;
   created_at: string;
 }
@@ -59,7 +58,6 @@ export default function KnowledgeListTab({ tenantId }: { tenantId: string }) {
   const [sortOption, setSortOption] = useState<SortOption>("newest");
   const [categoryFilter, setCategoryFilter] = useState<string>("all");
   const [publishFilter, setPublishFilter] = useState<"all" | "published" | "draft">("all");
-  const [globalFilter, setGlobalFilter] = useState<"all" | "global" | "tenant">("all");
 
   const [togglingId, setTogglingId] = useState<number | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<{
@@ -94,7 +92,7 @@ export default function KnowledgeListTab({ tenantId }: { tenantId: string }) {
   // 絞り込み条件が変わったら1ページ目に戻す
   useEffect(() => {
     setOffset(0);
-  }, [search, sortOption, categoryFilter, publishFilter, globalFilter]);
+  }, [search, sortOption, categoryFilter, publishFilter]);
 
   const categoryLabel = useCallback(
     (cat: string | null) => {
@@ -120,8 +118,6 @@ export default function KnowledgeListTab({ tenantId }: { tenantId: string }) {
       if (categoryFilter !== "all") params.set("category", categoryFilter);
       if (publishFilter === "published") params.set("is_published", "true");
       if (publishFilter === "draft") params.set("is_published", "false");
-      if (globalFilter === "global") params.set("is_global", "true");
-      if (globalFilter === "tenant") params.set("is_global", "false");
 
       const res = await fetchWithAuth(`${API_BASE}/v1/admin/knowledge/faq?${params}`);
       if (!res.ok) throw new Error(t("knowledge.load_error"));
@@ -151,7 +147,7 @@ export default function KnowledgeListTab({ tenantId }: { tenantId: string }) {
     } finally {
       setLoading(false);
     }
-  }, [navigate, tenantId, offset, search, sortOption, categoryFilter, publishFilter, globalFilter, t]);
+  }, [navigate, tenantId, offset, search, sortOption, categoryFilter, publishFilter, t]);
 
   useEffect(() => { fetchItems(); }, [fetchItems]);
 
@@ -420,35 +416,6 @@ export default function KnowledgeListTab({ tenantId }: { tenantId: string }) {
           );
         })}
       </div>
-      {/* グローバルナレッジフィルター */}
-      <div style={{ display: "flex", gap: 6, marginBottom: 16, alignItems: "center" }}>
-        {([
-          { v: "all", label: "全て" },
-          { v: "tenant", label: "テナント別" },
-          { v: "global", label: "⭐ グローバルのみ" },
-        ] as const).map(({ v, label }) => {
-          const active = globalFilter === v;
-          return (
-            <button
-              key={v}
-              onClick={() => setGlobalFilter(v)}
-              style={{
-                padding: "4px 12px",
-                minHeight: 32,
-                borderRadius: 999,
-                border: `1px solid ${active ? "rgba(234,179,8,0.5)" : "#374151"}`,
-                background: active ? "rgba(234,179,8,0.1)" : "transparent",
-                color: active ? "#fbbf24" : "#6b7280",
-                fontSize: 12,
-                cursor: "pointer",
-              }}
-            >
-              {label}
-            </button>
-          );
-        })}
-      </div>
-
       {error && (
         <div style={{ marginBottom: 16, padding: "14px 18px", borderRadius: 12, background: "rgba(127,29,29,0.4)", border: "1px solid rgba(248,113,113,0.3)", color: "#fca5a5", fontSize: 15 }}>
           {error}
@@ -539,14 +506,6 @@ export default function KnowledgeListTab({ tenantId }: { tenantId: string }) {
                       ? t("knowledge.badge_not_answering")
                       : t("knowledge.badge_answering")}
                   </span>
-                  {item.is_global && (
-                    <span style={{
-                      padding: "2px 8px", borderRadius: 999, fontSize: 11, fontWeight: 600,
-                      background: "rgba(234,179,8,0.12)", border: "1px solid rgba(234,179,8,0.3)", color: "#fbbf24",
-                    }}>
-                      ⭐ グローバル
-                    </span>
-                  )}
                   <span style={{ fontSize: 11, color: "#6b7280" }}>{formatDate(item.created_at, locale)}</span>
                 </div>
                 <p style={{ fontSize: 15, fontWeight: 600, color: "#f9fafb", margin: "0 0 4px", lineHeight: 1.4 }}>

--- a/src/api/admin/knowledge/faqCrudRoutes.ts
+++ b/src/api/admin/knowledge/faqCrudRoutes.ts
@@ -95,7 +95,6 @@ export function registerFaqCrudRoutes(
 
     const { limit, offset, search, sort, order, category } = parsed.data;
     const isPublishedRaw = req.query.is_published as string | undefined;
-    const isGlobalRaw = req.query.is_global as string | undefined;
 
     // ORDER BY — Zodのenum検証済み値を明示的なマッピングで二重保護
     const SORT_COLUMN_MAP: Record<string, string> = {
@@ -125,11 +124,6 @@ export function registerFaqCrudRoutes(
         whereClause += ` AND is_published = $${params.length}`;
       }
 
-      if (isGlobalRaw === "true") {
-        whereClause += ` AND is_global = true`;
-      } else if (isGlobalRaw === "false") {
-        whereClause += ` AND (is_global = false OR is_global IS NULL)`;
-      }
 
       const countResult = await db.query(
         `SELECT COUNT(*)::int AS total FROM faq_docs ${whereClause}`,
@@ -140,7 +134,7 @@ export function registerFaqCrudRoutes(
       params.push(limit);
       params.push(offset);
       const itemsResult = await db.query(
-        `SELECT id, tenant_id, question, answer, category, tags, is_published, is_excluded_from_search, is_global, created_at, updated_at
+        `SELECT id, tenant_id, question, answer, category, tags, is_published, is_excluded_from_search, created_at, updated_at
          FROM faq_docs
          ${whereClause}
          ORDER BY ${safeSortCol} ${safeOrder}
@@ -172,7 +166,7 @@ export function registerFaqCrudRoutes(
 
     try {
       const result = await db.query(
-        `SELECT id, tenant_id, question, answer, category, tags, is_published, is_excluded_from_search, is_global, created_at, updated_at
+        `SELECT id, tenant_id, question, answer, category, tags, is_published, is_excluded_from_search, created_at, updated_at
          FROM faq_docs
          WHERE id = $1`,
         [id]

--- a/src/api/admin/knowledge/routes.ts
+++ b/src/api/admin/knowledge/routes.ts
@@ -127,7 +127,6 @@ export function registerKnowledgeAdminRoutes(app: Express): void {
     const tenantId = resolveTenantId(req);
     const user = (req as KnowledgeReq).user;
     const category = req.query.category as string | undefined;
-    const isGlobalParam = req.query.is_global as string | undefined;
     const isPublishedParam = req.query.is_published as string | undefined;
 
     if (!tenantId && user?.role !== "super_admin") {
@@ -136,7 +135,7 @@ export function registerKnowledgeAdminRoutes(app: Express): void {
 
     try {
       const params: unknown[] = [];
-      let sql = `SELECT id, tenant_id, question, answer, category, tags, is_global, is_published, created_at FROM faq_docs`;
+      let sql = `SELECT id, tenant_id, question, answer, category, tags, is_published, created_at FROM faq_docs`;
       const conditions: string[] = [];
 
       if (tenantId) {
@@ -146,11 +145,6 @@ export function registerKnowledgeAdminRoutes(app: Express): void {
       if (category && category !== "all") {
         params.push(category);
         conditions.push(`category = $${params.length}`);
-      }
-      if (isGlobalParam === "true") {
-        conditions.push(`is_global = true`);
-      } else if (isGlobalParam === "false") {
-        conditions.push(`is_global = false OR is_global IS NULL`);
       }
       if (isPublishedParam === "true") {
         conditions.push(`is_published = true`);


### PR DESCRIPTION
`faq_docs.is_global` 列には**書き手が1箇所も存在しない**（SELECT と WHERE のみ）。そのため「⭐ グローバル」バッジと「グローバルのみ」フィルタは**永久に空**だった。押せるのに何も起きない UI を無くす（CLAUDE.md 禁止44 / 要件 Re）。

## ★ 別概念との切り分け

これが本 PR で最も注意した点。

| | 実体 | 本PR |
|---|---|---|
| **列 `is_global`** | 書き手ゼロ。バッジもフィルタも永久に空 | **読み取りと描画を撤去** |
| **`tenant_id = 'global'`** | **こちらが実体。**全テナントの検索に合流している | **一切触っていない** |

`GlobalKnowledgeCheckbox` / `TextInputTab` / `UrlScrapeTab` の `target: "global"` 送信と、`[tenantId].tsx` の `isGlobalTenant` は無傷（12 箇所の参照を確認）。

## 撤去したもの

- `faqCrudRoutes.ts` — `is_global` クエリ param（L98）/ WHERE 分岐（L128-131）/ **2 箇所**の SELECT 列（L143, L175）
- `knowledge/routes.ts` — 同等の重複実装（legacy、L130 / L139 / L150-154）
- `KnowledgeListTab.tsx` — 型フィールド / `globalFilter` state / effect 依存 / クエリ param / **フィルタUI（3ピル）** / **⭐バッジ**

## 残したもの

- `migration_add_is_global.sql` と列そのもの — 可逆性のため **DROP しない**
- 上記の `tenant_id = 'global'` 機構すべて

## 検証

- backend typecheck 0 / admin-ui typecheck 0
- admin-ui vitest **42 ファイル / 568 テスト 全通過**
- knowledge 関連 jest **16 スイート / 223 テスト 全通過**
- 残存 grep 0 件（`is_global` / `globalFilter`、migration ファイルを除く）

### ローカルのフルテストについて

ローカルの `jest` フル実行は並列時に不安定で、**docs のみ変更のブランチ（無関係）でも同種の失敗が出る**。横並び比較で差分に現れた `agentRoutes` と `conversion-type-api` は、**単独実行で 529 テスト全通過**することを確認済み（環境要因）。判定は CI に委ねる。

## 関連

- 要件定義 v1.3: https://claude.ai/code/artifact/4a311d89-76ba-4831-93ff-7c2e7348debe
- Asana: A3（学習ループUX）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgCQYt8UMPgm4HNVu7nv7z