### PR TITLE
feat(knowledge): 全店舗共通の知識をテナントに読み取り専用で見せる

### DIFF
--- a/admin-ui/src/components/knowledge/KnowledgeListTab.test.tsx
+++ b/admin-ui/src/components/knowledge/KnowledgeListTab.test.tsx
@@ -235,3 +235,65 @@ describe("KnowledgeListTab", () => {
     expect(screen.queryByText("🔒 Widgetの許可ドメイン設定")).toBeNull();
   });
 });
+
+// E2: 全店舗共通(global)の知識をテナントに読み取り専用で見せる。
+// テナントの回答は「自店 + global」の合算で作られるのに、一覧が自店分だけだと
+// 自分の答えを作っている知識の半分が確認できない(要件 Rg)。
+const ITEM_GLOBAL = {
+  id: 99,
+  tenant_id: "global",
+  question: "配送の一般的な流れは",
+  answer: "ご注文後、順次発送いたします",
+  category: "shipping",
+  tags: [],
+  is_published: true,
+  is_global: false,
+  created_at: "2026-06-01T00:00:00Z",
+};
+
+describe("KnowledgeListTab — 全店舗共通の知識", () => {
+  beforeEach(() => {
+    vi.mocked(fetchWithAuth).mockReset();
+    mockNavigate.mockReset();
+  });
+
+  it("一覧に表示され、出所が分かる", async () => {
+    vi.mocked(fetchWithAuth).mockReturnValue(mockList([ITEM_A, ITEM_GLOBAL]));
+    renderTab();
+
+    expect(await screen.findByText("Q: 配送の一般的な流れは")).toBeTruthy();
+    expect(screen.getByText("全店舗共通")).toBeTruthy();
+    // 自店の知識には出所バッジを付けない
+    expect(screen.getAllByText("全店舗共通")).toHaveLength(1);
+  });
+
+  it("編集・削除・公開切替のボタンを出さず、理由を書く(押せない操作を並べない)", async () => {
+    vi.mocked(fetchWithAuth).mockReturnValue(mockList([ITEM_GLOBAL]));
+    renderTab();
+
+    await screen.findByText("Q: 配送の一般的な流れは");
+    expect(screen.queryByRole("button", { name: "✏️ 編集" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "削除" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "AIが答えないようにする" })).toBeNull();
+    expect(screen.getByText(/R2Cが全店舗向けに用意した知識です/)).toBeTruthy();
+  });
+
+  it("一括操作の選択対象にしない(チェックボックスを出さない)", async () => {
+    vi.mocked(fetchWithAuth).mockReturnValue(mockList([ITEM_A, ITEM_GLOBAL]));
+    renderTab();
+
+    await screen.findByText("Q: 配送の一般的な流れは");
+    // 自店1件ぶんだけ(全選択用を除く)
+    const boxes = screen.getAllByRole("checkbox");
+    expect(boxes.length).toBeLessThan(3);
+  });
+
+  it("自店の知識には従来どおり編集・削除が出る(既存挙動を壊さない)", async () => {
+    vi.mocked(fetchWithAuth).mockReturnValue(mockList([ITEM_A]));
+    renderTab();
+
+    await screen.findByText("Q: 送料はいくらですか");
+    expect(screen.getByRole("button", { name: "✏️ 編集" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "削除" })).toBeTruthy();
+  });
+});

--- a/admin-ui/src/components/knowledge/KnowledgeListTab.tsx
+++ b/admin-ui/src/components/knowledge/KnowledgeListTab.tsx
@@ -227,9 +227,12 @@ export default function KnowledgeListTab({ tenantId }: { tenantId: string }) {
     });
   };
 
