### PR TITLE
feat(analytics): 本番スキーマとコードのズレを検知して計測ヘルスに出す

### DIFF
--- a/admin-ui/src/pages/admin/monitoring/index.tsx
+++ b/admin-ui/src/pages/admin/monitoring/index.tsx
@@ -19,6 +19,12 @@ interface MeasurementHealth {
   cvSessionLinkRate: RateMetric;
   outcomeRecordRate: RateMetric & { autoRecorded: number };
   validUserSessionCount: number;
+  /** super_admin のときだけ返る。コードが要求する列が実行中のDBに存在するか。 */
+  schemaHealth?: {
+    missing: Array<{ table: string; columns: string[]; tableMissing: boolean }>;
+    checkedTables: number;
+    checkedColumns: number;
+  };
 }
 
 interface MonitoringKpis {
@@ -513,6 +519,38 @@ export default function MonitoringPage() {
                 >
                   {health ? <MetricValue value={health.validUserSessionCount.toLocaleString("ja-JP")} /> : <MetricPlaceholder />}
                 </MeasurementHealthCard>
+
+                {/* スキーマ適用ズレ(R2C運用のみ)。コードは配備済みでも本番に列が無いと
+                    記録だけが無言で落ちる。2026-08-24 の visitor_id / product_* がその実例。 */}
+                {health?.schemaHealth && (
+                  <MeasurementHealthCard
+                    title="本番スキーマとコードの整合"
+                    description="コードが書き込む列が本番に存在するか（未適用のmigrationを検知する）"
+                  >
+                    {health.schemaHealth.missing.length === 0 ? (
+                      <div style={{ fontSize: 14, color: "var(--muted-foreground)" }}>
+                        欠落なし（{health.schemaHealth.checkedTables}テーブル / {health.schemaHealth.checkedColumns}列を確認）
+                      </div>
+                    ) : (
+                      <div style={{ display: "flex", flexDirection: "column", gap: 8 }}>
+                        <div style={{ fontSize: 14, fontWeight: 700, color: "#f87171" }}>
+                          {health.schemaHealth.missing.length}件のテーブルで列が不足しています
+                        </div>
+                        {health.schemaHealth.missing.map((m) => (
+                          <div key={m.table} style={{ fontSize: 13, lineHeight: 1.7 }}>
+                            <code style={{ fontWeight: 700 }}>{m.table}</code>
+                            {m.tableMissing ? "（テーブルごと存在しません）" : "："}
+                            {!m.tableMissing && <code>{m.columns.join(", ")}</code>}
+                          </div>
+                        ))}
+                        <div style={{ fontSize: 12, color: "var(--muted-foreground)", lineHeight: 1.7 }}>
+                          該当する migration を本番に適用してください。適用は人の承認が必要です。
+                          記録が無言で落ちるため、エラーログには現れません。
+                        </div>
+                      </div>
+                    )}
+                  </MeasurementHealthCard>
+                )}
               </div>
             )}
           </section>

--- a/src/api/admin/analytics/routes.ts
+++ b/src/api/admin/analytics/routes.ts
@@ -20,6 +20,7 @@ import {
   userSourceExists,
 } from "./summaryQueries";
 import { fetchMeasurementHealth } from "./measurementHealth";
