### PR TITLE
fix(search): 非公開FAQが実回答経路で答えに混ざるのを止める

### DIFF
--- a/src/search/pgvector.ts
+++ b/src/search/pgvector.ts
@@ -45,6 +45,36 @@ export interface PgVectorSearchParams {
  *     using ivfflat (embedding vector_cosine_ops)
  *     with (lists = 100);
  */
+/**
+ * FAQ の可視性判定 (Phase69-2 Round 4)。エイリアスは fe / fd に固定する。
+ *
+ * **この述語の実装はここ1箇所だけにする。** 同じ faq_embeddings を引く経路が
+ * 複数あり(searchTool→pgvector.ts / searchAgent→pgvectorSearch.ts)、
+ * 片方だけが is_published を見ている状態は「非公開にしたはずのFAQが
+ * もう片方の経路では答えに出る」という信頼の事故になる(2026-08-24 発見)。
+ *
+ * エイリアスを引数化しないのは、excludedIds.test.ts が本ファイルの SQL 文字列を
+ * そのまま検査しているため。テンプレート化すると機械的ガードが空振りする。
+ * 呼び出し側は faq_embeddings を fe、faq_docs を fd としてエイリアスすること。
+ */
+export const FAQ_VISIBILITY_JOIN = `left join faq_docs fd
+      on fe.metadata->>'faq_id' ~ '^[0-9]+$'
+     and fd.id = (fe.metadata->>'faq_id')::bigint`;
+
+export const FAQ_VISIBILITY_WHERE = `(
+        (
+          fe.metadata->>'faq_id' ~ '^[0-9]+$'
+          and fd.id IS NOT NULL
+          and fd.is_published = true
+          and (fd.is_excluded_from_search IS NULL OR fd.is_excluded_from_search = false)
+        )
+        OR
+        (
+          fe.metadata->>'faq_id' IS NULL
+          OR fe.metadata->>'faq_id' !~ '^[0-9]+$'
+        )
+      )`;
+
 export async function searchPgVector(
   params: PgVectorSearchParams
 ): Promise<PgVectorSearchResult> {
@@ -100,23 +130,9 @@ export async function searchPgVector(
       fe.metadata,
       1 - (fe.embedding <-> $2::vector) as score
     from faq_embeddings fe
-    left join faq_docs fd
-      on fe.metadata->>'faq_id' ~ '^[0-9]+$'
-     and fd.id = (fe.metadata->>'faq_id')::bigint
+    ${FAQ_VISIBILITY_JOIN}
     where (fe.tenant_id = $1 OR fe.tenant_id = 'global' OR fe.tenant_id = 'r2c_docs')
-      and (
-        (
-          fe.metadata->>'faq_id' ~ '^[0-9]+$'
-          and fd.id IS NOT NULL
-          and fd.is_published = true
-          and (fd.is_excluded_from_search IS NULL OR fd.is_excluded_from_search = false)
-        )
-        OR
-        (
-          fe.metadata->>'faq_id' IS NULL
-          OR fe.metadata->>'faq_id' !~ '^[0-9]+$'
-        )
-      )
+      and ${FAQ_VISIBILITY_WHERE}
       and (fe.is_excluded_from_search IS NULL OR fe.is_excluded_from_search = false)
       ${excludeClause}
     order by fe.embedding <-> $2::vector

--- a/src/search/pgvectorSearch.ts
+++ b/src/search/pgvectorSearch.ts
@@ -4,6 +4,7 @@ import { performance } from "node:perf_hooks";
 import { decryptText } from "../lib/crypto/textEncrypt";
 import { pool } from "../lib/db";
 import { logger } from '../lib/logger';
+import { FAQ_VISIBILITY_JOIN, FAQ_VISIBILITY_WHERE } from "./pgvector";
 
 export type PgvectorSearchParams = {
   tenantId: string;
@@ -44,20 +45,25 @@ export async function searchPgVector(
 
   const safeExcludedIds = (excludedIds ?? []).filter(Boolean);
   const excludeClause = safeExcludedIds.length > 0
-    ? `AND id::text != ALL($4::text[])`
+    ? `AND fe.id::text != ALL($4::text[])`
     : "";
 
+  // 非公開にしたFAQを回答に混ぜないため、faq_docs の可視性判定を必ず通す。
+  // 判定は pgvector.ts の 1 実装を共有する(第2の解釈を書かない)。
+  // エイリアスは fe / fd に揃える必要がある(FAQ_VISIBILITY_* の前提)。
   const query = `
       SELECT
-        id::text,
-        text,
-        metadata,
-        1 - (embedding <-> $1::vector) / 2 AS score
-      FROM faq_embeddings
-      WHERE (tenant_id = $2 OR tenant_id = 'global' OR tenant_id = 'r2c_docs')
-        AND (is_excluded_from_search IS NULL OR is_excluded_from_search = false)
+        fe.id::text,
+        fe.text,
+        fe.metadata,
+        1 - (fe.embedding <-> $1::vector) / 2 AS score
+      FROM faq_embeddings fe
+      ${FAQ_VISIBILITY_JOIN}
+      WHERE (fe.tenant_id = $2 OR fe.tenant_id = 'global' OR fe.tenant_id = 'r2c_docs')
+        AND (fe.is_excluded_from_search IS NULL OR fe.is_excluded_from_search = false)
+        AND ${FAQ_VISIBILITY_WHERE}
         ${excludeClause}
-      ORDER BY embedding <-> $1::vector
+      ORDER BY fe.embedding <-> $1::vector
       LIMIT $3
     `;
 

--- a/src/search/pgvectorSearchVisibility.test.ts
+++ b/src/search/pgvectorSearchVisibility.test.ts
@@ -1,0 +1,54 @@
+// src/search/pgvectorSearchVisibility.test.ts
+// 実回答経路(searchAgent → pgvectorSearch)が faq_docs の可視性判定を通ることの静的検証。
+//
+// 2026-08-24 発見: faq_embeddings を引く経路が2つあり、
+//   searchTool → pgvector.ts        … is_published を見ていた
+//   searchAgent → pgvectorSearch.ts … 見ていなかった(=実回答経路)
+// そのため「非公開にしたFAQが答えに出る」状態だった。
+// 本番SQLはPostgres側で評価されるため、SQL文字列に必要句が入ることで確認する
+// (excludedIds.test.ts / globalRag.test.ts と同じ流儀)。
+
+import fs from "node:fs";
+import path from "node:path";
+import { FAQ_VISIBILITY_JOIN, FAQ_VISIBILITY_WHERE } from "./pgvector";
+
+const source = fs.readFileSync(path.resolve(__dirname, "pgvectorSearch.ts"), "utf8");
+
+describe("pgvectorSearch.ts の可視性判定", () => {
+  it("共有の述語を pgvector.ts から import している(第2の実装を書かない)", () => {
+    expect(source).toMatch(
+      /import\s*\{[^}]*FAQ_VISIBILITY_JOIN[^}]*FAQ_VISIBILITY_WHERE[^}]*\}\s*from\s*"\.\/pgvector"/s,
+    );
+  });
+
+  it("SQL に JOIN と可視性 WHERE を両方埋めている", () => {
+    expect(source).toContain("${FAQ_VISIBILITY_JOIN}");
+    expect(source).toContain("${FAQ_VISIBILITY_WHERE}");
+  });
+
+  it("述語自体が is_published = true を要求する", () => {
+    expect(FAQ_VISIBILITY_WHERE).toMatch(/fd\.is_published\s*=\s*true/);
+    expect(FAQ_VISIBILITY_WHERE).toMatch(/fd\.is_excluded_from_search/);
+  });
+
+  it("非FAQ(book/web等・faq_id を持たない)は faq_docs を見ずに通す", () => {
+    expect(FAQ_VISIBILITY_WHERE).toMatch(/fe\.metadata->>'faq_id'\s+IS\s+NULL/);
+    expect(FAQ_VISIBILITY_WHERE).toMatch(/fe\.metadata->>'faq_id'\s+!~\s+'\^\[0-9\]\+\$'/);
+  });
+
+  it("JOIN に numeric guard があり、非数値 faq_id で bigint キャストが落ちない", () => {
+    expect(FAQ_VISIBILITY_JOIN).toMatch(/fe\.metadata->>'faq_id'\s*~\s*'\^\[0-9\]\+\$'/);
+  });
+
+  it("エイリアスが fe / fd に揃っている(述語の前提)", () => {
+    expect(source).toMatch(/FROM faq_embeddings fe/);
+    // 無修飾の列参照が残っていると faq_docs と ambiguous になりSQLが落ちる
+    expect(source).not.toMatch(/WHERE \(tenant_id =/);
+    expect(source).not.toMatch(/ORDER BY embedding </);
+  });
+
+  it("グローバル知識の合流は維持されている", () => {
+    expect(source).toContain("OR fe.tenant_id = 'global'");
+    expect(source).toContain("OR fe.tenant_id = 'r2c_docs'");
+  });
+});

--- a/tests/phase35/globalRag.test.ts
+++ b/tests/phase35/globalRag.test.ts
@@ -13,10 +13,14 @@ describe("pgvector global search — SQL source", () => {
     expect(source).toContain("OR fe.tenant_id = 'global'");
   });
 
-  it("pgvectorSearch.ts の SQL に OR tenant_id = 'global' が含まれる", () => {
+  // 2026-08-24: faq_docs との JOIN(可視性判定)を入れたため、列の修飾が必須になった
+  // (faq_docs にも tenant_id があり、無修飾だと ambiguous でSQLエラーになる)。
+  // 期待するリテラルを pgvector.ts 側と同じ fe. 修飾つきに揃える。
+  // ガードの意図(グローバル知識が全テナントの検索に合流すること)は変えていない。
+  it("pgvectorSearch.ts の SQL に OR fe.tenant_id = 'global' が含まれる", () => {
     const filePath = path.resolve(__dirname, "../../src/search/pgvectorSearch.ts");
     const source = fs.readFileSync(filePath, "utf8");
-    expect(source).toContain("OR tenant_id = 'global'");
+    expect(source).toContain("OR fe.tenant_id = 'global'");
   });
 });
 


### PR DESCRIPTION
## 事象

`faq_embeddings` を引く経路が**2つ**あり、可視性判定が片方にしか無かった。

| 経路 | 実装 | `is_published` |
|---|---|---|
| `searchTool` | `src/search/pgvector.ts` | **見ている**（`faq_docs` を JOIN） |
| `searchAgent` | `src/search/pgvectorSearch.ts` | **見ていない** |

**後者が `/api/chat` の実回答経路。** そのためテナントが非公開にしたFAQが pgvector 経由で取得され、回答生成に渡っていた。ES側（`hybrid.ts`）は `is_published` を見ているので、**経路によって答えが変わる非対称**でもあった。

## 第3の実装を書かない

`pgvector.ts` の述語を `FAQ_VISIBILITY_JOIN` / `FAQ_VISIBILITY_WHERE` として切り出し、**両方から使う**。

**エイリアスは `fe` / `fd` に固定した。** 引数化すると `excludedIds.test.ts` がソース文字列を検査している機械的ガードが空振りする。**テストを緩めるより、呼び出し側を揃える方を選んだ。** 生成されるSQLは `pgvector.ts` 側では従来と完全に同一で、既存ガード29件は緑のまま。

## 列の修飾

`pgvectorSearch.ts` は `faq_embeddings` に `fe` エイリアスを付け、全列を修飾した。JOIN 追加により `faq_docs` にも `tenant_id` があるため、**無修飾だと ambiguous でSQLが落ちる**。

これに伴い `globalRag.test.ts` の期待リテラルを `fe.` 修飾つきに更新した。**ガードの意図（グローバル知識が全テナントの検索に合流すること）は変えていない** — `pgvector.ts` 側は元から `fe.` 修飾つきを期待しており、そちらに揃えた形。

## 実害の現状

carnation の 63 件は**全て公開**のため、**今日時点の実害はゼロ**。知識件数が増える前に塞ぐという位置づけ（要件 Rb は実測により層外へ降格済み）。

## テスト（新規7件）

述語を import している / SQL に埋めている / `is_published` を要求する / 非FAQ（book等）は `faq_docs` を見ずに通す / JOIN の numeric guard / エイリアスが揃っている / グローバル合流が維持されている。

**可視性 WHERE を外すと1件が赤くなる**ことを確認済み。

## 検証

- typecheck 0 / oxlint 0
- 検索系 **19 スイート / 183 テスト 全通過**（直列）
- 並列実行では `faqCrud` 系が不定期に落ちるが `--maxWorkers=1` で全通過（既知の並列flaky）

## 関連

- 要件定義 v1.3（Rb）: https://claude.ai/code/artifact/4a311d89-76ba-4831-93ff-7c2e7348debe
- Asana: E1（学習ループUX）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgCQYt8UMPgm4HNVu7nv7z