### PR TITLE
docs(avatar): G2実測用のレイテンシログを一時的に仕込む

### DIFF
--- a/avatar-agent/agent.py
+++ b/avatar-agent/agent.py
@@ -430,6 +430,38 @@ groq_llm = openai_plugin.LLM(
 )
 
 
+def format_g2_latency_log(ev, tenant_id: str | None, room_name: str) -> str | None:
+    """G2(要件定義v1.3): アバターの応答レイテンシを実測するための一時計測。
+
+    conversation_item_added イベントから assistant ターンの ChatMessage.metrics
+    (livekit-agents 1.6.7 が公式に収集する e2e_latency/llm_node_ttft/tts_node_ttfb/
+    playback_latency)を読み、ログ1行に整形する。手動でタイムスタンプを打つより
+    フレームワーク計測を使う方が正確で壊れにくい
+    (session.on("metrics_collected") は本バージョンで非推奨、ChatMessage.metrics が代替)。
+
+    役目を終えたら(G2実測完了・方式決定後)削除する一時コードであることを明示しておく。
+    計測が失敗しても呼び出し側(entrypoint)が音声パイプラインを止めないよう、
+    例外はここでは投げず None を返すに留める(呼び出し側の try/except は保険)。
+
+    戻り値: ログに出す1行。計測値が無いターン(会話開始直後の挨拶等)は None。
+    """
+    item = getattr(ev, "item", None)
+    if getattr(item, "role", None) != "assistant":
+        return None
+    m = getattr(item, "metrics", None) or {}
+    e2e = m.get("e2e_latency")
+    ttft = m.get("llm_node_ttft")
+    ttfb = m.get("tts_node_ttfb")
+    playback = m.get("playback_latency")
+    if e2e is None and ttft is None and ttfb is None:
+        return None
+    return (
+        f"[G2-latency] tenant={tenant_id} room={room_name} "
+        f"e2e_latency_s={e2e} llm_ttft_s={ttft} tts_ttfb_s={ttfb} "
+        f"playback_latency_s={playback}"
+    )
+
+
 async def entrypoint(ctx: agents.JobContext) -> None:
     # 子プロセスでも確実に再ロード
     for _c in [_here / ".env", _here.parent / ".env"]:
@@ -548,6 +580,22 @@ async def entrypoint(ctx: agents.JobContext) -> None:
         tts=fish_tts,
         user_away_timeout=None,
     )
+
+    # G2(要件定義v1.3): アバターの応答レイテンシを実測し、知識連動(RAG)の
+    # 実現方式を決めるための一時的な計測。手動でタイムスタンプを打つのではなく、
+    # livekit-agents 1.6.7 が ChatMessage.metrics として公式に収集している値を読む
+    # (session.on("metrics_collected") は本バージョンで非推奨。
+    # ChatMessage.metrics が代替として明示されている)。
+    # 計測が失敗しても音声パイプラインを絶対に止めない(try/exceptで握り潰す)。
+    # 役目を終えたら削除する一時コードであることを明示しておく。
+    @session.on("conversation_item_added")
+    def on_conversation_item_added(ev) -> None:
+        try:
+            log_line = format_g2_latency_log(ev, tenant_id, ctx.room.name)
+            if log_line:
+                logger.info(log_line)
+        except Exception as e:
+            logger.warning(f"[G2-latency] failed to log metrics (non-fatal): {e}")
 
     @session.on("error")
     def on_session_error(ev) -> None:

