### PR TITLE
perf(billing): getTenantPlan()にTTL60秒キャッシュを追加

### DIFF
--- a/src/lib/billing/planFeatures.test.ts
+++ b/src/lib/billing/planFeatures.test.ts
@@ -6,7 +6,7 @@ jest.mock("../db", () => ({
   getPool: () => ({ query: mockQuery }),
 }));
 
-import { planHasFeature, getTenantPlan, tenantHasFeature } from "./planFeatures";
+import { planHasFeature, getTenantPlan, tenantHasFeature, tenantPlanCache } from "./planFeatures";
 
 describe("planHasFeature", () => {
   it.each([
@@ -78,17 +78,26 @@ describe("planHasFeature", () => {
 describe("getTenantPlan", () => {
   beforeEach(() => {
     mockQuery.mockReset();
+    // TTLキャッシュが前のテストの値を持ち越さないように毎回クリアする
+    // (下の「TTLキャッシュ」describeでは意図的にクリアしないテストがある)。
+    tenantPlanCache.clear();
   });
 
   it("DBのplan列をそのまま返す(4値とも)", async () => {
+    // 同一tenantIdでの連続呼び出しはTTLキャッシュに乗るため、
+    // DBの値をそのまま返す挙動そのものを検証するには都度クリアする
+    // (キャッシュそのものの挙動は下の「TTLキャッシュ」describeで検証する)。
     mockQuery.mockResolvedValueOnce({ rows: [{ plan: "free_ad" }] });
     expect(await getTenantPlan("tenant-a")).toBe("free_ad");
+    tenantPlanCache.clear();
 
     mockQuery.mockResolvedValueOnce({ rows: [{ plan: "starter" }] });
     expect(await getTenantPlan("tenant-a")).toBe("starter");
+    tenantPlanCache.clear();
 
     mockQuery.mockResolvedValueOnce({ rows: [{ plan: "growth" }] });
     expect(await getTenantPlan("tenant-a")).toBe("growth");
+    tenantPlanCache.clear();
 
     mockQuery.mockResolvedValueOnce({ rows: [{ plan: "enterprise" }] });
     expect(await getTenantPlan("tenant-a")).toBe("enterprise");
@@ -101,6 +110,7 @@ describe("getTenantPlan", () => {
   it("plan列がnull/不正値ならfree_adにフォールバック(starterへ「昇格」しない)", async () => {
     mockQuery.mockResolvedValueOnce({ rows: [{ plan: null }] });
     expect(await getTenantPlan("tenant-a")).toBe("free_ad");
+    tenantPlanCache.clear();
 
     mockQuery.mockResolvedValueOnce({ rows: [{ plan: "typo-plan" }] });
     expect(await getTenantPlan("tenant-a")).toBe("free_ad");
@@ -121,13 +131,82 @@ describe("getTenantPlan", () => {
 describe("tenantHasFeature", () => {
   beforeEach(() => {
     mockQuery.mockReset();
+    tenantPlanCache.clear();
   });
 
   it("plan取得結果に基づき機能可否を判定する", async () => {
     mockQuery.mockResolvedValueOnce({ rows: [{ plan: "enterprise" }] });
     expect(await tenantHasFeature("tenant-a", "voice_clone")).toBe(true);
+    tenantPlanCache.clear();
 
     mockQuery.mockResolvedValueOnce({ rows: [{ plan: "growth" }] });
     expect(await tenantHasFeature("tenant-a", "voice_clone")).toBe(false);
+  });
+});
+
+// P2c: getTenantPlan()のTTLキャッシュ。
+// /api/chat が全リクエストで無条件に呼ぶ関数のため、DBラウンドトリップを
+// 60秒キャッシュで間引く(queryTenantPlan自体・fail-safe挙動は変更しない)。
+describe("getTenantPlan TTLキャッシュ", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+    tenantPlanCache.clear();
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it("同一tenantIdへの連続呼び出しはDBクエリが1回しか発行されない", async () => {
+    mockQuery.mockResolvedValue({ rows: [{ plan: "growth" }] });
+
+    expect(await getTenantPlan("tenant-cache")).toBe("growth");
+    expect(await getTenantPlan("tenant-cache")).toBe("growth");
+    expect(await getTenantPlan("tenant-cache")).toBe("growth");
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+  });
+
+  it("TTL(60秒)経過後は再度DBに問い合わせる", async () => {
+    mockQuery.mockResolvedValue({ rows: [{ plan: "starter" }] });
+
+    expect(await getTenantPlan("tenant-cache")).toBe("starter");
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(60 * 1000 + 1);
+
+    expect(await getTenantPlan("tenant-cache")).toBe("starter");
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+  });
+
+  // 既知のトレードオフ: プラン変更(管理操作)はTTL内は反映されず古い値を返し得る。
+  // プラン変更は即時反映が必須の操作ではなく、動的ウィジェットルート自体が
+  // 既に24hキャッシュを許容している設計と整合するため許容する。
+  it("TTL内はプランが変わったテナントでも古い値を返し得る(既知のトレードオフ)", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ plan: "starter" }] });
+    expect(await getTenantPlan("tenant-cache")).toBe("starter");
+
+    // DB側では既にgrowthへ変更済みだが、TTL内はキャッシュのstarterを返す。
+    mockQuery.mockResolvedValueOnce({ rows: [{ plan: "growth" }] });
+    expect(await getTenantPlan("tenant-cache")).toBe("starter");
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+
+    jest.advanceTimersByTime(60 * 1000 + 1);
+
+    expect(await getTenantPlan("tenant-cache")).toBe("growth");
+    expect(mockQuery).toHaveBeenCalledTimes(2);
+  });
+
+  it("異なるtenantIdはそれぞれ独立してキャッシュされる", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ plan: "starter" }] });
+    expect(await getTenantPlan("tenant-x")).toBe("starter");
+
+    mockQuery.mockResolvedValueOnce({ rows: [{ plan: "enterprise" }] });
+    expect(await getTenantPlan("tenant-y")).toBe("enterprise");
+
+    expect(await getTenantPlan("tenant-x")).toBe("starter");
+    expect(await getTenantPlan("tenant-y")).toBe("enterprise");
+    expect(mockQuery).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/lib/billing/planFeatures.ts
+++ b/src/lib/billing/planFeatures.ts
@@ -98,9 +98,34 @@ export async function queryTenantPlan(
   }
 }
 
-/** DBからテナントの現在のプランを取得する（getPool()経由）。 */
+// /api/chat は全リクエストで getTenantPlan() を呼ぶ(free_ad以外のプランでも毎回)。
+// この関数がコードベース全体でqueryTenantPlanのprod唯一の呼び出し元であり、
+// 恒久的なDBラウンドトリップが最高トラフィックエンドポイントに乗っている状態を
+// 緩和するため、TTL 60秒の薄いインメモリキャッシュを手前に挟む。
+// queryTenantPlan自体(DB問い合わせ+fail-safe処理)は変更しない。
+// プラン変更(管理操作)がTTL内は反映されないトレードオフを許容する
+// (動的ウィジェットルート自体が既に24hキャッシュを許容している設計と整合、
+// src/lib/billing/planFeatures.test.ts 参照)。
+const TENANT_PLAN_CACHE_TTL_MS = 60 * 1000; // 60 seconds
+
+interface TenantPlanCacheEntry {
+  plan: TenantPlan;
+  expiresAt: number;
+}
+
+export const tenantPlanCache: Map<string, TenantPlanCacheEntry> = new Map();
+
+/** DBからテナントの現在のプランを取得する（getPool()経由、TTLキャッシュ付き）。 */
 export async function getTenantPlan(tenantId: string): Promise<TenantPlan> {
-  return queryTenantPlan(getPool(), tenantId);
+  const cached = tenantPlanCache.get(tenantId);
+  const now = Date.now();
+  if (cached && cached.expiresAt > now) {
+    return cached.plan;
+  }
+
+  const plan = await queryTenantPlan(getPool(), tenantId);
+  tenantPlanCache.set(tenantId, { plan, expiresAt: now + TENANT_PLAN_CACHE_TTL_MS });
+  return plan;
 }
 
 export async function tenantHasFeature(tenantId: string, feature: GatedFeature): Promise<boolean> {


### PR DESCRIPTION
## 概要
`getTenantPlan()` は `/api/chat` の `isFreeAdQuotaExceededForTenant()` から**全リクエストで無条件に**呼ばれており(free_ad以外のプランでも毎回)、コードベース全体で `queryTenantPlan` のprod唯一の呼び出し元になっている。恒久的なDBラウンドトリップが最高トラフィックエンドポイントに常時発生していたため、`getTenantPlan()` の手前にTTL 60秒のインメモリキャッシュ(`Map<tenantId, {plan, expiresAt}>`)を追加した。

`src/middleware/inputSanitizer.ts` の `sessionHistoryStore` と同じMapベースのパターンを踏襲。`queryTenantPlan()` 自体(DB問い合わせ+fail-safe処理)は一切変更していない。

## 既知のトレードオフ
プラン変更(管理操作)はTTL(60秒)内は反映されないことがある。プラン変更は即時反映が必須の操作ではなく、動的ウィジェットルート自体が既に24hキャッシュを許容している設計と整合するため許容する(テストにコメントで明記)。

## 優先度
**ローンチ前で緊急ではなく、優先度は低め。** 承認済み実装計画 `squishy-crafting-widget.md` の「P2c」セクションの実装。パフォーマンス改善であり、機能追加・バグ修正ではない。

## テスト
- `npm test -- src/lib/billing/planFeatures` — 45件全て通過(既存41件+新規4件のキャッシュテスト)
  - 同一tenantIdへの連続呼び出しでDBクエリが1回しか発行されないこと
  - TTL経過後は再度DBに問い合わせること(`jest.useFakeTimers`)
  - プランが変わったテナントでもTTL内は古い値を返し得ること(既知のトレードオフとして明示)
  - 異なるtenantIdは独立してキャッシュされること
- `npm run typecheck` — 通過

既存テストのうち同一tenantIdを連続で呼びDBの値をそのまま返すことを検証していたテストは、各呼び出し間で `tenantPlanCache.clear()` を挟むよう最小限の調整を行った(挙動自体は変更していない)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NF9b7Ew1PiYJmfP5wfs99h