### PR TITLE
test(admin-ui): Hermes同意トグルのテストが不定期に落ちるのを直す

### DIFF
--- a/admin-ui/src/pages/admin/avatar/HermesConsentToggle.test.tsx
+++ b/admin-ui/src/pages/admin/avatar/HermesConsentToggle.test.tsx
@@ -24,6 +24,18 @@ const mockErr = (status: number): Promise<Response> =>
     json: () => Promise.resolve({ error: "err" }),
   } as Response);
 
+// 初期取得が終わるまでボタンは disabled のまま。
+// findByRole はボタンが「存在する」時点で解決するため、待たずに click すると
+// 無効なボタンを押すことになり、後続の「保存中...」が現れずCIが不定期に落ちる
+// (2026-08-24: 同一コミットで Gate 3 が success/failure に割れる形で表面化)。
+// クリック前に必ず有効化を待つ。
+async function clickWhenEnabled(): Promise<HTMLButtonElement> {
+  const btn = (await screen.findByRole("button")) as HTMLButtonElement;
+  await waitFor(() => expect(btn.disabled).toBe(false));
+  fireEvent.click(btn);
+  return btn;
+}
+
 function mockInitialFetch(consent: boolean) {
   vi.mocked(authFetch).mockReturnValueOnce(
     mockOk({ features: { avatar: true, voice: false, rag: true, hermes_raw_data_consent: consent } }),
@@ -62,8 +74,7 @@ describe("HermesConsentToggle", () => {
     );
     render(<HermesConsentToggle />);
 
-    const btn = await screen.findByRole("button");
-    fireEvent.click(btn);
+    await clickWhenEnabled();
 
     // 楽観的更新: 即座に「保存中...」になる
     expect(screen.getByText("保存中...")).toBeTruthy();
@@ -78,8 +89,7 @@ describe("HermesConsentToggle", () => {
     vi.mocked(authFetch).mockReturnValueOnce(mockErr(500));
     render(<HermesConsentToggle />);
 
-    const btn = await screen.findByRole("button");
-    fireEvent.click(btn);
+    await clickWhenEnabled();
 
     // 初期状態が「未同意」なので、getByText("⏸️ 未同意") はロールバック後だけでなく
     // クリック処理が完了する前でも通ってしまう。既定の 1000ms では CI の負荷時に
@@ -107,8 +117,7 @@ describe("HermesConsentToggle", () => {
     vi.mocked(authFetch).mockRejectedValueOnce(new Error("network"));
     render(<HermesConsentToggle />);
 
-    const btn = await screen.findByRole("button");
-    fireEvent.click(btn);
+    await clickWhenEnabled();
 
     await waitFor(() => {
       expect(screen.getByText("⏸️ 未同意")).toBeTruthy();
@@ -120,8 +129,7 @@ describe("HermesConsentToggle", () => {
     vi.mocked(authFetch).mockReturnValueOnce(mockOk({ features: {} }));
     render(<HermesConsentToggle />);
 
-    const btn = await screen.findByRole("button");
-    fireEvent.click(btn);
+    await clickWhenEnabled();
 
     await waitFor(() => {
       expect(vi.mocked(authFetch)).toHaveBeenCalledWith(
@@ -154,8 +162,7 @@ describe("HermesConsentToggle", () => {
       expect(vi.mocked(authFetch)).toHaveBeenCalledWith("http://localhost:3100/v1/admin/tenants/preview-tenant");
     });
 
-    const btn = await screen.findByRole("button");
-    fireEvent.click(btn);
+    await clickWhenEnabled();
 
     await waitFor(() => {
       expect(vi.mocked(authFetch)).toHaveBeenCalledWith(


### PR DESCRIPTION
同一コミットで **Gate 3 が success / failure に割れる**形で表面化した（2026-08-24, PR #894）。

## 原因

CI のログでボタンが `disabled=""` のまま「⏸️ 未同意」で止まっており、直後の `getByText("保存中...")` が落ちていた。

`findByRole("button")` はボタンが**存在した時点**で解決するが、初期取得（`GET /v1/admin/my-tenant`）が終わるまでボタンは `disabled` のまま。待たずに `click` すると**無効なボタンを押す**ことになり、楽観的更新が始まらない。CI は手元より遅く負荷も高いため、この隙間が開きやすい。

## 修正

クリック前に有効化を待つ `clickWhenEnabled` ヘルパを追加し、同じパターンの**5箇所（T3〜T8）**を置き換えた。

「saving中はdisabledになる」**T7 は `disabled` を意図的に検証するテスト**なので従来のまま残している。

## ★ 正直に書いておくこと

**手元ではこのフレークを再現できなかった。** 待機を外した状態でも10回とも通る。CI固有のタイミング差に依存するため、**修正が効いていることをローカルで実証はできていない**。

根拠は次の2点：
1. CI ログで**ボタンが `disabled` のまま失敗していた**という直接の事実
2. 「無効なボタンを押しても何も起きない」という論理

いずれにせよ、**有効化を待ってからクリックするのは無条件に正しい**ので、実害のない改善ではある。

## 検証

- admin-ui typecheck 0
- 当該テスト **20回連続で 8件全通過**

## 背景

E2E も同時期に同じ外部デモサイト起因で不安定になっており、CIの再実行コストが積み上がっている。これは切り分け可能で再現条件も分かった1件なので先に潰す。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgCQYt8UMPgm4HNVu7nv7z