### PR TITLE
feat(widget): お客様がAI回答を評価できるようにする(👍👎)

### DIFF
--- a/public/widget.js
+++ b/public/widget.js
@@ -416,6 +416,38 @@
     '  color: #1e293b;',
     '  border-radius: 18px 18px 18px 4px;',
     '}',
+    // 要件K-6: 購入・相談導線より視覚的に弱く置く(CVを邪魔しない)。
+    // タップ領域は44px以上を確保しつつ、見た目は控えめにする。
+    '.feedback-row {',
+    '  display: flex;',
+    '  gap: 4px;',
+    '  margin-top: 2px;',
+    '}',
+    // box-sizing: border-box 前提(グローバルリセット済み)。
+    // 見た目は小さく(24pxのグリフ領域)保ちつつ、実タップ領域は
+    // 透明パディングで44x44を確保する(視覚サイズとタップ領域を分離)。
+    '.feedback-btn {',
+    '  width: 44px;',
+    '  height: 44px;',
+    '  padding: 0;',
+    '  border: none;',
+    '  background: transparent;',
+    '  border-radius: 8px;',
+    '  font-size: 14px;',
+    '  line-height: 1;',
+    '  opacity: 0.45;',
+    '  cursor: pointer;',
+    '  margin: -10px -6px;',
+    '}',
+    '.feedback-btn:hover { opacity: 0.75; }',
+    '.feedback-btn.active { opacity: 1; background-color: rgba(0,0,0,0.06); }',
+    '.escalate-btn.feedback-hint {',
+    '  animation: r2c-feedback-pulse 1.2s ease-in-out 2;',
+    '}',
+    '@keyframes r2c-feedback-pulse {',
+    '  0%, 100% { box-shadow: none; }',
+    '  50% { box-shadow: 0 0 0 3px rgba(59,130,246,0.35); }',
+    '}',
     '.msg-wrapper.operator { justify-content: flex-start; }',
     '.bubble.operator {',
     '  background-color: #dcfce7;',
@@ -1121,6 +1153,12 @@
   var _fabRestored = false; // closePanel後の非同期resetFabIcon呼び出しを防ぐフラグ
   var isLoading = false;
   var messages = [];
+  // E3a/E3b: お客様の回答評価(👍👎)。教師信号(要件Rj/決定D1)。
+  // サーバ側フラグの既定はON。fetch失敗時もD1の既定(出す)を維持する。
+  var _answerFeedbackEnabled = true;
+  // メッセージid -> 'up'|'down'。連打や複数クリックは最後の1つに収束させる
+  // (behavioral_eventsは追記専用なので、表示上の見た目をここで確定させる)。
+  var _feedbackGiven = {};
   // free_adプランの月次上限案内(403 plan_upgrade_required)を1会話(このウィジェット
   // インスタンスの生存期間)につき1回だけ表示するためのフラグ。
   // CLAUDE.md 絶対にやってはいけないこと11: 同一会話で繰り返さない。
@@ -2362,6 +2400,43 @@
     if (pipIdleDisconnectTimer) { clearTimeout(pipIdleDisconnectTimer); pipIdleDisconnectTimer = null; }
   }
 