-  const allOnPageSelected = items.length > 0 && items.every((i) => selectedIds.has(i.id));
+  // 全店舗共通(global)の知識はテナントからは読み取り専用。一括操作の対象にしない。
+  // サーバ側も tenant_id で絞って弾くが、選べる見た目を出さないこと自体が要件(禁止44)。
+  const ownItems = items.filter((i) => i.tenant_id !== "global");
+  const allOnPageSelected = ownItems.length > 0 && ownItems.every((i) => selectedIds.has(i.id));
   const toggleSelectAll = () => {
-    setSelectedIds(allOnPageSelected ? new Set() : new Set(items.map((i) => i.id)));
+    setSelectedIds(allOnPageSelected ? new Set() : new Set(ownItems.map((i) => i.id)));
   };
 
   const handleBulkUnpublish = async () => {
@@ -474,12 +477,17 @@ export default function KnowledgeListTab({ tenantId }: { tenantId: string }) {
                 transition: "opacity 0.2s",
               }}
             >
-              <input
-                type="checkbox"
-                checked={selectedIds.has(item.id)}
-                onChange={() => toggleSelect(item.id)}
-                style={{ width: 20, height: 20, marginTop: 2, flexShrink: 0, cursor: "pointer" }}
-              />
+              {item.tenant_id === "global" ? (
+                // 読み取り専用。チェックボックスの位置は空けて行の高さを揃える。
+                <span style={{ width: 20, flexShrink: 0 }} aria-hidden="true" />
+              ) : (
+                <input
+                  type="checkbox"
+                  checked={selectedIds.has(item.id)}
+                  onChange={() => toggleSelect(item.id)}
+                  style={{ width: 20, height: 20, marginTop: 2, flexShrink: 0, cursor: "pointer" }}
+                />
+              )}
               <div style={{ flex: 1, minWidth: 200 }}>
                 <div style={{ display: "flex", gap: 8, alignItems: "center", flexWrap: "wrap", marginBottom: 6 }}>
                   <span style={{
@@ -506,6 +514,14 @@ export default function KnowledgeListTab({ tenantId }: { tenantId: string }) {
                       ? t("knowledge.badge_not_answering")
                       : t("knowledge.badge_answering")}
                   </span>
+                  {item.tenant_id === "global" && (
+                    <span style={{
+                      padding: "2px 8px", borderRadius: 999, fontSize: 11, fontWeight: 600,
+                      background: "rgba(96,165,250,0.12)", border: "1px solid rgba(96,165,250,0.3)", color: "#93c5fd",
+                    }}>
+                      {t("knowledge.source_global")}
+                    </span>
+                  )}
                   <span style={{ fontSize: 11, color: "#6b7280" }}>{formatDate(item.created_at, locale)}</span>
                 </div>
                 <p style={{ fontSize: 15, fontWeight: 600, color: "#f9fafb", margin: "0 0 4px", lineHeight: 1.4 }}>
@@ -515,62 +531,70 @@ export default function KnowledgeListTab({ tenantId }: { tenantId: string }) {
                   A: {item.answer.slice(0, 120)}{item.answer.length > 120 ? "…" : ""}
                 </p>
               </div>
-              <div style={{ display: "flex", gap: 8, flexShrink: 0, alignItems: "center", flexWrap: "wrap" }}>
-                <button
-                  onClick={() => handleTogglePublish(item)}
-                  disabled={togglingId === item.id}
-                  style={{
-                    padding: "10px 14px",
-                    minHeight: 44,
-                    borderRadius: 10,
-                    border: `1px solid ${item.is_published === false ? "rgba(34,197,94,0.4)" : "#4b5563"}`,
-                    background: item.is_published === false ? "rgba(34,197,94,0.1)" : "rgba(75,85,99,0.15)",
-                    color: item.is_published === false ? "#4ade80" : "#9ca3af",
-                    fontSize: 13,
-                    cursor: togglingId === item.id ? "default" : "pointer",
-                    fontWeight: 500,
-                    whiteSpace: "nowrap",
-                    opacity: togglingId === item.id ? 0.6 : 1,
-                  }}
-                >
-                  {item.is_published === false
-                    ? t("knowledge.action_unmute")
-                    : t("knowledge.action_mute")}
-                </button>
-                <button
-                  onClick={() =>
-                    setEditTarget({
-                      id: item.id,
-                      question: item.question,
-                      answer: item.answer,
-                      category: item.category,
-                      tags: item.tags,
-                      is_published: item.is_published,
-                      is_excluded_from_search: item.is_excluded_from_search,
-                    })
-                  }
-                  style={{
-                    padding: "10px 16px",
-                    minHeight: 44,
-                    borderRadius: 10,
-                    border: "1px solid #1d4ed8",
-                    background: "rgba(29,78,216,0.15)",
-                    color: "#93c5fd",
-                    fontSize: 14,
-                    cursor: "pointer",
-                    fontWeight: 500,
-                    whiteSpace: "nowrap",
-                  }}
-                >
-                  {t("knowledge.edit")}
-                </button>
-                <button
-                  onClick={() => setDeleteTarget({ id: item.id, question: item.question, state: "confirming" })}
-                  style={BTN_DANGER}
-                >
-                  {t("knowledge.delete")}
-                </button>
-              </div>
+              {item.tenant_id === "global" ? (
+                // 全店舗共通の知識はR2Cが管理する。テナントからは読むだけ。
+                // 押せない操作を並べない(禁止44)ので、ボタン自体を出さず理由を書く。
+                <div style={{ flexShrink: 0, maxWidth: 220, fontSize: 12, color: "var(--muted-foreground)", lineHeight: 1.7 }}>
+                  {t("knowledge.global_readonly_hint")}
+                </div>
+              ) : (
+                <div style={{ display: "flex", gap: 8, flexShrink: 0, alignItems: "center", flexWrap: "wrap" }}>
+                  <button
+                    onClick={() => handleTogglePublish(item)}
+                    disabled={togglingId === item.id}
+                    style={{
+                      padding: "10px 14px",
+                      minHeight: 44,
+                      borderRadius: 10,
+                      border: `1px solid ${item.is_published === false ? "rgba(34,197,94,0.4)" : "#4b5563"}`,
+                      background: item.is_published === false ? "rgba(34,197,94,0.1)" : "rgba(75,85,99,0.15)",
+                      color: item.is_published === false ? "#4ade80" : "#9ca3af",
+                      fontSize: 13,
+                      cursor: togglingId === item.id ? "default" : "pointer",
+                      fontWeight: 500,
+                      whiteSpace: "nowrap",
+                      opacity: togglingId === item.id ? 0.6 : 1,
+                    }}
+                  >
+                    {item.is_published === false
+                      ? t("knowledge.action_unmute")
+                      : t("knowledge.action_mute")}
+                  </button>
+                  <button
+                    onClick={() =>
+                      setEditTarget({
+                        id: item.id,
+                        question: item.question,
+                        answer: item.answer,
+                        category: item.category,
+                        tags: item.tags,
+                        is_published: item.is_published,
+                        is_excluded_from_search: item.is_excluded_from_search,
+                      })
+                    }
+                    style={{
+                      padding: "10px 16px",
+                      minHeight: 44,
+                      borderRadius: 10,
+                      border: "1px solid #1d4ed8",
+                      background: "rgba(29,78,216,0.15)",
+                      color: "#93c5fd",
+                      fontSize: 14,
+                      cursor: "pointer",
+                      fontWeight: 500,
+                      whiteSpace: "nowrap",
+                    }}
+                  >
+                    {t("knowledge.edit")}
+                  </button>
+                  <button
+                    onClick={() => setDeleteTarget({ id: item.id, question: item.question, state: "confirming" })}
+                    style={BTN_DANGER}
+                  >
+                    {t("knowledge.delete")}
+                  </button>
+                </div>
+              )}
             </div>
           ))}
         </div>

