### PR TITLE
共有学習プールの参加モデル S4: プラン別share既定・強制と2軸チャット導線

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -445,6 +445,15 @@ R2C は、テナント（店舗・EC事業者）のサイトに1行で埋め込�
     `/api/avatar/chat-stream`。前者は本番発火0件のまま廃止済みモデルを指し続けていた（E5で撤去）。
     後者は既定で 503 に封鎖（`ANAM_CHAT_STREAM_ENABLED`）。**封鎖を外すなら先に知識経路を通すこと。**
     ガード: `avatar-agent/test_no_rag_free_answer_path.py`。
+47. **共有プールの読み取り権を同意と紐付けずに配る／出す(share)と読む(共有プール参照)を別フラグにする。**
+    共有学習プールの参加モデルでは「出す」と「読む」を1つの `share` 同意に統合する
+    （出すだけ同意して読み放題、読むだけ同意して提供義務なし、を作らない）。
+    プラン別の強制（free_ad は share 強制ON、有料プランは既定OFF・選択可）を実装する際も、
+    fail-safe の向きに注意する: プラン取得の「失敗」を `free_ad` の「確定」として扱うと、
+    DB障害の瞬間に全テナントが強制データ共有になる（`src/lib/billing/planFeatures.ts` の
+    `resolveShareForPlan` / `queryTenantPlanResult` 参照。判定不能時は強制しない）。
+    ガード: `tests/phase38/globalRuleGate.test.ts`（S3で追加予定。本ブランチ時点では未存在）。
+    根拠: 要件のX1/X2。
 
 ## テストの最低ライン
 

