### PR TITLE
fix(widget): バッジの遷移先を解決不能な r2c.biz apex から api.r2c.biz へ変更する

### DIFF
--- a/src/api/widget/routes.test.ts
+++ b/src/api/widget/routes.test.ts
@@ -196,6 +196,22 @@ describe('GET /widget/:tenantSlug.js — 「Powered by R2C」バッジ (PR-B)', 
     expect(url.searchParams.get('utm_campaign')).toBe('powered_by');
     expect(url.searchParams.get('r2c_ref')).toBe('tenant-a');
   });
+
+  // 2026-08-24 実機確認で発覚した回帰: apex の r2c.biz は DNS が存在せず解決不能
+  // （admin.r2c.biz / api.r2c.biz は稼働中）。LP_BASE_URL の既定値には、
+  // 実際に public/lp/ を配信している到達可能なホストのみを使うこと。
+  it('badgeUrl の既定ホストは解決不能な r2c.biz apex ではなく、稼働中の API_BASE_URL と一致する', async () => {
+    const db = makePool([
+      { rows: [{ id: 'tenant-a', is_active: true, features: {}, plan: 'starter' }], rowCount: 1 },
+    ]);
+    const app = makeApp(db);
+    await request(app).get('/widget/tenant-a.js');
+    const config = (generateWidgetJs as jest.Mock).mock.calls[0][0];
+    const badgeUrlHost = new URL(config.badgeUrl).host;
+    const apiBaseUrlHost = new URL(config.apiBaseUrl).host;
+    expect(badgeUrlHost).toBe(apiBaseUrlHost);
+    expect(badgeUrlHost).not.toBe('r2c.biz');
+  });
 });
 
 describe('GET /widget/:tenantSlug.js — バッジが表示されない既知の経路(仕様として固定)', () => {

--- a/src/api/widget/routes.ts
+++ b/src/api/widget/routes.ts
@@ -16,8 +16,12 @@ const API_BASE_URL =
   process.env.API_BASE_URL ?? "https://api.r2c.biz";
 
 // ウィジェットの「Powered by R2C」バッジの遷移先（LPトップではなく専用着地ページ）。
-// r2c.biz は admin-ui/LP と別ホストなので API_BASE_URL とは独立に持つ。
-const LP_BASE_URL = process.env.LP_BASE_URL ?? "https://r2c.biz";
+// 2026-08-24 実機確認: apex の r2c.biz は DNS レコードが存在せず解決不能
+// （admin.r2c.biz / api.r2c.biz は稼働中。R2C がローンチ前でマーケティング用
+// apex ドメインが未取得/未設定のため）。public/lp/ は本リポジトリの Express アプリ
+// (api.r2c.biz) が express.static で配信しているため、確実に到達できるこちらを既定にする。
+// r2c.biz apex が将来取得され次第、env で上書きする。
+const LP_BASE_URL = process.env.LP_BASE_URL ?? API_BASE_URL;
 
 /**
  * バッジのリンクURL（UTM + テナント識別子付き）を組み立てる。


### PR DESCRIPTION
## P0: 本番で今バッジのリンクが壊れています

PR #881 デプロイ後の実機確認（`curl`によるDNS解決確認）で発覚。

```
$ curl -sv https://r2c.biz/     → Could not resolve host: r2c.biz
$ curl -s  https://admin.r2c.biz/  → HTTP 200 (稼働中)
$ curl -s  https://api.r2c.biz/health → {"status":"ok",...} (稼働中)
```

`google.com` 等は問題なく解決できているため、サンドボックス制限ではなく **`r2c.biz` apex に DNS レコードが存在しない**ことを確認済みです。R2C はローンチ前で、マーケティング用 apex ドメインがまだ取得/設定されていないためと考えられます。

`.env.example` に `LP_BASE_URL` の定義は無く、本番に設定されている形跡もないため、PR #881 で入れたデフォルト値 `"https://r2c.biz"` がそのまま本番で使われています。**つまり現在、ウィジェットのバッジをクリックした実ユーザーは DNS エラーに遭遇します。**

## 修正

`public/lp/` は本リポジトリの Express アプリ（`api.r2c.biz`）が `express.static` で配信しており、こちらは実機で到達確認済みです（`GET /lp/from-chat/` → 200、title一致）。`LP_BASE_URL` の既定値を、確実に到達できる `API_BASE_URL` に変更しました。

```diff
- const LP_BASE_URL = process.env.LP_BASE_URL ?? "https://r2c.biz";
+ const LP_BASE_URL = process.env.LP_BASE_URL ?? API_BASE_URL;
```

`r2c.biz` apex が将来取得され次第、`LP_BASE_URL` env で上書きできます。

## 再発防止

`badgeUrl` のホストが `api.r2c.biz`（= `API_BASE_URL`）と一致し、`r2c.biz` ではないことを固定するテストを追加しました。

## Gate結果

- `pnpm typecheck`: 0 errors
- `pnpm lint`: 0 warnings(新規警告なし)
- `pnpm test`: `src/api/widget/routes.test.ts` 18/18 pass（新規1件含む）

## 緊急度

P0。本番に既にデプロイ済みの機能が壊れています。マージ後、**`SCRIPTS/deploy-vps.sh` での再デプロイが必要**です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NF9b7Ew1PiYJmfP5wfs99h