### PR TITLE
feat(analytics): 学習機能の点火状態をテナント×機能で可視化する

### DIFF
--- a/admin-ui/src/pages/admin/monitoring/index.tsx
+++ b/admin-ui/src/pages/admin/monitoring/index.tsx
@@ -25,6 +25,22 @@ interface MeasurementHealth {
     checkedTables: number;
     checkedColumns: number;
   };
+  /** super_admin のときだけ返る。テナント×機能の点火状態。 */
+  ignitionStatus?: {
+    rows: Array<{
+      tenantId: string;
+      cells: Array<{
+        feature: string;
+        label: string;
+        enabled: boolean;
+        reason: string;
+        configKey: string;
+        controlledBy: "env" | "tenants.features";
+      }>;
+    }>;
+    envControlledFeatures: string[];
+    anyEnabled: boolean;
+  };
 }
 
 interface MonitoringKpis {
@@ -442,6 +458,24 @@ export default function MonitoringPage() {
             >
               計測ヘルス（直近30日）
             </h2>
+            {health?.schemaHealth && (
+              <div
+                style={{
+                  marginBottom: 12,
+                  padding: "10px 14px",
+                  borderRadius: 10,
+                  fontSize: 14,
+                  fontWeight: 700,
+                  background: health.schemaHealth.missing.length === 0 ? "rgba(34,197,94,0.10)" : "rgba(248,113,113,0.12)",
+                  border: `1px solid ${health.schemaHealth.missing.length === 0 ? "rgba(34,197,94,0.35)" : "rgba(248,113,113,0.4)"}`,
+                  color: health.schemaHealth.missing.length === 0 ? "#4ade80" : "#f87171",
+                }}
+              >
+                {health.schemaHealth.missing.length === 0
+                  ? "異常なし — 本番スキーマはコードと一致しています"
+                  : `要対応 — 本番に存在しない列があります（${health.schemaHealth.missing.length}テーブル）`}
+              </div>
+            )}
             <p style={{ fontSize: 13, color: "var(--muted-foreground)", marginTop: 0, marginBottom: 16 }}>
               「何を直しても効果を測れない」状態を脱したかを確認する画面です。以降の効果測定の判定母数になります。
             </p>
@@ -547,6 +581,50 @@ export default function MonitoringPage() {
                           該当する migration を本番に適用してください。適用は人の承認が必要です。
                           記録が無言で落ちるため、エラーログには現れません。
                         </div>
+                      </div>
+                    )}
+                  </MeasurementHealthCard>
+                )}
+
+                {/* 点火状態(R2C運用のみ)。フラグの実効値を知る手段がSSHしかない状態を解消する。
+                    env でしか開閉できないものは画面から変えられない(CLAUDE.md 禁止41の是正対象)。 */}
+                {health?.ignitionStatus && (
+                  <MeasurementHealthCard
+                    title="学習機能の点火状態"
+                    description="どのテナントで何が有効か。無効なものは理由も出す"
+                  >
+                    {health.ignitionStatus.rows.length === 0 ? (
+                      <div style={{ fontSize: 14, color: "var(--muted-foreground)" }}>テナントがありません</div>
+                    ) : !health.ignitionStatus.anyEnabled ? (
+                      <div style={{ fontSize: 14, color: "var(--muted-foreground)" }}>
+                        有効な機能はありません
+                      </div>
+                    ) : null}
+                    <div style={{ display: "flex", flexDirection: "column", gap: 14, marginTop: 8 }}>
+                      {health.ignitionStatus.rows.map((row) => (
+                        <div key={row.tenantId}>
+                          <div style={{ fontSize: 13, fontWeight: 700, marginBottom: 4 }}>{row.tenantId}</div>
+                          <div style={{ display: "flex", flexDirection: "column", gap: 3 }}>
+                            {row.cells.map((c) => (
+                              <div key={c.feature} style={{ fontSize: 12.5, lineHeight: 1.7 }}>
+                                <span style={{ color: c.enabled ? "#4ade80" : "#6b7280", fontWeight: 700 }}>
+                                  {c.enabled ? "有効" : "無効"}
+                                </span>
+                                <span style={{ margin: "0 6px" }}>{c.label}</span>
+                                <span style={{ color: "var(--muted-foreground)" }}>— {c.reason}</span>
+                                <span style={{ color: "#6b7280", marginLeft: 6 }}>
+                                  <code>{c.configKey}</code>
+                                </span>
+                              </div>
+                            ))}
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                    {health.ignitionStatus.envControlledFeatures.length > 0 && (
+                      <div style={{ marginTop: 10, fontSize: 12, color: "var(--muted-foreground)", lineHeight: 1.7 }}>
+                        このうち {health.ignitionStatus.envControlledFeatures.length} 機能は環境変数でしか切り替えられません。
+                        画面から開閉できないため、点火し忘れに気づけない構造です（順次 tenants.features へ移行）。
                       </div>
                     )}
                   </MeasurementHealthCard>

--- a/src/agent/judge/judgeSweepRunner.ts
+++ b/src/agent/judge/judgeSweepRunner.ts
@@ -35,8 +35,10 @@ import { buildSweepCandidatesQuery, type SweepCandidateRow } from "./sweepCandid
 
 const logger = pino({ name: "judge-sweep" });
 
-/** 既定は r2c_default のみ(段階的開放。CLAUDE.md 禁止35と同じ理由)。 */
-function resolveSweepTenants(): string[] {
+/** 既定は r2c_default のみ(段階的開放。CLAUDE.md 禁止35と同じ理由)。
+ *  点火状態の可視化(analytics/ignitionStatus.ts)からも参照する。
+ *  **第2の解釈を書かない** — 対象テナントの判定はここが唯一の実装。 */
+export function resolveSweepTenants(): string[] {
   const raw = process.env.JUDGE_SWEEP_TENANTS;
   if (!raw || raw.trim() === "") return ["r2c_default"];
   return raw.split(",").map((s) => s.trim()).filter(Boolean);

--- a/src/api/admin/analytics/ignitionStatus.test.ts
+++ b/src/api/admin/analytics/ignitionStatus.test.ts
@@ -1,0 +1,121 @@
+// src/api/admin/analytics/ignitionStatus.test.ts
+//
+// 1) buildIgnitionStatus の純関数テスト(env の境界値を含む)
+// 2) 機械的ガード — 既存のフラグ判定を再実装していないこと。
+//    featureFlag.ts / judgeSweepRunner.ts の解釈が2箇所に割れると、
+//    画面が「有効」と言っているのに本番は無効、という最悪の食い違いが起きる。
+
+import fs from "node:fs";
+import path from "node:path";
+import { buildIgnitionStatus, type IgnitionDeps, type TenantIgnitionInput } from "./ignitionStatus";
+
+const TENANTS: TenantIgnitionInput[] = [
+  { id: "carnation", features: { sales_stage_continuity: true, hermes_raw_data_consent: false } },
+  { id: "r2c_default", features: null },
+];
+
+function deps(over: Partial<IgnitionDeps> = {}): IgnitionDeps {
+  return {
+    learnedMemoryWrite: () => false,
+    learnedMemoryRead: () => false,
+    sweepTenants: () => ["r2c_default"],
+    ...over,
+  };
+}
+
+const cell = (res: ReturnType<typeof buildIgnitionStatus>, tenant: string, feature: string) =>
+  res.rows.find((r) => r.tenantId === tenant)!.cells.find((c) => c.feature === feature)!;
+
+describe("buildIgnitionStatus", () => {
+  it("全テナント×全機能のセルを返す", () => {
+    const res = buildIgnitionStatus(TENANTS, deps());
+    expect(res.rows.map((r) => r.tenantId)).toEqual(["carnation", "r2c_default"]);
+    expect(res.rows[0]!.cells).toHaveLength(5);
+  });
+
+  it("定期評価の対象テナントだけ judge_sweep が有効になる", () => {
+    const res = buildIgnitionStatus(TENANTS, deps());
+    expect(cell(res, "r2c_default", "judge_sweep").enabled).toBe(true);
+    expect(cell(res, "carnation", "judge_sweep").enabled).toBe(false);
+  });
+
+  it("sweep対象が '*' なら全テナントが対象になる", () => {
+    const res = buildIgnitionStatus(TENANTS, deps({ sweepTenants: () => ["*"] }));
+    expect(res.rows.every((r) => r.cells.find((c) => c.feature === "judge_sweep")!.enabled)).toBe(true);
+  });
+
+  it("sweep対象が空配列なら誰も対象にならない", () => {
+    const res = buildIgnitionStatus(TENANTS, deps({ sweepTenants: () => [] }));
+    expect(res.rows.every((r) => !r.cells.find((c) => c.feature === "judge_sweep")!.enabled)).toBe(true);
+  });
+
+  it("features が null のテナントでも落ちず、全て無効として扱う", () => {
+    const res = buildIgnitionStatus(TENANTS, deps());
+    expect(cell(res, "r2c_default", "sales_stage_continuity").enabled).toBe(false);
+    expect(cell(res, "r2c_default", "hermes_raw_data_consent").enabled).toBe(false);
+  });
+
+  it("features の boolean true と文字列 \"true\" を同じ扱いにする(dialogAgent は ->> で文字列比較する)", () => {
+    const res = buildIgnitionStatus(
+      [{ id: "t", features: { sales_stage_continuity: "true" } }],
+      deps(),
+    );
+    expect(cell(res, "t", "sales_stage_continuity").enabled).toBe(true);
+  });
+
+  it('features の "yes" や 1 は有効にしない(dialogAgent の === "true" と揃える)', () => {
+    for (const v of ["yes", 1, "1", "TRUE", null]) {
+      const res = buildIgnitionStatus([{ id: "t", features: { sales_stage_continuity: v } }], deps());
+      expect(cell(res, "t", "sales_stage_continuity").enabled).toBe(false);
+    }
+  });
+
+  it("無効なセルには「なぜ無効か」が入る(数値だけを出さない)", () => {
+    const res = buildIgnitionStatus(TENANTS, deps());
+    const c = cell(res, "carnation", "judge_sweep");
+    expect(c.enabled).toBe(false);
+    expect(c.reason).toContain("対象外");
+    expect(c.configKey).toBe("JUDGE_SWEEP_TENANTS");
+  });
+
+  it("env でしか開閉できない機能を envControlledFeatures に列挙する(禁止41の是正対象)", () => {
+    const res = buildIgnitionStatus(TENANTS, deps());
+    expect(res.envControlledFeatures).toEqual([
+      "judge_sweep",
+      "learned_memory_read",
+      "learned_memory_write",
+    ]);
+  });
+
+  it("全機能が無効なら anyEnabled=false(「有効な機能はありません」を描けるようにする)", () => {
+    const res = buildIgnitionStatus([{ id: "t", features: null }], deps({ sweepTenants: () => [] }));
+    expect(res.anyEnabled).toBe(false);
+  });
+
+  it("テナントが0件でも落ちない", () => {
+    const res = buildIgnitionStatus([], deps());
+    expect(res.rows).toEqual([]);
+    expect(res.anyEnabled).toBe(false);
+  });
+
+  it("画面表示用の label に内部語(env名・列名)を出さない", () => {
+    const res = buildIgnitionStatus(TENANTS, deps());
+    for (const c of res.rows[0]!.cells) {
+      expect(c.label).not.toMatch(/LEARNED_MEMORY|JUDGE_SWEEP|tenants\.features|_id\b/);
+    }
+  });
+});
+
+describe("フラグ解釈を再実装していないことの機械的ガード", () => {
+  const src = fs.readFileSync(path.join(__dirname, "ignitionStatus.ts"), "utf-8");
+
+  it("featureFlag.ts と judgeSweepRunner.ts の判定を import している", () => {
+    expect(src).toMatch(/import\s*\{[^}]*isLearnedMemoryWriteEnabled[^}]*\}\s*from\s*".*featureFlag"/s);
+    expect(src).toMatch(/import\s*\{[^}]*resolveSweepTenants[^}]*\}\s*from\s*".*judgeSweepRunner"/s);
+  });
+
+  it("env を直接読んで判定を再実装していない", () => {
+    // process.env をこのファイルで読むと、featureFlag.ts と解釈が割れる余地が生まれる。
+    expect(src).not.toMatch(/process\.env/);
+  });
+});

--- a/src/api/admin/analytics/ignitionStatus.ts
+++ b/src/api/admin/analytics/ignitionStatus.ts
@@ -1,0 +1,168 @@
+// src/api/admin/analytics/ignitionStatus.ts
+// 学習・会話系機能の「点火状態」をテナント×機能で可視化する。
+//
+// なぜ必要か (2026-08-24 の実例):
+//   本番の .env には LEARNED_MEMORY_ENABLED=true / LEARNED_MEMORY_TENANTS=carnation が
+//   入っており、読込みは未設定時の既定 true。つまり読み書きとも有効だった。
+//   それでも learned_memory は 0 件で、原因はフラグではなく上流(Judge が評価しない)だった。
+//   **この切り分けに VPS への SSH が必要だったこと自体が問題**(CLAUDE.md 禁止41)。
+//
+// なぜ独立したファイルか:
+//   入力が env と DB の2系統で、出力は表示専用。measurementHealth の集計クエリ群とは形が違う。
+//   目的は「分散しているフラグ解釈を1箇所に集めること」で、
+//   featureFlag.ts / judgeSweepRunner.ts の判定は **import して使う。再実装しない**
+//   (2箇所目を作ると解釈が割れる)。
+//
+// 画面はR2C運用者(super_admin)専用。したがって label/reason は平易な日本語にしつつ、
+// 「どこを変えれば切り替わるか」は configKey で明示する(運用者にはこれが必要な情報)。
+
+import type { Pool } from "pg";
+import {
+  isLearnedMemoryWriteEnabled,
+  isLearnedMemoryReadEnabled,
+} from "../../../agent/memory/featureFlag";
+import { resolveSweepTenants } from "../../../agent/judge/judgeSweepRunner";
+
+type Db = Pick<Pool, "query">;
+
+/** 点火状態を判定する対象テナント1件分の入力。 */
+export interface TenantIgnitionInput {
+  id: string;
+  features: Record<string, unknown> | null;
+}
+
+export interface IgnitionCell {
+  feature: string;
+  /** 画面表示用。内部語(env名・列名)をここに出さない。 */
+  label: string;
+  enabled: boolean;
+  /** 有効/無効の根拠を1文で。 */
+  reason: string;
+  /** どこを変えると切り替わるか。運用者向けなので内部名でよい。 */
+  configKey: string;
+  /** env で決まるものは画面から開閉できない(禁止41)。 */
+  controlledBy: "env" | "tenants.features";
+}
+
+export interface IgnitionRow {
+  tenantId: string;
+  cells: IgnitionCell[];
+}
+
+export interface IgnitionStatusResponse {
+  rows: IgnitionRow[];
+  /** env だけで決まる機能(画面から開閉できない=禁止41 の是正対象)。 */
+  envControlledFeatures: string[];
+  /** 1つでも有効な機能があるか。全て false なら「有効な機能はありません」を描く。 */
+  anyEnabled: boolean;
+}
+
+/** テスト差し替え用。既定は実装の唯一の情報源をそのまま使う。 */
+export interface IgnitionDeps {
+  learnedMemoryWrite: (tenantId: string) => boolean;
+  learnedMemoryRead: (tenantId: string) => boolean;
+  sweepTenants: () => string[];
+}
+
+const DEFAULT_DEPS: IgnitionDeps = {
+  learnedMemoryWrite: isLearnedMemoryWriteEnabled,
+  learnedMemoryRead: isLearnedMemoryReadEnabled,
+  sweepTenants: resolveSweepTenants,
+};
+
+function featureFlagOn(features: Record<string, unknown> | null, key: string): boolean {
+  // dialogAgent.ts は features->>'key' === "true" で判定する(JSONBのbooleanが "true" になる)。
+  // JSON として読む本経路でも、boolean true と文字列 "true" の両方を有効として扱い挙動を揃える。
+  const v = features?.[key];
+  return v === true || v === "true";
+}
+
+/**
+ * テナント一覧から点火行列を組む純関数。DB アクセスは呼び出し側が行う。
+ */
+export function buildIgnitionStatus(
+  tenants: TenantIgnitionInput[],
+  deps: IgnitionDeps = DEFAULT_DEPS,
+): IgnitionStatusResponse {
+  const sweep = deps.sweepTenants();
+
+  const rows: IgnitionRow[] = tenants.map((t) => {
+    const inSweep = sweep.includes(t.id) || sweep.includes("*");
+    const write = deps.learnedMemoryWrite(t.id);
+    const read = deps.learnedMemoryRead(t.id);
+    const stage = featureFlagOn(t.features, "sales_stage_continuity");
+    const consent = featureFlagOn(t.features, "hermes_raw_data_consent");
+
+    const cells: IgnitionCell[] = [
+      {
+        feature: "judge_sweep",
+        label: "会話の自動評価（定期）",
+        enabled: inSweep,
+        reason: inSweep
+          ? "定期評価の対象になっています"
+          : "定期評価の対象外です。対象に入れないと評価が生まれず、後続の学習も起動しません",
+        configKey: "JUDGE_SWEEP_TENANTS",
+        controlledBy: "env",
+      },
+      {
+        feature: "learned_memory_write",
+        label: "会話から覚える（記録）",
+        enabled: write,
+        reason: write
+          ? "高評価の会話を記録します。ただし記録は自動評価が動いていることが前提です"
+          : "記録しません",
+        configKey: "LEARNED_MEMORY_ENABLED / LEARNED_MEMORY_TENANTS",
+        controlledBy: "env",
+      },
+      {
+        feature: "learned_memory_read",
+        label: "覚えたことを回答に使う",
+        enabled: read,
+        reason: read
+          ? "回答時に参照します（読込みは未設定なら有効が既定）"
+          : "参照しません",
+        configKey: "LEARNED_MEMORY_READ_ENABLED",
+        controlledBy: "env",
+      },
+      {
+        feature: "sales_stage_continuity",
+        label: "会話の流れを引き継ぐ",
+        enabled: stage,
+        reason: stage
+          ? "前のやり取りを踏まえて会話が進みます"
+          : "毎回ふりだしに戻ります。会話が1往復で終わる原因になります",
+        configKey: "tenants.features.sales_stage_continuity",
+        controlledBy: "tenants.features",
+      },
+      {
+        feature: "hermes_raw_data_consent",
+        label: "外部への学習データ提供の同意",
+        enabled: consent,
+        reason: consent ? "同意済みです" : "未同意です（提供しません）",
+        configKey: "tenants.features.hermes_raw_data_consent",
+        controlledBy: "tenants.features",
+      },
+    ];
+
+    return { tenantId: t.id, cells };
+  });
+
+  const envControlled = new Set<string>();
+  for (const r of rows) {
+    for (const c of r.cells) if (c.controlledBy === "env") envControlled.add(c.feature);
+  }
+
+  return {
+    rows,
+    envControlledFeatures: [...envControlled].sort(),
+    anyEnabled: rows.some((r) => r.cells.some((c) => c.enabled)),
+  };
+}
+
+/** tenants を1回引いて点火行列を返す。 */
+export async function fetchIgnitionStatus(db: Db): Promise<IgnitionStatusResponse> {
+  const rows = await db.query<{ id: string; features: Record<string, unknown> | null }>(
+    `SELECT id, features FROM tenants ORDER BY id`,
+  );
+  return buildIgnitionStatus(rows.rows);
+}

--- a/src/api/admin/analytics/routes.ts
+++ b/src/api/admin/analytics/routes.ts
@@ -21,6 +21,7 @@ import {
 } from "./summaryQueries";
 import { fetchMeasurementHealth } from "./measurementHealth";
 import { fetchSchemaHealth } from "./schemaHealth";
+import { fetchIgnitionStatus } from "./ignitionStatus";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -200,8 +201,13 @@ export function registerAnalyticsRoutes(app: Express): void {
         // スキーマ整合はテナント固有ではなくR2C運用の情報なので、
         // fetchMeasurementHealth(全クエリが tenant_id で絞られる契約)には入れず、
         // ここで super_admin にだけ合成する。新エンドポイントは作らない。
-        const schemaHealth = isSuperAdmin ? await fetchSchemaHealth(pool) : undefined;
-        return res.json(schemaHealth ? { ...response, schemaHealth } : response);
+        // 点火状態も同じ理由(テナント固有ではなくR2C運用の情報)で super_admin にだけ合成する。
+        const [schemaHealth, ignitionStatus] = isSuperAdmin
+          ? await Promise.all([fetchSchemaHealth(pool), fetchIgnitionStatus(pool)])
+          : [undefined, undefined];
+        return res.json(
+          isSuperAdmin ? { ...response, schemaHealth, ignitionStatus } : response,
+        );
       } catch (err) {
         logger.warn("[GET /v1/admin/analytics/measurement-health]", err);
         return res.status(500).json({ error: "計測ヘルスの取得に失敗しました" });

--- a/src/api/admin/analytics/schemaHealthRoute.test.ts
+++ b/src/api/admin/analytics/schemaHealthRoute.test.ts
@@ -1,19 +1,24 @@
 // src/api/admin/analytics/schemaHealthRoute.test.ts
-// GET /v1/admin/analytics/measurement-health に合流させたスキーマ整合の HTTP 層テスト。
-// 判定ロジックは schemaHealth.test.ts で純関数として検証済みなので、ここでは
-// 「R2C運用にだけ出す」ことと「新エンドポイントを作っていない」ことだけを固定する。
+// GET /v1/admin/analytics/measurement-health に合流させた **super_admin 限定の運用ペイロード**
+// (スキーマ整合 / 点火状態)の HTTP 層テスト。
+// 判定ロジックは schemaHealth.test.ts / ignitionStatus.test.ts で純関数として検証済みなので、
+// ここでは「R2C運用にだけ出す」ことと「新エンドポイントを作っていない」ことだけを固定する。
 
 import express from 'express';
 import request from 'supertest';
 
 const mockFetchMeasurementHealth = jest.fn();
 const mockFetchSchemaHealth = jest.fn();
+const mockFetchIgnitionStatus = jest.fn();
 
 jest.mock('./measurementHealth', () => ({
   fetchMeasurementHealth: (...args: unknown[]) => mockFetchMeasurementHealth(...args),
 }));
 jest.mock('./schemaHealth', () => ({
   fetchSchemaHealth: (...args: unknown[]) => mockFetchSchemaHealth(...args),
+}));
+jest.mock('./ignitionStatus', () => ({
+  fetchIgnitionStatus: (...args: unknown[]) => mockFetchIgnitionStatus(...args),
 }));
 
 jest.mock('../../../lib/db', () => ({ pool: {}, getPool: () => ({}) }));
@@ -61,6 +66,11 @@ describe('GET /v1/admin/analytics/measurement-health のスキーマ整合', () 
       checkedTables: 34,
       checkedColumns: 257,
     });
+    mockFetchIgnitionStatus.mockReset().mockResolvedValue({
+      rows: [{ tenantId: 'carnation', cells: [] }],
+      envControlledFeatures: ['judge_sweep'],
+      anyEnabled: false,
+    });
   });
 
   it('super_admin には欠落列を返す', async () => {
@@ -83,8 +93,10 @@ describe('GET /v1/admin/analytics/measurement-health のスキーマ整合', () 
 
     expect(res.status).toBe(200);
     expect(res.body.schemaHealth).toBeUndefined();
+    expect(res.body.ignitionStatus).toBeUndefined();
     // テナントに対して余計なクエリを投げない
     expect(mockFetchSchemaHealth).not.toHaveBeenCalled();
+    expect(mockFetchIgnitionStatus).not.toHaveBeenCalled();
     // 既存の計測ヘルス自体は従来どおり返る
     expect(res.body.validUserSessionCount).toBe(0);
   });
@@ -98,5 +110,16 @@ describe('GET /v1/admin/analytics/measurement-health のスキーマ整合', () 
 
     expect(res.body.schemaHealth.missing).toEqual([]);
     expect(res.body.schemaHealth.checkedTables).toBe(34);
+  });
+
+  it('super_admin には点火状態も返す(env でしか開閉できない機能を含む)', async () => {
+    const res = await request(makeApp())
+      .get('/v1/admin/analytics/measurement-health')
+      .set('x-role', 'super_admin');
+
+    expect(res.status).toBe(200);
+    expect(res.body.ignitionStatus.rows[0].tenantId).toBe('carnation');
+    expect(res.body.ignitionStatus.envControlledFeatures).toContain('judge_sweep');
+    expect(res.body.ignitionStatus.anyEnabled).toBe(false);
   });
 });