--- a/admin-ui/src/pages/copilot-preview/index.tsx
+++ b/admin-ui/src/pages/copilot-preview/index.tsx
@@ -235,7 +235,7 @@ const REAL_TOOL_LABEL: Record<string, string> = {
   activate_avatar: "アバターの有効化",
   deactivate_avatar: "アバターの停止",
   set_avatar_feature: "アバター機能のON/OFF",
-  set_hermes_consent: "外部データ提供同意のON/OFF",
+  set_hermes_consent: "学習同意(自社内学習/共有プール参加)のON/OFF",
   update_avatar_profile: "アバターの基本設定の更新",
   reset_avatar_to_default: "アバターを既定に戻す",
   suggest_avatar_preset: "アバター見本の提案",

--- a/src/api/admin/agent/actionExecutor.ts
+++ b/src/api/admin/agent/actionExecutor.ts
@@ -43,7 +43,7 @@ import { checkSaiMonthlyCostCeiling } from '../options/routes';
 import { submitSaiTask, getSaiTask } from '../../../lib/sai/saiClient';
 import { recordSaiTask, resolveSaiTaskTenant } from '../../../lib/sai/saiTaskRegistry';
 import { trackUsage } from '../../../lib/billing/usageTracker';
-import { queryTenantPlan, planHasFeature } from '../../../lib/billing/planFeatures';
+import { queryTenantPlan, planHasFeature, resolveShareForTenantPlan } from '../../../lib/billing/planFeatures';
 import { fetchAnalyticsSummary, fetchConversionSummary } from '../analytics/summaryQueries';
 import { getRuleEffect } from '../analytics/ruleEffect';
 import { isOnboardingIndustry, ONBOARDING_INDUSTRY_LABELS, INDUSTRY_FAQ_TEMPLATES } from './industryFaqTemplates';
@@ -1288,41 +1288,107 @@ export async function executeToolCall(
     }
 
     // -----------------------------------------------------------------------
-    // GID 1216978677372391(PR-16, D1): データ利用同意の2階層化。
-    // ①自テナント内学習(learned_memory等)はこのフラグを一切参照せず常時ON(同意不要)。
-    // このツールが操作する tenants.features.hermes_raw_data_consent は
-    // ②外部Hermes VPSへの生データ提供の同意のみを表す(src/lib/hermesConsent.ts)。
+    // GID 1216978677372391(PR-16, D1) / 共有学習プールの参加モデル S4:
+    // データ利用同意の2軸化。
+    // ①自テナント内学習(learned_memory等)は learn が表す(データは外に出ない)。
+    // ②共有プール参加(R2C共有プールに出し、かつ読む。外部Hermes VPSへ出る)は share が表す。
+    // 新形式は tenants.features.learning = {learn, share}
+    // (src/lib/hermesConsent.ts の resolveLearningConsent が読む形と一致させる)。
+    // 旧フラグ features.hermes_raw_data_consent はここでは書かない(読み取り専用の
+    // 後方互換経路として resolveLearningConsent 側にのみ残す)。
     // 旧UI(/admin/avatar のHermesConsentToggle)は2026-10-13まで閉鎖観察中のため、
-    // 閉鎖後もチャットから同意操作ができるようにこのツールを新設する。
+    // 閉鎖後もチャットから同意操作ができるようにこのツールを新設した(コメントは新設時のまま)。
     case 'set_hermes_consent': {
-      const enabled = parseBooleanArg(args['enabled']);
-      const confirmed = isConfirmed(args['confirmed']);
+      const learnArg = parseBooleanArg(args['learn']);
+      const shareArgRaw = parseBooleanArg(args['share']);
+      // 後方互換: 旧セッションが enabled(boolean)だけを送ってくる場合は share として解釈する。
+      const enabledArg = parseBooleanArg(args['enabled']);
+      const shareArg = shareArgRaw !== undefined ? shareArgRaw : enabledArg;
 
-      if (enabled === undefined) {
-        return truncate('enabled は必須です');
+      if (learnArg === undefined && shareArg === undefined) {
+        return truncate('learn または share(もしくは旧enabled)のいずれかを指定してください');
       }
+
+      const confirmed = isConfirmed(args['confirmed']);
       if (!confirmed) {
+        const parts: string[] = [];
+        if (learnArg !== undefined) parts.push(`learn=${learnArg ? 'ON' : 'OFF'}`);
+        if (shareArg !== undefined) parts.push(`share=${shareArg ? 'ON' : 'OFF'}`);
         return truncate(
-          `外部提供の同意を${enabled ? 'ON' : 'OFF'}にするには確認が必要です。confirmed=true を指定して再度実行してください`,
+          `学習設定(${parts.join('、')})を変更するには確認が必要です。confirmed=true を指定して再度実行してください`,
         );
       }
 
       try {
-        // features は他のフラグ(avatar/voice等)も持つJSONBのため、キーだけをマージで
-        // 上書きする(set_avatar_feature / my-tenantハンドラと同じ形。他のフラグを消さない)。
+        // 指定されなかった軸は現在値を維持する。features の learning キー自体は
+        // JSONBのトップレベルマージでは部分更新できない({learn, share}を毎回フルで
+        // 書き直す必要がある)ため、先に現在値を読む。
+        // 注入済みの db を直接読む(resolveLearningConsent を呼ぶと内部で getPool() の
+        // 実Poolを使ってしまい、テストのモックPoolと食い違って汚染するため。
+        // queryTenantPlan を直接使っている activate_avatar / set_avatar_feature と同じ理由)。
+        const currentRes = await db.query<{
+          features: { learning?: unknown; hermes_raw_data_consent?: boolean } | null;
+        }>(`SELECT features FROM tenants WHERE id = $1`, [tenantId]);
+        if (currentRes.rowCount === 0) {
+          return truncate('テナントが見つかりません');
+        }
+        const currentFeatures = currentRes.rows[0]?.features ?? {};
+        const currentLearning = currentFeatures.learning;
+        const current =
+          typeof currentLearning === 'object' &&
+          currentLearning !== null &&
+          !Array.isArray(currentLearning) &&
+          typeof (currentLearning as Record<string, unknown>)['learn'] === 'boolean' &&
+          typeof (currentLearning as Record<string, unknown>)['share'] === 'boolean'
+            ? {
+                learn: (currentLearning as Record<string, unknown>)['learn'] as boolean,
+                share: (currentLearning as Record<string, unknown>)['share'] as boolean,
+              }
+            // 新形式未設定の場合の後方互換解決(learn=true固定、shareは旧フラグから)は
+            // resolveLearningConsent と同じルール(src/lib/hermesConsent.ts 参照)。
+            : { learn: true, share: currentFeatures.hermes_raw_data_consent === true };
+
+        const nextLearn = learnArg !== undefined ? learnArg : current.learn;
+        const nextShare = shareArg !== undefined ? shareArg : current.share;
+
+        // G3: learn=false かつ share=true は不整合として拒否する
+        // (learningConsentSchema の refine と同じルール。src/api/admin/tenants/routes.ts 参照)。
+        if (nextLearn === false && nextShare === true) {
+          return truncate(
+            'learn=OFF(自社内学習なし)のまま share=ON(共有プールへ提供)にはできません。' +
+              '先に learn をONにするか、share の指定を外してください',
+          );
+        }
+
+        // 広告プラン(free_ad、確実に判定できた場合のみ)は share 強制ON。
+        // ★fail-safeの向きが反転する: 判定不能(DB障害・未知プラン)時は強制しない★
+        // (src/lib/billing/planFeatures.ts の resolveShareForPlan 参照。
+        // queryTenantPlan の fail-safe=free_ad にここで相乗りすると、DB障害時に
+        // 全テナントの share=OFF操作が拒否される=実質強制ONになってしまう)。
+        if (shareArg === false) {
+          const shareForPlan = await resolveShareForTenantPlan(db, tenantId);
+          if (shareForPlan.forced) {
+            return truncate('広告プランでは共有が必須です。有料プランへの変更が必要です');
+          }
+        }
+
+        // features は他のフラグ(avatar/voice等)も持つJSONBのため、learningキーだけを
+        // マージで上書きする(set_avatar_feature / my-tenantハンドラと同じ形。
+        // 他のフラグを消さない)。
         const result = await db.query(
           `UPDATE tenants SET features = COALESCE(features, '{}'::jsonb) || $1::jsonb, updated_at = NOW()
            WHERE id = $2
            RETURNING id`,
-          [JSON.stringify({ hermes_raw_data_consent: enabled }), tenantId],
+          [JSON.stringify({ learning: { learn: nextLearn, share: nextShare } }), tenantId],
         );
         if (result.rowCount === 0) {
           return truncate('テナントが見つかりません');
         }
         return truncate(
-          enabled
-            ? 'Hermesへのデータ提供同意をONにしました'
-            : 'Hermesへのデータ提供同意をOFFにしました',
+          `学習設定を更新しました(learn=${nextLearn ? 'ON' : 'OFF'}、share=${nextShare ? 'ON' : 'OFF'})。` +
+            (nextShare
+              ? ''
+              : ' 共有プールへの新規データ提供は今後止まりますが、提供済みのデータは取り消せません'),
         );
       } catch (err) {
         logger.warn('[actionExecutor] set_hermes_consent failed', err);

--- a/src/api/admin/agent/agentRoutes.test.ts
+++ b/src/api/admin/agent/agentRoutes.test.ts
@@ -10143,9 +10143,12 @@ describe('POST /v1/admin/agent/chat', () => {
   });
 
   // -------------------------------------------------------------------------
-  // GID 1216978677372391(PR-16, D1): set_hermes_consent — tenants.features.
-  // hermes_raw_data_consent(②外部Hermes VPSへの生データ提供同意)をチャットから
-  // 操作できるようにする。①自テナント内学習はこのフラグを参照しないため対象外。
+  // GID 1216978677372391(PR-16, D1) / 共有学習プールの参加モデル S4:
+  // set_hermes_consent — tenants.features.learning = {learn, share} をチャットから
+  // 2軸で操作できるようにする。learn=自社内学習(外に出ない)、
+  // share=共有プール参加(外部Hermes VPSへ出る)。
+  // free_ad(広告プラン)は share 強制ON。判定不能(DB障害・未知プラン)時は
+  // 強制しない(src/lib/billing/planFeatures.ts の resolveShareForPlan 参照)。
   // -------------------------------------------------------------------------
   describe('set_hermes_consent', () => {
     function toolCallResponse(id: string, name: string, args: Record<string, unknown> = {}) {
@@ -10163,73 +10166,175 @@ describe('POST /v1/admin/agent/chat', () => {
       };
     }
 
-    it('enabled=trueで成功し、features.hermes_raw_data_consentがtrueで更新される', async () => {
+    it('learn/shareを両方指定して成功し、features.learningが{learn,share}で更新される', async () => {
       mockFetch
-        .mockResolvedValueOnce(toolCallResponse('call-hc-1', 'set_hermes_consent', { enabled: true, confirmed: true }))
+        .mockResolvedValueOnce(toolCallResponse('call-hc-1', 'set_hermes_consent', { learn: true, share: true, confirmed: true }))
         .mockResolvedValueOnce(makeGroqResponse('ONにしました。'));
 
-      mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'tenant-abc' }] });
+      mockQuery
+        .mockResolvedValueOnce({ rowCount: 1, rows: [{ features: null }] }) // 現在値の読み取り
+        .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'tenant-abc' }] }); // UPDATE
 
       const res = await request(makeApp(CLIENT_ADMIN_USER))
         .post('/v1/admin/agent/chat')
-        .send({ message: 'Hermesへのデータ提供に同意して', sessionId: 'sess-hc-01' });
+        .send({ message: '学習にもデータ提供にも同意して', sessionId: 'sess-hc-01' });
 
       expect(res.status).toBe(200);
       const result = res.body.actions[0].result as string;
-      expect(result).toContain('Hermesへのデータ提供同意をONにしました');
+      expect(result).toContain('学習設定を更新しました');
+      expect(result).toContain('learn=ON');
+      expect(result).toContain('share=ON');
       expect(result).not.toContain('確認が必要');
+      // 他のフラグ(avatar等)を消さないマージ表現(COALESCE(...) || $1::jsonb)を維持していること。
       expect(mockQuery).toHaveBeenNthCalledWith(
-        1,
-        expect.stringContaining('UPDATE tenants SET features'),
-        [JSON.stringify({ hermes_raw_data_consent: true }), 'tenant-abc'],
+        2,
+        expect.stringContaining('UPDATE tenants SET features = COALESCE(features'),
+        [JSON.stringify({ learning: { learn: true, share: true } }), 'tenant-abc'],
       );
     });
 
-    it('enabled=falseで成功し、同意を取り消せる', async () => {
+    it('shareのみ指定した場合、現在のlearnの値が維持される(部分更新)', async () => {
       mockFetch
-        .mockResolvedValueOnce(toolCallResponse('call-hc-2', 'set_hermes_consent', { enabled: false, confirmed: true }))
+        .mockResolvedValueOnce(toolCallResponse('call-hc-2', 'set_hermes_consent', { share: false, confirmed: true }))
         .mockResolvedValueOnce(makeGroqResponse('OFFにしました。'));
 
-      mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'tenant-abc' }] });
+      mockQuery
+        .mockResolvedValueOnce({ rowCount: 1, rows: [{ features: { learning: { learn: true, share: true } } }] }) // 現在値
+        .mockResolvedValueOnce({ rows: [{ plan: 'starter' }] }) // share=false指定→forced判定(starterは強制なし)
+        .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'tenant-abc' }] }); // UPDATE
 
       const res = await request(makeApp(CLIENT_ADMIN_USER))
         .post('/v1/admin/agent/chat')
