### PR TITLE
feat(knowledge): 誤答是正の着地層を決める純関数を追加する

### DIFF
--- a/src/agent/knowledge/correctionRouter.test.ts
+++ b/src/agent/knowledge/correctionRouter.test.ts
@@ -1,0 +1,127 @@
+// 誤答是正の着地層判定。3層の役割分担を守る要なので、境界を厚めに固定する。
+// D5(要件定義 v1.3): 迷ったら知識(事実)に倒す。
+import { routeCorrection, type CorrectionInput } from "./correctionRouter";
+
+const ctx = (correction: string): CorrectionInput => ({
+  question: "保証期間は？",
+  answer: "1年です。",
+  correction,
+});
+
+const layerOf = (c: string) => routeCorrection(ctx(c)).layer;
+
+describe("事実の訂正は知識へ", () => {
+  it.each([
+    ["保証は2年です", "期間"],
+    ["価格は12800円です", "金額"],
+    ["営業時間は10:00からです", "時刻"],
+    ["発送は3営業日かかります", "日数"],
+    ["正しくは日本製です", "訂正の言い回し"],
+    ["1年ではなく2年です", "否定による訂正"],
+    ["創業は2015年4月1日です", "日付"],
+    ["送料は無料ではありません", "否定による訂正"],
+  ])("%s → knowledge (%s)", (correction) => {
+    expect(layerOf(correction)).toBe("knowledge");
+  });
+});
+
+describe("振る舞いの指示はルールへ", () => {
+  it.each([
+    ["もっと丁寧に answer してほしい"],
+    ["値引きの話は避けてください"],
+    ["保証について聞かれたら在庫も案内して"],
+    ["カジュアルな口調で話してください"],
+    ["競合の話は言わないでください"],
+    ["必ず問い合わせ先を伝えて"],
+  ])("%s → rule", (correction) => {
+    const r = routeCorrection(ctx(correction));
+    expect(r.layer).toBe("rule");
+    expect(r.requiresTrigger).toBe(true);
+  });
+});
+
+describe("D5: 迷ったら知識に倒す", () => {
+  it("事実と方針が混在する指摘は知識へ（事実を優先）", () => {
+    const r = routeCorrection(ctx("保証は2年なので、聞かれたらそう答えて"));
+    expect(r.layer).toBe("knowledge");
+    expect(r.signals.fact.length).toBeGreaterThan(0);
+    expect(r.signals.policy.length).toBeGreaterThan(0);
+    expect(r.reason).toContain("事実を優先");
+  });
+
+  it.each([
+    ["これは違う"],
+    ["ちがいます"],
+    ["🙅"],
+    ["あ"],
+  ])("判断材料が乏しい指摘 %s は知識へ", (correction) => {
+    expect(layerOf(correction)).toBe("knowledge");
+  });
+
+  it("空文字でも落ちず知識へ倒す", () => {
+    const r = routeCorrection(ctx(""));
+    expect(r.layer).toBe("knowledge");
+    expect(r.requiresTrigger).toBe(false);
+    expect(r.reason).toContain("D5");
+  });
+
+  it("空白のみの指摘も空として扱う", () => {
+    expect(routeCorrection(ctx("　  \n ")).layer).toBe("knowledge");
+  });
+});
+
+describe("境界・異常系", () => {
+  it("1万字の指摘でも落ちない", () => {
+    const long = "保証は2年です。".repeat(1200).slice(0, 10000);
+    expect(layerOf(long)).toBe("knowledge");
+  });
+
+  it("correction が undefined でも落ちない（LLM出力の欠損を想定）", () => {
+    const r = routeCorrection({ question: "q", answer: "a" } as unknown as CorrectionInput);
+    expect(r.layer).toBe("knowledge");
+  });
+
+  // 「層」だけを見ると既定(knowledge)に落ちて通ってしまい、正規化が壊れても気づけない。
+  // シグナルを直接検証する。
+  it("全角数字の期間も事実シグナルとして拾う(表記ゆれで不発にしない)", () => {
+    const r = routeCorrection(ctx("保証は２年です"));
+    expect(r.signals.fact).toContain("期間");
+    expect(r.layer).toBe("knowledge");
+  });
+
+  it("全角の金額・時刻も拾う", () => {
+    expect(routeCorrection(ctx("価格は１２８００円です")).signals.fact).toContain("金額・割合");
+    expect(routeCorrection(ctx("営業時間は１０：００からです")).signals.fact).toContain("時刻");
+  });
+
+  it("rule に着地するときは必ず requiresTrigger=true（空triggerでの保存事故を防ぐ）", () => {
+    const r = routeCorrection(ctx("値引きの話は避けて"));
+    expect(r.layer).toBe("rule");
+    expect(r.requiresTrigger).toBe(true);
+  });
+
+  it("knowledge に着地するときは requiresTrigger=false", () => {
+    expect(routeCorrection(ctx("保証は2年です")).requiresTrigger).toBe(false);
+  });
+
+  it("reason は必ず非空で、なぜその層かを説明する", () => {
+    for (const c of ["保証は2年です", "丁寧に話して", "", "あ"]) {
+      expect(routeCorrection(ctx(c)).reason.length).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe("純関数であること", () => {
+  it("同じ入力で常に同じ結果を返す", () => {
+    const a = routeCorrection(ctx("保証は2年です"));
+    const b = routeCorrection(ctx("保証は2年です"));
+    expect(a).toEqual(b);
+  });
+
+  it("入力オブジェクトを変更しない", () => {
+    const input = ctx("保証は2年です");
+    const snapshot = JSON.stringify(input);
+    routeCorrection(input);
+    expect(JSON.stringify(input)).toBe(snapshot);
+  });
+});

--- a/src/agent/knowledge/correctionRouter.ts
+++ b/src/agent/knowledge/correctionRouter.ts
@@ -1,0 +1,129 @@
+// src/agent/knowledge/correctionRouter.ts
+// 「この回答は間違っている」という店主の指摘を、知識(事実)と指示ルール(方針)の
+// どちらに着地させるかを決める純関数。DB・ネットワーク・LLM に触れない。
+//
+// なぜ独立したファイルか:
+//   actionExecutor.ts の case 内に書くと境界条件のテストが書けない。
+//   3層の役割分担(CLAUDE.md「指示ルールの不変ルール」)を守る要になるため、
+//   分類ロジックだけを切り出して網羅的なテストを隣に置く。
+//
+// なぜ2箇所目を作らないか:
+//   同じ指摘がチャット経由と旧UI経由で違う層に着地すると、
+//   事実がルール層に溜まり「なぜこの回答になるのか」を誰も辿れなくなる。
+//   着地層の判定はここが唯一の実装。
+//
+// 設計の前提(CLAUDE.md 禁止3):
+//   フローの分岐を LLM の応答文の文字列一致で作らない。
+//   この関数は決定的なシグナルだけで判定し、LLM を使う場合も
+//   呼び出し側が構造化した結果を signals として渡す。
+//
+// 迷ったら知識(事実)に倒す(要件定義 v1.3 決定 D5):
+//   ルール層に事実が溜まる方が回復不能。知識に入れた事実が方針だった場合は
+//   後からルールを足せば済むが、逆は「知識は誤ったまま、ルールだけが増える」。
+
+/** 着地先の層。approved_responses(文体)は本関数の対象外。 */
+export type CorrectionLayer = "knowledge" | "rule";
+
+export interface CorrectionInput {
+  /** エンドユーザーの元の質問。 */
+  question: string;
+  /** AIが返した誤答。 */
+  answer: string;
+  /** 店主の指摘文。 */
+  correction: string;
+}
+
+export interface CorrectionRoute {
+  layer: CorrectionLayer;
+  /** なぜその層にしたか。店主に見せる文ではなく、監査とテストのための根拠。 */
+  reason: string;
+  /** 判定に使ったシグナル。デバッグと「なぜこうなったか」の説明に使う。 */
+  signals: { fact: string[]; policy: string[] };
+  /**
+   * rule 層に着地する場合、発火条件(trigger)を別途決める必要がある。
+   * 空の trigger で保存すると「保存は成功し、永久に発火しない」最悪の失敗形になる
+   * (要件定義 v1.3 の既知の破れ)。呼び出し側は必ず trigger を確定させること。
+   */
+  requiresTrigger: boolean;
+}
+
+// ── 事実のシグナル ────────────────────────────────────────────────
+// 具体的な値(数量・期間・金額・時刻・日付)を含む指摘は事実の訂正とみなす。
+const FACT_PATTERNS: Array<[RegExp, string]> = [
+  [/\d+\s*(年|ヶ月|か月|カ月|ヵ月|month|year)/i, "期間"],
+  [/\d+\s*(円|ドル|dollars?|yen|%|％)/i, "金額・割合"],
+  [/\d+\s*(時|分|日|時間|営業日|weeks?|days?)/i, "時間・日数"],
+  [/\d{1,2}\s*[:：]\s*\d{2}/, "時刻"],
+  [/\d{4}\s*年|\d{1,2}\s*月\s*\d{1,2}\s*日/, "日付"],
+  [/(正しく|本当|実際)(は|には)/, "訂正の言い回し"],
+  [/(ではなく|じゃなく|ではありません|違います|間違い|誤り)/, "否定による訂正"],
+];
+
+// ── 方針のシグナル ────────────────────────────────────────────────
+// 「どう振る舞ってほしいか」を述べる指摘は方針とみなす。
+const POLICY_PATTERNS: Array<[RegExp, string]> = [
+  [/(もっと|もう少し|なるべく|できるだけ)/, "程度の指示"],
+  [/(丁寧|フレンドリー|カジュアル|敬語|口調|トーン|言い方|言い回し)/, "口調の指示"],
+  [/(避けて|触れないで|言わないで|出さないで|しないで|禁止)/, "禁止の指示"],
+  [/(必ず|いつも|毎回|常に)\s*[^。]{0,20}(して|伝えて|案内|触れて|勧めて)/, "常時の振る舞い"],
+  [/(聞かれたら|質問されたら|話が出たら|ときは|場合は)/, "条件つきの振る舞い"],
+  [/(優先|先に|後で)\s*[^。]{0,10}(して|案内|紹介)/, "順序の指示"],
+];
+
+// 全角英数・半角カナ等を畳む。triggerMatching.ts が同じ理由で NFKC を使っており、
+// 「２年」と「2年」で判定が割れないようにする(表記ゆれで不発、が最も気づきにくい)。
+function normalize(s: string): string {
+  return s.normalize("NFKC");
+}
+
+function collect(text: string, patterns: Array<[RegExp, string]>): string[] {
+  const hits: string[] = [];
+  for (const [re, label] of patterns) {
+    if (re.test(text)) hits.push(label);
+  }
+  return hits;
+}
+
+/**
+ * 指摘の着地層を決める。
+ *
+ * 判定は指摘文(correction)を主に見る。元の質問と誤答は、
+ * 指摘が短い場合(「2年です」等)に文脈を補うためだけに使う。
+ */
+export function routeCorrection(input: CorrectionInput): CorrectionRoute {
+  const correction = (input.correction ?? "").trim();
+
+  // 空の指摘は判定材料が無い。D5 に従い知識へ倒す(呼び出し側が内容を確定させる)。
+  if (correction === "") {
+    return {
+      layer: "knowledge",
+      reason: "指摘の内容が空のため、事実の訂正として扱う（D5: 迷ったら知識）",
+      signals: { fact: [], policy: [] },
+      requiresTrigger: false,
+    };
+  }
+
+  const normalized = normalize(correction);
+  const fact = collect(normalized, FACT_PATTERNS);
+  const policy = collect(normalized, POLICY_PATTERNS);
+
+  // 方針のシグナルだけがある場合のみルール層へ。
+  // 両方ある場合(「保証は2年なので、聞かれたらそう答えて」)は事実を含むため知識へ倒す。
+  if (policy.length > 0 && fact.length === 0) {
+    return {
+      layer: "rule",
+      reason: `振る舞いの指示のみで具体的な値を含まないため、方針として扱う（${policy.join("・")}）`,
+      signals: { fact, policy },
+      requiresTrigger: true,
+    };
+  }
+
+  const reason =
+    fact.length > 0 && policy.length > 0
+      ? `具体的な値と振る舞いの指示が混在するため、事実を優先して知識へ（${fact.join("・")}）`
+      : fact.length > 0
+        ? `具体的な値を含むため、事実の訂正として扱う（${fact.join("・")}）`
+        : "事実とも方針とも判断できないため、知識として扱う（D5: 迷ったら知識）";
+
+  return { layer: "knowledge", reason, signals: { fact, policy }, requiresTrigger: false };
+}


### PR DESCRIPTION
「この回答は間違っている」という店主の指摘を、**知識（事実）**と**指示ルール（方針）**のどちらに着地させるかを判定する純関数。C2b（チャットからの是正）の前提。

## なぜ純関数として切り出すか

`actionExecutor.ts` の `case` 内に書くと**境界条件のテストが書けない**。3層の役割分担（CLAUDE.md「指示ルールの不変ルール」）を守る要になるため、分類だけを独立させて網羅的なテストを隣に置く。

同じ指摘がチャット経由と旧UI経由で違う層に着地すると、**事実がルール層に溜まり「なぜこの回答になるのか」を誰も辿れなくなる**。着地層の判定はここが唯一の実装。

## 判定方針

| 指摘の内容 | 着地先 |
|---|---|
| 具体的な値（期間・金額・時刻・日付）や訂正の言い回しを含む | **知識** |
| 振る舞いの指示（口調・禁止・条件つき）のみ | **ルール** |
| 両方を含む | **知識**（事実を優先） |
| 判断できない・空 | **知識**（D5) |

**D5「迷ったら知識に倒す」の理由**: ルール層に事実が溜まる方が回復不能。知識に入れた事実が方針だった場合は後からルールを足せば済むが、逆は「知識は誤ったまま、ルールだけが増え続ける」。

## 守った制約

- **禁止3**: LLM の応答文の文字列一致で分岐しない。決定的なシグナルだけで判定し、LLM を使う場合も呼び出し側が構造化した結果を渡す
- **空 trigger 事故の予防**: rule 層に着地する場合は `requiresTrigger: true` を返す。空の trigger で保存すると「**保存は成功し、永久に発火しない**」最悪の失敗形になる（要件定義の既知の破れ）
- **NFKC 正規化**: `triggerMatching.ts` と同じ理由。「２年」と「2年」で判定が割れると、**表記ゆれで不発**という最も気づきにくい壊れ方をする
- DB・ネットワーク・LLM に触れない

## テスト 30 件

事実 8 / 方針 6 / D5（混在・判断不能・空・空白のみ）/ 1万字 / `undefined` / 全角の期間・金額・時刻 / 純関数性（同一入力同一出力・入力を変更しない）。

### 偽グリーンを1件潰した

当初「全角数字の期間も事実として拾う」は**層だけを見ており、既定の knowledge に落ちて通っていた** — 正規化が壊れても気づけない状態だった。`signals.fact` を直接検証する形に直し、**正規化を外すと2件が赤くなる**ことを確認した（CLAUDE.md「書いた回帰テストが実際に噛むことを確認する」）。

## 検証

- typecheck 0 / oxlint 0 / **30 テスト全通過**
- 既存ファイルは1つも変更していない（新規2ファイルのみ）

## 関連

- 要件定義 v1.3: https://claude.ai/code/artifact/4a311d89-76ba-4831-93ff-7c2e7348debe
- 後続: C2b（3点セット+UIの配線）
- Asana: C2a（学習ループUX）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgCQYt8UMPgm4HNVu7nv7z