+  // AI回答ごとの評価行(👍👎)を組み立てる。bubbleの兄弟要素として呼ばれる。
+  function buildFeedbackRow(messageRef) {
+    var given = _feedbackGiven[messageRef];
+    var row = el('div', { className: 'feedback-row' });
+
+    function makeBtn(rating, glyph, ariaLabel) {
+      var active = given === rating;
+      var btn = el('button', {
+        type: 'button',
+        className: 'feedback-btn' + (active ? ' active' : ''),
+        'aria-label': ariaLabel,
+        'aria-pressed': active ? 'true' : 'false',
+      });
+      btn.textContent = glyph;
+      btn.addEventListener('click', function () {
+        // 連打・複数クリックは最後の1つに収束させる(表示も送信も)。
+        if (_feedbackGiven[messageRef] === rating) return;
+        _feedbackGiven[messageRef] = rating;
+        sendAnswerFeedback(messageRef, rating);
+        renderMessages();
+        if (rating === 'down') {
+          // I-10相当: 👎の後は有人相談への導線を示す。会話を切らず、
+          // 既存の相談ボタンを一瞬強調するだけ(state/文言は変更しない)。
+          try {
+            escalateBtn.classList.add('feedback-hint');
+            setTimeout(function () { escalateBtn.classList.remove('feedback-hint'); }, 2400);
+          } catch (_e) {}
+        }
+      });
+      return btn;
+    }
+
+    row.appendChild(makeBtn('up', '👍', '役に立った'));
+    row.appendChild(makeBtn('down', '👎', '役に立たなかった'));
+    return row;
+  }
+
   function renderMessages() {
     // R0-②: エスカレーションボタンは会話開始前(空セッション)では無効。
     // scriptedモード/Anamクライアント側LLM/通常の/api/chatのいずれの経路で
@@ -2428,6 +2503,11 @@
         }
       } else {
         inner.appendChild(bubble);
+      }
+      // 要件Rj/F5: AI回答テキストと構造的に分離したDOM(禁止40)。
+      // bubble/actions/ts の兄弟要素として追加し、textContentの一部にしない。
+      if (msg.role === 'assistant' && !msg.system && _answerFeedbackEnabled) {
+        inner.appendChild(buildFeedbackRow(msg.id));
       }
       var ts = el('div', { className: 'ts' });
       ts.textContent = formatTime(msg.timestamp);
@@ -2910,6 +2990,7 @@
               role: 'assistant',
               content: err.serverMessage || '今月のご利用可能回数の上限に達しました。プランのアップグレードについては、サイト運営者にお問い合わせください。',
               timestamp: Date.now(),
+              system: true, // 実際のAI回答ではないため評価対象にしない
             });
           }
           return;
@@ -2974,6 +3055,7 @@
       role: 'assistant',
       content: 'スタッフにおつなぎしています。少々お待ちください。',
       timestamp: Date.now(),
+      system: true, // 実際のAI回答ではないため評価対象にしない
     });
     renderMessages();
     startEscalatePolling();
@@ -3603,6 +3685,7 @@
       role: 'assistant',
       content: rule.message_template,
       timestamp: Date.now(),
+      system: true, // ルール発火の声がけであり質問への回答ではないため評価対象にしない
     };
     messages.push(proactiveMsg);
     renderMessages();