-        .send({ message: 'Hermesへのデータ提供同意を取り消して', sessionId: 'sess-hc-02' });
+        .send({ message: '共有プールへの参加をやめて', sessionId: 'sess-hc-02' });
 
       expect(res.status).toBe(200);
-      expect(res.body.actions[0].result).toContain('Hermesへのデータ提供同意をOFFにしました');
+      expect(res.body.actions[0].result).toContain('learn=ON');
+      expect(res.body.actions[0].result).toContain('share=OFF');
+      expect(mockQuery).toHaveBeenNthCalledWith(
+        3,
+        expect.stringContaining('UPDATE tenants SET features'),
+        [JSON.stringify({ learning: { learn: true, share: false } }), 'tenant-abc'],
+      );
     });
 
-    it('confirmed無しではDBに触れずブロックされる', async () => {
+    it('旧enabled引数はshareとして解釈される(後方互換)', async () => {
       mockFetch
-        .mockResolvedValueOnce(toolCallResponse('call-hc-3', 'set_hermes_consent', { enabled: true, confirmed: false }))
-        .mockResolvedValueOnce(makeGroqResponse('確認してから切り替えます。'));
+        .mockResolvedValueOnce(toolCallResponse('call-hc-3', 'set_hermes_consent', { enabled: true, confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('ONにしました。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rowCount: 1, rows: [{ features: {} }] }) // 現在値未設定 → learn:true,share:false扱い
+        .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'tenant-abc' }] }); // UPDATE(enabled=true→share=trueなのでforced判定は通らない)
 
       const res = await request(makeApp(CLIENT_ADMIN_USER))
         .post('/v1/admin/agent/chat')
         .send({ message: 'Hermesへのデータ提供に同意して', sessionId: 'sess-hc-03' });
 
       expect(res.status).toBe(200);
-      expect(mockQuery).not.toHaveBeenCalled();
-      expect(res.body.actions[0].result).toContain('確認が必要');
+      expect(mockQuery).toHaveBeenNthCalledWith(
+        2,
+        expect.stringContaining('UPDATE tenants SET features'),
+        [JSON.stringify({ learning: { learn: true, share: true } }), 'tenant-abc'],
+      );
     });
 
-    it('成功時に tenant_settings_history へ features.hermes_raw_data_consent の変更が記録される', async () => {
+    it('confirmed無しではDBに触れずブロックされる', async () => {
       mockFetch
-        .mockResolvedValueOnce(toolCallResponse('call-hc-4', 'set_hermes_consent', { enabled: true, confirmed: true }))
-        .mockResolvedValueOnce(makeGroqResponse('ONにしました。'));
-
-      mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'tenant-abc' }] });
+        .mockResolvedValueOnce(toolCallResponse('call-hc-4', 'set_hermes_consent', { share: true, confirmed: false }))
+        .mockResolvedValueOnce(makeGroqResponse('確認してから切り替えます。'));
 
       const res = await request(makeApp(CLIENT_ADMIN_USER))
         .post('/v1/admin/agent/chat')
         .send({ message: 'Hermesへのデータ提供に同意して', sessionId: 'sess-hc-04' });
 
       expect(res.status).toBe(200);
+      expect(mockQuery).not.toHaveBeenCalled();
+      expect(res.body.actions[0].result).toContain('確認が必要');
+    });
+
+    // G3: learn=false かつ share=true は不整合として拒否する。
+    it('learn=false かつ share=true は拒否される(G3)', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-hc-5', 'set_hermes_consent', { learn: false, share: true, confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('拒否しました。'));
+
+      mockQuery.mockResolvedValueOnce({ rowCount: 1, rows: [{ features: {} }] }); // 現在値読み取りのみ
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '自社では学習しないけど共有プールには出して', sessionId: 'sess-hc-05' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('share=ON(共有プールへ提供)にはできません');
+      // 現在値読み取りの1回のみで、UPDATEには進んでいないこと。
+      expect(mockQuery).toHaveBeenCalledTimes(1);
+    });
+
+    // ★S4最大の罠の実測: free_adと確実に判明した場合のみ強制ON。判定不能時は強制しない。★
+    it('free_adと確実に判明したテナントがshare=falseを指定すると拒否され、理由が返る', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-hc-6', 'set_hermes_consent', { share: false, confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('拒否しました。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rowCount: 1, rows: [{ features: { learning: { learn: true, share: true } } }] }) // 現在値
+        .mockResolvedValueOnce({ rows: [{ plan: 'free_ad' }] }); // forced判定 → free_ad確定
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '共有プールへの参加をやめて', sessionId: 'sess-hc-06' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).toContain('広告プランでは共有が必須です');
+      expect(res.body.actions[0].result).toContain('有料プランへの変更が必要です');
+      // forced判定までの2回のみで、UPDATEには進んでいないこと(黙って無視せず理由を返す=G3)。
+      expect(mockQuery).toHaveBeenCalledTimes(2);
+    });
+
+    // ★噛み確認の実測版: プラン取得がDB障害等で判定不能な場合、free_ad扱いにせず
+    // 強制を適用しない(=share=falseの指定がそのまま通る)。★
+    it('プラン判定が不能(DB障害)な場合は強制されず、share=falseの指定が通る', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-hc-7', 'set_hermes_consent', { share: false, confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('OFFにしました。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rowCount: 1, rows: [{ features: { learning: { learn: true, share: true } } }] }) // 現在値
+        .mockRejectedValueOnce(new Error('db down')) // forced判定のDB問い合わせが失敗
+        .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'tenant-abc' }] }); // UPDATEは実行される
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '共有プールへの参加をやめて', sessionId: 'sess-hc-07' });
+
+      expect(res.status).toBe(200);
+      expect(res.body.actions[0].result).not.toContain('広告プランでは共有が必須です');
+      expect(res.body.actions[0].result).toContain('share=OFF');
+      expect(mockQuery).toHaveBeenNthCalledWith(
+        3,
+        expect.stringContaining('UPDATE tenants SET features'),
+        [JSON.stringify({ learning: { learn: true, share: false } }), 'tenant-abc'],
+      );
+    });
+
+    it('成功時に tenant_settings_history へ features.learning の変更が記録される', async () => {
+      mockFetch
+        .mockResolvedValueOnce(toolCallResponse('call-hc-8', 'set_hermes_consent', { learn: true, share: true, confirmed: true }))
+        .mockResolvedValueOnce(makeGroqResponse('ONにしました。'));
+
+      mockQuery
+        .mockResolvedValueOnce({ rowCount: 1, rows: [{ features: null }] })
+        .mockResolvedValueOnce({ rowCount: 1, rows: [{ id: 'tenant-abc' }] });
+
+      const res = await request(makeApp(CLIENT_ADMIN_USER))
+        .post('/v1/admin/agent/chat')
+        .send({ message: '学習にもデータ提供にも同意して', sessionId: 'sess-hc-08' });
+
+      expect(res.status).toBe(200);
       const recorded = recordedSettingsChanges();
       expect(recorded).toHaveLength(1);
-      expect(recorded[0]!['fieldName']).toBe('features.hermes_raw_data_consent');
-      expect(recorded[0]!['newValue']).toBe(true);
+      expect(recorded[0]!['fieldName']).toBe('features.learning');
+      expect(recorded[0]!['newValue']).toEqual({ learn: true, share: true });
     });
   });
 

