### PR TITLE
fix(admin-ui): 埋め込みコードのsrcを動的ルート(/widget/:tenantId.js)に切替

### DIFF
--- a/admin-ui/src/pages/admin/tenants/EmbedCodeTab.test.tsx
+++ b/admin-ui/src/pages/admin/tenants/EmbedCodeTab.test.tsx
@@ -89,10 +89,23 @@ describe("buildEmbedCode", () => {
     expect(code).not.toContain("data-color");
   });
 
-  it("実在するホスト(api.r2c.biz)を使う（cdn.r2c.bizはDNS解決不能なため貼っても繋がらない）", () => {
-    const code = buildEmbedCode(makeTenant(), "rjc_test_abc123");
-    expect(code).toContain("https://api.r2c.biz/widget.js");
+  it("実在するホスト(api.r2c.biz)の動的ルート(/widget/:tenantId.js)を使う（cdn.r2c.bizはDNS解決不能なため貼っても繋がらない）", () => {
+    const code = buildEmbedCode(makeTenant({ id: "acme" }), "rjc_test_abc123");
+    expect(code).toContain("https://api.r2c.biz/widget/acme.js");
     expect(code).not.toContain("cdn.r2c.biz");
+  });
+
+  it("テナントごとに src のURLが異なる（テナントIDが埋め込みコードのURLに反映される回帰テスト）", () => {
+    const codeA = buildEmbedCode(makeTenant({ id: "tenant-a" }), "rjc_test_abc123");
+    const codeB = buildEmbedCode(makeTenant({ id: "tenant-b" }), "rjc_test_abc123");
+    expect(codeA).toContain("https://api.r2c.biz/widget/tenant-a.js");
+    expect(codeB).toContain("https://api.r2c.biz/widget/tenant-b.js");
+    expect(codeA).not.toContain("https://api.r2c.biz/widget/tenant-b.js");
+  });
+
+  it("静的経路(/widget.js)はもう出力しない（動的ルートに切り替わったことの再発防止: GID 1217762331236037）", () => {
+    const code = buildEmbedCode(makeTenant({ id: "acme" }), "rjc_test_abc123");
+    expect(code).not.toContain('src="https://api.r2c.biz/widget.js"');
   });
 
   it("data-tenant には tenant.id を使う（slugはバックエンドが一度も返さないため常に空だった）", () => {

--- a/admin-ui/src/pages/admin/tenants/EmbedCodeTab.tsx
+++ b/admin-ui/src/pages/admin/tenants/EmbedCodeTab.tsx
@@ -55,7 +55,16 @@ export function buildEmbedCode(tenant: TenantDetail, apiKey: string): string {
   const placementLines = buildPlacementLines(tenant.widget_theme);
   // data-tenant は tenant.id を使う（widget.js/routes.ts のコメントで「slug = tenant ID」と
   // 明記されている。tenants テーブルに slug 列自体が存在しないため、別の slug フィールドは無い）。
-  return `<script src="https://api.r2c.biz/widget.js"
+  //
+  // src は動的ルート GET /widget/:tenantSlug.js（src/api/widget/routes.ts）を指す。
+  // 静的な /widget.js を直接返すだけの旧URLは、プラン別バッジ制御(showBrandingBadge)を
+  // 一切経由できず、free_ad等のバッジ配布経路が事実上存在しなかった(GID 1217762331236037)。
+  // 動的ルートのレスポンスは public/widget.js の全文にテナント設定ブロックを前置したものであり、
+  // data-api-key/data-tenant/data-accent-color/placement系の各属性は静的経路と全く同じ
+  // currentScript.getAttribute(...) の仕組みで読まれるため、ここでの変更は不要。
+  // 既に静的URLで埋め込み済みの稼働中テナントはこの変更の影響を受けない(後方互換)。
+  // 次回このタブでコードをコピーした時点から新URLになる。
+  return `<script src="https://api.r2c.biz/widget/${tenant.id}.js"
   data-api-key="${apiKey}"
   data-tenant="${tenant.id}"${accentColorLine}${placementLines}>
 </script>`;

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -1707,7 +1707,11 @@ export async function executeToolCall(
 
         return truncate(
           `ウィジェット埋め込みコードのひな形:\n\n` +
-          `<script src="https://api.r2c.biz/widget.js" data-api-key="YOUR_API_KEY"${accentColorAttr}${placementAttrs}></script>\n\n` +
+          // src は動的ルート GET /widget/:tenantSlug.js（src/api/widget/routes.ts）を指す。
+          // 静的な /widget.js への直リンクだとプラン別バッジ制御(showBrandingBadge)を
+          // 経由できず、バッジ配布経路が事実上存在しなかった(GID 1217762331236037、
+          // admin-ui/src/pages/admin/tenants/EmbedCodeTab.tsx と同一根本原因)。
+          `<script src="https://api.r2c.biz/widget/${tenantId}.js" data-api-key="YOUR_API_KEY"${accentColorAttr}${placementAttrs}></script>\n\n` +
           `現在のAPIキー先頭: ${keyPrefix}...\n` +
           `※ 実際のAPIキーは発行時のみ表示されます。再確認が必要な場合は新しいキーを発行してください`
         );

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -8084,6 +8084,26 @@ describe('POST /v1/admin/agent/chat', () => {
       expect(res.body.actions[0].result).not.toContain('data-position');
       expect(res.body.actions[0].result).not.toContain('data-offset');
     });
+
+    // GID 1217762331236037: admin-ui/EmbedCodeTab.tsx と同一根本原因(静的 /widget.js
+    // ハードコード)がこのチャットツール経由の埋め込みコード案内にも存在していた。
+    // 動的ルート(/widget/:tenantId.js)への切替そのものの再発防止テスト。
+    it('src は動的ルート(/widget/:tenantId.js)を指す。静的な /widget.js は返さない', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-ec-6', 'get_embed_code'))
+        .mockResolvedValueOnce(makeGroqResponse('埋め込みコードです。'));
+      mockQuery
+        .mockResolvedValueOnce({ rows: [{ key_prefix: 'r2c_live_abc' }] })
+        .mockResolvedValueOnce({ rows: [{ widget_theme: null }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '埋め込みコードを教えて', sessionId: 'sess-embed-06' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('src="https://api.r2c.biz/widget/tenant-abc.js"');
+      expect(res.body.actions[0].result).not.toContain('src="https://api.r2c.biz/widget.js"');
+    });
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- free_adプラン(広告表示プラン)のバッジ機能が、テナントへ実際に配布される埋め込みコード生成箇所から、バッジを配布できる唯一の経路(動的ルート `GET /widget/:tenantSlug.js`, `src/api/widget/routes.ts`)を一度も参照しておらず、本番のどのテナントにもバッジが表示されないP0欠陥を修正します。Asana起票済み: **GID 1217762331236037**
- 同一の根本原因(静的 `/widget.js` のハードコード)が、埋め込みコードの発行元が2箇所ある両方に存在していたため、両方を修正しました。
  1. `admin-ui/src/pages/admin/tenants/EmbedCodeTab.tsx`(admin-uiのテナント詳細画面から埋め込みコードをコピーする経路)
  2. `src/api/admin/agent/actionExecutor.ts` の `get_embed_code` アクション(管理エージェントのチャットツール経由で埋め込みコードを案内する経路)
- どちらも `src` を `https://api.r2c.biz/widget.js` → `https://api.r2c.biz/widget/${tenantId}.js` に変更。他属性(`data-api-key`/`data-tenant`/`data-accent-color`/placement系)は変更なし(動的ルートのレスポンスは `public/widget.js` の全文にテナント設定ブロックを前置したものであり、これらの属性は静的経路と全く同じ `currentScript.getAttribute(...)` の仕組みで読まれるため)。
- 既存の静的URLで埋め込み済みの稼働中テナントはこの変更の影響を受けません(後方互換)。次回コピー/案内時から新URLになります。

## Changes
- `admin-ui/src/pages/admin/tenants/EmbedCodeTab.tsx`: `src` を動的ルートに変更、経緯を説明するコメントを追加
- `admin-ui/src/pages/admin/tenants/EmbedCodeTab.test.tsx`:
  - 既存テストを新URLパターンに更新
  - 新規: テナントIDが異なれば埋め込みコードのURLも異なることを確認する回帰テスト
  - 新規: 静的経路の文字列 `/widget.js"` が単体では出力されない(=動的ルートへの切替そのもの)ことを確認する再発防止テスト
- `src/api/admin/agent/actionExecutor.ts`: `get_embed_code` アクションの `src` も動的ルートに変更
- `src/api/admin/agent/agentRoutes.test.ts`: `get_embed_code` describeブロックに、動的ルートのURLを返し静的 `/widget.js` を返さないことを確認する回帰テストを追加
- `src/api/widget/routes.test.ts`: `db===null` 時の `/widget.js` フォールバックリダイレクトの回帰テストは既存(40-45行目・229-236行目)のため追加変更なし

## Test plan
- [x] `cd admin-ui && npm run test:ui -- EmbedCodeTab` — 20 tests passed
- [x] `cd admin-ui && npm run typecheck` — passed
- [x] `npm test -- src/api/widget` (repo root) — 29 tests passed
- [x] `npm test -- src/api/admin/agent/agentRoutes.test.ts -t "get_embed_code"` — 6 tests passed
- [x] `npx tsc --noEmit` (repo root) — passed
- [ ] **本番投入後に実機確認必須**(未実施): 実テナント1件で新しい埋め込みコードをコピーし、`window.__RAJIUCE_TENANT_CFG__.badgeUrl` が実際に注入されること、バッジがクリックでき `/lp/from-chat/` に正しく遷移することをブラウザで確認する

## Notes
- admin-ui配下の変更のためTier S: 自動マージ対象外。人間の手動マージが必要です。
- Asana GID 1217762331236037 は、実機確認が取れ次第「完了」に更新してください。
- `agentRoutes.test.ts` フルスイート実行時に一部テストが `EADDRNOTAVAIL` で失敗することがありますが、環境側のポート枯渇による既知の不安定性であり本PRの変更とは無関係です(該当テストを単体実行するとすべてpass)。

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
https://claude.ai/code/session_01NF9b7Ew1PiYJmfP5wfs99h