@@ -3621,6 +3704,9 @@
     })
       .then(function (r) { return r.ok ? r.json() : { event_tracking: false }; })
       .then(function (cfg) {
+        // event_tracking(行動計測全般)とは独立した機能なので、
+        // event_tracking が無効でもここは先に評価する。
+        if (cfg.answer_feedback === false) _answerFeedbackEnabled = false;
         if (!cfg.event_tracking) return;
         _tracker = new EventTracker(apiKey, apiBase);
         _tracker.start();
@@ -3700,6 +3786,36 @@
   }
 
   // ─── R2C Conversion Tracking API ─────────────────────────────────────────
+  // お客様の回答評価(👍👎)を送信する。trackConversion と同じ独立パターンにする理由:
+  // event_tracking が無効なテナントでも answer_feedback は別フラグで動くため、
+  // _tracker(EventTrackerインスタンス)の有無に依存できない。
+  function sendAnswerFeedback(messageRef, rating) {
+    var visitorId = '';
+    var sessionId = '';
+    try { visitorId = localStorage.getItem('r2c_vid') || ''; } catch (_e) {}
+    try { sessionId = sessionStorage.getItem('r2c_sid') || ''; } catch (_e) {}
+
+    var payload = {
+      visitor_id: visitorId || 'unknown',
+      session_id: sessionId || 'unknown',
+      chat_session_id: conversationId,
+      events: [{
+        event_type: 'answer_feedback',
+        event_data: { rating: rating, message_ref: messageRef },
+        page_url: location.href,
+        referrer: document.referrer
+      }]
+    };
+
+    // keepalive: true — I-11(評価直後にページを閉じる)でも取りこぼさない。
+    fetch(apiBase + '/api/events', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', 'x-api-key': apiKey },
+      body: JSON.stringify(payload),
+      keepalive: true
+    }).catch(function () { /* fire-and-forget: 評価UIの見た目は既に確定済み */ });
+  }
+
   // パートナーが購入完了ページ等で呼び出す: window.r2c.trackConversion('purchase', 50000)
   window.r2c = window.r2c || {};
   window.r2c.trackConversion = function(conversionType, conversionValue) {

--- a/src/api/widget/featuresRouteInvariants.test.ts
+++ b/src/api/widget/featuresRouteInvariants.test.ts
@@ -1,0 +1,50 @@
+// src/api/widget/featuresRouteInvariants.test.ts
+// GET /api/widget/features は src/index.ts に直接書かれておりHTTP経路のユニットテストが
+// 無い(index.ts に supertest を通す既存慣習が無い)。widgetSourceInvariants.test.ts と同じ
+// 流儀で、ソーステキストに対する不変条件を機械的にロックする。
+//
+// answer_feedback(要件Rj/決定D1)は event_tracking と極性が逆(未設定=有効)。
+// この逆転が誤って揃えられると、テナントの意図しない機能OFFが広範囲に起きる。
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+const SRC = fs.readFileSync(path.resolve(__dirname, '../../index.ts'), 'utf8');
+
+function extractRouteBody(): string {
+  const start = SRC.indexOf("app.get('/api/widget/features'");
+  expect(start).toBeGreaterThan(-1);
+  // 次のルート登録までを本体とみなす(十分な余白)
+  return SRC.slice(start, start + 1200);
+}
+
+describe('GET /api/widget/features ソース不変条件', () => {
+  it('answer_feedback を返している', () => {
+    const body = extractRouteBody();
+    expect(body).toMatch(/answer_feedback/);
+  });
+
+  it('event_tracking(未設定=無効)と極性が逆(未設定=有効)であることが明示されている', () => {
+    const body = extractRouteBody();
+    // event_tracking 側: truthy 変換(未設定=false)
+    expect(body).toMatch(/event_tracking:\s*!!features\.event_tracking/);
+    // answer_feedback 側: 明示 false のときだけ無効(未設定=true)
+    expect(body).toMatch(/answer_feedback:\s*features\.answer_feedback !== false/);
+  });
+
+  it('DB接続なし・テナント不明のフォールバックでも answer_feedback は false を返さない', () => {
+    const body = extractRouteBody();
+    const fallback = body.match(/if \(!db \|\| !tenantId\) \{[\s\S]{0,120}\}/);
+    expect(fallback).not.toBeNull();
+    // このフォールバックには answer_feedback を含めない(=フロント側の既定trueに委ねる)。
+    // 誤って answer_feedback: false を書き足すと全テナントで機能が消える。
+    expect(fallback![0]).not.toMatch(/answer_feedback:\s*false/);
+  });
+
+  it('DBクエリ失敗時(catch節)も既定ONを維持する', () => {
+    const body = extractRouteBody();
+    const catchBlock = body.match(/\} catch \{[\s\S]{0,150}\}/);
+    expect(catchBlock).not.toBeNull();
+    expect(catchBlock![0]).toMatch(/answer_feedback:\s*true/);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -683,9 +683,16 @@ app.get('/api/widget/features', ...apiStack, async (req: express.Request, res: e
       [tenantId],
     );
     const features = result.rows[0]?.features ?? {};
-    return res.json({ event_tracking: !!features.event_tracking });
+    return res.json({
+      event_tracking: !!features.event_tracking,
+      // 決定D1: 未設定は「出す」(既定ON)。event_tracking とは極性が逆
+      // (機能追加時は既定OFFにする既存の慣習に対し、本件は「教師信号を
+      // 増やす」ことが目的で、テナントが積極的にOFFを選ぶ場合だけ切る設計)。
+      answer_feedback: features.answer_feedback !== false,
+    });
   } catch {
-    return res.json({ event_tracking: false });
+    // フラグ取得に失敗した場合も既定ONを維持する(D1: 出さない方が例外)。
+    return res.json({ event_tracking: false, answer_feedback: true });
   }
 });
 

--- a/tests/widget/widgetSourceInvariants.test.ts
+++ b/tests/widget/widgetSourceInvariants.test.ts
@@ -274,4 +274,57 @@ describe('public/widget.js バッジ描画条件 — 抽出ロジックとの契
     expect(rel).toContain('noopener');
     expect(rel).not.toContain('noreferrer');
   });
+
+  // E3b: お客様の回答評価(👍👎)。要件Rj/F5。
+  describe('answer_feedback (回答評価)', () => {
+    it('event_tracking とは独立に判定している(event_trackingが無効でも動く)', () => {
+      // answer_feedback の判定は event_tracking の早期returnより前にある
+      const idx1 = WIDGET_SRC.indexOf("cfg.answer_feedback === false");
+      const idx2 = WIDGET_SRC.indexOf('if (!cfg.event_tracking) return;');
+      expect(idx1).toBeGreaterThan(-1);
+      expect(idx2).toBeGreaterThan(-1);
+      expect(idx1).toBeLessThan(idx2);
+    });
+
+    it('既定は有効(D1)。fetch失敗時に無効化するコードが無い', () => {
+      // 唯一の無効化条件は明示 false のときだけ
+      expect(WIDGET_SRC).toMatch(/if\s*\(cfg\.answer_feedback === false\)\s*_answerFeedbackEnabled = false;/);
+      // 変数宣言時点の既定値
+      expect(WIDGET_SRC).toMatch(/var _answerFeedbackEnabled = true;/);
+    });
+
+    it('AI回答テキストと構造的に分離したDOMに描画している(bubbleのtextContentに混ぜない)', () => {
+      // buildFeedbackRow は bubble とは別要素として inner に append される
+      const idx = WIDGET_SRC.indexOf('buildFeedbackRow(msg.id)');
+      expect(idx).toBeGreaterThan(-1);
+      const before = WIDGET_SRC.slice(Math.max(0, idx - 1400), idx);
+      expect(before).toMatch(/bubble\.textContent = msg\.content;/);
+    });
+
+    it('system: true が付いた assistant メッセージ(通知・声がけ)には出さない', () => {
+      expect(WIDGET_SRC).toMatch(/msg\.role === 'assistant' && !msg\.system && _answerFeedbackEnabled/);
+    });
+
+    it('送信は event_tracking の EventTracker に依存しない独立経路を使う(keepalive付き)', () => {
+      const fnMatch = WIDGET_SRC.match(/function sendAnswerFeedback\(messageRef, rating\) \{[\s\S]{0,900}/);
+      expect(fnMatch).not.toBeNull();
+      const body = fnMatch ? fnMatch[0] : '';
+      expect(body).toMatch(/event_type:\s*'answer_feedback'/);
+      expect(body).toMatch(/rating:\s*rating/);
+      expect(body).toMatch(/message_ref:\s*messageRef/);
+      expect(body).toMatch(/keepalive:\s*true/);
+    });
+
+    it('連打しても同じ評価では再送信しない(最後の1つに収束)', () => {
+      expect(WIDGET_SRC).toMatch(/if\s*\(_feedbackGiven\[messageRef\] === rating\)\s*return;/);
+    });
+
+    it('👎の後にエスカレーションの状態(escalated/pending)やボタン文言を変更しない', () => {
+      const idx = WIDGET_SRC.indexOf("rating === 'down'");
+      expect(idx).toBeGreaterThan(-1);
+      const block = WIDGET_SRC.slice(idx, idx + 400);
+      expect(block).not.toMatch(/setEscalateBtnState/);
+      expect(block).toMatch(/feedback-hint/);
+    });
+  });
 });


