### PR TITLE
feat(agent): 会話の誤答をその場で直せるようにする

### DIFF
--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -793,6 +793,45 @@ describe("CopilotPreviewPage — 構造化カード(card)からの描画", () =>
     );
   });
 
+  // C2b: 誤答に気づいた場所から直せるようにする(CLAUDE.md 禁止45)。
+  // 「知識かルールか」は店主に選ばせず suggest_answer_correction が判定する。
+  it("「この回答を直す」はAI応答にのみ表示され、押すと是正の判定を実送信する", async () => {
+    mockAgent({
+      reply: "会話内容はこちらです。",
+      actions: [
+        {
+          tool: "get_chat_session_messages",
+          result: "セッション[a1b2c3d4]の会話（全2件中2件）:\nお客様: 保証期間は\nAI: 1年です",
+          card: {
+            kind: "chat_session_messages",
+            shortId: "a1b2c3d4",
+            totalMessages: 2,
+            messages: [
+              { role: "user", roleLabel: "お客様", content: "保証期間は" },
+              { role: "assistant", roleLabel: "AI", content: "1年です" },
+            ],
+          },
+        },
+      ],
+    });
+
+    await send("a1b2c3d4の会話を見せて");
+
+    const chip = await screen.findByRole("button", { name: "✏️ この回答を直す" });
+    expect(screen.getAllByRole("button", { name: "✏️ この回答を直す" })).toHaveLength(1);
+    await waitFor(() => expect((screen.getByLabelText("送信") as HTMLButtonElement).disabled).toBe(false));
+
+    fireEvent.click(chip);
+
+    await waitFor(() =>
+      expect(
+        screen.getByText(
+          "この回答(お客様:「保証期間は」→AI:「1年です」)は間違っています。どこが違うか伝えるので、直し方を判定してください",
+        ),
+      ).toBeTruthy(),
+    );
+  });
+
   it("「この会話からルールを作る」は直前のお客様発言が無いAI応答には表示されない", async () => {
     mockAgent({
       reply: "会話内容はこちらです。",

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -215,6 +215,7 @@ const TIER_LABEL: Record<"low" | "normal" | "high", string> = { low: "低", norm
 
 // 自由入力欄からの実API呼び出しで使うツール名 → 日本語ラベル
 const REAL_TOOL_LABEL: Record<string, string> = {
+  suggest_answer_correction: "誤った回答の直し方を判定",
   get_weekly_briefing: "週次ブリーフィングの取得",
   suggest_tuning_rule: "指示ルールの下書き提案",
   save_tuning_rule: "指示ルールの保存",
@@ -2574,6 +2575,20 @@ function CardView({
                     style={{ alignSelf: "flex-start", fontSize: 12.5, fontWeight: 700, padding: "8px 14px", borderRadius: 8, cursor: "pointer", border: "1px solid var(--border)", background: "transparent", color: "var(--muted-foreground)", minHeight: 44 }}
                   >
                     🎛️ この会話からルールを作る
+                  </button>
+                )}
+                {/* 要件 F1: 誤答に気づいた場所から直せるようにする(CLAUDE.md 禁止45)。
+                    「知識かルールか」は店主に選ばせず suggest_answer_correction が判定する。 */}
+                {prevUser && onSendReal && (
+                  <button
+                    onClick={() =>
+                      onSendReal(
+                        `__real:この回答(お客様:「${prevUser.content.slice(0, 300)}」→AI:「${m.content.slice(0, 300)}」)は間違っています。どこが違うか伝えるので、直し方を判定してください`,
+                      )
+                    }
+                    style={{ alignSelf: "flex-start", fontSize: 12.5, fontWeight: 700, padding: "8px 14px", borderRadius: 8, cursor: "pointer", border: "1px solid var(--border)", background: "transparent", color: "var(--muted-foreground)", minHeight: 44 }}
+                  >
+                    ✏️ この回答を直す
                   </button>
                 )}
               </div>

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -13,6 +13,7 @@ import { FAQ_CATEGORY_IDS } from '../../../lib/knowledge/faqCategories';
 import { callGroq8bSuggestFromText, callGroq8bSuggest } from '../tuning/routes';
 import { listRules, createRule, updateRule, deleteRule, type ApprovedResponse, type RuleEvidence } from '../tuning/tuningRulesRepository';
 import { splitTriggerKeywords } from '../tuning/triggerMatching';
+import { routeCorrection } from "../../../agent/knowledge/correctionRouter";
 import { generateTestResponses } from '../tuning/testResponseRoutes';
 import { searchKnowledgeForSuggestion, formatKnowledgeContext } from '../../../lib/knowledgeSearchUtil';
 import { getGaps, updateGapStatus } from '../knowledge/knowledgeGapRepository';
@@ -1746,6 +1747,49 @@ export async function executeToolCall(
     }
 
     // -----------------------------------------------------------------------
+    // 誤答の是正。**店主に「知識かルールか」を選ばせない**(要件 F1)。
+    // 層の判定は correctionRouter(純関数)が唯一の実装。ここで再実装しない。
+    // 書き込みは行わず、既存の save_faq / suggest_tuning_rule へ繋ぐだけ。
+    // 新しい書き込み経路も新しいカード種別も作らない(禁止6・32)。
+    case 'suggest_answer_correction': {
+      const userMessage = String(args['user_message'] ?? '').trim();
+      const aiMessage = String(args['ai_message'] ?? '').trim();
+      const correction = String(args['correction'] ?? '').trim();
+
+      if (!userMessage || !aiMessage) {
+        return truncate('元の質問(user_message)とAIの回答(ai_message)が必要です');
+      }
+      if (!correction) {
+        return truncate('どこが違うかを教えてください（例:「保証は2年です」「値引きの話は避けて」）');
+      }
+      if (!tenantId) {
+        return truncate('テナントが特定できません。super_admin の場合は対象テナントを指定してください');
+      }
+
+      const route = routeCorrection({ question: userMessage, answer: aiMessage, correction });
+
+      if (route.layer === 'knowledge') {
+        // 事実の訂正 → 知識データへ。下書きは決定的に組む(質問=元の質問、答え=指摘)。
+        return truncate(
+          `事実の訂正として扱います。\n` +
+          `質問: ${userMessage}\n` +
+          `新しい答え: ${correction}\n` +
+          `\nこの内容でよいか店舗管理者に確認し、同意が得られたら save_faq を呼び出してください` +
+          `（question は上記の「質問」、answer は上記の「新しい答え」を使うこと）。` +
+          `保存後は「次に『${userMessage.slice(0, 30)}』と聞かれたら、この内容で答えます」と伝えてください。`
+        );
+      }
+
+      // 振る舞いの指示 → 指示ルールへ。下書きの生成は suggest_tuning_rule が唯一の実装なので、
+      // ここでは作らずそちらへ渡す(2箇所目を作らない)。
+      return truncate(
+        `振る舞いの指示として扱います（${route.reason}）。\n` +
+        `\n続けて suggest_tuning_rule を呼び出してください` +
+        `（user_message と ai_message は今回と同じものを渡し、指摘の内容「${correction.slice(0, 60)}」を反映させること）。` +
+        `どんな質問のときに使うかが決まっていない場合は、店舗管理者に聞き返してください。`
+      );
+    }
+
     case 'suggest_tuning_rule': {
       const freeText = String(args['free_text'] ?? '').trim();
       const userMessage = String(args['user_message'] ?? '').trim();

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -946,6 +946,82 @@ describe('POST /v1/admin/agent/chat', () => {
   });
 
   // -------------------------------------------------------------------------
+  // C2b: suggest_answer_correction — 誤答の是正を正しい層へ振り分ける(書き込みなし)
+  // -------------------------------------------------------------------------
+  describe('suggest_answer_correction', () => {
+    function callWith(correction: string, sessionId: string) {
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            choices: [{
+              message: {
+                content: null,
+                tool_calls: [{
+                  id: 'call-ac-1',
+                  type: 'function',
+                  function: {
+                    name: 'suggest_answer_correction',
+                    arguments: JSON.stringify({
+                      user_message: '保証期間は？',
+                      ai_message: '1年です。',
+                      correction,
+                    }),
+                  },
+                }],
+              },
+            }],
+          }),
+          text: async () => '',
+        })
+        .mockResolvedValueOnce(makeGroqResponse('こう直します。よろしいですか？'));
+
+      return request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: 'この回答は間違っています', sessionId });
+    }
+
+    it('事実の指摘は知識として扱い、save_faq へ誘導する（DB書き込みは行わない）', async () => {
+      const res = await callWith('保証は2年です', 'sess-ac-1');
+
+      expect(res.status).toBe(200);
+      const action = res.body.actions[0];
+      expect(action.tool).toBe('suggest_answer_correction');
+      expect(action.result).toContain('事実の訂正として扱います');
+      expect(action.result).toContain('save_faq');
+      // ルール側へは誘導しない
+      expect(action.result).not.toContain('suggest_tuning_rule');
+      // 読み取り専用: 書き込みは一切起きない
+      expect(mockCreateRule).not.toHaveBeenCalled();
+    });
+
+    it('振る舞いの指摘はルールとして扱い、suggest_tuning_rule へ繋ぐ（下書き生成を二重に実装しない）', async () => {
+      const res = await callWith('値引きの話は避けてください', 'sess-ac-2');
+
+      expect(res.status).toBe(200);
+      const action = res.body.actions[0];
+      expect(action.result).toContain('振る舞いの指示として扱います');
+      expect(action.result).toContain('suggest_tuning_rule');
+      expect(mockCreateRule).not.toHaveBeenCalled();
+    });
+
+    it('指摘が空なら、どこが違うかを聞き返す（層を決め打ちしない）', async () => {
+      const res = await callWith('', 'sess-ac-3');
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('どこが違うかを教えてください');
+      expect(mockCreateRule).not.toHaveBeenCalled();
+    });
+
+    it('確認ゲートの文言を成功文に混ぜない（正常応答が blocked として計測される事故を防ぐ）', async () => {
+      const res = await callWith('保証は2年です', 'sess-ac-4');
+
+      const result = String(res.body.actions[0].result);
+      expect(result).not.toContain('確認が必要です');
+      expect(result).not.toContain('確認をスキップできません');
+    });
+  });
+
   // Phase1: suggest_tuning_rule — 読み取り専用の下書き提案
   // -------------------------------------------------------------------------
   describe('suggest_tuning_rule', () => {

--- a/src/api/admin/agent/confirmPolicy.ts
+++ b/src/api/admin/agent/confirmPolicy.ts
@@ -100,6 +100,9 @@ export const WRITE_TOOL_RISK_TIERS: Record<string, RiskTier> = {
 // 書き込みを伴わないツール。DBへの書き込みも外部への副作用のある送出も行わない。
 // （網羅性テストのために明示列挙する。新規ツールはここか上の表のどちらかへ必ず追加する）
 export const NON_WRITE_TOOLS: readonly string[] = [
+  // 誤答の是正: 層を判定して既存の save_faq / suggest_tuning_rule へ繋ぐだけ。
+  // 自身は一切書き込まないため NON_WRITE。書き込みは繋いだ先の確認ゲートが守る。
+  'suggest_answer_correction',
   'get_tenant_settings',
   'get_faq_list',
   'get_avatar_status',

--- a/src/api/admin/agent/toolDefinitions.ts
+++ b/src/api/admin/agent/toolDefinitions.ts
@@ -596,6 +596,36 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
   {
     type: 'function',
     function: {
+      name: 'suggest_answer_correction',
+      description:
+        '「この回答は間違っている」という店舗管理者の指摘を受け取り、事実の訂正(知識データ)と振る舞いの指示(指示ルール)のどちらとして扱うべきかを判定する。書き込みは行わない読み取り専用ツール。' +
+        '会話の全文表示でAIの回答に対して「これは違う」「正しくは〜」と言われた場合に使う。' +
+        '**店舗管理者にどちらの層か選ばせてはいけない。** このツールが返した層に従い、' +
+        'layer=knowledge なら save_faq、layer=rule なら suggest_tuning_rule(その後 save_tuning_rule)へ進むこと。' +
+        '判定結果と下書きは必ず店舗管理者に提示し、同意を得てから保存すること。',
+      parameters: {
+        type: 'object',
+        properties: {
+          user_message: {
+            type: 'string',
+            description: 'お客様側の元の質問。',
+          },
+          ai_message: {
+            type: 'string',
+            description: 'その質問に対してAIが返した誤答。',
+          },
+          correction: {
+            type: 'string',
+            description: '店舗管理者の指摘（例:「保証は2年です」「値引きの話は避けて」）。',
+          },
+        },
+        required: ['user_message', 'ai_message', 'correction'],
+      },
+    },
+  },
+  {
+    type: 'function',
+    function: {
       name: 'suggest_tuning_rule',
       description:
         '店舗管理者の自然な言葉による指示、または既存の会話のやりとり・知識ギャップから、AIチャットボットの「指示ルール」（トリガー条件・期待する応答方針・優先度）の下書きに変換する。書き込みは行わない読み取り専用ツール。' +


### PR DESCRIPTION
要件 F1: **誤答に気づいた場所から是正まで繋ぐ**（CLAUDE.md 禁止45）。

従来、会話からの是正は**ルール作成の一択**で、事実の誤り（FAQ）へ戻る道が無かった。そのため「保証は2年です」のような**事実の訂正までルール層に溜まっていた** — 3層の役割分担が壊れる方向に導線が引かれていた。

## ★ 店主に「知識かルールか」を選ばせない

層の判定は `correctionRouter`（#890 の純関数）が唯一の実装。ここでは**再実装しない**。

## ★ 新しい書き込みツールもカード種別も足していない

`suggest_answer_correction` は**読み取り専用のルーター**として実装した。

| 判定 | 繋ぐ先 |
|---|---|
| 事実 | **既存の** `save_faq`（下書きは決定的に組む） |
| 方針 | **既存の** `suggest_tuning_rule` → `save_tuning_rule` |

そのため：
- **FAQ書き込みの5本目**（禁止6）が発生しない
- **新カードの3層同期**（server / transport / UI）が発生しない
- 書き込みの確認ゲートは繋いだ先の既存実装がそのまま守る
- ルール下書きの生成ロジックを**二重に実装しない**

## 4点セット

`confirmPolicy.test.ts` が双方向で検査するので全て揃えた。

| # | 場所 |
|---|---|
| 1 | `toolDefinitions.ts` の定義 |
| 2 | `actionExecutor.ts` の `case` |
| 3 | `confirmPolicy.ts` の `NON_WRITE_TOOLS` |
| 4 | `copilot-preview` の `REAL_TOOL_LABEL` |

書き込みを行わないため `REAL_WRITE_TOOLS` には入れない（入れると `confirmPolicy.test.ts` の逆方向チェックが落ちる）。

## UI

会話カードのAI応答に **「✏️ この回答を直す」** チップを追加。既存の「🎛️ この会話からルールを作る」の隣に置き、**気づいた場所に操作を同居させる**。

## 禁止12 への対応

成功文言に「確認が必要です」「確認をスキップできません」を混ぜない — 混ぜると計測とフロントのチップ判定が部分一致で拾い、**正常応答が `blocked` として数えられる**。テストで固定した。

## テスト

- バックエンド4件: 事実→`save_faq` 誘導 / 方針→`suggest_tuning_rule` 誘導 / 指摘が空なら聞き返す / 確認ゲート文言を混ぜない
- UI 1件: チップの表示条件と実送信内容

**噛むことを確認済み** — 層判定を無効化すると自分の4件のうち1件が赤くなり、戻すと4件通過に戻ることを、`-t` で自分のテストだけに絞って確認した。

## 検証

- backend typecheck 0 / admin-ui typecheck 0 / oxlint 0
- `confirmPolicy` + `cardPayloadSync` + `agentRoutes` + `correctionRouter` **584 テスト全通過**
- admin-ui vitest **43 ファイル / 577 テスト 全通過**
- 並列実行時に `get_session_outcome` / `resolve_escalation` が落ちる回があるが（片方は 5021ms のタイムアウト）、**`--maxWorkers=1` で 526 テスト全通過**を確認。本変更と無関係の既知の並列flaky

## 関連

- 要件定義 v1.3: https://claude.ai/code/artifact/4a311d89-76ba-4831-93ff-7c2e7348debe
- 前提: #890（`correctionRouter`）
- Asana: C2b（学習ループUX）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgCQYt8UMPgm4HNVu7nv7z