--- a/avatar-agent/test_g2_latency.py
+++ b/avatar-agent/test_g2_latency.py
@@ -1,0 +1,82 @@
+"""
+G2(要件定義v1.3): アバター応答レイテンシ計測の回帰テスト。
+
+役目を終えたら(実測完了・E5の方式決定後)このファイルごと削除する前提の
+一時計測に対するテスト。format_g2_latency_log は entrypoint() の外に
+切り出した純関数(DB・LiveKit・LLMに一切触れない)。
+"""
+
+import os
+from types import SimpleNamespace
+
+os.environ.setdefault("GROQ_API_KEY", "test-dummy-key")
+os.environ.setdefault("FISH_AUDIO_API_KEY", "test-dummy-key")
+
+import agent  # noqa: E402
+
+
+def _ev(role="assistant", metrics=None):
+    item = SimpleNamespace(role=role, metrics=metrics if metrics is not None else {})
+    return SimpleNamespace(item=item)
+
+
+def test_assistant_turn_with_full_metrics_formats_all_fields():
+    ev = _ev(
+        role="assistant",
+        metrics={
+            "e2e_latency": 1.234,
+            "llm_node_ttft": 0.456,
+            "tts_node_ttfb": 0.321,
+            "playback_latency": 0.05,
+        },
+    )
+    line = agent.format_g2_latency_log(ev, "r2c_default", "room-abc")
+    assert line is not None
+    assert "tenant=r2c_default" in line
+    assert "room=room-abc" in line
+    assert "e2e_latency_s=1.234" in line
+    assert "llm_ttft_s=0.456" in line
+    assert "tts_ttfb_s=0.321" in line
+    assert "playback_latency_s=0.05" in line
+
+
+def test_user_turn_is_ignored():
+    ev = _ev(role="user", metrics={"e2e_latency": 1.0})
+    assert agent.format_g2_latency_log(ev, "r2c_default", "room-abc") is None
+
+
+def test_assistant_turn_with_no_metrics_returns_none():
+    """会話開始直後の挨拶等、計測値が一切無いターン。"""
+    ev = _ev(role="assistant", metrics={})
+    assert agent.format_g2_latency_log(ev, "r2c_default", "room-abc") is None
+
+
+def test_assistant_turn_with_partial_metrics_still_logs():
+    """e2e_latency が無くても llm_node_ttft だけあればログに出す
+    (どこが遅いかの切り分けに使うため、部分的な値も捨てない)。"""
+    ev = _ev(role="assistant", metrics={"llm_node_ttft": 0.5})
+    line = agent.format_g2_latency_log(ev, "r2c_default", "room-abc")
+    assert line is not None
+    assert "llm_ttft_s=0.5" in line
+    assert "e2e_latency_s=None" in line
+
+
+def test_missing_metrics_attribute_does_not_raise():
+    """ChatMessage 以外の item(AgentHandoff 等)が来ても例外にしない。"""
+    item = SimpleNamespace(role="assistant")  # metrics 属性が無い
+    ev = SimpleNamespace(item=item)
+    assert agent.format_g2_latency_log(ev, "r2c_default", "room-abc") is None
+
+
+def test_missing_role_attribute_does_not_raise():
+    item = SimpleNamespace(metrics={"e2e_latency": 1.0})  # role 属性が無い
+    ev = SimpleNamespace(item=item)
+    assert agent.format_g2_latency_log(ev, "r2c_default", "room-abc") is None
+
+
+def test_tenant_id_none_is_handled():
+    """super_admin のテストチャット等で tenant_id が None のことがある。"""
+    ev = _ev(role="assistant", metrics={"e2e_latency": 1.0})
+    line = agent.format_g2_latency_log(ev, None, "room-abc")
+    assert line is not None
+    assert "tenant=None" in line


### PR DESCRIPTION
要件定義v1.3 **G2**: アバターの応答レイテンシを実測し、E5（知識連動）の実現方式を決めるための着手前ゲート。**実装ではなく計測。**

## やったこと

`livekit-agents 1.6.7` が `ChatMessage.metrics` として公式収集している値を読む。手動でタイムスタンプを打つのではなく、フレームワーク標準の計測を使う方が正確で壊れにくい（`session.on("metrics_collected")` は本バージョンで非推奨、`ChatMessage.metrics` が代替として明示されている）。

取得する値（公式ドキュメントの定義）:
- `e2e_latency` — ユーザー発話終了→エージェント応答開始
- `llm_node_ttft` — LLMが最初のトークンを返すまで
- `tts_node_ttfb` — TTSが最初の音声チャンクを返すまで
- `playback_latency` — 音声再生開始の遅延

`conversation_item_added` イベントで assistant ターンのみログ出力する。ロジックは `format_g2_latency_log` としてモジュールレベルの純関数に切り出した（`entrypoint()` 内のネストしたクロージャのままだとテストできないため）。

## ★ 音声パイプラインを絶対に止めない

ハンドラ内を `try/except` で囲み、例外は warning ログに落として再送出しない。計測が失敗してもアバターの応答は止まらない。

## ★ 一時コードである

G2実測が終わり E5 の方式（同期/事前要約/非同期のいずれか）が決まったら、このハンドラと `test_g2_latency.py` ごと削除する。

## テスト 7件

全指標が揃うケース / userターンは無視 / 計測値ゼロのターンはNone / **一部指標のみでもログに出す**（どこが遅いかの切り分けに使うため） / `metrics` 属性が無い item / `role` 属性が無い item / `tenant_id` が None。

**role判定を無効化すると2件が赤くなる**ことを確認済み。

## 検証

- Python構文OK
- avatar-agent 全 **95テスト通過**（既存を含む）
- 既存 `test_avatar_identity.py` が環境変数無しでは単独実行できない問題は main ブランチでも同一に再現することを確認済み（本変更と無関係）

## この後の手順（マージ後）

1. `bash SCRIPTS/deploy-vps.sh` で本番デプロイ（`r2c_default` の `rajiuce-avatar` プロセス再起動を伴う。実顧客への影響なし）
2. `admin.r2c.biz/admin/chat-test` から実際にアバターと会話し、`pm2 logs rajiuce-avatar` でレイテンシを収集
3. 実測後、方式決定 → このPRのコードを削除するフォローアップPR

## 関連

- 要件定義 v1.3（G2）: https://claude.ai/code/artifact/4a311d89-76ba-4831-93ff-7c2e7348debe
- 後続: E5（アバター知識連動）
- Asana: G2（学習ループUX）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgCQYt8UMPgm4HNVu7nv7z