### PR TITLE
feat(avatar): 知識(RAG)を通さない回答経路を封鎖する(E5)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -184,6 +184,12 @@ OPENVIKING_URL=
 OPENVIKING_TENANTS=
 OPENVIKING_TIMEOUT_MS=3000
 
+# ==== Anam アバターの回答経路 (E5) ====
+# /api/avatar/chat-stream は RAG(FAQ/pgvector/learned_memory/tuning_rules)を介さない
+# Groq 直呼び出し経路。true にすると顧客に知識ゼロの回答が出るため既定で封鎖している。
+# 有効化する前に、本体API /api/chat と同じ知識経路をこのルートにも通すこと。
+ANAM_CHAT_STREAM_ENABLED=false
+
 # ==== Learned Memory (Phase71-A: メモリベース学習ループ) ====
 # Judge高スコア会話を蒸留し learned_memory に蓄積、RAG検索へ還元する。
 LEARNED_MEMORY_ENABLED=false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -436,6 +436,15 @@ R2C は、テナント（店舗・EC事業者）のサイトに1行で埋め込�
     AI提案ルールの承認がチャットにしか無く、旧UI `/admin/tuning` では提案が
     「ただの無効ルール」に見えて `is_active` トグルで**承認を経ず本番へ載る**のが実例。
     分けた瞬間に、低リテラシーのユーザーは操作をあきらめる。
+46. **知識（RAG）を通さずに顧客への回答を生成する経路を作る。**
+    顧客に出す回答は本体API `/api/chat`（FAQ/pgvector/learned_memory/tuning_rules を通る
+    実回答経路）が生成したものだけ。アバターは受け取ったテキストを TTS 再生するだけで、
+    **自分で LLM を呼んで答えを作らない**。この経路を足すと、FAQ を直しても学習が進んでも
+    その回答だけ古いまま・知識ゼロのままになり、**画面上は正常に見える**。
+    実例: `avatar-agent/agent.py` の `handle_chat`（data channel `type:"chat"` → Groq 直呼び）と
+    `/api/avatar/chat-stream`。前者は本番発火0件のまま廃止済みモデルを指し続けていた（E5で撤去）。
+    後者は既定で 503 に封鎖（`ANAM_CHAT_STREAM_ENABLED`）。**封鎖を外すなら先に知識経路を通すこと。**
+    ガード: `avatar-agent/test_no_rag_free_answer_path.py`。
 
 ## テストの最低ライン
 

--- a/avatar-agent/agent.py
+++ b/avatar-agent/agent.py
@@ -1,6 +1,11 @@
 """
 RAJIUCE Avatar Agent
-Groq LLM + Lemonslice Self-Managed Avatar orchestration via LiveKit Agents v1.4+.
+Lemonslice Self-Managed Avatar orchestration via LiveKit Agents v1.4+.
+
+このエージェントは回答を生成しない。本体API /api/chat が RAG(FAQ/pgvector/
+learned_memory/tuning_rules)を通して生成した応答テキストを widget から data channel
+の tts_request で受け取り、TTS 再生するだけ。ここで LLM を直接呼んで回答を作ると
+知識を通さない回答経路になるため、絶対に追加しないこと。
 
 NOTE: Silero VAD は除外（VPS に GPU/CUDA/libva-drm がないため SIGABRT でクラッシュ）。
 """
@@ -32,7 +37,6 @@ from livekit.agents.types import NOT_GIVEN
 from livekit.agents.voice import SpeechHandle
 from livekit.plugins import fishaudio
 from livekit.plugins import lemonslice
-from livekit.plugins import openai as openai_plugin
 from emotion_tags import sales_flow_emotion_prefix
 
 logger = logging.getLogger("rajiuce-avatar")
