### PR TITLE
refactor(billing): billing内部の重複整理(TenantPlan整合性テスト+JST算術共通化)

### DIFF
--- a/src/lib/billing/planQuota.ts
+++ b/src/lib/billing/planQuota.ts
@@ -16,9 +16,9 @@
 // 値になる——1セッションが200ターンを超える極端な単一会話がある場合、その月の
 // 残り新規会話が止まる可能性はあるが、原価上限(月あたり最大 200 × 約0.11円
 // ≈ 22円/テナント)を超えることはなく、R2C負担としては安全側に倒れている。
-export const FREE_AD_MONTHLY_REQUEST_LIMIT = 200;
+import { JST_OFFSET_MS, shiftToJstWallClock } from "../date/jstOffset";
 
-const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+export const FREE_AD_MONTHLY_REQUEST_LIMIT = 200;
 
 export interface MonthRangeJst {
   /** 当月の開始（1日 00:00:00 JST）をUTC Dateで表したもの */
@@ -37,7 +37,7 @@ export interface MonthRangeJst {
  * UTC Date を返す。SQL 側で `AT TIME ZONE` を書く必要はない。
  */
 export function getMonthRangeJst(now: Date): MonthRangeJst {
-  const shifted = new Date(now.getTime() + JST_OFFSET_MS);
+  const shifted = shiftToJstWallClock(now);
   const shiftedMonthStart = Date.UTC(
     shifted.getUTCFullYear(),
     shifted.getUTCMonth(),

--- a/src/lib/date/jstOffset.ts
+++ b/src/lib/date/jstOffset.ts
@@ -1,0 +1,17 @@
+// src/lib/date/jstOffset.ts
+// JST(UTC+9固定・DSTなし)壁時計計算の共通化。
+//
+// weekRange.ts(getWeekRange)とplanQuota.ts(getMonthRangeJst)が同じ手法
+// 「+9hシフト→UTCゲッターで読む→-9hシフトで戻す」を個別に実装していたため、
+// シフト量とシフト処理そのものをここへ集約する(出力は変更しない純粋なリファクタ)。
+
+export const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+/**
+ * now を +9h シフトした Date を返す。
+ * 呼び出し側がこの Date の UTC ゲッター(getUTCFullYear/getUTCMonth/getUTCDate/getUTCDay等)
+ * を読むと、process TZ に依存せず JST の壁時計表現(年月日・曜日)が得られる。
+ */
+export function shiftToJstWallClock(now: Date): Date {
+  return new Date(now.getTime() + JST_OFFSET_MS);
+}

--- a/src/lib/date/weekRange.ts
+++ b/src/lib/date/weekRange.ts
@@ -9,7 +9,8 @@
  *  #602で撤去済み。現在の唯一の利用箇所は actionExecutor.ts の get_weekly_briefing)
  */
 
-const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
+import { JST_OFFSET_MS, shiftToJstWallClock } from "./jstOffset";
+
 const DAY_MS = 24 * 60 * 60 * 1000;
 const WEEK_MS = 7 * DAY_MS;
 
@@ -29,7 +30,7 @@ export interface WeekRange {
 export function getWeekRange(now: Date): WeekRange {
   // now を +9h シフトしてから UTC ゲッターで読むと、process TZ に依存せず JST の
   // 壁時計表現（年月日・曜日）が得られる。
-  const shifted = new Date(now.getTime() + JST_OFFSET_MS);
+  const shifted = shiftToJstWallClock(now);
   const dayOfWeek = shifted.getUTCDay(); // 0=日,1=月,...,6=土
   const daysSinceMonday = (dayOfWeek + 6) % 7;
 

--- a/tests/billing/planRankInvariants.test.ts
+++ b/tests/billing/planRankInvariants.test.ts
@@ -1,0 +1,88 @@
+// tests/billing/planRankInvariants.test.ts
+//
+// TenantPlan/PLAN_RANK/FEATURE_MIN_PLAN は以下の3箇所に独立して定義されている
+// (src/lib/billing/planFeatures.ts と admin-ui/src/lib/planFeatures.ts はimportで
+// 共有できない — server と admin-ui はビルド・tsconfigが別のcross-packageのため)。
+// 過去に実際に1回この3箇所がズレたことがあるが、通常のimportベースのテストでは
+// 検知できない(admin-uiはserver側のモジュールをimportしていないため、片方だけ
+// 直し忘れてもTypeScriptの型チェックすら通ってしまう)。
+//
+// このファイルは tests/widget/widgetSourceInvariants.test.ts と同じ手法を踏襲し、
+// 3ファイルのソーステキストを直接読み込んで PLAN_RANK / FEATURE_MIN_PLAN の
+// オブジェクトリテラルを正規表現で抽出・パースし、内容が一致することをロックする。
+
+import fs from 'fs';
+import path from 'path';
+
+const SERVER_SRC = fs.readFileSync(
+  path.resolve(__dirname, '../../src/lib/billing/planFeatures.ts'),
+  'utf8',
+);
+const ADMIN_UI_SRC = fs.readFileSync(
+  path.resolve(__dirname, '../../admin-ui/src/lib/planFeatures.ts'),
+  'utf8',
+);
+const USE_AUTH_SRC = fs.readFileSync(
+  path.resolve(__dirname, '../../admin-ui/src/auth/useAuth.tsx'),
+  'utf8',
+);
+
+/**
+ * `NAME: Record<...> = { ...obj literal... };` の形の宣言を抽出し、
+ * 素朴な変換(コメント除去→キーをクォート→末尾カンマ除去)でJSONとしてパースする。
+ * 値は文字列/数値のみを想定(このリポジトリのPLAN_RANK/FEATURE_MIN_PLANは全てそう)。
+ */
+function extractRecordLiteral(src: string, name: string): Record<string, unknown> {
+  const re = new RegExp(`${name}\\s*:\\s*Record<[^>]+>\\s*=\\s*(\\{[\\s\\S]*?\\n\\});`);
+  const match = src.match(re);
+  if (!match) {
+    throw new Error(`${name} のオブジェクトリテラルが見つからない: 抽出用正規表現の更新が必要`);
+  }
+  const jsonish = match[1]
+    .replace(/\/\/.*$/gm, '')
+    .replace(/(\w+)\s*:/g, '"$1":')
+    .replace(/,(\s*[}\]])/g, '$1');
+  return JSON.parse(jsonish);
+}
+
+/**
+ * `export type TenantPlan = "a" | "b" | ...;` の形の union type 宣言から
+ * リテラル値の一覧を抽出する。
+ */
+function extractStringUnion(src: string, typeName: string): string[] {
+  const re = new RegExp(`export type ${typeName}\\s*=\\s*([^;]+);`);
+  const match = src.match(re);
+  if (!match) {
+    throw new Error(`type ${typeName} が見つからない: 抽出用正規表現の更新が必要`);
+  }
+  return match[1]
+    .split('|')
+    .map((s) => s.trim().replace(/^"(.*)"$/, '$1'))
+    .filter((s) => s.length > 0);
+}
+
+describe('TenantPlan/PLAN_RANK/FEATURE_MIN_PLAN のクロスパッケージ整合性', () => {
+  it('PLAN_RANK が server(src/lib/billing/planFeatures.ts) と admin-ui(admin-ui/src/lib/planFeatures.ts) で一致する', () => {
+    const serverRank = extractRecordLiteral(SERVER_SRC, 'PLAN_RANK');
+    const adminUiRank = extractRecordLiteral(ADMIN_UI_SRC, 'PLAN_RANK');
+    expect(adminUiRank).toEqual(serverRank);
+  });
+
+  it('FEATURE_MIN_PLAN が server と admin-ui で一致する', () => {
+    const serverFeatureMinPlan = extractRecordLiteral(SERVER_SRC, 'FEATURE_MIN_PLAN');
+    const adminUiFeatureMinPlan = extractRecordLiteral(ADMIN_UI_SRC, 'FEATURE_MIN_PLAN');
+    expect(adminUiFeatureMinPlan).toEqual(serverFeatureMinPlan);
+  });
+
+  it('TenantPlan の取りうる値が admin-ui/src/auth/useAuth.tsx の TenantPlan と一致する(既知の三重化)', () => {
+    const serverRank = extractRecordLiteral(SERVER_SRC, 'PLAN_RANK');
+    const useAuthPlans = extractStringUnion(USE_AUTH_SRC, 'TenantPlan');
+    expect(useAuthPlans.slice().sort()).toEqual(Object.keys(serverRank).sort());
+  });
+
+  it('TenantPlan の取りうる値が admin-ui/src/lib/planFeatures.ts の PLAN_RANK のキーと一致する', () => {
+    const adminUiRank = extractRecordLiteral(ADMIN_UI_SRC, 'PLAN_RANK');
+    const useAuthPlans = extractStringUnion(USE_AUTH_SRC, 'TenantPlan');
+    expect(useAuthPlans.slice().sort()).toEqual(Object.keys(adminUiRank).sort());
+  });
+});


### PR DESCRIPTION
## Summary
- P2a: `TenantPlan`/`PLAN_RANK`/`FEATURE_MIN_PLAN` が `src/lib/billing/planFeatures.ts`、`admin-ui/src/lib/planFeatures.ts`、`admin-ui/src/auth/useAuth.tsx` の3箇所に独立定義されておりドリフトを検知できなかったため、`tests/widget/widgetSourceInvariants.test.ts` と同じソーステキスト抽出方式で `tests/billing/planRankInvariants.test.ts` を追加(過去に実際に1回ズレが発覚した実績あり)。
- P2b: `src/lib/date/weekRange.ts` と `src/lib/billing/planQuota.ts` に重複していたJST壁時計算術(`JST_OFFSET_MS` + シフト処理)を新規 `src/lib/date/jstOffset.ts` へ切り出し。出力を変更しない純粋なリファクタ。

## Test plan
- [x] `npm test -- src/lib/date src/lib/billing tests/billing` (既存の `weekRange.test.ts` / `planQuota.test.ts` を変更せずそのまま通過)
- [x] `npm run typecheck`
- [x] `admin-ui`側 `npm run typecheck`
- [x] `npm run lint`(既存warningのみ、新規ファイルにwarningなし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NF9b7Ew1PiYJmfP5wfs99h