--- a/src/api/admin/agent/agentRoutes.ts
+++ b/src/api/admin/agent/agentRoutes.ts
@@ -107,13 +107,25 @@ const AUDITED_SETTINGS_TOOLS: Record<
     // そのまま読むと "true"(文字列)がbooleanのつもりで監査ログに残ってしまう。
     readNewValue: (args) => parseBooleanArg(args['enabled']),
   },
-  // GID 1216978677372391(PR-16, D1): tenants.features.hermes_raw_data_consent
-  // (②外部Hermes VPSへの生データ提供同意)。①自テナント内学習はこのフラグを
-  // 参照しないため対象外(src/lib/hermesConsent.ts)。
+  // GID 1216978677372391(PR-16, D1) / 共有学習プールの参加モデル S4:
+  // tenants.features.learning = {learn, share}。learn=自社内学習(外に出ない)、
+  // share=共有プール参加(外部Hermes VPSへ出る)。actionExecutor.ts の
+  // case 'set_hermes_consent' 参照。newValueは「今回引数で指定された軸のみ」を
+  // 記録する(set_widget_theme と同じ「当てた差分だけ」の考え方。旧enabled引数は
+  // shareとして解釈する後方互換)。
   set_hermes_consent: {
-    fieldName: 'features.hermes_raw_data_consent',
-    successMarker: 'Hermesへのデータ提供同意を',
-    readNewValue: (args) => parseBooleanArg(args['enabled']),
+    fieldName: 'features.learning',
+    successMarker: '学習設定を更新しました',
+    readNewValue: (args) => {
+      const learn = parseBooleanArg(args['learn']);
+      const shareRaw = parseBooleanArg(args['share']);
+      const enabled = parseBooleanArg(args['enabled']);
+      const share = shareRaw !== undefined ? shareRaw : enabled;
+      const value: Record<string, boolean> = {};
+      if (learn !== undefined) value['learn'] = learn;
+      if (share !== undefined) value['share'] = share;
+      return value;
+    },
   },
   // オンボ 是正B-2: オンボ2ツールが未登録で tenant_settings_history に一切記録されず、
   // 「各段階の到達に actor が記録される」(AC-4)が未達だった。successMarker は

