### PR TITLE
共有学習プールS3: global tuning_rules の読み取りに share 同意判定を適用

### DIFF
--- a/src/agent/judge/judgeEvaluator.test.ts
+++ b/src/agent/judge/judgeEvaluator.test.ts
@@ -44,6 +44,7 @@ import { getPool } from '../../lib/db';
 import { readFile } from 'fs/promises';
 import { evaluateSession, SessionNotFoundError, SessionTenantMismatchError, SessionTooShortError, SessionAlreadyEvaluatedError } from './judgeEvaluator';
 import { sendRewardSignal } from '../openclaw/rewardBridge';
+import { GLOBAL_RULE_VISIBILITY_WHERE } from '../../api/admin/tuning/tuningRulesRepository';
 
 const mockCallGroq = callGeminiJudge as jest.MockedFunction<typeof callGeminiJudge>;
 const mockGetPool = getPool as jest.MockedFunction<typeof getPool>;
@@ -143,11 +144,12 @@ describe('evaluateSession', () => {
     expect(result!.stage_progress_score).toBe(75);
     expect(result!.taboo_violation_score).toBe(90);
 
-    // tuning_rules SELECT (call index 2) must include the 'global' shared-tenant fallback
-    // so judge evaluates against the same rule set runtime applies (tenant + global)
+    // tuning_rules SELECT (call index 2) must use the same GLOBAL_RULE_VISIBILITY_WHERE
+    // predicate as runtime (tuningRulesRepository) so judge evaluates against the same
+    // rule set (tenant + share同意済みなら global) — S3(GID 1217769376950104)
     const tuningSelectCall = mockPool.query.mock.calls[2]!;
     expect(tuningSelectCall[0]).toContain('tuning_rules');
-    expect(tuningSelectCall[0]).toMatch(/tenant_id = \$1\s+OR\s+tenant_id = 'global'/);
+    expect(tuningSelectCall[0]).toContain(GLOBAL_RULE_VISIBILITY_WHERE);
 
     // INSERT was called with tenant_id and session_id (index 3 after Phase60-A tuning_rules SELECT)
     const insertCall = mockPool.query.mock.calls[3]!;

--- a/src/agent/judge/judgeEvaluator.ts
+++ b/src/agent/judge/judgeEvaluator.ts
@@ -18,6 +18,7 @@ import {
   getCrossTenantContext,
   formatCrossTenantContext,
 } from '../../lib/crossTenantContext';
+import { GLOBAL_RULE_VISIBILITY_WHERE } from '../../api/admin/tuning/tuningRulesRepository';
 
 const logger = pino();
 
@@ -266,9 +267,11 @@ export async function evaluateSession(sessionId: string, expectedTenantId?: stri
         : Promise.resolve({ results: [] }),
       pool
         .query(
-          // runtime (tuningRulesRepository) は tenant + 'global' 共有ルールを適用するため、
-          // judge も同じルール集合で psychology_fit を評価する (他RAG経路と一貫)。
-          "SELECT trigger_pattern, expected_behavior FROM tuning_rules WHERE (tenant_id = $1 OR tenant_id = 'global') AND is_active = true LIMIT 10",
+          // S3(共有学習プールの参加モデル): runtime (tuningRulesRepository) と同じ述語
+          // GLOBAL_RULE_VISIBILITY_WHERE を共有しているため、judge も同じルール集合
+          // (tenant + share同意済みなら global) で psychology_fit を評価する
+          // (他RAG経路と一貫。述語をコピーせず1箇所を import して使う)。
+          `SELECT trigger_pattern, expected_behavior FROM tuning_rules WHERE ${GLOBAL_RULE_VISIBILITY_WHERE} AND is_active = true LIMIT 10`,
           [tenantId],
         )
         .then((res: { rows: Array<{ trigger_pattern: string; expected_behavior: string }> }) => res.rows)

--- a/src/agent/tools/synthesisTool.variant.test.ts
+++ b/src/agent/tools/synthesisTool.variant.test.ts
@@ -101,7 +101,10 @@ describe("synthesizeAnswer — variant選択(真のsticky)", () => {
     expect(result.variantName).toBe("積極版");
 
     // JOIN で chat_sessions.session_id を絞り込んでいることを確認する
-    const tenantsCall = query.mock.calls.find(([sql]) => sql.includes("FROM tenants"));
+    // S3(共有学習プールの参加モデル): tuning_rules クエリの EXISTS 述語にも
+    // "FROM tenants" という部分文字列が含まれるようになったため、実際の
+    // variant取得クエリだけに現れる "system_prompt_variants" で区別する。
+    const tenantsCall = query.mock.calls.find(([sql]) => sql.includes("system_prompt_variants"));
     expect(tenantsCall![0]).toContain("LEFT JOIN chat_sessions");
     expect(tenantsCall![1]).toEqual(["tenant-1", "sess-sticky-1"]);
   });
@@ -182,7 +185,10 @@ describe("synthesizeAnswer — variant選択(真のsticky)", () => {
     });
 
     expect(["variant_a", "variant_b"]).toContain(result.variantId);
-    const tenantsCall = query.mock.calls.find(([sql]) => sql.includes("FROM tenants"));
+    // S3(共有学習プールの参加モデル): tuning_rules クエリの EXISTS 述語にも
+    // "FROM tenants" という部分文字列が含まれるようになったため、実際の
+    // variant取得クエリだけに現れる "system_prompt_variants" で区別する。
+    const tenantsCall = query.mock.calls.find(([sql]) => sql.includes("system_prompt_variants"));
     expect(tenantsCall![0]).not.toContain("chat_sessions");
   });
 

--- a/src/api/admin/tuning/tuningRulesRepository.test.ts
+++ b/src/api/admin/tuning/tuningRulesRepository.test.ts
@@ -16,6 +16,7 @@ import {
   updateRule,
   getActiveRulesForTenant,
   buildTuningPromptSection,
+  GLOBAL_RULE_VISIBILITY_WHERE,
   type TuningRule,
 } from './tuningRulesRepository';
 import { getRuleEffect } from '../analytics/ruleEffect';
@@ -26,11 +27,14 @@ describe('listRules', () => {
     mockQuery.mockResolvedValue({ rows: [] });
   });
 
-  it('tenantId指定・filtersなし → 従来通りWHERE tenant_id/global のみ、引数は[tenantId]', async () => {
+  // S3(GID 1217769376950104): 管理UI一覧も回答経路(getActiveRulesForTenant)と
+  // 同じ述語(GLOBAL_RULE_VISIBILITY_WHERE)でフィルタする方針にした
+  // (share=OFF のテナントに「効かないルール」を一覧に出さない)。
+  it('tenantId指定・filtersなし → WHERE句にGLOBAL_RULE_VISIBILITY_WHEREが使われ、引数は[tenantId]', async () => {
     await listRules('tenant-abc');
 
     const [sql, args] = mockQuery.mock.calls[0];
-    expect(sql).toContain("tenant_id = $1 OR tenant_id = 'global'");
+    expect(sql).toContain(GLOBAL_RULE_VISIBILITY_WHERE);
     expect(sql).not.toContain('source =');
     expect(sql).not.toContain('status =');
     expect(args).toEqual(['tenant-abc']);
@@ -315,6 +319,241 @@ describe('getActiveRulesForTenant', () => {
     expect(mockQuery).toHaveBeenCalledTimes(1);
     const [sql] = mockQuery.mock.calls[0];
     expect(sql).toMatch(/SELECT[\s\S]*approved_responses/);
+  });
+
+  // S3(GID 1217769376950104): 回答経路にDBラウンドトリップを追加しない(1クエリ内の
+  // EXISTS相関サブクエリで share 同意判定する)。バインドは tenantId のみ([tenantId])。
+  it('WHERE句にGLOBAL_RULE_VISIBILITY_WHEREが使われ、バインドはtenantId 1つのみ(追加クエリなし)', async () => {
+    await getActiveRulesForTenant('tenant-abc');
+
+    const [sql, args] = mockQuery.mock.calls[0];
+    expect(sql).toContain(GLOBAL_RULE_VISIBILITY_WHERE);
+    expect(args).toEqual(['tenant-abc']);
+  });
+
+  it('DB障害時: getActiveRulesForTenantはrejectする(呼び出し元 synthesisTool.ts:219 が.catch(()=>[])で拾い、global行を含め何も返さない側に倒す)', async () => {
+    mockQuery.mockRejectedValueOnce(new Error('db down'));
+    await expect(getActiveRulesForTenant('tenant-abc')).rejects.toThrow('db down');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// S3(GID 1217769376950104 / 要件§6 X1・X2 / 受け入れ G1・E4・E9・E10):
+// global ルール可視性の挙動テスト。
+//
+// globalRuleGate.test.ts(機械ガード)とは別に必須。ここでは pool.query を
+// 「実際に渡されたSQL文字列を見て判定を変えるフェイク」に差し替える。
+// これにより、述語を GLOBAL_RULE_VISIBILITY_WHERE(EXISTS...tenants t...)経由から
+// 生の "tenant_id = $1 OR tenant_id = 'global'" に戻すと、下記の挙動テストが
+// 実際に赤くなる(噛み確認)。単純に固定の rows を返すだけのモックでは
+// 「渡したSQLの中身」を無視してしまい、この退行を検出できないため。
+// ---------------------------------------------------------------------------
+describe('S3: global ルール可視性の挙動テスト', () => {
+  type TenantFixture = {
+    learning?: { learn: boolean; share: boolean };
+    hermes_raw_data_consent?: boolean;
+  };
+
+  function makeGlobalTestRule(overrides: Partial<TuningRule> = {}): TuningRule {
+    return {
+      id: 1,
+      tenant_id: 'tenant-abc',
+      trigger_pattern: 'x',
+      expected_behavior: 'y',
+      priority: 0,
+      is_active: true,
+      created_by: null,
+      source_message_id: null,
+      created_at: '',
+      updated_at: '',
+      ...overrides,
+    };
+  }
+
+  /**
+   * pool.query を「渡されたSQL文字列に EXISTS(...tenants t...) 述語が含まれるか」で
+   * 挙動を分岐するフェイクに差し替える。
+   * - 述語を経由している(isGated=true): fixture.tenants の share 判定(hermesConsent.ts と
+   *   同じ優先順位: features.learning があればそちらを優先、無ければ旧フラグ)に従って
+   *   global 行の有無を決める。
+   * - 述語を経由していない(isGated=false, 生SQLへ後退した場合): global 行は常に含む
+   *   (=旧脆弱挙動の再現。噛み確認でこの分岐に落ちることを確認する)。
+   */
+  function installFakePool(fixture: { tuningRules: TuningRule[]; tenants: Record<string, TenantFixture | undefined> }) {
+    mockQuery.mockReset();
+    mockQuery.mockImplementation((sql: string, args: unknown[]) => {
+      const tenantId = args[0] as string | undefined;
+      const isGated = /EXISTS\s*\(\s*SELECT 1 FROM tenants t/.test(sql);
+      const tenantRow = tenantId ? fixture.tenants[tenantId] : undefined;
+      const shareGranted =
+        tenantRow !== undefined &&
+        (tenantRow.learning !== undefined
+          ? tenantRow.learning.share === true
+          : tenantRow.hermes_raw_data_consent === true);
+
+      const rows = fixture.tuningRules
+        .filter((r) => {
+          if (r.tenant_id === tenantId) return true;
+          if (r.tenant_id === 'global') {
+            if (!isGated) return true; // 生SQL: 無条件にglobalを返す(脆弱)
+            return shareGranted; // 述語経由: share同意が無ければ返さない
+          }
+          return false;
+        })
+        // 実SQLのORDER BY(global を後ろ、各グループ内 priority DESC)を模す
+        .slice()
+        .sort((a, b) => {
+          const aGlobal = a.tenant_id === 'global' ? 1 : 0;
+          const bGlobal = b.tenant_id === 'global' ? 1 : 0;
+          if (aGlobal !== bGlobal) return aGlobal - bGlobal;
+          return b.priority - a.priority;
+        });
+
+      return Promise.resolve({ rows });
+    });
+  }
+
+  const FIXTURE_RULES: TuningRule[] = [
+    makeGlobalTestRule({ id: 1, tenant_id: 'tenant-abc', trigger_pattern: '自テナント', priority: 5 }),
+    makeGlobalTestRule({ id: 2, tenant_id: 'global', trigger_pattern: 'global高優先', priority: 10 }),
+    makeGlobalTestRule({ id: 3, tenant_id: 'global', trigger_pattern: 'global低優先', priority: 1 }),
+  ];
+
+  it('share=ON のテナント: global + 自テナントの両方が返り、ORDER(globalを後ろ)が維持される', async () => {
+    installFakePool({
+      tuningRules: FIXTURE_RULES,
+      tenants: { 'tenant-abc': { learning: { learn: true, share: true } } },
+    });
+
+    const rows = await getActiveRulesForTenant('tenant-abc');
+    expect(rows.map((r) => r.id)).toEqual([1, 2, 3]); // 自テナント→global(priority降順)
+  });
+
+  it('share=OFF のテナント: 自テナントのみが返り、global が1行も混ざらない(G1)', async () => {
+    installFakePool({
+      tuningRules: FIXTURE_RULES,
+      tenants: { 'tenant-abc': { learning: { learn: true, share: false } } },
+    });
+
+    const rows = await getActiveRulesForTenant('tenant-abc');
+    expect(rows.map((r) => r.id)).toEqual([1]);
+    expect(rows.some((r) => r.tenant_id === 'global')).toBe(false);
+  });
+
+  it('旧フラグのみ(hermes_raw_data_consent=true, learning未設定): global が返る(後方互換)', async () => {
+    installFakePool({
+      tuningRules: FIXTURE_RULES,
+      tenants: { 'tenant-abc': { hermes_raw_data_consent: true } },
+    });
+
+    const rows = await getActiveRulesForTenant('tenant-abc');
+    expect(rows.map((r) => r.id)).toEqual([1, 2, 3]);
+  });
+
+  it('旧フラグがfalse(hermes_raw_data_consent=false, learning未設定): global が返らない', async () => {
+    installFakePool({
+      tuningRules: FIXTURE_RULES,
+      tenants: { 'tenant-abc': { hermes_raw_data_consent: false } },
+    });
+
+    const rows = await getActiveRulesForTenant('tenant-abc');
+    expect(rows.map((r) => r.id)).toEqual([1]);
+  });
+
+  it('新形式が優先される: learning.share=false かつ旧フラグ=true でも global は返らない', async () => {
+    installFakePool({
+      tuningRules: FIXTURE_RULES,
+      tenants: { 'tenant-abc': { learning: { learn: true, share: false }, hermes_raw_data_consent: true } },
+    });
+
+    const rows = await getActiveRulesForTenant('tenant-abc');
+    expect(rows.map((r) => r.id)).toEqual([1]);
+  });
+
+  it('テナント行が存在しないtenantId: 自テナントのルールは返るが、global は返らない(fail-closed)', async () => {
+    installFakePool({
+      tuningRules: FIXTURE_RULES,
+      tenants: {}, // tenant-abc の行が無い
+    });
+
+    const rows = await getActiveRulesForTenant('tenant-abc');
+    expect(rows.map((r) => r.id)).toEqual([1]);
+    expect(rows.some((r) => r.tenant_id === 'global')).toBe(false);
+  });
+
+  it('share を ON→OFF に切り替えた直後: 次のクエリから global が返らない', async () => {
+    const fixture = {
+      tuningRules: FIXTURE_RULES,
+      tenants: { 'tenant-abc': { learning: { learn: true, share: true } } } as Record<string, TenantFixture | undefined>,
+    };
+    installFakePool(fixture);
+
+    const before = await getActiveRulesForTenant('tenant-abc');
+    expect(before.some((r) => r.tenant_id === 'global')).toBe(true);
+
+    // share を OFF に切り替え(同じ fixture オブジェクトを書き換えて即時反映)
+    fixture.tenants['tenant-abc'] = { learning: { learn: true, share: false } };
+
+    const after = await getActiveRulesForTenant('tenant-abc');
+    expect(after.some((r) => r.tenant_id === 'global')).toBe(false);
+  });
+
+  it('global ルールが多数(200件)でも黙って切らない(LIMIT等での暗黙の打ち切りが無い)', async () => {
+    const manyGlobalRules: TuningRule[] = Array.from({ length: 200 }, (_, i) =>
+      makeGlobalTestRule({ id: 100 + i, tenant_id: 'global', trigger_pattern: `g${i}`, priority: i }),
+    );
+    installFakePool({
+      tuningRules: [makeGlobalTestRule({ id: 1, tenant_id: 'tenant-abc' }), ...manyGlobalRules],
+      tenants: { 'tenant-abc': { learning: { learn: true, share: true } } },
+    });
+
+    const rows = await getActiveRulesForTenant('tenant-abc');
+    expect(rows).toHaveLength(201); // 自テナント1件 + global 200件、暗黙の打ち切りなし
+  });
+
+  // 噛み確認そのもの: このテストファイル内のフェイクpoolは「渡されたSQLにEXISTS述語が
+  // 含まれるか」で挙動を変えるため、実装側が述語を生SQLへ後退させると isGated=false に
+  // 落ち、share=OFFでもglobalが混ざるようになる(=下記のような結果になり、上記
+  // 'share=OFFのテナント...' のテストが実際に赤くなる)。この事実をコメントで明示する。
+  it('(ドキュメント用) 生SQL相当(isGated=false)をシミュレートすると share=OFF でも global が混ざる', async () => {
+    mockQuery.mockReset();
+    mockQuery.mockImplementation((_sql: string, args: unknown[]) => {
+      const tenantId = args[0] as string;
+      // 生SQL: tenant_id = $1 OR tenant_id = 'global' 相当(share判定なし)
+      const rows = FIXTURE_RULES.filter((r) => r.tenant_id === tenantId || r.tenant_id === 'global');
+      return Promise.resolve({ rows });
+    });
+
+    const rows = await getActiveRulesForTenant('tenant-abc');
+    // share=OFFのはずが global が漏れる = これが本タスクで塞ぐ脆弱性そのもの
+    expect(rows.some((r) => r.tenant_id === 'global')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// listRules も同じ述語でフィルタする(本タスクの既定方針)。
+// share=OFF のテナントに「効かないルール」を一覧に出すのは「押せるのに何も
+// 起きないUI」の禁止に触れるため、getActiveRulesForTenant と同じ可視性にする。
+// ---------------------------------------------------------------------------
+describe('S3: listRules も同じ可視性判定を使う(管理UI一覧)', () => {
+  it('share=OFF のテナントの一覧には global ルールが出ない(押せるのに何も起きないUIを作らない)', async () => {
+    mockQuery.mockReset();
+    mockQuery.mockImplementation((sql: string, args: unknown[]) => {
+      const tenantId = args[0] as string;
+      const isGated = /EXISTS\s*\(\s*SELECT 1 FROM tenants t/.test(sql);
+      // このテストの fixture では share=false
+      const rows = [
+        { id: 1, tenant_id: tenantId },
+        ...(isGated ? [] : [{ id: 2, tenant_id: 'global' }]),
+      ];
+      return Promise.resolve({ rows });
+    });
+
+    const rows = await listRules('tenant-abc');
+    expect(rows.some((r) => r.tenant_id === 'global')).toBe(false);
+    // 実装がGLOBAL_RULE_VISIBILITY_WHERE(EXISTS述語)を使っていること自体もSQLで確認する
+    const [sql] = mockQuery.mock.calls[0];
+    expect(sql).toContain(GLOBAL_RULE_VISIBILITY_WHERE);
   });
 });
 

--- a/src/api/admin/tuning/tuningRulesRepository.ts
+++ b/src/api/admin/tuning/tuningRulesRepository.ts
@@ -49,6 +49,58 @@ export interface ListRulesFilters {
   status?: string;
 }
 
+// ---------------------------------------------------------------------------
+// 共有学習プール S3(要件§6 X1・X2 / 受け入れ G1・E4・E9・E10): global ルール可視性判定
+// ---------------------------------------------------------------------------
+
+/**
+ * global(tenant_id='global') な tuning_rules 行を「読んでよいか」の判定述語。
+ *
+ * S1/S2までは「共有プールに出す」側(hermesConsent.ts の share フラグ)だけが同意で
+ * 絞られ、「読む」側は無条件に全テナントが global 行の恩恵を受けていた。出す側だけ
+ * 絞ると「参加しない」ことが常に得なテナントの最適戦略になり、差別化が成立しない
+ * ため、読み取り側にも hermesConsent.ts の resolveLearningConsent と同じ share
+ * 判定を適用する(このコメント末尾の優先順位の再現)。
+ *
+ * バインド変数は $1 = tenantId 固定。呼び出し側は tenantId を必ずクエリの $1 に
+ * 置くこと(listRules / getActiveRulesForTenant / judgeEvaluator.ts で共通)。
+ *
+ * 1クエリで完結させるため EXISTS 相関サブクエリで表現する(回答経路にDBラウンド
+ * トリップを追加しない)。対象テナント行が存在しない、または share が真でなければ
+ * EXISTS が false になり global 行は返らない(fail-closed)。
+ *
+ * SQL述語の優先順位は hermesConsent.ts の listHermesConsentingTenantIds と同一にする
+ * (新形式 features.learning.share を優先し、features.learning が未設定の場合のみ
+ * 旧フラグ features.hermes_raw_data_consent にフォールバック):
+ *   (features->'learning'->>'share') = 'true'
+ *      OR (
+ *           (features->'learning') IS NULL
+ *           AND (features->>'hermes_raw_data_consent') = 'true'
+ *         )
+ *
+ * ★この述語はここ1箇所だけで定義する(コピーして各所に書かない)。★
+ * ★tenants テーブルのエイリアスは t に固定する★。エイリアスを引数化すると
+ * tests/phase38/globalRuleGate.test.ts の正規表現検査(alias t を要求)が
+ * 空振りする(PR #896 で FAQ_VISIBILITY_WHERE のエイリアスを固定した際と同じ理由)。
+ */
+export const GLOBAL_RULE_VISIBILITY_WHERE = `(
+        tenant_id = $1
+        OR (
+          tenant_id = 'global'
+          AND EXISTS (
+            SELECT 1 FROM tenants t
+             WHERE t.id = $1
+               AND (
+                 (t.features->'learning'->>'share') = 'true'
+                 OR (
+                      (t.features->'learning') IS NULL
+                      AND (t.features->>'hermes_raw_data_consent') = 'true'
+                    )
+               )
+          )
+        )
+      )`;
+
 export interface CreateRuleParams {
   tenant_id: string;
   trigger_pattern: string;
@@ -78,15 +130,20 @@ export interface UpdateRuleParams {
 
 /**
  * ルール一覧取得。
- * - tenantId 指定: そのテナント + global のルールを返す
- * - tenantId 未指定 (super_admin): 全ルールを返す
+ * - tenantId 指定: そのテナントのルール + (S3) share 同意済みなら global のルールも返す
+ *   (GLOBAL_RULE_VISIBILITY_WHERE 参照。share=OFF のテナントには global 行を出さない)
+ * - tenantId 未指定 (super_admin): 全ルールを返す(share の有無に関わらず全件)
  * - ORDER: tenant_id = 'global' を後ろ、各グループ内で priority DESC
  */
 export async function listRules(tenantId?: string, filters?: ListRulesFilters): Promise<TuningRule[]> {
   const pool = getPool();
 
   const args: unknown[] = tenantId ? [tenantId] : [];
-  const conditions: string[] = tenantId ? ["(tenant_id = $1 OR tenant_id = 'global')"] : [];
+  // S3(GID 1217769376950104): 管理UI一覧も同じ述語でフィルタする方針(既定方針を採用)。
+  // share=OFF のテナントに「効かないルール(global)」を一覧に出すのは
+  // 「押せるのに何も起きないUI」の禁止に触れるため、share を ON にすれば
+  // global 行が現れる、という素直な挙動にする(PR本文に理由を記載)。
+  const conditions: string[] = tenantId ? [GLOBAL_RULE_VISIBILITY_WHERE] : [];
   if (filters?.source) {
     // R6: 配列(複数source)なら ANY、単一文字列なら従来通り = で絞り込む
     if (Array.isArray(filters.source)) {
@@ -133,6 +190,8 @@ export async function listRules(tenantId?: string, filters?: ListRulesFilters): 
 /**
  * アクティブなルールをテナント用に取得（RAG / プロンプト注入向け）。
  * テナント固有ルールを先に、次に global ルール、各グループ内で priority DESC。
+ * S3: global ルールは GLOBAL_RULE_VISIBILITY_WHERE により share 同意済みテナントのみ
+ * 返る(1クエリ内の EXISTS 相関サブクエリで判定。追加のDBラウンドトリップなし)。
  */
 export async function getActiveRulesForTenant(
   tenantId: string,
@@ -144,7 +203,7 @@ export async function getActiveRulesForTenant(
             priority, is_active, created_by, source_message_id,
             created_at, updated_at, approved_responses
      FROM tuning_rules
-     WHERE (tenant_id = $1 OR tenant_id = 'global')
+     WHERE ${GLOBAL_RULE_VISIBILITY_WHERE}
        AND is_active = true
      ORDER BY
        CASE WHEN tenant_id = 'global' THEN 1 ELSE 0 END ASC,

--- a/src/lib/crossTenantContext.ts
+++ b/src/lib/crossTenantContext.ts
@@ -8,6 +8,14 @@
 //   - 集計値（平均・件数・比率）のみを返す
 // キャッシュ: 1時間TTL のインメモリキャッシュ（DB負荷最小化）
 // エラー: 全クエリ失敗時は空コンテキストを返す（silent fail）
+//
+// 共有学習プールS3(GID 1217769376950104)スコープ対象外の理由:
+// このファイルは tuning_rules を一切読まず、tenant_id='global' 判定の
+// GLOBAL_RULE_VISIBILITY_WHERE(tuningRulesRepository.ts)の対象にもならない。
+// conversation_evaluations 等からの匿名集計(平均・件数・比率)のみを返し、
+// tenant_id・会話内容・faq_embeddings に一切触れない設計(上記PII除去ルール参照)。
+// 「global を読む箇所」として塞ぎ忘れていると誤解されないよう、対象外である理由を
+// ここに明記する(S3タスクの噛み確認で確認済み)。
 
 import { pool } from './db';
 import { logger } from './logger';

--- a/tests/phase38/globalRuleGate.test.ts
+++ b/tests/phase38/globalRuleGate.test.ts
@@ -1,0 +1,91 @@
+// tests/phase38/globalRuleGate.test.ts
+// 共有学習プールの参加モデル S3(GID 1217769376950104: 要件§6 X1・X2 / 受け入れ G1・E4・E9・E10)
+//
+// tuningRulesRepository.test.ts / judgeEvaluator.test.ts は「正しい入力に正しい出力が
+// 返るか」を検証する挙動テスト。このファイルは excludedIds.test.ts /
+// widgetSourceInvariants.test.ts / confirmPolicy.test.ts と同じ流儀で、ソースコードを
+// 正規表現で走査する「機械ガード」に専念する(挙動テストと目的を混ぜない)。
+//
+// 検査内容:
+//   a) src/ 配下に「述語(GLOBAL_RULE_VISIBILITY_WHERE)を経由しない生の
+//      tenant_id = 'global'(tuning_rules 文脈)」が残っていないこと。
+//      許可リストは crossTenantContext.ts のコメントのみ(同ファイルは tuning_rules を
+//      一切読まないため、そもそも本チェックには引っかからない設計)。
+//   b) judgeEvaluator.ts が GLOBAL_RULE_VISIBILITY_WHERE を import していること
+//   c) GLOBAL_RULE_VISIBILITY_WHERE がエイリアス t(tenants)を含むこと
+//      (引数化されていないこと。PR #896 の FAQ_VISIBILITY_WHERE と同じ理由)
+
+import fs from 'fs';
+import path from 'path';
+import { GLOBAL_RULE_VISIBILITY_WHERE } from '../../src/api/admin/tuning/tuningRulesRepository';
+
+const SRC_DIR = path.resolve(__dirname, '../../src');
+
+function walkTsFiles(dir: string, out: string[] = []): string[] {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue;
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walkTsFiles(full, out);
+    } else if (entry.isFile() && entry.name.endsWith('.ts') && !entry.name.endsWith('.test.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+// 「述語を経由しない生の tenant_id = 'global'」の判定パターン。
+// tuning_rules 文脈だけを対象にするため、"FROM tuning_rules" の近傍(前後300文字)に
+// 生のOR結合パターンが現れる場合のみ違反とみなす。他テーブル
+// (faq_embeddings / sai_task_rules / principles 等)の同型パターンはこのタスクの
+// スコープ外であり、対象にしない(誤検知防止。実測: 最も近い他テーブルの
+// 事例でも距離1000文字以上あり、tuning_rules 実例は距離30文字以内)。
+const RAW_OR_GLOBAL = /tenant_id\s*=\s*\$\d+\s*OR\s*tenant_id\s*=\s*'global'/;
+const PROXIMITY_WINDOW = 300;
+
+describe('tuning_rules の global 可視性: 機械ガード(S3, GID 1217769376950104)', () => {
+  const files = walkTsFiles(SRC_DIR);
+
+  it('a) src/ 配下に、述語を経由しない生の "tenant_id = $N OR tenant_id = \'global\'"(tuning_rules 文脈)が残っていない', () => {
+    const violations: string[] = [];
+
+    for (const file of files) {
+      const content = fs.readFileSync(file, 'utf8');
+      let fromIdx = content.indexOf('FROM tuning_rules');
+      while (fromIdx !== -1) {
+        const windowStart = Math.max(0, fromIdx - PROXIMITY_WINDOW);
+        const windowEnd = Math.min(content.length, fromIdx + PROXIMITY_WINDOW);
+        const window = content.slice(windowStart, windowEnd);
+        if (RAW_OR_GLOBAL.test(window)) {
+          violations.push(path.relative(SRC_DIR, file));
+        }
+        fromIdx = content.indexOf('FROM tuning_rules', fromIdx + 1);
+      }
+    }
+
+    expect(violations).toEqual([]);
+  });
+
+  it('b) judgeEvaluator.ts が GLOBAL_RULE_VISIBILITY_WHERE を import している', () => {
+    const judgeSrc = fs.readFileSync(
+      path.resolve(SRC_DIR, 'agent/judge/judgeEvaluator.ts'),
+      'utf8',
+    );
+    expect(judgeSrc).toMatch(
+      /import\s*\{\s*GLOBAL_RULE_VISIBILITY_WHERE\s*\}\s*from\s*['"][^'"]*tuningRulesRepository['"]/,
+    );
+  });
+
+  it('c) GLOBAL_RULE_VISIBILITY_WHERE はエイリアス t(tenants)を含む(引数化されていない)', () => {
+    expect(GLOBAL_RULE_VISIBILITY_WHERE).toMatch(/FROM tenants t\b/);
+    expect(GLOBAL_RULE_VISIBILITY_WHERE).toMatch(/\bt\.id\s*=\s*\$1\b/);
+    expect(GLOBAL_RULE_VISIBILITY_WHERE).toMatch(/\bt\.features\b/);
+  });
+
+  // 補助: bindは$1=tenantId固定。呼び出し側がプレースホルダ番号をずらして使うと
+  // 述語が別の値と誤って比較される事故になるため、定数自体が$1のみを参照することを固定する。
+  it('補助: GLOBAL_RULE_VISIBILITY_WHERE が参照するバインド変数は $1 のみ', () => {
+    const placeholders = GLOBAL_RULE_VISIBILITY_WHERE.match(/\$\d+/g) ?? [];
+    expect(new Set(placeholders)).toEqual(new Set(['$1']));
+  });
+});


### PR DESCRIPTION
## 概要

共有学習プールの参加モデル S3(要件§6 X1・X2 / 受け入れ G1・E4・E9・E10)。
Asanaタスク: https://app.asana.com/1/817733952351708/project/1213607637045514/task/1217769376950104

これまで `tenant_id='global'` の `tuning_rules` 行は同意の有無に関係なく全テナントが読んでいた
(出す側だけが `hermesConsent.ts` の `share` フラグで絞られ、受け取る側は無条件)。これでは
「共有プールに参加しない」ことが常に最適戦略になり、「解放すると質が上がる」という差別化が
成立しない。本PRは **読み取り側にも share 同意判定を適用する**。

## 変更内容

### 1. `src/api/admin/tuning/tuningRulesRepository.ts`
述語を `GLOBAL_RULE_VISIBILITY_WHERE` として1箇所に export し、`getActiveRulesForTenant`
(回答経路)と `listRules`(管理UI一覧)の両方で使う。1クエリ内の `EXISTS` 相関サブクエリで
判定するため、回答経路にDBラウンドトリップを追加しない。対象テナント行が存在しない、または
`share` が真でなければ `EXISTS` が `false` になり `global` 行は返らない(fail-closed)。

SQL述語の優先順位は S2 の `hermesConsent.ts`(`resolveLearningConsent` /
`listHermesConsentingTenantIds`)と同一にした: 新形式 `features.learning.share` を優先し、
`features.learning` が未設定の場合のみ旧フラグ `features.hermes_raw_data_consent` に
フォールバックする。

### 2. `src/agent/judge/judgeEvaluator.ts`
生SQLリテラル(`tenant_id = $1 OR tenant_id = 'global'`)をやめ、同じ
`GLOBAL_RULE_VISIBILITY_WHERE` を import して使う。runtime(tuningRulesRepository)と
judge が違う述語で評価すると、psychology_fit の評価基準が黙ってズレるため(既存コメントの
不変条件を維持)。

### 3. `src/lib/crossTenantContext.ts`
`tuning_rules` を一切読まず、匿名集計(平均・件数・比率)のみを扱う設計であることをコメントで
明記した。将来「global を読む箇所を塞ぎ忘れているのでは」と誤解されないための対象外宣言。

### 4. `tests/phase38/globalRuleGate.test.ts`(新規)
既存の `tuningRulesRepository.test.ts` は挙動テストであり、ソースを正規表現で走査する
機械ガードを混ぜると目的が濁るため新規ファイルにした
(`excludedIds.test.ts` / `widgetSourceInvariants.test.ts` と同じ流儀)。検査内容:
- a) `src/` 配下に述語を経由しない生の `tenant_id = 'global'`(tuning_rules 文脈)が残っていない
- b) `judgeEvaluator.ts` が `GLOBAL_RULE_VISIBILITY_WHERE` を import している
- c) `GLOBAL_RULE_VISIBILITY_WHERE` がエイリアス `t`(tenants)を含む(引数化されていない)

### 5. 挙動テスト(`tuningRulesRepository.test.ts` に追加)
`pool.query` を「実際に渡されたSQL文字列に `EXISTS(...tenants t...)` 述語が含まれるか」で
挙動を変えるフェイクに差し替える手法で検証した(固定rowsを返すだけのモックだと、述語を
生SQLへ後退させても検出できないため)。カバー内容:
- share=ON: global + 自テナント両方、ORDER(globalが後ろ)維持
- share=OFF: 自テナントのみ、global混入なし(G1)
- 旧フラグのみ: 後方互換でglobalが返る / 旧フラグ=false: 返らない
- 新形式優先: share=false かつ旧フラグ=true でもglobalは返らない
- テナント行が存在しない: fail-closed
- share ON→OFF切替直後に反映
- global 200件でも暗黙の打ち切りなし
- DB障害時はreject(呼び出し元 synthesisTool.ts:219 の `.catch(()=>[])` で拾う設計)

### 6. `src/agent/tools/synthesisTool.variant.test.ts`
新しい `EXISTS` 述語にも `"FROM tenants"` という部分文字列が入るようになったため、既存テストの
`query.mock.calls.find(...)` がtuning_rulesクエリを誤って拾ってしまっていた。検索条件を
実際のvariantクエリにしか現れない `"system_prompt_variants"` に修正した(無関係だが実際に
壊れたテストなので同じPRで修正)。

## listRules の方針(フィルタ / 表示)

**フィルタする方針を採用した。** share=OFF のテナントの管理UI一覧には global ルールを
一切表示しない。理由: share=OFF のテナントに「適用されない(効かない)global ルール」を
一覧に出すのは、リポジトリのCLAUDE.mdが禁止する「押せるのに何も起きないUI」に触れる。
share を ON にすれば global ルールが一覧に現れる、という素直な挙動にした
(「出すが適用外と表示する」別案は採らなかった)。

## 噛み確認(実施済み)

述語を生SQL(`tenant_id = $1 OR tenant_id = 'global'`)に戻し、以下が実際に赤くなることを
確認してから元に戻した:
- `globalRuleGate.test.ts` の a)(機械ガード)
- `tuningRulesRepository.test.ts` の S3挙動テスト(share=OFF系5件)
- `judgeEvaluator.test.ts` の該当テスト
- `judgeEvaluator.ts` の import を外すと `globalRuleGate.test.ts` の b) が赤くなることも確認

## テスト結果

- `pnpm typecheck` ✅
- `pnpm lint` ✅(既存の無関係な警告のみ、新規warningなし)
- `npx jest tuningRulesRepository judgeEvaluator globalRuleGate --maxWorkers=1` ✅ 79 passed
- `npx jest synthesisTool --maxWorkers=1` ✅ 7 passed(誤マッチ修正後)

フルスイート(`npx jest --maxWorkers=1`)実行時に `EADDRNOTAVAIL` による無関係なsupertest系
テストの失敗が多数出たが、該当ファイルを個別実行するとすべて成功しており、ローカル環境の
ポート枯渇によるもの(本PRの変更とは無関係)と判断した。

## Test plan
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `npx jest tuningRulesRepository judgeEvaluator globalRuleGate --maxWorkers=1`
- [x] `npx jest synthesisTool --maxWorkers=1`
- [x] 噛み確認(述語を生SQLに戻して機械ガード・挙動テストが赤くなることを実測)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgCQYt8UMPgm4HNVu7nv7z