### PR DESCRIPTION
要件 **Rj / F5**、決定 **D1**。#900（サーバ側）に対応するウィジェットUI。

**本番のテナントサイトに出る変更**なので、実装前に既存のブラウザ検証手順で見た目と挙動を確認済み。

## なぜ必要か

教師信号ゼロが学習ループ最上流のボトルネックで、Judge は4通未満の会話を評価しないため、**実会話が1往復で終わる現状では回答単位の評価が唯一機能するシグナル**になる。

## 配線

- `GET /api/widget/features` に `answer_feedback` を追加。既定は「出す」（D1）。`event_tracking` とは**極性が逆**（未設定=無効）であることを明示コメントし、`featuresRouteInvariants.test.ts` でソース不変条件として固定した（`event_tracking` と同じ書き方に「揃えられる」誤修正を防ぐため）
- widget.js: features取得は `event_tracking` の早期returnより前に評価する。`answer_feedback` は独立した機能なので `event_tracking` が無効でも動く
- 送信は `trackConversion` と同じ**独立keepaliveパターン**（`_tracker` 経由ではない）。`event_tracking` 無効テナントでも取りこぼさない

## UI（要件どおりの制約）

- **AI回答テキストと構造的に分離したDOM**（禁止40）。`bubble` の `textContent` に混ぜず、兄弟要素として追加
- `innerHTML` 不使用（既存の `widgetSourceInvariants.test.ts` が機械検査）
- 購入・相談導線より視覚的に弱く（K-6）: `opacity 0.45`、押すと `1.0`
- タップ領域は44×44確保。見た目は小さく保ちつつ透明パディングで広げる（`box-sizing: border-box` のため `width:44px` と `padding:6px` の併用は矛盾することに気づき、`margin` でオフセットする形に直した）
- 連打・複数クリックは最後の1つに収束（表示も送信も）
- **👎の後は既存エスカレーションボタンを一瞬強調するだけ**で、state/文言（`escalated`/`escalatePending`/`setEscalateBtnState`）は一切変更しない
- 通知・声がけ等の system メッセージ（3箇所）には出さない — 実際のAI回答ではないため