--- a/src/api/admin/agent/toolDefinitions.ts
+++ b/src/api/admin/agent/toolDefinitions.ts
@@ -365,27 +365,42 @@ export const ADMIN_AGENT_TOOLS: GroqTool[] = [
     function: {
       name: 'set_hermes_consent',
       description:
-        '外部Hermes VPS(社外の分析エージェント)への会話ログ生データ提供の同意をON/OFFする。' +
-        'これは「①自テナント内での学習(常時ON、同意不要)」とは別の、' +
-        '「②社外へのデータ提供」専用の同意であり、このツールが操作するのは②のみ。' +
-        'ONにすると翌日以降、貴社の会話ログ(QA AI・アバターの応答)に加え、その会話に至るまでの' +
-        'ページ閲覧履歴・流入元(URLのパス部分。検索語や会員IDなどのクエリ文字列は除く)が' +
-        'Hermes VPSでの分析対象になる。' +
-        'OFFにすると以降の新規データ提供は止まるが、それまでに提供済みのデータは取り消せない。' +
+        '共有学習プールへの参加同意(2軸)をON/OFFする。' +
+        'learn=自社内学習の同意(自テナントの会話から自テナント用に学習する。データは外に出ない)。' +
+        'share=共有プール参加の同意(R2C共有プールに出し、かつ読む。外部Hermes VPSへ出る)。' +
+        'shareをONにすると、貴社の会話ログ・行動データが外部Hermes VPSでの分析対象になる' +
+        '代わりに、他社の学びも使えるようになる。' +
+        'shareをOFFにすると以降の新規データ提供は止まるが、それまでに提供済みのデータは取り消せない。' +
+        'learn=false かつ share=true(自社が学ばないのに他社へ出す)は矛盾するため指定できない。' +
+        '広告プラン(free_ad)ではshareが強制ONのため、shareをOFFにする指定は拒否され理由が返る' +
+        '(有料プランへの変更が必要)。' +
+        '後方互換: 旧引数 enabled(boolean)が来た場合は share の指定として解釈する。' +
         'confirmed=true の場合のみ実行される。',
       parameters: {
         type: 'object',
         properties: {
+          learn: {
+            type: 'boolean',
+            description: '自社内学習(learn)の同意。true でON、false でOFF。省略時は現在の値を維持する',
+          },
+          share: {
+            type: 'boolean',
+            description:
+              '共有プール参加(share)の同意。true でON、false でOFF。省略時は現在の値を維持する' +
+              '（旧引数 enabled が指定された場合はそちらを share として使う）',
+          },
           enabled: {
             type: 'boolean',
-            description: 'true で外部提供の同意をON、false でOFF(同意取消)にする',
+            description:
+              '非推奨・後方互換用。share と同じ意味(true で外部提供の同意をON、false でOFF)。' +
+              '新規にはshareを使うこと',
           },
           confirmed: {
             type: 'boolean',
             description: '変更確認フラグ（true でのみ実行）',
           },
         },
-        required: ['enabled', 'confirmed'],
+        required: ['confirmed'],
       },
     },
   },

