### PR TITLE
feat(hermes-pool): S5a ウィジェットにデータ共有開示バナーを実装

### DIFF
--- a/public/widget.js
+++ b/public/widget.js
@@ -500,6 +500,33 @@
     prefersReducedMotion ? '' : '.dot:nth-child(2){animation:bounce 1.2s 0.2s infinite}',
     prefersReducedMotion ? '' : '.dot:nth-child(3){animation:bounce 1.2s 0.4s infinite}',
 
+    /* S5a: データ共有開示バナー(エラーではないため中立色。青系で情報通知トーン) */
+    '.consent-banner {',
+    '  padding: 10px 16px;',
+    '  background: #eff6ff;',
+    '  color: #1e3a8a;',
+    '  font-size: 12px;',
+    '  line-height: 1.5;',
+    '  border-bottom: 1px solid #bfdbfe;',
+    '  display: flex;',
+    '  flex-direction: column;',
+    '  gap: 8px;',
+    '  flex-shrink: 0;',
+    '}',
+    '.consent-text { margin: 0; }',
+    '.consent-ack-btn {',
+    '  align-self: flex-end;',
+    '  min-height: 36px;',
+    '  padding: 6px 14px;',
+    '  background: #2563eb;',
+    '  color: #fff;',
+    '  border: none;',
+    '  border-radius: 8px;',
+    '  font-size: 13px;',
+    '  font-weight: 600;',
+    '  cursor: pointer;',
+    '}',
+
     /* エラーバナー */
     '.error-banner {',
     '  padding: 10px 16px;',
@@ -980,6 +1007,33 @@
   closeBtn.appendChild(CLOSE_SVG.cloneNode(true));
   var header = el('div', { className: 'header' }, [headerInfo, closeBtn]);
   panel.appendChild(header);
+
+  /* --- S5a(「D1・D5決定案」): 消費者向けデータ共有開示バナー（非表示で作成） ---
+   * テナントが共有学習プールに参加(share=true)している場合のみ、
+   * /api/widget/features 取得後に表示する(下記の features フェッチ内)。
+   * 一度同意すれば以後は出さない(テナントごとにlocalStorageへ記録)。
+   * AI発話・エラーバナーとは構造的に分離したDOM(禁止40と同じ考え方: 開示は
+   * ウィジェットのUIであり、AIの発話に混ぜない)。
+   */
+  var consentAckBtn = el('button', { className: 'consent-ack-btn', type: 'button' }, '同意して続ける');
+  var consentText = el('p', { className: 'consent-text' },
+    'サービス向上のため、この会話とページ閲覧情報を外部の分析パートナーと共有することがあります。' +
+    '連絡先やお名前など会話に含まれる情報について、自動的な伏字処理は行っておりません。'
+  );
+  var consentBanner = el('div', { className: 'consent-banner', role: 'note', 'aria-label': 'データ共有に関するお知らせ' }, [consentText, consentAckBtn]);
+  consentBanner.style.display = 'none';
+  panel.appendChild(consentBanner);
+
+  function consentAckKey() {
+    return 'r2c_consent_ack_' + (tenantId || 'unknown');
+  }
+  function hasConsentAck() {
+    try { return localStorage.getItem(consentAckKey()) === '1'; } catch (_e) { return false; }
+  }
+  consentAckBtn.addEventListener('click', function () {
+    consentBanner.style.display = 'none';
+    try { localStorage.setItem(consentAckKey(), '1'); } catch (_e) { /* ストレージ不可でも表示だけは閉じる */ }
+  });
 
   /* --- エラーバナー（非表示で作成） --- */
   var errorText = el('span', {});
@@ -3707,6 +3761,11 @@
         // event_tracking(行動計測全般)とは独立した機能なので、
         // event_tracking が無効でもここは先に評価する。
         if (cfg.answer_feedback === false) _answerFeedbackEnabled = false;
+        // S5a: data_shared_externally も event_tracking とは独立(共有プール参加は
+        // 行動計測とは別の設定軸)。同意済み(localStorage記録済み)なら出さない。
+        if (cfg.data_shared_externally && !hasConsentAck()) {
+          consentBanner.style.display = 'flex';
+        }
         if (!cfg.event_tracking) return;
         _tracker = new EventTracker(apiKey, apiBase);
         _tracker.start();

