### PR TITLE
feat(events): お客様が回答を評価する(👍👎)受け口をサーバに用意する

### DIFF
--- a/admin-ui/src/pages/admin/tenants/types.ts
+++ b/admin-ui/src/pages/admin/tenants/types.ts
@@ -25,6 +25,8 @@ export interface TenantFeatures {
   // 会話の段階引き継ぎ(SalesFlow)。off だと毎ターン最初の段階に戻る。
   // 実顧客の会話の進み方が変わるため、段階的に開ける(CLAUDE.md 禁止35)。
   sales_stage_continuity?: boolean;
+  /** お客様の回答評価(👍👎)をウィジェットに出すか。未設定は「出す」(既定ON)。 */
+  answer_feedback?: boolean;
 }
 
 export interface TenantDetail {

--- a/src/api/admin/tenants/routes.ts
+++ b/src/api/admin/tenants/routes.ts
@@ -84,6 +84,11 @@ const featuresSchema = z.object({
   // CLAUDE.md 禁止35: 会話の振る舞いを変える機能なので全テナント一斉に開けない。
   // 運用者が開ける機能であり、client_admin 自己申告の PATCH /v1/admin/my-tenant には足さない。
   sales_stage_continuity: z.boolean().optional(),
+  // お客様がAIの回答を評価する(👍👎)UIをウィジェットに出すか。
+  // **未設定は「出す」**(決定 D1: 既定ON)。教師信号を集めるのが目的で、
+  // 出さない選択はテナント側の事情(購入導線を邪魔したくない等)にのみ使う。
+  // false を明示したテナントだけ非表示にする。
+  answer_feedback: z.boolean().optional(),
 });
 
 const updateTenantSchema = z.object({

--- a/src/api/events/eventRoutes.ts
+++ b/src/api/events/eventRoutes.ts
@@ -22,7 +22,20 @@ const VALID_EVENT_TYPES = [
   'exit_intent', 'chat_open', 'chat_message', 'chat_conversion',
   // 「Powered by R2C」バッジのクリック（widget.js）
   'branding_badge_click',
+  // AIの回答に対するお客様の評価(👍👎)。学習ループの教師信号。
+  // Judge は 4通未満の会話を評価しないため、1往復で終わる現状ではこれが
+  // 唯一機能する品質シグナルになる(要件 Rj / 決定 D1)。
+  // **新テーブルを作らない**(CLAUDE.md 禁止32)。既存 behavioral_events に載せる。
+  'answer_feedback',
 ] as const;
+
+/** answer_feedback の event_data。どの回答への評価かを識別できる必要がある。 */
+const AnswerFeedbackDataSchema = z.object({
+  rating: z.enum(['up', 'down']),
+  /** 評価対象のAI回答を指す識別子(widget が採番する会話内の連番など)。
+   *  同じ回答への評価はこの値で名寄せする。 */
+  message_ref: z.string().min(1).max(128),
+});
 
 const EventSchema = z.object({
   event_type: z.enum(VALID_EVENT_TYPES),
@@ -30,6 +43,21 @@ const EventSchema = z.object({
   page_url: z.string().max(2048).optional(),
   referrer: z.string().max(2048).optional(),
   timestamp: z.string().optional(),
+});
+
+// answer_feedback だけは event_data の形を強制する。
+// 他イベントは自由形式(既存互換)だが、評価は集計に使うため
+// rating/message_ref が無いものを受け取ると後段で数えられなくなる。
+const EventSchemaWithFeedback = EventSchema.superRefine((ev, ctx) => {
+  if (ev.event_type !== 'answer_feedback') return;
+  const parsed = AnswerFeedbackDataSchema.safeParse(ev.event_data);
+  if (!parsed.success) {
+    ctx.addIssue({
+      code: 'custom',
+      path: ['event_data'],
+      message: 'answer_feedback には rating(up|down)と message_ref が必要です',
+    });
+  }
 });
 
 const EventBatchSchema = z.object({
@@ -40,7 +68,7 @@ const EventBatchSchema = z.object({
   // conversion_attributions への結合にのみ使う(任意: 会話が無いページでの
   // trackConversion呼び出しでは無いことがある)。
   chat_session_id: z.string().min(1).max(128).optional(),
-  events: z.array(EventSchema).min(1).max(50),
+  events: z.array(EventSchemaWithFeedback).min(1).max(50),
 });
 
 export function registerEventRoutes(

--- a/tests/phase55/eventRoutes.test.ts
+++ b/tests/phase55/eventRoutes.test.ts
@@ -172,3 +172,69 @@ describe('POST /api/events', () => {
     });
   });
 });
+
+// E3a: お客様がAIの回答を評価する(👍👎)。学習ループの教師信号。
+// Judge は 4通未満の会話を評価しないため、1往復で終わる現状ではこれが
+// 唯一機能する品質シグナルになる(要件 Rj / 決定 D1)。
+describe('POST /api/events — answer_feedback', () => {
+  const feedback = (event_data: unknown) => ({
+    visitor_id: 'vid-fb',
+    session_id: 'sid-fb',
+    events: [{ event_type: 'answer_feedback', event_data }],
+  });
+
+  it('rating と message_ref が揃っていれば受理し、既存テーブルへ記録する', async () => {
+    const { app, mockDb } = makeApp({});
+    const res = await request(app).post('/api/events').send(feedback({ rating: 'up', message_ref: 'm-1' }));
+
+    expect(res.status).toBe(202);
+    // 新テーブルを作らず behavioral_events に載せる(CLAUDE.md 禁止32)
+    const sqls = mockDb.query.mock.calls.map((c: unknown[]) => String(c[0]));
+    expect(sqls.some((q: string) => /INSERT INTO behavioral_events/i.test(q))).toBe(true);
+    expect(sqls.some((q: string) => /INSERT INTO answer_feedback/i.test(q))).toBe(false);
+  });
+
+  it('👎 も受理する', async () => {
+    const { app } = makeApp({});
+    const res = await request(app).post('/api/events').send(feedback({ rating: 'down', message_ref: 'm-2' }));
+    expect(res.status).toBe(202);
+  });
+
+  it('rating が不正なら 400(集計できないデータを受け取らない)', async () => {
+    const { app } = makeApp({});
+    const res = await request(app).post('/api/events').send(feedback({ rating: 'maybe', message_ref: 'm-3' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('message_ref が無ければ 400(どの回答への評価か分からない)', async () => {
+    const { app } = makeApp({});
+    const res = await request(app).post('/api/events').send(feedback({ rating: 'up' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('event_data が空でも 400 になる', async () => {
+    const { app } = makeApp({});
+    const res = await request(app).post('/api/events').send(feedback({}));
+    expect(res.status).toBe(400);
+  });
+
+  it('他のイベント型の event_data 自由形式は従来どおり通る(既存互換を壊さない)', async () => {
+    const { app } = makeApp({});
+    const res = await request(app)
+      .post('/api/events')
+      .send({
+        visitor_id: 'vid-x',
+        session_id: 'sid-x',
+        events: [{ event_type: 'scroll_depth', event_data: { anything: 'goes' } }],
+      });
+    expect(res.status).toBe(202);
+  });
+
+  it('未知のイベント型は従来どおり 400', async () => {
+    const { app } = makeApp({});
+    const res = await request(app)
+      .post('/api/events')
+      .send({ visitor_id: 'v', session_id: 's', events: [{ event_type: 'not_a_real_event' }] });
+    expect(res.status).toBe(400);
+  });
+});


### PR DESCRIPTION
要件 **Rj** / 決定 **D1**: 学習ループの最上流のボトルネックである「**教師信号ゼロ**」を解消する。

現在の品質シグナルは Judge・エスカレーション・CV の3つで、いずれも実データがほぼゼロ。しかも **Judge は 4通未満の会話を評価しない**ため、実会話が1往復で終わっている現状では、**回答単位の評価だけが唯一機能するシグナル**になる。

**このPRはサーバ側のみ。** ウィジェットのUI（E3b）は本番のテナントサイトに出るため別PRにする。

## 実装

- `behavioral_events` の `VALID_EVENT_TYPES` に `answer_feedback` を追加。**新テーブルを作らない**（CLAUDE.md 禁止32）
- **`answer_feedback` だけ `event_data` の形を強制する**（`rating: 'up'|'down'` と `message_ref`）。他イベントの自由形式は従来どおり。集計に使うデータなので、欠けたものを受け取ると**後段で数えられなくなる**
- `tenants.features` に `answer_feedback` を追加。**未設定は「出す」**（D1: 既定ON）。`false` を明示したテナントだけ非表示にする

## 名寄せの方針

`behavioral_events` は**追記専用のまま**。同じ回答に複数回の評価が来た場合は `message_ref` で名寄せし、**集計時に最新の1件だけを採る**。

書き込み時に過去行を消す方式は取らない — 履歴が失われ、書き込みも複雑になるため。

## テスト 7件

up/down を受理し既存テーブルに載る（`INSERT INTO answer_feedback` のような新テーブルを使っていないことも確認）/ `rating` 不正は400 / `message_ref` 欠落は400 / `event_data` 空は400 / **他イベントの自由形式は通る（既存互換）** / 未知のイベント型は従来どおり400。

**検証を無効化すると3件が赤くなる**ことを確認済み。

## 補足

受理時のステータスは既存仕様どおり **202**（記録は非同期）。最初 200 を期待するテストを書いて落とし、実装に合わせて修正した。

## 検証

- backend typecheck 0 / admin-ui typecheck 0 / oxlint 0
- events + tenants **5 スイート / 181 テスト 全通過**
- admin-ui vitest **43 ファイル / 596 テスト 全通過**

## 次

E3b（ウィジェットのUI）は **AI回答テキストと構造的に分離したDOM**で出し、`innerHTML` を使わず、配布3経路と24時間キャッシュを確認したうえで実装する必要がある。テナントのサイトに出る変更なので、着手前に改めて相談したい。

## 関連

- 要件定義 v1.3（Rj / F5）: https://claude.ai/code/artifact/4a311d89-76ba-4831-93ff-7c2e7348debe
- Asana: E3a（学習ループUX）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgCQYt8UMPgm4HNVu7nv7z