--- a/src/lib/billing/planFeatures.test.ts
+++ b/src/lib/billing/planFeatures.test.ts
@@ -6,7 +6,15 @@ jest.mock("../db", () => ({
   getPool: () => ({ query: mockQuery }),
 }));
 
-import { planHasFeature, getTenantPlan, tenantHasFeature, tenantPlanCache } from "./planFeatures";
+import {
+  planHasFeature,
+  getTenantPlan,
+  tenantHasFeature,
+  tenantPlanCache,
+  queryTenantPlanResult,
+  resolveShareForPlan,
+  resolveShareForTenantPlan,
+} from "./planFeatures";
 
 describe("planHasFeature", () => {
   it.each([
@@ -208,5 +216,117 @@ describe("getTenantPlan TTLキャッシュ", () => {
     expect(await getTenantPlan("tenant-x")).toBe("starter");
     expect(await getTenantPlan("tenant-y")).toBe("enterprise");
     expect(mockQuery).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// S4(共有学習プールの参加モデル): queryTenantPlanResult / resolveShareForPlan
+//
+// ★このタスク最大の罠のテスト★
+// queryTenantPlan の fail-safe(未知/null/DB障害 → free_ad)に share の強制ロジックが
+// 相乗りすると、DB障害の瞬間に全テナントが強制データ共有になる。
+// queryTenantPlanResult は queryTenantPlan とは独立に「確実に判明したか」を
+// null で区別して返し、resolveShareForPlan は null(判定不能)を free_ad として
+// 扱わないことを固定する。
+// ---------------------------------------------------------------------------
+
+describe("queryTenantPlanResult", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it("既知の4値はそのまま返す", async () => {
+    for (const plan of ["free_ad", "starter", "growth", "enterprise"] as const) {
+      mockQuery.mockResolvedValueOnce({ rows: [{ plan }] });
+      expect(await queryTenantPlanResult({ query: mockQuery }, "tenant-a")).toBe(plan);
+    }
+  });
+
+  it("plan列がnullの場合は null(未確定。free_adに確定させない)", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ plan: null }] });
+    expect(await queryTenantPlanResult({ query: mockQuery }, "tenant-a")).toBeNull();
+  });
+
+  it("未知のplan文字列の場合は null(未確定。free_adに確定させない)", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ plan: "typo-plan" }] });
+    expect(await queryTenantPlanResult({ query: mockQuery }, "tenant-a")).toBeNull();
+  });
+
+  it("テナントが存在しない場合(rowsが空)は null", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    expect(await queryTenantPlanResult({ query: mockQuery }, "nonexistent")).toBeNull();
+  });
+
+  it("★DB障害(reject)時は null(free_adに確定させない。queryTenantPlanと違いfree_adへ倒さない)★", async () => {
+    mockQuery.mockRejectedValueOnce(new Error("db down"));
+    expect(await queryTenantPlanResult({ query: mockQuery }, "tenant-a")).toBeNull();
+  });
+});
+
+describe("resolveShareForPlan", () => {
+  it("free_ad確定 → 強制ON({forced:true, value:true})", () => {
+    expect(resolveShareForPlan("free_ad")).toEqual({ forced: true, value: true });
+  });
+
+  it.each(["starter", "growth", "enterprise"] as const)(
+    "%s → 強制なし・既定OFF({forced:false, default:false})",
+    (plan) => {
+      expect(resolveShareForPlan(plan)).toEqual({ forced: false, default: false });
+    },
+  );
+
+  it("★判定不能(null)の場合は強制しない。free_ad扱いで強制ONにしない★", () => {
+    expect(resolveShareForPlan(null)).toEqual({ forced: false, default: false });
+    // free_ad確定の場合(forced:true)とは明確に異なる結果であることを対比で固定する。
+    expect(resolveShareForPlan(null)).not.toEqual(resolveShareForPlan("free_ad"));
+  });
+});
+
+describe("resolveShareForTenantPlan(queryTenantPlanResult + resolveShareForPlanの結合)", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it("free_ad確定テナント → 強制ON", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ plan: "free_ad" }] });
+    expect(await resolveShareForTenantPlan({ query: mockQuery }, "tenant-a")).toEqual({
+      forced: true,
+      value: true,
+    });
+  });
+
+  it.each(["starter", "growth", "enterprise"] as const)(
+    "%sテナント → 強制なし・既定OFF",
+    async (plan) => {
+      mockQuery.mockResolvedValueOnce({ rows: [{ plan }] });
+      expect(await resolveShareForTenantPlan({ query: mockQuery }, "tenant-a")).toEqual({
+        forced: false,
+        default: false,
+      });
+    },
+  );
+
+  it("★DB障害時 → 強制を適用せず share=OFF相当({forced:false})。free_ad扱いで強制ONにしない★", async () => {
+    mockQuery.mockRejectedValueOnce(new Error("db down"));
+    expect(await resolveShareForTenantPlan({ query: mockQuery }, "tenant-a")).toEqual({
+      forced: false,
+      default: false,
+    });
+  });
+
+  it("★plan列がnull → 同上(強制ONにしない)★", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ plan: null }] });
+    expect(await resolveShareForTenantPlan({ query: mockQuery }, "tenant-a")).toEqual({
+      forced: false,
+      default: false,
+    });
+  });
+
+  it("★プランが未知の文字列 → 同上(強制ONにしない)★", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [{ plan: "typo-plan" }] });
+    expect(await resolveShareForTenantPlan({ query: mockQuery }, "tenant-a")).toEqual({
+      forced: false,
+      default: false,
+    });
   });
 });

