### PR TITLE
feat(hermes-pool): S5b free_adプランの新規発行を同意バナー実装まで一時ブロック

### DIFF
--- a/src/api/admin/tenants/routes.test.ts
+++ b/src/api/admin/tenants/routes.test.ts
@@ -778,21 +778,23 @@ describe("PATCH /v1/admin/my-tenant — avatar/voice plan ゲート", () => {
 // 400 invalid_requestで拒否される(型はコンパイルが通るのに実行時に壊れる典型例)。
 // 型チェック・lintでは検出できず、実機で初めて気づいた。二度と壊さないための回帰テスト。
 describe("PATCH /v1/admin/tenants/:id — free_ad プラン受理(P0回帰)", () => {
-  it("plan='free_ad' への変更を400にせず受理する", async () => {
-    const dbQuery = jest
-      .fn()
-      .mockResolvedValueOnce({ rows: [{ id: "tenant-a", plan: "starter", features: {}, billing_enabled: false, is_active: true }], rowCount: 1 })
-      .mockResolvedValueOnce({ rows: [{ id: "tenant-a", name: "テストテナント", plan: "free_ad", is_active: true }], rowCount: 1 })
-      .mockResolvedValue({ rows: [], rowCount: 1 });
+  // S5b(共有学習プールの参加モデル・D1決定案)により、free_adは消費者向け同意バナー
+  // 実装まで一時的に403でブロックされるようになった。ただしこのテストの本来の目的
+  // (zodのplanValuesにfree_adが登録されておらず400 invalid_requestで弾かれる、という
+  // P0バグの再発防止)は今も生きている: 403(S5bの意図的なブロック)と400(スキーマが
+  // 値自体を知らない)は全く別の失敗であり、後者に戻っていないことを確認する。
+  it("plan='free_ad' はスキーマ未知の値としては拒否されない(400にはならない。S5bにより403でブロックされる)", async () => {
+    const dbQuery = jest.fn();
     const db = { query: dbQuery };
 
     const res = await request(makeApp(db, "super_admin"))
       .patch("/v1/admin/tenants/tenant-a")
       .send({ plan: "free_ad" });
 
-    expect(res.status).toBe(200);
     expect(res.status).not.toBe(400);
-    expect(res.body.plan).toBe("free_ad");
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("free_ad_plan_not_yet_available");
+    expect(dbQuery).not.toHaveBeenCalled();
   });
 
   it("存在しないプラン文字列('gold'等)は引き続き400で拒否する(何でも通す壊れ方をしていない)", async () => {
@@ -806,31 +808,56 @@ describe("PATCH /v1/admin/tenants/:id — free_ad プラン受理(P0回帰)", ()
     expect(res.status).toBe(400);
     expect(dbQuery).not.toHaveBeenCalled();
   });
+
+  // S5b: ガードは fields.plan === "free_ad" のみを見る。plan を含まない更新
+  // (free_adテナントが既に存在する場合の他フィールド編集を含む)は一律ブロックしない。
+  it("S5b: planを含まない更新(free_adテナントの改名等)はブロックしない", async () => {
+    const dbQuery = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ id: "tenant-a", plan: "free_ad", features: {}, billing_enabled: false, is_active: true }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ id: "tenant-a", name: "改名後", plan: "free_ad", is_active: true }], rowCount: 1 })
+      .mockResolvedValue({ rows: [], rowCount: 1 });
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "super_admin"))
+      .patch("/v1/admin/tenants/tenant-a")
+      .send({ name: "改名後" });
+
+    expect(res.status).toBe(200);
+  });
+
+  // S5b: free_adからの降格(離脱)は同ガードの対象外。塞ぐのは「新規移行」のみ。
+  it("S5b: free_ad → starter への降格はブロックしない", async () => {
+    const dbQuery = jest
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ id: "tenant-a", plan: "free_ad", features: {}, billing_enabled: false, is_active: true }], rowCount: 1 })
+      .mockResolvedValueOnce({ rows: [{ id: "tenant-a", name: "テストテナント", plan: "starter", is_active: true }], rowCount: 1 })
+      .mockResolvedValue({ rows: [], rowCount: 1 });
+    const db = { query: dbQuery };
+
+    const res = await request(makeApp(db, "super_admin"))
+      .patch("/v1/admin/tenants/tenant-a")
+      .send({ plan: "starter" });
+
+    expect(res.status).toBe(200);
+    expect(res.body.plan).toBe("starter");
+  });
 });
 
 describe("POST /v1/admin/tenants — free_ad プラン受理(P0回帰)", () => {
-  it("plan='free_ad' を指定したテナント作成を400にせず受理する(201)", async () => {
-    const CREATED_ROW = {
-      id: "new-tenant",
-      name: "新規テナント",
-      plan: "free_ad",
-      is_active: true,
-      created_at: new Date().toISOString(),
-      updated_at: new Date().toISOString(),
-    };
-    const dbQuery = jest
-      .fn()
-      .mockResolvedValueOnce({ rows: [CREATED_ROW], rowCount: 1 })
-      // 以降はデフォルトアバター18体分の背景INSERT(fire-and-forget)。中身は本テストの対象外。
-      .mockResolvedValue({ rows: [], rowCount: 1 });
+  // S5bにより新規作成時点でのfree_ad指定は403でブロックされる(理由は上記PATCH側と同じ)。
+  it("plan='free_ad' を指定したテナント作成はスキーマ未知の値としては拒否されない(S5bにより403でブロックされる)", async () => {
+    const dbQuery = jest.fn();
     const db = { query: dbQuery };
 
     const res = await request(makeApp(db, "super_admin"))
       .post("/v1/admin/tenants")
       .send({ id: "new-tenant", name: "新規テナント", plan: "free_ad" });
 
-    expect(res.status).toBe(201);
-    expect(res.body.plan).toBe("free_ad");
+    expect(res.status).not.toBe(400);
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe("free_ad_plan_not_yet_available");
+    expect(dbQuery).not.toHaveBeenCalled();
   });
 
   it("plan省略時のデフォルトは引き続きstarterであり、free_adへは自動で倒れない(新規テナントは既定で有料想定)", async () => {

--- a/src/api/admin/tenants/routes.ts
+++ b/src/api/admin/tenants/routes.ts
@@ -514,6 +514,18 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
       return res.status(400).json({ error: "invalid_request", details: parsed.error.issues });
     }
     const { id, name, plan } = parsed.data;
+    // S5b(共有学習プールの参加モデル・D1決定案): free_adはshareが強制ONだが、
+    // ウィジェットに消費者向け同意バナーがまだ無い(docs/DATA_RETENTION_POLICY.md設計のみ)。
+    // 開示基盤が整うまでfree_adテナントを新規作成できないようにする。free_adは現状
+    // super_admin専用(公開サインアップ導線が無い)なので、ここを塞げば足りる。
+    // バナー実装後にこのブロックごと撤去する前提の一時的なガード(環境変数化しない: 誰にも
+    // 開ける余地を残さないため。撤去はコード変更のみで行う)。
+    if (plan === "free_ad") {
+      return res.status(403).json({
+        error: "free_ad_plan_not_yet_available",
+        message: "free_adプランは消費者向け同意バナー実装まで新規発行できません(D1決定案)。",
+      });
+    }
     try {
       const result = await db.query(
         `INSERT INTO tenants (id, name, plan, is_active)
@@ -626,6 +638,15 @@ export function registerTenantAdminRoutes(app: Express, db: Pool): void {
     const fields = parsed.data;
     if (Object.keys(fields).length === 0) {
       return res.status(400).json({ error: "no_fields", message: "更新フィールドが必要です。" });
+    }
+    // S5b(共有学習プールの参加モデル・D1決定案): 消費者向け同意バナー実装まで、
+    // free_adへの移行そのものを塞ぐ(POST /v1/admin/tenantsと同じ一時的なガード)。
+    // DBに触れる前に弾く(POSTと同様、既存テナントかどうかを問わず一律ブロック)。
+    if (fields.plan === "free_ad") {
+      return res.status(403).json({
+        error: "free_ad_plan_not_yet_available",
+        message: "free_adプランは消費者向け同意バナー実装まで新規発行できません(D1決定案)。",
+      });
     }
     try {
       // 存在チェック + Phase72-A: 変更前の監査対象フィールドを取得


### PR DESCRIPTION
## 背景

「D1・D5決定案」段階1の残り。free_adはshareが強制ONだが、ウィジェットに消費者向け同意バナーがまだ無い(`docs/DATA_RETENTION_POLICY.md`に設計はあるが未実装)。開示基盤が無いまま無料プランでデータ提供必須のテナントを増やさないよう、新規発行を一時ブロックする。

## 実装前に確認した前提の訂正

当初「free_adプランの新規販売を止める」という想定だったが、調査の結果 **free_adは現状super_admin専用**(`POST`/`PATCH /v1/admin/tenants`とも`requireSuperAdmin`)で、公開サインアップ等のセルフサービス導線は存在しないことを確認した。つまり止めるべき「販売チャネル」自体が無く、実質は**R2Cスタッフがバナー実装前に誤ってfree_adを割り当てるのを防ぐ社内ガード**になる。

## 変更内容

- `POST /v1/admin/tenants`: `plan==='free_ad'`での新規作成を403で拒否
- `PATCH /v1/admin/tenants/:id`: `fields.plan==='free_ad'`への変更を403で拒否(DBに触れる前に弾く)
  - `plan`を含まない更新(free_adテナントが将来存在した場合の改名等)や、free_adからの降格はブロックしない
- 環境変数化しない(CLAUDE.md禁止41の精神。撤去はS5a完了後のコード変更のみで行う、一時的なガードのため)

## 既存テストへの影響

`free_ad`プラン追加時のP0回帰テスト(「zodスキーマがfree_adを未知の値として400で拒否しない」ことを保証するテスト)が、本ガードの403と衝突していた。**元のテストの意図(スキーマレベルでは`free_ad`を認識している)と、本PRの意図(運用上は一時ブロックする)は別物**なので、400(スキーマが値自体を知らない)と403(意図的なブロック)を区別する形に更新した。

## Test plan

- [x] `pnpm typecheck` / lint 通過
- [x] `src/api/admin/tenants/routes.test.ts` 47件通過(新規4件: POST/PATCHのブロック確認、plan以外の更新は素通り、free_adからの降格は素通り)
- [x] 噛み確認: POST側・PATCH側それぞれのガードを個別に無効化し、対応するテストが赤くなることを実測。復元後は全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgCQYt8UMPgm4HNVu7nv7z