### PR TITLE
feat(tenants): 会話の段階引き継ぎを画面から開閉できるようにする

### DIFF
--- a/admin-ui/src/components/admin/TenantTuningTab.test.tsx
+++ b/admin-ui/src/components/admin/TenantTuningTab.test.tsx
@@ -17,6 +17,13 @@ vi.mock('../../lib/api', () => ({
 const mockOk = (data: unknown): Promise<Response> =>
   Promise.resolve({ ok: true, json: () => Promise.resolve(data) } as Response);
 
+// features は sales_stage_continuity トグルの描画に使う。未設定=無効(fail-safe)。
+const TENANT = {
+  id: "tenant-a",
+  name: "Tenant A",
+  features: { avatar: false, voice: false, rag: true },
+} as unknown as import("../../pages/admin/tenants/types").TenantDetail;
+
 const RULE = {
   id: 42,
   tenant_id: 'tenant-a',
@@ -40,7 +47,7 @@ describe('TenantTuningTab — 判定ルールトグル', () => {
       return mockOk({});
     });
 
-    render(<TenantTuningTab tenantId="tenant-a" tenantName="Tenant A" />);
+    render(<TenantTuningTab tenantId="tenant-a" tenantName="Tenant A" tenant={TENANT} onUpdate={() => {}} />);
 
     const toggleBtn = await screen.findByRole('button', { name: '無効化' });
     fireEvent.click(toggleBtn);
@@ -53,6 +60,54 @@ describe('TenantTuningTab — 判定ルールトグル', () => {
       expect(toggleCall![1]).toEqual(
         expect.objectContaining({ method: 'PUT', body: JSON.stringify({ is_active: false }) }),
       );
+    });
+  });
+});
+
+// D1: 会話の段階引き継ぎ(SalesFlow)のトグル。実装済みだが featuresSchema に無く
+// DB直更新でしか開けられなかった機能を、画面から開閉できるようにした。
+describe('TenantTuningTab — 会話の流れを引き継ぐ', () => {
+  beforeEach(() => {
+    vi.mocked(authFetch).mockReset();
+    vi.mocked(authFetch).mockImplementation((url: string) => {
+      if (String(url).includes('/tuning-rules?')) return mockOk({ rules: [] });
+      return mockOk({});
+    });
+  });
+
+  it('未設定なら無効として描画し、「ふりだしに戻る」と伝える', async () => {
+    render(<TenantTuningTab tenantId="tenant-a" tenantName="Tenant A" tenant={TENANT} onUpdate={() => {}} />);
+
+    expect(await screen.findByText('会話の流れを引き継ぐ')).toBeTruthy();
+    expect(screen.getByRole('button', { name: '⬜ 無効' })).toBeTruthy();
+    expect(screen.getByText(/毎回ふりだしに戻ります/)).toBeTruthy();
+  });
+
+  it('有効なテナントでは有効として描画する', async () => {
+    const on = { ...TENANT, features: { ...TENANT.features, sales_stage_continuity: true } };
+    render(<TenantTuningTab tenantId="tenant-a" tenantName="Tenant A" tenant={on} onUpdate={() => {}} />);
+
+    expect(await screen.findByRole('button', { name: '✅ 有効' })).toBeTruthy();
+  });
+
+  it('押すと既存の PATCH /v1/admin/tenants/:id を叩き、他の features キーを落とさない', async () => {
+    const withConsent = {
+      ...TENANT,
+      features: { ...TENANT.features, hermes_raw_data_consent: true },
+    };
+    render(<TenantTuningTab tenantId="tenant-a" tenantName="Tenant A" tenant={withConsent} onUpdate={() => {}} />);
+
+    const btn = await screen.findByRole('button', { name: '⬜ 無効' });
+    fireEvent.click(btn);
+
+    await waitFor(() => {
+      const call = vi.mocked(authFetch).mock.calls.find((c) => /\/v1\/admin\/tenants\/tenant-a$/.test(String(c[0])));
+      expect(call).toBeTruthy();
+      const body = JSON.parse(String((call![1] as RequestInit).body));
+      expect(body.features.sales_stage_continuity).toBe(true);
+      // 既存キーを落とさない
+      expect(body.features.hermes_raw_data_consent).toBe(true);
+      expect(body.features.rag).toBe(true);
     });
   });
 });

--- a/admin-ui/src/components/admin/TenantTuningTab.tsx
+++ b/admin-ui/src/components/admin/TenantTuningTab.tsx
@@ -7,10 +7,32 @@ import { authFetch, API_BASE } from "../../lib/api";
 import TuningRuleModal, {
   type TuningRule,
 } from "../tuning/TuningRuleModal";
