### PR TITLE
test(lp,admin-ui): P3のテスト抜けを補完(from-chat LP UTM転送 / PLAN_OPTIONS free_ad)

### DIFF
--- a/admin-ui/src/pages/admin/tenants/types.test.ts
+++ b/admin-ui/src/pages/admin/tenants/types.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { PLAN_OPTIONS } from "./types";
+
+describe("PLAN_OPTIONS", () => {
+  it("free_ad エントリを含む", () => {
+    const freeAd = PLAN_OPTIONS.find((p) => p.value === "free_ad");
+    expect(freeAd).toBeDefined();
+  });
+
+  it("free_ad の multiplier は 0(広告原資の無料プラン)である", () => {
+    const freeAd = PLAN_OPTIONS.find((p) => p.value === "free_ad");
+    expect(freeAd?.multiplier).toBe(0);
+  });
+
+  it("free_ad のラベルは「Free（広告表示）」である", () => {
+    const freeAd = PLAN_OPTIONS.find((p) => p.value === "free_ad");
+    expect(freeAd?.label).toBe("Free（広告表示）");
+  });
+
+  it("free_ad の説明文はバッジ表示・月200会話上限に言及している", () => {
+    const freeAd = PLAN_OPTIONS.find((p) => p.value === "free_ad");
+    expect(freeAd?.desc).toContain("Powered by R2C");
+    expect(freeAd?.desc).toContain("200");
+  });
+
+  it("free_ad は starter より下(最下段)の並び順である", () => {
+    const values = PLAN_OPTIONS.map((p) => p.value);
+    expect(values.indexOf("free_ad")).toBeLessThan(values.indexOf("starter"));
+  });
+
+  it("全プラン(free_ad/starter/growth/enterprise)が揃っている", () => {
+    const values = PLAN_OPTIONS.map((p) => p.value);
+    expect(values).toEqual(["free_ad", "starter", "growth", "enterprise"]);
+  });
+});

