### PR TITLE
feat(admin-ui): hide_branding のプラン別バッジ表示状態をEmbedCodeTabに可視化

### DIFF
--- a/admin-ui/src/pages/admin/tenants/EmbedCodeTab.test.tsx
+++ b/admin-ui/src/pages/admin/tenants/EmbedCodeTab.test.tsx
@@ -215,3 +215,22 @@ describe("EmbedCodeTab", () => {
     expect(screen.getByRole("button", { name: "📋 コードをコピー" })).toBeTruthy();
   });
 });
+
+// ─── バッジ表示ステータス: hide_branding は admin-ui にゲート判定が一切無く、
+// テナント管理者が自分のバッジ表示状態を確認する手段が無かった(planFeatures.ts の
+// hide_branding = growth はサーバ側 src/api/widget/routes.ts でしか参照されていなかった)。
+// src/api/widget/routes.ts の showBrandingBadge = !planHasFeature(plan, "hide_branding")
+// と同じ判定をここでも表示するようにした回帰ガード。
+
+describe("EmbedCodeTab バッジ表示ステータス", () => {
+  it.each(["free_ad", "starter"] as const)("plan=%s では「表示中」と表示する", (plan) => {
+    render(<EmbedCodeTab tenant={makeTenant({ plan })} apiKeys={[]} />);
+    expect(screen.getByText(/Powered by R2C.*バッジ.*表示中/)).toBeTruthy();
+    expect(screen.queryByText(/Powered by R2C.*バッジ.*非表示中/)).toBeNull();
+  });
+
+  it.each(["growth", "enterprise"] as const)("plan=%s では「非表示中」と表示する", (plan) => {
+    render(<EmbedCodeTab tenant={makeTenant({ plan })} apiKeys={[]} />);
+    expect(screen.getByText(/Powered by R2C.*バッジ.*非表示中/)).toBeTruthy();
+  });
+});

--- a/admin-ui/src/pages/admin/tenants/EmbedCodeTab.tsx
+++ b/admin-ui/src/pages/admin/tenants/EmbedCodeTab.tsx
@@ -2,7 +2,8 @@ import { useState } from "react";
 import { useLang } from "../../../i18n/LangContext";
 import ApiKeyCreateModal from "../../../components/ApiKeyCreateModal";
 import type { TenantDetail, ApiKey } from "./types";
-import { CARD_STYLE } from "./types";
+import { CARD_STYLE, PLAN_OPTIONS } from "./types";
+import { planHasFeature } from "../../../lib/planFeatures";
 
 /** 既定値と同じ設定・不正値は出力しない（コピペ用スニペットを短く保ち、壊れた属性を出さない） */
 function buildPlacementLines(theme: TenantDetail["widget_theme"]): string {
@@ -72,6 +73,8 @@ export default function EmbedCodeTab({ tenant, apiKeys }: { tenant: TenantDetail
   const [showIssueModal, setShowIssueModal] = useState(false);
 
   const activeKey = apiKeys.find((k) => k.status === "active");
+  // src/api/widget/routes.ts の showBrandingBadge と同じ判定(hide_branding 未達 = バッジ表示)。
+  const brandingHidden = planHasFeature(tenant.plan, "hide_branding");
 
   const handleIssueClick = () => {
     // 既に有効なキーがある状態での発行は、そのキーを即座に無効化する
@@ -169,6 +172,14 @@ export default function EmbedCodeTab({ tenant, apiKeys }: { tenant: TenantDetail
       <div style={CARD_STYLE}>
         <p style={{ fontSize: 14, color: "var(--muted-foreground)", marginBottom: 16, lineHeight: 1.6 }}>
           {t("tenant_detail.embed_desc")}
+        </p>
+
+        <p style={{ fontSize: 13, color: "var(--muted-foreground)", marginBottom: 16, lineHeight: 1.6 }}>
+          {brandingHidden
+            ? "🏷️ 「Powered by R2C」バッジ: 非表示中"
+            : `🏷️ 「Powered by R2C」バッジ: 表示中（Growth以上のプランで非表示にできます。現在のプラン: ${
+                PLAN_OPTIONS.find((p) => p.value === tenant.plan)?.label ?? tenant.plan
+              }）`}
         </p>
 
         {embedCode ? (


### PR DESCRIPTION
## Summary
- `hide_branding` フラグ(`admin-ui/src/lib/planFeatures.ts` の `FEATURE_MIN_PLAN.hide_branding = "growth"`)はサーバ側(`src/api/widget/routes.ts` の `showBrandingBadge`)で「Powered by R2C」バッジ表示可否に使われているが、admin-ui側で一切参照されておらず、テナント管理者が自分のバッジ表示状態を確認する手段が無かった。
- `EmbedCodeTab.tsx` に、`AvatarTab.tsx`/`DeepResearchTab.tsx` と同様の「（現在のプラン: X）」表示パターンを踏襲し、`planHasFeature(tenant.plan, "hide_branding")` に基づくバッジ表示状態のステータス行を追加した。
- サーバ側の判定(`!planHasFeature(plan, "hide_branding")` = バッジ表示)と同一ロジックを使用している。

## Test plan
- [x] `npx vitest run --config vitest.config.ts EmbedCodeTab`（22 tests passed、free_ad/starter/growth/enterprise の分岐テスト含む）
- [x] `npx tsc -b`（admin-ui typecheck、エラーなし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NF9b7Ew1PiYJmfP5wfs99h