### PR TITLE
fix(copilot): PDF添付の宣伝をR2C運用者だけに見せる

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -4362,6 +4362,17 @@ describe("CopilotPreviewPage — コンポーザへのPDFドラッグ＆ドロ�
     await waitFor(() => expect(screen.getByLabelText("実際の操作 1件")).toBeTruthy());
   });
 
+  // 禁止13の回帰: useAuth の isSuperAdmin は previewMode 中 false に落ちるため、
+  // 表示条件に isSuperAdmin を使うと R2C 運用者自身から機能が消える。
+  // canUploadBookPdf は生の user.role を見ているのでここが緑であり続けること。
+  it("previewMode中のsuper_adminでも📎とフッタ文言が消えない", async () => {
+    await readyPage(SUPER_ADMIN_IN_PREVIEW);
+
+    expect(screen.getByLabelText("PDFを添付")).toBeTruthy();
+    expect(document.querySelector('input[type="file"]')).toBeTruthy();
+    expect(screen.getByText(/PDFはここへドラッグ＆ドロップできます/)).toBeTruthy();
+  });
+
   it("📎ボタンからでも同じ取り込みができる(ドラッグできない環境向け)", async () => {
     await readyPage(SUPER_ADMIN_IN_PREVIEW);
 
@@ -4476,11 +4487,30 @@ describe("CopilotPreviewPage — PDF取り込みのR2C運用限定ガード(clie
     expect(screen.queryByText(/確認が必要です|確認をスキップできません/)).toBeNull();
   });
 
-  it("client_adminが📎ボタンから選んでも同様に断る", async () => {
+  // 旧: 「📎から選んでも断る」。CLAUDE.md 禁止44(押せるのに何も起きないUIを置かない)により、
+  // client_admin には 📎 とファイル入力そのものを出さない方針へ変更した。
+  // 「選んでから断られる」体験自体が無くなったので、非表示を固定する。
+  it("client_adminには📎ボタンもファイル入力も描画されない", async () => {
     await readyPage();
 
-    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
-    fireEvent.change(input, { target: { files: [makeFile("料金表.pdf", "application/pdf")] } });
+    expect(screen.queryByLabelText("PDFを添付")).toBeNull();
+    expect(document.querySelector('input[type="file"]')).toBeNull();
+  });
+
+  it("client_adminにはD&Dを宣伝するフッタ文言を出さない", async () => {
+    await readyPage();
+
+    expect(screen.queryByText(/PDFはここへドラッグ＆ドロップできます/)).toBeNull();
+    // 接続状態の案内自体は残す(空白にしない)
+    expect(screen.getByText(/実際の R2Cエージェントに接続されています/)).toBeTruthy();
+  });
+
+  // 受け皿(onDrop)は残す。外すとブラウザ既定動作でPDFが開かれ、会話ごとページを離脱する。
+  // 誤ってドロップされた場合に丁寧に断る挙動は上のテストで固定済み。
+  it("宣伝を消してもドロップの受け皿は残っている(ブラウザ既定の離脱を防ぐ)", async () => {
+    await readyPage();
+
+    dropFiles([makeFile("料金表.pdf", "application/pdf")]);
 
     expect(await screen.findByText("PDFを受け取れませんでした")).toBeTruthy();
     expect(MockXHR.instances.length).toBe(0);

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -1811,18 +1811,20 @@ export default function CopilotPreviewPage() {
               onDragOver={(e) => e.preventDefault()}
               onDragLeave={handlePdfDragLeave}
               onDrop={handlePdfDrop}
-              style={{ display: "flex", alignItems: "center", gap: 12, padding: "12px 12px 12px 20px", border: pdfDragOver ? `2px dashed ${AGENT}` : `1px solid ${sending ? AGENT_BORDER : "var(--border)"}`, borderRadius: 16, background: pdfDragOver ? AGENT_SOFT : "var(--input, var(--card))" }}
+              style={{ display: "flex", alignItems: "center", gap: 12, padding: "12px 12px 12px 20px", border: canUploadBookPdf && pdfDragOver ? `2px dashed ${AGENT}` : `1px solid ${sending ? AGENT_BORDER : "var(--border)"}`, borderRadius: 16, background: canUploadBookPdf && pdfDragOver ? AGENT_SOFT : "var(--input, var(--card))" }}
             >
-              <input
-                ref={pdfInputRef}
-                type="file"
-                accept=".pdf,.zip,application/pdf,application/zip"
-                multiple
-                style={{ display: "none" }}
-                aria-hidden="true"
-                tabIndex={-1}
-                onChange={handlePdfInputChange}
-              />
+              {canUploadBookPdf && (
+                <input
+                  ref={pdfInputRef}
+                  type="file"
+                  accept=".pdf,.zip,application/pdf,application/zip"
+                  multiple
+                  style={{ display: "none" }}
+                  aria-hidden="true"
+                  tabIndex={-1}
+                  onChange={handlePdfInputChange}
+                />
+              )}
               {/* textarea(1行から始まり複数行も書ける)。Enterで送信、Shift+Enterで改行。
                   IME変換中のEnterは shouldSubmitOnEnter が弾く(旧UIパネルと共通実装) */}
               <textarea
@@ -1837,20 +1839,23 @@ export default function CopilotPreviewPage() {
                 disabled={sending}
                 style={{ flex: 1, border: "none", outline: "none", background: "transparent", color: "var(--foreground)", fontSize: 16, maxHeight: 140, resize: "none", fontFamily: "inherit", lineHeight: 1.6, padding: 0, overflowY: "auto" }}
               />
-              <button
-                onClick={() => pdfInputRef.current?.click()}
-                aria-label="PDFを添付"
-                title="PDFを添付（ここへドラッグ＆ドロップでも取り込めます）"
-                style={{ width: 40, height: 40, borderRadius: 12, border: "1px solid var(--border)", background: "transparent", color: "var(--muted-foreground)", cursor: "pointer", fontSize: 17, flexShrink: 0 }}
-              >
-                📎
-              </button>
+              {canUploadBookPdf && (
+                <button
+                  onClick={() => pdfInputRef.current?.click()}
+                  aria-label="PDFを添付"
+                  title="PDFを添付（ここへドラッグ＆ドロップでも取り込めます）"
+                  style={{ width: 40, height: 40, borderRadius: 12, border: "1px solid var(--border)", background: "transparent", color: "var(--muted-foreground)", cursor: "pointer", fontSize: 17, flexShrink: 0 }}
+                >
+                  📎
+                </button>
+              )}
               <button onClick={handleSend} disabled={sending} aria-label="送信" style={{ width: 40, height: 40, borderRadius: 12, border: "none", background: AGENT, color: "#fff", cursor: sending ? "not-allowed" : "pointer", opacity: sending ? 0.6 : 1, fontSize: 18 }}>
                 {sending ? "…" : "↑"}
               </button>
             </div>
             <div style={{ marginTop: 8, fontSize: 12, color: "var(--muted-foreground)", textAlign: "center" }}>
-              実際の R2Cエージェントに接続されています。要ログイン。PDFはここへドラッグ＆ドロップできます。
+              実際の R2Cエージェントに接続されています。要ログイン。
+              {canUploadBookPdf && "PDFはここへドラッグ＆ドロップできます。"}
             </div>
           </div>
         </div>


### PR DESCRIPTION
サーバ側の 403 は既に正しく、**見た目だけが全ユーザーに出ていた**。テナントは 📎 を押しファイルを選んで初めて「使えない」と分かる状態だった（CLAUDE.md 禁止44 / 要件 Re）。

## ★ 撤去したのは「宣伝」だけ。受け皿は意図的に残す

| | 扱い | 理由 |
|---|---|---|
| 📎 ボタン ＋ 隠しファイル入力 | **撤去** | ボタンが無ければ input に起動経路が無いのでセットで |
| フッタ「PDFはここへドラッグ＆ドロップできます。」 | **撤去** | 使えない操作の広告 |
| ドラッグ中の破線ハイライト | **撤去** | 「ここに落とせる」の示唆 |
| `onDragOver` / `onDrop` | **残す** | **外すとブラウザ既定動作で PDF が開かれ、会話ごとページを離脱する** |

当初プランでは D&D 配線ごと外す想定だったが、実装中に**外す方が体験が悪化する**ことに気づいて方針を変えた。誤ってドロップされた場合に丁寧に断る既存の挙動はそのまま残る。「選ぶ導線を出さない」ことと「誤操作を受け止める」ことは両立する。

## 判定に生の `user?.role` を使う理由（禁止13）

既存の `canUploadBookPdf = user?.role === "super_admin"` をそのまま表示条件に適用した。`useAuth` の `isSuperAdmin` は **previewMode 中に false へ落ちる**ため、表示条件に使うと **R2C 運用者自身から機能が消える**。

## テスト

- client_admin で 📎・`input[type=file]`・フッタ文言が**描画されない**
- 宣伝を消しても**受け皿は残る**（ドロップすると従来どおり丁寧に断り、通信は発生しない）
- **previewMode 中の super_admin で消えない**（禁止13 の回帰テスト）
- 旧「📎 から選んでも断る」は、**選ぶ経路自体が無くなった**ため非表示の固定に置き換え

## 検証

- backend typecheck 0 / admin-ui typecheck 0 / oxlint 0
- admin-ui vitest **42 ファイル / 571 テスト 全通過**（copilot-preview 193 テストを含む）

## 関連

- 要件定義 v1.3: https://claude.ai/code/artifact/4a311d89-76ba-4831-93ff-7c2e7348debe
- Asana: A4（学習ループUX）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgCQYt8UMPgm4HNVu7nv7z