--- a/src/lib/billing/planFeatures.ts
+++ b/src/lib/billing/planFeatures.ts
@@ -132,3 +132,88 @@ export async function tenantHasFeature(tenantId: string, feature: GatedFeature):
   const plan = await getTenantPlan(tenantId);
   return planHasFeature(plan, feature);
 }
+
+// ---------------------------------------------------------------------------
+// S4(共有学習プールの参加モデル): プラン別の share(共有プール参加)既定値・強制。
+//
+// ★fail-safeの向きがqueryTenantPlanと反転する★
+// queryTenantPlan/getTenantPlanのfail-safe(未知・null・DB障害を free_ad に倒す)は
+// 機能ゲート(planHasFeature)にとっては正しい(free_adが最も制限が強い段だから)。
+// しかしデータ提供(share)にとっては free_ad が最も「開いている」側になる
+// (free_ad は share 強制ON)。そのため
+//   if (plan === "free_ad") share = true
+// を queryTenantPlan の結果にそのまま適用すると、DB障害や未知プランの瞬間に
+// 全テナントが強制データ共有になってしまう。
+//
+// これを避けるため、「プランが確実に free_ad と判明した」ケースと
+// 「プラン取得に失敗した／未知だった」ケースを型で区別できる
+// queryTenantPlanResult を queryTenantPlan とは別に用意する。判定不能時は
+// 強制を適用しない(share は既定OFFへ倒す)。
+// ---------------------------------------------------------------------------
+
+/**
+ * テナントの現在のプランを取得する。queryTenantPlan と異なり fail-safe に相乗りせず、
+ * 「確実に4値のいずれかと判明したか」を呼び出し側が区別できるよう null で失敗を表す。
+ *
+ * - DB例外 → null（取得失敗。free_ad と確定させない）
+ * - plan列が null / 未知の文字列 / テナント不在(rowsが空) → null（未確定）
+ * - 既知の4値のいずれか → その値
+ *
+ * queryTenantPlan(機能ゲート用。未知/null/DB障害はfree_adへ倒す)とは用途が異なるため、
+ * 実装を共有せず独立させている。共有すると片方の修正がもう片方のfail-safeの向きを
+ * 意図せず変えてしまう事故が起きやすい。
+ */
+export async function queryTenantPlanResult(
+  pool: Pick<Pool, "query">,
+  tenantId: string,
+): Promise<TenantPlan | null> {
+  try {
+    const result = await pool.query<{ plan: string | null }>(
+      `SELECT plan FROM tenants WHERE id = $1`,
+      [tenantId],
+    );
+    const plan = result.rows[0]?.plan;
+    if (plan === "free_ad" || plan === "starter" || plan === "growth" || plan === "enterprise") {
+      return plan;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// resolveShareForPlan の戻り値。「強制されているか」と「(強制でない場合の)既定値」を
+// 呼び出し側が区別できる形にする。強制されていない場合、default は常に false
+// (share は外部提供を伴うため、fail-safeとしても既定は無効側に倒す)。
+export type ShareForPlanResolution = { forced: true; value: true } | { forced: false; default: boolean };
+
+/**
+ * 「確実に判明したプラン(または未確定=null)」から、share(共有プール参加)の
+ * 既定値・強制を解決する。
+ *
+ * - plan が確実に free_ad と判明した場合のみ、強制ON({forced:true, value:true})。
+ * - plan が null(取得失敗・未知・未設定などプラン確定不能)の場合は、
+ *   free_ad 扱いにせず強制しない({forced:false, default:false})。
+ *   ★ここが本タスク最大の罠: queryTenantPlan の fail-safe(未知→free_ad)に
+ *   相乗りしてはいけない。相乗りすると DB障害時に全テナントが強制共有になる。★
+ * - starter/growth/enterprise は選択可能・既定OFF({forced:false, default:false})。
+ */
+export function resolveShareForPlan(plan: TenantPlan | null): ShareForPlanResolution {
+  if (plan === "free_ad") {
+    return { forced: true, value: true };
+  }
+  return { forced: false, default: false };
+}
+
+/**
+ * queryTenantPlanResult + resolveShareForPlan をまとめた便宜関数。
+ * 呼び出し元が独自にPoolを注入できる箇所(actionExecutor.ts等、テストのモックPoolと
+ * 食い違わせないため getPool() を直接呼ばない箇所)向け。
+ */
+export async function resolveShareForTenantPlan(
+  pool: Pick<Pool, "query">,
+  tenantId: string,
+): Promise<ShareForPlanResolution> {
+  const plan = await queryTenantPlanResult(pool, tenantId);
+  return resolveShareForPlan(plan);
+}


### PR DESCRIPTION
## Summary
共有学習プールの参加モデル S4(要件 §3 S4 / 受け入れ G3・E3)。プランによる share(共有プール参加)の既定値と強制を入れ、テナントがチャットから learn/share を個別に切り替えられる導線を通す。

- **free_ad(広告プラン)**: share 強制ON
- **starter/growth/enterprise(有料プラン)**: share 選択可能・既定OFF

### ★fail-safeの向きの反転への対応(本タスク最大の罠)
`queryTenantPlan`/`getTenantPlan` の fail-safe(未知プラン・null・DB障害を `free_ad` に倒す)は機能ゲートでは正しい挙動だが、データ提供(share)にとっては `free_ad` が最も「開いている」側になる。素朴に `if (plan === "free_ad") share = true` を適用すると、DB障害の瞬間に全テナントが強制データ共有になってしまう。

これを避けるため `src/lib/billing/planFeatures.ts` に、既存の `queryTenantPlan` とは独立した `queryTenantPlanResult`(プランが確実に判明したかを `TenantPlan | null` で区別)と `resolveShareForPlan`(`{forced:true,value:true} | {forced:false,default:boolean}` を返す)を追加。**プラン取得の「失敗」と `free_ad` の「確定」を型で区別し、判定不能時は強制を適用しない**ことをテストで固定した。

### 噛み確認(実施済み)
`resolveShareForPlan` を一時的に `if (plan === "free_ad" || plan === null) forced=true` という誤実装に書き換え、DB障害・null plan・未知プランの3ケースでテストが赤くなることを確認 → 正しい実装に戻した。結果は planFeatures.test.ts に統合済み。

## 変更内容
1. **`src/lib/billing/planFeatures.ts`**: `queryTenantPlanResult` / `resolveShareForPlan` / `resolveShareForTenantPlan` を追加。既存の `planHasFeature` / `FEATURE_MIN_PLAN` / `queryTenantPlan` の挙動は変更なし。
2. **`src/api/admin/agent/toolDefinitions.ts`**: `set_hermes_consent` の引数を `enabled(boolean)` から `learn`/`share` の2軸に拡張(新ツールは作らず既存ツールの更新)。旧 `enabled` 引数も後方互換で残す。
3. **`src/api/admin/agent/actionExecutor.ts`**: `case 'set_hermes_consent'` を2軸対応に更新。`features.learning={learn,share}` をマージ更新(他フラグを消さない)。`learn=false && share=true` は拒否(G3)。free_ad確定テナントの `share=false` 指定は理由付きで拒否(黙って無視しない)。旧 `enabled` は `share` として解釈。
4. **`admin-ui/src/pages/copilot-preview/index.tsx`**: `REAL_TOOL_LABEL` の文言を2軸の意味に更新。
5. **`src/api/admin/agent/confirmPolicy.ts`**: `set_hermes_consent` は `medium` を維持(変更なし、テストで確認)。
6. **`src/api/admin/agent/agentRoutes.ts` / `agentRoutes.test.ts`**(5ファイルの指定外だが必要な追随): `tenant_settings_history` 監査対象の `fieldName` を `features.hermes_raw_data_consent` から `features.learning` へ更新。actionExecutor の書き込み先変更(旧フラグを書かなくなった)に追随するため。set_hermes_consentの統合テストも新しい2軸挙動に全面更新。
7. **`CLAUDE.md`**: 禁止47として「共有プールの読み取り権を同意と紐付けない/出す・読むを別フラグにする」を追加(mainの最新採番46を確認の上、47で追記)。ガードの `tests/phase38/globalRuleGate.test.ts` はS3で追加予定のため、本ブランチ時点では未存在である旨を明記。

## 本番の状況(実測、2026-08-24)
```
    plan    | count
------------+-------
 enterprise |     1
 starter    |     3
```
`free_ad` は0件。**強制ON経路(free_adテナントのshare強制、およびshare=false拒否)は本番未検証**。動作確認は単体テスト(`planFeatures.test.ts` の `queryTenantPlanResult`/`resolveShareForPlan`)と統合テスト(`agentRoutes.test.ts` の `set_hermes_consent` describe、free_ad確定シナリオを含む)、および上記の噛み確認でのみ担保している。確認は `ssh root@65.108.159.161` で `/opt/rajiuce/.env` の `DATABASE_URL` を使い `SELECT plan, count(*) FROM tenants GROUP BY 1;` を実行(SELECTのみ、書き込みなし)。

## Test plan
- [x] `pnpm typecheck` — pass
- [x] `pnpm lint` — pass(既存の未関連warningのみ、exit 0)
- [x] `npx jest src/lib/billing/planFeatures.test.ts src/api/admin/agent/agentRoutes.test.ts src/api/admin/agent/confirmPolicy.test.ts src/lib/hermesConsent.test.ts --maxWorkers=1` — 641/641 pass
- [x] fail-safe反転の噛み確認(誤実装で赤 → 正実装で緑を実測)
- [x] 本番 `tenants.features`/`plan` への書き込みは一切行っていない(SELECTのみ)
- [ ] full jest suite: 本PRと無関係なファイル(objection-patterns / evaluations / avatar/routes)で `EADDRNOTAVAIL`/`socket hang up` 等の環境要因フレークが再現するが、単独実行では全てpass。ポート枯渇によるローカルテスト不安定という既知の問題(このリポジトリで過去にも確認済み)であり、本PRの変更とは無関係と判断。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgCQYt8UMPgm4HNVu7nv7z