--- a/tests/lp/fromChatSourceInvariants.test.ts
+++ b/tests/lp/fromChatSourceInvariants.test.ts
@@ -1,0 +1,48 @@
+// tests/lp/fromChatSourceInvariants.test.ts
+//
+// tests/lp/fromChatUtmForwarding.test.ts は public/lp/from-chat/index.html の
+// UTM等クエリ転送ロジックを"同一実装として抽出"してテストする方針（widgetSourceInvariants.test.ts
+// と同じ慣習）を取っているため、実ファイル側だけがリファクタで変わり、テスト側の
+// コピーが古いまま緑になり続ける"ドリフト"を検知できない弱点がある。
+//
+// このファイルは実際に配布される public/lp/from-chat/index.html のソーステキストを
+// 直接読み込み、抽出ロジックとの契約(=同一の条件式・遷移先)が実ファイル側から
+// 乖離していないことを機械的にロックする。
+
+import fs from "fs";
+import path from "path";
+
+const LP_SRC = fs.readFileSync(
+  path.resolve(__dirname, "../../public/lp/from-chat/index.html"),
+  "utf8"
+);
+
+describe("public/lp/from-chat/index.html ソース不変条件", () => {
+  it("window.location.search を読み取っている", () => {
+    expect(LP_SRC).toMatch(/window\.location\.search/);
+  });
+
+  it("空のクエリ文字列では早期returnし、href書き換えを行わない", () => {
+    expect(LP_SRC).toMatch(/if\s*\(\s*!q\s*\)\s*return;/);
+  });
+
+  it("#cta-primary 要素を取得している", () => {
+    expect(LP_SRC).toMatch(/getElementById\(\s*['"]cta-primary['"]\s*\)/);
+  });
+
+  it("cta要素が存在するときだけ href を書き換えるガードがある", () => {
+    expect(LP_SRC).toMatch(/if\s*\(\s*cta\s*\)\s*cta\.href\s*=/);
+  });
+
+  it("遷移先は /lp/index.html + クエリ文字列 + #contact の連結である(既存LPの問い合わせフォームへ引き継ぐ)", () => {
+    expect(LP_SRC).toMatch(
+      /cta\.href\s*=\s*['"]\/lp\/index\.html['"]\s*\+\s*q\s*\+\s*['"]#contact['"]/
+    );
+  });
+
+  it("#cta-primary のデフォルトhrefは /lp/index.html#contact である(クエリなし時のフォールバック)", () => {
+    expect(LP_SRC).toMatch(
+      /id="cta-primary"[^>]*href="\/lp\/index\.html#contact"|href="\/lp\/index\.html#contact"[^>]*id="cta-primary"/
+    );
+  });
+});

--- a/tests/lp/fromChatUtmForwarding.test.ts
+++ b/tests/lp/fromChatUtmForwarding.test.ts
@@ -1,0 +1,56 @@
+// tests/lp/fromChatUtmForwarding.test.ts
+// public/lp/from-chat/index.html の UTM等クエリ文字列転記ロジックのユニットテスト。
+//
+// 方針: tests/widget/freeAdBadgeLogic.test.ts と同様、実際のHTML/scriptを評価せず、
+// 同一ロジックを抽出して検証する（public/lp/from-chat/index.html の該当箇所と完全同一に保つこと）。
+// ロジックの乖離は tests/lp/fromChatSourceInvariants.test.ts が実ファイル側の
+// 実装をこの契約から外れていないか正規表現で機械的にチェックする。
+
+// public/lp/from-chat/index.html 171-178行目付近:
+// バッジ経由の流入(utm_source等・r2c_ref)を、問い合わせ導線(#contact)まで引き継ぐ。
+function buildCtaHref(search: string): string | null {
+  if (!search) return null;
+  return "/lp/index.html" + search + "#contact";
+}
+
+describe("from-chat LP buildCtaHref", () => {
+  describe("正常系", () => {
+    it("クエリ文字列なし(空文字) → hrefを書き換えない(null)", () => {
+      expect(buildCtaHref("")).toBeNull();
+    });
+
+    it("単一パラメータ → #contactを維持したままクエリを差し込む", () => {
+      expect(buildCtaHref("?utm_source=badge")).toBe(
+        "/lp/index.html?utm_source=badge#contact"
+      );
+    });
+
+    it("複数パラメータ → そのまま連結される", () => {
+      expect(buildCtaHref("?utm_source=badge&utm_medium=chat&r2c_ref=t1")).toBe(
+        "/lp/index.html?utm_source=badge&utm_medium=chat&r2c_ref=t1#contact"
+      );
+    });
+  });
+
+  describe("境界値・異常系", () => {
+    it("'?'のみ(値なしクエリ) → そのまま連結される(falsyではないため)", () => {
+      expect(buildCtaHref("?")).toBe("/lp/index.html?#contact");
+    });
+
+    it("'#'を含む異常なsearch値(URLエンコード済み等) → そのまま連結される(サニタイズはしない)", () => {
+      expect(buildCtaHref("?redirect=%23top")).toBe(
+        "/lp/index.html?redirect=%23top#contact"
+      );
+    });
+
+    it("生の'#'を含む異常なsearch値でも例外を投げず連結する", () => {
+      expect(buildCtaHref("?a=1#b")).toBe("/lp/index.html?a=1#b#contact");
+    });
+
+    it("日本語等マルチバイト値を含んでいても連結する", () => {
+      expect(buildCtaHref("?utm_campaign=%E5%A4%8F%E3%82%BB%E3%83%BC%E3%83%AB")).toBe(
+        "/lp/index.html?utm_campaign=%E5%A4%8F%E3%82%BB%E3%83%BC%E3%83%AB#contact"
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- `public/lp/from-chat/index.html` のUTM等クエリ文字列転送ロジック(#cta-primaryへの引き継ぎ)を、`tests/widget/freeAdBadgeLogic.test.ts` / `tests/widget/widgetSourceInvariants.test.ts` と同じ二層構成(抽出ロジック単体テスト + ソース不変条件テスト)でカバーする(P3a)。
- `admin-ui/src/pages/admin/tenants/types.ts` の `PLAN_OPTIONS` に `free_ad` エントリ(`multiplier: 0`、ラベル/説明文)が期待通り含まれることを検証する軽量データテストを追加する(P3b)。BillingSection.tsxのコンポーネントレンダリングテストはスコープ外。

計画: `/Users/hkobayashi/.claude-r2c-config/plans/squishy-crafting-widget.md` セクション5「P3: テスト抜けの補完」に基づく。

## Test plan
- [x] `npm test -- tests/lp` (ルートリポジトリ) — 2 suites / 13 tests pass
- [x] `cd admin-ui && npm run test:ui -- types.test` — 1 suite / 6 tests pass
- [x] `npm run typecheck` (ルート) — clean
- [x] `cd admin-ui && npm run typecheck` — clean

admin-ui配下の変更を含むためTier S。マージは行わず、hkobayashi の手動マージ待ちとします。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NF9b7Ew1PiYJmfP5wfs99h