@@ -43,8 +47,10 @@ logger.info(f"[module] LIVEKIT_API_KEY={'SET' if os.environ.get('LIVEKIT_API_KEY
 logger.info(f"[module] LEMONSLICE_API_KEY={'SET' if os.environ.get('LEMONSLICE_API_KEY') else 'NOT SET'}")
 
 # --- 定数 ---
-FALLBACK_MSG = "申し訳ございません。もう一度お尋ねください。"
-
+# SYSTEM_PROMPT は Agent(instructions=...) のペルソナ設定にのみ使う。
+# このエージェントは回答を生成しない（本体API /api/chat が RAG を通して生成した
+# テキストを data channel の tts_request で受け取り、TTS 再生するだけ）ので、
+# ここから LLM を呼んで回答を作ってはいけない（知識を通さない回答経路になる）。
 SYSTEM_PROMPT = (
     "あなたはカーネーション自動車（BROSS新潟）のAI営業アシスタントです。\n"
     "以下のルールに従って、お客様に日本語で応答してください。\n\n"
@@ -151,7 +157,6 @@ def resolve_category_persona(category: object, category_persona_map: object) -> 
     return None
 
 
-# --- Groq LLM 直接呼び出し ---
 async def fetch_avatar_config(
     tenant_id: str, api_url: str, avatar_config_id: str | None = None
 ) -> tuple[dict | None, bool]:
@@ -224,77 +229,6 @@ def resolve_avatar_identity(
     return None
 
 
-async def call_groq_llm(
-    user_text: str,
-    http: aiohttp.ClientSession,
-    system_prompt: str = SYSTEM_PROMPT,
-    tenant_id: str | None = None,
-) -> str:
-    """Groq LLM を aiohttp で直接呼び出し、応答テキストを返す。"""
-    try:
-        async with http.post(
-            "https://api.groq.com/openai/v1/chat/completions",
-            headers={
-                "Authorization": f"Bearer {os.environ['GROQ_API_KEY']}",
-                "Content-Type": "application/json",
-            },
-            json={
-                "model": "llama-3.3-70b-versatile",
-                "messages": [
-                    {"role": "system", "content": system_prompt},
-                    {"role": "user", "content": user_text},
-                ],
-                "max_tokens": 300,
-                "temperature": 0.7,
-            },
-            timeout=aiohttp.ClientTimeout(total=15),
-        ) as resp:
-            if resp.status != 200:
-                logger.error(f"[Groq] error {resp.status}: {await resp.text()}")
-                return FALLBACK_MSG
-            data = await resp.json()
-            content = data["choices"][0]["message"]["content"].strip()
-            # Phase53: トークン数を非同期レポート（fire-and-forget）
-            usage = data.get("usage", {})
-            prompt_tokens = usage.get("prompt_tokens", 0)
-            completion_tokens = usage.get("completion_tokens", 0)
-            if tenant_id and (prompt_tokens > 0 or completion_tokens > 0):
-                asyncio.ensure_future(
-                    _report_groq_usage(tenant_id, prompt_tokens, completion_tokens)
-                )
-            return content
-    except Exception as e:
-        logger.error(f"[Groq] exception: {e}")
-        return FALLBACK_MSG
-
-
-async def _report_groq_usage(
-    tenant_id: str, prompt_tokens: int, completion_tokens: int
-) -> None:
-    """Avatar内Groqトークン使用量をRAJIUCE APIに非同期レポート（fire-and-forget）。"""
-    api_url = os.environ.get("RAJIUCE_API_URL", "http://localhost:3100")
-    try:
-        async with aiohttp.ClientSession() as http_session:
-            await http_session.post(
-                f"{api_url}/api/internal/usage",
-                headers={"X-Internal-Request": "1", "Content-Type": "application/json"},
-                json={
-                    "tenantId": tenant_id,
-                    "inputTokens": prompt_tokens,
-                    "outputTokens": completion_tokens,
-                    "model": "llama-3.3-70b-versatile",
-                    "featureUsed": "avatar",
-                },
-                timeout=aiohttp.ClientTimeout(total=5),
-            )
-        logger.debug(
-            f"[usage] Groq token usage reported: tenant={tenant_id} "
-            f"prompt={prompt_tokens} completion={completion_tokens}"
-        )
-    except Exception as e:
-        logger.warning(f"[usage] Groq token usage report failed (non-critical): {e}")
-
-
 # --- Fish Audio TTS ---
 
 async def _report_tts_usage(tenant_id: str, tts_text_bytes: int, tts_model: str) -> None:
@@ -315,33 +249,6 @@ async def _report_tts_usage(tenant_id: str, tts_text_bytes: int, tts_model: str)
 
 # LemonSlice は約24.5クレジット/分消費（料金表の割当 1000credit/41min・5400/220・15000/610 から逆算）。
 LEMONSLICE_CREDITS_PER_MINUTE = 24.5
-
-
-async def _report_avatar_transcript(
-    tenant_id: str, session_id: str, role: str, content: str
-) -> None:
-    """Phase75: legacy/fallbackパス(agent内でGroqを直接呼ぶ経路)の会話テキストを
-    RAJIUCE APIへ永続化リクエスト（fire-and-forget）。
-    LemonSlice経由の「本体API」応答パス(tts_request)はwidget側が既に
-    通常のchat APIでsaveMessage済みのため、ここでは呼ばない(二重保存防止)。
-    """
-    api_url = os.environ.get("RAJIUCE_API_URL", "http://localhost:3100")
-    try:
-        async with aiohttp.ClientSession() as http_session:
-            await http_session.post(
-                f"{api_url}/api/internal/avatar-transcript",
-                headers={"X-Internal-Request": "1", "Content-Type": "application/json"},
-                json={
-                    "tenantId": tenant_id,
-                    "sessionId": session_id,
-                    "role": role,
-                    "content": content,
-                },
-                timeout=aiohttp.ClientTimeout(total=5),
-            )
-        logger.debug(f"[transcript] reported: tenant={tenant_id} role={role}")
-    except Exception as e:
-        logger.warning(f"[transcript] report failed (non-critical): {e}")
 
 
 async def _report_avatar_usage(tenant_id: str, session_ms: int) -> None:
@@ -420,14 +327,6 @@ def _compose_speak_texts(
     )
     tts_text = emotion_tags_prefix + publish_text
     return tts_text, publish_text
-
-
-# --- Groq LLM (AgentSession 用 — session.say() のコンテキスト保持に使用) ---
-groq_llm = openai_plugin.LLM(
-    model="llama-3.3-70b-versatile",
-    api_key=os.environ["GROQ_API_KEY"],
-    base_url="https://api.groq.com/openai/v1",
-)
 
 
 async def entrypoint(ctx: agents.JobContext) -> None:
@@ -543,8 +442,10 @@ async def entrypoint(ctx: agents.JobContext) -> None:
     # speak() が TTS 送信直前にテキスト先頭へ付与する（Widget のチャット吹き出しには漏らさない）。
     _emotion_tags_prefix = _build_emotion_tags_prefix(effective_emotion_tags)
 
+    # llm は渡さない(SDK上オプショナル)。このエージェントは回答を生成せず
+    # session.say() で TTS 再生するだけなので、LLM を持たせると「知識を通さない
+    # 回答経路」を復活させる余地になる。
     session = AgentSession(
-        llm=groq_llm,
         tts=fish_tts,
         user_away_timeout=None,
     )
@@ -632,31 +533,6 @@ async def entrypoint(ctx: agents.JobContext) -> None:
         except Exception as e:
             logger.error(f"[handle_tts_request] error: {e}")
 
-    async def handle_chat(user_text: str) -> None:
-        """レガシー/フォールバック: Groq LLM 直接呼び出し → session.say() でTTS再生。"""
-        try:
-            # 1. Groq LLM で応答生成（毎回新しいSessionで "Session is closed" を回避）
-            async with aiohttp.ClientSession() as http:
-                reply = await call_groq_llm(user_text, http, system_prompt=effective_system_prompt, tenant_id=tenant_id)
-            logger.info(f"[Groq] reply ({len(reply)} chars): {reply!r}")
-
-            # 2. speak() で FishAudio TTS パイプラインに渡し、Data Channel にも送信
-            #    （フォールバックメッセージは publish スキップ）
-            speak(reply, publish=(reply != FALLBACK_MSG), emotion_prefix=False)
-            logger.debug(f"[say] sent to TTS: {reply!r}")
-
-            # Phase75: 会話ログ永続化(fire-and-forget)。room名をsession_idとして使う。
-            if tenant_id:
-                asyncio.ensure_future(
-                    _report_avatar_transcript(tenant_id, ctx.room.name, "user", user_text)
-                )
-                if reply != FALLBACK_MSG:
-                    asyncio.ensure_future(
-                        _report_avatar_transcript(tenant_id, ctx.room.name, "assistant", reply)
-                    )
-        except Exception as e:
-            logger.error(f"[handle_chat] error: {e}")
-
     @ctx.room.on("data_received")
     def on_data_received(data_packet):
         try:
@@ -673,12 +549,6 @@ async def entrypoint(ctx: agents.JobContext) -> None:
                 if text:
                     logger.info(f"[data_channel] tts_request received: {text[:80]}")
                     asyncio.create_task(handle_tts_request(text))
-            elif msg_type == "chat":
-                # レガシー/フォールバック: agent側でGroq呼び出し
-                text = msg.get("text", "").strip()
-                if text:
-                    logger.info(f"[data_channel] chat received (fallback): {text[:80]}")
-                    asyncio.create_task(handle_chat(text))
             elif msg_type == "state_change":
                 # I-4: フロー状態に応じて表情プロンプトを差し替え（fire-and-forget）
                 state = msg.get("state")

--- a/avatar-agent/test_no_rag_free_answer_path.py
+++ b/avatar-agent/test_no_rag_free_answer_path.py
@@ -1,0 +1,109 @@
+"""
+E5: アバターが知識(RAG)を通さずに回答を生成する経路が復活しないことを固定する。
+
+背景(2026-08-24 の調査): 稼働中のアバター(lemonslice)は本体API /api/chat が
+RAG(FAQ/pgvector/learned_memory/tuning_rules)を通して生成した応答テキストを
+data channel の tts_request で受け取り、TTS 再生するだけなので既に知識連動済み。
+一方 agent.py には知識を通さない回答経路(handle_chat → call_groq_llm。
+system_prompt + user_text だけで Groq を直呼びし、しかも配信停止済みの
+llama-3.3-70b-versatile を指していた)が死蔵されていた。本番ログでの発火は
+通算0件だったが、data channel に type:"chat" を投げるだけで顧客に知識ゼロの
+回答が出る状態だった。
+
+このテストは agent.py を走査して、その経路が再導入されていないことを検査する
+(confirmPolicy.test.ts / widgetSourceInvariants.test.ts と同じ流儀)。
+"""
+
+import ast
+from pathlib import Path
+
+AGENT_PY = Path(__file__).parent / "agent.py"
+
+
+def _source() -> str:
+    return AGENT_PY.read_text(encoding="utf-8")
+
+
+def _tree() -> ast.AST:
+    return ast.parse(_source())
+
+
+# 回答生成に使える汎用チャット補完エンドポイント。
+# TTS(fish audio)・埋め込み・アバター制御など「回答を作らない」外部APIは対象外。
+FORBIDDEN_LLM_ENDPOINTS = (
+    "/chat/completions",
+    "/v1/messages",
+    "/v1/responses",
+    "generativelanguage.googleapis.com",
+)
+
+
+def test_no_llm_chat_completion_endpoint_is_called():
+    """agent.py から LLM のチャット補完APIを直接叩いてはいけない。
+
+    叩けてしまうと、その応答は RAG を経由していないため知識ゼロの回答になる。
+    回答生成は本体API /api/chat の責務。
+    """
+    src = _source()
+    for endpoint in FORBIDDEN_LLM_ENDPOINTS:
+        assert endpoint not in src, (
+            f"agent.py が LLM チャット補完API({endpoint})を参照している。"
+            "アバターの回答は本体API /api/chat(RAG経由)が生成したものを "
+            'data channel の tts_request で受け取ること。'
+        )
+
+
+def test_agent_session_has_no_llm():
+    """AgentSession に llm を渡さない(SDK上オプショナル)。
+
+    llm を持たせると session.generate_reply() で知識を通さない回答を作れてしまう。
+    このエージェントは session.say() で TTS 再生するだけ。
+    """
+    tree = _tree()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        name = func.id if isinstance(func, ast.Name) else getattr(func, "attr", None)
+        if name != "AgentSession":
+            continue
+        kwargs = {kw.arg for kw in node.keywords if kw.arg}
+        assert "llm" not in kwargs, (
+            "AgentSession に llm が渡されている。回答生成経路を復活させないため "
+            "llm は渡さないこと(SDK では NOT_GIVEN 既定でオプショナル)。"
+        )
+
+
+def test_generate_reply_is_never_called():
+    """session.generate_reply() を呼ばない(呼べば知識を通さない回答になる)。"""
+    tree = _tree()
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call) and getattr(node.func, "attr", None) == "generate_reply":
+            raise AssertionError(
+                "generate_reply() が呼ばれている。アバターは回答を生成せず、"
+                "本体API /api/chat の応答を TTS 再生するだけにすること。"
+            )
+
+
+def test_data_channel_has_no_answer_generating_message_type():
+    """data channel の受信分岐に、回答生成を伴う type を足さない。
+
+    type:"chat" は agent 側で Groq を直呼びして回答を作る経路だった(E5で撤去)。
+    再導入すると widget から1メッセージ投げるだけで知識ゼロ回答が顧客に出る。
+    """
+    src = _source()
+    assert 'msg_type == "chat"' not in src, (
+        'data channel に type:"chat"(agent側で回答生成)の分岐が復活している。'
+        "回答生成は本体API /api/chat の責務。"
+    )
+
+
+def test_deprecated_groq_models_are_not_referenced():
+    """配信停止済みモデルIDを参照しない。
+
+    2026-08-23 に Groq が llama-3.3-70b-versatile / llama-3.1-8b-instant を廃止し、
+    参照が残ると 404 でフォールバック文言だけが顧客に出る。
+    """
+    src = _source()
+    for model in ("llama-3.3-70b-versatile", "llama-3.1-8b-instant"):
+        assert model not in src, f"配信停止済みモデル {model} を参照している。"

--- a/avatar-agent/test_speak_funnel.py
+++ b/avatar-agent/test_speak_funnel.py
@@ -1,7 +1,7 @@
 """
 agent.py の speak() ファネル導入を検証するテスト。
 
-speak() / handle_chat / handle_tts_request 等は entrypoint() 内のネストした
+speak() / handle_tts_request 等は entrypoint() 内のネストした
 クロージャのため、confirmPolicy.test.ts と同じ手法（ソースを読み込んで
 契約を検証する）で agent.py の内容を直接検査する。
 """
@@ -11,9 +11,7 @@ import json
 import os
 from pathlib import Path
 
-# agent.py はモジュールレベルで GROQ_API_KEY / FISH_AUDIO_API_KEY を要求する
-# (groq_llm = openai_plugin.LLM(api_key=os.environ["GROQ_API_KEY"], ...))。
-os.environ.setdefault("GROQ_API_KEY", "test-dummy-key")
+# agent.py はモジュールレベルで FISH_AUDIO_API_KEY を要求する。
 os.environ.setdefault("FISH_AUDIO_API_KEY", "test-dummy-key")
 
 import agent  # noqa: E402
@@ -199,15 +197,11 @@ class TestComposeSpeakTexts:
 
 
 class TestCallSitesUseSpeakFunnel:
-    """DoD: 4箇所（tts_request / handle_chat / filler / 挨拶）全てが speak() 経由。"""
+    """DoD: 3箇所（tts_request / filler / 挨拶）全てが speak() 経由。"""
 
     def test_handle_tts_request_uses_speak_without_publish(self):
         src = AGENT_PY.read_text(encoding="utf-8")
         assert "speak(reply_text, publish=False, emotion_prefix=True)" in src
-
-    def test_handle_chat_skips_publish_for_fallback_message(self):
-        src = AGENT_PY.read_text(encoding="utf-8")
-        assert "speak(reply, publish=(reply != FALLBACK_MSG), emotion_prefix=False)" in src
 
     def test_filler_uses_speak_without_publish(self):
         src = AGENT_PY.read_text(encoding="utf-8")

--- a/src/api/avatar/anamChatStreamRoutes.test.ts
+++ b/src/api/avatar/anamChatStreamRoutes.test.ts
@@ -38,6 +38,17 @@ function makeApp(tenantId: string | null = 'carnation', requestId?: string) {
   return app;
 }
 
+// E5: この経路は RAG を介さないため本番では既定で封鎖されている。以下のテスト群は
+// 「有効化した場合の中身」を検証するものなので、明示的にフラグを立てて実行する。
+// 封鎖そのものの検証は describe('E5: RAGを介さない回答経路の封鎖') 側で行う。
+beforeEach(() => {
+  process.env.ANAM_CHAT_STREAM_ENABLED = 'true';
+});
+
+afterEach(() => {
+  delete process.env.ANAM_CHAT_STREAM_ENABLED;
+});
+
 /**
  * Groqのstreaming SSEレスポンスを模したReadableStream風オブジェクトを作る。
  * usage を渡すと、OpenAI互換のstream_options.include_usage同様、最終チャンクとして
@@ -557,5 +568,57 @@ describe('POST /api/avatar/chat-stream — gpt-oss の reasoning_effort', () => 
     // 退避後に設定が抜け落ちると、退避先で同じ無言停止が起きる
     expect(first.reasoning_effort).toBe('low');
     expect(second.reasoning_effort).toBe('low');
+  });
+});
+
+describe('E5: RAGを介さない回答経路の封鎖', () => {
+  // この経路は本体API /api/chat と違い RAG(FAQ/pgvector/learned_memory/tuning_rules)を
+  // 通さないため、有効化すると顧客に知識ゼロの回答が出る。既定は封鎖。
+  beforeEach(() => {
+    delete process.env.ANAM_CHAT_STREAM_ENABLED;
+  });
+
+  it('フラグ未設定なら 503 を返し、Groq を呼ばない', async () => {
+    const fetchMock = jest.fn();
+    global.fetch = fetchMock as any;
+
+    const res = await request(makeApp())
+      .post('/api/avatar/chat-stream')
+      .send({ messages: [{ role: 'user', content: '営業時間は' }], sessionId: 'sess-blocked' });
+
+    expect(res.status).toBe(503);
+    expect(res.body.error).toBe('anam_chat_stream_disabled');
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('封鎖時は会話ログを保存せず、課金も計上しない', async () => {
+    global.fetch = jest.fn() as any;
+    mockSaveMessage.mockClear();
+    mockTrackUsage.mockClear();
+
+    await request(makeApp())
+      .post('/api/avatar/chat-stream')
+      .send({ messages: [{ role: 'user', content: '営業時間は' }], sessionId: 'sess-blocked-2' });
+
+    expect(mockSaveMessage).not.toHaveBeenCalled();
+    expect(mockTrackUsage).not.toHaveBeenCalled();
+  });
+
+  it("'true' 以外の値では有効にならない（1 / yes / TRUE を有効と誤読しない）", async () => {
+    for (const value of ['1', 'yes', 'TRUE', 'True', '']) {
+      process.env.ANAM_CHAT_STREAM_ENABLED = value;
+      const res = await request(makeApp())
+        .post('/api/avatar/chat-stream')
+        .send({ messages: [{ role: 'user', content: 'x' }], sessionId: 'sess-flag' });
+      expect(res.status).toBe(503);
+    }
+  });
+
+  it('未認証(401)の判定は封鎖より先に行われる', async () => {
+    const res = await request(makeApp(null))
+      .post('/api/avatar/chat-stream')
+      .send({ messages: [{ role: 'user', content: 'x' }] });
+
+    expect(res.status).toBe(401);
   });
 });

--- a/src/api/avatar/anamChatStreamRoutes.ts
+++ b/src/api/avatar/anamChatStreamRoutes.ts
@@ -21,6 +21,18 @@ import { checkTopic } from '../../middleware/topicGuard';
 const MAX_ANAM_MESSAGES = 20;
 const MAX_ANAM_MESSAGE_LENGTH = 2000;
 
+/**
+ * E5: RAG を介さない回答経路のため既定で封鎖する。
+ * 有効化する前に、本体API /api/chat と同じ知識経路(FAQ/pgvector/learned_memory/
+ * tuning_rules)をこのルートにも通すこと。フラグだけ立てると顧客に知識ゼロの
+ * 回答が出る。
+ * モジュール読み込み時ではなくリクエスト時に読むことで、封鎖状態を切り替えても
+ * 再デプロイ前提にならないようにする。
+ */
+function isAnamChatStreamEnabled(): boolean {
+  return process.env.ANAM_CHAT_STREAM_ENABLED === 'true';
+}
+
 const GROQ_API_BASE = 'https://api.groq.com/openai/v1/chat/completions';
 
 /**
@@ -64,6 +76,24 @@ export function registerAnamChatStreamRoutes(app: Express, apiStack: RequestHand
     const tenantId = (req as AuthedRequest).tenantId;
     if (!tenantId) {
       return res.status(401).json({ error: 'unauthorized' });
+    }
+
+    // E5: この経路は RAG を介さない Groq 直呼び出しで、有効化すると顧客に
+    // 知識(FAQ/pgvector/learned_memory/tuning_rules)を通さない回答が出る。
+    // 現在 avatar_configs は全件 lemonslice で anam は0件のため到達しないが、
+    // テナントを anam に切り替えるだけで無言で知識ゼロ回答が始まる状態だった。
+    // 有効化するなら先に本体API /api/chat と同じ知識経路を通すこと。それまでは
+    // 無言で劣化した回答を返すのではなく、ここで大きく失敗させる。
+    if (!isAnamChatStreamEnabled()) {
+      logger.warn(
+        { tenantId, requestId: (req as any).requestId },
+        '[anamChatStream] blocked: RAGを介さない回答経路のため無効化されている(E5)',
+      );
+      return res.status(503).json({
+        error: 'anam_chat_stream_disabled',
+        message:
+          'この経路は知識(RAG)を通さないため無効化されています。アバターの回答は /api/chat を経由してください。',
+      });
     }
 
     const { messages, sessionId: bodySessionId } = req.body as {


### PR DESCRIPTION
## 調査結果: アバターは既に知識連動済みだった

E5「アバター知識連動」の前提を本番で確認したところ、**稼働中のアバターは既に知識連動している**ことが判明しました。

- `avatar_configs` 全37件が `lemonslice`、`anam` は **0件**
- lemonsliceパスでは widget が `/api/chat`（FAQ/pgvector/learned_memory/tuning_rules を通る実回答経路）を叩き、その応答テキストを data channel の `tts_request` でアバターに渡して TTS 再生するだけ（`public/widget.js:2944`）
- G2実測の reply_wait_s ≈ 1.5〜1.8秒は「RAG済みテキスト到着 → 発話開始」の区間。RAGは上流で完了しているため、アバター側にRAGを足すのは二重実行＋レイテンシ増で利得ゼロ

つまり E5 に「追加実装」は不要でした。実際の課題は別にありました。

## 実際の課題: 知識を通さない回答経路が3つ死蔵されていた

本番発火は0件ですが、テナントを `anam` に切り替えるか data channel に `type:"chat"` を1通投げるだけで、顧客に**知識ゼロの回答**（または廃止済みモデル由来のフォールバック文）が出る状態でした。FAQを直しても学習が進んでもその回答だけ古いまま、しかも**画面上は正常に見える**種類の事故です。

| 経路 | 対処 |
|---|---|
| `agent.py` の `handle_chat`/`call_groq_llm`（data channel `type:"chat"`）。system_promptのみでGroq直呼び、モデルは廃止済み `llama-3.3-70b-versatile` | 撤去 |
| `AgentSession(llm=groq_llm)`。同じ廃止済みモデル参照 | `llm=` ごと撤去（SDK上オプショナル、`generate_reply` は未使用） |
| `/api/avatar/chat-stream`。コード自身が「RAGを介さないGroq直呼び出し経路」と明記 | 既定で503に封鎖（`ANAM_CHAT_STREAM_ENABLED`） |

## 変更内容

- **`avatar-agent/agent.py`**: 上記2経路を撤去。orphanになった `FALLBACK_MSG`/`_report_groq_usage`/`_report_avatar_transcript`/`openai_plugin` import も撤去。結果、**アバターエージェントは `GROQ_API_KEY` を一切必要としなくなった**（環境変数なしでのimportを実機確認済み）
- **`anamChatStreamRoutes.ts`**: 削除ではなく封鎖。actively maintained（#845/#847で最近モデル修正）なコードなので消さず、有効化時に無言で劣化させるのでなく大きく失敗させる。既存24テストはフラグを立てて中身の検証を継続
- **`test_no_rag_free_answer_path.py`（新規）**: 再発防止の機械ガード。LLMチャット補完API直呼び / `AgentSession` の `llm` / `generate_reply` / `type:"chat"` 分岐 / 廃止済みモデルID をソース走査（AST＋文字列）で検出
- **CLAUDE.md 禁止46** として不変ルール化

## Test plan

- [x] avatar-agent Python 92件全通過（VPS venv = 本番同一の Python 3.12 + livekit-agents 1.6.7）
- [x] **機械ガードの噛み確認**: agent.py を変異させ（`llm=`復活 / Groq URL+廃止モデル追加 / `type:"chat"`分岐復活）、4件が赤くなることを実測。変異させていない `generate_reply` のみ通過＝偽グリーンでないことを確認
- [x] `src/api/avatar` jest 85件全通過（`--maxWorkers=1` で2回連続、安定を確認）
- [x] 封鎖の検証テスト4件を追加（503を返す / Groqを呼ばない / ログも課金も発生しない / `'true'` 以外を有効と誤読しない / 401判定が封鎖より先）
- [x] `tsc --noEmit` 通過
- [x] `agent.py` が `GROQ_API_KEY` なしで import できることを実機確認

## 補足

`/api/internal/avatar-transcript` は本PRで呼び出し元が無くなります（legacyパス専用だったため）。ルート自体の扱いは別スコープとして残置しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgCQYt8UMPgm4HNVu7nv7z