### PR TITLE
feat(agent): 週次サマリに「AIが新しく覚えたこと」を追加する

### DIFF
--- a/admin-ui/src/lib/useAgentChatTransport.ts
+++ b/admin-ui/src/lib/useAgentChatTransport.ts
@@ -133,6 +133,8 @@ export type WeeklySummaryAgentActionCard = {
   faq: { total: number; published: number; lastUpdated: string | null } | null;
   pendingTuningRules: number | null;
   gaps: { total: number; top: Array<{ id: number; question: string }> } | null;
+  /** 今週AIが覚えたこと。0 は「動きが無かった」なので取得失敗(null)と区別する。 */
+  learned: { faqAdded: number; memorized: number } | null;
 };
 
 // GID 1217752900578379 (R4): ルール効果(DiD推定)カード。フィールド形状は

--- a/admin-ui/src/pages/copilot-preview/index.test.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.test.tsx
@@ -1141,6 +1141,80 @@ describe("CopilotPreviewPage — 構造化カード(card)からの描画", () =>
     expect(screen.getByRole("button", { name: "確認する" })).toBeTruthy();
   });
 
+  // E4: 「今週AIが覚えたこと」。学習が起きているかを店主の言葉で返す。
+  it("AIが覚えたことを描画する(FAQ追加と会話からの自動学習の内訳つき)", async () => {
+    mockAgent({
+      reply: "今週の学習です。",
+      actions: [
+        {
+          tool: "get_weekly_briefing",
+          result: "今週(月曜起点)の状況:\nAIが新しく覚えたこと 5件",
+          card: {
+            kind: "weekly_summary",
+            asOf: new Date().toISOString(),
+            sessions: null, avgScore: null, conversions: null, faq: null,
+            pendingTuningRules: null, gaps: null,
+            learned: { faqAdded: 3, memorized: 2 },
+          },
+        },
+      ],
+    });
+
+    await send("今週の状況を教えて");
+
+    expect(await screen.findByText("AIが新しく覚えたこと")).toBeTruthy();
+    expect(screen.getByText("5件")).toBeTruthy();
+    expect(screen.getByText(/追加したFAQ 3件・会話から自動 2件/)).toBeTruthy();
+  });
+
+  it("覚えたことが0件なら「なし」と出す(伏せない)", async () => {
+    mockAgent({
+      reply: "今週の学習です。",
+      actions: [
+        {
+          tool: "get_weekly_briefing",
+          result: "今週(月曜起点)の状況:\nAIが新しく覚えたこと なし",
+          card: {
+            kind: "weekly_summary",
+            asOf: new Date().toISOString(),
+            sessions: null, avgScore: null, conversions: null, faq: null,
+            pendingTuningRules: null, gaps: null,
+            learned: { faqAdded: 0, memorized: 0 },
+          },
+        },
+      ],
+    });
+
+    await send("今週の状況を教えて");
+
+    expect(await screen.findByText("AIが新しく覚えたこと")).toBeTruthy();
+    expect(screen.getByText("なし")).toBeTruthy();
+    // 0件は「動きが無かった」という情報。取得失敗のメッセージは出さない
+    expect(screen.queryByText("今週は動きがありませんでした。")).toBeNull();
+  });
+
+  it("全指標が取得できなかったら空のカードにせず文で伝える", async () => {
+    mockAgent({
+      reply: "取得できませんでした。",
+      actions: [
+        {
+          tool: "get_weekly_briefing",
+          result: "今週(月曜起点)の状況:",
+          card: {
+            kind: "weekly_summary",
+            asOf: new Date().toISOString(),
+            sessions: null, avgScore: null, conversions: null, faq: null,
+            pendingTuningRules: null, gaps: null, learned: null,
+          },
+        },
+      ],
+    });
+
+    await send("今週の状況を教えて");
+
+    expect(await screen.findByText("今週は動きがありませんでした。")).toBeTruthy();
+  });
+
   it("未回答質問・承認待ちルールが0件なら行動チップを出さない", async () => {
     mockAgent({
       reply: "順調です。",

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -766,11 +766,11 @@ export default function CopilotPreviewPage() {
         return { id: nextId(), role: "ai", card: { kind: "knowledgeGapsList", gaps, totalCount } };
       }
       if (a.card?.kind === "weekly_summary") {
-        const { asOf, sessions, avgScore, conversions, faq, pendingTuningRules, gaps } = a.card;
+        const { asOf, sessions, avgScore, conversions, faq, pendingTuningRules, gaps, learned } = a.card;
         return {
           id: nextId(),
           role: "ai",
-          card: { kind: "weeklySummary", asOf, sessions, avgScore, conversions, faq, pendingTuningRules, gaps },
+          card: { kind: "weeklySummary", asOf, sessions, avgScore, conversions, faq, pendingTuningRules, gaps, learned },
         };
       }
       if (a.card?.kind === "rule_effect") {
@@ -2656,7 +2656,7 @@ function CardView({
 // (権威の分離: 数値=サーバ、解釈と「次にやるべきこと」=LLMの文)。各グループが null なのは
 // 取得できなかった場合で、0とは区別して表示自体を省く。
 function WeeklySummaryCard({ card }: { card: Extract<Card, { kind: "weeklySummary" }> }) {
-  const { sessions, avgScore, conversions, faq, pendingTuningRules, gaps } = card;
+  const { sessions, avgScore, conversions, faq, pendingTuningRules, gaps, learned } = card;
   const stats: Array<{ label: string; value: string; sub?: string }> = [];
 
   if (sessions) {
@@ -2684,6 +2684,14 @@ function WeeklySummaryCard({ card }: { card: Extract<Card, { kind: "weeklySummar
   }
   if (pendingTuningRules !== null) stats.push({ label: "承認待ちの指示ルール", value: `${pendingTuningRules}件` });
   if (gaps) stats.push({ label: "AIが答えられなかった質問", value: `${gaps.total}件（未対応の累計）` });
+  if (learned) {
+    const total = learned.faqAdded + learned.memorized;
+    stats.push({
+      label: "AIが新しく覚えたこと",
+      value: total === 0 ? "なし" : `${total}件`,
+      sub: total === 0 ? undefined : `追加したFAQ ${learned.faqAdded}件・会話から自動 ${learned.memorized}件`,
+    });
+  }
 
   // 会話復元(sessionStorage)で古いまとめがそのまま画面に残るケースがあるため、
   // 集計時点(asOf)を常に表示する。取得日時をJSTの暦日で比較し、今日でなければ
@@ -2719,6 +2727,13 @@ function WeeklySummaryCard({ card }: { card: Extract<Card, { kind: "weeklySummar
         </div>
       }
     >
+      {stats.length === 0 && (
+        // 全指標が取得できなかった場合。空のカードを出すと「壊れている」のか
+        // 「動きが無かった」のか区別できないため、必ず文で伝える。
+        <div style={{ fontSize: 14, color: "var(--muted-foreground)", lineHeight: 1.8 }}>
+          今週は動きがありませんでした。
+        </div>
+      )}
       <div style={{ display: "flex", flexWrap: "wrap", gap: 10 }}>
         {stats.map((s) => (
           <div

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -406,6 +406,9 @@ export type WeeklySummaryCardPayload = {
   faq: { total: number; published: number; lastUpdated: string | null } | null;
   pendingTuningRules: number | null;
   gaps: { total: number; top: Array<{ id: number; question: string }> } | null;
+  /** 今週AIが覚えたこと。faqAdded=今週追加されたFAQ、memorized=会話から自動で覚えた件数。
+   *  **0 は「動きが無かった」という正しい情報**なので、取得失敗(null)と区別して 0 のまま出す。 */
+  learned: { faqAdded: number; memorized: number } | null;
 };
 
 // 会話一覧カード。短縮ID(shortId)をそのまま次のツール呼び出しに使える形で持たせ、
@@ -2173,7 +2176,7 @@ export async function executeToolCall(
         // 指標ごとに Promise.allSettled で独立させる。以前は1本の失敗で全指標が
         // 「取得に失敗しました」に落ちていたが、指標が増えるほど1本の不調が全体を
         // 巻き込む確率が上がるため、取れた指標だけを出す方式に変更する。
-        const [sessionsRes, prevSessionsRes, evalRes, cvRes, faqRes, tuningRes, gapsRes] = await Promise.allSettled([
+        const [sessionsRes, prevSessionsRes, evalRes, cvRes, faqRes, tuningRes, gapsRes, learnedRes] = await Promise.allSettled([
           db.query(
             `SELECT COUNT(*)::int AS n FROM chat_sessions
              WHERE tenant_id = $1 AND started_at >= $2
@@ -2223,6 +2226,18 @@ export async function executeToolCall(
             [tenantId],
           ),
           getGaps({ tenantId, status: 'open', limit: 3 }),
+          // 今週AIが覚えたこと。店主に「学習が起きているか」を返すための指標。
+          // faq_docs は人が足したもの、learned_memory は会話から自動で覚えたもの。
+          // learned_memory は未適用環境もありうるので、この1本が失敗しても
+          // allSettled で他の指標を巻き込まない。
+          db.query(
+            `SELECT
+               (SELECT COUNT(*)::int FROM faq_docs
+                 WHERE tenant_id = $1 AND created_at >= $2) AS faq_added,
+               (SELECT COUNT(*)::int FROM learned_memory
+                 WHERE tenant_id = $1 AND created_at >= $2) AS memorized`,
+            [tenantId, weekStart],
+          ),
         ]);
 
         const lines: string[] = ['今週(月曜起点)の状況:'];
@@ -2237,6 +2252,7 @@ export async function executeToolCall(
           faq: null,
           pendingTuningRules: null,
           gaps: null,
+          learned: null,
         };
 
         if (sessionsRes.status === 'fulfilled') {
@@ -2309,6 +2325,20 @@ export async function executeToolCall(
               lines.push(`${i + 1}. 「${g.user_question.slice(0, 60)}」`);
             });
           }
+        }
+
+        if (learnedRes.status === 'fulfilled') {
+          const row = learnedRes.value?.rows?.[0];
+          const faqAdded = Number(row?.faq_added ?? 0);
+          const memorized = Number(row?.memorized ?? 0);
+          card.learned = { faqAdded, memorized };
+          // 0 は「今週は動きが無かった」という正しい情報。伏せずにそのまま伝える
+          // (CLAUDE.md 禁止34 の趣旨: 母数不足で率は出さないが、件数の 0 は 0 と書く)。
+          lines.push(
+            faqAdded + memorized === 0
+              ? 'AIが新しく覚えたこと なし'
+              : `AIが新しく覚えたこと ${faqAdded + memorized}件（追加したFAQ ${faqAdded}件・会話から自動 ${memorized}件）`,
+          );
         }
 
         if (lines.length === 1) {

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -2122,6 +2122,16 @@ describe('POST /v1/admin/agent/chat', () => {
   // Phase2 (P7): get_weekly_briefing — 直近7日間の状況を1回で要約取得
   // -------------------------------------------------------------------------
   describe('get_weekly_briefing', () => {
+    // 指標は Promise.allSettled で並列に投げており、本数は増えていく。
+    // 各テストが mockResolvedValueOnce の連鎖で必要な分だけ用意する形なので、
+    // 指標を1本足すたびに全テストが「連鎖を使い切って未定義」になり、
+    // await が解決せず 5000ms タイムアウトで落ちる(E4 で実際に踏んだ)。
+    // 連鎖を使い切った後の既定値をここで与え、追加した指標は「0件」として扱う。
+    // 個々のテストは自分が検証したい指標だけを Once で上書きすればよい。
+    beforeEach(() => {
+      mockQuery.mockResolvedValue({ rows: [{ faq_added: 0, memorized: 0 }] });
+    });
+
     it('会話数・前週比・品質スコア・成約・FAQ集計・承認待ちルール・未回答質問トップ3を1つの結果文字列にまとめる', async () => {
       mockFetch
         .mockResolvedValueOnce({


### PR DESCRIPTION
要件 **Rf / F4**: 学習の結果を店主の言葉で返す。従来のカードには承認待ちルールと未回答質問はあったが、**「今週何を覚えたか」が無く**、学習が起きているかを店主が知る手段が無かった。

## 追加した指標

`faq_docs`（人が追加したFAQ）と `learned_memory`（会話から自動で覚えたもの）の今週分を1本のクエリで数える。`Promise.allSettled` の1本として足したので、**`learned_memory` が無い環境でもこの1本だけが失敗し、他の指標を巻き込まない**。

## 0件の扱い

**0 は「今週は動きが無かった」という正しい情報**なので、取得失敗（`null`）と区別してそのまま「なし」と出す。

全指標が取得できなかった場合は**カードを空にせず**「今週は動きがありませんでした。」と文で伝える — 空のカードだと「壊れている」のか「動きが無い」のか区別できないため。

`text` と `card` は**同一の値から組み立てている**（CLAUDE.md 禁止17）。

## カード3層同期

サーバの `WeeklySummaryCardPayload` / transport の型 / UI の `kind` 変換の3箇所。UI の `Card` union は `Omit` で自動追随するが、**変換は手動列挙**なので漏れやすい。

**実際この実装中に変換への追加を1度忘れた。** `cardPayloadSync.test.ts` は `kind` しか見ないため素通りし、TypeScript が必須フィールドとして捕捉した。UIテストで「変換から落とすと赤くなる」ことを確認済み。

## ★ テスト側の構造的な修正

指標を1本増やしたことで、`mockResolvedValueOnce` の連鎖を使い切ったテストが**未解決の `await` で 5000ms タイムアウト**した（16テストが該当）。

`describe` に `beforeEach` で既定値を与え、連鎖を使い切った後も解決するようにした。**指標を足すたびに全テストが落ちる構造だった**ので、今後の追加にも耐える形にしてある。

## テスト

UI 3件 — 覚えたことを内訳つきで描画 / 0件なら「なし」と出す（伏せない）/ 全指標null なら文で伝える

## 検証

- backend typecheck 0 / admin-ui typecheck 0 / oxlint 0
- `agentRoutes` **526 テスト全通過**（直列・2回）
- admin-ui vitest **43 ファイル / 596 テスト 全通過**

### ローカル環境の注意

本セッションでローカルの**一時ポートが枯渇**し（`EADDRNOTAVAIL`）、supertest を使うスイートの並列フル実行が不安定になっている。セッションを通じて失敗数が乱高下していた真因はこれ。**判定はCIに委ねる。**

## 関連

- 要件定義 v1.3（Rf / F4）: https://claude.ai/code/artifact/4a311d89-76ba-4831-93ff-7c2e7348debe
- Asana: E4（学習ループUX）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgCQYt8UMPgm4HNVu7nv7z