--- a/src/api/widget/featuresRouteInvariants.test.ts
+++ b/src/api/widget/featuresRouteInvariants.test.ts
@@ -15,7 +15,7 @@ function extractRouteBody(): string {
   const start = SRC.indexOf("app.get('/api/widget/features'");
   expect(start).toBeGreaterThan(-1);
   // 次のルート登録までを本体とみなす(十分な余白)
-  return SRC.slice(start, start + 1200);
+  return SRC.slice(start, start + 1500);
 }
 
 describe('GET /api/widget/features ソース不変条件', () => {
@@ -43,8 +43,22 @@ describe('GET /api/widget/features ソース不変条件', () => {
 
   it('DBクエリ失敗時(catch節)も既定ONを維持する', () => {
     const body = extractRouteBody();
-    const catchBlock = body.match(/\} catch \{[\s\S]{0,150}\}/);
+    const catchBlock = body.match(/\} catch \{[\s\S]{0,260}\}/);
     expect(catchBlock).not.toBeNull();
     expect(catchBlock![0]).toMatch(/answer_feedback:\s*true/);
+  });
+
+  it('S5a: data_shared_externally を全ての応答経路(正常系/フォールバック2箇所)で返している', () => {
+    const body = extractRouteBody();
+    // 正常系: resolveLearningConsentFromFeatures の share をそのまま使う
+    expect(body).toMatch(/data_shared_externally:\s*resolveLearningConsentFromFeatures\(features,\s*\{\s*tenantId\s*\}\)\.share/);
+    // db/tenantId不明フォールバック
+    const fallback = body.match(/if \(!db \|\| !tenantId\) \{[\s\S]{0,120}\}/);
+    expect(fallback).not.toBeNull();
+    expect(fallback![0]).toMatch(/data_shared_externally:\s*false/);
+    // catch節フォールバック。falseで固定(fail-safe: DB障害時に「外に出ている」と誤表示しない)。
+    const catchBlock = body.match(/\} catch \{[\s\S]{0,260}\}/);
+    expect(catchBlock).not.toBeNull();
+    expect(catchBlock![0]).toMatch(/data_shared_externally:\s*false/);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -53,6 +53,7 @@ import { registerBillingAdminRoutes } from "./lib/billing/billingApi";
 import { createStripeWebhookHandler } from "./lib/billing/stripeWebhook";
 import { initUsageTracker } from "./lib/billing/usageTracker";
 import { initFlowLogger } from "./lib/analytics/flowLogger";
+import { resolveLearningConsentFromFeatures } from "./lib/hermesConsent";
 import { reportUsageToStripe } from "./lib/billing/stripeSync";
 import { pipelineQueue } from "./lib/book-pipeline/pipelineQueue";
 import { supabaseAuthMiddleware } from "./admin/http/supabaseAuthMiddleware";
@@ -674,7 +675,7 @@ registerHermesMcpRoutes(app);
 app.get('/api/widget/features', ...apiStack, async (req: express.Request, res: express.Response) => {
   const tenantId: string = (req as any).tenantId ?? '';
   if (!db || !tenantId) {
-    return res.json({ event_tracking: false });
+    return res.json({ event_tracking: false, data_shared_externally: false });
   }
   void recordWidgetSeenOnce(db, tenantId);
   try {
@@ -689,10 +690,16 @@ app.get('/api/widget/features', ...apiStack, async (req: express.Request, res: e
       // (機能追加時は既定OFFにする既存の慣習に対し、本件は「教師信号を
       // 増やす」ことが目的で、テナントが積極的にOFFを選ぶ場合だけ切る設計)。
       answer_feedback: features.answer_feedback !== false,
+      // S5a(「D1・D5決定案」): 共有学習プールへの参加(share)がONのテナントは、
+      // 会話ログが外部Hermes VPSへ送られる。ウィジェット側で消費者向け開示バナーを
+      // 出す判定に使う。プラン(free_ad等)ではなく実際にデータが外に出る条件(share)
+      // そのもので判定する(resolveLearningConsentFromFeaturesと優先順位を共有)。
+      data_shared_externally: resolveLearningConsentFromFeatures(features, { tenantId }).share,
     });
   } catch {
     // フラグ取得に失敗した場合も既定ONを維持する(D1: 出さない方が例外)。
-    return res.json({ event_tracking: false, answer_feedback: true });
+    // data_shared_externally は fail-safeでfalse(resolveLearningConsentと同じ向き)。
+    return res.json({ event_tracking: false, answer_feedback: true, data_shared_externally: false });
   }
 });
 

--- a/src/lib/hermesConsent.ts
+++ b/src/lib/hermesConsent.ts
@@ -50,6 +50,42 @@ function isValidLearningShape(value: unknown): value is LearningConsent {
 }
 
 /**
+ * 既に取得済みの features オブジェクトから同期的に解決する純関数。
+ * resolveLearningConsent() と同じ優先順位(新形式優先→旧フラグ→fail-safe)だが、
+ * 呼び出し元が既に tenants 行を持っている場合(例: /api/widget/features のように
+ * 高頻度に呼ばれ、余分なDBラウンドトリップを避けたい経路)向けに、DBアクセスを
+ * 行わない形で切り出す。ロジック本体はここに集約し、resolveLearningConsent() は
+ * このラッパーとして実装する(優先順位のドリフトを防ぐため実装を2箇所に持たない)。
+ */
+export function resolveLearningConsentFromFeatures(
+  features: TenantFeaturesRow | null | undefined,
+  context?: { tenantId?: string },
+): LearningConsent {
+  const learning = features?.learning;
+
+  if (learning === undefined) {
+    // 新形式が未設定 → 後方互換で旧フラグから解決する。
+    return {
+      learn: true,
+      share: features?.hermes_raw_data_consent === true,
+    };
+  }
+
+  if (isValidLearningShape(learning)) {
+    return { learn: learning.learn, share: learning.share };
+  }
+
+  // features.learning が存在するが壊れた形(文字列/配列/null/不完全なオブジェクト等)。
+  // 黙って後方互換にフォールバックすると壊れたデータに気付けないため、fail-safeへ倒しつつ
+  // warnログを残す。
+  logger.warn("[resolveLearningConsent] features.learning が不正な形式です。fail-safeへ倒します。", {
+    tenantId: context?.tenantId,
+    learning,
+  });
+  return { ...FAILSAFE_CONSENT };
+}
+
+/**
  * テナントの学習同意(2軸: learn / share)を解決する。
  *
  * features.learning が新形式({learn, share})で設定されていればそれを使う。
@@ -67,29 +103,7 @@ export async function resolveLearningConsent(tenantId: string): Promise<Learning
       `SELECT features FROM tenants WHERE id = $1`,
       [tenantId],
     );
-    const features = result.rows[0]?.features;
-    const learning = features?.learning;
-
-    if (learning === undefined) {
-      // 新形式が未設定 → 後方互換で旧フラグから解決する。
-      return {
-        learn: true,
-        share: features?.hermes_raw_data_consent === true,
-      };
-    }
-
-    if (isValidLearningShape(learning)) {
-      return { learn: learning.learn, share: learning.share };
-    }
-
-    // features.learning が存在するが壊れた形(文字列/配列/null/不完全なオブジェクト等)。
-    // 黙って後方互換にフォールバックすると壊れたデータに気付けないため、fail-safeへ倒しつつ
-    // warnログを残す。
-    logger.warn("[resolveLearningConsent] features.learning が不正な形式です。fail-safeへ倒します。", {
-      tenantId,
-      learning,
-    });
-    return { ...FAILSAFE_CONSENT };
+    return resolveLearningConsentFromFeatures(result.rows[0]?.features, { tenantId });
   } catch (err) {
     // DB障害時は fail-safe で {learn:true, share:false} 扱い(データ露出よりも可用性低下を優先)
     logger.warn("[resolveLearningConsent] DB障害のためfail-safeへ倒します。", { tenantId, err });

--- a/tests/widget/widgetSourceInvariants.test.ts
+++ b/tests/widget/widgetSourceInvariants.test.ts
@@ -328,3 +328,42 @@ describe('public/widget.js バッジ描画条件 — 抽出ロジックとの契
     });
   });
 });
+
+// S5a(「D1・D5決定案」): 消費者向けデータ共有開示バナー
+describe('public/widget.js — S5a データ共有開示バナー', () => {
+  it('consent-banner は非表示で作成される(displayをnoneで初期化)', () => {
+    const idx = WIDGET_SRC.indexOf("className: 'consent-banner'");
+    expect(idx).toBeGreaterThan(-1);
+    const block = WIDGET_SRC.slice(idx, idx + 200);
+    expect(block).toMatch(/consentBanner\.style\.display = 'none';/);
+  });
+
+  it('data_shared_externally かつ 未同意のときだけバナーを表示する(event_trackingとは独立)', () => {
+    // answer_feedback と同じく event_tracking の早期returnより前で評価されていること
+    // (event_tracking=falseのテナントでも開示が必要なため)。
+    const earlyReturnIdx = WIDGET_SRC.indexOf('if (!cfg.event_tracking) return;');
+    expect(earlyReturnIdx).toBeGreaterThan(-1);
+    const before = WIDGET_SRC.slice(Math.max(0, earlyReturnIdx - 300), earlyReturnIdx);
+    expect(before).toMatch(/cfg\.data_shared_externally\s*&&\s*!hasConsentAck\(\)/);
+  });
+
+  it('同意はテナントごとにlocalStorageへ記録し、以後は表示しない(hasConsentAck)', () => {
+    expect(WIDGET_SRC).toMatch(/function hasConsentAck\(\)\s*\{[\s\S]{0,150}localStorage\.getItem\(consentAckKey\(\)\)/);
+    expect(WIDGET_SRC).toMatch(/function consentAckKey\(\)\s*\{[\s\S]{0,80}tenantId/);
+  });
+
+  it('同意ボタンのクリックでバナーを閉じ、localStorageに記録する', () => {
+    const idx = WIDGET_SRC.indexOf('consentAckBtn.addEventListener');
+    expect(idx).toBeGreaterThan(-1);
+    const block = WIDGET_SRC.slice(idx, idx + 250);
+    expect(block).toMatch(/consentBanner\.style\.display = 'none';/);
+    expect(block).toMatch(/localStorage\.setItem\(consentAckKey\(\), '1'\);/);
+  });
+
+  it('セキュリティ原則: 開示バナーもinnerHTMLを使わずel()/createElementで構築している', () => {
+    const idx = WIDGET_SRC.indexOf("className: 'consent-banner'");
+    expect(idx).toBeGreaterThan(-1);
+    const block = WIDGET_SRC.slice(Math.max(0, idx - 500), idx + 100);
+    expect(block).not.toMatch(/\.innerHTML\s*=/);
+  });
+});


### PR DESCRIPTION
## 背景

「D1・D5決定案」段階1の最後のピース。共有学習プールに参加(`share=true`)しているテナントのウィジェットに、会話ログ・ページ閲覧情報が外部Hermes VPSへ渡ることを消費者へ開示するバナーを実装する。

## スコープの修正(決定案作成後の実装時)

決定案では「free_adプラン限定」で設計していたが、その後**r2c_defaultで`share=true`を実際に有効化した**(starter/enterpriseプランでも share は選択できるため)。free_ad限定の条件だと、r2c_defaultのような有料プランでも share=true のテナントがこのバナーの対象から漏れてしまう。実際にデータが外部へ出るかどうかを決めるのはプラン階層ではなく`share`そのものなので、**表示条件を「share=true の全テナント」に修正**した。

## 変更内容

- **`src/lib/hermesConsent.ts`**: `resolveLearningConsentFromFeatures`を新設。既に取得済みの`features`から同期的に`share`を解決できるようにした(`resolveLearningConsent`はこのラッパーとして実装し直し、優先順位ロジックを2箇所に持たない)。`/api/widget/features`は高頻度に呼ばれるため、余分なDBラウンドトリップを避ける狙い。
- **`src/index.ts`**: `/api/widget/features`に`data_shared_externally`を追加。DB障害時・テナント不明時は`false`(`resolveLearningConsent`のfail-safeと同じ向き。「外に出ている」と誤ってバナーを出さない)。
- **`public/widget.js`**: `consent-banner`を非表示で作成し、`data_shared_externally && !hasConsentAck()`のときだけ表示(`event_tracking`とは独立に評価。行動計測が無効なテナントでも開示は必要なため)。同意はテナントごとにlocalStorageへ記録(`r2c_consent_ack_{tenantId}`)。AI発話とは構造的に分離したDOM(innerHTML不使用)。

## PII開示についての注記

`docs/ANONYMIZATION_PIPELINE_DESIGN.md`のPII自動伏字処理は設計のみで未実装のため、バナー文言はその事実を隠さず明示している(「連絡先やお名前など会話に含まれる情報について、自動的な伏字処理は行っておりません」)。

## Test plan

- [x] `pnpm typecheck` / lint 通過(既存の未使用import警告1件は本PRと無関係・main上に既存)
- [x] `tests/widget/widgetSourceInvariants.test.ts` に新規5件追加、既存含め52件通過
- [x] `src/api/widget/featuresRouteInvariants.test.ts` に新規1件追加、既存含め27件通過
- [x] `src/lib/hermesConsent.test.ts` 全件通過(リファクタで実装を分離しても優先順位は不変)
- [x] 噛み確認: バックエンド側は機械ガードのwindow拡張が必要になったことで一度赤くなることを確認。widget.js側はトリガー条件を実際に削除してガードが赤くなることを実測(単純な`false &&`否定では正規表現ベースのガードが反応しないことも実測で確認し、より強い変異に切り替えた)
- [x] ブラウザ実機確認(claude-in-chrome, ローカルhttpサーバでwidget.js配信): `/api/widget/features`をモックしパネルオープン→バナー表示(`display:flex`)→同意ボタンクリック→localStorage記録(`r2c_consent_ack_preview-tenant`)→バナー非表示→リロード後も再表示されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NgCQYt8UMPgm4HNVu7nv7z