### PR DESCRIPTION
フラグの実効値を知る手段が **VPS への SSH しかない**状態を解消する（CLAUDE.md 禁止41 / 要件 Ra）。

## なぜ必要か（2026-08-24 の実例）

本番の `.env` には `LEARNED_MEMORY_ENABLED=true` / `LEARNED_MEMORY_TENANTS=carnation` が入っており、読込みは未設定時の既定 `true`。つまり **読み書きとも有効だった**。それでも `learned_memory` は 0 件で、原因はフラグではなく上流（Judge が評価しない）だった。

**この切り分けに SSH が必要だったこと自体が問題。**

## ★ 判定を再実装していない

`featureFlag.ts` の `isLearnedMemoryWriteEnabled` / `isLearnedMemoryReadEnabled` と、`judgeSweepRunner.ts` の `resolveSweepTenants` を **import して使う**。後者は未エクスポートだったので `export` に変更した（第2の解釈を書かないため）。

**2箇所目を作ると「画面は有効と言うのに本番は無効」という最悪の食い違いが起きる。** そこで `ignitionStatus.test.ts` が機械的に検査する：

- `process.env` を直接読んでいないこと
- 両モジュールを import していること

**ガードが噛むことを確認済み** — `sweepTenants` を `process.env` 直読みに書き換えると3テストが赤くなり、戻すと緑に戻ることを見た。

