### PR TITLE
共有学習プール参加モデル S2: 同意の2軸化(learn/share)

### DIFF
--- a/src/api/admin/tenants/routes.test.ts
+++ b/src/api/admin/tenants/routes.test.ts
@@ -231,6 +231,123 @@ describe("PATCH /v1/admin/tenants/:id — sales_stage_continuity", () => {
   });
 });
 
+// --------------------------------------------------------------------------
+// S2: 共有学習プールの参加モデル — 同意の2軸化(features.learning: {learn, share})
+// --------------------------------------------------------------------------
+
+describe("PATCH /v1/admin/tenants/:id — features.learning(共有学習プール同意の2軸化)", () => {
+  const ROW = {
+    id: "tenant-a", name: "テストテナント", plan: "starter", is_active: true,
+    allowed_origins: [], system_prompt: null, billing_enabled: false,
+    billing_free_from: null, billing_free_until: null,
+    features: { avatar: false, voice: false, rag: true },
+    lemonslice_agent_id: null, conversion_types: [], tenant_contact_email: null,
+    created_at: new Date().toISOString(), updated_at: new Date().toISOString(),
+  };
+
+  function makeDb(returned: Record<string, unknown>) {
+    return {
+      query: jest
+        .fn()
+        .mockResolvedValueOnce({ rows: [{ id: "tenant-a", plan: "starter", features: ROW.features, billing_enabled: false, is_active: true }], rowCount: 1 })
+        .mockResolvedValueOnce({ rows: [{ ...ROW, features: returned }], rowCount: 1 })
+        .mockResolvedValue({ rows: [], rowCount: 1 }),
+    };
+  }
+
+  it("E8: learn=false かつ share=true は super_admin 経由でも 400", async () => {
+    const res = await request(makeApp(makeDb({}), "super_admin"))
+      .patch("/v1/admin/tenants/tenant-a")
+      .set("Authorization", "Bearer dummy")
+      .send({ features: { avatar: false, voice: false, rag: true, learning: { learn: false, share: true } } });
+
+    expect(res.status).toBe(400);
+  });
+
+  it("learn=true, share=false のような整合する組み合わせは super_admin 経由で更新できる", async () => {
+    const features = { avatar: false, voice: false, rag: true, learning: { learn: true, share: false } };
+    const res = await request(makeApp(makeDb(features), "super_admin"))
+      .patch("/v1/admin/tenants/tenant-a")
+      .set("Authorization", "Bearer dummy")
+      .send({ features });
+
+    expect(res.status).toBe(200);
+    expect(res.body.features.learning).toEqual({ learn: true, share: false });
+  });
+
+  it("E11: features.learning を送っても avatar 等の既存フラグが消えない（|| マージ、送信側は全キーを送る）", async () => {
+    const features = {
+      avatar: true, voice: true, rag: true,
+      learning: { learn: true, share: true },
+    };
+    const db = makeDb(features);
+    const res = await request(makeApp(db, "super_admin"))
+      .patch("/v1/admin/tenants/tenant-a")
+      .set("Authorization", "Bearer dummy")
+      .send({ features });
+
+    expect(res.status).toBe(200);
+    expect(res.body.features.avatar).toBe(true);
+    expect(res.body.features.voice).toBe(true);
+    expect(res.body.features.learning).toEqual({ learn: true, share: true });
+  });
+});
+
+describe("PATCH /v1/admin/my-tenant — features.learning(共有学習プール同意の2軸化・自己申告)", () => {
+  const ROW = {
+    id: "tenant-a", name: "テストテナント",
+    features: { avatar: false, voice: false, rag: true },
+    lemonslice_agent_id: null, faq_question_hint: null, faq_answer_hint: null,
+    onboarding_industry: null, onboarding_completed_at: null, allowed_origins: [],
+  };
+
+  it("E8: learn=false かつ share=true は my-tenant(client_admin自己申告)でも 400", async () => {
+    const db = { query: jest.fn().mockResolvedValue({ rows: [ROW], rowCount: 1 }) };
+    const res = await request(makeApp(db, "client_admin"))
+      .patch("/v1/admin/my-tenant")
+      .set("Authorization", "Bearer dummy")
+      .send({ features: { avatar: false, voice: false, rag: true, learning: { learn: false, share: true } } });
+
+    expect(res.status).toBe(400);
+    expect(JSON.stringify(res.body)).toMatch(/learn=false.*share=true|learning/);
+  });
+
+  it("client_admin は自己申告(my-tenant)で learn/share の整合する組み合わせを更新できる", async () => {
+    const updated = { ...ROW, features: { avatar: false, voice: false, rag: true, learning: { learn: true, share: true } } };
+    const db = {
+      query: jest
+        .fn()
+        .mockResolvedValueOnce({ rows: [updated], rowCount: 1 }),
+    };
+    const res = await request(makeApp(db, "client_admin"))
+      .patch("/v1/admin/my-tenant")
+      .set("Authorization", "Bearer dummy")
+      .send({ features: { avatar: false, voice: false, rag: true, learning: { learn: true, share: true } } });
+
+    expect(res.status).toBe(200);
+    expect(res.body.features.learning).toEqual({ learn: true, share: true });
+  });
+
+  it("E11: my-tenant 経由で features.learning を送っても他の既存フラグ(pre_dispatch)が消えない", async () => {
+    // avatar/voice=true は別途プラン制限クエリを挟むため、ここでは無関係のフラグ
+    // (pre_dispatch)でマージ挙動のみを確認する。avatar/voiceのゲートは既存の
+    // 「PATCH /v1/admin/my-tenant — avatar/voice plan ゲート」describeでカバー済み。
+    const updated = {
+      ...ROW,
+      features: { avatar: false, voice: false, rag: true, pre_dispatch: true, learning: { learn: true, share: false } },
+    };
+    const db = { query: jest.fn().mockResolvedValueOnce({ rows: [updated], rowCount: 1 }) };
+    const res = await request(makeApp(db, "client_admin"))
+      .patch("/v1/admin/my-tenant")
+      .set("Authorization", "Bearer dummy")
+      .send({ features: { avatar: false, voice: false, rag: true, pre_dispatch: true, learning: { learn: true, share: false } } });
+
+    expect(res.status).toBe(200);
+    expect(res.body.features.pre_dispatch).toBe(true);
+    expect(res.body.features.learning).toEqual({ learn: true, share: false });
+  });
+});
+
 describe("GET /v1/admin/tenants/:id/settings-history", () => {
   const HISTORY_ROW = {
     id: 1,

--- a/src/api/admin/tenants/routes.ts
+++ b/src/api/admin/tenants/routes.ts
@@ -36,6 +36,26 @@ const allowedOriginsSchema = z
   .max(20)
   .optional();
 
+// S2: 共有学習プールの参加モデル。同意を「1フラグ」から独立した2軸に分ける。
+// - learn : 自社内学習。自テナントの会話から自テナント用に学習する(データは外に出ない)。
+// - share : 共有プール参加。R2C共有プールに「出し、かつ読む」(外部Hermes VPSへ出る)。
+// learn=false かつ share=true(自社が学ばないのに他社へ出す)は不整合として拒否する。
+// 同意は本来テナント自身のものなので、super_admin用スキーマ(featuresSchema)と
+// client_admin自己申告用(PATCH /v1/admin/my-tenant)の両方に足す必要がある。ただし
+// featuresSchema全体を共有インスタンス化すると sales_stage_continuity 等の
+// 運用者限定フラグ(上記コメント参照)まで自己申告できてしまうため、featuresSchema自体は
+// 共有せず、learning部分だけを切り出して同一インスタンスを共有する
+// (allowed_originsSchemaと同じ考え方: 検証ロジック・エラーメッセージの重複による
+// 片方だけ緩くなる事故を防ぐ)。
+const learningConsentSchema = z
+  .object({
+    learn: z.boolean(),
+    share: z.boolean(),
+  })
+  .refine((v) => !(v.learn === false && v.share === true), {
+    message: "learn=false かつ share=true は指定できません",
+  });
+
 // 日付のみの文字列("2026-01-01"等)はUTC深夜と解釈されるため、意図したタイムゾーンと
 // ズレて「まだ未来のつもりが過去判定される」事故が起きやすい。バリデーションのロジックは
 // 変えず、エラーメッセージでタイムゾーン付きISO-8601形式を案内する。
@@ -89,6 +109,10 @@ const featuresSchema = z.object({
   // 出さない選択はテナント側の事情(購入導線を邪魔したくない等)にのみ使う。
   // false を明示したテナントだけ非表示にする。
   answer_feedback: z.boolean().optional(),
+  // S2: 共有学習プールの参加モデル。同意の2軸(learn/share)。詳細は learningConsentSchema
+  // のコメント参照。未設定時の後方互換解決(learn=true固定、shareは旧hermes_raw_data_consent
+  // から)は src/lib/hermesConsent.ts の resolveLearningConsent が行う。
+  learning: learningConsentSchema.optional(),
 });
 
 const updateTenantSchema = z.object({
@@ -269,6 +293,9 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
         pre_dispatch: z.boolean().optional(),
         // Phase75: テナント自身によるHermes Agent向け生データ利用同意の自己申告
         hermes_raw_data_consent: z.boolean().optional(),
+        // S2: 共有学習プールの参加モデル。同意はテナント自身のものなので、super_admin用の
+        // featuresSchemaと同一インスタンス(learningConsentSchema)を共有する。
+        learning: learningConsentSchema.optional(),
       }).optional(),
       // GID 1216274385106667: FAQ登録フォームの質問/回答欄カスタムヒント（client_admin自己申告）
       faq_question_hint: z.string().max(200).nullable().optional(),

--- a/src/lib/hermesConsent.test.ts
+++ b/src/lib/hermesConsent.test.ts
@@ -1,7 +1,11 @@
 // src/lib/hermesConsent.test.ts
-// Phase75: hermesConsent テスト
+// Phase75 / S2(共有学習プール参加モデル: 同意の2軸化) hermesConsent テスト
 
-import { isHermesDataConsentGranted, listHermesConsentingTenantIds } from "./hermesConsent";
+import {
+  isHermesDataConsentGranted,
+  listHermesConsentingTenantIds,
+  resolveLearningConsent,
+} from "./hermesConsent";
 
 jest.mock("./db", () => ({
   getPool: jest.fn(),
@@ -18,7 +22,91 @@ beforeEach(() => {
   mockGetPool.mockReset();
 });
 
-describe("isHermesDataConsentGranted", () => {
+describe("resolveLearningConsent", () => {
+  it("a) features.learning未設定 + hermes_raw_data_consent=true → {learn:true, share:true}", async () => {
+    mockQuery(jest.fn().mockResolvedValue({ rows: [{ features: { hermes_raw_data_consent: true } }] }));
+    expect(await resolveLearningConsent("carnation")).toEqual({ learn: true, share: true });
+  });
+
+  it("b) features.learning未設定 + hermes_raw_data_consent=false → {learn:true, share:false}", async () => {
+    mockQuery(jest.fn().mockResolvedValue({ rows: [{ features: { hermes_raw_data_consent: false } }] }));
+    expect(await resolveLearningConsent("carnation")).toEqual({ learn: true, share: false });
+  });
+
+  it("b') features.learning・hermes_raw_data_consentともに未設定 → {learn:true, share:false}", async () => {
+    mockQuery(jest.fn().mockResolvedValue({ rows: [{ features: { avatar: true } }] }));
+    expect(await resolveLearningConsent("carnation")).toEqual({ learn: true, share: false });
+  });
+
+  it("c) features自体がnull → {learn:true, share:false}", async () => {
+    mockQuery(jest.fn().mockResolvedValue({ rows: [{ features: null }] }));
+    expect(await resolveLearningConsent("carnation")).toEqual({ learn: true, share: false });
+  });
+
+  it("該当テナントが存在しない場合 → {learn:true, share:false}", async () => {
+    mockQuery(jest.fn().mockResolvedValue({ rows: [] }));
+    expect(await resolveLearningConsent("nonexistent")).toEqual({ learn: true, share: false });
+  });
+
+  it("d) features.learningが文字列(壊れた形) → {learn:true, share:false} かつ warnログ", async () => {
+    const { logger } = await import("./logger");
+    const warnSpy = jest.spyOn(logger, "warn").mockImplementation(() => {});
+    mockQuery(jest.fn().mockResolvedValue({ rows: [{ features: { learning: "broken" } }] }));
+    expect(await resolveLearningConsent("carnation")).toEqual({ learn: true, share: false });
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("d) features.learningが配列(壊れた形) → {learn:true, share:false} かつ warnログ", async () => {
+    const { logger } = await import("./logger");
+    const warnSpy = jest.spyOn(logger, "warn").mockImplementation(() => {});
+    mockQuery(jest.fn().mockResolvedValue({ rows: [{ features: { learning: [1, 2] } }] }));
+    expect(await resolveLearningConsent("carnation")).toEqual({ learn: true, share: false });
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("d) features.learningがnull(壊れた形) → {learn:true, share:false} かつ warnログ", async () => {
+    const { logger } = await import("./logger");
+    const warnSpy = jest.spyOn(logger, "warn").mockImplementation(() => {});
+    mockQuery(jest.fn().mockResolvedValue({ rows: [{ features: { learning: null } }] }));
+    expect(await resolveLearningConsent("carnation")).toEqual({ learn: true, share: false });
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("d) features.learningのlearn/shareが型不正(壊れた形) → {learn:true, share:false} かつ warnログ", async () => {
+    const { logger } = await import("./logger");
+    const warnSpy = jest.spyOn(logger, "warn").mockImplementation(() => {});
+    mockQuery(jest.fn().mockResolvedValue({ rows: [{ features: { learning: { learn: "yes", share: 1 } } }] }));
+    expect(await resolveLearningConsent("carnation")).toEqual({ learn: true, share: false });
+    expect(warnSpy).toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("e) features.learning={learn:false,share:false} → そのまま返す", async () => {
+    mockQuery(
+      jest.fn().mockResolvedValue({ rows: [{ features: { learning: { learn: false, share: false } } }] }),
+    );
+    expect(await resolveLearningConsent("carnation")).toEqual({ learn: false, share: false });
+  });
+
+  it("e') features.learning={learn:true,share:true} → そのまま返す(新形式優先、旧フラグは無視)", async () => {
+    mockQuery(
+      jest.fn().mockResolvedValue({
+        rows: [{ features: { learning: { learn: true, share: true }, hermes_raw_data_consent: false } }],
+      }),
+    );
+    expect(await resolveLearningConsent("carnation")).toEqual({ learn: true, share: true });
+  });
+
+  it("f) DBクエリがreject → {learn:true, share:false}", async () => {
+    mockQuery(jest.fn().mockRejectedValue(new Error("db down")));
+    await expect(resolveLearningConsent("carnation")).resolves.toEqual({ learn: true, share: false });
+  });
+});
+
+describe("isHermesDataConsentGranted (resolveLearningConsent().share を返す)", () => {
   it("features.hermes_raw_data_consent === true のときのみ true", async () => {
     mockQuery(jest.fn().mockResolvedValue({ rows: [{ features: { hermes_raw_data_consent: true } }] }));
     expect(await isHermesDataConsentGranted("carnation")).toBe(true);
@@ -48,15 +136,33 @@ describe("isHermesDataConsentGranted", () => {
     mockQuery(jest.fn().mockResolvedValue({ rows: [{ features: { hermes_raw_data_consent: false } }] }));
     expect(await isHermesDataConsentGranted("carnation")).toBe(false);
   });
+
+  it("新形式 features.learning.share=true のときはtrue", async () => {
+    mockQuery(
+      jest.fn().mockResolvedValue({ rows: [{ features: { learning: { learn: true, share: true } } }] }),
+    );
+    expect(await isHermesDataConsentGranted("carnation")).toBe(true);
+  });
 });
 
 describe("listHermesConsentingTenantIds", () => {
-  it("同意済みテナントのIDのみ返す", async () => {
-    const query = jest.fn().mockResolvedValue({ rows: [{ id: "carnation" }, { id: "other" }] });
+  it("旧形式(hermes_raw_data_consent=true)のテナントIDを拾う", async () => {
+    const query = jest.fn().mockResolvedValue({ rows: [{ id: "carnation" }] });
     mockQuery(query);
     const ids = await listHermesConsentingTenantIds();
-    expect(ids).toEqual(["carnation", "other"]);
-    expect(query.mock.calls[0][0]).toContain("hermes_raw_data_consent");
+    expect(ids).toEqual(["carnation"]);
+  });
+
+  it("g) 新形式(features.learning.share=true)と旧形式(hermes_raw_data_consent=true)の両方を拾うSQLになっている", async () => {
+    const query = jest.fn().mockResolvedValue({ rows: [{ id: "new_format" }, { id: "old_format" }] });
+    mockQuery(query);
+    const ids = await listHermesConsentingTenantIds();
+    expect(ids).toEqual(["new_format", "old_format"]);
+    const sql = query.mock.calls[0][0] as string;
+    // 新形式(features->'learning'->>'share')・旧形式(features->>'hermes_raw_data_consent')
+    // の両方をSQLが参照していること。片方だけだとexport対象が黙って欠ける。
+    expect(sql).toContain("learning");
+    expect(sql).toContain("hermes_raw_data_consent");
   });
 
   it("DB障害時は空配列", async () => {

--- a/src/lib/hermesConsent.ts
+++ b/src/lib/hermesConsent.ts
@@ -1,35 +1,125 @@
 // src/lib/hermesConsent.ts
-// Phase75: Hermes Agent(CVR学習エージェント)向けデータ利用同意チェック
 //
-// テナントの会話ログ生データをHermes Agent(外部, MCP経由)に公開してよいかを判定する。
-// fail-safe設計: features.hermes_raw_data_consent が明示的に true でない限り、
-// 常に false(=非公開)として扱う。新規テナント・未設定テナントは自動的に除外される。
+// ファイル名(hermesConsent)と中身のズレに関する注記:
+// このファイルは元々「Hermes Agentへの生データ公開同意(1フラグ)」だけを扱っていたが、
+// 共有学習プールの参加モデル S2 で「自社内学習(learn)」と「共有プール参加(share)」の
+// 2軸に拡張した。学習(learning)全般を扱うファイルになっており、hermesConsent という
+// ファイル名は実態とややズレている。将来のリネーム候補として残すが、このタスクでは
+// リネームしない(呼び出し元を広く変更するスコープ外の作業になるため)。
+//
+// Phase75由来のfail-safe設計を踏襲する: DB障害・データ破損時は必ず安全側(=共有プール
+// には出さない)に倒す。
+//
+// ■ 2軸の定義
+// - learn : 自社内学習。自テナントの会話から自テナント用に学習する。データは外に出ない。
+// - share : 共有プール参加。R2C共有プールに「出し、かつ読む」。外部Hermes VPSへ出る。
+//
+// ■ 既定値(向きが逆になる点に注意)
+// - learn 未設定 → true  (外に出ないため、既定で有効にしてよい)
+// - share 未設定 → false (外に出るため、fail-safeで既定は無効)
+//
+// ■ 禁止の組み合わせ
+// - learn=false かつ share=true (自社が学ばないのに他社へ出すのは不整合。zodスキーマ側
+//   でも拒否する。src/api/admin/tenants/routes.ts 参照)
 
 import { getPool } from "./db";
+import { logger } from "./logger";
 
-export async function isHermesDataConsentGranted(tenantId: string): Promise<boolean> {
-  const pool = getPool();
-  try {
-    const result = await pool.query<{ features: { hermes_raw_data_consent?: boolean } | null }>(
-      `SELECT features FROM tenants WHERE id = $1`,
-      [tenantId],
-    );
-    return result.rows[0]?.features?.hermes_raw_data_consent === true;
-  } catch {
-    // DB障害時は fail-safe で非公開扱い(データ露出よりも可用性低下を優先)
-    return false;
-  }
+export interface LearningConsent {
+  learn: boolean;
+  share: boolean;
+}
+
+// DB障害・パース失敗時の既定値。learnは「外に出ない」ため安全側でtrue、
+// shareは「外に出る」ため安全側でfalse。
+const FAILSAFE_CONSENT: LearningConsent = { learn: true, share: false };
+
+interface TenantFeaturesRow {
+  learning?: unknown;
+  hermes_raw_data_consent?: boolean;
+}
+
+function isValidLearningShape(value: unknown): value is LearningConsent {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    !Array.isArray(value) &&
+    typeof (value as Record<string, unknown>).learn === "boolean" &&
+    typeof (value as Record<string, unknown>).share === "boolean"
+  );
 }
 
 /**
- * 同意済みテナントのIDを全件取得する。
+ * テナントの学習同意(2軸: learn / share)を解決する。
+ *
+ * features.learning が新形式({learn, share})で設定されていればそれを使う。
+ * 未設定の場合は旧フラグ features.hermes_raw_data_consent から後方互換で解決する
+ * (learn=true固定、share=旧フラグの値)。
+ *
+ * features.learning が壊れた形(文字列・配列・null・learn/shareの型不正等)の場合は
+ * fail-safeとして {learn:true, share:false} に倒し、原因調査のためwarnログを残す。
+ * DB障害時も同様にfail-safeへ倒す。
+ */
+export async function resolveLearningConsent(tenantId: string): Promise<LearningConsent> {
+  const pool = getPool();
+  try {
+    const result = await pool.query<{ features: TenantFeaturesRow | null }>(
+      `SELECT features FROM tenants WHERE id = $1`,
+      [tenantId],
+    );
+    const features = result.rows[0]?.features;
+    const learning = features?.learning;
+
+    if (learning === undefined) {
+      // 新形式が未設定 → 後方互換で旧フラグから解決する。
+      return {
+        learn: true,
+        share: features?.hermes_raw_data_consent === true,
+      };
+    }
+
+    if (isValidLearningShape(learning)) {
+      return { learn: learning.learn, share: learning.share };
+    }
+
+    // features.learning が存在するが壊れた形(文字列/配列/null/不完全なオブジェクト等)。
+    // 黙って後方互換にフォールバックすると壊れたデータに気付けないため、fail-safeへ倒しつつ
+    // warnログを残す。
+    logger.warn("[resolveLearningConsent] features.learning が不正な形式です。fail-safeへ倒します。", {
+      tenantId,
+      learning,
+    });
+    return { ...FAILSAFE_CONSENT };
+  } catch (err) {
+    // DB障害時は fail-safe で {learn:true, share:false} 扱い(データ露出よりも可用性低下を優先)
+    logger.warn("[resolveLearningConsent] DB障害のためfail-safeへ倒します。", { tenantId, err });
+    return { ...FAILSAFE_CONSENT };
+  }
+}
+
+export async function isHermesDataConsentGranted(tenantId: string): Promise<boolean> {
+  return (await resolveLearningConsent(tenantId)).share;
+}
+
+/**
+ * 共有プール参加(share)に同意済みのテナントIDを全件取得する。
  * MCPサーバーが公開してよいテナント一覧を返す用途。
+ *
+ * features.learning(新形式)・features.hermes_raw_data_consent(旧形式)の
+ * 両方を拾う。片方だけ拾うと export 対象が黙って欠けるため、
+ * resolveLearningConsent と同じ優先順位(新形式があればそちらを優先、
+ * 新形式が壊れた形の場合は対象外)をSQLでも再現する。
  */
 export async function listHermesConsentingTenantIds(): Promise<string[]> {
   const pool = getPool();
   try {
     const result = await pool.query<{ id: string }>(
-      `SELECT id FROM tenants WHERE features->>'hermes_raw_data_consent' = 'true'`,
+      `SELECT id FROM tenants
+       WHERE (features->'learning'->>'share') = 'true'
+          OR (
+               (features->'learning') IS NULL
+               AND (features->>'hermes_raw_data_consent') = 'true'
+             )`,
     );
     return result.rows.map((r) => r.id);
   } catch {


### PR DESCRIPTION
## 概要
共有学習プールの参加モデル S2。要件 §2 / 受け入れ G4・G5・E1・E2・E8・E11。

同意を「hermes_raw_data_consent 1フラグ」から独立した2軸に拡張する。**このPR単体では本番の誰の挙動も変わらない**(resolveLearningConsent を消費している呼び出し元はまだ存在しない。既存の `isHermesDataConsentGranted` の呼び出し元 `src/api/hermes-mcp/routes.ts` の2箇所は無変更で、内部実装のみを新関数に寄せた)。S3/S4 が使い始めて初めて効く。

Asana: https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217769336622964

## 2軸の定義
- `learn` : 自社内学習。自テナントの会話から自テナント用に学習する。データは外に出ない。
- `share` : 共有プール参加。R2C共有プールに「出し、かつ読む」。外部Hermes VPSへ出る。

既定値の向きが逆(間違えやすいので明記):
- `learn` 未設定 → **true**(外に出ないため)
- `share` 未設定 → **false**(外に出るため。fail-safe)

禁止の組み合わせ: `learn=false` かつ `share=true`(自社が学ばないのに他社へ出すのは不整合)。zodの `refine` で拒否する。

## 変更ファイル
1. `src/lib/hermesConsent.ts` — `resolveLearningConsent(tenantId): Promise<{learn, share}>` を追加。`features.learning` を読み、無ければ旧 `hermes_raw_data_consent` から後方互換で解決(`learn=true`固定、`share`=旧フラグ)。壊れた形(文字列/配列/null/型不正)はfail-safeで `{learn:true, share:false}` に倒しwarnログを残す。`isHermesDataConsentGranted` は内部実装をこれに寄せた(呼び出し元は無変更)。`listHermesConsentingTenantIds` も新形式・旧形式の両方を拾うSQLに変更(片方だけだとexport対象が黙って欠けるため)。冒頭コメントにファイル名と中身のズレ(将来リネーム候補)を明記。
2. `src/lib/hermesConsent.test.ts` — 7ケース(未設定+新旧フラグ、features自体がnull、壊れた形3種、正常系2種、DB reject、list関数の新旧両形式)を追加。
3. `src/api/admin/tenants/routes.ts` — `featuresSchema` と `PATCH /v1/admin/my-tenant` の両方に `learning` を追加(下記「my-tenant重複スキーマの扱い」参照)。
4. `src/api/admin/tenants/routes.test.ts` — `learn=false & share=true` が400になることをsuper_admin/my-tenant両方で確認、既存featuresフラグ(avatar/pre_dispatch)が消えないこと(E11)を確認するテストを追加。

## my-tenant重複スキーマの扱い
`PATCH /v1/admin/my-tenant` は `featuresSchema` を再利用せずインラインで重複定義されている(avatar/voice/ragが必須という点は実は両者で既に一致していたが、`sales_stage_continuity` のような運用者限定フラグが `my-tenant` 側には意図的に無い、という差分がある)。

`featuresSchema` 全体を共有インスタンス化すると、`sales_stage_continuity`(super_adminのみが開けるべき機能、コメントに明記済み)まで client_admin が自己申告できてしまい、既存の防御を壊す。

そのため **`learning` サブスキーマだけを切り出して共有インスタンス化**した(`learningConsentSchema` という定数を新設し、`featuresSchema` と `my-tenant` 側の両方から参照)。同意はテナント自身のものなので両方に必要という要件と、`sales_stage_continuity` のような運用者限定フラグを誤って自己申告可能にしないという既存の防御方針を両立させている。`allowed_originsSchema` が同じ理由で共有インスタンス化されている前例に倣った。

## 噛み確認(実測)
1. `resolveLearningConsent` の後方互換分岐 (`if (learning === undefined) { ... }`) を一時的に `if (false)` に書き換えてテストを実行 → テストa(新形式未設定+旧フラグ`hermes_raw_data_consent=true`→期待値`{learn:true,share:true}`)が赤くなることを確認(`isHermesDataConsentGranted`側の連動テストも同時に赤くなった)。元に戻し、diffが無いことを確認して全緑に復帰。
2. 本番VPS(`root@65.108.159.161`、`/opt/rajiuce/.env`のDATABASE_URL)にpsqlで接続し、4テナント分の`features`実データをSELECTで取得:
   ```
   carnation   | {"rag": true, "voice": false, "avatar": true, "deep_research": false, "event_tracking": true, "hermes_raw_data_consent": false}
   demo        | {"rag": true, "voice": false, "avatar": false, "deep_research": false}
   lp-demo     | {"rag": true, "voice": true, "avatar": true, "pre_dispatch": false}
   r2c_default | {"rag": false, "voice": false, "avatar": true, "sales_stage_continuity": true}
   ```
   4テナントとも `features.learning` キーが存在しないため後方互換分岐に入り、`resolveLearningConsent` が全テナントで `{learn: true, share: false}` に解決されることをローカルテスト(実データをそのまま使用)で再現確認済み。SQL更新は一切実行していない(SELECTのみ)。

## 受け入れ条件チェック
- [x] `pnpm typecheck` 通過
- [x] `pnpm lint`(`oxlint src admin-ui/src --max-warnings 63`)通過、新規warning無し
- [x] `npx jest src/lib/hermesConsent.test.ts src/api/admin/tenants --maxWorkers=1` 通過(80 tests passed)
- [x] 上記7ケース + API 400テスト(super_admin/my-tenant両方)通過
- [x] 本番4テナントが `{learn:true, share:false}` に解決されることを実測値として記載(上記)
- [x] このPR単体で本番挙動が変わらないことを明記(誰も `resolveLearningConsent` を消費していない。既存の `isHermesDataConsentGranted` 呼び出し元2箇所は無変更)
- [x] マイグレーション未追加(featuresはJSONBのため列追加不要)
- [x] 環境変数による有効/無効判定を追加していない(判定は `tenants.features` のみ)

## テスト計画
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `npx jest src/lib/hermesConsent.test.ts src/api/admin/tenants --maxWorkers=1`(80 tests passed)
- [x] `npx jest tests/api/admin/tenants --maxWorkers=1`(既存90 tests、回帰なし)
- [x] `npx jest src/api/hermes-mcp --maxWorkers=1`(既存の呼び出し元51 tests、回帰なし)
- [x] 噛み確認(後方互換分岐無効化→再有効化)
- [x] 本番4テナントの実データでの解決結果確認

Claude-Session: https://claude.ai/code/session_01NgCQYt8UMPgm4HNVu7nv7z