+import { fetchSchemaHealth } from "./schemaHealth";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -196,7 +197,11 @@ export function registerAnalyticsRoutes(app: Express): void {
 
       try {
         const response = await fetchMeasurementHealth(pool, tenantId, period);
-        return res.json(response);
+        // スキーマ整合はテナント固有ではなくR2C運用の情報なので、
+        // fetchMeasurementHealth(全クエリが tenant_id で絞られる契約)には入れず、
+        // ここで super_admin にだけ合成する。新エンドポイントは作らない。
+        const schemaHealth = isSuperAdmin ? await fetchSchemaHealth(pool) : undefined;
+        return res.json(schemaHealth ? { ...response, schemaHealth } : response);
       } catch (err) {
         logger.warn("[GET /v1/admin/analytics/measurement-health]", err);
         return res.status(500).json({ error: "計測ヘルスの取得に失敗しました" });

--- a/src/api/admin/analytics/schemaHealth.test.ts
+++ b/src/api/admin/analytics/schemaHealth.test.ts
@@ -1,0 +1,127 @@
+// src/api/admin/analytics/schemaHealth.test.ts
+//
+// 2本立て:
+//   1) findMissingColumns の純関数テスト(境界含む)
+//   2) 機械的ガード — REQUIRED_COLUMNS が src/**/*.ts の INSERT 文と完全一致すること。
+//      手書きレジストリは DEPLOY_CHECKLIST.md と同じ腐り方をするため、
+//      confirmPolicy.test.ts と同じ流儀でソースを readFileSync して同期を強制する。
+//
+// このテストが落ちたら、レジストリを直すだけで終わらせないこと。
+// 「その列を追加する migration が存在し、docs/DEPLOY_CHECKLIST.md に載っているか」を必ず確認する。
+
+import fs from "node:fs";
+import path from "node:path";
+import { REQUIRED_COLUMNS, findMissingColumns } from "./schemaHealth";
+
+describe("findMissingColumns", () => {
+  const required = { t1: ["a", "b"], t2: ["x"] } as const;
+
+  it("全て揃っていれば空を返す(欠落なしが正常)", () => {
+    const actual = new Map([
+      ["t1", new Set(["a", "b", "extra"])],
+      ["t2", new Set(["x"])],
+    ]);
+    expect(findMissingColumns(actual, required)).toEqual([]);
+  });
+
+  it("1列欠けたらその列だけを返す", () => {
+    const actual = new Map([
+      ["t1", new Set(["a"])],
+      ["t2", new Set(["x"])],
+    ]);
+    expect(findMissingColumns(actual, required)).toEqual([
+      { table: "t1", columns: ["b"], tableMissing: false },
+    ]);
+  });
+
+  it("テーブルごと無い場合は tableMissing=true で全列を返す", () => {
+    const actual = new Map([["t2", new Set(["x"])]]);
+    expect(findMissingColumns(actual, required)).toEqual([
+      { table: "t1", columns: ["a", "b"], tableMissing: true },
+    ]);
+  });
+
+  it("DBが1行も返さない(接続直後・権限不足)場合は全テーブルを欠落として報告する", () => {
+    const actual = new Map<string, Set<string>>();
+    const missing = findMissingColumns(actual, required);
+    expect(missing).toHaveLength(2);
+    expect(missing.every((m) => m.tableMissing)).toBe(true);
+  });
+
+  it("実DBに余分な列があっても欠落として扱わない", () => {
+    const actual = new Map([
+      ["t1", new Set(["a", "b", "legacy_col"])],
+      ["t2", new Set(["x", "another"])],
+    ]);
+    expect(findMissingColumns(actual, required)).toEqual([]);
+  });
+
+  it("要求が空なら常に空を返す", () => {
+    expect(findMissingColumns(new Map(), {})).toEqual([]);
+  });
+});
+
+describe("REQUIRED_COLUMNS の機械的ガード", () => {
+  // src/**/*.ts を走査して INSERT INTO <table> (cols) を集める。
+  // schemaHealth.ts の生成時と同一のロジック。変更する場合は両方を同時に直すこと。
+  function scanInsertColumns(): Record<string, string[]> {
+    const root = path.resolve(__dirname, "../../..");
+    const found: Record<string, Set<string>> = {};
+
+    const walk = (dir: string): void => {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          walk(full);
+        } else if (entry.name.endsWith(".ts") && !entry.name.includes(".test.")) {
+          const src = fs.readFileSync(full, "utf-8");
+          const re = /INSERT\s+INTO\s+([a-z_]+)\s*\(([^)]{0,1200})\)/gi;
+          let m: RegExpExecArray | null;
+          while ((m = re.exec(src)) !== null) {
+            const table = m[1]!.toLowerCase();
+            const cols = m[2]!
+              .split(",")
+              .map((c) => c.trim().replace(/"/g, "").toLowerCase())
+              .filter((c) => /^[a-z_][a-z0-9_]*$/.test(c));
+            if (cols.length === 0) continue;
+            found[table] = found[table] ?? new Set<string>();
+            for (const c of cols) found[table]!.add(c);
+          }
+        }
+      }
+    };
+    walk(root);
+
+    const out: Record<string, string[]> = {};
+    for (const t of Object.keys(found).sort()) out[t] = [...found[t]!].sort();
+    return out;
+  }
+
+  it("レジストリがソースの INSERT 文と完全一致する", () => {
+    const scanned = scanInsertColumns();
+    const registryTables = Object.keys(REQUIRED_COLUMNS).sort();
+    const scannedTables = Object.keys(scanned).sort();
+
+    // 正規表現が壊れて空振りしていないことの下限アサーション
+    expect(scannedTables.length).toBeGreaterThan(20);
+
+    expect(scannedTables).toEqual(registryTables);
+
+    for (const t of scannedTables) {
+      expect({ table: t, columns: [...(REQUIRED_COLUMNS[t] ?? [])].sort() }).toEqual({
+        table: t,
+        columns: scanned[t]!,
+      });
+    }
+  });
+
+  it("学習ループの主要テーブルがレジストリに含まれている", () => {
+    // 2026-08-24 に実害が出た経路。取りこぼしを固定する。
+    for (const t of ["chat_sessions", "chat_messages", "faq_docs", "tuning_rules"]) {
+      expect(Object.keys(REQUIRED_COLUMNS)).toContain(t);
+    }
+    expect(REQUIRED_COLUMNS["chat_sessions"]).toContain("visitor_id");
+    expect(REQUIRED_COLUMNS["faq_docs"]).toContain("product_price");
+    expect(REQUIRED_COLUMNS["tuning_rules"]).toContain("dedup_key");
+  });
+});

--- a/src/api/admin/analytics/schemaHealth.ts
+++ b/src/api/admin/analytics/schemaHealth.ts
@@ -1,0 +1,128 @@
+// src/api/admin/analytics/schemaHealth.ts
+// 本番スキーマとコードのズレを検知する。
+//
+// なぜ measurementHealth.ts に入れないか:
+//   measurementHealth は「計測データの健全性」(母数・結合率・記録率)を見るもので、
+//   本ファイルは「スキーマの整合」を見る。混ぜると母数の話と配線の話が同じ関数に入る。
+//   レスポンスは同じ measurement-health エンドポイントに合流させるが、算出は分ける。
+//
+// なぜ必要か (2026-08-24 の実例):
+//   chat_sessions.visitor_id が本番未適用のまま、配備コードが無条件に INSERT していた。
+//   saveMessage は fire-and-forget なので **客には答えが返り、記録だけが無言で落ちた**。
+//   500 も出ずログにも残らないため、監査でしか見つからなかった。
+//   同時に faq_docs.product_* の未適用で URL取得タブが1件も保存できていなかった。
+//   既存のスキーマ↔コード整合テスト(evaluationAnalyzer.test.ts 等)は
+//   **migration ファイルの文字列**を読むだけで、本番に適用されたかは見ていない。
+//
+// レジストリが腐らない理由:
+//   REQUIRED_COLUMNS は手書きではなく、schemaHealth.test.ts が src/**/*.ts の
+//   `INSERT INTO <table> (cols)` を走査して**完全一致**を強制する。
+//   INSERT に列を足してレジストリを更新し忘れるとテストが落ちる。
+//   これは confirmPolicy.test.ts と同じ流儀(手で守らせない)。
+//   落ちたら「レジストリに足す」だけでなく、**その列の migration が存在し
+//   DEPLOY_CHECKLIST.md に載っているか**を必ず確認すること。
+
+import type { Pool } from "pg";
+
+/** 既存の analytics 層と同じ最小インターフェース(measurementHealth.ts / summaryQueries.ts に倣う)。 */
+type Db = Pick<Pool, "query">;
+
+/** コードが INSERT で要求する列。schemaHealth.test.ts がソース走査で同期を強制する。 */
+export const REQUIRED_COLUMNS: Record<string, readonly string[]> = {
+  ab_experiments: ["min_sample_size", "name", "tenant_id", "traffic_split", "variant_a", "variant_b"],
+  ab_results: ["converted", "experiment_id", "session_id", "variant"],
+  admin_feedback: ["ai_answered", "ai_response", "category", "message", "parent_feedback_id", "priority", "tenant_id", "user_email"],
+  audit_logs: ["action", "actor_email", "actor_role", "metadata", "target_id", "target_type", "tenant_id"],
+  avatar_configs: ["agent_idle_prompt", "agent_prompt", "anam_avatar_id", "anam_llm_id", "anam_persona_id", "anam_voice_id", "avatar_provider", "behavior_description", "default_name", "default_personality_prompt", "default_template_id", "default_voice_id", "emotion_tags", "image_prompt", "image_url", "is_active", "is_default", "lemonslice_agent_id", "name", "personality_prompt", "tenant_id", "voice_description", "voice_id"],
+  behavioral_events: ["event_data", "event_type", "page_url", "referrer", "session_id", "tenant_id", "visitor_id"],
+  billing_adjustments: ["adjusted_by", "amount", "reason", "tenant_id"],
+  book_pipeline_jobs: ["book_id", "enqueued_at", "status"],
+  book_uploads: ["encryption_iv", "file_size_bytes", "original_filename", "storage_path", "tenant_id", "title", "uploaded_by"],
+  chat_messages: ["content", "metadata", "rag_sources", "role", "session_id", "tenant_id"],
+  chat_sessions: ["last_message_at", "message_count", "metadata", "prompt_variant_id", "prompt_variant_name", "session_id", "tenant_id", "visitor_id"],
+  conversation_evaluations: ["customer_reaction_score", "effective_principles", "evaluation_axes", "failed_principles", "feedback", "judge_model", "message_count", "model_used", "notes", "psychology_fit_score", "score", "session_id", "stage_progress_score", "suggested_rules", "taboo_violation_score", "tenant_id", "used_principles"],
+  conversation_flow_logs: ["from_state", "metadata", "session_id", "tenant_id", "to_state", "turn_index"],
+  conversion_attributions: ["conversion_type", "conversion_value", "created_at", "deduplicated_at", "event_id", "event_type", "message_count", "psychology_principle_used", "sales_stage_at_conversion", "session_duration_sec", "session_id", "source", "temp_score_at_conversion", "tenant_id", "trigger_rule_id", "trigger_type"],
+  faq_docs: ["answer", "category", "es_doc_id", "is_published", "product_cta_url", "product_image_url", "product_price", "question", "tags", "tenant_id"],
+  faq_embeddings: ["embedding", "is_excluded_from_search", "metadata", "tenant_id", "text"],
+  feedback_messages: ["content", "sender_email", "sender_role", "tenant_id"],
+  knowledge_gaps: ["detection_source", "frequency", "last_detected_at", "message_id", "rag_hit_count", "rag_top_score", "recommendation_status", "session_id", "tenant_id", "user_question"],
+  learned_memory: ["answer", "embedding", "judge_score", "metadata", "question", "source_session_id", "tenant_id"],
+  metrics_snapshots: ["labels", "metric_name", "tenant_id", "value"],
+  notification_preferences: ["email_enabled", "in_app_enabled", "notification_type", "tenant_id", "threshold"],
+  notifications: ["link", "message", "metadata", "recipient_role", "recipient_tenant_id", "title", "type"],
+  objection_patterns: ["principle_used", "response_strategy", "sample_count", "source", "success_rate", "tenant_id", "trigger_phrase", "updated_at"],
+  option_orders: ["chat_session_id", "description", "llm_estimate_amount", "status", "tenant_id", "type"],
+  sai_task_rules: ["created_by", "evidence", "expected_behavior", "priority", "source", "tenant_id", "trigger_pattern"],
+  sai_tasks: ["description", "order_id", "requested_by", "task_id", "tenant_id"],
+  stripe_usage_reports: ["idempotency_key", "period_yyyymm", "tenant_id", "total_cost_cents", "total_requests"],
+  stripe_webhook_events: ["claimed_at", "event_id", "event_type"],
+  tenant_api_keys: ["expires_at", "is_active", "key_hash", "key_prefix", "tenant_id"],
+  tenant_settings_history: ["changed_by", "field_name", "new_value", "old_value", "tenant_id"],
+  tenants: ["id", "is_active", "name", "plan"],
+  trigger_rules: ["is_active", "message_template", "priority", "tenant_id", "trigger_config", "trigger_type"],
+  tuning_rules: ["approved_at", "created_by", "dedup_key", "edited_at", "edited_by", "evidence", "expected_behavior", "is_active", "original_text", "priority", "source", "source_message_id", "status", "suggested_at", "tenant_id", "trigger_pattern"],
+  usage_logs: ["anam_session_seconds", "avatar_credits", "avatar_session_ms", "billable", "cost_llm_cents", "cost_total_cents", "feature_used", "input_tokens", "model", "output_tokens", "request_id", "tenant_id", "tts_text_bytes"],
+};
+
+export interface MissingColumn {
+  table: string;
+  /** 実行中のDBに存在しない列。テーブルごと欠落している場合は requiredColumns 全件。 */
+  columns: string[];
+  /** テーブル自体が存在しないか */
+  tableMissing: boolean;
+}
+
+export interface SchemaHealthResponse {
+  /** 欠落なしなら空配列。空であることが正常。 */
+  missing: MissingColumn[];
+  checkedTables: number;
+  checkedColumns: number;
+}
+
+/**
+ * 実DBの列一覧と要求列を突き合わせる純関数。
+ * actual は「テーブル名 -> 列名の集合」。DB アクセスは呼び出し側が行う。
+ */
+export function findMissingColumns(
+  actual: Map<string, Set<string>>,
+  required: Record<string, readonly string[]> = REQUIRED_COLUMNS,
+): MissingColumn[] {
+  const missing: MissingColumn[] = [];
+  for (const [table, cols] of Object.entries(required)) {
+    const have = actual.get(table);
+    if (!have) {
+      missing.push({ table, columns: [...cols], tableMissing: true });
+      continue;
+    }
+    const lacking = cols.filter((c) => !have.has(c));
+    if (lacking.length > 0) {
+      missing.push({ table, columns: lacking, tableMissing: false });
+    }
+  }
+  return missing;
+}
+
+/** information_schema を1回引いて欠落列を返す。欠落なしが正常。 */
+export async function fetchSchemaHealth(db: Db): Promise<SchemaHealthResponse> {
+  const tables = Object.keys(REQUIRED_COLUMNS);
+  const rows = await db.query<{ table_name: string; column_name: string }>(
+    `SELECT table_name, column_name
+       FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = ANY($1)`,
+    [tables],
+  );
+
+  const actual = new Map<string, Set<string>>();
+  for (const r of rows.rows) {
+    const set = actual.get(r.table_name) ?? new Set<string>();
+    set.add(r.column_name);
+    actual.set(r.table_name, set);
+  }
+
+  return {
+    missing: findMissingColumns(actual),
+    checkedTables: tables.length,
+    checkedColumns: Object.values(REQUIRED_COLUMNS).reduce((n, c) => n + c.length, 0),
+  };
+}

--- a/src/api/admin/analytics/schemaHealthRoute.test.ts
+++ b/src/api/admin/analytics/schemaHealthRoute.test.ts
@@ -1,0 +1,102 @@
+// src/api/admin/analytics/schemaHealthRoute.test.ts
+// GET /v1/admin/analytics/measurement-health に合流させたスキーマ整合の HTTP 層テスト。
+// 判定ロジックは schemaHealth.test.ts で純関数として検証済みなので、ここでは
+// 「R2C運用にだけ出す」ことと「新エンドポイントを作っていない」ことだけを固定する。
+
+import express from 'express';
+import request from 'supertest';
+
+const mockFetchMeasurementHealth = jest.fn();
+const mockFetchSchemaHealth = jest.fn();
+
+jest.mock('./measurementHealth', () => ({
+  fetchMeasurementHealth: (...args: unknown[]) => mockFetchMeasurementHealth(...args),
+}));
+jest.mock('./schemaHealth', () => ({
+  fetchSchemaHealth: (...args: unknown[]) => mockFetchSchemaHealth(...args),
+}));
+
+jest.mock('../../../lib/db', () => ({ pool: {}, getPool: () => ({}) }));
+jest.mock('../../../lib/logger', () => ({
+  logger: { info: jest.fn(), warn: jest.fn(), error: jest.fn() },
+}));
+jest.mock('../../../lib/notifications', () => ({
+  createNotification: jest.fn(),
+  notificationExists: jest.fn().mockResolvedValue(false),
+}));
+jest.mock('../../../admin/http/supabaseAuthMiddleware', () => ({
+  supabaseAuthMiddleware: (req: any, _res: any, next: any) => {
+    req.supabaseUser = {
+      app_metadata: {
+        role: (req.headers['x-role'] as string) ?? 'client_admin',
+        tenant_id: (req.headers['x-tenant-id'] as string) ?? 'tenant-A',
+      },
+    };
+    next();
+  },
+}));
+
+import { registerAnalyticsRoutes } from './routes';
+
+function makeApp() {
+  const app = express();
+  app.use(express.json());
+  registerAnalyticsRoutes(app);
+  return app;
+}
+
+const BASE_HEALTH = {
+  sourceBreakdown: [],
+  emptySessionCount: 0,
+  cvSessionLinkRate: { numerator: 0, denominator: 0, rate: null },
+  outcomeRecordRate: { numerator: 0, denominator: 0, rate: null, autoRecorded: 0 },
+  validUserSessionCount: 0,
+};
+
+describe('GET /v1/admin/analytics/measurement-health のスキーマ整合', () => {
+  beforeEach(() => {
+    mockFetchMeasurementHealth.mockReset().mockResolvedValue(BASE_HEALTH);
+    mockFetchSchemaHealth.mockReset().mockResolvedValue({
+      missing: [{ table: 'chat_sessions', columns: ['visitor_id'], tableMissing: false }],
+      checkedTables: 34,
+      checkedColumns: 257,
+    });
+  });
+
+  it('super_admin には欠落列を返す', async () => {
+    const res = await request(makeApp())
+      .get('/v1/admin/analytics/measurement-health')
+      .set('x-role', 'super_admin');
+
+    expect(res.status).toBe(200);
+    expect(res.body.schemaHealth.missing).toEqual([
+      { table: 'chat_sessions', columns: ['visitor_id'], tableMissing: false },
+    ]);
+    expect(mockFetchSchemaHealth).toHaveBeenCalledTimes(1);
+  });
+
+  it('client_admin には返さない(R2C運用の情報であり、テナントの関心事ではない)', async () => {
+    const res = await request(makeApp())
+      .get('/v1/admin/analytics/measurement-health')
+      .set('x-role', 'client_admin')
+      .set('x-tenant-id', 'tenant-A');
+
+    expect(res.status).toBe(200);
+    expect(res.body.schemaHealth).toBeUndefined();
+    // テナントに対して余計なクエリを投げない
+    expect(mockFetchSchemaHealth).not.toHaveBeenCalled();
+    // 既存の計測ヘルス自体は従来どおり返る
+    expect(res.body.validUserSessionCount).toBe(0);
+  });
+
+  it('欠落なしのときも missing: [] を返す(「異常なし」を描けるようにする)', async () => {
+    mockFetchSchemaHealth.mockResolvedValueOnce({ missing: [], checkedTables: 34, checkedColumns: 257 });
+
+    const res = await request(makeApp())
+      .get('/v1/admin/analytics/measurement-health')
+      .set('x-role', 'super_admin');
+
+    expect(res.body.schemaHealth.missing).toEqual([]);
+    expect(res.body.schemaHealth.checkedTables).toBe(34);
+  });
+});


### PR DESCRIPTION
「マージ済み・デプロイ済みでも本番で動いていない」を検知する（CLAUDE.md 禁止42 / 要件 Ra）。

## なぜ必要か（2026-08-24 に実際に起きたこと）

`chat_sessions.visitor_id` が本番未適用のまま、配備コードが `chatHistoryRepository.ts:63` で**無条件に INSERT** していた。`saveMessage` は fire-and-forget なので**客には答えが返り、記録だけが無言で落ちる**。**500 も出ずログにも残らず、監査でしか見つからなかった。**

同時に `faq_docs.product_*` の未適用で **URL取得タブが1件も保存できていなかった**（全件 catch に落ち `inserted: 0` を返す）。

既存のスキーマ↔コード整合テスト（`evaluationAnalyzer.test.ts` 等）は **migration ファイルの文字列**を読むだけで、**本番に適用されたか**は見ていない。そこを埋める。

## 新規ファイルは1本だけ

`src/api/admin/analytics/schemaHealth.ts` — 要求列レジストリ ＋ `information_schema` との突き合わせ。

`measurementHealth.ts` に入れないのは、あちらが「**計測データの健全性**」（母数・結合率・記録率）を見るもので、本ファイルは「**スキーマの整合**」を見るため。混ぜると母数の話と配線の話が同じ関数に入る。冒頭コメントに理由を明記した。

## ★ レジストリが腐らない仕組み

手書きの台帳は `docs/DEPLOY_CHECKLIST.md` と同じ腐り方をする（実際、今回の3件はどれもそこに載っていなかった）。

なので `REQUIRED_COLUMNS` は手書きで維持しない。**`schemaHealth.test.ts` が `src/**/*.ts` の `INSERT INTO` を走査し、完全一致を強制する**（`confirmPolicy.test.ts` と同じ流儀）。INSERT に列を足してレジストリを更新し忘れるとテストが落ちる。正規表現が空振りして vacuously pass しないよう下限アサーションも入れた。

**ガードが実際に噛むことを確認済み** — レジストリから `visitor_id` を外すと2テストが赤くなり、戻すと緑に戻ることを見た（CLAUDE.md「書いた回帰テストが実際に噛むことを確認する」）。

## 合流先を途中で変えた

当初 `fetchMeasurementHealth` の中で呼んだが、**既存テスト「tenantId指定時は全クエリに tenant_id 絞り込みが入る」を壊した**。`information_schema` への問い合わせはテナント絞り込みを持たないので当然だが、この不変条件は残す価値がある。

スキーマ整合は**テナント固有ではなく R2C 運用の情報**なので、ルート側で **super_admin にだけ合成**する形に変更した。テナントには返さないし、余計なクエリも投げない。**新エンドポイントは作っていない。**

## 表示

`/admin/monitoring` の計測ヘルスに合流。欠落0件なら「欠落なし（34テーブル / 257列を確認）」、欠落ありなら**列名を名指し**で出し、「適用は人の承認が必要」「記録が無言で落ちるためエラーログには現れない」を添える。**新規ダッシュボードは作っていない。**

## テスト

- `findMissingColumns` の純関数 6 件（全て揃う / 1列欠け / テーブルごと欠落 / DBが0行 / 余分な列 / 要求が空）
- レジストリ同期の機械ガード 2 件
- ルート 3 件（super_admin に返る / client_admin に返さずクエリも投げない / 欠落0件でも `missing: []` を返す）

## 検証

- backend typecheck 0 / admin-ui typecheck 0 / oxlint 0
- analytics + schemaHealth **20 スイート / 228 テスト 全通過**
- admin-ui vitest **42 ファイル / 571 テスト 全通過**

## 関連

- 要件定義 v1.3: https://claude.ai/code/artifact/4a311d89-76ba-4831-93ff-7c2e7348debe
- Asana: B1（学習ループUX）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgCQYt8UMPgm4HNVu7nv7z