--- a/admin-ui/src/i18n/en.ts
+++ b/admin-ui/src/i18n/en.ts
@@ -60,6 +60,8 @@ const en: Record<TranslationKey, string> = {
   "knowledge.count": "{n} knowledge items",
   "knowledge.edit": "✏️ Edit",
   "knowledge.delete": "Delete",
+  "knowledge.source_global": "Shared",
+  "knowledge.global_readonly_hint": "Provided by R2C for all stores. It cannot be changed here.",
   "knowledge.delete_confirm_title": "Are you sure you want to delete?",
   "knowledge.delete_confirm_body": "Deleting this will prevent the AI from referencing it. This cannot be undone.",
   "knowledge.cancel_delete": "Cancel",

--- a/admin-ui/src/i18n/ja.ts
+++ b/admin-ui/src/i18n/ja.ts
@@ -62,6 +62,8 @@ const ja = {
   "knowledge.count": "{n}件のナレッジ",
   "knowledge.edit": "✏️ 編集",
   "knowledge.delete": "削除",
+  "knowledge.source_global": "全店舗共通",
+  "knowledge.global_readonly_hint": "R2Cが全店舗向けに用意した知識です。ここからは変更できません。",
   "knowledge.delete_confirm_title": "本当に削除しますか？",
   "knowledge.delete_confirm_body": "削除するとAIがこの情報を参照できなくなります。この操作は取り消せません。",
   "knowledge.cancel_delete": "やめる",

--- a/src/api/admin/knowledge/faqCrudRoutes.ts
+++ b/src/api/admin/knowledge/faqCrudRoutes.ts
@@ -106,8 +106,14 @@ export function registerFaqCrudRoutes(
     const safeOrder = order === "asc" ? "ASC" : "DESC";
 
     try {
+      // テナントの回答は「自店の知識 + 全店舗共通(global)の知識」の合算で作られる
+      // (pgvectorSearch.ts / hybrid.ts が OR tenant_id = 'global' で引いている)。
+      // 一覧が自店分だけだと、自分の答えを作っている知識の半分が確認できず、
+      // 「精度が悪い」の原因究明が構造的に不可能になる。
+      // **読み取りだけを広げる。** 書き込み(PUT/PATCH/DELETE)は従来どおり
+      // `AND tenant_id = $n` で絞られており、テナントからグローバル行は変更できない。
       const params: unknown[] = [tenantId];
-      let whereClause = "WHERE tenant_id = $1";
+      let whereClause = "WHERE (tenant_id = $1 OR tenant_id = 'global')";
 
       if (search) {
         params.push(`%${search}%`);

--- a/tests/faqCrud.test.ts
+++ b/tests/faqCrud.test.ts
@@ -784,3 +784,33 @@ describe("hybridSearch ES query — is_excluded_from_search must_not filter (Pha
     expect(hybridSrc).toMatch(/must_not:\s*{\s*term:\s*{\s*is_excluded_from_search:\s*true\s*}\s*}/);
   });
 });
+
+// E2: テナントの回答は「自店 + global」の合算で作られるため、一覧の読み取りだけを
+// global に広げる。書き込みは従来どおり tenant_id で絞り、グローバル行は変更できない。
+describe("GET /v1/admin/knowledge/faq — 全店舗共通(global)の読み取り", () => {
+  it("一覧の WHERE が global を含む(自分の答えを作っている知識の全体が見える)", () => {
+    const fs = require("node:fs") as typeof import("node:fs");
+    const path = require("node:path") as typeof import("node:path");
+    const src = fs.readFileSync(
+      path.resolve(__dirname, "../src/api/admin/knowledge/faqCrudRoutes.ts"),
+      "utf8",
+    );
+    expect(src).toContain(`WHERE (tenant_id = $1 OR tenant_id = 'global')`);
+  });
+
+  it("書き込みは tenant_id で絞られたまま(グローバル行を変更・削除できない)", () => {
+    const fs = require("node:fs") as typeof import("node:fs");
+    const path = require("node:path") as typeof import("node:path");
+    const src = fs.readFileSync(
+      path.resolve(__dirname, "../src/api/admin/knowledge/faqCrudRoutes.ts"),
+      "utf8",
+    );
+    // UPDATE / DELETE / 一括削除 のいずれも tenant_id 述語を持つ
+    expect(src).toMatch(/WHERE id = \$6 AND tenant_id = \$7/);
+    expect(src).toMatch(/DELETE FROM faq_docs WHERE id = \$1 AND tenant_id = \$2/);
+    expect(src).toMatch(/DELETE FROM faq_docs WHERE id = ANY\(\$1::int\[\]\) AND tenant_id = \$2/);
+    // 読み取りの拡張が書き込み側に漏れていないこと
+    expect(src).not.toMatch(/UPDATE faq_docs[\s\S]{0,400}OR tenant_id = 'global'/);
+    expect(src).not.toMatch(/DELETE FROM faq_docs[\s\S]{0,200}OR tenant_id = 'global'/);
+  });
+});


### PR DESCRIPTION
テナントの回答は **「自店の知識 + 全店舗共通（global）の知識」の合算**で作られる（`pgvectorSearch.ts` / `hybrid.ts` が `OR tenant_id = 'global'` で引いている）。

にもかかわらず一覧は `WHERE tenant_id = $1` で固定されており、**自分の答えを作っている知識の半分が確認も検証もできない**状態だった。「精度が悪い」の原因究明が構造的に不可能になる（要件 Rg）。

## ★ 読み取りだけを広げる。書き込みは一切変えない

| 操作 | 変更 |
|---|---|
| 一覧（GET） | `WHERE (tenant_id = $1 OR tenant_id = 'global')` に拡張 |
| UPDATE / DELETE / 一括削除 | **従来どおり `AND tenant_id = $n`**。テナントからグローバル行は変更も削除もできない |
| `requireKnowledgeTenant` / `target='global'` の super_admin ガード | **未変更** |

## UI

- グローバル行に **「全店舗共通」バッジ**を出し、出所が分かるようにする
- 編集・削除・公開切替のボタンを**出さない**。押せない操作を並べる代わりに「**R2Cが全店舗向けに用意した知識です。ここからは変更できません。**」と理由を書く（CLAUDE.md 禁止44）
- **一括操作の選択対象からも外す**（チェックボックスを出さない）。サーバ側でも弾かれるが、選べる見た目自体を出さないことが要件

## テスト

**UI 4件** — 一覧に出て出所が分かる / 操作ボタンを出さず理由を書く / 一括選択に含めない / **自店の知識は従来どおり編集できる**（既存挙動を壊していない）

**backend 2件** — 一覧が global を含む / **書き込みが `tenant_id` で絞られたまま**、かつ読み取りの拡張が書き込み側に漏れていない

**読み取り専用化を無効にすると1件が赤くなる**ことを確認済み。

## 途中で潰した偽グリーン

最初に書いた否定テストは `name: "編集"` で完全一致を期待していたが、**実ラベルは `"✏️ 編集"`** のため、ボタンが存在しても `null` になる偽グリーンだった。実ラベルに揃えて噛むようにした。

公開切替も `/答えない|答える/` では**フィルタのピルまで拾ってしまう**ため、実ラベル `"AIが答えないようにする"` に修正した。

## 検証

- backend typecheck 0 / admin-ui typecheck 0 / oxlint 0
- knowledge + search 系 **18 スイート / 262 テスト 全通過**（直列）
- admin-ui vitest **43 ファイル / 593 テスト 全通過**

## 関連

- 要件定義 v1.3（Rg）: https://claude.ai/code/artifact/4a311d89-76ba-4831-93ff-7c2e7348debe
- Asana: E2（学習ループUX）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgCQYt8UMPgm4HNVu7nv7z