## ブラウザでの実地確認（claude-in-chrome、mock した `/api/widget/features` `/api/chat` `/api/events` に対して）

- フィードバック行が `bubble` と**別要素**で描画されることを確認
- 👍クリックで `opacity 0.45 → 1`、`aria-pressed=true` に変化することを確認
- 送信ペイロードが `event_type=answer_feedback` / `rating` / `message_ref` の期待形であることを `console.log` で確認
- 👎クリックで `escalateBtn` に `feedback-hint` クラスが付き、**2.4秒後に消える**ことを確認。ボタン文言・`disabled` 状態は不変であることも確認
- 44×44のタップ領域は**CSS上は正しい**ことを確認（`getBoundingClientRect` の差異は `devicePixelRatio` 起因のブラウザ表示スケーリングで、実装は正しい）

## テスト

**`featuresRouteInvariants.test.ts`（新規4件）** — `answer_feedback` を返す / `event_tracking` と極性が逆 / DB無しフォールバックで `false` を返さない / catch節でも既定ONを維持。**極性を実際に壊すと1件が赤くなる**ことを確認済み。

**`widgetSourceInvariants.test.ts` に7件追加** — `event_tracking` 非依存の判定順序 / 既定ON / DOM分離 / systemメッセージ除外 / 独立送信経路+keepalive / 連打の収束 / エスカレーション状態の不変。**連打ガードを外すと1件が赤くなる**ことを確認済み。

## 検証

- backend typecheck 0 / oxlint 0 / widget.js 構文OK
- widget + events + index.wiring + featuresRouteInvariants **223テスト全通過**（1回目）
- 2回目実行は本セッション既知のポート枯渇（`EADDRNOTAVAIL`）で11件flaky、本変更と無関係

## 関連

- 要件定義 v1.3（Rj / F5）: https://claude.ai/code/artifact/4a311d89-76ba-4831-93ff-7c2e7348debe
- 前提: #900（サーバ側の受け口）
- Asana: E3b（学習ループUX）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgCQYt8UMPgm4HNVu7nv7z