+import type { TenantDetail, TenantFeatures } from "../../pages/admin/tenants/types";
 
 interface Props {
   tenantId: string;
   tenantName: string;
+  tenant: TenantDetail;
+  onUpdate: (t: TenantDetail) => void;
+}
+
+// 会話の段階引き継ぎ(SalesFlow)の開閉。DeepResearchTab と同じ
+// { ...currentFeatures, key } の形で PATCH する(未指定キーはサーバ側の
+// `features || $n::jsonb` マージで保持されるが、送る側でも落とさない)。
+async function updateStageContinuity(
+  tenantId: string,
+  enabled: boolean,
+  currentFeatures: TenantFeatures,
+): Promise<TenantDetail> {
+  const features: TenantFeatures = { ...currentFeatures, sales_stage_continuity: enabled };
+  const res = await authFetch(`${API_BASE}/v1/admin/tenants/${tenantId}`, {
+    method: "PATCH",
+    body: JSON.stringify({ features }),
+  });
+  if (!res.ok) throw new Error("save_error");
+  const raw = (await res.json()) as Record<string, unknown>;
+  const json = ("tenant" in raw ? raw["tenant"] : raw) as TenantDetail;
+  return { ...json, features: json.features ?? features };
 }
 
 async function fetchRules(tenantId: string): Promise<TuningRule[]> {
@@ -34,7 +56,7 @@ async function toggleRule(id: number, is_active: boolean): Promise<void> {
   if (!res.ok) throw new Error("toggle_error");
 }
 
-export default function TenantTuningTab({ tenantId, tenantName }: Props) {
+export default function TenantTuningTab({ tenantId, tenantName, tenant, onUpdate }: Props) {
   const { isSuperAdmin } = useAuth();
   const [rules, setRules] = useState<TuningRule[]>([]);
   const [loading, setLoading] = useState(true);
@@ -42,6 +64,7 @@ export default function TenantTuningTab({ tenantId, tenantName }: Props) {
   const [showModal, setShowModal] = useState(false);
   const [editTarget, setEditTarget] = useState<TuningRule | undefined>(undefined);
   const [toast, setToast] = useState<string | null>(null);
+  const [savingStage, setSavingStage] = useState(false);
 
   const showToast = (msg: string) => {
     setToast(msg);
@@ -92,8 +115,56 @@ export default function TenantTuningTab({ tenantId, tenantName }: Props) {
 
   const tenantOptions = [{ value: tenantId, label: tenantName }];
 
+  const stageOn = tenant.features?.sales_stage_continuity === true;
+  const handleToggleStage = async () => {
+    setSavingStage(true);
+    try {
+      const updated = await updateStageContinuity(tenantId, !stageOn, tenant.features);
+      onUpdate(updated);
+      showToast(!stageOn ? "会話の流れを引き継ぐようにしました" : "会話の流れの引き継ぎを止めました");
+    } catch {
+      showToast("うまく保存できませんでした。もう一度お試しください 🙏");
+    } finally {
+      setSavingStage(false);
+    }
+  };
+
   return (
     <div style={{ position: "relative" }}>
+      {/* 会話の段階引き継ぎ。実装済みだが featuresSchema に無く、DB直更新でしか
+          開けられなかった機能を画面から開閉できるようにする。
+          お客様の会話の進み方が実際に変わるため、まず自社テナントで目視してから
+          実顧客に開くこと(CLAUDE.md 禁止35)。 */}
+      <div
+        style={{
+          marginBottom: 20, padding: "14px 18px", borderRadius: 12,
+          border: "1px solid var(--border)", background: "var(--card)",
+          display: "flex", alignItems: "center", gap: 14, flexWrap: "wrap",
+        }}
+      >
+        <div style={{ flex: 1, minWidth: 240 }}>
+          <div style={{ fontSize: 14, fontWeight: 700, marginBottom: 2 }}>会話の流れを引き継ぐ</div>
+          <div style={{ fontSize: 12.5, color: "var(--muted-foreground)", lineHeight: 1.7 }}>
+            {stageOn
+              ? "前のやり取りを踏まえて会話が進みます。"
+              : "今は毎回ふりだしに戻ります。会話が1往復で終わる原因になります。"}
+          </div>
+        </div>
+        <button
+          onClick={() => void handleToggleStage()}
+          disabled={savingStage}
+          style={{
+            padding: "10px 20px", minHeight: 44, borderRadius: 999,
+            border: `1px solid ${stageOn ? "rgba(34,197,94,0.4)" : "#374151"}`,
+            background: stageOn ? "rgba(34,197,94,0.1)" : "transparent",
+            color: stageOn ? "#4ade80" : "#9ca3af",
+            fontSize: 13, fontWeight: 700, cursor: savingStage ? "not-allowed" : "pointer",
+            opacity: savingStage ? 0.6 : 1,
+          }}
+        >
+          {savingStage ? "保存中…" : stageOn ? "✅ 有効" : "⬜ 無効"}
+        </button>
+      </div>
       {/* トースト */}
       {toast && (
         <div

--- a/admin-ui/src/pages/admin/tenants/[id].tsx
+++ b/admin-ui/src/pages/admin/tenants/[id].tsx
@@ -381,7 +381,12 @@ export default function TenantDetailPage() {
             />
           )}
           {activeTab === "tuning" && tenant && (
-            <TenantTuningTab tenantId={tenantId} tenantName={tenant.name} />
+            <TenantTuningTab
+              tenantId={tenantId}
+              tenantName={tenant.name}
+              tenant={tenant}
+              onUpdate={(updated) => setTenant(updated)}
+            />
           )}
           {activeTab === "test" && tenant && (
             <TenantTestTab tenantId={tenantId} tenantName={tenant.name} />

--- a/admin-ui/src/pages/admin/tenants/types.ts
+++ b/admin-ui/src/pages/admin/tenants/types.ts
@@ -20,6 +20,9 @@ export interface TenantFeatures {
   pre_dispatch?: boolean;
   // Phase75: Hermes Agent(会話ログ学習エージェント)へのデータ提供同意
   hermes_raw_data_consent?: boolean;
+  // 会話の段階引き継ぎ(SalesFlow)。off だと毎ターン最初の段階に戻る。
+  // 実顧客の会話の進み方が変わるため、段階的に開ける(CLAUDE.md 禁止35)。
+  sales_stage_continuity?: boolean;
 }
 
 export interface TenantDetail {

--- a/src/api/admin/tenants/routes.test.ts
+++ b/src/api/admin/tenants/routes.test.ts
@@ -160,6 +160,77 @@ describe("PATCH /v1/admin/tenants/:id — Phase72-A 監査ログ", () => {
 // ② GET /v1/admin/tenants/:id/settings-history — { history, total } を返す
 // --------------------------------------------------------------------------
 
+// D1: 会話の段階引き継ぎ(SalesFlow)を画面から開閉できるようにする。
+// dialogAgent.ts は実装済みだったが featuresSchema にキーが無く、super_admin の
+// PATCH が zod で弾かれて **DB直更新でしか開けられなかった**。
+describe("PATCH /v1/admin/tenants/:id — sales_stage_continuity", () => {
+  const ROW = {
+    id: "tenant-a", name: "テストテナント", plan: "starter", is_active: true,
+    allowed_origins: [], system_prompt: null, billing_enabled: false,
+    billing_free_from: null, billing_free_until: null,
+    features: { avatar: false, voice: false, rag: true },
+    lemonslice_agent_id: null, conversion_types: [], tenant_contact_email: null,
+    created_at: new Date().toISOString(), updated_at: new Date().toISOString(),
+  };
+
+  function makeDb(returned: Record<string, unknown>) {
+    return {
+      query: jest
+        .fn()
+        .mockResolvedValueOnce({ rows: [{ id: "tenant-a", plan: "starter", features: ROW.features, billing_enabled: false, is_active: true }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [{ ...ROW, features: returned }], rowCount: 1 })
+        .mockResolvedValue({ rows: [], rowCount: 1 }),
+    };
+  }
+
+  it("super_admin は sales_stage_continuity を有効化できる（zodで弾かれない）", async () => {
+    const features = { avatar: false, voice: false, rag: true, sales_stage_continuity: true };
+    const res = await request(makeApp(makeDb(features), "super_admin"))
+      .patch("/v1/admin/tenants/tenant-a")
+      .set("Authorization", "Bearer dummy")
+      .send({ features });
+
+    expect(res.status).toBe(200);
+    expect(res.body.features.sales_stage_continuity).toBe(true);
+  });
+
+  it("既存の features キーを落とさない（サーバ側は || マージ、送信側も全キーを送る）", async () => {
+    const features = {
+      avatar: true, voice: true, rag: true,
+      hermes_raw_data_consent: true, sales_stage_continuity: true,
+    };
+    const db = makeDb(features);
+    const res = await request(makeApp(db, "super_admin"))
+      .patch("/v1/admin/tenants/tenant-a")
+      .set("Authorization", "Bearer dummy")
+      .send({ features });
+
+    expect(res.status).toBe(200);
+    expect(res.body.features.hermes_raw_data_consent).toBe(true);
+    expect(res.body.features.avatar).toBe(true);
+  });
+
+  it("boolean 以外は 400（\"true\" のような文字列で有効化できない）", async () => {
+    const res = await request(makeApp(makeDb({}), "super_admin"))
+      .patch("/v1/admin/tenants/tenant-a")
+      .set("Authorization", "Bearer dummy")
+      .send({ features: { avatar: false, voice: false, rag: true, sales_stage_continuity: "true" } });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("client_admin は自己申告(my-tenant)で有効化できない（運用者が開ける機能）", async () => {
+    const db = { query: jest.fn().mockResolvedValue({ rows: [ROW], rowCount: 1 }) };
+    const res = await request(makeApp(db, "client_admin"))
+      .patch("/v1/admin/my-tenant")
+      .set("Authorization", "Bearer dummy")
+      .send({ features: { sales_stage_continuity: true } });
+
+    // my-tenant の features スキーマにキーが無いので、有効化された状態では返らない
+    expect(res.body?.features?.sales_stage_continuity).not.toBe(true);
+  });
+});
+
 describe("GET /v1/admin/tenants/:id/settings-history", () => {
   const HISTORY_ROW = {
     id: 1,

--- a/src/api/admin/tenants/routes.ts
+++ b/src/api/admin/tenants/routes.ts
@@ -75,6 +75,12 @@ const featuresSchema = z.object({
   // 行うべきものなので、super_admin用スキーマだけでなく client_admin 自己申告の
   // PATCH /v1/admin/my-tenant(下記)にも同じキーを追加している。
   hermes_raw_data_consent: z.boolean().optional(),
+  // 会話の段階引き継ぎ(SalesFlow)。dialogAgent.ts の isSalesStageContinuityEnabled が
+  // features->>'sales_stage_continuity' === "true" で読む。実装済みだがこのスキーマに
+  // 無かったため、super_admin の PATCH が zod で弾かれ **DB直更新でしか開けられなかった**。
+  // CLAUDE.md 禁止35: 会話の振る舞いを変える機能なので全テナント一斉に開けない。
+  // 運用者が開ける機能であり、client_admin 自己申告の PATCH /v1/admin/my-tenant には足さない。
+  sales_stage_continuity: z.boolean().optional(),
 });
 
 const updateTenantSchema = z.object({


### PR DESCRIPTION
`dialogAgent.ts` の `isSalesStageContinuityEnabled` は実装済みで `features->>'sales_stage_continuity'` を読んでいたが、**`featuresSchema`（`tenants/routes.ts`）にキーが無く super_admin の PATCH が zod で弾かれていた**。そのため **DB直更新でしか開けられない**状態だった（要件 Rk）。

## ★ このPR自体は挙動を変えない

本番は**全4テナントとも未設定（＝無効）**で、マージ後も未設定のまま。実際に開けるのは**運用作業で人の承認が要る**（CLAUDE.md 禁止35: 会話の振る舞いを変える機能を全テナント一斉に有効化しない）。

順序は **`r2c_default` で目視 → 観察 → carnation**。実顧客の会話の進み方が実際に変わるため。

## 変更

- `featuresSchema` に `sales_stage_continuity` を追加（**super_admin 用のみ**）
- **`client_admin` 自己申告の `PATCH /v1/admin/my-tenant` には足さない** — 運用者が開ける機能であり、テナントが自分で会話の振る舞いを変えられては困る
- `TenantFeatures` 型に追加
- 置き場は**既存の「🎛 チューニング」タブ**（AIの振る舞いの設定が集まる面）。**新タブは作らない**。`DeepResearchTab` と同じ `{ ...currentFeatures, key }` の形で PATCH し、送る側でも既存キーを落とさない
- 文言は内部語を出さない。無効時は「**今は毎回ふりだしに戻ります。会話が1往復で終わる原因になります**」と、なぜ有効化するのかが分かる書き方にした

## テスト

**backend 4件**
- super_admin が有効化できる（zod で弾かれない）
- 既存の features キーを落とさない
- **boolean 以外は 400** — `"true"` のような文字列で有効化できない（`dialogAgent` は `=== "true"` で判定するため、文字列が通ると判定が割れる）
- **client_admin は `my-tenant` で有効化できない**

**UI 3件**
- 未設定は無効として描画し「ふりだしに戻る」と伝える
- 有効時の描画
- 押すと**既存の** `PATCH /v1/admin/tenants/:id` を叩き、**他の features キーを落とさない**

既存の `TenantTuningTab` テストには新しい必須 props を渡すよう更新した。

## 検証

- backend typecheck 0 / admin-ui typecheck 0 / oxlint 0
- `tenants` + `dialogAgent` **6 スイート / 146 テスト 全通過**
- admin-ui vitest **43 ファイル / 580 テスト 全通過**
- **フラグ OFF で従来挙動が変わらない**ことを既存 `dialogAgent` 13 テストで確認（段階的開放の担保はこれだけ）
- 本番の現在値を読み取り専用で再確認: 全4テナント未設定

## 関連

- 要件定義 v1.3: https://claude.ai/code/artifact/4a311d89-76ba-4831-93ff-7c2e7348debe
- 点火状態は #888 の画面で確認できる
- Asana: D1（学習ループUX）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgCQYt8UMPgm4HNVu7nv7z