## 画面（R2C運用専用）

- **最上部に「異常なし / 要対応」の一行サマリ** — 要件 F6「スクロールせずに正常／異常が判定できる」
- テナント × 機能の行列。**無効なセルには必ず「なぜ無効か」**を出す（数値やバッジだけにしない）
- `label` に内部語（env 名・列名）を出さない。ただし `configKey` で「**どこを変えれば切り替わるか**」は明示する — この画面の読者は運用者なので、それが必要な情報
- **env でしか開閉できない機能数を明示**し、順次 `tenants.features` へ移す方針を書いた（禁止41 の是正対象を画面自身が申告する）

## 対象の機能

| 機能 | 表示ラベル | 制御 |
|---|---|---|
| `judge_sweep` | 会話の自動評価（定期） | env |
| `learned_memory_write` | 会話から覚える（記録） | env |
| `learned_memory_read` | 覚えたことを回答に使う | env |
| `sales_stage_continuity` | 会話の流れを引き継ぐ | tenants.features |
| `hermes_raw_data_consent` | 外部への学習データ提供の同意 | tenants.features |

## 合流先

`schemaHealth`（#887）と同じ理由 — テナント固有ではなく R2C 運用の情報なので、`measurement-health` に **super_admin 限定で合成**。テナントには返さず余計なクエリも投げない。**新エンドポイントは作っていない。**

## テスト

- 純関数 12 件（sweep 対象 / `*` 指定 / 空配列 / `features` が null / boolean `true` と文字列 `"true"` の同一視 / `"yes"`・`1` を有効にしない / 理由が入る / テナント0件 / label に内部語を出さない など）
- 再実装ガード 2 件
- ルート 1 件追加（既存の schemaHealth ルートテストを「super_admin 限定の運用ペイロード」として拡張）

## 検証

- backend typecheck 0 / admin-ui typecheck 0 / oxlint 0
- analytics + ignition + schemaHealth + judgeSweep + memory **25 スイート / 289 テスト 全通過**
- admin-ui vitest **42 ファイル / 571 テスト 全通過**

## 関連

- 要件定義 v1.3: https://claude.ai/code/artifact/4a311d89-76ba-4831-93ff-7c2e7348debe
- 前提: #887（同じ画面・同じルートに合流）
- Asana: B2（学習ループUX）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgCQYt8UMPgm4HNVu7nv7z